### PR TITLE
SWDEV-439933 - Use relative path in hipfc script (#137)

### DIFF
--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -20,15 +20,21 @@ add_custom_command( OUTPUT bindir
 add_custom_command( OUTPUT gputable.txt
    COMMAND /bin/cp -p ${CMAKE_CURRENT_SOURCE_DIR}/gputable.txt ${CMAKE_CURRENT_BINARY_DIR}/../libexec/hipfort/gputable.txt
    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/gputable.txt libexecdir)
-
-string(REGEX REPLACE "[/]" "\\\\/" escaped_path ${HIPFORT_COMPILER})
+# Use relative path with respect to hipfc install directory
+file(RELATIVE_PATH HIPFORT_COMPILER_RELATIVE_PATH ${HIPFORT_INSTALL_DIR}/${CMAKE_INSTALL_BINDIR} ${HIPFORT_COMPILER})
+string(REGEX REPLACE "[/]" "\\\\/" escaped_path ${HIPFORT_COMPILER_RELATIVE_PATH})
 set(sed_str s/gfortran/${escaped_path}/g)
-string(REGEX REPLACE "[/]" "\\\\/" installed_path ${HIPFORT_INSTALL_DIR})
+file(RELATIVE_PATH HIPFORT_INSTALL_RELATIVE_PATH ${HIPFORT_INSTALL_DIR}/${CMAKE_INSTALL_BINDIR} ${HIPFORT_INSTALL_DIR})
+string(REGEX REPLACE "[/]" "\\\\/" installed_path ${HIPFORT_INSTALL_RELATIVE_PATH})
 set(sed_str2 s/_HIPFORT_INSTALL_DIR_/${installed_path}/g)
+# Use relative path with respect to Makefile.hipfort install directory
+file(RELATIVE_PATH HIPFORT_MAKEFILE_REL_PATH ${HIPFORT_INSTALL_DIR}/${CMAKE_INSTALL_DATADIR}/hipfort ${HIPFORT_COMPILER})
+string(REGEX REPLACE "[/]" "\\\\/" mkfile_escaped_path ${HIPFORT_MAKEFILE_REL_PATH})
+set(sed_str3 s/gfortran/${mkfile_escaped_path}/g)
 
 add_custom_command( OUTPUT Makefile.hipfort
    COMMAND /bin/cp -p ${CMAKE_CURRENT_SOURCE_DIR}/Makefile.hipfort ${CMAKE_CURRENT_BINARY_DIR}/../share/hipfort/Makefile.hipfort.needs_edit
-   COMMAND /bin/sed -e '${sed_str}' ${CMAKE_CURRENT_BINARY_DIR}/../share/hipfort/Makefile.hipfort.needs_edit > ../share/hipfort/Makefile.hipfort
+   COMMAND /bin/sed -e '${sed_str3}' ${CMAKE_CURRENT_BINARY_DIR}/../share/hipfort/Makefile.hipfort.needs_edit > ../share/hipfort/Makefile.hipfort
    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/Makefile.hipfort sharedir)
 
 add_custom_command( OUTPUT mymcpu

--- a/bin/hipfc
+++ b/bin/hipfc
@@ -262,14 +262,14 @@ if [ -z "$FIRST_INPUT_FILE_NAME" ]  ; then
 fi
 
 cdir=$(getdname $0)
-[ ! -L "$cdir/hipfc" ] || cdir=$(getdname `readlink "$cdir/hipfc"`)
+[ ! -L "$cdir/hipfc" ] || cdir="$(getdname "$(realpath "$cdir/hipfc")")"
 HOW_CALLED=${0##*/}
 
 CUDA_PATH=${CUDA_PATH:-/usr/local/cuda}
 ROCM_PATH=${ROCM_PATH:-/opt/rocm}
 HIP_PLATFORM=${HIP_PLATFORM:-amd}
 
-HIPFORT=${HIPFORT:-_HIPFORT_INSTALL_DIR_}
+HIPFORT=${HIPFORT:-$cdir/_HIPFORT_INSTALL_DIR_}
 if [ ! -d $HIPFORT ] ; then
    HIPFORT="$ROCM_PATH/hipfort"
 fi
@@ -282,7 +282,7 @@ if [ ! -d $HIPFORT ] ; then
    exit 1
 fi
 
-HIPFORT_COMPILER=${HIPFORT_COMPILER:-gfortran}
+HIPFORT_COMPILER=${HIPFORT_COMPILER:-$cdir/gfortran}
 if [ ! -f $HIPFORT_COMPILER ] ; then
    HIPFORT_COMPILER=`which $HIPFORT_COMPILER`
 fi
@@ -374,7 +374,7 @@ else
 fi 
 
 sdir=$(getdname $0)
-[ ! -L "$sdir/hipfc" ] || sdir=$(getdname `readlink "$sdir/hipfc"`)
+[ ! -L "$sdir/hipfc" ] || sdir="$(getdname "$(realpath "$sdir/hipfc")")"
 ROCC_DIR=$sdir
 
 TMPNAME="hipfc-tmp-$$"


### PR DESCRIPTION
* SWDEV-439933 - Use relative path in hipfc script

Absolute paths are used in hipfc scripts for hipfort compiler and hipfort install directory Use relative paths for the same

* Correct the hipfort compiler relative path in Makefile.hipfort

The relative path of Makefile.hipfort should be calculated with respect to the install path of the file

* Correct the relative path generation in hipfc

hipfc can be invoked from any directory, since update-alternatives is run for hipfc binary. Invoking hipfc from a directory other than /opt/rocm-ver/bin was providing incorrect relative paths. Corrected the same

(cherry picked from commit a0cff897acd551efcd45d6e588975490cd7f8432)