### PR TITLE
Disable -march=native by default

### DIFF
--- a/cmake/Modules/SetFortranFlags.cmake
+++ b/cmake/Modules/SetFortranFlags.cmake
@@ -57,19 +57,22 @@ IF(NOT CMAKE_Fortran_COMPILER_ID MATCHES "Cray")
 SET_COMPILE_FLAG(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS}"
                  Fortran "-fno-underscoring")
 
-# There is some bug where -march=native doesn't work on Mac
-IF(APPLE)
-    SET(GNUNATIVE "-mtune=native")
-ELSE()
-    SET(GNUNATIVE "-march=native")
-ENDIF()
-# Optimize for the host's architecture
-SET_COMPILE_FLAG(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS}"
-                 Fortran "-xHost"        # Intel
-                         "/QxHost"       # Intel Windows
-                         ${GNUNATIVE}    # GNU
-                         "-ta=host"      # Portland Group
-                )
+option(BUILD_NATIVE "Enable optimizations that make the binaries non-portable" OFF)
+if(BUILD_NATIVE)
+  # There is some bug where -march=native doesn't work on Mac
+  IF(APPLE)
+      SET(GNUNATIVE "-mtune=native")
+  ELSE()
+      SET(GNUNATIVE "-march=native")
+  ENDIF()
+  # Optimize for the host's architecture
+  SET_COMPILE_FLAG(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS}"
+                   Fortran "-xHost"        # Intel
+                           "/QxHost"       # Intel Windows
+                           ${GNUNATIVE}    # GNU
+                           "-ta=host"      # Portland Group
+                  )
+endif()
 
 ENDIF(NOT CMAKE_Fortran_COMPILER_ID MATCHES "Cray")
 


### PR DESCRIPTION
The `-march=native` flag should not be added by default, as the resulting binaries are not guaranteed to be portable between machines.

I'm not sure why, but the flag didn't seem to be used when compiling anyway. Nevertheless, I'm guarding it behind a configuration option to be sure that it is never enabled by mistake.