### PR TITLE
Add patch version to cmake project call

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ if(DEFINED HIPFORT_INSTALL_DIR)
 endif()
 
 # hip-config.cmake requires CXX enabled
-PROJECT(hipfort VERSION 0.7 LANGUAGES Fortran C CXX)
+PROJECT(hipfort VERSION 0.7.0 LANGUAGES Fortran C CXX)
 
 #include definitions for GNU install dir cmake flags.
 include(GNUInstallDirs)


### PR DESCRIPTION
https://github.com/ROCm/hipfort/pull/222 set project version from the previous 0.7.0 to 0.7 which causes the below error when packaging on some OS profiles. 

CPackRPM:Debug: *** error: line 9: Illegal sequence ".." in: Version:        0.7..60500

This PR restores the patch version which should resolve the above issue.