### PR TITLE
Update os in readthedocs yaml config and copyright for PDF output

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,7 +13,7 @@ python:
    - requirements: docs/sphinx/requirements.txt
 
 build:
-   os: ubuntu-20.04
+   os: ubuntu-22.04
    tools:
       python: "3.8"
    apt_packages:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,7 +55,7 @@ left_nav_title = f"hipfort {version_number} Documentation"
 # for PDF output on Read the Docs
 project = "hipfort Documentation"
 author = "Advanced Micro Devices, Inc."
-copyright = "Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved."
+copyright = "Copyright (c) 2024 Advanced Micro Devices, Inc. All rights reserved."
 version = version_number
 release = version_number
 

--- a/docs/sphinx/requirements.in
+++ b/docs/sphinx/requirements.in
@@ -1,1 +1,1 @@
-rocm-docs-core[api_reference]>=0.24.0
+rocm-docs-core[api_reference]==0.30.3

--- a/docs/sphinx/requirements.txt
+++ b/docs/sphinx/requirements.txt
@@ -116,7 +116,7 @@ requests==2.28.2
     # via
     #   pygithub
     #   sphinx
-rocm-docs-core[api_reference]>=0.24.0
+rocm-docs-core[api_reference]==0.30.3
     # via -r requirements.in
 smmap==5.0.0
     # via gitdb


### PR DESCRIPTION
Update for ReadtheDocs configurations:

- Use Ubuntu 22 instead of 20 for doc builds on readthedocs.com
- Update PDF copyright generated by readthedocs to 2024