### PR TITLE
Cherry-pick to release-staging/rocm-rel-6.5: Fix title on index page (#234)

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,7 +24,7 @@ The hipFORT public repository is located at `<https://github.com/ROCm/hipFORT>`_
 
   .. grid-item-card:: How to
 
-     * :doc:`Tutorials <./how-to/using-hipfort>`
+     * :doc:`Use hipFORT <./how-to/using-hipfort>`
 
   .. grid-item-card:: Tutorials
 

--- a/docs/tutorials/examples.rst
+++ b/docs/tutorials/examples.rst
@@ -3,7 +3,7 @@
   :keywords: hipFORT, ROCm, API, documentation, examples, tutorials
 
 ****************
-hipFORT Examples
+hipFORT examples
 ****************
 
 Use the following examples to express Fortran 2003 (`f2003`) interfaces:


### PR DESCRIPTION
* Fix title

* Minor capitalization fix

(cherry picked from commit 7152676c7955cd4391bd3fe0ca25f37271bb5d1b)