### PR TITLE
Update Depends with correct HIP Runtime package name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,8 +141,8 @@ ADD_SUBDIRECTORY(${CMAKE_SOURCE_DIR}/lib)
 ADD_SUBDIRECTORY(${CMAKE_SOURCE_DIR}/test)
 ADD_SUBDIRECTORY(${CMAKE_SOURCE_DIR}/bin)
 
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "hip-runtime-amd (>= 3.5.0)")
-set(CPACK_RPM_PACKAGE_REQUIRES "hip-runtime-amd >= 3.5.0")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "hip-runtime-amd (>= 4.5.0)")
+set(CPACK_RPM_PACKAGE_REQUIRES "hip-runtime-amd >= 4.5.0")
 # Package name changed from hipfort to hipfort-devel/dev
 # Backward compatibility support for old package name
 set(CPACK_DEBIAN_PACKAGE_PROVIDES "hipfort")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,8 +141,8 @@ ADD_SUBDIRECTORY(${CMAKE_SOURCE_DIR}/lib)
 ADD_SUBDIRECTORY(${CMAKE_SOURCE_DIR}/test)
 ADD_SUBDIRECTORY(${CMAKE_SOURCE_DIR}/bin)
 
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "hip-rocclr (>= 3.5.0)")
-set(CPACK_RPM_PACKAGE_REQUIRES "hip-rocclr >= 3.5.0")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "hip-runtime-amd (>= 3.5.0)")
+set(CPACK_RPM_PACKAGE_REQUIRES "hip-runtime-amd >= 3.5.0")
 # Package name changed from hipfort to hipfort-devel/dev
 # Backward compatibility support for old package name
 set(CPACK_DEBIAN_PACKAGE_PROVIDES "hipfort")


### PR DESCRIPTION
Proposed Changes:
- hip-rocclr package is deprecated 
- This is replaced with latest package hip-runtime-amd.
- This change is to update the package depends of hipfort to the latest package name.