### PR TITLE
Add support for ROCTX

### DIFF
--- a/bin/hipfc
+++ b/bin/hipfc
@@ -47,6 +47,7 @@ function usage(){
     -lrocblas   Link to rocblas library
     -lrocfft    Link to rocfft library
     -lrocrand   Link to rocrand library
+    -lroctx64   Link to roctx library
     -lhipblas   Link to hipblas library
     -lhipsparse Link to hipsparse library
     -lhipsolver Link to hipsolver library

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -123,6 +123,13 @@ else()
   message(STATUS "Skipping hipfort::hip target export")
 endif()
 
+find_package(roctx PATHS ${ROCM_PATH} /opt/rocm)
+if(roctx_FOUND)
+  hipfort_add_component(roctx roc::roctx)
+else()
+  message(STATUS "Skipping hipfort::roctx target export")
+endif()
+
 find_package(rocblas PATHS ${ROCM_PATH} /opt/rocm)
 if(rocblas_FOUND)
   hipfort_add_component(rocblas roc::rocblas)

--- a/lib/hipfort/hipfort_roctx.f
+++ b/lib/hipfort/hipfort_roctx.f
@@ -27,13 +27,13 @@
 module hipfort_roctx
 
    interface
-      subroutine roctxMarkA(message) bind(c, name="roctxMarkA")
+      subroutine roctxMark(message) bind(c, name="roctxMarkA")
          use iso_c_binding, only: c_char
          implicit none
          character(kind=c_char) :: message(*)
       end subroutine roctxMarkA
 
-      function roctxRangePushA(message) bind(c, name="roctxRangePushA")
+      function roctxRangePush(message) bind(c, name="roctxRangePushA")
          use iso_c_binding, only: c_int,&
                                   c_char
          implicit none
@@ -47,7 +47,7 @@ module hipfort_roctx
          integer(c_int) :: roctxRangePop
       end function roctxRangePop
 
-      function roctxRangeStartA(message) bind(c, name="roctxRangeStartA")
+      function roctxRangeStart(message) bind(c, name="roctxRangeStartA")
          use iso_c_binding, only: c_size_t,&
                                   c_char
          implicit none

--- a/lib/hipfort/hipfort_roctx.f
+++ b/lib/hipfort/hipfort_roctx.f
@@ -1,0 +1,65 @@
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ==============================================================================
+! hipfort: FORTRAN Interfaces for GPU kernels
+! ==============================================================================
+! Copyright (c) 2024 Advanced Micro Devices, Inc. All rights reserved.
+! [MITx11 License]
+!
+! Permission is hereby granted, free of charge, to any person obtaining a copy
+! of this software and associated documentation files (the "Software"), to deal
+! in the Software without restriction, including without limitation the rights
+! to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+! copies of the Software, and to permit persons to whom the Software is
+! furnished to do so, subject to the following conditions:
+!
+! The above copyright notice and this permission notice shall be included in
+! all copies or substantial portions of the Software.
+!
+! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+! IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+! AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+! OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+! THE SOFTWARE.
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+module hipfort_roctx
+
+   interface
+      subroutine roctxMarkA(message) bind(c, name="roctxMarkA")
+         use iso_c_binding, only: c_char
+         implicit none
+         character(kind=c_char) :: message(*)
+      end subroutine roctxMarkA
+
+      function roctxRangePushA(message) bind(c, name="roctxRangePushA")
+         use iso_c_binding, only: c_int,&
+                                  c_char
+         implicit none
+         integer(c_int) :: roctxRangePushA
+         character(kind=c_char) :: message(*)
+      end function roctxRangePushA
+
+      function roctxRangePop() bind(c, name="roctxRangePop")
+         use iso_c_binding, only: c_int
+         implicit none
+         integer(c_int) :: roctxRangePop
+      end function roctxRangePop
+
+      function roctxRangeStartA(message) bind(c, name="roctxRangeStartA")
+         use iso_c_binding, only: c_size_t,&
+                                  c_char
+         implicit none
+         integer(c_size_t) :: roctxRangeStartA
+         character(kind=c_char) :: message(*)
+      end function roctxRangeStartA
+
+      subroutine roctxRangeStop(range_id) bind (c, name="roctxRangeStop")
+         use iso_c_binding, only: c_size_t
+         implicit none
+         integer(c_size_t) :: range_id
+      end subroutine roctxRangeStop
+   end interface
+
+end module hipfort_roctx

--- a/test/f2003/roctx/Makefile
+++ b/test/f2003/roctx/Makefile
@@ -1,0 +1,12 @@
+.PHONY: build run clean
+
+build: main
+
+main: main.f03 hip_implementation.cpp
+	hipfc $(CFLAGS) main.f03 hip_implementation.cpp -o main -lroctx64
+
+run: main
+	rocprof -d rocprof_out -o rocprof_out/results.csv --hip-trace --roctx-trace ./main
+
+clean:
+	rm -rf main *.o *.mod rocprof_out

--- a/test/f2003/roctx/hip_implementation.cpp
+++ b/test/f2003/roctx/hip_implementation.cpp
@@ -1,0 +1,15 @@
+#include <hip/hip_runtime.h>
+#include <cstdio>
+
+__global__ void empty()
+{
+}
+
+
+extern "C"
+{
+  void launch()
+  {
+    hipLaunchKernelGGL((empty), dim3(1), dim3(1), 0, 0);
+  }
+}

--- a/test/f2003/roctx/main.f03
+++ b/test/f2003/roctx/main.f03
@@ -1,0 +1,45 @@
+program fortran_hip
+  use iso_c_binding
+  use hipfort
+  use hipfort_check
+  use hipfort_roctx
+
+  implicit none
+
+  interface
+     subroutine launch() bind(c)
+       use iso_c_binding
+       implicit none
+     end subroutine
+  end interface
+
+  integer :: i
+  integer :: ret
+  type(hipDeviceProp_t),target :: props
+
+  call hipCheck(hipGetDeviceProperties(props,0))
+  write(*,"(a)",advance="no") "-- Running test 'roctx' (Fortran 2003 interfaces)"
+  write(*,"(a)",advance="no") "- device: "
+  i=1
+  do while ( iachar(props%name(i)) .ne. 0 ) ! print till end char
+    write(*,"(a)",advance="no") props%name(i)
+    i = i+1
+  end do
+  write(*,"(a)",advance="no") " - "
+
+  ret = roctxRangePushA(c_char_"hello_world"//c_null_char)
+  if (ret /= 0) then
+    write (*, *) "ROCTX ERROR: roctxRangePushA: Invalid nested range level ", ret
+  end if
+
+  call launch()
+  call hipCheck(hipDeviceSynchronize())
+
+  ret = roctxRangePop()
+  if (ret /= 0) then
+    write (*, *) "ROCTX ERROR: roctxRangePop: Invalid nested range level ", ret
+  end if
+
+  write(*,*) "PASSED!"
+
+end program fortran_hip


### PR DESCRIPTION
Add bindings for the roctxMarkA, roctxRangePushA, roctxRangePop, roctxRangeStartA, and roctxRangeStop ROCTX API functions.

Add a rudimentary test in teat/f2003/roctx. The test pushes a ROCTX range around a kernel dispatch and device synchronization. The test uses rocprof to trace both HIP events and ROCTX events.