### PR TITLE
Add metadata info and pointer to docs to the readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 This repository contains the source and testing for hipfort.  
 This is a FORTRAN interface library for accessing GPU Kernels.
 
+## Documentation
+
+> [!NOTE]
+> The published hipfort documentation is available at [hipfort](https://rocm.docs.amd.com/projects/hipfort/en/latest/index.html) in an organized, easy-to-read format, with search and a table of contents. The documentation source files reside in the hipfort/docs folder of this repository. As with all ROCm projects, the documentation is open source. For more information, see [Contribute to ROCm documentation](https://rocm.docs.amd.com/en/latest/contribute/contributing.html).
+
 ## Known issues
 
 * `hipSOLVER` interfaces will only work for AMD GPUs.

--- a/docs/license.md
+++ b/docs/license.md
@@ -1,3 +1,7 @@
+.. meta::
+  :description: hipFORT license information
+  :keywords: hipfort, ROCm, API, documentation, license
+
 # License
 
 ```{include} ../LICENSE

--- a/docs/tutorials/examples.rst
+++ b/docs/tutorials/examples.rst
@@ -1,3 +1,6 @@
+.. meta::
+  :description: hipFORT examples and API references
+  :keywords: hipfort, ROCm, API, documentation, examples, tutorials
 
 *************
 Examples


### PR DESCRIPTION
This PR adds missing metadata information to two files and adds the standard note pointing to the ROCm docs to the README file.