### PR TITLE
Deprecate hipfc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log for hipfort
 
+## hipfort 0.6.0 for ROCm 6.4.0
+
+### Deprecations
+
+* The hipfc compiler wrapper has been deprecated and may be removed in
+  a future release. Users are encouraged to directly invoke their
+  Fortran or HIP compilers as appropriate for each source file.
+
+
 ## hipfort 0.5.0 for ROCm 6.3.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Upcoming changes
 
-* The hipfc compiler wrapper has been deprecated and may be removed in
-  a future release. Users are encouraged to directly invoke their
+* The hipfc compiler wrapper has been deprecated and will be removed
+  in a future release. Users are encouraged to directly invoke their
   Fortran or HIP compilers as appropriate for each source file.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## hipfort 0.6.0 for ROCm 6.4.0
 
-### Deprecations
+### Upcoming changes
 
 * The hipfc compiler wrapper has been deprecated and may be removed in
   a future release. Users are encouraged to directly invoke their

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ set(HIPFORT_BUILD_TYPE "RELEASE"  CACHE STRING "Set to RELEASE TESTING or DEBUG"
 #  The ROCm release manager and other integrators should build hipfort as follows:
 #     cmake -DHIPFORT_INSTALL_DIR=/opt/rocm-<release>/hipfort -DHIPFORT_VERSION=<release> <githubrepo>
 
-set(HIPFORT_VERSION "0.5.0"  CACHE STRING "Version of HIPFORT to build")
+set(HIPFORT_VERSION "0.6.0"  CACHE STRING "Version of HIPFORT to build")
 set(HIPFORT_INSTALL_DIR  "/usr/local/hipfort-${HIPFORT_VERSION}" CACHE STRING "Install directory for hipfort")
 IF(CMAKE_INSTALL_PREFIX)
   # Make HIPFORT_INSTALL_DIR be the same as CmAKE_INSTALL_PREFIX

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ You may further find it convenient to directly use the search function on
 
 ## hipfc wrapper compiler and Makefile.hipfort
 
-The hipfc wrapper compiler is deprecated and may be removed in a future release. Users are
+The hipfc wrapper compiler is deprecated and will be removed in a future release. Users are
 encouraged to call their Fortran or HIP compilers directly instead of relying on the hipfc wrapper.
 The hipfort project provides exported CMake targets that can be used for linking to the appropriate
 ROCm libraries.

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ The hipfort project provides exported CMake targets that can be used for linking
 ROCm libraries.
 
 hipfort currently ships the `hipfc` wrapper compiler and a `Makefile.hipfort` that can be included
-into a project's build system. hipfc located in the `bin/` subdirectory and Makefile.hipfort in
+in a project's build system. hipfc is located in the `bin/` subdirectory and Makefile.hipfort in
 share/hipfort of the repository. While both can be configured via a number of environment variables,
 `hipfc` also understands a greater number of command line options that you can print to the screen via
 `hipfc -h`.

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ ROCm libraries.
 hipfort currently ships the `hipfc` wrapper compiler and a `Makefile.hipfort` that can be included
 into a project's build system. hipfc located in the `bin/` subdirectory and Makefile.hipfort in
 share/hipfort of the repository. While both can be configured via a number of environment variables,
-`hipfc` also understands a greater number of command line options that you can print to screen via
+`hipfc` also understands a greater number of command line options that you can print to the screen via
 `hipfc -h`.
 
 Among the environment variables, the most important are:

--- a/README.md
+++ b/README.md
@@ -19,18 +19,12 @@ Install `gfortran`, `git`, `cmake`, and HIP, if not yet installed.
 Then build, install, and test hipfort from source with the commands below:
 
 ```shell
-git clone https://github.com/ROCmSoftwarePlatform/hipfort
-mkdir build ; cd build
-cmake -DHIPFORT_INSTALL_DIR=/tmp/hipfort ..
-make install
-export PATH=/tmp/hipfort/bin:$PATH
-cd ../test/f2003/vecadd
-hipfc -v hip_implementation.cpp main.f03
-./a.out
+git clone https://github.com/ROCm/hipfort.git
+cd hipfort
+cmake -S. -Bbuild -DHIPFORT_INSTALL_DIR=/tmp/hipfort -DBUILD_TESTING=ON
+make -C build
+make -C build check
 ```
-
-The above steps demonstrate the use of the `hipfc` utility. `hipfc` calls `hipcc` for non-Fortran files and then
-compiles the Fortran files and links to the object file created by `hipcc`.
 
 ## Fortran interfaces
 
@@ -122,10 +116,16 @@ You may further find it convenient to directly use the search function on
 
 ## hipfc wrapper compiler and Makefile.hipfort
 
-Aside from Fortran interfaces to the HIP and ROCm libraries, hipfort ships the `hipfc` wrapper compiler
-and a `Makefile.hipfort` that can be included into a project's build system. hipfc located in the `bin/` subdirectory and
-Makefile.hipfort in share/hipfort of the repository. While both can be configured via a number of environment variables,`
-hipfc` also understands a greater number of command line options that you can print to screen via `hipfc -h`.
+The hipfc wrapper compiler is deprecated and may be removed in a future release. Users are
+encouraged to call their Fortran or HIP compilers directly instead of relying on the hipfc wrapper.
+The hipfort project provides exported CMake targets that can be used for linking to the appropriate
+ROCm libraries.
+
+hipfort currently ships the `hipfc` wrapper compiler and a `Makefile.hipfort` that can be included
+into a project's build system. hipfc located in the `bin/` subdirectory and Makefile.hipfort in
+share/hipfort of the repository. While both can be configured via a number of environment variables,
+`hipfc` also understands a greater number of command line options that you can print to screen via
+`hipfc -h`.
 
 Among the environment variables, the most important are:
 

--- a/bin/hipfc
+++ b/bin/hipfc
@@ -28,8 +28,13 @@ PROGVERSION=X.Y-Z
 function usage(){
 /bin/cat 2>&1 <<"EOF" 
 
-   hipfc: Wrapper to call Fortran compiler with hipfort
+   hipfc: A deprecated wrapper to call Fortran compiler with hipfort
           This script also calls hipcc for non Fortran files.
+
+          Users of hipfc are encourged to migrate to a build system
+          such as CMake to link with the hipfort libraries, and to
+          directly invoke the appropriate compiler for Fortran or HIP
+          language source files.
 
    Usage:  hipfc [ options ] input-files
 


### PR DESCRIPTION
The hipfc compiler wrapper has been deprecated and may be removed in a future release. Users are encouraged to directly invoke their Fortran or HIP compilers as appropriate for each source file.

