### PR TITLE
[Issue #154] Add note not needing to set `HIP_PLATFORM`

### DIFF
--- a/docs/install/install.rst
+++ b/docs/install/install.rst
@@ -27,8 +27,22 @@ Building and testing hipFORT from source
       make -C build check
 
 .. note::
-        You can control the location of the hipFORT installation by setting the ``HIPFORT_INSTALL_DIR`` build variable.
         The hipFORT installation will compile backends for both ROCm (``hipfort-amdgcn``) and CUDA (``hipfort-nvptx``) backends. When installing hipFORT from source, you do not need to specify the `HIP_PLATFORM` environment variable.
+
+Customizing the build
+=======================
+You can customize the build by setting the following environment variables:
+
+* `HIPFORT_COMPILER` - Fortran compiler to be used
+* `HIPFORT_AR` - Static archive command
+* `HIPFORT_RANLIB` - ranlib used to create Static archive
+* `HIPFORT_COMPILER_FLAGS` - Compiler flags to build hipFORT
+* `HIPFORT_BUILD_TYPE` - Set to RELEASE TESTING or DEBUG
+* `HIPFORT_INSTALL_DIR` - Install directory for hipFORT
+
+.. note::
+        Setting the `CMAKE_INSTALL_DIR` build variable will **not** influence the installation location.
+        Setting the `CMAKE_Fortran_COMPILER` build variable will **not** influence the Fortran compiler used to build hipFORT.
 
 Fortran interfaces
 ===================

--- a/docs/install/install.rst
+++ b/docs/install/install.rst
@@ -26,6 +26,10 @@ Building and testing hipFORT from source
       make -C build
       make -C build check
 
+.. note::
+        You can control the location of the hipFORT installation by setting the ``HIPFORT_INSTALL_DIR`` build variable.
+        The hipFORT installation will compile backends for both ROCm (``hipfort-amdgcn``) and CUDA (``hipfort-nvptx``) backends. When installing hipFORT from source, you do not need to specify the `HIP_PLATFORM` environment variable.
+
 Fortran interfaces
 ===================
 


### PR DESCRIPTION
This partially resolves #154 by adding a note in the documentation about not needing to set `HIP_PLATFORM`