### PR TITLE
hipfc: Do not modify caller environment anymore

### DIFF
--- a/bin/hipfc
+++ b/bin/hipfc
@@ -287,13 +287,6 @@ if [ ! $HIPFORT_GPU ] ; then
    fi
 fi
 
-# Future versions of ROCm will install the device library in ROCM_PATH/amdgcn/bitcode
-if [ -d $ROCM_PATH/amdgcn/bitcode ] ; then
-    DEVICE_LIB_PATH=$ROCM_PATH/amdgcn/bitcode
-else
-    DEVICE_LIB_PATH=$ROCM_PATH/lib
-fi
-
 #  Handle all differences between amdgcn and nvidia here
 if [ "${HIPFORT_GPU:0:3}" == "sm_" ] ; then 
    TARGET_ARCH="nvptx"
@@ -319,7 +312,18 @@ else
    TARGET_TRIPLE=${TARGET_TRIPLE:-amdgcn-amd-amdhsa}
    TARGET_ARCH="amdgcn"
    TARGET_LIBS="-L$ROCM_PATH/lib -lamdhip64 -Wl,-rpath=$ROCM_PATH/lib "
-   HIPCC_ENV="HIP_PLATFORM=$HIP_PLATFORM DEVICE_LIB_PATH=$DEVICE_LIB_PATH HIP_CLANG_PATH=$ROCM_PATH/llvm/bin"
+   HIPCC_ENV="HIP_PLATFORM=$HIP_PLATFORM"
+   if [ -z ${HIP_CLANG_PATH+x} ]; then
+     HIPCC_ENV+=" HIP_CLANG_PATH=$ROCM_PATH/llvm/bin"
+   fi 
+   if [ -z ${DEVICE_LIB_PATH+x} ]; then
+     # Future versions of ROCm will install the device library in ROCM_PATH/amdgcn/bitcode
+     if [ -d $ROCM_PATH/amdgcn/bitcode ] ; then
+         HIPCC_ENV+=" DEVICE_LIB_PATH=$ROCM_PATH/amdgcn/bitcode"
+     else
+         HIPCC_ENV+=" DEVICE_LIB_PATH=$ROCM_PATH/lib"
+     fi
+   fi 
    HIPCC_OPTS="-fno-gpu-rdc -fPIC --offload-arch=$HIPFORT_GPU"
 fi
 
@@ -472,9 +476,7 @@ if [ "$__HIPCC_INPUTS" != "" ] ; then
       echo "        Please install hip"
       exit $DEADRC
    fi
-   [ $VERBOSE ] && echo "export $HIPCC_ENV"
-   export $HIPCC_ENV
-   runcmd "$ROCM_PATH/bin/hipcc $HIPCC_OPTS $PASSTHRUARGS $__HIPCC_INPUTS $__HIPCC_LINKOPTS -o $__HIPCC_OUTFILE"
+   runcmd "$HIPCC_ENV $ROCM_PATH/bin/hipcc $HIPCC_OPTS $PASSTHRUARGS $__HIPCC_INPUTS $__HIPCC_LINKOPTS -o $__HIPCC_OUTFILE"
 fi
 
 if [ "$__INPUTS" != "" ] ; then


### PR DESCRIPTION
hipfc changes:

* Do not export HIP_CLANG_PATH and DEVICE_LIB_PATH anymore use `<var>=<val> <command>`
  shell syntax instead.
* Do not redefine HIP_CLANG_PATH  and DEVICE_LIB_PATH anymore if already set.
