### PR TITLE
Fix indexing in hipblas tests

### DIFF
--- a/test/f2003/hipblas/saxpy.f03
+++ b/test/f2003/hipblas/saxpy.f03
@@ -29,7 +29,7 @@ program hip_saxpy
   allocate(y(n))
   allocate(y_exact(n))
 
-  do j = 0, n
+  do j = 1,n
     x(j) = j
     y(j) = j
   end do

--- a/test/f2003/hipblas/scopy.f03
+++ b/test/f2003/hipblas/scopy.f03
@@ -25,14 +25,14 @@ program hip_scopy
   allocate(x(n))
   allocate(y(n))
 
-  do j = 0, n
+  do j = 1,n
     x(j) = j
    ! write(*,*) "value of x(j)" , x(j)
   end do
 
   write(*,"(a)",advance="no") "-- Running test 'Scopy' (Fortran 2003 interfaces) - "
 
-  do j = 0,n
+  do j = 1,n
     y(j) = x(j)
    ! write(*,*) "value of y(j)" , y(j)
   end do
@@ -51,7 +51,7 @@ program hip_scopy
 
   call hipCheck(hipMemcpy(c_loc(y(1)), dy, Nybytes, hipMemcpyDeviceToHost))
 
-  do j = 0,n
+  do j = 1,n
     error = abs(y(j) - x(j))
       if( error > error_max )then
         write(*,*) "FAILED! Error bigger than max! Error = ", error

--- a/test/f2008/hipblas/saxpy.f03
+++ b/test/f2008/hipblas/saxpy.f03
@@ -22,7 +22,7 @@ program hip_saxpy
   allocate(y(n))
   allocate(y_exact(n))
 
-  do j = 0, n
+  do j = 1,n
     x(j) = j
     y(j) = j
   end do

--- a/test/f2008/hipblas/scopy.f03
+++ b/test/f2008/hipblas/scopy.f03
@@ -20,14 +20,14 @@ program hip_scopy
   allocate(x(n))
   allocate(y(n))
 
-  do j = 0, n
+  do j = 1,n
     x(j) = j
    ! write(*,*) "value of x(j)" , x(j)
   end do
 
   write(*,"(a)",advance="no") "-- Running test 'Scopy' (Fortran 2008 interfaces) - "
 
-  do j = 0,n
+  do j = 1,n
     y(j) = x(j)
    ! write(*,*) "value of y(j)" , y(j)
   end do
@@ -43,7 +43,7 @@ program hip_scopy
 
   call hipCheck(hipMemcpy(y, dy, hipMemcpyDeviceToHost))
 
-  do j = 0,n
+  do j = 1,n
     error = abs(y(j) - x(j))
       if( error > error_max )then
         write(*,*) "FAILED! Error bigger than max! Error = ", error


### PR DESCRIPTION
A few of the hipblas tests are using 0-based indexing when they should be using 1-based indexing.