### PR TITLE
Fix broken link to gfortran site (#224)

### DIFF
--- a/docs/install/quick-start.rst
+++ b/docs/install/quick-start.rst
@@ -10,7 +10,7 @@ Installation
 Prerequisites
 ===============
 
-* GFortran version 7.5.0 or newer. For more information, refer to the `GFortran website. <https://fortran-lang.org/en/learn/os_setup/install_gfortran/>`_
+* GFortran version 7.5.0 or newer. For more information, refer to the `GFortran website. <https://fortran-lang.org/learn/os_setup/install_gfortran/>`_
 
 Building and testing hipFORT from source
 ==========================================


### PR DESCRIPTION
(cherry picked from commit 969f46c01cdf2b61491fa45b9cc6e47fe161c8a8)