### PR TITLE
Fix for a possible overflow

### DIFF
--- a/lib/hipfort/hipfort_hipmalloc.F90
+++ b/lib/hipfort/hipfort_hipmalloc.F90
@@ -26,6 +26,22 @@
 
 module hipfort_hipmalloc
 
+  use, intrinsic :: iso_fortran_env , only : int32, int64, real32, real64
+
+  integer(int32) :: elem_int32
+  integer(int64) :: elem_int64
+  real(real32)   :: elem_real32
+  real(real64)   :: elem_real64
+
+  private :: byte_size
+
+  interface byte_size
+    module procedure byte_size_int32, &
+    byte_size_int64,  &
+    byte_size_real32, &
+    byte_size_real64
+  endinterface
+
   interface hipMalloc
     !> 
     !>    @brief Allocate memory on the default accelerator
@@ -796,6 +812,34 @@ module hipfort_hipmalloc
 #ifdef USE_FPOINTER_INTERFACES
   contains
 
+    elemental function byte_size_int32(x) result(bytes)
+      integer(int32), intent(in) :: x
+      integer(int64)             :: bytes
+    
+      bytes = storage_size(x) / 8_int64
+    endfunction byte_size_int32
+
+    elemental function byte_size_int64(x) result(bytes)
+      integer(int64), intent(in) :: x
+      integer(int64)             :: bytes
+    
+      bytes = storage_size(x) / 8_int64
+    endfunction byte_size_int64
+
+    elemental function byte_size_real32(x) result(bytes)
+      real(real32), intent(in) :: x
+      integer(int64)           :: bytes
+    
+      bytes = storage_size(x) / 8_int64
+    endfunction byte_size_real32
+
+    elemental function byte_size_real64(x) result(bytes)
+      real(real64), intent(in) :: x
+      integer(int64)           :: bytes
+    
+      bytes = storage_size(x) / 8_int64
+    endfunction byte_size_real64
+
 ! scalars
                                                               
     function hipMalloc_l_0_source(ptr,dsource,source)
@@ -825,15 +869,15 @@ module hipfort_hipmalloc
       if ( nOptArgs > 1 ) ERROR STOP "ERROR: hipMalloc (scalar version): Only one optional argument ('dsource','source') must be specified."
     
       if ( present(dsource) ) then
-        hipMalloc_l_0_source = hipMalloc_(cptr,1_8)
-        hipMalloc_l_0_source = hipMemcpy(cptr,c_loc(dsource),1_8,hipMemcpyDeviceToDevice)
+        hipMalloc_l_0_source = hipMalloc_(cptr,1_int64)
+        hipMalloc_l_0_source = hipMemcpy(cptr,c_loc(dsource),1_int64,hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,ptr)
       else if ( present(source) ) then
-        hipMalloc_l_0_source = hipMalloc_(cptr,1_8)
-        hipMalloc_l_0_source = hipMemcpy(cptr,c_loc(source),1_8,hipMemcpyHostToDevice)
+        hipMalloc_l_0_source = hipMalloc_(cptr,1_int64)
+        hipMalloc_l_0_source = hipMemcpy(cptr,c_loc(source),1_int64,hipMemcpyHostToDevice)
         call c_f_pointer(cptr,ptr)
       else
-        hipMalloc_l_0_source = hipMalloc_(cptr,1_8)
+        hipMalloc_l_0_source = hipMalloc_(cptr,1_int64)
         call c_f_pointer(cptr,ptr)
       end if
     end function
@@ -850,8 +894,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       logical(c_bool),pointer,dimension(:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(1),dims(1)
-      integer(8),intent(in),optional :: lbounds8(1),dims8(1)
+      integer(int32),intent(in),optional :: lbounds(1),dims(1)
+      integer(int64),intent(in),optional :: lbounds8(1),dims8(1)
       logical(c_bool),target,dimension(:),intent(in),optional :: dsource,source,mold
          
       ! 
@@ -880,21 +924,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMalloc_l_1_source = hipMalloc_(cptr,size(dsource)*1_8)
-        hipMalloc_l_1_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*1_8,hipMemcpyDeviceToDevice)
+        hipMalloc_l_1_source = hipMalloc_(cptr,size(dsource,kind=int64))
+        hipMalloc_l_1_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):) => tmp
       else if ( present(source) ) then
-        hipMalloc_l_1_source = hipMalloc_(cptr,size(source)*1_8)
-        hipMalloc_l_1_source = hipMemcpy(cptr,c_loc(source),size(source)*1_8,hipMemcpyHostToDevice)
+        hipMalloc_l_1_source = hipMalloc_(cptr,size(source,kind=int64))
+        hipMalloc_l_1_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):) => tmp
       else if ( present(mold) ) then
-        hipMalloc_l_1_source = hipMalloc_(cptr,size(mold)*1_8)
+        hipMalloc_l_1_source = hipMalloc_(cptr,size(mold,kind=int64))
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):) => tmp
       else if ( present(dims8) ) then
-        hipMalloc_l_1_source = hipMalloc_(cptr,PRODUCT(dims8)*1_8)
+        hipMalloc_l_1_source = hipMalloc_(cptr,PRODUCT(dims8))
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):) => tmp
@@ -902,7 +946,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMalloc_l_1_source = hipMalloc_(cptr,PRODUCT(dims)*1_8)
+        hipMalloc_l_1_source = hipMalloc_(cptr,PRODUCT(int(dims,kind=int64)))
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):) => tmp
@@ -932,7 +976,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_l_1_c_int
 #endif
       !
-      hipMalloc_l_1_c_int = hipMalloc_(cptr,length1*1_8)
+      hipMalloc_l_1_c_int = hipMalloc_(cptr,int(length1,kind=int64))
       call c_f_pointer(cptr,ptr,shape=[length1])
     end function
 
@@ -956,7 +1000,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_l_1_c_size_t
 #endif
       !
-      hipMalloc_l_1_c_size_t = hipMalloc_(cptr,length1*1_8)
+      hipMalloc_l_1_c_size_t = hipMalloc_(cptr,int(length1,kind=int64))
       call c_f_pointer(cptr,ptr,shape=[length1])
     end function
 
@@ -971,8 +1015,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       logical(c_bool),pointer,dimension(:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(2),dims(2)
-      integer(8),intent(in),optional :: lbounds8(2),dims8(2)
+      integer(int32),intent(in),optional :: lbounds(2),dims(2)
+      integer(int64),intent(in),optional :: lbounds8(2),dims8(2)
       logical(c_bool),target,dimension(:,:),intent(in),optional :: dsource,source,mold
          
       ! 
@@ -1001,21 +1045,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMalloc_l_2_source = hipMalloc_(cptr,size(dsource)*1_8)
-        hipMalloc_l_2_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*1_8,hipMemcpyDeviceToDevice)
+        hipMalloc_l_2_source = hipMalloc_(cptr,size(dsource,kind=int64))
+        hipMalloc_l_2_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):) => tmp
       else if ( present(source) ) then
-        hipMalloc_l_2_source = hipMalloc_(cptr,size(source)*1_8)
-        hipMalloc_l_2_source = hipMemcpy(cptr,c_loc(source),size(source)*1_8,hipMemcpyHostToDevice)
+        hipMalloc_l_2_source = hipMalloc_(cptr,size(source,kind=int64))
+        hipMalloc_l_2_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):) => tmp
       else if ( present(mold) ) then
-        hipMalloc_l_2_source = hipMalloc_(cptr,size(mold)*1_8)
+        hipMalloc_l_2_source = hipMalloc_(cptr,size(mold,kind=int64))
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):) => tmp
       else if ( present(dims8) ) then
-        hipMalloc_l_2_source = hipMalloc_(cptr,PRODUCT(dims8)*1_8)
+        hipMalloc_l_2_source = hipMalloc_(cptr,PRODUCT(dims8))
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):) => tmp
@@ -1023,7 +1067,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMalloc_l_2_source = hipMalloc_(cptr,PRODUCT(dims)*1_8)
+        hipMalloc_l_2_source = hipMalloc_(cptr,PRODUCT(int(dims,kind=int64)))
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):) => tmp
@@ -1053,7 +1097,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_l_2_c_int
 #endif
       !
-      hipMalloc_l_2_c_int = hipMalloc_(cptr,length1*length2*1_8)
+      hipMalloc_l_2_c_int = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64))
       call c_f_pointer(cptr,ptr,shape=[length1,length2])
     end function
 
@@ -1077,7 +1121,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_l_2_c_size_t
 #endif
       !
-      hipMalloc_l_2_c_size_t = hipMalloc_(cptr,length1*length2*1_8)
+      hipMalloc_l_2_c_size_t = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64))
       call c_f_pointer(cptr,ptr,shape=[length1,length2])
     end function
 
@@ -1092,8 +1136,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       logical(c_bool),pointer,dimension(:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(3),dims(3)
-      integer(8),intent(in),optional :: lbounds8(3),dims8(3)
+      integer(int32),intent(in),optional :: lbounds(3),dims(3)
+      integer(int64),intent(in),optional :: lbounds8(3),dims8(3)
       logical(c_bool),target,dimension(:,:,:),intent(in),optional :: dsource,source,mold
          
       ! 
@@ -1122,21 +1166,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMalloc_l_3_source = hipMalloc_(cptr,size(dsource)*1_8)
-        hipMalloc_l_3_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*1_8,hipMemcpyDeviceToDevice)
+        hipMalloc_l_3_source = hipMalloc_(cptr,size(dsource,kind=int64))
+        hipMalloc_l_3_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):) => tmp
       else if ( present(source) ) then
-        hipMalloc_l_3_source = hipMalloc_(cptr,size(source)*1_8)
-        hipMalloc_l_3_source = hipMemcpy(cptr,c_loc(source),size(source)*1_8,hipMemcpyHostToDevice)
+        hipMalloc_l_3_source = hipMalloc_(cptr,size(source,kind=int64))
+        hipMalloc_l_3_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):) => tmp
       else if ( present(mold) ) then
-        hipMalloc_l_3_source = hipMalloc_(cptr,size(mold)*1_8)
+        hipMalloc_l_3_source = hipMalloc_(cptr,size(mold,kind=int64))
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):) => tmp
       else if ( present(dims8) ) then
-        hipMalloc_l_3_source = hipMalloc_(cptr,PRODUCT(dims8)*1_8)
+        hipMalloc_l_3_source = hipMalloc_(cptr,PRODUCT(dims8))
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):) => tmp
@@ -1144,7 +1188,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMalloc_l_3_source = hipMalloc_(cptr,PRODUCT(dims)*1_8)
+        hipMalloc_l_3_source = hipMalloc_(cptr,PRODUCT(int(dims,kind=int64)))
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):) => tmp
@@ -1174,7 +1218,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_l_3_c_int
 #endif
       !
-      hipMalloc_l_3_c_int = hipMalloc_(cptr,length1*length2*length3*1_8)
+      hipMalloc_l_3_c_int = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3])
     end function
 
@@ -1198,7 +1242,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_l_3_c_size_t
 #endif
       !
-      hipMalloc_l_3_c_size_t = hipMalloc_(cptr,length1*length2*length3*1_8)
+      hipMalloc_l_3_c_size_t = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3])
     end function
 
@@ -1213,8 +1257,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       logical(c_bool),pointer,dimension(:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(4),dims(4)
-      integer(8),intent(in),optional :: lbounds8(4),dims8(4)
+      integer(int32),intent(in),optional :: lbounds(4),dims(4)
+      integer(int64),intent(in),optional :: lbounds8(4),dims8(4)
       logical(c_bool),target,dimension(:,:,:,:),intent(in),optional :: dsource,source,mold
          
       ! 
@@ -1243,21 +1287,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMalloc_l_4_source = hipMalloc_(cptr,size(dsource)*1_8)
-        hipMalloc_l_4_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*1_8,hipMemcpyDeviceToDevice)
+        hipMalloc_l_4_source = hipMalloc_(cptr,size(dsource,kind=int64))
+        hipMalloc_l_4_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):) => tmp
       else if ( present(source) ) then
-        hipMalloc_l_4_source = hipMalloc_(cptr,size(source)*1_8)
-        hipMalloc_l_4_source = hipMemcpy(cptr,c_loc(source),size(source)*1_8,hipMemcpyHostToDevice)
+        hipMalloc_l_4_source = hipMalloc_(cptr,size(source,kind=int64))
+        hipMalloc_l_4_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):) => tmp
       else if ( present(mold) ) then
-        hipMalloc_l_4_source = hipMalloc_(cptr,size(mold)*1_8)
+        hipMalloc_l_4_source = hipMalloc_(cptr,size(mold,kind=int64))
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):) => tmp
       else if ( present(dims8) ) then
-        hipMalloc_l_4_source = hipMalloc_(cptr,PRODUCT(dims8)*1_8)
+        hipMalloc_l_4_source = hipMalloc_(cptr,PRODUCT(dims8))
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):) => tmp
@@ -1265,7 +1309,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMalloc_l_4_source = hipMalloc_(cptr,PRODUCT(dims)*1_8)
+        hipMalloc_l_4_source = hipMalloc_(cptr,PRODUCT(int(dims,kind=int64)))
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):) => tmp
@@ -1295,7 +1339,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_l_4_c_int
 #endif
       !
-      hipMalloc_l_4_c_int = hipMalloc_(cptr,length1*length2*length3*length4*1_8)
+      hipMalloc_l_4_c_int = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                            int(length4,kind=int64))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4])
     end function
 
@@ -1319,7 +1364,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_l_4_c_size_t
 #endif
       !
-      hipMalloc_l_4_c_size_t = hipMalloc_(cptr,length1*length2*length3*length4*1_8)
+      hipMalloc_l_4_c_size_t = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                               int(length4,kind=int64))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4])
     end function
 
@@ -1334,8 +1380,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       logical(c_bool),pointer,dimension(:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(5),dims(5)
-      integer(8),intent(in),optional :: lbounds8(5),dims8(5)
+      integer(int32),intent(in),optional :: lbounds(5),dims(5)
+      integer(int64),intent(in),optional :: lbounds8(5),dims8(5)
       logical(c_bool),target,dimension(:,:,:,:,:),intent(in),optional :: dsource,source,mold
          
       ! 
@@ -1364,21 +1410,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMalloc_l_5_source = hipMalloc_(cptr,size(dsource)*1_8)
-        hipMalloc_l_5_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*1_8,hipMemcpyDeviceToDevice)
+        hipMalloc_l_5_source = hipMalloc_(cptr,size(dsource,kind=int64))
+        hipMalloc_l_5_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):) => tmp
       else if ( present(source) ) then
-        hipMalloc_l_5_source = hipMalloc_(cptr,size(source)*1_8)
-        hipMalloc_l_5_source = hipMemcpy(cptr,c_loc(source),size(source)*1_8,hipMemcpyHostToDevice)
+        hipMalloc_l_5_source = hipMalloc_(cptr,size(source,kind=int64))
+        hipMalloc_l_5_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):) => tmp
       else if ( present(mold) ) then
-        hipMalloc_l_5_source = hipMalloc_(cptr,size(mold)*1_8)
+        hipMalloc_l_5_source = hipMalloc_(cptr,size(mold,kind=int64))
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):) => tmp
       else if ( present(dims8) ) then
-        hipMalloc_l_5_source = hipMalloc_(cptr,PRODUCT(dims8)*1_8)
+        hipMalloc_l_5_source = hipMalloc_(cptr,PRODUCT(dims8))
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):) => tmp
@@ -1386,7 +1432,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMalloc_l_5_source = hipMalloc_(cptr,PRODUCT(dims)*1_8)
+        hipMalloc_l_5_source = hipMalloc_(cptr,PRODUCT(int(dims,kind=int64)))
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):) => tmp
@@ -1416,7 +1462,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_l_5_c_int
 #endif
       !
-      hipMalloc_l_5_c_int = hipMalloc_(cptr,length1*length2*length3*length4*length5*1_8)
+      hipMalloc_l_5_c_int = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                            int(length4,kind=int64)*int(length5,kind=int64))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5])
     end function
 
@@ -1440,7 +1487,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_l_5_c_size_t
 #endif
       !
-      hipMalloc_l_5_c_size_t = hipMalloc_(cptr,length1*length2*length3*length4*length5*1_8)
+      hipMalloc_l_5_c_size_t = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                               int(length4,kind=int64)*int(length5,kind=int64))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5])
     end function
 
@@ -1455,8 +1503,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       logical(c_bool),pointer,dimension(:,:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(6),dims(6)
-      integer(8),intent(in),optional :: lbounds8(6),dims8(6)
+      integer(int32),intent(in),optional :: lbounds(6),dims(6)
+      integer(int64),intent(in),optional :: lbounds8(6),dims8(6)
       logical(c_bool),target,dimension(:,:,:,:,:,:),intent(in),optional :: dsource,source,mold
          
       ! 
@@ -1485,21 +1533,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMalloc_l_6_source = hipMalloc_(cptr,size(dsource)*1_8)
-        hipMalloc_l_6_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*1_8,hipMemcpyDeviceToDevice)
+        hipMalloc_l_6_source = hipMalloc_(cptr,size(dsource,kind=int64))
+        hipMalloc_l_6_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):,LBOUND(dsource,6):) => tmp
       else if ( present(source) ) then
-        hipMalloc_l_6_source = hipMalloc_(cptr,size(source)*1_8)
-        hipMalloc_l_6_source = hipMemcpy(cptr,c_loc(source),size(source)*1_8,hipMemcpyHostToDevice)
+        hipMalloc_l_6_source = hipMalloc_(cptr,size(source,kind=int64))
+        hipMalloc_l_6_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):,LBOUND(source,6):) => tmp
       else if ( present(mold) ) then
-        hipMalloc_l_6_source = hipMalloc_(cptr,size(mold)*1_8)
+        hipMalloc_l_6_source = hipMalloc_(cptr,size(mold,kind=int64))
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):,LBOUND(mold,6):) => tmp
       else if ( present(dims8) ) then
-        hipMalloc_l_6_source = hipMalloc_(cptr,PRODUCT(dims8)*1_8)
+        hipMalloc_l_6_source = hipMalloc_(cptr,PRODUCT(dims8))
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):,lbounds8(6):) => tmp
@@ -1507,7 +1555,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMalloc_l_6_source = hipMalloc_(cptr,PRODUCT(dims)*1_8)
+        hipMalloc_l_6_source = hipMalloc_(cptr,PRODUCT(int(dims,kind=int64)))
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):,lbounds(6):) => tmp
@@ -1537,7 +1585,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_l_6_c_int
 #endif
       !
-      hipMalloc_l_6_c_int = hipMalloc_(cptr,length1*length2*length3*length4*length5*length6*1_8)
+      hipMalloc_l_6_c_int = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                            int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6])
     end function
 
@@ -1561,7 +1610,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_l_6_c_size_t
 #endif
       !
-      hipMalloc_l_6_c_size_t = hipMalloc_(cptr,length1*length2*length3*length4*length5*length6*1_8)
+      hipMalloc_l_6_c_size_t = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                               int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6])
     end function
 
@@ -1576,8 +1626,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       logical(c_bool),pointer,dimension(:,:,:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(7),dims(7)
-      integer(8),intent(in),optional :: lbounds8(7),dims8(7)
+      integer(int32),intent(in),optional :: lbounds(7),dims(7)
+      integer(int64),intent(in),optional :: lbounds8(7),dims8(7)
       logical(c_bool),target,dimension(:,:,:,:,:,:,:),intent(in),optional :: dsource,source,mold
          
       ! 
@@ -1606,21 +1656,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMalloc_l_7_source = hipMalloc_(cptr,size(dsource)*1_8)
-        hipMalloc_l_7_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*1_8,hipMemcpyDeviceToDevice)
+        hipMalloc_l_7_source = hipMalloc_(cptr,size(dsource,kind=int64))
+        hipMalloc_l_7_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):,LBOUND(dsource,6):,LBOUND(dsource,7):) => tmp
       else if ( present(source) ) then
-        hipMalloc_l_7_source = hipMalloc_(cptr,size(source)*1_8)
-        hipMalloc_l_7_source = hipMemcpy(cptr,c_loc(source),size(source)*1_8,hipMemcpyHostToDevice)
+        hipMalloc_l_7_source = hipMalloc_(cptr,size(source,kind=int64))
+        hipMalloc_l_7_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):,LBOUND(source,6):,LBOUND(source,7):) => tmp
       else if ( present(mold) ) then
-        hipMalloc_l_7_source = hipMalloc_(cptr,size(mold)*1_8)
+        hipMalloc_l_7_source = hipMalloc_(cptr,size(mold,kind=int64))
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):,LBOUND(mold,6):,LBOUND(mold,7):) => tmp
       else if ( present(dims8) ) then
-        hipMalloc_l_7_source = hipMalloc_(cptr,PRODUCT(dims8)*1_8)
+        hipMalloc_l_7_source = hipMalloc_(cptr,PRODUCT(dims8))
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):,lbounds8(6):,lbounds8(7):) => tmp
@@ -1628,7 +1678,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMalloc_l_7_source = hipMalloc_(cptr,PRODUCT(dims)*1_8)
+        hipMalloc_l_7_source = hipMalloc_(cptr,PRODUCT(int(dims,kind=int64)))
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):,lbounds(6):,lbounds(7):) => tmp
@@ -1658,7 +1708,9 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_l_7_c_int
 #endif
       !
-      hipMalloc_l_7_c_int = hipMalloc_(cptr,length1*length2*length3*length4*length5*length6*length7*1_8)
+      hipMalloc_l_7_c_int = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                            int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*&
+                                            int(length7,kind=int64))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6,length7])
     end function
 
@@ -1682,7 +1734,9 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_l_7_c_size_t
 #endif
       !
-      hipMalloc_l_7_c_size_t = hipMalloc_(cptr,length1*length2*length3*length4*length5*length6*length7*1_8)
+      hipMalloc_l_7_c_size_t = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                               int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*&
+                                               int(length7,kind=int64))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6,length7])
     end function
 
@@ -1715,15 +1769,15 @@ module hipfort_hipmalloc
       if ( nOptArgs > 1 ) ERROR STOP "ERROR: hipMalloc (scalar version): Only one optional argument ('dsource','source') must be specified."
     
       if ( present(dsource) ) then
-        hipMalloc_i4_0_source = hipMalloc_(cptr,4_8)
-        hipMalloc_i4_0_source = hipMemcpy(cptr,c_loc(dsource),4_8,hipMemcpyDeviceToDevice)
+        hipMalloc_i4_0_source = hipMalloc_(cptr,byte_size(elem_int32))
+        hipMalloc_i4_0_source = hipMemcpy(cptr,c_loc(dsource),byte_size(elem_int32),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,ptr)
       else if ( present(source) ) then
-        hipMalloc_i4_0_source = hipMalloc_(cptr,4_8)
-        hipMalloc_i4_0_source = hipMemcpy(cptr,c_loc(source),4_8,hipMemcpyHostToDevice)
+        hipMalloc_i4_0_source = hipMalloc_(cptr,byte_size(elem_int32))
+        hipMalloc_i4_0_source = hipMemcpy(cptr,c_loc(source),byte_size(elem_int32),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,ptr)
       else
-        hipMalloc_i4_0_source = hipMalloc_(cptr,4_8)
+        hipMalloc_i4_0_source = hipMalloc_(cptr,byte_size(elem_int32))
         call c_f_pointer(cptr,ptr)
       end if
     end function
@@ -1740,8 +1794,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       integer(c_int),pointer,dimension(:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(1),dims(1)
-      integer(8),intent(in),optional :: lbounds8(1),dims8(1)
+      integer(int32),intent(in),optional :: lbounds(1),dims(1)
+      integer(int64),intent(in),optional :: lbounds8(1),dims8(1)
       integer(c_int),target,dimension(:),intent(in),optional :: dsource,source,mold
          
       ! 
@@ -1770,21 +1824,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMalloc_i4_1_source = hipMalloc_(cptr,size(dsource)*4_8)
-        hipMalloc_i4_1_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*4_8,hipMemcpyDeviceToDevice)
+        hipMalloc_i4_1_source = hipMalloc_(cptr,size(dsource,kind=int64)*byte_size(elem_int32))
+        hipMalloc_i4_1_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_int32),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):) => tmp
       else if ( present(source) ) then
-        hipMalloc_i4_1_source = hipMalloc_(cptr,size(source)*4_8)
-        hipMalloc_i4_1_source = hipMemcpy(cptr,c_loc(source),size(source)*4_8,hipMemcpyHostToDevice)
+        hipMalloc_i4_1_source = hipMalloc_(cptr,size(source,kind=int64)*byte_size(elem_int32))
+        hipMalloc_i4_1_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_int32),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):) => tmp
       else if ( present(mold) ) then
-        hipMalloc_i4_1_source = hipMalloc_(cptr,size(mold)*4_8)
+        hipMalloc_i4_1_source = hipMalloc_(cptr,size(mold,kind=int64)*byte_size(elem_int32))
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):) => tmp
       else if ( present(dims8) ) then
-        hipMalloc_i4_1_source = hipMalloc_(cptr,PRODUCT(dims8)*4_8)
+        hipMalloc_i4_1_source = hipMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_int32))
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):) => tmp
@@ -1792,7 +1846,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMalloc_i4_1_source = hipMalloc_(cptr,PRODUCT(dims)*4_8)
+        hipMalloc_i4_1_source = hipMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_int32))
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):) => tmp
@@ -1822,7 +1876,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_i4_1_c_int
 #endif
       !
-      hipMalloc_i4_1_c_int = hipMalloc_(cptr,length1*4_8)
+      hipMalloc_i4_1_c_int = hipMalloc_(cptr,int(length1,kind=int64)*byte_size(elem_int32))
       call c_f_pointer(cptr,ptr,shape=[length1])
     end function
 
@@ -1846,7 +1900,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_i4_1_c_size_t
 #endif
       !
-      hipMalloc_i4_1_c_size_t = hipMalloc_(cptr,length1*4_8)
+      hipMalloc_i4_1_c_size_t = hipMalloc_(cptr,int(length1,kind=int64)*byte_size(elem_int32))
       call c_f_pointer(cptr,ptr,shape=[length1])
     end function
 
@@ -1861,8 +1915,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       integer(c_int),pointer,dimension(:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(2),dims(2)
-      integer(8),intent(in),optional :: lbounds8(2),dims8(2)
+      integer(int32),intent(in),optional :: lbounds(2),dims(2)
+      integer(int64),intent(in),optional :: lbounds8(2),dims8(2)
       integer(c_int),target,dimension(:,:),intent(in),optional :: dsource,source,mold
          
       ! 
@@ -1891,21 +1945,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMalloc_i4_2_source = hipMalloc_(cptr,size(dsource)*4_8)
-        hipMalloc_i4_2_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*4_8,hipMemcpyDeviceToDevice)
+        hipMalloc_i4_2_source = hipMalloc_(cptr,size(dsource,kind=int64)*byte_size(elem_int32))
+        hipMalloc_i4_2_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_int32),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):) => tmp
       else if ( present(source) ) then
-        hipMalloc_i4_2_source = hipMalloc_(cptr,size(source)*4_8)
-        hipMalloc_i4_2_source = hipMemcpy(cptr,c_loc(source),size(source)*4_8,hipMemcpyHostToDevice)
+        hipMalloc_i4_2_source = hipMalloc_(cptr,size(source,kind=int64)*byte_size(elem_int32))
+        hipMalloc_i4_2_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_int32),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):) => tmp
       else if ( present(mold) ) then
-        hipMalloc_i4_2_source = hipMalloc_(cptr,size(mold)*4_8)
+        hipMalloc_i4_2_source = hipMalloc_(cptr,size(mold,kind=int64)*byte_size(elem_int32))
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):) => tmp
       else if ( present(dims8) ) then
-        hipMalloc_i4_2_source = hipMalloc_(cptr,PRODUCT(dims8)*4_8)
+        hipMalloc_i4_2_source = hipMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_int32))
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):) => tmp
@@ -1913,7 +1967,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMalloc_i4_2_source = hipMalloc_(cptr,PRODUCT(dims)*4_8)
+        hipMalloc_i4_2_source = hipMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_int32))
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):) => tmp
@@ -1943,7 +1997,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_i4_2_c_int
 #endif
       !
-      hipMalloc_i4_2_c_int = hipMalloc_(cptr,length1*length2*4_8)
+      hipMalloc_i4_2_c_int = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*byte_size(elem_int32))
       call c_f_pointer(cptr,ptr,shape=[length1,length2])
     end function
 
@@ -1967,7 +2021,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_i4_2_c_size_t
 #endif
       !
-      hipMalloc_i4_2_c_size_t = hipMalloc_(cptr,length1*length2*4_8)
+      hipMalloc_i4_2_c_size_t = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*byte_size(elem_int32))
       call c_f_pointer(cptr,ptr,shape=[length1,length2])
     end function
 
@@ -1982,8 +2036,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       integer(c_int),pointer,dimension(:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(3),dims(3)
-      integer(8),intent(in),optional :: lbounds8(3),dims8(3)
+      integer(int32),intent(in),optional :: lbounds(3),dims(3)
+      integer(int64),intent(in),optional :: lbounds8(3),dims8(3)
       integer(c_int),target,dimension(:,:,:),intent(in),optional :: dsource,source,mold
          
       ! 
@@ -2012,21 +2066,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMalloc_i4_3_source = hipMalloc_(cptr,size(dsource)*4_8)
-        hipMalloc_i4_3_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*4_8,hipMemcpyDeviceToDevice)
+        hipMalloc_i4_3_source = hipMalloc_(cptr,size(dsource,kind=int64)*byte_size(elem_int32))
+        hipMalloc_i4_3_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_int32),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):) => tmp
       else if ( present(source) ) then
-        hipMalloc_i4_3_source = hipMalloc_(cptr,size(source)*4_8)
-        hipMalloc_i4_3_source = hipMemcpy(cptr,c_loc(source),size(source)*4_8,hipMemcpyHostToDevice)
+        hipMalloc_i4_3_source = hipMalloc_(cptr,size(source,kind=int64)*byte_size(elem_int32))
+        hipMalloc_i4_3_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_int32),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):) => tmp
       else if ( present(mold) ) then
-        hipMalloc_i4_3_source = hipMalloc_(cptr,size(mold)*4_8)
+        hipMalloc_i4_3_source = hipMalloc_(cptr,size(mold,kind=int64)*byte_size(elem_int32))
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):) => tmp
       else if ( present(dims8) ) then
-        hipMalloc_i4_3_source = hipMalloc_(cptr,PRODUCT(dims8)*4_8)
+        hipMalloc_i4_3_source = hipMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_int32))
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):) => tmp
@@ -2034,7 +2088,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMalloc_i4_3_source = hipMalloc_(cptr,PRODUCT(dims)*4_8)
+        hipMalloc_i4_3_source = hipMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_int32))
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):) => tmp
@@ -2064,7 +2118,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_i4_3_c_int
 #endif
       !
-      hipMalloc_i4_3_c_int = hipMalloc_(cptr,length1*length2*length3*4_8)
+      hipMalloc_i4_3_c_int = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*byte_size(elem_int32))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3])
     end function
 
@@ -2088,7 +2142,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_i4_3_c_size_t
 #endif
       !
-      hipMalloc_i4_3_c_size_t = hipMalloc_(cptr,length1*length2*length3*4_8)
+      hipMalloc_i4_3_c_size_t = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*byte_size(elem_int32))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3])
     end function
 
@@ -2103,8 +2157,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       integer(c_int),pointer,dimension(:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(4),dims(4)
-      integer(8),intent(in),optional :: lbounds8(4),dims8(4)
+      integer(int32),intent(in),optional :: lbounds(4),dims(4)
+      integer(int64),intent(in),optional :: lbounds8(4),dims8(4)
       integer(c_int),target,dimension(:,:,:,:),intent(in),optional :: dsource,source,mold
          
       ! 
@@ -2133,21 +2187,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMalloc_i4_4_source = hipMalloc_(cptr,size(dsource)*4_8)
-        hipMalloc_i4_4_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*4_8,hipMemcpyDeviceToDevice)
+        hipMalloc_i4_4_source = hipMalloc_(cptr,size(dsource,kind=int64)*byte_size(elem_int32))
+        hipMalloc_i4_4_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_int32),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):) => tmp
       else if ( present(source) ) then
-        hipMalloc_i4_4_source = hipMalloc_(cptr,size(source)*4_8)
-        hipMalloc_i4_4_source = hipMemcpy(cptr,c_loc(source),size(source)*4_8,hipMemcpyHostToDevice)
+        hipMalloc_i4_4_source = hipMalloc_(cptr,size(source,kind=int64)*byte_size(elem_int32))
+        hipMalloc_i4_4_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_int32),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):) => tmp
       else if ( present(mold) ) then
-        hipMalloc_i4_4_source = hipMalloc_(cptr,size(mold)*4_8)
+        hipMalloc_i4_4_source = hipMalloc_(cptr,size(mold,kind=int64)*byte_size(elem_int32))
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):) => tmp
       else if ( present(dims8) ) then
-        hipMalloc_i4_4_source = hipMalloc_(cptr,PRODUCT(dims8)*4_8)
+        hipMalloc_i4_4_source = hipMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_int32))
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):) => tmp
@@ -2155,7 +2209,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMalloc_i4_4_source = hipMalloc_(cptr,PRODUCT(dims)*4_8)
+        hipMalloc_i4_4_source = hipMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_int32))
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):) => tmp
@@ -2185,7 +2239,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_i4_4_c_int
 #endif
       !
-      hipMalloc_i4_4_c_int = hipMalloc_(cptr,length1*length2*length3*length4*4_8)
+      hipMalloc_i4_4_c_int = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                             int(length4,kind=int64)*byte_size(elem_int32))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4])
     end function
 
@@ -2209,7 +2264,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_i4_4_c_size_t
 #endif
       !
-      hipMalloc_i4_4_c_size_t = hipMalloc_(cptr,length1*length2*length3*length4*4_8)
+      hipMalloc_i4_4_c_size_t = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                int(length4,kind=int64)*byte_size(elem_int32))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4])
     end function
 
@@ -2224,8 +2280,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       integer(c_int),pointer,dimension(:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(5),dims(5)
-      integer(8),intent(in),optional :: lbounds8(5),dims8(5)
+      integer(int32),intent(in),optional :: lbounds(5),dims(5)
+      integer(int64),intent(in),optional :: lbounds8(5),dims8(5)
       integer(c_int),target,dimension(:,:,:,:,:),intent(in),optional :: dsource,source,mold
          
       ! 
@@ -2254,21 +2310,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMalloc_i4_5_source = hipMalloc_(cptr,size(dsource)*4_8)
-        hipMalloc_i4_5_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*4_8,hipMemcpyDeviceToDevice)
+        hipMalloc_i4_5_source = hipMalloc_(cptr,size(dsource,kind=int64)*byte_size(elem_int32))
+        hipMalloc_i4_5_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_int32),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):) => tmp
       else if ( present(source) ) then
-        hipMalloc_i4_5_source = hipMalloc_(cptr,size(source)*4_8)
-        hipMalloc_i4_5_source = hipMemcpy(cptr,c_loc(source),size(source)*4_8,hipMemcpyHostToDevice)
+        hipMalloc_i4_5_source = hipMalloc_(cptr,size(source,kind=int64)*byte_size(elem_int32))
+        hipMalloc_i4_5_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_int32),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):) => tmp
       else if ( present(mold) ) then
-        hipMalloc_i4_5_source = hipMalloc_(cptr,size(mold)*4_8)
+        hipMalloc_i4_5_source = hipMalloc_(cptr,size(mold,kind=int64)*byte_size(elem_int32))
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):) => tmp
       else if ( present(dims8) ) then
-        hipMalloc_i4_5_source = hipMalloc_(cptr,PRODUCT(dims8)*4_8)
+        hipMalloc_i4_5_source = hipMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_int32))
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):) => tmp
@@ -2276,7 +2332,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMalloc_i4_5_source = hipMalloc_(cptr,PRODUCT(dims)*4_8)
+        hipMalloc_i4_5_source = hipMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_int32))
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):) => tmp
@@ -2306,7 +2362,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_i4_5_c_int
 #endif
       !
-      hipMalloc_i4_5_c_int = hipMalloc_(cptr,length1*length2*length3*length4*length5*4_8)
+      hipMalloc_i4_5_c_int = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                             int(length4,kind=int64)*int(length5,kind=int64)*byte_size(elem_int32))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5])
     end function
 
@@ -2330,7 +2387,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_i4_5_c_size_t
 #endif
       !
-      hipMalloc_i4_5_c_size_t = hipMalloc_(cptr,length1*length2*length3*length4*length5*4_8)
+      hipMalloc_i4_5_c_size_t = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                int(length4,kind=int64)*int(length5,kind=int64)*byte_size(elem_int32))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5])
     end function
 
@@ -2345,8 +2403,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       integer(c_int),pointer,dimension(:,:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(6),dims(6)
-      integer(8),intent(in),optional :: lbounds8(6),dims8(6)
+      integer(int32),intent(in),optional :: lbounds(6),dims(6)
+      integer(int64),intent(in),optional :: lbounds8(6),dims8(6)
       integer(c_int),target,dimension(:,:,:,:,:,:),intent(in),optional :: dsource,source,mold
          
       ! 
@@ -2375,21 +2433,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMalloc_i4_6_source = hipMalloc_(cptr,size(dsource)*4_8)
-        hipMalloc_i4_6_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*4_8,hipMemcpyDeviceToDevice)
+        hipMalloc_i4_6_source = hipMalloc_(cptr,size(dsource,kind=int64)*byte_size(elem_int32))
+        hipMalloc_i4_6_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_int32),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):,LBOUND(dsource,6):) => tmp
       else if ( present(source) ) then
-        hipMalloc_i4_6_source = hipMalloc_(cptr,size(source)*4_8)
-        hipMalloc_i4_6_source = hipMemcpy(cptr,c_loc(source),size(source)*4_8,hipMemcpyHostToDevice)
+        hipMalloc_i4_6_source = hipMalloc_(cptr,size(source,kind=int64)*byte_size(elem_int32))
+        hipMalloc_i4_6_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_int32),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):,LBOUND(source,6):) => tmp
       else if ( present(mold) ) then
-        hipMalloc_i4_6_source = hipMalloc_(cptr,size(mold)*4_8)
+        hipMalloc_i4_6_source = hipMalloc_(cptr,size(mold,kind=int64)*byte_size(elem_int32))
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):,LBOUND(mold,6):) => tmp
       else if ( present(dims8) ) then
-        hipMalloc_i4_6_source = hipMalloc_(cptr,PRODUCT(dims8)*4_8)
+        hipMalloc_i4_6_source = hipMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_int32))
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):,lbounds8(6):) => tmp
@@ -2397,7 +2455,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMalloc_i4_6_source = hipMalloc_(cptr,PRODUCT(dims)*4_8)
+        hipMalloc_i4_6_source = hipMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_int32))
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):,lbounds(6):) => tmp
@@ -2427,7 +2485,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_i4_6_c_int
 #endif
       !
-      hipMalloc_i4_6_c_int = hipMalloc_(cptr,length1*length2*length3*length4*length5*length6*4_8)
+      hipMalloc_i4_6_c_int = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                             int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*byte_size(elem_int32))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6])
     end function
 
@@ -2451,7 +2510,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_i4_6_c_size_t
 #endif
       !
-      hipMalloc_i4_6_c_size_t = hipMalloc_(cptr,length1*length2*length3*length4*length5*length6*4_8)
+      hipMalloc_i4_6_c_size_t = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*byte_size(elem_int32))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6])
     end function
 
@@ -2466,8 +2526,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       integer(c_int),pointer,dimension(:,:,:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(7),dims(7)
-      integer(8),intent(in),optional :: lbounds8(7),dims8(7)
+      integer(int32),intent(in),optional :: lbounds(7),dims(7)
+      integer(int64),intent(in),optional :: lbounds8(7),dims8(7)
       integer(c_int),target,dimension(:,:,:,:,:,:,:),intent(in),optional :: dsource,source,mold
          
       ! 
@@ -2496,21 +2556,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMalloc_i4_7_source = hipMalloc_(cptr,size(dsource)*4_8)
-        hipMalloc_i4_7_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*4_8,hipMemcpyDeviceToDevice)
+        hipMalloc_i4_7_source = hipMalloc_(cptr,size(dsource,kind=int64)*byte_size(elem_int32))
+        hipMalloc_i4_7_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_int32),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):,LBOUND(dsource,6):,LBOUND(dsource,7):) => tmp
       else if ( present(source) ) then
-        hipMalloc_i4_7_source = hipMalloc_(cptr,size(source)*4_8)
-        hipMalloc_i4_7_source = hipMemcpy(cptr,c_loc(source),size(source)*4_8,hipMemcpyHostToDevice)
+        hipMalloc_i4_7_source = hipMalloc_(cptr,size(source,kind=int64)*byte_size(elem_int32))
+        hipMalloc_i4_7_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_int32),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):,LBOUND(source,6):,LBOUND(source,7):) => tmp
       else if ( present(mold) ) then
-        hipMalloc_i4_7_source = hipMalloc_(cptr,size(mold)*4_8)
+        hipMalloc_i4_7_source = hipMalloc_(cptr,size(mold,kind=int64)*byte_size(elem_int32))
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):,LBOUND(mold,6):,LBOUND(mold,7):) => tmp
       else if ( present(dims8) ) then
-        hipMalloc_i4_7_source = hipMalloc_(cptr,PRODUCT(dims8)*4_8)
+        hipMalloc_i4_7_source = hipMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_int32))
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):,lbounds8(6):,lbounds8(7):) => tmp
@@ -2518,7 +2578,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMalloc_i4_7_source = hipMalloc_(cptr,PRODUCT(dims)*4_8)
+        hipMalloc_i4_7_source = hipMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_int32))
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):,lbounds(6):,lbounds(7):) => tmp
@@ -2548,7 +2608,9 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_i4_7_c_int
 #endif
       !
-      hipMalloc_i4_7_c_int = hipMalloc_(cptr,length1*length2*length3*length4*length5*length6*length7*4_8)
+      hipMalloc_i4_7_c_int = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                             int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*&
+                                             int(length7,kind=int64)*byte_size(elem_int32))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6,length7])
     end function
 
@@ -2572,7 +2634,9 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_i4_7_c_size_t
 #endif
       !
-      hipMalloc_i4_7_c_size_t = hipMalloc_(cptr,length1*length2*length3*length4*length5*length6*length7*4_8)
+      hipMalloc_i4_7_c_size_t = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*&
+                                                int(length7,kind=int64)*byte_size(elem_int32))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6,length7])
     end function
 
@@ -2630,8 +2694,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       integer(c_long),pointer,dimension(:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(1),dims(1)
-      integer(8),intent(in),optional :: lbounds8(1),dims8(1)
+      integer(int32),intent(in),optional :: lbounds(1),dims(1)
+      integer(int64),intent(in),optional :: lbounds8(1),dims8(1)
       integer(c_long),target,dimension(:),intent(in),optional :: dsource,source,mold
          
       ! 
@@ -2660,21 +2724,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMalloc_i8_1_source = hipMalloc_(cptr,size(dsource)*8_8)
-        hipMalloc_i8_1_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*8_8,hipMemcpyDeviceToDevice)
+        hipMalloc_i8_1_source = hipMalloc_(cptr,size(dsource,kind=int64)*byte_size(elem_int64))
+        hipMalloc_i8_1_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_int64),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):) => tmp
       else if ( present(source) ) then
-        hipMalloc_i8_1_source = hipMalloc_(cptr,size(source)*8_8)
-        hipMalloc_i8_1_source = hipMemcpy(cptr,c_loc(source),size(source)*8_8,hipMemcpyHostToDevice)
+        hipMalloc_i8_1_source = hipMalloc_(cptr,size(source,kind=int64)*byte_size(elem_int64))
+        hipMalloc_i8_1_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_int64),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):) => tmp
       else if ( present(mold) ) then
-        hipMalloc_i8_1_source = hipMalloc_(cptr,size(mold)*8_8)
+        hipMalloc_i8_1_source = hipMalloc_(cptr,size(mold,kind=int64)*byte_size(elem_int64))
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):) => tmp
       else if ( present(dims8) ) then
-        hipMalloc_i8_1_source = hipMalloc_(cptr,PRODUCT(dims8)*8_8)
+        hipMalloc_i8_1_source = hipMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_int64))
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):) => tmp
@@ -2682,7 +2746,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMalloc_i8_1_source = hipMalloc_(cptr,PRODUCT(dims)*8_8)
+        hipMalloc_i8_1_source = hipMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_int64))
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):) => tmp
@@ -2712,7 +2776,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_i8_1_c_int
 #endif
       !
-      hipMalloc_i8_1_c_int = hipMalloc_(cptr,length1*8_8)
+      hipMalloc_i8_1_c_int = hipMalloc_(cptr,int(length1,kind=int64)*byte_size(elem_int64))
       call c_f_pointer(cptr,ptr,shape=[length1])
     end function
 
@@ -2736,7 +2800,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_i8_1_c_size_t
 #endif
       !
-      hipMalloc_i8_1_c_size_t = hipMalloc_(cptr,length1*8_8)
+      hipMalloc_i8_1_c_size_t = hipMalloc_(cptr,int(length1,kind=int64)*byte_size(elem_int64))
       call c_f_pointer(cptr,ptr,shape=[length1])
     end function
 
@@ -2751,8 +2815,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       integer(c_long),pointer,dimension(:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(2),dims(2)
-      integer(8),intent(in),optional :: lbounds8(2),dims8(2)
+      integer(int32),intent(in),optional :: lbounds(2),dims(2)
+      integer(int64),intent(in),optional :: lbounds8(2),dims8(2)
       integer(c_long),target,dimension(:,:),intent(in),optional :: dsource,source,mold
          
       ! 
@@ -2781,21 +2845,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMalloc_i8_2_source = hipMalloc_(cptr,size(dsource)*8_8)
-        hipMalloc_i8_2_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*8_8,hipMemcpyDeviceToDevice)
+        hipMalloc_i8_2_source = hipMalloc_(cptr,size(dsource,kind=int64)*byte_size(elem_int64))
+        hipMalloc_i8_2_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_int64),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):) => tmp
       else if ( present(source) ) then
-        hipMalloc_i8_2_source = hipMalloc_(cptr,size(source)*8_8)
-        hipMalloc_i8_2_source = hipMemcpy(cptr,c_loc(source),size(source)*8_8,hipMemcpyHostToDevice)
+        hipMalloc_i8_2_source = hipMalloc_(cptr,size(source,kind=int64)*byte_size(elem_int64))
+        hipMalloc_i8_2_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_int64),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):) => tmp
       else if ( present(mold) ) then
-        hipMalloc_i8_2_source = hipMalloc_(cptr,size(mold)*8_8)
+        hipMalloc_i8_2_source = hipMalloc_(cptr,size(mold,kind=int64)*byte_size(elem_int64))
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):) => tmp
       else if ( present(dims8) ) then
-        hipMalloc_i8_2_source = hipMalloc_(cptr,PRODUCT(dims8)*8_8)
+        hipMalloc_i8_2_source = hipMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_int64))
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):) => tmp
@@ -2803,7 +2867,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMalloc_i8_2_source = hipMalloc_(cptr,PRODUCT(dims)*8_8)
+        hipMalloc_i8_2_source = hipMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_int64))
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):) => tmp
@@ -2833,7 +2897,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_i8_2_c_int
 #endif
       !
-      hipMalloc_i8_2_c_int = hipMalloc_(cptr,length1*length2*8_8)
+      hipMalloc_i8_2_c_int = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*byte_size(elem_int64))
       call c_f_pointer(cptr,ptr,shape=[length1,length2])
     end function
 
@@ -2857,7 +2921,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_i8_2_c_size_t
 #endif
       !
-      hipMalloc_i8_2_c_size_t = hipMalloc_(cptr,length1*length2*8_8)
+      hipMalloc_i8_2_c_size_t = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*byte_size(elem_int64))
       call c_f_pointer(cptr,ptr,shape=[length1,length2])
     end function
 
@@ -2872,8 +2936,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       integer(c_long),pointer,dimension(:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(3),dims(3)
-      integer(8),intent(in),optional :: lbounds8(3),dims8(3)
+      integer(int32),intent(in),optional :: lbounds(3),dims(3)
+      integer(int64),intent(in),optional :: lbounds8(3),dims8(3)
       integer(c_long),target,dimension(:,:,:),intent(in),optional :: dsource,source,mold
          
       ! 
@@ -2902,21 +2966,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMalloc_i8_3_source = hipMalloc_(cptr,size(dsource)*8_8)
-        hipMalloc_i8_3_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*8_8,hipMemcpyDeviceToDevice)
+        hipMalloc_i8_3_source = hipMalloc_(cptr,size(dsource,kind=int64)*byte_size(elem_int64))
+        hipMalloc_i8_3_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_int64),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):) => tmp
       else if ( present(source) ) then
-        hipMalloc_i8_3_source = hipMalloc_(cptr,size(source)*8_8)
-        hipMalloc_i8_3_source = hipMemcpy(cptr,c_loc(source),size(source)*8_8,hipMemcpyHostToDevice)
+        hipMalloc_i8_3_source = hipMalloc_(cptr,size(source,kind=int64)*byte_size(elem_int64))
+        hipMalloc_i8_3_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_int64),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):) => tmp
       else if ( present(mold) ) then
-        hipMalloc_i8_3_source = hipMalloc_(cptr,size(mold)*8_8)
+        hipMalloc_i8_3_source = hipMalloc_(cptr,size(mold,kind=int64)*byte_size(elem_int64))
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):) => tmp
       else if ( present(dims8) ) then
-        hipMalloc_i8_3_source = hipMalloc_(cptr,PRODUCT(dims8)*8_8)
+        hipMalloc_i8_3_source = hipMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_int64))
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):) => tmp
@@ -2924,7 +2988,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMalloc_i8_3_source = hipMalloc_(cptr,PRODUCT(dims)*8_8)
+        hipMalloc_i8_3_source = hipMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_int64))
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):) => tmp
@@ -2954,7 +3018,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_i8_3_c_int
 #endif
       !
-      hipMalloc_i8_3_c_int = hipMalloc_(cptr,length1*length2*length3*8_8)
+      hipMalloc_i8_3_c_int = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*byte_size(elem_int64))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3])
     end function
 
@@ -2978,7 +3042,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_i8_3_c_size_t
 #endif
       !
-      hipMalloc_i8_3_c_size_t = hipMalloc_(cptr,length1*length2*length3*8_8)
+      hipMalloc_i8_3_c_size_t = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*byte_size(elem_int64))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3])
     end function
 
@@ -2993,8 +3057,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       integer(c_long),pointer,dimension(:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(4),dims(4)
-      integer(8),intent(in),optional :: lbounds8(4),dims8(4)
+      integer(int32),intent(in),optional :: lbounds(4),dims(4)
+      integer(int64),intent(in),optional :: lbounds8(4),dims8(4)
       integer(c_long),target,dimension(:,:,:,:),intent(in),optional :: dsource,source,mold
          
       ! 
@@ -3023,21 +3087,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMalloc_i8_4_source = hipMalloc_(cptr,size(dsource)*8_8)
-        hipMalloc_i8_4_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*8_8,hipMemcpyDeviceToDevice)
+        hipMalloc_i8_4_source = hipMalloc_(cptr,size(dsource,kind=int64)*byte_size(elem_int64))
+        hipMalloc_i8_4_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_int64),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):) => tmp
       else if ( present(source) ) then
-        hipMalloc_i8_4_source = hipMalloc_(cptr,size(source)*8_8)
-        hipMalloc_i8_4_source = hipMemcpy(cptr,c_loc(source),size(source)*8_8,hipMemcpyHostToDevice)
+        hipMalloc_i8_4_source = hipMalloc_(cptr,size(source,kind=int64)*byte_size(elem_int64))
+        hipMalloc_i8_4_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_int64),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):) => tmp
       else if ( present(mold) ) then
-        hipMalloc_i8_4_source = hipMalloc_(cptr,size(mold)*8_8)
+        hipMalloc_i8_4_source = hipMalloc_(cptr,size(mold,kind=int64)*byte_size(elem_int64))
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):) => tmp
       else if ( present(dims8) ) then
-        hipMalloc_i8_4_source = hipMalloc_(cptr,PRODUCT(dims8)*8_8)
+        hipMalloc_i8_4_source = hipMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_int64))
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):) => tmp
@@ -3045,7 +3109,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMalloc_i8_4_source = hipMalloc_(cptr,PRODUCT(dims)*8_8)
+        hipMalloc_i8_4_source = hipMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_int64))
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):) => tmp
@@ -3075,7 +3139,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_i8_4_c_int
 #endif
       !
-      hipMalloc_i8_4_c_int = hipMalloc_(cptr,length1*length2*length3*length4*8_8)
+      hipMalloc_i8_4_c_int = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                             int(length4,kind=int64)*byte_size(elem_int64))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4])
     end function
 
@@ -3099,7 +3164,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_i8_4_c_size_t
 #endif
       !
-      hipMalloc_i8_4_c_size_t = hipMalloc_(cptr,length1*length2*length3*length4*8_8)
+      hipMalloc_i8_4_c_size_t = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                int(length4,kind=int64)*byte_size(elem_int64))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4])
     end function
 
@@ -3114,8 +3180,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       integer(c_long),pointer,dimension(:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(5),dims(5)
-      integer(8),intent(in),optional :: lbounds8(5),dims8(5)
+      integer(int32),intent(in),optional :: lbounds(5),dims(5)
+      integer(int64),intent(in),optional :: lbounds8(5),dims8(5)
       integer(c_long),target,dimension(:,:,:,:,:),intent(in),optional :: dsource,source,mold
          
       ! 
@@ -3144,21 +3210,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMalloc_i8_5_source = hipMalloc_(cptr,size(dsource)*8_8)
-        hipMalloc_i8_5_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*8_8,hipMemcpyDeviceToDevice)
+        hipMalloc_i8_5_source = hipMalloc_(cptr,size(dsource,kind=int64)*byte_size(elem_int64))
+        hipMalloc_i8_5_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_int64),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):) => tmp
       else if ( present(source) ) then
-        hipMalloc_i8_5_source = hipMalloc_(cptr,size(source)*8_8)
-        hipMalloc_i8_5_source = hipMemcpy(cptr,c_loc(source),size(source)*8_8,hipMemcpyHostToDevice)
+        hipMalloc_i8_5_source = hipMalloc_(cptr,size(source,kind=int64)*byte_size(elem_int64))
+        hipMalloc_i8_5_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_int64),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):) => tmp
       else if ( present(mold) ) then
-        hipMalloc_i8_5_source = hipMalloc_(cptr,size(mold)*8_8)
+        hipMalloc_i8_5_source = hipMalloc_(cptr,size(mold,kind=int64)*byte_size(elem_int64))
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):) => tmp
       else if ( present(dims8) ) then
-        hipMalloc_i8_5_source = hipMalloc_(cptr,PRODUCT(dims8)*8_8)
+        hipMalloc_i8_5_source = hipMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_int64))
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):) => tmp
@@ -3166,7 +3232,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMalloc_i8_5_source = hipMalloc_(cptr,PRODUCT(dims)*8_8)
+        hipMalloc_i8_5_source = hipMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_int64))
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):) => tmp
@@ -3196,7 +3262,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_i8_5_c_int
 #endif
       !
-      hipMalloc_i8_5_c_int = hipMalloc_(cptr,length1*length2*length3*length4*length5*8_8)
+      hipMalloc_i8_5_c_int = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                             int(length4,kind=int64)*int(length5,kind=int64)*byte_size(elem_int64))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5])
     end function
 
@@ -3220,7 +3287,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_i8_5_c_size_t
 #endif
       !
-      hipMalloc_i8_5_c_size_t = hipMalloc_(cptr,length1*length2*length3*length4*length5*8_8)
+      hipMalloc_i8_5_c_size_t = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                int(length4,kind=int64)*int(length5,kind=int64)*byte_size(elem_int64))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5])
     end function
 
@@ -3235,8 +3303,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       integer(c_long),pointer,dimension(:,:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(6),dims(6)
-      integer(8),intent(in),optional :: lbounds8(6),dims8(6)
+      integer(int32),intent(in),optional :: lbounds(6),dims(6)
+      integer(int64),intent(in),optional :: lbounds8(6),dims8(6)
       integer(c_long),target,dimension(:,:,:,:,:,:),intent(in),optional :: dsource,source,mold
          
       ! 
@@ -3265,21 +3333,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMalloc_i8_6_source = hipMalloc_(cptr,size(dsource)*8_8)
-        hipMalloc_i8_6_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*8_8,hipMemcpyDeviceToDevice)
+        hipMalloc_i8_6_source = hipMalloc_(cptr,size(dsource,kind=int64)*byte_size(elem_int64))
+        hipMalloc_i8_6_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_int64),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):,LBOUND(dsource,6):) => tmp
       else if ( present(source) ) then
-        hipMalloc_i8_6_source = hipMalloc_(cptr,size(source)*8_8)
-        hipMalloc_i8_6_source = hipMemcpy(cptr,c_loc(source),size(source)*8_8,hipMemcpyHostToDevice)
+        hipMalloc_i8_6_source = hipMalloc_(cptr,size(source,kind=int64)*byte_size(elem_int64))
+        hipMalloc_i8_6_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_int64),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):,LBOUND(source,6):) => tmp
       else if ( present(mold) ) then
-        hipMalloc_i8_6_source = hipMalloc_(cptr,size(mold)*8_8)
+        hipMalloc_i8_6_source = hipMalloc_(cptr,size(mold,kind=int64)*byte_size(elem_int64))
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):,LBOUND(mold,6):) => tmp
       else if ( present(dims8) ) then
-        hipMalloc_i8_6_source = hipMalloc_(cptr,PRODUCT(dims8)*8_8)
+        hipMalloc_i8_6_source = hipMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_int64))
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):,lbounds8(6):) => tmp
@@ -3287,7 +3355,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMalloc_i8_6_source = hipMalloc_(cptr,PRODUCT(dims)*8_8)
+        hipMalloc_i8_6_source = hipMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_int64))
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):,lbounds(6):) => tmp
@@ -3317,7 +3385,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_i8_6_c_int
 #endif
       !
-      hipMalloc_i8_6_c_int = hipMalloc_(cptr,length1*length2*length3*length4*length5*length6*8_8)
+      hipMalloc_i8_6_c_int = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                             int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*byte_size(elem_int64))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6])
     end function
 
@@ -3341,7 +3410,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_i8_6_c_size_t
 #endif
       !
-      hipMalloc_i8_6_c_size_t = hipMalloc_(cptr,length1*length2*length3*length4*length5*length6*8_8)
+      hipMalloc_i8_6_c_size_t = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*byte_size(elem_int64))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6])
     end function
 
@@ -3356,8 +3426,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       integer(c_long),pointer,dimension(:,:,:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(7),dims(7)
-      integer(8),intent(in),optional :: lbounds8(7),dims8(7)
+      integer(int32),intent(in),optional :: lbounds(7),dims(7)
+      integer(int64),intent(in),optional :: lbounds8(7),dims8(7)
       integer(c_long),target,dimension(:,:,:,:,:,:,:),intent(in),optional :: dsource,source,mold
          
       ! 
@@ -3386,21 +3456,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMalloc_i8_7_source = hipMalloc_(cptr,size(dsource)*8_8)
-        hipMalloc_i8_7_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*8_8,hipMemcpyDeviceToDevice)
+        hipMalloc_i8_7_source = hipMalloc_(cptr,size(dsource,kind=int64)*byte_size(elem_int64))
+        hipMalloc_i8_7_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_int64),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):,LBOUND(dsource,6):,LBOUND(dsource,7):) => tmp
       else if ( present(source) ) then
-        hipMalloc_i8_7_source = hipMalloc_(cptr,size(source)*8_8)
-        hipMalloc_i8_7_source = hipMemcpy(cptr,c_loc(source),size(source)*8_8,hipMemcpyHostToDevice)
+        hipMalloc_i8_7_source = hipMalloc_(cptr,size(source,kind=int64)*byte_size(elem_int64))
+        hipMalloc_i8_7_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_int64),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):,LBOUND(source,6):,LBOUND(source,7):) => tmp
       else if ( present(mold) ) then
-        hipMalloc_i8_7_source = hipMalloc_(cptr,size(mold)*8_8)
+        hipMalloc_i8_7_source = hipMalloc_(cptr,size(mold,kind=int64)*byte_size(elem_int64))
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):,LBOUND(mold,6):,LBOUND(mold,7):) => tmp
       else if ( present(dims8) ) then
-        hipMalloc_i8_7_source = hipMalloc_(cptr,PRODUCT(dims8)*8_8)
+        hipMalloc_i8_7_source = hipMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_int64))
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):,lbounds8(6):,lbounds8(7):) => tmp
@@ -3408,7 +3478,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMalloc_i8_7_source = hipMalloc_(cptr,PRODUCT(dims)*8_8)
+        hipMalloc_i8_7_source = hipMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_int64))
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):,lbounds(6):,lbounds(7):) => tmp
@@ -3438,7 +3508,9 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_i8_7_c_int
 #endif
       !
-      hipMalloc_i8_7_c_int = hipMalloc_(cptr,length1*length2*length3*length4*length5*length6*length7*8_8)
+      hipMalloc_i8_7_c_int = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                             int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*&
+                                             int(length7,kind=int64)*byte_size(elem_int64))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6,length7])
     end function
 
@@ -3462,7 +3534,9 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_i8_7_c_size_t
 #endif
       !
-      hipMalloc_i8_7_c_size_t = hipMalloc_(cptr,length1*length2*length3*length4*length5*length6*length7*8_8)
+      hipMalloc_i8_7_c_size_t = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*&
+                                                int(length7,kind=int64)*byte_size(elem_int64))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6,length7])
     end function
 
@@ -3520,8 +3594,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       real(c_float),pointer,dimension(:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(1),dims(1)
-      integer(8),intent(in),optional :: lbounds8(1),dims8(1)
+      integer(int32),intent(in),optional :: lbounds(1),dims(1)
+      integer(int64),intent(in),optional :: lbounds8(1),dims8(1)
       real(c_float),target,dimension(:),intent(in),optional :: dsource,source,mold
          
       ! 
@@ -3550,21 +3624,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMalloc_r4_1_source = hipMalloc_(cptr,size(dsource)*4_8)
-        hipMalloc_r4_1_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*4_8,hipMemcpyDeviceToDevice)
+        hipMalloc_r4_1_source = hipMalloc_(cptr,size(dsource,kind=int64)*byte_size(elem_real32))
+        hipMalloc_r4_1_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_real32),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):) => tmp
       else if ( present(source) ) then
-        hipMalloc_r4_1_source = hipMalloc_(cptr,size(source)*4_8)
-        hipMalloc_r4_1_source = hipMemcpy(cptr,c_loc(source),size(source)*4_8,hipMemcpyHostToDevice)
+        hipMalloc_r4_1_source = hipMalloc_(cptr,size(source,kind=int64)*byte_size(elem_real32))
+        hipMalloc_r4_1_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_real32),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):) => tmp
       else if ( present(mold) ) then
-        hipMalloc_r4_1_source = hipMalloc_(cptr,size(mold)*4_8)
+        hipMalloc_r4_1_source = hipMalloc_(cptr,size(mold,kind=int64)*byte_size(elem_real32))
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):) => tmp
       else if ( present(dims8) ) then
-        hipMalloc_r4_1_source = hipMalloc_(cptr,PRODUCT(dims8)*4_8)
+        hipMalloc_r4_1_source = hipMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_real32))
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):) => tmp
@@ -3572,7 +3646,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMalloc_r4_1_source = hipMalloc_(cptr,PRODUCT(dims)*4_8)
+        hipMalloc_r4_1_source = hipMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_real32))
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):) => tmp
@@ -3602,7 +3676,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_r4_1_c_int
 #endif
       !
-      hipMalloc_r4_1_c_int = hipMalloc_(cptr,length1*4_8)
+      hipMalloc_r4_1_c_int = hipMalloc_(cptr,int(length1,kind=int64)*byte_size(elem_real32))
       call c_f_pointer(cptr,ptr,shape=[length1])
     end function
 
@@ -3626,7 +3700,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_r4_1_c_size_t
 #endif
       !
-      hipMalloc_r4_1_c_size_t = hipMalloc_(cptr,length1*4_8)
+      hipMalloc_r4_1_c_size_t = hipMalloc_(cptr,int(length1,kind=int64)*byte_size(elem_real32))
       call c_f_pointer(cptr,ptr,shape=[length1])
     end function
 
@@ -3641,8 +3715,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       real(c_float),pointer,dimension(:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(2),dims(2)
-      integer(8),intent(in),optional :: lbounds8(2),dims8(2)
+      integer(int32),intent(in),optional :: lbounds(2),dims(2)
+      integer(int64),intent(in),optional :: lbounds8(2),dims8(2)
       real(c_float),target,dimension(:,:),intent(in),optional :: dsource,source,mold
          
       ! 
@@ -3671,21 +3745,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMalloc_r4_2_source = hipMalloc_(cptr,size(dsource)*4_8)
-        hipMalloc_r4_2_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*4_8,hipMemcpyDeviceToDevice)
+        hipMalloc_r4_2_source = hipMalloc_(cptr,size(dsource,kind=int64)*byte_size(elem_real32))
+        hipMalloc_r4_2_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_real32),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):) => tmp
       else if ( present(source) ) then
-        hipMalloc_r4_2_source = hipMalloc_(cptr,size(source)*4_8)
-        hipMalloc_r4_2_source = hipMemcpy(cptr,c_loc(source),size(source)*4_8,hipMemcpyHostToDevice)
+        hipMalloc_r4_2_source = hipMalloc_(cptr,size(source,kind=int64)*byte_size(elem_real32))
+        hipMalloc_r4_2_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_real32),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):) => tmp
       else if ( present(mold) ) then
-        hipMalloc_r4_2_source = hipMalloc_(cptr,size(mold)*4_8)
+        hipMalloc_r4_2_source = hipMalloc_(cptr,size(mold,kind=int64)*byte_size(elem_real32))
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):) => tmp
       else if ( present(dims8) ) then
-        hipMalloc_r4_2_source = hipMalloc_(cptr,PRODUCT(dims8)*4_8)
+        hipMalloc_r4_2_source = hipMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_real32))
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):) => tmp
@@ -3693,7 +3767,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMalloc_r4_2_source = hipMalloc_(cptr,PRODUCT(dims)*4_8)
+        hipMalloc_r4_2_source = hipMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_real32))
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):) => tmp
@@ -3723,7 +3797,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_r4_2_c_int
 #endif
       !
-      hipMalloc_r4_2_c_int = hipMalloc_(cptr,length1*length2*4_8)
+      hipMalloc_r4_2_c_int = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*byte_size(elem_real32))
       call c_f_pointer(cptr,ptr,shape=[length1,length2])
     end function
 
@@ -3747,7 +3821,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_r4_2_c_size_t
 #endif
       !
-      hipMalloc_r4_2_c_size_t = hipMalloc_(cptr,length1*length2*4_8)
+      hipMalloc_r4_2_c_size_t = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*byte_size(elem_real32))
       call c_f_pointer(cptr,ptr,shape=[length1,length2])
     end function
 
@@ -3762,8 +3836,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       real(c_float),pointer,dimension(:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(3),dims(3)
-      integer(8),intent(in),optional :: lbounds8(3),dims8(3)
+      integer(int32),intent(in),optional :: lbounds(3),dims(3)
+      integer(int64),intent(in),optional :: lbounds8(3),dims8(3)
       real(c_float),target,dimension(:,:,:),intent(in),optional :: dsource,source,mold
          
       ! 
@@ -3792,21 +3866,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMalloc_r4_3_source = hipMalloc_(cptr,size(dsource)*4_8)
-        hipMalloc_r4_3_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*4_8,hipMemcpyDeviceToDevice)
+        hipMalloc_r4_3_source = hipMalloc_(cptr,size(dsource,kind=int64)*byte_size(elem_real32))
+        hipMalloc_r4_3_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_real32),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):) => tmp
       else if ( present(source) ) then
-        hipMalloc_r4_3_source = hipMalloc_(cptr,size(source)*4_8)
-        hipMalloc_r4_3_source = hipMemcpy(cptr,c_loc(source),size(source)*4_8,hipMemcpyHostToDevice)
+        hipMalloc_r4_3_source = hipMalloc_(cptr,size(source,kind=int64)*byte_size(elem_real32))
+        hipMalloc_r4_3_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_real32),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):) => tmp
       else if ( present(mold) ) then
-        hipMalloc_r4_3_source = hipMalloc_(cptr,size(mold)*4_8)
+        hipMalloc_r4_3_source = hipMalloc_(cptr,size(mold,kind=int64)*byte_size(elem_real32))
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):) => tmp
       else if ( present(dims8) ) then
-        hipMalloc_r4_3_source = hipMalloc_(cptr,PRODUCT(dims8)*4_8)
+        hipMalloc_r4_3_source = hipMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_real32))
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):) => tmp
@@ -3814,7 +3888,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMalloc_r4_3_source = hipMalloc_(cptr,PRODUCT(dims)*4_8)
+        hipMalloc_r4_3_source = hipMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_real32))
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):) => tmp
@@ -3844,7 +3918,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_r4_3_c_int
 #endif
       !
-      hipMalloc_r4_3_c_int = hipMalloc_(cptr,length1*length2*length3*4_8)
+      hipMalloc_r4_3_c_int = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*byte_size(elem_real32))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3])
     end function
 
@@ -3868,7 +3942,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_r4_3_c_size_t
 #endif
       !
-      hipMalloc_r4_3_c_size_t = hipMalloc_(cptr,length1*length2*length3*4_8)
+      hipMalloc_r4_3_c_size_t = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*byte_size(elem_real32))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3])
     end function
 
@@ -3883,8 +3957,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       real(c_float),pointer,dimension(:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(4),dims(4)
-      integer(8),intent(in),optional :: lbounds8(4),dims8(4)
+      integer(int32),intent(in),optional :: lbounds(4),dims(4)
+      integer(int64),intent(in),optional :: lbounds8(4),dims8(4)
       real(c_float),target,dimension(:,:,:,:),intent(in),optional :: dsource,source,mold
          
       ! 
@@ -3913,21 +3987,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMalloc_r4_4_source = hipMalloc_(cptr,size(dsource)*4_8)
-        hipMalloc_r4_4_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*4_8,hipMemcpyDeviceToDevice)
+        hipMalloc_r4_4_source = hipMalloc_(cptr,size(dsource,kind=int64)*byte_size(elem_real32))
+        hipMalloc_r4_4_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_real32),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):) => tmp
       else if ( present(source) ) then
-        hipMalloc_r4_4_source = hipMalloc_(cptr,size(source)*4_8)
-        hipMalloc_r4_4_source = hipMemcpy(cptr,c_loc(source),size(source)*4_8,hipMemcpyHostToDevice)
+        hipMalloc_r4_4_source = hipMalloc_(cptr,size(source,kind=int64)*byte_size(elem_real32))
+        hipMalloc_r4_4_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_real32),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):) => tmp
       else if ( present(mold) ) then
-        hipMalloc_r4_4_source = hipMalloc_(cptr,size(mold)*4_8)
+        hipMalloc_r4_4_source = hipMalloc_(cptr,size(mold,kind=int64)*byte_size(elem_real32))
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):) => tmp
       else if ( present(dims8) ) then
-        hipMalloc_r4_4_source = hipMalloc_(cptr,PRODUCT(dims8)*4_8)
+        hipMalloc_r4_4_source = hipMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_real32))
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):) => tmp
@@ -3935,7 +4009,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMalloc_r4_4_source = hipMalloc_(cptr,PRODUCT(dims)*4_8)
+        hipMalloc_r4_4_source = hipMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_real32))
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):) => tmp
@@ -3965,7 +4039,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_r4_4_c_int
 #endif
       !
-      hipMalloc_r4_4_c_int = hipMalloc_(cptr,length1*length2*length3*length4*4_8)
+      hipMalloc_r4_4_c_int = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                             int(length4,kind=int64)*byte_size(elem_real32))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4])
     end function
 
@@ -3989,7 +4064,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_r4_4_c_size_t
 #endif
       !
-      hipMalloc_r4_4_c_size_t = hipMalloc_(cptr,length1*length2*length3*length4*4_8)
+      hipMalloc_r4_4_c_size_t = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                int(length4,kind=int64)*byte_size(elem_real32))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4])
     end function
 
@@ -4004,8 +4080,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       real(c_float),pointer,dimension(:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(5),dims(5)
-      integer(8),intent(in),optional :: lbounds8(5),dims8(5)
+      integer(int32),intent(in),optional :: lbounds(5),dims(5)
+      integer(int64),intent(in),optional :: lbounds8(5),dims8(5)
       real(c_float),target,dimension(:,:,:,:,:),intent(in),optional :: dsource,source,mold
          
       ! 
@@ -4034,21 +4110,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMalloc_r4_5_source = hipMalloc_(cptr,size(dsource)*4_8)
-        hipMalloc_r4_5_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*4_8,hipMemcpyDeviceToDevice)
+        hipMalloc_r4_5_source = hipMalloc_(cptr,size(dsource,kind=int64)*byte_size(elem_real32))
+        hipMalloc_r4_5_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_real32),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):) => tmp
       else if ( present(source) ) then
-        hipMalloc_r4_5_source = hipMalloc_(cptr,size(source)*4_8)
-        hipMalloc_r4_5_source = hipMemcpy(cptr,c_loc(source),size(source)*4_8,hipMemcpyHostToDevice)
+        hipMalloc_r4_5_source = hipMalloc_(cptr,size(source,kind=int64)*byte_size(elem_real32))
+        hipMalloc_r4_5_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_real32),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):) => tmp
       else if ( present(mold) ) then
-        hipMalloc_r4_5_source = hipMalloc_(cptr,size(mold)*4_8)
+        hipMalloc_r4_5_source = hipMalloc_(cptr,size(mold,kind=int64)*byte_size(elem_real32))
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):) => tmp
       else if ( present(dims8) ) then
-        hipMalloc_r4_5_source = hipMalloc_(cptr,PRODUCT(dims8)*4_8)
+        hipMalloc_r4_5_source = hipMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_real32))
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):) => tmp
@@ -4056,7 +4132,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMalloc_r4_5_source = hipMalloc_(cptr,PRODUCT(dims)*4_8)
+        hipMalloc_r4_5_source = hipMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_real32))
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):) => tmp
@@ -4086,7 +4162,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_r4_5_c_int
 #endif
       !
-      hipMalloc_r4_5_c_int = hipMalloc_(cptr,length1*length2*length3*length4*length5*4_8)
+      hipMalloc_r4_5_c_int = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                             int(length4,kind=int64)*int(length5,kind=int64)*byte_size(elem_real32))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5])
     end function
 
@@ -4110,7 +4187,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_r4_5_c_size_t
 #endif
       !
-      hipMalloc_r4_5_c_size_t = hipMalloc_(cptr,length1*length2*length3*length4*length5*4_8)
+      hipMalloc_r4_5_c_size_t = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                int(length4,kind=int64)*int(length5,kind=int64)*byte_size(elem_real32))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5])
     end function
 
@@ -4125,8 +4203,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       real(c_float),pointer,dimension(:,:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(6),dims(6)
-      integer(8),intent(in),optional :: lbounds8(6),dims8(6)
+      integer(int32),intent(in),optional :: lbounds(6),dims(6)
+      integer(int64),intent(in),optional :: lbounds8(6),dims8(6)
       real(c_float),target,dimension(:,:,:,:,:,:),intent(in),optional :: dsource,source,mold
          
       ! 
@@ -4155,21 +4233,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMalloc_r4_6_source = hipMalloc_(cptr,size(dsource)*4_8)
-        hipMalloc_r4_6_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*4_8,hipMemcpyDeviceToDevice)
+        hipMalloc_r4_6_source = hipMalloc_(cptr,size(dsource,kind=int64)*byte_size(elem_real32))
+        hipMalloc_r4_6_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_real32),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):,LBOUND(dsource,6):) => tmp
       else if ( present(source) ) then
-        hipMalloc_r4_6_source = hipMalloc_(cptr,size(source)*4_8)
-        hipMalloc_r4_6_source = hipMemcpy(cptr,c_loc(source),size(source)*4_8,hipMemcpyHostToDevice)
+        hipMalloc_r4_6_source = hipMalloc_(cptr,size(source,kind=int64)*byte_size(elem_real32))
+        hipMalloc_r4_6_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_real32),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):,LBOUND(source,6):) => tmp
       else if ( present(mold) ) then
-        hipMalloc_r4_6_source = hipMalloc_(cptr,size(mold)*4_8)
+        hipMalloc_r4_6_source = hipMalloc_(cptr,size(mold,kind=int64)*byte_size(elem_real32))
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):,LBOUND(mold,6):) => tmp
       else if ( present(dims8) ) then
-        hipMalloc_r4_6_source = hipMalloc_(cptr,PRODUCT(dims8)*4_8)
+        hipMalloc_r4_6_source = hipMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_real32))
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):,lbounds8(6):) => tmp
@@ -4177,7 +4255,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMalloc_r4_6_source = hipMalloc_(cptr,PRODUCT(dims)*4_8)
+        hipMalloc_r4_6_source = hipMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_real32))
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):,lbounds(6):) => tmp
@@ -4207,7 +4285,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_r4_6_c_int
 #endif
       !
-      hipMalloc_r4_6_c_int = hipMalloc_(cptr,length1*length2*length3*length4*length5*length6*4_8)
+      hipMalloc_r4_6_c_int = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                             int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*byte_size(elem_real32))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6])
     end function
 
@@ -4231,7 +4310,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_r4_6_c_size_t
 #endif
       !
-      hipMalloc_r4_6_c_size_t = hipMalloc_(cptr,length1*length2*length3*length4*length5*length6*4_8)
+      hipMalloc_r4_6_c_size_t = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*byte_size(elem_real32))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6])
     end function
 
@@ -4246,8 +4326,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       real(c_float),pointer,dimension(:,:,:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(7),dims(7)
-      integer(8),intent(in),optional :: lbounds8(7),dims8(7)
+      integer(int32),intent(in),optional :: lbounds(7),dims(7)
+      integer(int64),intent(in),optional :: lbounds8(7),dims8(7)
       real(c_float),target,dimension(:,:,:,:,:,:,:),intent(in),optional :: dsource,source,mold
          
       ! 
@@ -4276,21 +4356,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMalloc_r4_7_source = hipMalloc_(cptr,size(dsource)*4_8)
-        hipMalloc_r4_7_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*4_8,hipMemcpyDeviceToDevice)
+        hipMalloc_r4_7_source = hipMalloc_(cptr,size(dsource,kind=int64)*byte_size(elem_real32))
+        hipMalloc_r4_7_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_real32),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):,LBOUND(dsource,6):,LBOUND(dsource,7):) => tmp
       else if ( present(source) ) then
-        hipMalloc_r4_7_source = hipMalloc_(cptr,size(source)*4_8)
-        hipMalloc_r4_7_source = hipMemcpy(cptr,c_loc(source),size(source)*4_8,hipMemcpyHostToDevice)
+        hipMalloc_r4_7_source = hipMalloc_(cptr,size(source,kind=int64)*byte_size(elem_real32))
+        hipMalloc_r4_7_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_real32),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):,LBOUND(source,6):,LBOUND(source,7):) => tmp
       else if ( present(mold) ) then
-        hipMalloc_r4_7_source = hipMalloc_(cptr,size(mold)*4_8)
+        hipMalloc_r4_7_source = hipMalloc_(cptr,size(mold,kind=int64)*byte_size(elem_real32))
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):,LBOUND(mold,6):,LBOUND(mold,7):) => tmp
       else if ( present(dims8) ) then
-        hipMalloc_r4_7_source = hipMalloc_(cptr,PRODUCT(dims8)*4_8)
+        hipMalloc_r4_7_source = hipMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_real32))
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):,lbounds8(6):,lbounds8(7):) => tmp
@@ -4298,7 +4378,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMalloc_r4_7_source = hipMalloc_(cptr,PRODUCT(dims)*4_8)
+        hipMalloc_r4_7_source = hipMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_real32))
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):,lbounds(6):,lbounds(7):) => tmp
@@ -4328,7 +4408,9 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_r4_7_c_int
 #endif
       !
-      hipMalloc_r4_7_c_int = hipMalloc_(cptr,length1*length2*length3*length4*length5*length6*length7*4_8)
+      hipMalloc_r4_7_c_int = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                             int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*&
+                                             int(length7,kind=int64)*byte_size(elem_real32))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6,length7])
     end function
 
@@ -4352,7 +4434,9 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_r4_7_c_size_t
 #endif
       !
-      hipMalloc_r4_7_c_size_t = hipMalloc_(cptr,length1*length2*length3*length4*length5*length6*length7*4_8)
+      hipMalloc_r4_7_c_size_t = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*&
+                                                int(length7,kind=int64)*byte_size(elem_real32))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6,length7])
     end function
 
@@ -4385,15 +4469,15 @@ module hipfort_hipmalloc
       if ( nOptArgs > 1 ) ERROR STOP "ERROR: hipMalloc (scalar version): Only one optional argument ('dsource','source') must be specified."
     
       if ( present(dsource) ) then
-        hipMalloc_r8_0_source = hipMalloc_(cptr,8_8)
-        hipMalloc_r8_0_source = hipMemcpy(cptr,c_loc(dsource),8_8,hipMemcpyDeviceToDevice)
+        hipMalloc_r8_0_source = hipMalloc_(cptr,byte_size(elem_real64))
+        hipMalloc_r8_0_source = hipMemcpy(cptr,c_loc(dsource),byte_size(elem_real64),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,ptr)
       else if ( present(source) ) then
-        hipMalloc_r8_0_source = hipMalloc_(cptr,8_8)
-        hipMalloc_r8_0_source = hipMemcpy(cptr,c_loc(source),8_8,hipMemcpyHostToDevice)
+        hipMalloc_r8_0_source = hipMalloc_(cptr,byte_size(elem_real64))
+        hipMalloc_r8_0_source = hipMemcpy(cptr,c_loc(source),byte_size(elem_real64),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,ptr)
       else
-        hipMalloc_r8_0_source = hipMalloc_(cptr,8_8)
+        hipMalloc_r8_0_source = hipMalloc_(cptr,byte_size(elem_real64))
         call c_f_pointer(cptr,ptr)
       end if
     end function
@@ -4410,8 +4494,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       real(c_double),pointer,dimension(:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(1),dims(1)
-      integer(8),intent(in),optional :: lbounds8(1),dims8(1)
+      integer(int32),intent(in),optional :: lbounds(1),dims(1)
+      integer(int64),intent(in),optional :: lbounds8(1),dims8(1)
       real(c_double),target,dimension(:),intent(in),optional :: dsource,source,mold
          
       ! 
@@ -4440,21 +4524,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMalloc_r8_1_source = hipMalloc_(cptr,size(dsource)*8_8)
-        hipMalloc_r8_1_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*8_8,hipMemcpyDeviceToDevice)
+        hipMalloc_r8_1_source = hipMalloc_(cptr,size(dsource)*byte_size(elem_real64))
+        hipMalloc_r8_1_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*byte_size(elem_real64),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):) => tmp
       else if ( present(source) ) then
-        hipMalloc_r8_1_source = hipMalloc_(cptr,size(source)*8_8)
-        hipMalloc_r8_1_source = hipMemcpy(cptr,c_loc(source),size(source)*8_8,hipMemcpyHostToDevice)
+        hipMalloc_r8_1_source = hipMalloc_(cptr,size(source)*byte_size(elem_real64))
+        hipMalloc_r8_1_source = hipMemcpy(cptr,c_loc(source),size(source)*byte_size(elem_real64),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):) => tmp
       else if ( present(mold) ) then
-        hipMalloc_r8_1_source = hipMalloc_(cptr,size(mold)*8_8)
+        hipMalloc_r8_1_source = hipMalloc_(cptr,size(mold)*byte_size(elem_real64))
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):) => tmp
       else if ( present(dims8) ) then
-        hipMalloc_r8_1_source = hipMalloc_(cptr,PRODUCT(dims8)*8_8)
+        hipMalloc_r8_1_source = hipMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_real64))
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):) => tmp
@@ -4462,7 +4546,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMalloc_r8_1_source = hipMalloc_(cptr,PRODUCT(dims)*8_8)
+        hipMalloc_r8_1_source = hipMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_real64))
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):) => tmp
@@ -4492,7 +4576,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_r8_1_c_int
 #endif
       !
-      hipMalloc_r8_1_c_int = hipMalloc_(cptr,length1*8_8)
+      hipMalloc_r8_1_c_int = hipMalloc_(cptr,int(length1,kind=int64)*byte_size(elem_real64))
       call c_f_pointer(cptr,ptr,shape=[length1])
     end function
 
@@ -4516,7 +4600,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_r8_1_c_size_t
 #endif
       !
-      hipMalloc_r8_1_c_size_t = hipMalloc_(cptr,length1*8_8)
+      hipMalloc_r8_1_c_size_t = hipMalloc_(cptr,int(length1,kind=int64)*byte_size(elem_real64))
       call c_f_pointer(cptr,ptr,shape=[length1])
     end function
 
@@ -4531,8 +4615,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       real(c_double),pointer,dimension(:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(2),dims(2)
-      integer(8),intent(in),optional :: lbounds8(2),dims8(2)
+      integer(int32),intent(in),optional :: lbounds(2),dims(2)
+      integer(int64),intent(in),optional :: lbounds8(2),dims8(2)
       real(c_double),target,dimension(:,:),intent(in),optional :: dsource,source,mold
          
       ! 
@@ -4561,21 +4645,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMalloc_r8_2_source = hipMalloc_(cptr,size(dsource)*8_8)
-        hipMalloc_r8_2_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*8_8,hipMemcpyDeviceToDevice)
+        hipMalloc_r8_2_source = hipMalloc_(cptr,size(dsource)*byte_size(elem_real64))
+        hipMalloc_r8_2_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*byte_size(elem_real64),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):) => tmp
       else if ( present(source) ) then
-        hipMalloc_r8_2_source = hipMalloc_(cptr,size(source)*8_8)
-        hipMalloc_r8_2_source = hipMemcpy(cptr,c_loc(source),size(source)*8_8,hipMemcpyHostToDevice)
+        hipMalloc_r8_2_source = hipMalloc_(cptr,size(source)*byte_size(elem_real64))
+        hipMalloc_r8_2_source = hipMemcpy(cptr,c_loc(source),size(source)*byte_size(elem_real64),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):) => tmp
       else if ( present(mold) ) then
-        hipMalloc_r8_2_source = hipMalloc_(cptr,size(mold)*8_8)
+        hipMalloc_r8_2_source = hipMalloc_(cptr,size(mold)*byte_size(elem_real64))
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):) => tmp
       else if ( present(dims8) ) then
-        hipMalloc_r8_2_source = hipMalloc_(cptr,PRODUCT(dims8)*8_8)
+        hipMalloc_r8_2_source = hipMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_real64))
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):) => tmp
@@ -4583,7 +4667,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMalloc_r8_2_source = hipMalloc_(cptr,PRODUCT(dims)*8_8)
+        hipMalloc_r8_2_source = hipMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_real64))
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):) => tmp
@@ -4613,7 +4697,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_r8_2_c_int
 #endif
       !
-      hipMalloc_r8_2_c_int = hipMalloc_(cptr,length1*length2*8_8)
+      hipMalloc_r8_2_c_int = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*byte_size(elem_real64))
       call c_f_pointer(cptr,ptr,shape=[length1,length2])
     end function
 
@@ -4637,7 +4721,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_r8_2_c_size_t
 #endif
       !
-      hipMalloc_r8_2_c_size_t = hipMalloc_(cptr,length1*length2*8_8)
+      hipMalloc_r8_2_c_size_t = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*byte_size(elem_real64))
       call c_f_pointer(cptr,ptr,shape=[length1,length2])
     end function
 
@@ -4652,8 +4736,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       real(c_double),pointer,dimension(:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(3),dims(3)
-      integer(8),intent(in),optional :: lbounds8(3),dims8(3)
+      integer(int32),intent(in),optional :: lbounds(3),dims(3)
+      integer(int64),intent(in),optional :: lbounds8(3),dims8(3)
       real(c_double),target,dimension(:,:,:),intent(in),optional :: dsource,source,mold
          
       ! 
@@ -4682,21 +4766,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMalloc_r8_3_source = hipMalloc_(cptr,size(dsource)*8_8)
-        hipMalloc_r8_3_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*8_8,hipMemcpyDeviceToDevice)
+        hipMalloc_r8_3_source = hipMalloc_(cptr,size(dsource)*byte_size(elem_real64))
+        hipMalloc_r8_3_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*byte_size(elem_real64),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):) => tmp
       else if ( present(source) ) then
-        hipMalloc_r8_3_source = hipMalloc_(cptr,size(source)*8_8)
-        hipMalloc_r8_3_source = hipMemcpy(cptr,c_loc(source),size(source)*8_8,hipMemcpyHostToDevice)
+        hipMalloc_r8_3_source = hipMalloc_(cptr,size(source)*byte_size(elem_real64))
+        hipMalloc_r8_3_source = hipMemcpy(cptr,c_loc(source),size(source)*byte_size(elem_real64),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):) => tmp
       else if ( present(mold) ) then
-        hipMalloc_r8_3_source = hipMalloc_(cptr,size(mold)*8_8)
+        hipMalloc_r8_3_source = hipMalloc_(cptr,size(mold)*byte_size(elem_real64))
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):) => tmp
       else if ( present(dims8) ) then
-        hipMalloc_r8_3_source = hipMalloc_(cptr,PRODUCT(dims8)*8_8)
+        hipMalloc_r8_3_source = hipMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_real64))
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):) => tmp
@@ -4704,7 +4788,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMalloc_r8_3_source = hipMalloc_(cptr,PRODUCT(dims)*8_8)
+        hipMalloc_r8_3_source = hipMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_real64))
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):) => tmp
@@ -4734,7 +4818,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_r8_3_c_int
 #endif
       !
-      hipMalloc_r8_3_c_int = hipMalloc_(cptr,length1*length2*length3*8_8)
+      hipMalloc_r8_3_c_int = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*byte_size(elem_real64))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3])
     end function
 
@@ -4758,7 +4842,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_r8_3_c_size_t
 #endif
       !
-      hipMalloc_r8_3_c_size_t = hipMalloc_(cptr,length1*length2*length3*8_8)
+      hipMalloc_r8_3_c_size_t = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*byte_size(elem_real64))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3])
     end function
 
@@ -4773,8 +4857,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       real(c_double),pointer,dimension(:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(4),dims(4)
-      integer(8),intent(in),optional :: lbounds8(4),dims8(4)
+      integer(int32),intent(in),optional :: lbounds(4),dims(4)
+      integer(int64),intent(in),optional :: lbounds8(4),dims8(4)
       real(c_double),target,dimension(:,:,:,:),intent(in),optional :: dsource,source,mold
          
       ! 
@@ -4803,21 +4887,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMalloc_r8_4_source = hipMalloc_(cptr,size(dsource)*8_8)
-        hipMalloc_r8_4_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*8_8,hipMemcpyDeviceToDevice)
+        hipMalloc_r8_4_source = hipMalloc_(cptr,size(dsource)*byte_size(elem_real64))
+        hipMalloc_r8_4_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*byte_size(elem_real64),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):) => tmp
       else if ( present(source) ) then
-        hipMalloc_r8_4_source = hipMalloc_(cptr,size(source)*8_8)
-        hipMalloc_r8_4_source = hipMemcpy(cptr,c_loc(source),size(source)*8_8,hipMemcpyHostToDevice)
+        hipMalloc_r8_4_source = hipMalloc_(cptr,size(source)*byte_size(elem_real64))
+        hipMalloc_r8_4_source = hipMemcpy(cptr,c_loc(source),size(source)*byte_size(elem_real64),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):) => tmp
       else if ( present(mold) ) then
-        hipMalloc_r8_4_source = hipMalloc_(cptr,size(mold)*8_8)
+        hipMalloc_r8_4_source = hipMalloc_(cptr,size(mold)*byte_size(elem_real64))
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):) => tmp
       else if ( present(dims8) ) then
-        hipMalloc_r8_4_source = hipMalloc_(cptr,PRODUCT(dims8)*8_8)
+        hipMalloc_r8_4_source = hipMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_real64))
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):) => tmp
@@ -4825,7 +4909,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMalloc_r8_4_source = hipMalloc_(cptr,PRODUCT(dims)*8_8)
+        hipMalloc_r8_4_source = hipMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_real64))
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):) => tmp
@@ -4855,7 +4939,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_r8_4_c_int
 #endif
       !
-      hipMalloc_r8_4_c_int = hipMalloc_(cptr,length1*length2*length3*length4*8_8)
+      hipMalloc_r8_4_c_int = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                             int(length4,kind=int64)*byte_size(elem_real64))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4])
     end function
 
@@ -4879,7 +4964,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_r8_4_c_size_t
 #endif
       !
-      hipMalloc_r8_4_c_size_t = hipMalloc_(cptr,length1*length2*length3*length4*8_8)
+      hipMalloc_r8_4_c_size_t = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                int(length4,kind=int64)*byte_size(elem_real64))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4])
     end function
 
@@ -4894,8 +4980,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       real(c_double),pointer,dimension(:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(5),dims(5)
-      integer(8),intent(in),optional :: lbounds8(5),dims8(5)
+      integer(int32),intent(in),optional :: lbounds(5),dims(5)
+      integer(int64),intent(in),optional :: lbounds8(5),dims8(5)
       real(c_double),target,dimension(:,:,:,:,:),intent(in),optional :: dsource,source,mold
          
       ! 
@@ -4924,21 +5010,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMalloc_r8_5_source = hipMalloc_(cptr,size(dsource)*8_8)
-        hipMalloc_r8_5_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*8_8,hipMemcpyDeviceToDevice)
+        hipMalloc_r8_5_source = hipMalloc_(cptr,size(dsource)*byte_size(elem_real64))
+        hipMalloc_r8_5_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*byte_size(elem_real64),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):) => tmp
       else if ( present(source) ) then
-        hipMalloc_r8_5_source = hipMalloc_(cptr,size(source)*8_8)
-        hipMalloc_r8_5_source = hipMemcpy(cptr,c_loc(source),size(source)*8_8,hipMemcpyHostToDevice)
+        hipMalloc_r8_5_source = hipMalloc_(cptr,size(source)*byte_size(elem_real64))
+        hipMalloc_r8_5_source = hipMemcpy(cptr,c_loc(source),size(source)*byte_size(elem_real64),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):) => tmp
       else if ( present(mold) ) then
-        hipMalloc_r8_5_source = hipMalloc_(cptr,size(mold)*8_8)
+        hipMalloc_r8_5_source = hipMalloc_(cptr,size(mold)*byte_size(elem_real64))
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):) => tmp
       else if ( present(dims8) ) then
-        hipMalloc_r8_5_source = hipMalloc_(cptr,PRODUCT(dims8)*8_8)
+        hipMalloc_r8_5_source = hipMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_real64))
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):) => tmp
@@ -4946,7 +5032,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMalloc_r8_5_source = hipMalloc_(cptr,PRODUCT(dims)*8_8)
+        hipMalloc_r8_5_source = hipMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_real64))
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):) => tmp
@@ -4976,7 +5062,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_r8_5_c_int
 #endif
       !
-      hipMalloc_r8_5_c_int = hipMalloc_(cptr,length1*length2*length3*length4*length5*8_8)
+      hipMalloc_r8_5_c_int = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                             int(length4,kind=int64)*int(length5,kind=int64)*byte_size(elem_real64))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5])
     end function
 
@@ -5000,7 +5087,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_r8_5_c_size_t
 #endif
       !
-      hipMalloc_r8_5_c_size_t = hipMalloc_(cptr,length1*length2*length3*length4*length5*8_8)
+      hipMalloc_r8_5_c_size_t = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                int(length4,kind=int64)*int(length5,kind=int64)*byte_size(elem_real64))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5])
     end function
 
@@ -5015,8 +5103,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       real(c_double),pointer,dimension(:,:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(6),dims(6)
-      integer(8),intent(in),optional :: lbounds8(6),dims8(6)
+      integer(int32),intent(in),optional :: lbounds(6),dims(6)
+      integer(int64),intent(in),optional :: lbounds8(6),dims8(6)
       real(c_double),target,dimension(:,:,:,:,:,:),intent(in),optional :: dsource,source,mold
          
       ! 
@@ -5045,21 +5133,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMalloc_r8_6_source = hipMalloc_(cptr,size(dsource)*8_8)
-        hipMalloc_r8_6_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*8_8,hipMemcpyDeviceToDevice)
+        hipMalloc_r8_6_source = hipMalloc_(cptr,size(dsource)*byte_size(elem_real64))
+        hipMalloc_r8_6_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*byte_size(elem_real64),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):,LBOUND(dsource,6):) => tmp
       else if ( present(source) ) then
-        hipMalloc_r8_6_source = hipMalloc_(cptr,size(source)*8_8)
-        hipMalloc_r8_6_source = hipMemcpy(cptr,c_loc(source),size(source)*8_8,hipMemcpyHostToDevice)
+        hipMalloc_r8_6_source = hipMalloc_(cptr,size(source)*byte_size(elem_real64))
+        hipMalloc_r8_6_source = hipMemcpy(cptr,c_loc(source),size(source)*byte_size(elem_real64),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):,LBOUND(source,6):) => tmp
       else if ( present(mold) ) then
-        hipMalloc_r8_6_source = hipMalloc_(cptr,size(mold)*8_8)
+        hipMalloc_r8_6_source = hipMalloc_(cptr,size(mold)*byte_size(elem_real64))
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):,LBOUND(mold,6):) => tmp
       else if ( present(dims8) ) then
-        hipMalloc_r8_6_source = hipMalloc_(cptr,PRODUCT(dims8)*8_8)
+        hipMalloc_r8_6_source = hipMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_real64))
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):,lbounds8(6):) => tmp
@@ -5067,7 +5155,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMalloc_r8_6_source = hipMalloc_(cptr,PRODUCT(dims)*8_8)
+        hipMalloc_r8_6_source = hipMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_real64))
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):,lbounds(6):) => tmp
@@ -5097,7 +5185,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_r8_6_c_int
 #endif
       !
-      hipMalloc_r8_6_c_int = hipMalloc_(cptr,length1*length2*length3*length4*length5*length6*8_8)
+      hipMalloc_r8_6_c_int = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                             int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*byte_size(elem_real64))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6])
     end function
 
@@ -5121,7 +5210,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_r8_6_c_size_t
 #endif
       !
-      hipMalloc_r8_6_c_size_t = hipMalloc_(cptr,length1*length2*length3*length4*length5*length6*8_8)
+      hipMalloc_r8_6_c_size_t = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*byte_size(elem_real64))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6])
     end function
 
@@ -5136,8 +5226,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       real(c_double),pointer,dimension(:,:,:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(7),dims(7)
-      integer(8),intent(in),optional :: lbounds8(7),dims8(7)
+      integer(int32),intent(in),optional :: lbounds(7),dims(7)
+      integer(int64),intent(in),optional :: lbounds8(7),dims8(7)
       real(c_double),target,dimension(:,:,:,:,:,:,:),intent(in),optional :: dsource,source,mold
          
       ! 
@@ -5166,21 +5256,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMalloc_r8_7_source = hipMalloc_(cptr,size(dsource)*8_8)
-        hipMalloc_r8_7_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*8_8,hipMemcpyDeviceToDevice)
+        hipMalloc_r8_7_source = hipMalloc_(cptr,size(dsource)*byte_size(elem_real64))
+        hipMalloc_r8_7_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*byte_size(elem_real64),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):,LBOUND(dsource,6):,LBOUND(dsource,7):) => tmp
       else if ( present(source) ) then
-        hipMalloc_r8_7_source = hipMalloc_(cptr,size(source)*8_8)
-        hipMalloc_r8_7_source = hipMemcpy(cptr,c_loc(source),size(source)*8_8,hipMemcpyHostToDevice)
+        hipMalloc_r8_7_source = hipMalloc_(cptr,size(source)*byte_size(elem_real64))
+        hipMalloc_r8_7_source = hipMemcpy(cptr,c_loc(source),size(source)*byte_size(elem_real64),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):,LBOUND(source,6):,LBOUND(source,7):) => tmp
       else if ( present(mold) ) then
-        hipMalloc_r8_7_source = hipMalloc_(cptr,size(mold)*8_8)
+        hipMalloc_r8_7_source = hipMalloc_(cptr,size(mold)*byte_size(elem_real64))
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):,LBOUND(mold,6):,LBOUND(mold,7):) => tmp
       else if ( present(dims8) ) then
-        hipMalloc_r8_7_source = hipMalloc_(cptr,PRODUCT(dims8)*8_8)
+        hipMalloc_r8_7_source = hipMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_real64))
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):,lbounds8(6):,lbounds8(7):) => tmp
@@ -5188,7 +5278,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMalloc_r8_7_source = hipMalloc_(cptr,PRODUCT(dims)*8_8)
+        hipMalloc_r8_7_source = hipMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_real64))
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):,lbounds(6):,lbounds(7):) => tmp
@@ -5218,7 +5308,9 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_r8_7_c_int
 #endif
       !
-      hipMalloc_r8_7_c_int = hipMalloc_(cptr,length1*length2*length3*length4*length5*length6*length7*8_8)
+      hipMalloc_r8_7_c_int = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                             int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*&
+                                             int(length7,kind=int64)*byte_size(elem_real64))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6,length7])
     end function
 
@@ -5242,7 +5334,9 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_r8_7_c_size_t
 #endif
       !
-      hipMalloc_r8_7_c_size_t = hipMalloc_(cptr,length1*length2*length3*length4*length5*length6*length7*8_8)
+      hipMalloc_r8_7_c_size_t = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*&
+                                                int(length7,kind=int64)*byte_size(elem_real64))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6,length7])
     end function
 
@@ -5275,15 +5369,15 @@ module hipfort_hipmalloc
       if ( nOptArgs > 1 ) ERROR STOP "ERROR: hipMalloc (scalar version): Only one optional argument ('dsource','source') must be specified."
     
       if ( present(dsource) ) then
-        hipMalloc_c4_0_source = hipMalloc_(cptr,2*4_8)
-        hipMalloc_c4_0_source = hipMemcpy(cptr,c_loc(dsource),2*4_8,hipMemcpyDeviceToDevice)
+        hipMalloc_c4_0_source = hipMalloc_(cptr,2_int64*byte_size(elem_real32))
+        hipMalloc_c4_0_source = hipMemcpy(cptr,c_loc(dsource),2_int64*byte_size(elem_real32),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,ptr)
       else if ( present(source) ) then
-        hipMalloc_c4_0_source = hipMalloc_(cptr,2*4_8)
-        hipMalloc_c4_0_source = hipMemcpy(cptr,c_loc(source),2*4_8,hipMemcpyHostToDevice)
+        hipMalloc_c4_0_source = hipMalloc_(cptr,2_int64*byte_size(elem_real32))
+        hipMalloc_c4_0_source = hipMemcpy(cptr,c_loc(source),2_int64*byte_size(elem_real32),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,ptr)
       else
-        hipMalloc_c4_0_source = hipMalloc_(cptr,2*4_8)
+        hipMalloc_c4_0_source = hipMalloc_(cptr,2_int64*byte_size(elem_real32))
         call c_f_pointer(cptr,ptr)
       end if
     end function
@@ -5300,8 +5394,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       complex(c_float_complex),pointer,dimension(:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(1),dims(1)
-      integer(8),intent(in),optional :: lbounds8(1),dims8(1)
+      integer(int32),intent(in),optional :: lbounds(1),dims(1)
+      integer(int64),intent(in),optional :: lbounds8(1),dims8(1)
       complex(c_float_complex),target,dimension(:),intent(in),optional :: dsource,source,mold
          
       ! 
@@ -5330,21 +5424,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMalloc_c4_1_source = hipMalloc_(cptr,size(dsource)*2*4_8)
-        hipMalloc_c4_1_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*2*4_8,hipMemcpyDeviceToDevice)
+        hipMalloc_c4_1_source = hipMalloc_(cptr,size(dsource,kind=int64)*2_int64*byte_size(elem_real32))
+        hipMalloc_c4_1_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*2_int64*byte_size(elem_real32),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):) => tmp
       else if ( present(source) ) then
-        hipMalloc_c4_1_source = hipMalloc_(cptr,size(source)*2*4_8)
-        hipMalloc_c4_1_source = hipMemcpy(cptr,c_loc(source),size(source)*2*4_8,hipMemcpyHostToDevice)
+        hipMalloc_c4_1_source = hipMalloc_(cptr,size(source,kind=int64)*2_int64*byte_size(elem_real32))
+        hipMalloc_c4_1_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*2_int64*byte_size(elem_real32),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):) => tmp
       else if ( present(mold) ) then
-        hipMalloc_c4_1_source = hipMalloc_(cptr,size(mold)*2*4_8)
+        hipMalloc_c4_1_source = hipMalloc_(cptr,size(mold,kind=int64)*2_int64*byte_size(elem_real32))
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):) => tmp
       else if ( present(dims8) ) then
-        hipMalloc_c4_1_source = hipMalloc_(cptr,PRODUCT(dims8)*2*4_8)
+        hipMalloc_c4_1_source = hipMalloc_(cptr,PRODUCT(dims8)*2_int64*byte_size(elem_real32))
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):) => tmp
@@ -5352,7 +5446,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMalloc_c4_1_source = hipMalloc_(cptr,PRODUCT(dims)*2*4_8)
+        hipMalloc_c4_1_source = hipMalloc_(cptr,PRODUCT(int(dims,kind=int64))*2_int64*byte_size(elem_real32))
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):) => tmp
@@ -5382,7 +5476,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_c4_1_c_int
 #endif
       !
-      hipMalloc_c4_1_c_int = hipMalloc_(cptr,length1*2*4_8)
+      hipMalloc_c4_1_c_int = hipMalloc_(cptr,int(length1,kind=int64)*2_int64*byte_size(elem_real32))
       call c_f_pointer(cptr,ptr,shape=[length1])
     end function
 
@@ -5406,7 +5500,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_c4_1_c_size_t
 #endif
       !
-      hipMalloc_c4_1_c_size_t = hipMalloc_(cptr,length1*2*4_8)
+      hipMalloc_c4_1_c_size_t = hipMalloc_(cptr,int(length1,kind=int64)*2_int64*byte_size(elem_real32))
       call c_f_pointer(cptr,ptr,shape=[length1])
     end function
 
@@ -5421,8 +5515,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       complex(c_float_complex),pointer,dimension(:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(2),dims(2)
-      integer(8),intent(in),optional :: lbounds8(2),dims8(2)
+      integer(int32),intent(in),optional :: lbounds(2),dims(2)
+      integer(int64),intent(in),optional :: lbounds8(2),dims8(2)
       complex(c_float_complex),target,dimension(:,:),intent(in),optional :: dsource,source,mold
          
       ! 
@@ -5451,21 +5545,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMalloc_c4_2_source = hipMalloc_(cptr,size(dsource)*2*4_8)
-        hipMalloc_c4_2_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*2*4_8,hipMemcpyDeviceToDevice)
+        hipMalloc_c4_2_source = hipMalloc_(cptr,size(dsource,kind=int64)*2_int64*byte_size(elem_real32))
+        hipMalloc_c4_2_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*2_int64*byte_size(elem_real32),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):) => tmp
       else if ( present(source) ) then
-        hipMalloc_c4_2_source = hipMalloc_(cptr,size(source)*2*4_8)
-        hipMalloc_c4_2_source = hipMemcpy(cptr,c_loc(source),size(source)*2*4_8,hipMemcpyHostToDevice)
+        hipMalloc_c4_2_source = hipMalloc_(cptr,size(source,kind=int64)*2_int64*byte_size(elem_real32))
+        hipMalloc_c4_2_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*2_int64*byte_size(elem_real32),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):) => tmp
       else if ( present(mold) ) then
-        hipMalloc_c4_2_source = hipMalloc_(cptr,size(mold)*2*4_8)
+        hipMalloc_c4_2_source = hipMalloc_(cptr,size(mold,kind=int64)*2_int64*byte_size(elem_real32))
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):) => tmp
       else if ( present(dims8) ) then
-        hipMalloc_c4_2_source = hipMalloc_(cptr,PRODUCT(dims8)*2*4_8)
+        hipMalloc_c4_2_source = hipMalloc_(cptr,PRODUCT(dims8)*2_int64*byte_size(elem_real32))
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):) => tmp
@@ -5473,7 +5567,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMalloc_c4_2_source = hipMalloc_(cptr,PRODUCT(dims)*2*4_8)
+        hipMalloc_c4_2_source = hipMalloc_(cptr,PRODUCT(int(dims,kind=int64))*2_int64*byte_size(elem_real32))
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):) => tmp
@@ -5503,7 +5597,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_c4_2_c_int
 #endif
       !
-      hipMalloc_c4_2_c_int = hipMalloc_(cptr,length1*length2*2*4_8)
+      hipMalloc_c4_2_c_int = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*2_int64*byte_size(elem_real32))
       call c_f_pointer(cptr,ptr,shape=[length1,length2])
     end function
 
@@ -5527,7 +5621,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_c4_2_c_size_t
 #endif
       !
-      hipMalloc_c4_2_c_size_t = hipMalloc_(cptr,length1*length2*2*4_8)
+      hipMalloc_c4_2_c_size_t = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*2_int64*byte_size(elem_real32))
       call c_f_pointer(cptr,ptr,shape=[length1,length2])
     end function
 
@@ -5542,8 +5636,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       complex(c_float_complex),pointer,dimension(:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(3),dims(3)
-      integer(8),intent(in),optional :: lbounds8(3),dims8(3)
+      integer(int32),intent(in),optional :: lbounds(3),dims(3)
+      integer(int64),intent(in),optional :: lbounds8(3),dims8(3)
       complex(c_float_complex),target,dimension(:,:,:),intent(in),optional :: dsource,source,mold
          
       ! 
@@ -5572,21 +5666,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMalloc_c4_3_source = hipMalloc_(cptr,size(dsource)*2*4_8)
-        hipMalloc_c4_3_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*2*4_8,hipMemcpyDeviceToDevice)
+        hipMalloc_c4_3_source = hipMalloc_(cptr,size(dsource,kind=int64)*2_int64*byte_size(elem_real32))
+        hipMalloc_c4_3_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*2_int64*byte_size(elem_real32),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):) => tmp
       else if ( present(source) ) then
-        hipMalloc_c4_3_source = hipMalloc_(cptr,size(source)*2*4_8)
-        hipMalloc_c4_3_source = hipMemcpy(cptr,c_loc(source),size(source)*2*4_8,hipMemcpyHostToDevice)
+        hipMalloc_c4_3_source = hipMalloc_(cptr,size(source,kind=int64)*2_int64*byte_size(elem_real32))
+        hipMalloc_c4_3_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*2_int64*byte_size(elem_real32),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):) => tmp
       else if ( present(mold) ) then
-        hipMalloc_c4_3_source = hipMalloc_(cptr,size(mold)*2*4_8)
+        hipMalloc_c4_3_source = hipMalloc_(cptr,size(mold,kind=int64)*2_int64*byte_size(elem_real32))
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):) => tmp
       else if ( present(dims8) ) then
-        hipMalloc_c4_3_source = hipMalloc_(cptr,PRODUCT(dims8)*2*4_8)
+        hipMalloc_c4_3_source = hipMalloc_(cptr,PRODUCT(dims8)*2_int64*byte_size(elem_real32))
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):) => tmp
@@ -5594,7 +5688,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMalloc_c4_3_source = hipMalloc_(cptr,PRODUCT(dims)*2*4_8)
+        hipMalloc_c4_3_source = hipMalloc_(cptr,PRODUCT(int(dims,kind=int64))*2_int64*byte_size(elem_real32))
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):) => tmp
@@ -5624,7 +5718,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_c4_3_c_int
 #endif
       !
-      hipMalloc_c4_3_c_int = hipMalloc_(cptr,length1*length2*length3*2*4_8)
+      hipMalloc_c4_3_c_int = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*2_int64*byte_size(elem_real32))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3])
     end function
 
@@ -5648,7 +5742,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_c4_3_c_size_t
 #endif
       !
-      hipMalloc_c4_3_c_size_t = hipMalloc_(cptr,length1*length2*length3*2*4_8)
+      hipMalloc_c4_3_c_size_t = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*2_int64*byte_size(elem_real32))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3])
     end function
 
@@ -5663,8 +5757,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       complex(c_float_complex),pointer,dimension(:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(4),dims(4)
-      integer(8),intent(in),optional :: lbounds8(4),dims8(4)
+      integer(int32),intent(in),optional :: lbounds(4),dims(4)
+      integer(int64),intent(in),optional :: lbounds8(4),dims8(4)
       complex(c_float_complex),target,dimension(:,:,:,:),intent(in),optional :: dsource,source,mold
          
       ! 
@@ -5693,21 +5787,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMalloc_c4_4_source = hipMalloc_(cptr,size(dsource)*2*4_8)
-        hipMalloc_c4_4_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*2*4_8,hipMemcpyDeviceToDevice)
+        hipMalloc_c4_4_source = hipMalloc_(cptr,size(dsource,kind=int64)*2_int64*byte_size(elem_real32))
+        hipMalloc_c4_4_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*2_int64*byte_size(elem_real32),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):) => tmp
       else if ( present(source) ) then
-        hipMalloc_c4_4_source = hipMalloc_(cptr,size(source)*2*4_8)
-        hipMalloc_c4_4_source = hipMemcpy(cptr,c_loc(source),size(source)*2*4_8,hipMemcpyHostToDevice)
+        hipMalloc_c4_4_source = hipMalloc_(cptr,size(source,kind=int64)*2_int64*byte_size(elem_real32))
+        hipMalloc_c4_4_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*2_int64*byte_size(elem_real32),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):) => tmp
       else if ( present(mold) ) then
-        hipMalloc_c4_4_source = hipMalloc_(cptr,size(mold)*2*4_8)
+        hipMalloc_c4_4_source = hipMalloc_(cptr,size(mold,kind=int64)*2_int64*byte_size(elem_real32))
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):) => tmp
       else if ( present(dims8) ) then
-        hipMalloc_c4_4_source = hipMalloc_(cptr,PRODUCT(dims8)*2*4_8)
+        hipMalloc_c4_4_source = hipMalloc_(cptr,PRODUCT(dims8)*2_int64*byte_size(elem_real32))
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):) => tmp
@@ -5715,7 +5809,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMalloc_c4_4_source = hipMalloc_(cptr,PRODUCT(dims)*2*4_8)
+        hipMalloc_c4_4_source = hipMalloc_(cptr,PRODUCT(int(dims,kind=int64))*2_int64*byte_size(elem_real32))
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):) => tmp
@@ -5745,7 +5839,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_c4_4_c_int
 #endif
       !
-      hipMalloc_c4_4_c_int = hipMalloc_(cptr,length1*length2*length3*length4*2*4_8)
+      hipMalloc_c4_4_c_int = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                             int(length4,kind=int64)*2_int64*byte_size(elem_real32))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4])
     end function
 
@@ -5769,7 +5864,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_c4_4_c_size_t
 #endif
       !
-      hipMalloc_c4_4_c_size_t = hipMalloc_(cptr,length1*length2*length3*length4*2*4_8)
+      hipMalloc_c4_4_c_size_t = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                int(length4,kind=int64)*2_int64*byte_size(elem_real32))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4])
     end function
 
@@ -5784,8 +5880,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       complex(c_float_complex),pointer,dimension(:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(5),dims(5)
-      integer(8),intent(in),optional :: lbounds8(5),dims8(5)
+      integer(int32),intent(in),optional :: lbounds(5),dims(5)
+      integer(int64),intent(in),optional :: lbounds8(5),dims8(5)
       complex(c_float_complex),target,dimension(:,:,:,:,:),intent(in),optional :: dsource,source,mold
          
       ! 
@@ -5814,21 +5910,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMalloc_c4_5_source = hipMalloc_(cptr,size(dsource)*2*4_8)
-        hipMalloc_c4_5_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*2*4_8,hipMemcpyDeviceToDevice)
+        hipMalloc_c4_5_source = hipMalloc_(cptr,size(dsource,kind=int64)*2_int64*byte_size(elem_real32))
+        hipMalloc_c4_5_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*2_int64*byte_size(elem_real32),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):) => tmp
       else if ( present(source) ) then
-        hipMalloc_c4_5_source = hipMalloc_(cptr,size(source)*2*4_8)
-        hipMalloc_c4_5_source = hipMemcpy(cptr,c_loc(source),size(source)*2*4_8,hipMemcpyHostToDevice)
+        hipMalloc_c4_5_source = hipMalloc_(cptr,size(source,kind=int64)*2_int64*byte_size(elem_real32))
+        hipMalloc_c4_5_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*2_int64*byte_size(elem_real32),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):) => tmp
       else if ( present(mold) ) then
-        hipMalloc_c4_5_source = hipMalloc_(cptr,size(mold)*2*4_8)
+        hipMalloc_c4_5_source = hipMalloc_(cptr,size(mold,kind=int64)*2_int64*byte_size(elem_real32))
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):) => tmp
       else if ( present(dims8) ) then
-        hipMalloc_c4_5_source = hipMalloc_(cptr,PRODUCT(dims8)*2*4_8)
+        hipMalloc_c4_5_source = hipMalloc_(cptr,PRODUCT(dims8)*2_int64*byte_size(elem_real32))
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):) => tmp
@@ -5836,7 +5932,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMalloc_c4_5_source = hipMalloc_(cptr,PRODUCT(dims)*2*4_8)
+        hipMalloc_c4_5_source = hipMalloc_(cptr,PRODUCT(int(dims,kind=int64))*2_int64*byte_size(elem_real32))
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):) => tmp
@@ -5866,7 +5962,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_c4_5_c_int
 #endif
       !
-      hipMalloc_c4_5_c_int = hipMalloc_(cptr,length1*length2*length3*length4*length5*2*4_8)
+      hipMalloc_c4_5_c_int = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                             int(length4,kind=int64)*int(length5,kind=int64)*2_int64*byte_size(elem_real32))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5])
     end function
 
@@ -5890,7 +5987,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_c4_5_c_size_t
 #endif
       !
-      hipMalloc_c4_5_c_size_t = hipMalloc_(cptr,length1*length2*length3*length4*length5*2*4_8)
+      hipMalloc_c4_5_c_size_t = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                int(length4,kind=int64)*int(length5,kind=int64)*2_int64*byte_size(elem_real32))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5])
     end function
 
@@ -5905,8 +6003,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       complex(c_float_complex),pointer,dimension(:,:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(6),dims(6)
-      integer(8),intent(in),optional :: lbounds8(6),dims8(6)
+      integer(int32),intent(in),optional :: lbounds(6),dims(6)
+      integer(int64),intent(in),optional :: lbounds8(6),dims8(6)
       complex(c_float_complex),target,dimension(:,:,:,:,:,:),intent(in),optional :: dsource,source,mold
          
       ! 
@@ -5935,21 +6033,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMalloc_c4_6_source = hipMalloc_(cptr,size(dsource)*2*4_8)
-        hipMalloc_c4_6_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*2*4_8,hipMemcpyDeviceToDevice)
+        hipMalloc_c4_6_source = hipMalloc_(cptr,size(dsource,kind=int64)*2_int64*byte_size(elem_real32))
+        hipMalloc_c4_6_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*2_int64*byte_size(elem_real32),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):,LBOUND(dsource,6):) => tmp
       else if ( present(source) ) then
-        hipMalloc_c4_6_source = hipMalloc_(cptr,size(source)*2*4_8)
-        hipMalloc_c4_6_source = hipMemcpy(cptr,c_loc(source),size(source)*2*4_8,hipMemcpyHostToDevice)
+        hipMalloc_c4_6_source = hipMalloc_(cptr,size(source,kind=int64)*2_int64*byte_size(elem_real32))
+        hipMalloc_c4_6_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*2_int64*byte_size(elem_real32),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):,LBOUND(source,6):) => tmp
       else if ( present(mold) ) then
-        hipMalloc_c4_6_source = hipMalloc_(cptr,size(mold)*2*4_8)
+        hipMalloc_c4_6_source = hipMalloc_(cptr,size(mold,kind=int64)*2_int64*byte_size(elem_real32))
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):,LBOUND(mold,6):) => tmp
       else if ( present(dims8) ) then
-        hipMalloc_c4_6_source = hipMalloc_(cptr,PRODUCT(dims8)*2*4_8)
+        hipMalloc_c4_6_source = hipMalloc_(cptr,PRODUCT(dims8)*2_int64*byte_size(elem_real32))
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):,lbounds8(6):) => tmp
@@ -5957,7 +6055,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMalloc_c4_6_source = hipMalloc_(cptr,PRODUCT(dims)*2*4_8)
+        hipMalloc_c4_6_source = hipMalloc_(cptr,PRODUCT(int(dims,kind=int64))*2_int64*byte_size(elem_real32))
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):,lbounds(6):) => tmp
@@ -5987,7 +6085,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_c4_6_c_int
 #endif
       !
-      hipMalloc_c4_6_c_int = hipMalloc_(cptr,length1*length2*length3*length4*length5*length6*2*4_8)
+      hipMalloc_c4_6_c_int = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                             int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*2_int64*byte_size(elem_real32))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6])
     end function
 
@@ -6011,7 +6110,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_c4_6_c_size_t
 #endif
       !
-      hipMalloc_c4_6_c_size_t = hipMalloc_(cptr,length1*length2*length3*length4*length5*length6*2*4_8)
+      hipMalloc_c4_6_c_size_t = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*2_int64*byte_size(elem_real32))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6])
     end function
 
@@ -6026,8 +6126,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       complex(c_float_complex),pointer,dimension(:,:,:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(7),dims(7)
-      integer(8),intent(in),optional :: lbounds8(7),dims8(7)
+      integer(int32),intent(in),optional :: lbounds(7),dims(7)
+      integer(int64),intent(in),optional :: lbounds8(7),dims8(7)
       complex(c_float_complex),target,dimension(:,:,:,:,:,:,:),intent(in),optional :: dsource,source,mold
          
       ! 
@@ -6056,21 +6156,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMalloc_c4_7_source = hipMalloc_(cptr,size(dsource)*2*4_8)
-        hipMalloc_c4_7_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*2*4_8,hipMemcpyDeviceToDevice)
+        hipMalloc_c4_7_source = hipMalloc_(cptr,size(dsource,kind=int64)*2_int64*byte_size(elem_real32))
+        hipMalloc_c4_7_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*2_int64*byte_size(elem_real32),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):,LBOUND(dsource,6):,LBOUND(dsource,7):) => tmp
       else if ( present(source) ) then
-        hipMalloc_c4_7_source = hipMalloc_(cptr,size(source)*2*4_8)
-        hipMalloc_c4_7_source = hipMemcpy(cptr,c_loc(source),size(source)*2*4_8,hipMemcpyHostToDevice)
+        hipMalloc_c4_7_source = hipMalloc_(cptr,size(source,kind=int64)*2_int64*byte_size(elem_real32))
+        hipMalloc_c4_7_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*2_int64*byte_size(elem_real32),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):,LBOUND(source,6):,LBOUND(source,7):) => tmp
       else if ( present(mold) ) then
-        hipMalloc_c4_7_source = hipMalloc_(cptr,size(mold)*2*4_8)
+        hipMalloc_c4_7_source = hipMalloc_(cptr,size(mold,kind=int64)*2_int64*byte_size(elem_real32))
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):,LBOUND(mold,6):,LBOUND(mold,7):) => tmp
       else if ( present(dims8) ) then
-        hipMalloc_c4_7_source = hipMalloc_(cptr,PRODUCT(dims8)*2*4_8)
+        hipMalloc_c4_7_source = hipMalloc_(cptr,PRODUCT(dims8)*2_int64*byte_size(elem_real32))
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):,lbounds8(6):,lbounds8(7):) => tmp
@@ -6078,7 +6178,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMalloc_c4_7_source = hipMalloc_(cptr,PRODUCT(dims)*2*4_8)
+        hipMalloc_c4_7_source = hipMalloc_(cptr,PRODUCT(int(dims,kind=int64))*2_int64*byte_size(elem_real32))
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):,lbounds(6):,lbounds(7):) => tmp
@@ -6108,7 +6208,9 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_c4_7_c_int
 #endif
       !
-      hipMalloc_c4_7_c_int = hipMalloc_(cptr,length1*length2*length3*length4*length5*length6*length7*2*4_8)
+      hipMalloc_c4_7_c_int = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                             int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*&
+                                             int(length7,kind=int64)*2_int64*byte_size(elem_real32))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6,length7])
     end function
 
@@ -6132,7 +6234,9 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_c4_7_c_size_t
 #endif
       !
-      hipMalloc_c4_7_c_size_t = hipMalloc_(cptr,length1*length2*length3*length4*length5*length6*length7*2*4_8)
+      hipMalloc_c4_7_c_size_t = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*&
+                                                int(length7,kind=int64)*2_int64*byte_size(elem_real32))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6,length7])
     end function
 
@@ -6165,15 +6269,15 @@ module hipfort_hipmalloc
       if ( nOptArgs > 1 ) ERROR STOP "ERROR: hipMalloc (scalar version): Only one optional argument ('dsource','source') must be specified."
     
       if ( present(dsource) ) then
-        hipMalloc_c8_0_source = hipMalloc_(cptr,2*8_8)
-        hipMalloc_c8_0_source = hipMemcpy(cptr,c_loc(dsource),2*8_8,hipMemcpyDeviceToDevice)
+        hipMalloc_c8_0_source = hipMalloc_(cptr,2_int64*byte_size(elem_real64))
+        hipMalloc_c8_0_source = hipMemcpy(cptr,c_loc(dsource),2_int64*byte_size(elem_real64),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,ptr)
       else if ( present(source) ) then
-        hipMalloc_c8_0_source = hipMalloc_(cptr,2*8_8)
-        hipMalloc_c8_0_source = hipMemcpy(cptr,c_loc(source),2*8_8,hipMemcpyHostToDevice)
+        hipMalloc_c8_0_source = hipMalloc_(cptr,2_int64*byte_size(elem_real64))
+        hipMalloc_c8_0_source = hipMemcpy(cptr,c_loc(source),2_int64*byte_size(elem_real64),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,ptr)
       else
-        hipMalloc_c8_0_source = hipMalloc_(cptr,2*8_8)
+        hipMalloc_c8_0_source = hipMalloc_(cptr,2_int64*byte_size(elem_real64))
         call c_f_pointer(cptr,ptr)
       end if
     end function
@@ -6190,8 +6294,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       complex(c_double_complex),pointer,dimension(:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(1),dims(1)
-      integer(8),intent(in),optional :: lbounds8(1),dims8(1)
+      integer(int32),intent(in),optional :: lbounds(1),dims(1)
+      integer(int64),intent(in),optional :: lbounds8(1),dims8(1)
       complex(c_double_complex),target,dimension(:),intent(in),optional :: dsource,source,mold
          
       ! 
@@ -6220,21 +6324,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMalloc_c8_1_source = hipMalloc_(cptr,size(dsource)*2*8_8)
-        hipMalloc_c8_1_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*2*8_8,hipMemcpyDeviceToDevice)
+        hipMalloc_c8_1_source = hipMalloc_(cptr,size(dsource,kind=int64)*2_int64*byte_size(elem_real64))
+        hipMalloc_c8_1_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*2_int64*byte_size(elem_real64),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):) => tmp
       else if ( present(source) ) then
-        hipMalloc_c8_1_source = hipMalloc_(cptr,size(source)*2*8_8)
-        hipMalloc_c8_1_source = hipMemcpy(cptr,c_loc(source),size(source)*2*8_8,hipMemcpyHostToDevice)
+        hipMalloc_c8_1_source = hipMalloc_(cptr,size(source,kind=int64)*2_int64*byte_size(elem_real64))
+        hipMalloc_c8_1_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*2_int64*byte_size(elem_real64),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):) => tmp
       else if ( present(mold) ) then
-        hipMalloc_c8_1_source = hipMalloc_(cptr,size(mold)*2*8_8)
+        hipMalloc_c8_1_source = hipMalloc_(cptr,size(mold,kind=int64)*2_int64*byte_size(elem_real64))
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):) => tmp
       else if ( present(dims8) ) then
-        hipMalloc_c8_1_source = hipMalloc_(cptr,PRODUCT(dims8)*2*8_8)
+        hipMalloc_c8_1_source = hipMalloc_(cptr,PRODUCT(dims8)*2_int64*byte_size(elem_real64))
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):) => tmp
@@ -6242,7 +6346,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMalloc_c8_1_source = hipMalloc_(cptr,PRODUCT(dims)*2*8_8)
+        hipMalloc_c8_1_source = hipMalloc_(cptr,PRODUCT(int(dims,kind=int64))*2_int64*byte_size(elem_real64))
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):) => tmp
@@ -6272,7 +6376,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_c8_1_c_int
 #endif
       !
-      hipMalloc_c8_1_c_int = hipMalloc_(cptr,length1*2*8_8)
+      hipMalloc_c8_1_c_int = hipMalloc_(cptr,int(length1,kind=int64)*2_int64*byte_size(elem_real64))
       call c_f_pointer(cptr,ptr,shape=[length1])
     end function
 
@@ -6296,7 +6400,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_c8_1_c_size_t
 #endif
       !
-      hipMalloc_c8_1_c_size_t = hipMalloc_(cptr,length1*2*8_8)
+      hipMalloc_c8_1_c_size_t = hipMalloc_(cptr,int(length1,kind=int64)*2_int64*byte_size(elem_real64))
       call c_f_pointer(cptr,ptr,shape=[length1])
     end function
 
@@ -6311,8 +6415,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       complex(c_double_complex),pointer,dimension(:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(2),dims(2)
-      integer(8),intent(in),optional :: lbounds8(2),dims8(2)
+      integer(int32),intent(in),optional :: lbounds(2),dims(2)
+      integer(int64),intent(in),optional :: lbounds8(2),dims8(2)
       complex(c_double_complex),target,dimension(:,:),intent(in),optional :: dsource,source,mold
          
       ! 
@@ -6341,21 +6445,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMalloc_c8_2_source = hipMalloc_(cptr,size(dsource)*2*8_8)
-        hipMalloc_c8_2_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*2*8_8,hipMemcpyDeviceToDevice)
+        hipMalloc_c8_2_source = hipMalloc_(cptr,size(dsource,kind=int64)*2_int64*byte_size(elem_real64))
+        hipMalloc_c8_2_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*2_int64*byte_size(elem_real64),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):) => tmp
       else if ( present(source) ) then
-        hipMalloc_c8_2_source = hipMalloc_(cptr,size(source)*2*8_8)
-        hipMalloc_c8_2_source = hipMemcpy(cptr,c_loc(source),size(source)*2*8_8,hipMemcpyHostToDevice)
+        hipMalloc_c8_2_source = hipMalloc_(cptr,size(source,kind=int64)*2_int64*byte_size(elem_real64))
+        hipMalloc_c8_2_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*2_int64*byte_size(elem_real64),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):) => tmp
       else if ( present(mold) ) then
-        hipMalloc_c8_2_source = hipMalloc_(cptr,size(mold)*2*8_8)
+        hipMalloc_c8_2_source = hipMalloc_(cptr,size(mold,kind=int64)*2_int64*byte_size(elem_real64))
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):) => tmp
       else if ( present(dims8) ) then
-        hipMalloc_c8_2_source = hipMalloc_(cptr,PRODUCT(dims8)*2*8_8)
+        hipMalloc_c8_2_source = hipMalloc_(cptr,PRODUCT(dims8)*2_int64*byte_size(elem_real64))
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):) => tmp
@@ -6363,7 +6467,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMalloc_c8_2_source = hipMalloc_(cptr,PRODUCT(dims)*2*8_8)
+        hipMalloc_c8_2_source = hipMalloc_(cptr,PRODUCT(int(dims,kind=int64))*2_int64*byte_size(elem_real64))
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):) => tmp
@@ -6393,7 +6497,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_c8_2_c_int
 #endif
       !
-      hipMalloc_c8_2_c_int = hipMalloc_(cptr,length1*length2*2*8_8)
+      hipMalloc_c8_2_c_int = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*2_int64*byte_size(elem_real64))
       call c_f_pointer(cptr,ptr,shape=[length1,length2])
     end function
 
@@ -6417,7 +6521,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_c8_2_c_size_t
 #endif
       !
-      hipMalloc_c8_2_c_size_t = hipMalloc_(cptr,length1*length2*2*8_8)
+      hipMalloc_c8_2_c_size_t = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*2_int64*byte_size(elem_real64))
       call c_f_pointer(cptr,ptr,shape=[length1,length2])
     end function
 
@@ -6432,8 +6536,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       complex(c_double_complex),pointer,dimension(:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(3),dims(3)
-      integer(8),intent(in),optional :: lbounds8(3),dims8(3)
+      integer(int32),intent(in),optional :: lbounds(3),dims(3)
+      integer(int64),intent(in),optional :: lbounds8(3),dims8(3)
       complex(c_double_complex),target,dimension(:,:,:),intent(in),optional :: dsource,source,mold
          
       ! 
@@ -6462,21 +6566,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMalloc_c8_3_source = hipMalloc_(cptr,size(dsource)*2*8_8)
-        hipMalloc_c8_3_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*2*8_8,hipMemcpyDeviceToDevice)
+        hipMalloc_c8_3_source = hipMalloc_(cptr,size(dsource,kind=int64)*2_int64*byte_size(elem_real64))
+        hipMalloc_c8_3_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*2_int64*byte_size(elem_real64),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):) => tmp
       else if ( present(source) ) then
-        hipMalloc_c8_3_source = hipMalloc_(cptr,size(source)*2*8_8)
-        hipMalloc_c8_3_source = hipMemcpy(cptr,c_loc(source),size(source)*2*8_8,hipMemcpyHostToDevice)
+        hipMalloc_c8_3_source = hipMalloc_(cptr,size(source,kind=int64)*2_int64*byte_size(elem_real64))
+        hipMalloc_c8_3_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*2_int64*byte_size(elem_real64),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):) => tmp
       else if ( present(mold) ) then
-        hipMalloc_c8_3_source = hipMalloc_(cptr,size(mold)*2*8_8)
+        hipMalloc_c8_3_source = hipMalloc_(cptr,size(mold,kind=int64)*2_int64*byte_size(elem_real64))
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):) => tmp
       else if ( present(dims8) ) then
-        hipMalloc_c8_3_source = hipMalloc_(cptr,PRODUCT(dims8)*2*8_8)
+        hipMalloc_c8_3_source = hipMalloc_(cptr,PRODUCT(dims8)*2_int64*byte_size(elem_real64))
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):) => tmp
@@ -6484,7 +6588,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMalloc_c8_3_source = hipMalloc_(cptr,PRODUCT(dims)*2*8_8)
+        hipMalloc_c8_3_source = hipMalloc_(cptr,PRODUCT(int(dims,kind=int64))*2_int64*byte_size(elem_real64))
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):) => tmp
@@ -6514,7 +6618,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_c8_3_c_int
 #endif
       !
-      hipMalloc_c8_3_c_int = hipMalloc_(cptr,length1*length2*length3*2*8_8)
+      hipMalloc_c8_3_c_int = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*2_int64*byte_size(elem_real64))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3])
     end function
 
@@ -6538,7 +6642,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_c8_3_c_size_t
 #endif
       !
-      hipMalloc_c8_3_c_size_t = hipMalloc_(cptr,length1*length2*length3*2*8_8)
+      hipMalloc_c8_3_c_size_t = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*2_int64*byte_size(elem_real64))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3])
     end function
 
@@ -6553,8 +6657,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       complex(c_double_complex),pointer,dimension(:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(4),dims(4)
-      integer(8),intent(in),optional :: lbounds8(4),dims8(4)
+      integer(int32),intent(in),optional :: lbounds(4),dims(4)
+      integer(int64),intent(in),optional :: lbounds8(4),dims8(4)
       complex(c_double_complex),target,dimension(:,:,:,:),intent(in),optional :: dsource,source,mold
          
       ! 
@@ -6583,21 +6687,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMalloc_c8_4_source = hipMalloc_(cptr,size(dsource)*2*8_8)
-        hipMalloc_c8_4_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*2*8_8,hipMemcpyDeviceToDevice)
+        hipMalloc_c8_4_source = hipMalloc_(cptr,size(dsource,kind=int64)*2_int64*byte_size(elem_real64))
+        hipMalloc_c8_4_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*2_int64*byte_size(elem_real64),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):) => tmp
       else if ( present(source) ) then
-        hipMalloc_c8_4_source = hipMalloc_(cptr,size(source)*2*8_8)
-        hipMalloc_c8_4_source = hipMemcpy(cptr,c_loc(source),size(source)*2*8_8,hipMemcpyHostToDevice)
+        hipMalloc_c8_4_source = hipMalloc_(cptr,size(source,kind=int64)*2_int64*byte_size(elem_real64))
+        hipMalloc_c8_4_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*2_int64*byte_size(elem_real64),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):) => tmp
       else if ( present(mold) ) then
-        hipMalloc_c8_4_source = hipMalloc_(cptr,size(mold)*2*8_8)
+        hipMalloc_c8_4_source = hipMalloc_(cptr,size(mold,kind=int64)*2_int64*byte_size(elem_real64))
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):) => tmp
       else if ( present(dims8) ) then
-        hipMalloc_c8_4_source = hipMalloc_(cptr,PRODUCT(dims8)*2*8_8)
+        hipMalloc_c8_4_source = hipMalloc_(cptr,PRODUCT(dims8)*2_int64*byte_size(elem_real64))
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):) => tmp
@@ -6605,7 +6709,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMalloc_c8_4_source = hipMalloc_(cptr,PRODUCT(dims)*2*8_8)
+        hipMalloc_c8_4_source = hipMalloc_(cptr,PRODUCT(int(dims,kind=int64))*2_int64*byte_size(elem_real64))
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):) => tmp
@@ -6635,7 +6739,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_c8_4_c_int
 #endif
       !
-      hipMalloc_c8_4_c_int = hipMalloc_(cptr,length1*length2*length3*length4*2*8_8)
+      hipMalloc_c8_4_c_int = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                             int(length4,kind=int64)*2_int64*byte_size(elem_real64))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4])
     end function
 
@@ -6659,7 +6764,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_c8_4_c_size_t
 #endif
       !
-      hipMalloc_c8_4_c_size_t = hipMalloc_(cptr,length1*length2*length3*length4*2*8_8)
+      hipMalloc_c8_4_c_size_t = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                int(length4,kind=int64)*2_int64*byte_size(elem_real64))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4])
     end function
 
@@ -6674,8 +6780,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       complex(c_double_complex),pointer,dimension(:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(5),dims(5)
-      integer(8),intent(in),optional :: lbounds8(5),dims8(5)
+      integer(int32),intent(in),optional :: lbounds(5),dims(5)
+      integer(int64),intent(in),optional :: lbounds8(5),dims8(5)
       complex(c_double_complex),target,dimension(:,:,:,:,:),intent(in),optional :: dsource,source,mold
          
       ! 
@@ -6704,21 +6810,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMalloc_c8_5_source = hipMalloc_(cptr,size(dsource)*2*8_8)
-        hipMalloc_c8_5_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*2*8_8,hipMemcpyDeviceToDevice)
+        hipMalloc_c8_5_source = hipMalloc_(cptr,size(dsource,kind=int64)*2_int64*byte_size(elem_real64))
+        hipMalloc_c8_5_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*2_int64*byte_size(elem_real64),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):) => tmp
       else if ( present(source) ) then
-        hipMalloc_c8_5_source = hipMalloc_(cptr,size(source)*2*8_8)
-        hipMalloc_c8_5_source = hipMemcpy(cptr,c_loc(source),size(source)*2*8_8,hipMemcpyHostToDevice)
+        hipMalloc_c8_5_source = hipMalloc_(cptr,size(source,kind=int64)*2_int64*byte_size(elem_real64))
+        hipMalloc_c8_5_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*2_int64*byte_size(elem_real64),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):) => tmp
       else if ( present(mold) ) then
-        hipMalloc_c8_5_source = hipMalloc_(cptr,size(mold)*2*8_8)
+        hipMalloc_c8_5_source = hipMalloc_(cptr,size(mold,kind=int64)*2_int64*byte_size(elem_real64))
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):) => tmp
       else if ( present(dims8) ) then
-        hipMalloc_c8_5_source = hipMalloc_(cptr,PRODUCT(dims8)*2*8_8)
+        hipMalloc_c8_5_source = hipMalloc_(cptr,PRODUCT(dims8)*2_int64*byte_size(elem_real64))
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):) => tmp
@@ -6726,7 +6832,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMalloc_c8_5_source = hipMalloc_(cptr,PRODUCT(dims)*2*8_8)
+        hipMalloc_c8_5_source = hipMalloc_(cptr,PRODUCT(int(dims,kind=int64))*2_int64*byte_size(elem_real64))
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):) => tmp
@@ -6756,7 +6862,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_c8_5_c_int
 #endif
       !
-      hipMalloc_c8_5_c_int = hipMalloc_(cptr,length1*length2*length3*length4*length5*2*8_8)
+      hipMalloc_c8_5_c_int = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                             int(length4,kind=int64)*int(length5,kind=int64)*2_int64*byte_size(elem_real64))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5])
     end function
 
@@ -6780,7 +6887,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_c8_5_c_size_t
 #endif
       !
-      hipMalloc_c8_5_c_size_t = hipMalloc_(cptr,length1*length2*length3*length4*length5*2*8_8)
+      hipMalloc_c8_5_c_size_t = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                int(length4,kind=int64)*int(length5,kind=int64)*2_int64*byte_size(elem_real64))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5])
     end function
 
@@ -6795,8 +6903,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       complex(c_double_complex),pointer,dimension(:,:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(6),dims(6)
-      integer(8),intent(in),optional :: lbounds8(6),dims8(6)
+      integer(int32),intent(in),optional :: lbounds(6),dims(6)
+      integer(int64),intent(in),optional :: lbounds8(6),dims8(6)
       complex(c_double_complex),target,dimension(:,:,:,:,:,:),intent(in),optional :: dsource,source,mold
          
       ! 
@@ -6825,21 +6933,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMalloc_c8_6_source = hipMalloc_(cptr,size(dsource)*2*8_8)
-        hipMalloc_c8_6_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*2*8_8,hipMemcpyDeviceToDevice)
+        hipMalloc_c8_6_source = hipMalloc_(cptr,size(dsource,kind=int64)*2_int64*byte_size(elem_real64))
+        hipMalloc_c8_6_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*2_int64*byte_size(elem_real64),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):,LBOUND(dsource,6):) => tmp
       else if ( present(source) ) then
-        hipMalloc_c8_6_source = hipMalloc_(cptr,size(source)*2*8_8)
-        hipMalloc_c8_6_source = hipMemcpy(cptr,c_loc(source),size(source)*2*8_8,hipMemcpyHostToDevice)
+        hipMalloc_c8_6_source = hipMalloc_(cptr,size(source,kind=int64)*2_int64*byte_size(elem_real64))
+        hipMalloc_c8_6_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*2_int64*byte_size(elem_real64),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):,LBOUND(source,6):) => tmp
       else if ( present(mold) ) then
-        hipMalloc_c8_6_source = hipMalloc_(cptr,size(mold)*2*8_8)
+        hipMalloc_c8_6_source = hipMalloc_(cptr,size(mold,kind=int64)*2_int64*byte_size(elem_real64))
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):,LBOUND(mold,6):) => tmp
       else if ( present(dims8) ) then
-        hipMalloc_c8_6_source = hipMalloc_(cptr,PRODUCT(dims8)*2*8_8)
+        hipMalloc_c8_6_source = hipMalloc_(cptr,PRODUCT(dims8)*2_int64*byte_size(elem_real64))
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):,lbounds8(6):) => tmp
@@ -6847,7 +6955,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMalloc_c8_6_source = hipMalloc_(cptr,PRODUCT(dims)*2*8_8)
+        hipMalloc_c8_6_source = hipMalloc_(cptr,PRODUCT(int(dims,kind=int64))*2_int64*byte_size(elem_real64))
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):,lbounds(6):) => tmp
@@ -6877,7 +6985,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_c8_6_c_int
 #endif
       !
-      hipMalloc_c8_6_c_int = hipMalloc_(cptr,length1*length2*length3*length4*length5*length6*2*8_8)
+      hipMalloc_c8_6_c_int = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                             int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*2_int64*byte_size(elem_real64))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6])
     end function
 
@@ -6901,7 +7010,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_c8_6_c_size_t
 #endif
       !
-      hipMalloc_c8_6_c_size_t = hipMalloc_(cptr,length1*length2*length3*length4*length5*length6*2*8_8)
+      hipMalloc_c8_6_c_size_t = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*2_int64*byte_size(elem_real64))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6])
     end function
 
@@ -6916,8 +7026,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       complex(c_double_complex),pointer,dimension(:,:,:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(7),dims(7)
-      integer(8),intent(in),optional :: lbounds8(7),dims8(7)
+      integer(int32),intent(in),optional :: lbounds(7),dims(7)
+      integer(int64),intent(in),optional :: lbounds8(7),dims8(7)
       complex(c_double_complex),target,dimension(:,:,:,:,:,:,:),intent(in),optional :: dsource,source,mold
          
       ! 
@@ -6946,21 +7056,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMalloc_c8_7_source = hipMalloc_(cptr,size(dsource)*2*8_8)
-        hipMalloc_c8_7_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*2*8_8,hipMemcpyDeviceToDevice)
+        hipMalloc_c8_7_source = hipMalloc_(cptr,size(dsource,kind=int64)*2_int64*byte_size(elem_real64))
+        hipMalloc_c8_7_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*2_int64*byte_size(elem_real64),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):,LBOUND(dsource,6):,LBOUND(dsource,7):) => tmp
       else if ( present(source) ) then
-        hipMalloc_c8_7_source = hipMalloc_(cptr,size(source)*2*8_8)
-        hipMalloc_c8_7_source = hipMemcpy(cptr,c_loc(source),size(source)*2*8_8,hipMemcpyHostToDevice)
+        hipMalloc_c8_7_source = hipMalloc_(cptr,size(source,kind=int64)*2_int64*byte_size(elem_real64))
+        hipMalloc_c8_7_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*2_int64*byte_size(elem_real64),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):,LBOUND(source,6):,LBOUND(source,7):) => tmp
       else if ( present(mold) ) then
-        hipMalloc_c8_7_source = hipMalloc_(cptr,size(mold)*2*8_8)
+        hipMalloc_c8_7_source = hipMalloc_(cptr,size(mold,kind=int64)*2_int64*byte_size(elem_real64))
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):,LBOUND(mold,6):,LBOUND(mold,7):) => tmp
       else if ( present(dims8) ) then
-        hipMalloc_c8_7_source = hipMalloc_(cptr,PRODUCT(dims8)*2*8_8)
+        hipMalloc_c8_7_source = hipMalloc_(cptr,PRODUCT(dims8)*2_int64*byte_size(elem_real64))
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):,lbounds8(6):,lbounds8(7):) => tmp
@@ -6968,7 +7078,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMalloc_c8_7_source = hipMalloc_(cptr,PRODUCT(dims)*2*8_8)
+        hipMalloc_c8_7_source = hipMalloc_(cptr,PRODUCT(int(dims,kind=int64))*2_int64*byte_size(elem_real64))
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):,lbounds(6):,lbounds(7):) => tmp
@@ -6998,7 +7108,9 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_c8_7_c_int
 #endif
       !
-      hipMalloc_c8_7_c_int = hipMalloc_(cptr,length1*length2*length3*length4*length5*length6*length7*2*8_8)
+      hipMalloc_c8_7_c_int = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                             int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*&
+                                             int(length7,kind=int64)*2_int64*byte_size(elem_real64))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6,length7])
     end function
 
@@ -7022,7 +7134,9 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMalloc_c8_7_c_size_t
 #endif
       !
-      hipMalloc_c8_7_c_size_t = hipMalloc_(cptr,length1*length2*length3*length4*length5*length6*length7*2*8_8)
+      hipMalloc_c8_7_c_size_t = hipMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*&
+                                                int(length7,kind=int64)*2_int64*byte_size(elem_real64))
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6,length7])
     end function
 
@@ -7945,15 +8059,15 @@ module hipfort_hipmalloc
       if ( nOptArgs > 1 ) ERROR STOP "ERROR: hipMallocManaged (scalar version): Only one optional argument ('dsource','source') must be specified."
     
       if ( present(dsource) ) then
-        hipMallocManaged_i4_0_source = hipMallocManaged_(cptr,4_8,flags)
-        hipMallocManaged_i4_0_source = hipMemcpy(cptr,c_loc(dsource),4_8,hipMemcpyDeviceToDevice)
+        hipMallocManaged_i4_0_source = hipMallocManaged_(cptr,byte_size(elem_int32),flags)
+        hipMallocManaged_i4_0_source = hipMemcpy(cptr,c_loc(dsource),byte_size(elem_int32),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,ptr)
       else if ( present(source) ) then
-        hipMallocManaged_i4_0_source = hipMallocManaged_(cptr,4_8,flags)
-        hipMallocManaged_i4_0_source = hipMemcpy(cptr,c_loc(source),4_8,hipMemcpyHostToDevice)
+        hipMallocManaged_i4_0_source = hipMallocManaged_(cptr,byte_size(elem_int32),flags)
+        hipMallocManaged_i4_0_source = hipMemcpy(cptr,c_loc(source),byte_size(elem_int32),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,ptr)
       else
-        hipMallocManaged_i4_0_source = hipMallocManaged_(cptr,4_8,flags)
+        hipMallocManaged_i4_0_source = hipMallocManaged_(cptr,byte_size(elem_int32),flags)
         call c_f_pointer(cptr,ptr)
       end if
     end function
@@ -7970,8 +8084,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       integer(c_int),pointer,dimension(:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(1),dims(1)
-      integer(8),intent(in),optional :: lbounds8(1),dims8(1)
+      integer(int32),intent(in),optional :: lbounds(1),dims(1)
+      integer(int64),intent(in),optional :: lbounds8(1),dims8(1)
       integer(c_int),target,dimension(:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags   
       ! 
@@ -8000,21 +8114,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMallocManaged_i4_1_source = hipMallocManaged_(cptr,size(dsource)*4_8,flags)
-        hipMallocManaged_i4_1_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*4_8,hipMemcpyDeviceToDevice)
+        hipMallocManaged_i4_1_source = hipMallocManaged_(cptr,size(dsource,kind=int64)*byte_size(elem_int32),flags)
+        hipMallocManaged_i4_1_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_int32),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):) => tmp
       else if ( present(source) ) then
-        hipMallocManaged_i4_1_source = hipMallocManaged_(cptr,size(source)*4_8,flags)
-        hipMallocManaged_i4_1_source = hipMemcpy(cptr,c_loc(source),size(source)*4_8,hipMemcpyHostToDevice)
+        hipMallocManaged_i4_1_source = hipMallocManaged_(cptr,size(source,kind=int64)*byte_size(elem_int32),flags)
+        hipMallocManaged_i4_1_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_int32),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):) => tmp
       else if ( present(mold) ) then
-        hipMallocManaged_i4_1_source = hipMallocManaged_(cptr,size(mold)*4_8,flags)
+        hipMallocManaged_i4_1_source = hipMallocManaged_(cptr,size(mold,kind=int64)*byte_size(elem_int32),flags)
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):) => tmp
       else if ( present(dims8) ) then
-        hipMallocManaged_i4_1_source = hipMallocManaged_(cptr,PRODUCT(dims8)*4_8,flags)
+        hipMallocManaged_i4_1_source = hipMallocManaged_(cptr,PRODUCT(dims8)*byte_size(elem_int32),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):) => tmp
@@ -8022,7 +8136,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMallocManaged_i4_1_source = hipMallocManaged_(cptr,PRODUCT(dims)*4_8,flags)
+        hipMallocManaged_i4_1_source = hipMallocManaged_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_int32),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):) => tmp
@@ -8052,7 +8166,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_i4_1_c_int
 #endif
       !
-      hipMallocManaged_i4_1_c_int = hipMallocManaged_(cptr,length1*4_8,flags)
+      hipMallocManaged_i4_1_c_int = hipMallocManaged_(cptr,int(length1,kind=int64)*byte_size(elem_int32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1])
     end function
 
@@ -8076,7 +8190,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_i4_1_c_size_t
 #endif
       !
-      hipMallocManaged_i4_1_c_size_t = hipMallocManaged_(cptr,length1*4_8,flags)
+      hipMallocManaged_i4_1_c_size_t = hipMallocManaged_(cptr,int(length1,kind=int64)*byte_size(elem_int32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1])
     end function
 
@@ -8091,8 +8205,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       integer(c_int),pointer,dimension(:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(2),dims(2)
-      integer(8),intent(in),optional :: lbounds8(2),dims8(2)
+      integer(int32),intent(in),optional :: lbounds(2),dims(2)
+      integer(int64),intent(in),optional :: lbounds8(2),dims8(2)
       integer(c_int),target,dimension(:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags   
       ! 
@@ -8121,21 +8235,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMallocManaged_i4_2_source = hipMallocManaged_(cptr,size(dsource)*4_8,flags)
-        hipMallocManaged_i4_2_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*4_8,hipMemcpyDeviceToDevice)
+        hipMallocManaged_i4_2_source = hipMallocManaged_(cptr,size(dsource,kind=int64)*byte_size(elem_int32),flags)
+        hipMallocManaged_i4_2_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_int32),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):) => tmp
       else if ( present(source) ) then
-        hipMallocManaged_i4_2_source = hipMallocManaged_(cptr,size(source)*4_8,flags)
-        hipMallocManaged_i4_2_source = hipMemcpy(cptr,c_loc(source),size(source)*4_8,hipMemcpyHostToDevice)
+        hipMallocManaged_i4_2_source = hipMallocManaged_(cptr,size(source,kind=int64)*byte_size(elem_int32),flags)
+        hipMallocManaged_i4_2_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_int32),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):) => tmp
       else if ( present(mold) ) then
-        hipMallocManaged_i4_2_source = hipMallocManaged_(cptr,size(mold)*4_8,flags)
+        hipMallocManaged_i4_2_source = hipMallocManaged_(cptr,size(mold,kind=int64)*byte_size(elem_int32),flags)
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):) => tmp
       else if ( present(dims8) ) then
-        hipMallocManaged_i4_2_source = hipMallocManaged_(cptr,PRODUCT(dims8)*4_8,flags)
+        hipMallocManaged_i4_2_source = hipMallocManaged_(cptr,PRODUCT(dims8)*byte_size(elem_int32),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):) => tmp
@@ -8143,7 +8257,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMallocManaged_i4_2_source = hipMallocManaged_(cptr,PRODUCT(dims)*4_8,flags)
+        hipMallocManaged_i4_2_source = hipMallocManaged_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_int32),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):) => tmp
@@ -8173,7 +8287,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_i4_2_c_int
 #endif
       !
-      hipMallocManaged_i4_2_c_int = hipMallocManaged_(cptr,length1*length2*4_8,flags)
+      hipMallocManaged_i4_2_c_int = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*byte_size(elem_int32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2])
     end function
 
@@ -8197,7 +8311,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_i4_2_c_size_t
 #endif
       !
-      hipMallocManaged_i4_2_c_size_t = hipMallocManaged_(cptr,length1*length2*4_8,flags)
+      hipMallocManaged_i4_2_c_size_t = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*byte_size(elem_int32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2])
     end function
 
@@ -8212,8 +8326,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       integer(c_int),pointer,dimension(:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(3),dims(3)
-      integer(8),intent(in),optional :: lbounds8(3),dims8(3)
+      integer(int32),intent(in),optional :: lbounds(3),dims(3)
+      integer(int64),intent(in),optional :: lbounds8(3),dims8(3)
       integer(c_int),target,dimension(:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags   
       ! 
@@ -8242,21 +8356,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMallocManaged_i4_3_source = hipMallocManaged_(cptr,size(dsource)*4_8,flags)
-        hipMallocManaged_i4_3_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*4_8,hipMemcpyDeviceToDevice)
+        hipMallocManaged_i4_3_source = hipMallocManaged_(cptr,size(dsource,kind=int64)*byte_size(elem_int32),flags)
+        hipMallocManaged_i4_3_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_int32),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):) => tmp
       else if ( present(source) ) then
-        hipMallocManaged_i4_3_source = hipMallocManaged_(cptr,size(source)*4_8,flags)
-        hipMallocManaged_i4_3_source = hipMemcpy(cptr,c_loc(source),size(source)*4_8,hipMemcpyHostToDevice)
+        hipMallocManaged_i4_3_source = hipMallocManaged_(cptr,size(source,kind=int64)*byte_size(elem_int32),flags)
+        hipMallocManaged_i4_3_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_int32),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):) => tmp
       else if ( present(mold) ) then
-        hipMallocManaged_i4_3_source = hipMallocManaged_(cptr,size(mold)*4_8,flags)
+        hipMallocManaged_i4_3_source = hipMallocManaged_(cptr,size(mold,kind=int64)*byte_size(elem_int32),flags)
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):) => tmp
       else if ( present(dims8) ) then
-        hipMallocManaged_i4_3_source = hipMallocManaged_(cptr,PRODUCT(dims8)*4_8,flags)
+        hipMallocManaged_i4_3_source = hipMallocManaged_(cptr,PRODUCT(dims8)*byte_size(elem_int32),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):) => tmp
@@ -8264,7 +8378,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMallocManaged_i4_3_source = hipMallocManaged_(cptr,PRODUCT(dims)*4_8,flags)
+        hipMallocManaged_i4_3_source = hipMallocManaged_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_int32),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):) => tmp
@@ -8294,7 +8408,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_i4_3_c_int
 #endif
       !
-      hipMallocManaged_i4_3_c_int = hipMallocManaged_(cptr,length1*length2*length3*4_8,flags)
+      hipMallocManaged_i4_3_c_int = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*byte_size(elem_int32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3])
     end function
 
@@ -8318,7 +8432,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_i4_3_c_size_t
 #endif
       !
-      hipMallocManaged_i4_3_c_size_t = hipMallocManaged_(cptr,length1*length2*length3*4_8,flags)
+      hipMallocManaged_i4_3_c_size_t = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*byte_size(elem_int32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3])
     end function
 
@@ -8333,8 +8447,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       integer(c_int),pointer,dimension(:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(4),dims(4)
-      integer(8),intent(in),optional :: lbounds8(4),dims8(4)
+      integer(int32),intent(in),optional :: lbounds(4),dims(4)
+      integer(int64),intent(in),optional :: lbounds8(4),dims8(4)
       integer(c_int),target,dimension(:,:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags   
       ! 
@@ -8363,21 +8477,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMallocManaged_i4_4_source = hipMallocManaged_(cptr,size(dsource)*4_8,flags)
-        hipMallocManaged_i4_4_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*4_8,hipMemcpyDeviceToDevice)
+        hipMallocManaged_i4_4_source = hipMallocManaged_(cptr,size(dsource,kind=int64)*byte_size(elem_int32),flags)
+        hipMallocManaged_i4_4_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_int32),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):) => tmp
       else if ( present(source) ) then
-        hipMallocManaged_i4_4_source = hipMallocManaged_(cptr,size(source)*4_8,flags)
-        hipMallocManaged_i4_4_source = hipMemcpy(cptr,c_loc(source),size(source)*4_8,hipMemcpyHostToDevice)
+        hipMallocManaged_i4_4_source = hipMallocManaged_(cptr,size(source,kind=int64)*byte_size(elem_int32),flags)
+        hipMallocManaged_i4_4_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_int32),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):) => tmp
       else if ( present(mold) ) then
-        hipMallocManaged_i4_4_source = hipMallocManaged_(cptr,size(mold)*4_8,flags)
+        hipMallocManaged_i4_4_source = hipMallocManaged_(cptr,size(mold,kind=int64)*byte_size(elem_int32),flags)
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):) => tmp
       else if ( present(dims8) ) then
-        hipMallocManaged_i4_4_source = hipMallocManaged_(cptr,PRODUCT(dims8)*4_8,flags)
+        hipMallocManaged_i4_4_source = hipMallocManaged_(cptr,PRODUCT(dims8)*byte_size(elem_int32),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):) => tmp
@@ -8385,7 +8499,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMallocManaged_i4_4_source = hipMallocManaged_(cptr,PRODUCT(dims)*4_8,flags)
+        hipMallocManaged_i4_4_source = hipMallocManaged_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_int32),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):) => tmp
@@ -8415,7 +8529,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_i4_4_c_int
 #endif
       !
-      hipMallocManaged_i4_4_c_int = hipMallocManaged_(cptr,length1*length2*length3*length4*4_8,flags)
+      hipMallocManaged_i4_4_c_int = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                           int(length4,kind=int64)*byte_size(elem_int32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4])
     end function
 
@@ -8439,7 +8554,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_i4_4_c_size_t
 #endif
       !
-      hipMallocManaged_i4_4_c_size_t = hipMallocManaged_(cptr,length1*length2*length3*length4*4_8,flags)
+      hipMallocManaged_i4_4_c_size_t = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                              int(length4,kind=int64)*byte_size(elem_int32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4])
     end function
 
@@ -8454,8 +8570,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       integer(c_int),pointer,dimension(:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(5),dims(5)
-      integer(8),intent(in),optional :: lbounds8(5),dims8(5)
+      integer(int32),intent(in),optional :: lbounds(5),dims(5)
+      integer(int64),intent(in),optional :: lbounds8(5),dims8(5)
       integer(c_int),target,dimension(:,:,:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags   
       ! 
@@ -8484,21 +8600,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMallocManaged_i4_5_source = hipMallocManaged_(cptr,size(dsource)*4_8,flags)
-        hipMallocManaged_i4_5_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*4_8,hipMemcpyDeviceToDevice)
+        hipMallocManaged_i4_5_source = hipMallocManaged_(cptr,size(dsource,kind=int64)*byte_size(elem_int32),flags)
+        hipMallocManaged_i4_5_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_int32),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):) => tmp
       else if ( present(source) ) then
-        hipMallocManaged_i4_5_source = hipMallocManaged_(cptr,size(source)*4_8,flags)
-        hipMallocManaged_i4_5_source = hipMemcpy(cptr,c_loc(source),size(source)*4_8,hipMemcpyHostToDevice)
+        hipMallocManaged_i4_5_source = hipMallocManaged_(cptr,size(source,kind=int64)*byte_size(elem_int32),flags)
+        hipMallocManaged_i4_5_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_int32),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):) => tmp
       else if ( present(mold) ) then
-        hipMallocManaged_i4_5_source = hipMallocManaged_(cptr,size(mold)*4_8,flags)
+        hipMallocManaged_i4_5_source = hipMallocManaged_(cptr,size(mold,kind=int64)*byte_size(elem_int32),flags)
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):) => tmp
       else if ( present(dims8) ) then
-        hipMallocManaged_i4_5_source = hipMallocManaged_(cptr,PRODUCT(dims8)*4_8,flags)
+        hipMallocManaged_i4_5_source = hipMallocManaged_(cptr,PRODUCT(dims8)*byte_size(elem_int32),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):) => tmp
@@ -8506,7 +8622,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMallocManaged_i4_5_source = hipMallocManaged_(cptr,PRODUCT(dims)*4_8,flags)
+        hipMallocManaged_i4_5_source = hipMallocManaged_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_int32),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):) => tmp
@@ -8536,7 +8652,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_i4_5_c_int
 #endif
       !
-      hipMallocManaged_i4_5_c_int = hipMallocManaged_(cptr,length1*length2*length3*length4*length5*4_8,flags)
+      hipMallocManaged_i4_5_c_int = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                           int(length4,kind=int64)*int(length5,kind=int64)*byte_size(elem_int32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5])
     end function
 
@@ -8560,7 +8677,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_i4_5_c_size_t
 #endif
       !
-      hipMallocManaged_i4_5_c_size_t = hipMallocManaged_(cptr,length1*length2*length3*length4*length5*4_8,flags)
+      hipMallocManaged_i4_5_c_size_t = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                              int(length4,kind=int64)*int(length5,kind=int64)*byte_size(elem_int32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5])
     end function
 
@@ -8575,8 +8693,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       integer(c_int),pointer,dimension(:,:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(6),dims(6)
-      integer(8),intent(in),optional :: lbounds8(6),dims8(6)
+      integer(int32),intent(in),optional :: lbounds(6),dims(6)
+      integer(int64),intent(in),optional :: lbounds8(6),dims8(6)
       integer(c_int),target,dimension(:,:,:,:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags   
       ! 
@@ -8605,21 +8723,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMallocManaged_i4_6_source = hipMallocManaged_(cptr,size(dsource)*4_8,flags)
-        hipMallocManaged_i4_6_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*4_8,hipMemcpyDeviceToDevice)
+        hipMallocManaged_i4_6_source = hipMallocManaged_(cptr,size(dsource,kind=int64)*byte_size(elem_int32),flags)
+        hipMallocManaged_i4_6_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_int32),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):,LBOUND(dsource,6):) => tmp
       else if ( present(source) ) then
-        hipMallocManaged_i4_6_source = hipMallocManaged_(cptr,size(source)*4_8,flags)
-        hipMallocManaged_i4_6_source = hipMemcpy(cptr,c_loc(source),size(source)*4_8,hipMemcpyHostToDevice)
+        hipMallocManaged_i4_6_source = hipMallocManaged_(cptr,size(source,kind=int64)*byte_size(elem_int32),flags)
+        hipMallocManaged_i4_6_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_int32),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):,LBOUND(source,6):) => tmp
       else if ( present(mold) ) then
-        hipMallocManaged_i4_6_source = hipMallocManaged_(cptr,size(mold)*4_8,flags)
+        hipMallocManaged_i4_6_source = hipMallocManaged_(cptr,size(mold,kind=int64)*byte_size(elem_int32),flags)
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):,LBOUND(mold,6):) => tmp
       else if ( present(dims8) ) then
-        hipMallocManaged_i4_6_source = hipMallocManaged_(cptr,PRODUCT(dims8)*4_8,flags)
+        hipMallocManaged_i4_6_source = hipMallocManaged_(cptr,PRODUCT(dims8)*byte_size(elem_int32),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):,lbounds8(6):) => tmp
@@ -8627,7 +8745,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMallocManaged_i4_6_source = hipMallocManaged_(cptr,PRODUCT(dims)*4_8,flags)
+        hipMallocManaged_i4_6_source = hipMallocManaged_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_int32),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):,lbounds(6):) => tmp
@@ -8657,7 +8775,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_i4_6_c_int
 #endif
       !
-      hipMallocManaged_i4_6_c_int = hipMallocManaged_(cptr,length1*length2*length3*length4*length5*length6*4_8,flags)
+      hipMallocManaged_i4_6_c_int = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                           int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*byte_size(elem_int32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6])
     end function
 
@@ -8681,7 +8800,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_i4_6_c_size_t
 #endif
       !
-      hipMallocManaged_i4_6_c_size_t = hipMallocManaged_(cptr,length1*length2*length3*length4*length5*length6*4_8,flags)
+      hipMallocManaged_i4_6_c_size_t = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                              int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*byte_size(elem_int32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6])
     end function
 
@@ -8696,8 +8816,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       integer(c_int),pointer,dimension(:,:,:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(7),dims(7)
-      integer(8),intent(in),optional :: lbounds8(7),dims8(7)
+      integer(int32),intent(in),optional :: lbounds(7),dims(7)
+      integer(int64),intent(in),optional :: lbounds8(7),dims8(7)
       integer(c_int),target,dimension(:,:,:,:,:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags   
       ! 
@@ -8726,21 +8846,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMallocManaged_i4_7_source = hipMallocManaged_(cptr,size(dsource)*4_8,flags)
-        hipMallocManaged_i4_7_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*4_8,hipMemcpyDeviceToDevice)
+        hipMallocManaged_i4_7_source = hipMallocManaged_(cptr,size(dsource,kind=int64)*byte_size(elem_int32),flags)
+        hipMallocManaged_i4_7_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_int32),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):,LBOUND(dsource,6):,LBOUND(dsource,7):) => tmp
       else if ( present(source) ) then
-        hipMallocManaged_i4_7_source = hipMallocManaged_(cptr,size(source)*4_8,flags)
-        hipMallocManaged_i4_7_source = hipMemcpy(cptr,c_loc(source),size(source)*4_8,hipMemcpyHostToDevice)
+        hipMallocManaged_i4_7_source = hipMallocManaged_(cptr,size(source,kind=int64)*byte_size(elem_int32),flags)
+        hipMallocManaged_i4_7_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_int32),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):,LBOUND(source,6):,LBOUND(source,7):) => tmp
       else if ( present(mold) ) then
-        hipMallocManaged_i4_7_source = hipMallocManaged_(cptr,size(mold)*4_8,flags)
+        hipMallocManaged_i4_7_source = hipMallocManaged_(cptr,size(mold,kind=int64)*byte_size(elem_int32),flags)
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):,LBOUND(mold,6):,LBOUND(mold,7):) => tmp
       else if ( present(dims8) ) then
-        hipMallocManaged_i4_7_source = hipMallocManaged_(cptr,PRODUCT(dims8)*4_8,flags)
+        hipMallocManaged_i4_7_source = hipMallocManaged_(cptr,PRODUCT(dims8)*byte_size(elem_int32),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):,lbounds8(6):,lbounds8(7):) => tmp
@@ -8748,7 +8868,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMallocManaged_i4_7_source = hipMallocManaged_(cptr,PRODUCT(dims)*4_8,flags)
+        hipMallocManaged_i4_7_source = hipMallocManaged_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_int32),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):,lbounds(6):,lbounds(7):) => tmp
@@ -8778,7 +8898,9 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_i4_7_c_int
 #endif
       !
-      hipMallocManaged_i4_7_c_int = hipMallocManaged_(cptr,length1*length2*length3*length4*length5*length6*length7*4_8,flags)
+      hipMallocManaged_i4_7_c_int = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                           int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*&
+                                                           int(length7,kind=int64)*byte_size(elem_int32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6,length7])
     end function
 
@@ -8802,7 +8924,9 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_i4_7_c_size_t
 #endif
       !
-      hipMallocManaged_i4_7_c_size_t = hipMallocManaged_(cptr,length1*length2*length3*length4*length5*length6*length7*4_8,flags)
+      hipMallocManaged_i4_7_c_size_t = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                              int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*&
+                                                              int(length7,kind=int64)*byte_size(elem_int32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6,length7])
     end function
 
@@ -8835,15 +8959,15 @@ module hipfort_hipmalloc
       if ( nOptArgs > 1 ) ERROR STOP "ERROR: hipMallocManaged (scalar version): Only one optional argument ('dsource','source') must be specified."
     
       if ( present(dsource) ) then
-        hipMallocManaged_i8_0_source = hipMallocManaged_(cptr,8_8,flags)
-        hipMallocManaged_i8_0_source = hipMemcpy(cptr,c_loc(dsource),8_8,hipMemcpyDeviceToDevice)
+        hipMallocManaged_i8_0_source = hipMallocManaged_(cptr,byte_size(elem_int64),flags)
+        hipMallocManaged_i8_0_source = hipMemcpy(cptr,c_loc(dsource),byte_size(elem_int64),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,ptr)
       else if ( present(source) ) then
-        hipMallocManaged_i8_0_source = hipMallocManaged_(cptr,8_8,flags)
-        hipMallocManaged_i8_0_source = hipMemcpy(cptr,c_loc(source),8_8,hipMemcpyHostToDevice)
+        hipMallocManaged_i8_0_source = hipMallocManaged_(cptr,byte_size(elem_int64),flags)
+        hipMallocManaged_i8_0_source = hipMemcpy(cptr,c_loc(source),byte_size(elem_int64),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,ptr)
       else
-        hipMallocManaged_i8_0_source = hipMallocManaged_(cptr,8_8,flags)
+        hipMallocManaged_i8_0_source = hipMallocManaged_(cptr,byte_size(elem_int64),flags)
         call c_f_pointer(cptr,ptr)
       end if
     end function
@@ -8860,8 +8984,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       integer(c_long),pointer,dimension(:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(1),dims(1)
-      integer(8),intent(in),optional :: lbounds8(1),dims8(1)
+      integer(int32),intent(in),optional :: lbounds(1),dims(1)
+      integer(int64),intent(in),optional :: lbounds8(1),dims8(1)
       integer(c_long),target,dimension(:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags   
       ! 
@@ -8890,21 +9014,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMallocManaged_i8_1_source = hipMallocManaged_(cptr,size(dsource)*8_8,flags)
-        hipMallocManaged_i8_1_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*8_8,hipMemcpyDeviceToDevice)
+        hipMallocManaged_i8_1_source = hipMallocManaged_(cptr,size(dsource,kind=int64)*byte_size(elem_int64),flags)
+        hipMallocManaged_i8_1_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_int64),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):) => tmp
       else if ( present(source) ) then
-        hipMallocManaged_i8_1_source = hipMallocManaged_(cptr,size(source)*8_8,flags)
-        hipMallocManaged_i8_1_source = hipMemcpy(cptr,c_loc(source),size(source)*8_8,hipMemcpyHostToDevice)
+        hipMallocManaged_i8_1_source = hipMallocManaged_(cptr,size(source,kind=int64)*byte_size(elem_int64),flags)
+        hipMallocManaged_i8_1_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_int64),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):) => tmp
       else if ( present(mold) ) then
-        hipMallocManaged_i8_1_source = hipMallocManaged_(cptr,size(mold)*8_8,flags)
+        hipMallocManaged_i8_1_source = hipMallocManaged_(cptr,size(mold,kind=int64)*byte_size(elem_int64),flags)
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):) => tmp
       else if ( present(dims8) ) then
-        hipMallocManaged_i8_1_source = hipMallocManaged_(cptr,PRODUCT(dims8)*8_8,flags)
+        hipMallocManaged_i8_1_source = hipMallocManaged_(cptr,PRODUCT(dims8)*byte_size(elem_int64),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):) => tmp
@@ -8912,7 +9036,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMallocManaged_i8_1_source = hipMallocManaged_(cptr,PRODUCT(dims)*8_8,flags)
+        hipMallocManaged_i8_1_source = hipMallocManaged_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_int64),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):) => tmp
@@ -8942,7 +9066,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_i8_1_c_int
 #endif
       !
-      hipMallocManaged_i8_1_c_int = hipMallocManaged_(cptr,length1*8_8,flags)
+      hipMallocManaged_i8_1_c_int = hipMallocManaged_(cptr,int(length1,kind=int64)*byte_size(elem_int64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1])
     end function
 
@@ -8966,7 +9090,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_i8_1_c_size_t
 #endif
       !
-      hipMallocManaged_i8_1_c_size_t = hipMallocManaged_(cptr,length1*8_8,flags)
+      hipMallocManaged_i8_1_c_size_t = hipMallocManaged_(cptr,int(length1,kind=int64)*byte_size(elem_int64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1])
     end function
 
@@ -8981,8 +9105,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       integer(c_long),pointer,dimension(:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(2),dims(2)
-      integer(8),intent(in),optional :: lbounds8(2),dims8(2)
+      integer(int32),intent(in),optional :: lbounds(2),dims(2)
+      integer(int64),intent(in),optional :: lbounds8(2),dims8(2)
       integer(c_long),target,dimension(:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags   
       ! 
@@ -9011,21 +9135,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMallocManaged_i8_2_source = hipMallocManaged_(cptr,size(dsource)*8_8,flags)
-        hipMallocManaged_i8_2_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*8_8,hipMemcpyDeviceToDevice)
+        hipMallocManaged_i8_2_source = hipMallocManaged_(cptr,size(dsource,kind=int64)*byte_size(elem_int64),flags)
+        hipMallocManaged_i8_2_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_int64),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):) => tmp
       else if ( present(source) ) then
-        hipMallocManaged_i8_2_source = hipMallocManaged_(cptr,size(source)*8_8,flags)
-        hipMallocManaged_i8_2_source = hipMemcpy(cptr,c_loc(source),size(source)*8_8,hipMemcpyHostToDevice)
+        hipMallocManaged_i8_2_source = hipMallocManaged_(cptr,size(source,kind=int64)*byte_size(elem_int64),flags)
+        hipMallocManaged_i8_2_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_int64),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):) => tmp
       else if ( present(mold) ) then
-        hipMallocManaged_i8_2_source = hipMallocManaged_(cptr,size(mold)*8_8,flags)
+        hipMallocManaged_i8_2_source = hipMallocManaged_(cptr,size(mold,kind=int64)*byte_size(elem_int64),flags)
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):) => tmp
       else if ( present(dims8) ) then
-        hipMallocManaged_i8_2_source = hipMallocManaged_(cptr,PRODUCT(dims8)*8_8,flags)
+        hipMallocManaged_i8_2_source = hipMallocManaged_(cptr,PRODUCT(dims8)*byte_size(elem_int64),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):) => tmp
@@ -9033,7 +9157,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMallocManaged_i8_2_source = hipMallocManaged_(cptr,PRODUCT(dims)*8_8,flags)
+        hipMallocManaged_i8_2_source = hipMallocManaged_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_int64),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):) => tmp
@@ -9063,7 +9187,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_i8_2_c_int
 #endif
       !
-      hipMallocManaged_i8_2_c_int = hipMallocManaged_(cptr,length1*length2*8_8,flags)
+      hipMallocManaged_i8_2_c_int = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*byte_size(elem_int64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2])
     end function
 
@@ -9087,7 +9211,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_i8_2_c_size_t
 #endif
       !
-      hipMallocManaged_i8_2_c_size_t = hipMallocManaged_(cptr,length1*length2*8_8,flags)
+      hipMallocManaged_i8_2_c_size_t = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*byte_size(elem_int64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2])
     end function
 
@@ -9102,8 +9226,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       integer(c_long),pointer,dimension(:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(3),dims(3)
-      integer(8),intent(in),optional :: lbounds8(3),dims8(3)
+      integer(int32),intent(in),optional :: lbounds(3),dims(3)
+      integer(int64),intent(in),optional :: lbounds8(3),dims8(3)
       integer(c_long),target,dimension(:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags   
       ! 
@@ -9132,21 +9256,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMallocManaged_i8_3_source = hipMallocManaged_(cptr,size(dsource)*8_8,flags)
-        hipMallocManaged_i8_3_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*8_8,hipMemcpyDeviceToDevice)
+        hipMallocManaged_i8_3_source = hipMallocManaged_(cptr,size(dsource,kind=int64)*byte_size(elem_int64),flags)
+        hipMallocManaged_i8_3_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_int64),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):) => tmp
       else if ( present(source) ) then
-        hipMallocManaged_i8_3_source = hipMallocManaged_(cptr,size(source)*8_8,flags)
-        hipMallocManaged_i8_3_source = hipMemcpy(cptr,c_loc(source),size(source)*8_8,hipMemcpyHostToDevice)
+        hipMallocManaged_i8_3_source = hipMallocManaged_(cptr,size(source,kind=int64)*byte_size(elem_int64),flags)
+        hipMallocManaged_i8_3_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_int64),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):) => tmp
       else if ( present(mold) ) then
-        hipMallocManaged_i8_3_source = hipMallocManaged_(cptr,size(mold)*8_8,flags)
+        hipMallocManaged_i8_3_source = hipMallocManaged_(cptr,size(mold,kind=int64)*byte_size(elem_int64),flags)
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):) => tmp
       else if ( present(dims8) ) then
-        hipMallocManaged_i8_3_source = hipMallocManaged_(cptr,PRODUCT(dims8)*8_8,flags)
+        hipMallocManaged_i8_3_source = hipMallocManaged_(cptr,PRODUCT(dims8)*byte_size(elem_int64),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):) => tmp
@@ -9154,7 +9278,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMallocManaged_i8_3_source = hipMallocManaged_(cptr,PRODUCT(dims)*8_8,flags)
+        hipMallocManaged_i8_3_source = hipMallocManaged_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_int64),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):) => tmp
@@ -9184,7 +9308,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_i8_3_c_int
 #endif
       !
-      hipMallocManaged_i8_3_c_int = hipMallocManaged_(cptr,length1*length2*length3*8_8,flags)
+      hipMallocManaged_i8_3_c_int = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*byte_size(elem_int64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3])
     end function
 
@@ -9208,7 +9332,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_i8_3_c_size_t
 #endif
       !
-      hipMallocManaged_i8_3_c_size_t = hipMallocManaged_(cptr,length1*length2*length3*8_8,flags)
+      hipMallocManaged_i8_3_c_size_t = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*byte_size(elem_int64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3])
     end function
 
@@ -9223,8 +9347,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       integer(c_long),pointer,dimension(:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(4),dims(4)
-      integer(8),intent(in),optional :: lbounds8(4),dims8(4)
+      integer(int32),intent(in),optional :: lbounds(4),dims(4)
+      integer(int64),intent(in),optional :: lbounds8(4),dims8(4)
       integer(c_long),target,dimension(:,:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags   
       ! 
@@ -9253,21 +9377,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMallocManaged_i8_4_source = hipMallocManaged_(cptr,size(dsource)*8_8,flags)
-        hipMallocManaged_i8_4_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*8_8,hipMemcpyDeviceToDevice)
+        hipMallocManaged_i8_4_source = hipMallocManaged_(cptr,size(dsource,kind=int64)*byte_size(elem_int64),flags)
+        hipMallocManaged_i8_4_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_int64),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):) => tmp
       else if ( present(source) ) then
-        hipMallocManaged_i8_4_source = hipMallocManaged_(cptr,size(source)*8_8,flags)
-        hipMallocManaged_i8_4_source = hipMemcpy(cptr,c_loc(source),size(source)*8_8,hipMemcpyHostToDevice)
+        hipMallocManaged_i8_4_source = hipMallocManaged_(cptr,size(source,kind=int64)*byte_size(elem_int64),flags)
+        hipMallocManaged_i8_4_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_int64),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):) => tmp
       else if ( present(mold) ) then
-        hipMallocManaged_i8_4_source = hipMallocManaged_(cptr,size(mold)*8_8,flags)
+        hipMallocManaged_i8_4_source = hipMallocManaged_(cptr,size(mold,kind=int64)*byte_size(elem_int64),flags)
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):) => tmp
       else if ( present(dims8) ) then
-        hipMallocManaged_i8_4_source = hipMallocManaged_(cptr,PRODUCT(dims8)*8_8,flags)
+        hipMallocManaged_i8_4_source = hipMallocManaged_(cptr,PRODUCT(dims8)*byte_size(elem_int64),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):) => tmp
@@ -9275,7 +9399,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMallocManaged_i8_4_source = hipMallocManaged_(cptr,PRODUCT(dims)*8_8,flags)
+        hipMallocManaged_i8_4_source = hipMallocManaged_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_int64),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):) => tmp
@@ -9305,7 +9429,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_i8_4_c_int
 #endif
       !
-      hipMallocManaged_i8_4_c_int = hipMallocManaged_(cptr,length1*length2*length3*length4*8_8,flags)
+      hipMallocManaged_i8_4_c_int = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                           int(length4,kind=int64)*byte_size(elem_int64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4])
     end function
 
@@ -9329,7 +9454,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_i8_4_c_size_t
 #endif
       !
-      hipMallocManaged_i8_4_c_size_t = hipMallocManaged_(cptr,length1*length2*length3*length4*8_8,flags)
+      hipMallocManaged_i8_4_c_size_t = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                              int(length4,kind=int64)*byte_size(elem_int64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4])
     end function
 
@@ -9344,8 +9470,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       integer(c_long),pointer,dimension(:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(5),dims(5)
-      integer(8),intent(in),optional :: lbounds8(5),dims8(5)
+      integer(int32),intent(in),optional :: lbounds(5),dims(5)
+      integer(int64),intent(in),optional :: lbounds8(5),dims8(5)
       integer(c_long),target,dimension(:,:,:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags   
       ! 
@@ -9374,21 +9500,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMallocManaged_i8_5_source = hipMallocManaged_(cptr,size(dsource)*8_8,flags)
-        hipMallocManaged_i8_5_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*8_8,hipMemcpyDeviceToDevice)
+        hipMallocManaged_i8_5_source = hipMallocManaged_(cptr,size(dsource,kind=int64)*byte_size(elem_int64),flags)
+        hipMallocManaged_i8_5_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_int64),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):) => tmp
       else if ( present(source) ) then
-        hipMallocManaged_i8_5_source = hipMallocManaged_(cptr,size(source)*8_8,flags)
-        hipMallocManaged_i8_5_source = hipMemcpy(cptr,c_loc(source),size(source)*8_8,hipMemcpyHostToDevice)
+        hipMallocManaged_i8_5_source = hipMallocManaged_(cptr,size(source,kind=int64)*byte_size(elem_int64),flags)
+        hipMallocManaged_i8_5_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_int64),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):) => tmp
       else if ( present(mold) ) then
-        hipMallocManaged_i8_5_source = hipMallocManaged_(cptr,size(mold)*8_8,flags)
+        hipMallocManaged_i8_5_source = hipMallocManaged_(cptr,size(mold,kind=int64)*byte_size(elem_int64),flags)
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):) => tmp
       else if ( present(dims8) ) then
-        hipMallocManaged_i8_5_source = hipMallocManaged_(cptr,PRODUCT(dims8)*8_8,flags)
+        hipMallocManaged_i8_5_source = hipMallocManaged_(cptr,PRODUCT(dims8)*byte_size(elem_int64),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):) => tmp
@@ -9396,7 +9522,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMallocManaged_i8_5_source = hipMallocManaged_(cptr,PRODUCT(dims)*8_8,flags)
+        hipMallocManaged_i8_5_source = hipMallocManaged_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_int64),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):) => tmp
@@ -9426,7 +9552,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_i8_5_c_int
 #endif
       !
-      hipMallocManaged_i8_5_c_int = hipMallocManaged_(cptr,length1*length2*length3*length4*length5*8_8,flags)
+      hipMallocManaged_i8_5_c_int = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                           int(length4,kind=int64)*int(length5,kind=int64)*byte_size(elem_int64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5])
     end function
 
@@ -9450,7 +9577,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_i8_5_c_size_t
 #endif
       !
-      hipMallocManaged_i8_5_c_size_t = hipMallocManaged_(cptr,length1*length2*length3*length4*length5*8_8,flags)
+      hipMallocManaged_i8_5_c_size_t = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                              int(length4,kind=int64)*int(length5,kind=int64)*byte_size(elem_int64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5])
     end function
 
@@ -9465,8 +9593,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       integer(c_long),pointer,dimension(:,:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(6),dims(6)
-      integer(8),intent(in),optional :: lbounds8(6),dims8(6)
+      integer(int32),intent(in),optional :: lbounds(6),dims(6)
+      integer(int64),intent(in),optional :: lbounds8(6),dims8(6)
       integer(c_long),target,dimension(:,:,:,:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags   
       ! 
@@ -9495,21 +9623,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMallocManaged_i8_6_source = hipMallocManaged_(cptr,size(dsource)*8_8,flags)
-        hipMallocManaged_i8_6_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*8_8,hipMemcpyDeviceToDevice)
+        hipMallocManaged_i8_6_source = hipMallocManaged_(cptr,size(dsource,kind=int64)*byte_size(elem_int64),flags)
+        hipMallocManaged_i8_6_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_int64),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):,LBOUND(dsource,6):) => tmp
       else if ( present(source) ) then
-        hipMallocManaged_i8_6_source = hipMallocManaged_(cptr,size(source)*8_8,flags)
-        hipMallocManaged_i8_6_source = hipMemcpy(cptr,c_loc(source),size(source)*8_8,hipMemcpyHostToDevice)
+        hipMallocManaged_i8_6_source = hipMallocManaged_(cptr,size(source,kind=int64)*byte_size(elem_int64),flags)
+        hipMallocManaged_i8_6_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_int64),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):,LBOUND(source,6):) => tmp
       else if ( present(mold) ) then
-        hipMallocManaged_i8_6_source = hipMallocManaged_(cptr,size(mold)*8_8,flags)
+        hipMallocManaged_i8_6_source = hipMallocManaged_(cptr,size(mold,kind=int64)*byte_size(elem_int64),flags)
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):,LBOUND(mold,6):) => tmp
       else if ( present(dims8) ) then
-        hipMallocManaged_i8_6_source = hipMallocManaged_(cptr,PRODUCT(dims8)*8_8,flags)
+        hipMallocManaged_i8_6_source = hipMallocManaged_(cptr,PRODUCT(dims8)*byte_size(elem_int64),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):,lbounds8(6):) => tmp
@@ -9517,7 +9645,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMallocManaged_i8_6_source = hipMallocManaged_(cptr,PRODUCT(dims)*8_8,flags)
+        hipMallocManaged_i8_6_source = hipMallocManaged_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_int64),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):,lbounds(6):) => tmp
@@ -9547,7 +9675,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_i8_6_c_int
 #endif
       !
-      hipMallocManaged_i8_6_c_int = hipMallocManaged_(cptr,length1*length2*length3*length4*length5*length6*8_8,flags)
+      hipMallocManaged_i8_6_c_int = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                           int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*byte_size(elem_int64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6])
     end function
 
@@ -9571,7 +9700,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_i8_6_c_size_t
 #endif
       !
-      hipMallocManaged_i8_6_c_size_t = hipMallocManaged_(cptr,length1*length2*length3*length4*length5*length6*8_8,flags)
+      hipMallocManaged_i8_6_c_size_t = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                              int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*byte_size(elem_int64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6])
     end function
 
@@ -9586,8 +9716,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       integer(c_long),pointer,dimension(:,:,:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(7),dims(7)
-      integer(8),intent(in),optional :: lbounds8(7),dims8(7)
+      integer(int32),intent(in),optional :: lbounds(7),dims(7)
+      integer(int64),intent(in),optional :: lbounds8(7),dims8(7)
       integer(c_long),target,dimension(:,:,:,:,:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags   
       ! 
@@ -9616,21 +9746,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMallocManaged_i8_7_source = hipMallocManaged_(cptr,size(dsource)*8_8,flags)
-        hipMallocManaged_i8_7_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*8_8,hipMemcpyDeviceToDevice)
+        hipMallocManaged_i8_7_source = hipMallocManaged_(cptr,size(dsource,kind=int64)*byte_size(elem_int64),flags)
+        hipMallocManaged_i8_7_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_int64),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):,LBOUND(dsource,6):,LBOUND(dsource,7):) => tmp
       else if ( present(source) ) then
-        hipMallocManaged_i8_7_source = hipMallocManaged_(cptr,size(source)*8_8,flags)
-        hipMallocManaged_i8_7_source = hipMemcpy(cptr,c_loc(source),size(source)*8_8,hipMemcpyHostToDevice)
+        hipMallocManaged_i8_7_source = hipMallocManaged_(cptr,size(source,kind=int64)*byte_size(elem_int64),flags)
+        hipMallocManaged_i8_7_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_int64),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):,LBOUND(source,6):,LBOUND(source,7):) => tmp
       else if ( present(mold) ) then
-        hipMallocManaged_i8_7_source = hipMallocManaged_(cptr,size(mold)*8_8,flags)
+        hipMallocManaged_i8_7_source = hipMallocManaged_(cptr,size(mold,kind=int64)*byte_size(elem_int64),flags)
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):,LBOUND(mold,6):,LBOUND(mold,7):) => tmp
       else if ( present(dims8) ) then
-        hipMallocManaged_i8_7_source = hipMallocManaged_(cptr,PRODUCT(dims8)*8_8,flags)
+        hipMallocManaged_i8_7_source = hipMallocManaged_(cptr,PRODUCT(dims8)*byte_size(elem_int64),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):,lbounds8(6):,lbounds8(7):) => tmp
@@ -9638,7 +9768,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMallocManaged_i8_7_source = hipMallocManaged_(cptr,PRODUCT(dims)*8_8,flags)
+        hipMallocManaged_i8_7_source = hipMallocManaged_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_int64),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):,lbounds(6):,lbounds(7):) => tmp
@@ -9668,7 +9798,9 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_i8_7_c_int
 #endif
       !
-      hipMallocManaged_i8_7_c_int = hipMallocManaged_(cptr,length1*length2*length3*length4*length5*length6*length7*8_8,flags)
+      hipMallocManaged_i8_7_c_int = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                           int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*&
+                                                           int(length7,kind=int64)*byte_size(elem_int64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6,length7])
     end function
 
@@ -9692,7 +9824,9 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_i8_7_c_size_t
 #endif
       !
-      hipMallocManaged_i8_7_c_size_t = hipMallocManaged_(cptr,length1*length2*length3*length4*length5*length6*length7*8_8,flags)
+      hipMallocManaged_i8_7_c_size_t = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                              int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*&
+                                                              int(length7,kind=int64)*byte_size(elem_int64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6,length7])
     end function
 
@@ -9725,15 +9859,15 @@ module hipfort_hipmalloc
       if ( nOptArgs > 1 ) ERROR STOP "ERROR: hipMallocManaged (scalar version): Only one optional argument ('dsource','source') must be specified."
     
       if ( present(dsource) ) then
-        hipMallocManaged_r4_0_source = hipMallocManaged_(cptr,4_8,flags)
-        hipMallocManaged_r4_0_source = hipMemcpy(cptr,c_loc(dsource),4_8,hipMemcpyDeviceToDevice)
+        hipMallocManaged_r4_0_source = hipMallocManaged_(cptr,byte_size(elem_real32),flags)
+        hipMallocManaged_r4_0_source = hipMemcpy(cptr,c_loc(dsource),byte_size(elem_real32),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,ptr)
       else if ( present(source) ) then
-        hipMallocManaged_r4_0_source = hipMallocManaged_(cptr,4_8,flags)
-        hipMallocManaged_r4_0_source = hipMemcpy(cptr,c_loc(source),4_8,hipMemcpyHostToDevice)
+        hipMallocManaged_r4_0_source = hipMallocManaged_(cptr,byte_size(elem_real32),flags)
+        hipMallocManaged_r4_0_source = hipMemcpy(cptr,c_loc(source),byte_size(elem_real32),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,ptr)
       else
-        hipMallocManaged_r4_0_source = hipMallocManaged_(cptr,4_8,flags)
+        hipMallocManaged_r4_0_source = hipMallocManaged_(cptr,byte_size(elem_real32),flags)
         call c_f_pointer(cptr,ptr)
       end if
     end function
@@ -9750,8 +9884,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       real(c_float),pointer,dimension(:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(1),dims(1)
-      integer(8),intent(in),optional :: lbounds8(1),dims8(1)
+      integer(int32),intent(in),optional :: lbounds(1),dims(1)
+      integer(int64),intent(in),optional :: lbounds8(1),dims8(1)
       real(c_float),target,dimension(:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags   
       ! 
@@ -9780,21 +9914,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMallocManaged_r4_1_source = hipMallocManaged_(cptr,size(dsource)*4_8,flags)
-        hipMallocManaged_r4_1_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*4_8,hipMemcpyDeviceToDevice)
+        hipMallocManaged_r4_1_source = hipMallocManaged_(cptr,size(dsource,kind=int64)*byte_size(elem_real32),flags)
+        hipMallocManaged_r4_1_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_real32),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):) => tmp
       else if ( present(source) ) then
-        hipMallocManaged_r4_1_source = hipMallocManaged_(cptr,size(source)*4_8,flags)
-        hipMallocManaged_r4_1_source = hipMemcpy(cptr,c_loc(source),size(source)*4_8,hipMemcpyHostToDevice)
+        hipMallocManaged_r4_1_source = hipMallocManaged_(cptr,size(source,kind=int64)*byte_size(elem_real32),flags)
+        hipMallocManaged_r4_1_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_real32),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):) => tmp
       else if ( present(mold) ) then
-        hipMallocManaged_r4_1_source = hipMallocManaged_(cptr,size(mold)*4_8,flags)
+        hipMallocManaged_r4_1_source = hipMallocManaged_(cptr,size(mold,kind=int64)*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):) => tmp
       else if ( present(dims8) ) then
-        hipMallocManaged_r4_1_source = hipMallocManaged_(cptr,PRODUCT(dims8)*4_8,flags)
+        hipMallocManaged_r4_1_source = hipMallocManaged_(cptr,PRODUCT(dims8)*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):) => tmp
@@ -9802,7 +9936,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMallocManaged_r4_1_source = hipMallocManaged_(cptr,PRODUCT(dims)*4_8,flags)
+        hipMallocManaged_r4_1_source = hipMallocManaged_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):) => tmp
@@ -9832,7 +9966,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_r4_1_c_int
 #endif
       !
-      hipMallocManaged_r4_1_c_int = hipMallocManaged_(cptr,length1*4_8,flags)
+      hipMallocManaged_r4_1_c_int = hipMallocManaged_(cptr,int(length1,kind=int64)*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1])
     end function
 
@@ -9856,7 +9990,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_r4_1_c_size_t
 #endif
       !
-      hipMallocManaged_r4_1_c_size_t = hipMallocManaged_(cptr,length1*4_8,flags)
+      hipMallocManaged_r4_1_c_size_t = hipMallocManaged_(cptr,int(length1,kind=int64)*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1])
     end function
 
@@ -9871,8 +10005,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       real(c_float),pointer,dimension(:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(2),dims(2)
-      integer(8),intent(in),optional :: lbounds8(2),dims8(2)
+      integer(int32),intent(in),optional :: lbounds(2),dims(2)
+      integer(int64),intent(in),optional :: lbounds8(2),dims8(2)
       real(c_float),target,dimension(:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags   
       ! 
@@ -9901,21 +10035,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMallocManaged_r4_2_source = hipMallocManaged_(cptr,size(dsource)*4_8,flags)
-        hipMallocManaged_r4_2_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*4_8,hipMemcpyDeviceToDevice)
+        hipMallocManaged_r4_2_source = hipMallocManaged_(cptr,size(dsource,kind=int64)*byte_size(elem_real32),flags)
+        hipMallocManaged_r4_2_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_real32),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):) => tmp
       else if ( present(source) ) then
-        hipMallocManaged_r4_2_source = hipMallocManaged_(cptr,size(source)*4_8,flags)
-        hipMallocManaged_r4_2_source = hipMemcpy(cptr,c_loc(source),size(source)*4_8,hipMemcpyHostToDevice)
+        hipMallocManaged_r4_2_source = hipMallocManaged_(cptr,size(source,kind=int64)*byte_size(elem_real32),flags)
+        hipMallocManaged_r4_2_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_real32),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):) => tmp
       else if ( present(mold) ) then
-        hipMallocManaged_r4_2_source = hipMallocManaged_(cptr,size(mold)*4_8,flags)
+        hipMallocManaged_r4_2_source = hipMallocManaged_(cptr,size(mold,kind=int64)*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):) => tmp
       else if ( present(dims8) ) then
-        hipMallocManaged_r4_2_source = hipMallocManaged_(cptr,PRODUCT(dims8)*4_8,flags)
+        hipMallocManaged_r4_2_source = hipMallocManaged_(cptr,PRODUCT(dims8)*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):) => tmp
@@ -9923,7 +10057,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMallocManaged_r4_2_source = hipMallocManaged_(cptr,PRODUCT(dims)*4_8,flags)
+        hipMallocManaged_r4_2_source = hipMallocManaged_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):) => tmp
@@ -9953,7 +10087,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_r4_2_c_int
 #endif
       !
-      hipMallocManaged_r4_2_c_int = hipMallocManaged_(cptr,length1*length2*4_8,flags)
+      hipMallocManaged_r4_2_c_int = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2])
     end function
 
@@ -9977,7 +10111,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_r4_2_c_size_t
 #endif
       !
-      hipMallocManaged_r4_2_c_size_t = hipMallocManaged_(cptr,length1*length2*4_8,flags)
+      hipMallocManaged_r4_2_c_size_t = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2])
     end function
 
@@ -9992,8 +10126,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       real(c_float),pointer,dimension(:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(3),dims(3)
-      integer(8),intent(in),optional :: lbounds8(3),dims8(3)
+      integer(int32),intent(in),optional :: lbounds(3),dims(3)
+      integer(int64),intent(in),optional :: lbounds8(3),dims8(3)
       real(c_float),target,dimension(:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags   
       ! 
@@ -10022,21 +10156,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMallocManaged_r4_3_source = hipMallocManaged_(cptr,size(dsource)*4_8,flags)
-        hipMallocManaged_r4_3_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*4_8,hipMemcpyDeviceToDevice)
+        hipMallocManaged_r4_3_source = hipMallocManaged_(cptr,size(dsource,kind=int64)*byte_size(elem_real32),flags)
+        hipMallocManaged_r4_3_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_real32),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):) => tmp
       else if ( present(source) ) then
-        hipMallocManaged_r4_3_source = hipMallocManaged_(cptr,size(source)*4_8,flags)
-        hipMallocManaged_r4_3_source = hipMemcpy(cptr,c_loc(source),size(source)*4_8,hipMemcpyHostToDevice)
+        hipMallocManaged_r4_3_source = hipMallocManaged_(cptr,size(source,kind=int64)*byte_size(elem_real32),flags)
+        hipMallocManaged_r4_3_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_real32),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):) => tmp
       else if ( present(mold) ) then
-        hipMallocManaged_r4_3_source = hipMallocManaged_(cptr,size(mold)*4_8,flags)
+        hipMallocManaged_r4_3_source = hipMallocManaged_(cptr,size(mold,kind=int64)*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):) => tmp
       else if ( present(dims8) ) then
-        hipMallocManaged_r4_3_source = hipMallocManaged_(cptr,PRODUCT(dims8)*4_8,flags)
+        hipMallocManaged_r4_3_source = hipMallocManaged_(cptr,PRODUCT(dims8)*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):) => tmp
@@ -10044,7 +10178,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMallocManaged_r4_3_source = hipMallocManaged_(cptr,PRODUCT(dims)*4_8,flags)
+        hipMallocManaged_r4_3_source = hipMallocManaged_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):) => tmp
@@ -10074,7 +10208,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_r4_3_c_int
 #endif
       !
-      hipMallocManaged_r4_3_c_int = hipMallocManaged_(cptr,length1*length2*length3*4_8,flags)
+      hipMallocManaged_r4_3_c_int = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3])
     end function
 
@@ -10098,7 +10232,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_r4_3_c_size_t
 #endif
       !
-      hipMallocManaged_r4_3_c_size_t = hipMallocManaged_(cptr,length1*length2*length3*4_8,flags)
+      hipMallocManaged_r4_3_c_size_t = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3])
     end function
 
@@ -10113,8 +10247,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       real(c_float),pointer,dimension(:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(4),dims(4)
-      integer(8),intent(in),optional :: lbounds8(4),dims8(4)
+      integer(int32),intent(in),optional :: lbounds(4),dims(4)
+      integer(int64),intent(in),optional :: lbounds8(4),dims8(4)
       real(c_float),target,dimension(:,:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags   
       ! 
@@ -10143,21 +10277,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMallocManaged_r4_4_source = hipMallocManaged_(cptr,size(dsource)*4_8,flags)
-        hipMallocManaged_r4_4_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*4_8,hipMemcpyDeviceToDevice)
+        hipMallocManaged_r4_4_source = hipMallocManaged_(cptr,size(dsource,kind=int64)*byte_size(elem_real32),flags)
+        hipMallocManaged_r4_4_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_real32),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):) => tmp
       else if ( present(source) ) then
-        hipMallocManaged_r4_4_source = hipMallocManaged_(cptr,size(source)*4_8,flags)
-        hipMallocManaged_r4_4_source = hipMemcpy(cptr,c_loc(source),size(source)*4_8,hipMemcpyHostToDevice)
+        hipMallocManaged_r4_4_source = hipMallocManaged_(cptr,size(source,kind=int64)*byte_size(elem_real32),flags)
+        hipMallocManaged_r4_4_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_real32),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):) => tmp
       else if ( present(mold) ) then
-        hipMallocManaged_r4_4_source = hipMallocManaged_(cptr,size(mold)*4_8,flags)
+        hipMallocManaged_r4_4_source = hipMallocManaged_(cptr,size(mold,kind=int64)*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):) => tmp
       else if ( present(dims8) ) then
-        hipMallocManaged_r4_4_source = hipMallocManaged_(cptr,PRODUCT(dims8)*4_8,flags)
+        hipMallocManaged_r4_4_source = hipMallocManaged_(cptr,PRODUCT(dims8)*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):) => tmp
@@ -10165,7 +10299,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMallocManaged_r4_4_source = hipMallocManaged_(cptr,PRODUCT(dims)*4_8,flags)
+        hipMallocManaged_r4_4_source = hipMallocManaged_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):) => tmp
@@ -10195,7 +10329,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_r4_4_c_int
 #endif
       !
-      hipMallocManaged_r4_4_c_int = hipMallocManaged_(cptr,length1*length2*length3*length4*4_8,flags)
+      hipMallocManaged_r4_4_c_int = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*int(length4,kind=int64)*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4])
     end function
 
@@ -10219,7 +10353,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_r4_4_c_size_t
 #endif
       !
-      hipMallocManaged_r4_4_c_size_t = hipMallocManaged_(cptr,length1*length2*length3*length4*4_8,flags)
+      hipMallocManaged_r4_4_c_size_t = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*int(length4,kind=int64)*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4])
     end function
 
@@ -10234,8 +10368,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       real(c_float),pointer,dimension(:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(5),dims(5)
-      integer(8),intent(in),optional :: lbounds8(5),dims8(5)
+      integer(int32),intent(in),optional :: lbounds(5),dims(5)
+      integer(int64),intent(in),optional :: lbounds8(5),dims8(5)
       real(c_float),target,dimension(:,:,:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags   
       ! 
@@ -10264,21 +10398,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMallocManaged_r4_5_source = hipMallocManaged_(cptr,size(dsource)*4_8,flags)
-        hipMallocManaged_r4_5_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*4_8,hipMemcpyDeviceToDevice)
+        hipMallocManaged_r4_5_source = hipMallocManaged_(cptr,size(dsource,kind=int64)*byte_size(elem_real32),flags)
+        hipMallocManaged_r4_5_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_real32),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):) => tmp
       else if ( present(source) ) then
-        hipMallocManaged_r4_5_source = hipMallocManaged_(cptr,size(source)*4_8,flags)
-        hipMallocManaged_r4_5_source = hipMemcpy(cptr,c_loc(source),size(source)*4_8,hipMemcpyHostToDevice)
+        hipMallocManaged_r4_5_source = hipMallocManaged_(cptr,size(source,kind=int64)*byte_size(elem_real32),flags)
+        hipMallocManaged_r4_5_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_real32),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):) => tmp
       else if ( present(mold) ) then
-        hipMallocManaged_r4_5_source = hipMallocManaged_(cptr,size(mold)*4_8,flags)
+        hipMallocManaged_r4_5_source = hipMallocManaged_(cptr,size(mold,kind=int64)*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):) => tmp
       else if ( present(dims8) ) then
-        hipMallocManaged_r4_5_source = hipMallocManaged_(cptr,PRODUCT(dims8)*4_8,flags)
+        hipMallocManaged_r4_5_source = hipMallocManaged_(cptr,PRODUCT(dims8)*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):) => tmp
@@ -10286,7 +10420,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMallocManaged_r4_5_source = hipMallocManaged_(cptr,PRODUCT(dims)*4_8,flags)
+        hipMallocManaged_r4_5_source = hipMallocManaged_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):) => tmp
@@ -10316,7 +10450,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_r4_5_c_int
 #endif
       !
-      hipMallocManaged_r4_5_c_int = hipMallocManaged_(cptr,length1*length2*length3*length4*length5*4_8,flags)
+      hipMallocManaged_r4_5_c_int = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*int(length4,kind=int64)*int(length5,kind=int64)*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5])
     end function
 
@@ -10340,7 +10474,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_r4_5_c_size_t
 #endif
       !
-      hipMallocManaged_r4_5_c_size_t = hipMallocManaged_(cptr,length1*length2*length3*length4*length5*4_8,flags)
+      hipMallocManaged_r4_5_c_size_t = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*int(length4,kind=int64)*int(length5,kind=int64)*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5])
     end function
 
@@ -10355,8 +10489,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       real(c_float),pointer,dimension(:,:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(6),dims(6)
-      integer(8),intent(in),optional :: lbounds8(6),dims8(6)
+      integer(int32),intent(in),optional :: lbounds(6),dims(6)
+      integer(int64),intent(in),optional :: lbounds8(6),dims8(6)
       real(c_float),target,dimension(:,:,:,:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags   
       ! 
@@ -10385,21 +10519,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMallocManaged_r4_6_source = hipMallocManaged_(cptr,size(dsource)*4_8,flags)
-        hipMallocManaged_r4_6_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*4_8,hipMemcpyDeviceToDevice)
+        hipMallocManaged_r4_6_source = hipMallocManaged_(cptr,size(dsource,kind=int64)*byte_size(elem_real32),flags)
+        hipMallocManaged_r4_6_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_real32),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):,LBOUND(dsource,6):) => tmp
       else if ( present(source) ) then
-        hipMallocManaged_r4_6_source = hipMallocManaged_(cptr,size(source)*4_8,flags)
-        hipMallocManaged_r4_6_source = hipMemcpy(cptr,c_loc(source),size(source)*4_8,hipMemcpyHostToDevice)
+        hipMallocManaged_r4_6_source = hipMallocManaged_(cptr,size(source,kind=int64)*byte_size(elem_real32),flags)
+        hipMallocManaged_r4_6_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_real32),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):,LBOUND(source,6):) => tmp
       else if ( present(mold) ) then
-        hipMallocManaged_r4_6_source = hipMallocManaged_(cptr,size(mold)*4_8,flags)
+        hipMallocManaged_r4_6_source = hipMallocManaged_(cptr,size(mold,kind=int64)*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):,LBOUND(mold,6):) => tmp
       else if ( present(dims8) ) then
-        hipMallocManaged_r4_6_source = hipMallocManaged_(cptr,PRODUCT(dims8)*4_8,flags)
+        hipMallocManaged_r4_6_source = hipMallocManaged_(cptr,PRODUCT(dims8)*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):,lbounds8(6):) => tmp
@@ -10407,7 +10541,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMallocManaged_r4_6_source = hipMallocManaged_(cptr,PRODUCT(dims)*4_8,flags)
+        hipMallocManaged_r4_6_source = hipMallocManaged_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):,lbounds(6):) => tmp
@@ -10437,7 +10571,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_r4_6_c_int
 #endif
       !
-      hipMallocManaged_r4_6_c_int = hipMallocManaged_(cptr,length1*length2*length3*length4*length5*length6*4_8,flags)
+      hipMallocManaged_r4_6_c_int = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6])
     end function
 
@@ -10461,7 +10595,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_r4_6_c_size_t
 #endif
       !
-      hipMallocManaged_r4_6_c_size_t = hipMallocManaged_(cptr,length1*length2*length3*length4*length5*length6*4_8,flags)
+      hipMallocManaged_r4_6_c_size_t = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6])
     end function
 
@@ -10476,8 +10610,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       real(c_float),pointer,dimension(:,:,:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(7),dims(7)
-      integer(8),intent(in),optional :: lbounds8(7),dims8(7)
+      integer(int32),intent(in),optional :: lbounds(7),dims(7)
+      integer(int64),intent(in),optional :: lbounds8(7),dims8(7)
       real(c_float),target,dimension(:,:,:,:,:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags   
       ! 
@@ -10506,21 +10640,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMallocManaged_r4_7_source = hipMallocManaged_(cptr,size(dsource)*4_8,flags)
-        hipMallocManaged_r4_7_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*4_8,hipMemcpyDeviceToDevice)
+        hipMallocManaged_r4_7_source = hipMallocManaged_(cptr,size(dsource,kind=int64)*byte_size(elem_real32),flags)
+        hipMallocManaged_r4_7_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_real32),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):,LBOUND(dsource,6):,LBOUND(dsource,7):) => tmp
       else if ( present(source) ) then
-        hipMallocManaged_r4_7_source = hipMallocManaged_(cptr,size(source)*4_8,flags)
-        hipMallocManaged_r4_7_source = hipMemcpy(cptr,c_loc(source),size(source)*4_8,hipMemcpyHostToDevice)
+        hipMallocManaged_r4_7_source = hipMallocManaged_(cptr,size(source,kind=int64)*byte_size(elem_real32),flags)
+        hipMallocManaged_r4_7_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_real32),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):,LBOUND(source,6):,LBOUND(source,7):) => tmp
       else if ( present(mold) ) then
-        hipMallocManaged_r4_7_source = hipMallocManaged_(cptr,size(mold)*4_8,flags)
+        hipMallocManaged_r4_7_source = hipMallocManaged_(cptr,size(mold,kind=int64)*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):,LBOUND(mold,6):,LBOUND(mold,7):) => tmp
       else if ( present(dims8) ) then
-        hipMallocManaged_r4_7_source = hipMallocManaged_(cptr,PRODUCT(dims8)*4_8,flags)
+        hipMallocManaged_r4_7_source = hipMallocManaged_(cptr,PRODUCT(dims8)*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):,lbounds8(6):,lbounds8(7):) => tmp
@@ -10528,7 +10662,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMallocManaged_r4_7_source = hipMallocManaged_(cptr,PRODUCT(dims)*4_8,flags)
+        hipMallocManaged_r4_7_source = hipMallocManaged_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):,lbounds(6):,lbounds(7):) => tmp
@@ -10558,7 +10692,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_r4_7_c_int
 #endif
       !
-      hipMallocManaged_r4_7_c_int = hipMallocManaged_(cptr,length1*length2*length3*length4*length5*length6*length7*4_8,flags)
+      hipMallocManaged_r4_7_c_int = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*int(length7,kind=int64)*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6,length7])
     end function
 
@@ -10582,7 +10716,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_r4_7_c_size_t
 #endif
       !
-      hipMallocManaged_r4_7_c_size_t = hipMallocManaged_(cptr,length1*length2*length3*length4*length5*length6*length7*4_8,flags)
+      hipMallocManaged_r4_7_c_size_t = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*int(length7,kind=int64)*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6,length7])
     end function
 
@@ -10615,15 +10749,15 @@ module hipfort_hipmalloc
       if ( nOptArgs > 1 ) ERROR STOP "ERROR: hipMallocManaged (scalar version): Only one optional argument ('dsource','source') must be specified."
     
       if ( present(dsource) ) then
-        hipMallocManaged_r8_0_source = hipMallocManaged_(cptr,8_8,flags)
-        hipMallocManaged_r8_0_source = hipMemcpy(cptr,c_loc(dsource),8_8,hipMemcpyDeviceToDevice)
+        hipMallocManaged_r8_0_source = hipMallocManaged_(cptr,byte_size(elem_real64),flags)
+        hipMallocManaged_r8_0_source = hipMemcpy(cptr,c_loc(dsource),byte_size(elem_real64),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,ptr)
       else if ( present(source) ) then
-        hipMallocManaged_r8_0_source = hipMallocManaged_(cptr,8_8,flags)
-        hipMallocManaged_r8_0_source = hipMemcpy(cptr,c_loc(source),8_8,hipMemcpyHostToDevice)
+        hipMallocManaged_r8_0_source = hipMallocManaged_(cptr,byte_size(elem_real64),flags)
+        hipMallocManaged_r8_0_source = hipMemcpy(cptr,c_loc(source),byte_size(elem_real64),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,ptr)
       else
-        hipMallocManaged_r8_0_source = hipMallocManaged_(cptr,8_8,flags)
+        hipMallocManaged_r8_0_source = hipMallocManaged_(cptr,byte_size(elem_real64),flags)
         call c_f_pointer(cptr,ptr)
       end if
     end function
@@ -10640,8 +10774,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       real(c_double),pointer,dimension(:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(1),dims(1)
-      integer(8),intent(in),optional :: lbounds8(1),dims8(1)
+      integer(int32),intent(in),optional :: lbounds(1),dims(1)
+      integer(int64),intent(in),optional :: lbounds8(1),dims8(1)
       real(c_double),target,dimension(:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags   
       ! 
@@ -10670,21 +10804,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMallocManaged_r8_1_source = hipMallocManaged_(cptr,size(dsource)*8_8,flags)
-        hipMallocManaged_r8_1_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*8_8,hipMemcpyDeviceToDevice)
+        hipMallocManaged_r8_1_source = hipMallocManaged_(cptr,size(dsource,kind=int64)*byte_size(elem_real64),flags)
+        hipMallocManaged_r8_1_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_real64),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):) => tmp
       else if ( present(source) ) then
-        hipMallocManaged_r8_1_source = hipMallocManaged_(cptr,size(source)*8_8,flags)
-        hipMallocManaged_r8_1_source = hipMemcpy(cptr,c_loc(source),size(source)*8_8,hipMemcpyHostToDevice)
+        hipMallocManaged_r8_1_source = hipMallocManaged_(cptr,size(source,kind=int64)*byte_size(elem_real64),flags)
+        hipMallocManaged_r8_1_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_real64),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):) => tmp
       else if ( present(mold) ) then
-        hipMallocManaged_r8_1_source = hipMallocManaged_(cptr,size(mold)*8_8,flags)
+        hipMallocManaged_r8_1_source = hipMallocManaged_(cptr,size(mold,kind=int64)*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):) => tmp
       else if ( present(dims8) ) then
-        hipMallocManaged_r8_1_source = hipMallocManaged_(cptr,PRODUCT(dims8)*8_8,flags)
+        hipMallocManaged_r8_1_source = hipMallocManaged_(cptr,PRODUCT(dims8)*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):) => tmp
@@ -10692,7 +10826,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMallocManaged_r8_1_source = hipMallocManaged_(cptr,PRODUCT(dims)*8_8,flags)
+        hipMallocManaged_r8_1_source = hipMallocManaged_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):) => tmp
@@ -10722,7 +10856,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_r8_1_c_int
 #endif
       !
-      hipMallocManaged_r8_1_c_int = hipMallocManaged_(cptr,length1*8_8,flags)
+      hipMallocManaged_r8_1_c_int = hipMallocManaged_(cptr,int(length1,kind=int64)*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1])
     end function
 
@@ -10746,7 +10880,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_r8_1_c_size_t
 #endif
       !
-      hipMallocManaged_r8_1_c_size_t = hipMallocManaged_(cptr,length1*8_8,flags)
+      hipMallocManaged_r8_1_c_size_t = hipMallocManaged_(cptr,int(length1,kind=int64)*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1])
     end function
 
@@ -10761,8 +10895,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       real(c_double),pointer,dimension(:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(2),dims(2)
-      integer(8),intent(in),optional :: lbounds8(2),dims8(2)
+      integer(int32),intent(in),optional :: lbounds(2),dims(2)
+      integer(int64),intent(in),optional :: lbounds8(2),dims8(2)
       real(c_double),target,dimension(:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags   
       ! 
@@ -10791,21 +10925,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMallocManaged_r8_2_source = hipMallocManaged_(cptr,size(dsource)*8_8,flags)
-        hipMallocManaged_r8_2_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*8_8,hipMemcpyDeviceToDevice)
+        hipMallocManaged_r8_2_source = hipMallocManaged_(cptr,size(dsource,kind=int64)*byte_size(elem_real64),flags)
+        hipMallocManaged_r8_2_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_real64),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):) => tmp
       else if ( present(source) ) then
-        hipMallocManaged_r8_2_source = hipMallocManaged_(cptr,size(source)*8_8,flags)
-        hipMallocManaged_r8_2_source = hipMemcpy(cptr,c_loc(source),size(source)*8_8,hipMemcpyHostToDevice)
+        hipMallocManaged_r8_2_source = hipMallocManaged_(cptr,size(source,kind=int64)*byte_size(elem_real64),flags)
+        hipMallocManaged_r8_2_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_real64),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):) => tmp
       else if ( present(mold) ) then
-        hipMallocManaged_r8_2_source = hipMallocManaged_(cptr,size(mold)*8_8,flags)
+        hipMallocManaged_r8_2_source = hipMallocManaged_(cptr,size(mold,kind=int64)*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):) => tmp
       else if ( present(dims8) ) then
-        hipMallocManaged_r8_2_source = hipMallocManaged_(cptr,PRODUCT(dims8)*8_8,flags)
+        hipMallocManaged_r8_2_source = hipMallocManaged_(cptr,PRODUCT(dims8)*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):) => tmp
@@ -10813,7 +10947,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMallocManaged_r8_2_source = hipMallocManaged_(cptr,PRODUCT(dims)*8_8,flags)
+        hipMallocManaged_r8_2_source = hipMallocManaged_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):) => tmp
@@ -10843,7 +10977,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_r8_2_c_int
 #endif
       !
-      hipMallocManaged_r8_2_c_int = hipMallocManaged_(cptr,length1*length2*8_8,flags)
+      hipMallocManaged_r8_2_c_int = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2])
     end function
 
@@ -10867,7 +11001,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_r8_2_c_size_t
 #endif
       !
-      hipMallocManaged_r8_2_c_size_t = hipMallocManaged_(cptr,length1*length2*8_8,flags)
+      hipMallocManaged_r8_2_c_size_t = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2])
     end function
 
@@ -10882,8 +11016,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       real(c_double),pointer,dimension(:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(3),dims(3)
-      integer(8),intent(in),optional :: lbounds8(3),dims8(3)
+      integer(int32),intent(in),optional :: lbounds(3),dims(3)
+      integer(int64),intent(in),optional :: lbounds8(3),dims8(3)
       real(c_double),target,dimension(:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags   
       ! 
@@ -10912,21 +11046,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMallocManaged_r8_3_source = hipMallocManaged_(cptr,size(dsource)*8_8,flags)
-        hipMallocManaged_r8_3_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*8_8,hipMemcpyDeviceToDevice)
+        hipMallocManaged_r8_3_source = hipMallocManaged_(cptr,size(dsource,kind=int64)*byte_size(elem_real64),flags)
+        hipMallocManaged_r8_3_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_real64),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):) => tmp
       else if ( present(source) ) then
-        hipMallocManaged_r8_3_source = hipMallocManaged_(cptr,size(source)*8_8,flags)
-        hipMallocManaged_r8_3_source = hipMemcpy(cptr,c_loc(source),size(source)*8_8,hipMemcpyHostToDevice)
+        hipMallocManaged_r8_3_source = hipMallocManaged_(cptr,size(source,kind=int64)*byte_size(elem_real64),flags)
+        hipMallocManaged_r8_3_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_real64),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):) => tmp
       else if ( present(mold) ) then
-        hipMallocManaged_r8_3_source = hipMallocManaged_(cptr,size(mold)*8_8,flags)
+        hipMallocManaged_r8_3_source = hipMallocManaged_(cptr,size(mold,kind=int64)*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):) => tmp
       else if ( present(dims8) ) then
-        hipMallocManaged_r8_3_source = hipMallocManaged_(cptr,PRODUCT(dims8)*8_8,flags)
+        hipMallocManaged_r8_3_source = hipMallocManaged_(cptr,PRODUCT(dims8)*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):) => tmp
@@ -10934,7 +11068,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMallocManaged_r8_3_source = hipMallocManaged_(cptr,PRODUCT(dims)*8_8,flags)
+        hipMallocManaged_r8_3_source = hipMallocManaged_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):) => tmp
@@ -10964,7 +11098,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_r8_3_c_int
 #endif
       !
-      hipMallocManaged_r8_3_c_int = hipMallocManaged_(cptr,length1*length2*length3*8_8,flags)
+      hipMallocManaged_r8_3_c_int = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3])
     end function
 
@@ -10988,7 +11122,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_r8_3_c_size_t
 #endif
       !
-      hipMallocManaged_r8_3_c_size_t = hipMallocManaged_(cptr,length1*length2*length3*8_8,flags)
+      hipMallocManaged_r8_3_c_size_t = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3])
     end function
 
@@ -11003,8 +11137,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       real(c_double),pointer,dimension(:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(4),dims(4)
-      integer(8),intent(in),optional :: lbounds8(4),dims8(4)
+      integer(int32),intent(in),optional :: lbounds(4),dims(4)
+      integer(int64),intent(in),optional :: lbounds8(4),dims8(4)
       real(c_double),target,dimension(:,:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags   
       ! 
@@ -11033,21 +11167,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMallocManaged_r8_4_source = hipMallocManaged_(cptr,size(dsource)*8_8,flags)
-        hipMallocManaged_r8_4_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*8_8,hipMemcpyDeviceToDevice)
+        hipMallocManaged_r8_4_source = hipMallocManaged_(cptr,size(dsource,kind=int64)*byte_size(elem_real64),flags)
+        hipMallocManaged_r8_4_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_real64),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):) => tmp
       else if ( present(source) ) then
-        hipMallocManaged_r8_4_source = hipMallocManaged_(cptr,size(source)*8_8,flags)
-        hipMallocManaged_r8_4_source = hipMemcpy(cptr,c_loc(source),size(source)*8_8,hipMemcpyHostToDevice)
+        hipMallocManaged_r8_4_source = hipMallocManaged_(cptr,size(source,kind=int64)*byte_size(elem_real64),flags)
+        hipMallocManaged_r8_4_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_real64),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):) => tmp
       else if ( present(mold) ) then
-        hipMallocManaged_r8_4_source = hipMallocManaged_(cptr,size(mold)*8_8,flags)
+        hipMallocManaged_r8_4_source = hipMallocManaged_(cptr,size(mold,kind=int64)*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):) => tmp
       else if ( present(dims8) ) then
-        hipMallocManaged_r8_4_source = hipMallocManaged_(cptr,PRODUCT(dims8)*8_8,flags)
+        hipMallocManaged_r8_4_source = hipMallocManaged_(cptr,PRODUCT(dims8)*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):) => tmp
@@ -11055,7 +11189,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMallocManaged_r8_4_source = hipMallocManaged_(cptr,PRODUCT(dims)*8_8,flags)
+        hipMallocManaged_r8_4_source = hipMallocManaged_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):) => tmp
@@ -11085,7 +11219,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_r8_4_c_int
 #endif
       !
-      hipMallocManaged_r8_4_c_int = hipMallocManaged_(cptr,length1*length2*length3*length4*8_8,flags)
+      hipMallocManaged_r8_4_c_int = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*int(length4,kind=int64)*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4])
     end function
 
@@ -11109,7 +11243,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_r8_4_c_size_t
 #endif
       !
-      hipMallocManaged_r8_4_c_size_t = hipMallocManaged_(cptr,length1*length2*length3*length4*8_8,flags)
+      hipMallocManaged_r8_4_c_size_t = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*int(length4,kind=int64)*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4])
     end function
 
@@ -11124,8 +11258,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       real(c_double),pointer,dimension(:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(5),dims(5)
-      integer(8),intent(in),optional :: lbounds8(5),dims8(5)
+      integer(int32),intent(in),optional :: lbounds(5),dims(5)
+      integer(int64),intent(in),optional :: lbounds8(5),dims8(5)
       real(c_double),target,dimension(:,:,:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags   
       ! 
@@ -11154,21 +11288,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMallocManaged_r8_5_source = hipMallocManaged_(cptr,size(dsource)*8_8,flags)
-        hipMallocManaged_r8_5_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*8_8,hipMemcpyDeviceToDevice)
+        hipMallocManaged_r8_5_source = hipMallocManaged_(cptr,size(dsource,kind=int64)*byte_size(elem_real64),flags)
+        hipMallocManaged_r8_5_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_real64),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):) => tmp
       else if ( present(source) ) then
-        hipMallocManaged_r8_5_source = hipMallocManaged_(cptr,size(source)*8_8,flags)
-        hipMallocManaged_r8_5_source = hipMemcpy(cptr,c_loc(source),size(source)*8_8,hipMemcpyHostToDevice)
+        hipMallocManaged_r8_5_source = hipMallocManaged_(cptr,size(source,kind=int64)*byte_size(elem_real64),flags)
+        hipMallocManaged_r8_5_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_real64),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):) => tmp
       else if ( present(mold) ) then
-        hipMallocManaged_r8_5_source = hipMallocManaged_(cptr,size(mold)*8_8,flags)
+        hipMallocManaged_r8_5_source = hipMallocManaged_(cptr,size(mold,kind=int64)*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):) => tmp
       else if ( present(dims8) ) then
-        hipMallocManaged_r8_5_source = hipMallocManaged_(cptr,PRODUCT(dims8)*8_8,flags)
+        hipMallocManaged_r8_5_source = hipMallocManaged_(cptr,PRODUCT(dims8)*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):) => tmp
@@ -11176,7 +11310,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMallocManaged_r8_5_source = hipMallocManaged_(cptr,PRODUCT(dims)*8_8,flags)
+        hipMallocManaged_r8_5_source = hipMallocManaged_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):) => tmp
@@ -11206,7 +11340,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_r8_5_c_int
 #endif
       !
-      hipMallocManaged_r8_5_c_int = hipMallocManaged_(cptr,length1*length2*length3*length4*length5*8_8,flags)
+      hipMallocManaged_r8_5_c_int = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*int(length4,kind=int64)*int(length5,kind=int64)*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5])
     end function
 
@@ -11230,7 +11364,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_r8_5_c_size_t
 #endif
       !
-      hipMallocManaged_r8_5_c_size_t = hipMallocManaged_(cptr,length1*length2*length3*length4*length5*8_8,flags)
+      hipMallocManaged_r8_5_c_size_t = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*int(length4,kind=int64)*int(length5,kind=int64)*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5])
     end function
 
@@ -11245,8 +11379,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       real(c_double),pointer,dimension(:,:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(6),dims(6)
-      integer(8),intent(in),optional :: lbounds8(6),dims8(6)
+      integer(int32),intent(in),optional :: lbounds(6),dims(6)
+      integer(int64),intent(in),optional :: lbounds8(6),dims8(6)
       real(c_double),target,dimension(:,:,:,:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags   
       ! 
@@ -11275,21 +11409,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMallocManaged_r8_6_source = hipMallocManaged_(cptr,size(dsource)*8_8,flags)
-        hipMallocManaged_r8_6_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*8_8,hipMemcpyDeviceToDevice)
+        hipMallocManaged_r8_6_source = hipMallocManaged_(cptr,size(dsource,kind=int64)*byte_size(elem_real64),flags)
+        hipMallocManaged_r8_6_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_real64),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):,LBOUND(dsource,6):) => tmp
       else if ( present(source) ) then
-        hipMallocManaged_r8_6_source = hipMallocManaged_(cptr,size(source)*8_8,flags)
-        hipMallocManaged_r8_6_source = hipMemcpy(cptr,c_loc(source),size(source)*8_8,hipMemcpyHostToDevice)
+        hipMallocManaged_r8_6_source = hipMallocManaged_(cptr,size(source,kind=int64)*byte_size(elem_real64),flags)
+        hipMallocManaged_r8_6_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_real64),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):,LBOUND(source,6):) => tmp
       else if ( present(mold) ) then
-        hipMallocManaged_r8_6_source = hipMallocManaged_(cptr,size(mold)*8_8,flags)
+        hipMallocManaged_r8_6_source = hipMallocManaged_(cptr,size(mold,kind=int64)*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):,LBOUND(mold,6):) => tmp
       else if ( present(dims8) ) then
-        hipMallocManaged_r8_6_source = hipMallocManaged_(cptr,PRODUCT(dims8)*8_8,flags)
+        hipMallocManaged_r8_6_source = hipMallocManaged_(cptr,PRODUCT(dims8)*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):,lbounds8(6):) => tmp
@@ -11297,7 +11431,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMallocManaged_r8_6_source = hipMallocManaged_(cptr,PRODUCT(dims)*8_8,flags)
+        hipMallocManaged_r8_6_source = hipMallocManaged_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):,lbounds(6):) => tmp
@@ -11327,7 +11461,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_r8_6_c_int
 #endif
       !
-      hipMallocManaged_r8_6_c_int = hipMallocManaged_(cptr,length1*length2*length3*length4*length5*length6*8_8,flags)
+      hipMallocManaged_r8_6_c_int = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6])
     end function
 
@@ -11351,7 +11485,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_r8_6_c_size_t
 #endif
       !
-      hipMallocManaged_r8_6_c_size_t = hipMallocManaged_(cptr,length1*length2*length3*length4*length5*length6*8_8,flags)
+      hipMallocManaged_r8_6_c_size_t = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6])
     end function
 
@@ -11366,8 +11500,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       real(c_double),pointer,dimension(:,:,:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(7),dims(7)
-      integer(8),intent(in),optional :: lbounds8(7),dims8(7)
+      integer(int32),intent(in),optional :: lbounds(7),dims(7)
+      integer(int64),intent(in),optional :: lbounds8(7),dims8(7)
       real(c_double),target,dimension(:,:,:,:,:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags   
       ! 
@@ -11396,21 +11530,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMallocManaged_r8_7_source = hipMallocManaged_(cptr,size(dsource)*8_8,flags)
-        hipMallocManaged_r8_7_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*8_8,hipMemcpyDeviceToDevice)
+        hipMallocManaged_r8_7_source = hipMallocManaged_(cptr,size(dsource,kind=int64)*byte_size(elem_real64),flags)
+        hipMallocManaged_r8_7_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_real64),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):,LBOUND(dsource,6):,LBOUND(dsource,7):) => tmp
       else if ( present(source) ) then
-        hipMallocManaged_r8_7_source = hipMallocManaged_(cptr,size(source)*8_8,flags)
-        hipMallocManaged_r8_7_source = hipMemcpy(cptr,c_loc(source),size(source)*8_8,hipMemcpyHostToDevice)
+        hipMallocManaged_r8_7_source = hipMallocManaged_(cptr,size(source,kind=int64)*byte_size(elem_real64),flags)
+        hipMallocManaged_r8_7_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_real64),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):,LBOUND(source,6):,LBOUND(source,7):) => tmp
       else if ( present(mold) ) then
-        hipMallocManaged_r8_7_source = hipMallocManaged_(cptr,size(mold)*8_8,flags)
+        hipMallocManaged_r8_7_source = hipMallocManaged_(cptr,size(mold,kind=int64)*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):,LBOUND(mold,6):,LBOUND(mold,7):) => tmp
       else if ( present(dims8) ) then
-        hipMallocManaged_r8_7_source = hipMallocManaged_(cptr,PRODUCT(dims8)*8_8,flags)
+        hipMallocManaged_r8_7_source = hipMallocManaged_(cptr,PRODUCT(dims8)*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):,lbounds8(6):,lbounds8(7):) => tmp
@@ -11418,7 +11552,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMallocManaged_r8_7_source = hipMallocManaged_(cptr,PRODUCT(dims)*8_8,flags)
+        hipMallocManaged_r8_7_source = hipMallocManaged_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):,lbounds(6):,lbounds(7):) => tmp
@@ -11448,7 +11582,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_r8_7_c_int
 #endif
       !
-      hipMallocManaged_r8_7_c_int = hipMallocManaged_(cptr,length1*length2*length3*length4*length5*length6*length7*8_8,flags)
+      hipMallocManaged_r8_7_c_int = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*int(length7,kind=int64)*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6,length7])
     end function
 
@@ -11472,7 +11606,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_r8_7_c_size_t
 #endif
       !
-      hipMallocManaged_r8_7_c_size_t = hipMallocManaged_(cptr,length1*length2*length3*length4*length5*length6*length7*8_8,flags)
+      hipMallocManaged_r8_7_c_size_t = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*int(length7,kind=int64)*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6,length7])
     end function
 
@@ -11505,15 +11639,15 @@ module hipfort_hipmalloc
       if ( nOptArgs > 1 ) ERROR STOP "ERROR: hipMallocManaged (scalar version): Only one optional argument ('dsource','source') must be specified."
     
       if ( present(dsource) ) then
-        hipMallocManaged_c4_0_source = hipMallocManaged_(cptr,2*4_8,flags)
-        hipMallocManaged_c4_0_source = hipMemcpy(cptr,c_loc(dsource),2*4_8,hipMemcpyDeviceToDevice)
+        hipMallocManaged_c4_0_source = hipMallocManaged_(cptr,2_int64*byte_size(elem_real32),flags)
+        hipMallocManaged_c4_0_source = hipMemcpy(cptr,c_loc(dsource),2_int64*byte_size(elem_real32),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,ptr)
       else if ( present(source) ) then
-        hipMallocManaged_c4_0_source = hipMallocManaged_(cptr,2*4_8,flags)
-        hipMallocManaged_c4_0_source = hipMemcpy(cptr,c_loc(source),2*4_8,hipMemcpyHostToDevice)
+        hipMallocManaged_c4_0_source = hipMallocManaged_(cptr,2_int64*byte_size(elem_real32),flags)
+        hipMallocManaged_c4_0_source = hipMemcpy(cptr,c_loc(source),2_int64*byte_size(elem_real32),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,ptr)
       else
-        hipMallocManaged_c4_0_source = hipMallocManaged_(cptr,2*4_8,flags)
+        hipMallocManaged_c4_0_source = hipMallocManaged_(cptr,2_int64*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,ptr)
       end if
     end function
@@ -11530,8 +11664,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       complex(c_float_complex),pointer,dimension(:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(1),dims(1)
-      integer(8),intent(in),optional :: lbounds8(1),dims8(1)
+      integer(int32),intent(in),optional :: lbounds(1),dims(1)
+      integer(int64),intent(in),optional :: lbounds8(1),dims8(1)
       complex(c_float_complex),target,dimension(:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags   
       ! 
@@ -11560,21 +11694,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMallocManaged_c4_1_source = hipMallocManaged_(cptr,size(dsource)*2*4_8,flags)
-        hipMallocManaged_c4_1_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*2*4_8,hipMemcpyDeviceToDevice)
+        hipMallocManaged_c4_1_source = hipMallocManaged_(cptr,size(dsource,kind=int64)*2_int64*byte_size(elem_real32),flags)
+        hipMallocManaged_c4_1_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*2_int64*byte_size(elem_real32),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):) => tmp
       else if ( present(source) ) then
-        hipMallocManaged_c4_1_source = hipMallocManaged_(cptr,size(source)*2*4_8,flags)
-        hipMallocManaged_c4_1_source = hipMemcpy(cptr,c_loc(source),size(source)*2*4_8,hipMemcpyHostToDevice)
+        hipMallocManaged_c4_1_source = hipMallocManaged_(cptr,size(source,kind=int64)*2_int64*byte_size(elem_real32),flags)
+        hipMallocManaged_c4_1_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*2_int64*byte_size(elem_real32),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):) => tmp
       else if ( present(mold) ) then
-        hipMallocManaged_c4_1_source = hipMallocManaged_(cptr,size(mold)*2*4_8,flags)
+        hipMallocManaged_c4_1_source = hipMallocManaged_(cptr,size(mold,kind=int64)*2_int64*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):) => tmp
       else if ( present(dims8) ) then
-        hipMallocManaged_c4_1_source = hipMallocManaged_(cptr,PRODUCT(dims8)*2*4_8,flags)
+        hipMallocManaged_c4_1_source = hipMallocManaged_(cptr,PRODUCT(dims8)*2_int64*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):) => tmp
@@ -11582,7 +11716,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMallocManaged_c4_1_source = hipMallocManaged_(cptr,PRODUCT(dims)*2*4_8,flags)
+        hipMallocManaged_c4_1_source = hipMallocManaged_(cptr,PRODUCT(int(dims,kind=int64))*2_int64*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):) => tmp
@@ -11612,7 +11746,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_c4_1_c_int
 #endif
       !
-      hipMallocManaged_c4_1_c_int = hipMallocManaged_(cptr,length1*2*4_8,flags)
+      hipMallocManaged_c4_1_c_int = hipMallocManaged_(cptr,int(length1,kind=int64)*2_int64*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1])
     end function
 
@@ -11636,7 +11770,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_c4_1_c_size_t
 #endif
       !
-      hipMallocManaged_c4_1_c_size_t = hipMallocManaged_(cptr,length1*2*4_8,flags)
+      hipMallocManaged_c4_1_c_size_t = hipMallocManaged_(cptr,int(length1,kind=int64)*2_int64*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1])
     end function
 
@@ -11651,8 +11785,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       complex(c_float_complex),pointer,dimension(:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(2),dims(2)
-      integer(8),intent(in),optional :: lbounds8(2),dims8(2)
+      integer(int32),intent(in),optional :: lbounds(2),dims(2)
+      integer(int64),intent(in),optional :: lbounds8(2),dims8(2)
       complex(c_float_complex),target,dimension(:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags   
       ! 
@@ -11681,21 +11815,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMallocManaged_c4_2_source = hipMallocManaged_(cptr,size(dsource)*2*4_8,flags)
-        hipMallocManaged_c4_2_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*2*4_8,hipMemcpyDeviceToDevice)
+        hipMallocManaged_c4_2_source = hipMallocManaged_(cptr,size(dsource,kind=int64)*2_int64*byte_size(elem_real32),flags)
+        hipMallocManaged_c4_2_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*2_int64*byte_size(elem_real32),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):) => tmp
       else if ( present(source) ) then
-        hipMallocManaged_c4_2_source = hipMallocManaged_(cptr,size(source)*2*4_8,flags)
-        hipMallocManaged_c4_2_source = hipMemcpy(cptr,c_loc(source),size(source)*2*4_8,hipMemcpyHostToDevice)
+        hipMallocManaged_c4_2_source = hipMallocManaged_(cptr,size(source,kind=int64)*2_int64*byte_size(elem_real32),flags)
+        hipMallocManaged_c4_2_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*2_int64*byte_size(elem_real32),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):) => tmp
       else if ( present(mold) ) then
-        hipMallocManaged_c4_2_source = hipMallocManaged_(cptr,size(mold)*2*4_8,flags)
+        hipMallocManaged_c4_2_source = hipMallocManaged_(cptr,size(mold,kind=int64)*2_int64*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):) => tmp
       else if ( present(dims8) ) then
-        hipMallocManaged_c4_2_source = hipMallocManaged_(cptr,PRODUCT(dims8)*2*4_8,flags)
+        hipMallocManaged_c4_2_source = hipMallocManaged_(cptr,PRODUCT(dims8)*2_int64*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):) => tmp
@@ -11703,7 +11837,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMallocManaged_c4_2_source = hipMallocManaged_(cptr,PRODUCT(dims)*2*4_8,flags)
+        hipMallocManaged_c4_2_source = hipMallocManaged_(cptr,PRODUCT(int(dims,kind=int64))*2_int64*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):) => tmp
@@ -11733,7 +11867,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_c4_2_c_int
 #endif
       !
-      hipMallocManaged_c4_2_c_int = hipMallocManaged_(cptr,length1*length2*2*4_8,flags)
+      hipMallocManaged_c4_2_c_int = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*2_int64*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2])
     end function
 
@@ -11757,7 +11891,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_c4_2_c_size_t
 #endif
       !
-      hipMallocManaged_c4_2_c_size_t = hipMallocManaged_(cptr,length1*length2*2*4_8,flags)
+      hipMallocManaged_c4_2_c_size_t = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*2_int64*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2])
     end function
 
@@ -11772,8 +11906,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       complex(c_float_complex),pointer,dimension(:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(3),dims(3)
-      integer(8),intent(in),optional :: lbounds8(3),dims8(3)
+      integer(int32),intent(in),optional :: lbounds(3),dims(3)
+      integer(int64),intent(in),optional :: lbounds8(3),dims8(3)
       complex(c_float_complex),target,dimension(:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags   
       ! 
@@ -11802,21 +11936,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMallocManaged_c4_3_source = hipMallocManaged_(cptr,size(dsource)*2*4_8,flags)
-        hipMallocManaged_c4_3_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*2*4_8,hipMemcpyDeviceToDevice)
+        hipMallocManaged_c4_3_source = hipMallocManaged_(cptr,size(dsource,kind=int64)*2_int64*byte_size(elem_real32),flags)
+        hipMallocManaged_c4_3_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*2_int64*byte_size(elem_real32),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):) => tmp
       else if ( present(source) ) then
-        hipMallocManaged_c4_3_source = hipMallocManaged_(cptr,size(source)*2*4_8,flags)
-        hipMallocManaged_c4_3_source = hipMemcpy(cptr,c_loc(source),size(source)*2*4_8,hipMemcpyHostToDevice)
+        hipMallocManaged_c4_3_source = hipMallocManaged_(cptr,size(source,kind=int64)*2_int64*byte_size(elem_real32),flags)
+        hipMallocManaged_c4_3_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*2_int64*byte_size(elem_real32),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):) => tmp
       else if ( present(mold) ) then
-        hipMallocManaged_c4_3_source = hipMallocManaged_(cptr,size(mold)*2*4_8,flags)
+        hipMallocManaged_c4_3_source = hipMallocManaged_(cptr,size(mold,kind=int64)*2_int64*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):) => tmp
       else if ( present(dims8) ) then
-        hipMallocManaged_c4_3_source = hipMallocManaged_(cptr,PRODUCT(dims8)*2*4_8,flags)
+        hipMallocManaged_c4_3_source = hipMallocManaged_(cptr,PRODUCT(dims8)*2_int64*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):) => tmp
@@ -11824,7 +11958,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMallocManaged_c4_3_source = hipMallocManaged_(cptr,PRODUCT(dims)*2*4_8,flags)
+        hipMallocManaged_c4_3_source = hipMallocManaged_(cptr,PRODUCT(int(dims,kind=int64))*2_int64*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):) => tmp
@@ -11854,7 +11988,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_c4_3_c_int
 #endif
       !
-      hipMallocManaged_c4_3_c_int = hipMallocManaged_(cptr,length1*length2*length3*2*4_8,flags)
+      hipMallocManaged_c4_3_c_int = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*2_int64*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3])
     end function
 
@@ -11878,7 +12012,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_c4_3_c_size_t
 #endif
       !
-      hipMallocManaged_c4_3_c_size_t = hipMallocManaged_(cptr,length1*length2*length3*2*4_8,flags)
+      hipMallocManaged_c4_3_c_size_t = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*2_int64*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3])
     end function
 
@@ -11893,8 +12027,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       complex(c_float_complex),pointer,dimension(:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(4),dims(4)
-      integer(8),intent(in),optional :: lbounds8(4),dims8(4)
+      integer(int32),intent(in),optional :: lbounds(4),dims(4)
+      integer(int64),intent(in),optional :: lbounds8(4),dims8(4)
       complex(c_float_complex),target,dimension(:,:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags   
       ! 
@@ -11923,21 +12057,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMallocManaged_c4_4_source = hipMallocManaged_(cptr,size(dsource)*2*4_8,flags)
-        hipMallocManaged_c4_4_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*2*4_8,hipMemcpyDeviceToDevice)
+        hipMallocManaged_c4_4_source = hipMallocManaged_(cptr,size(dsource,kind=int64)*2_int64*byte_size(elem_real32),flags)
+        hipMallocManaged_c4_4_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*2_int64*byte_size(elem_real32),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):) => tmp
       else if ( present(source) ) then
-        hipMallocManaged_c4_4_source = hipMallocManaged_(cptr,size(source)*2*4_8,flags)
-        hipMallocManaged_c4_4_source = hipMemcpy(cptr,c_loc(source),size(source)*2*4_8,hipMemcpyHostToDevice)
+        hipMallocManaged_c4_4_source = hipMallocManaged_(cptr,size(source,kind=int64)*2_int64*byte_size(elem_real32),flags)
+        hipMallocManaged_c4_4_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*2_int64*byte_size(elem_real32),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):) => tmp
       else if ( present(mold) ) then
-        hipMallocManaged_c4_4_source = hipMallocManaged_(cptr,size(mold)*2*4_8,flags)
+        hipMallocManaged_c4_4_source = hipMallocManaged_(cptr,size(mold,kind=int64)*2_int64*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):) => tmp
       else if ( present(dims8) ) then
-        hipMallocManaged_c4_4_source = hipMallocManaged_(cptr,PRODUCT(dims8)*2*4_8,flags)
+        hipMallocManaged_c4_4_source = hipMallocManaged_(cptr,PRODUCT(dims8)*2_int64*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):) => tmp
@@ -11945,7 +12079,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMallocManaged_c4_4_source = hipMallocManaged_(cptr,PRODUCT(dims)*2*4_8,flags)
+        hipMallocManaged_c4_4_source = hipMallocManaged_(cptr,PRODUCT(int(dims,kind=int64))*2_int64*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):) => tmp
@@ -11975,7 +12109,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_c4_4_c_int
 #endif
       !
-      hipMallocManaged_c4_4_c_int = hipMallocManaged_(cptr,length1*length2*length3*length4*2*4_8,flags)
+      hipMallocManaged_c4_4_c_int = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                           int(length4,kind=int64)*2_int64*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4])
     end function
 
@@ -11999,7 +12134,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_c4_4_c_size_t
 #endif
       !
-      hipMallocManaged_c4_4_c_size_t = hipMallocManaged_(cptr,length1*length2*length3*length4*2*4_8,flags)
+      hipMallocManaged_c4_4_c_size_t = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                              int(length4,kind=int64)*2_int64*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4])
     end function
 
@@ -12014,8 +12150,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       complex(c_float_complex),pointer,dimension(:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(5),dims(5)
-      integer(8),intent(in),optional :: lbounds8(5),dims8(5)
+      integer(int32),intent(in),optional :: lbounds(5),dims(5)
+      integer(int64),intent(in),optional :: lbounds8(5),dims8(5)
       complex(c_float_complex),target,dimension(:,:,:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags   
       ! 
@@ -12044,21 +12180,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMallocManaged_c4_5_source = hipMallocManaged_(cptr,size(dsource)*2*4_8,flags)
-        hipMallocManaged_c4_5_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*2*4_8,hipMemcpyDeviceToDevice)
+        hipMallocManaged_c4_5_source = hipMallocManaged_(cptr,size(dsource,kind=int64)*2_int64*byte_size(elem_real32),flags)
+        hipMallocManaged_c4_5_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*2_int64*byte_size(elem_real32),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):) => tmp
       else if ( present(source) ) then
-        hipMallocManaged_c4_5_source = hipMallocManaged_(cptr,size(source)*2*4_8,flags)
-        hipMallocManaged_c4_5_source = hipMemcpy(cptr,c_loc(source),size(source)*2*4_8,hipMemcpyHostToDevice)
+        hipMallocManaged_c4_5_source = hipMallocManaged_(cptr,size(source,kind=int64)*2_int64*byte_size(elem_real32),flags)
+        hipMallocManaged_c4_5_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*2_int64*byte_size(elem_real32),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):) => tmp
       else if ( present(mold) ) then
-        hipMallocManaged_c4_5_source = hipMallocManaged_(cptr,size(mold)*2*4_8,flags)
+        hipMallocManaged_c4_5_source = hipMallocManaged_(cptr,size(mold,kind=int64)*2_int64*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):) => tmp
       else if ( present(dims8) ) then
-        hipMallocManaged_c4_5_source = hipMallocManaged_(cptr,PRODUCT(dims8)*2*4_8,flags)
+        hipMallocManaged_c4_5_source = hipMallocManaged_(cptr,PRODUCT(dims8)*2_int64*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):) => tmp
@@ -12066,7 +12202,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMallocManaged_c4_5_source = hipMallocManaged_(cptr,PRODUCT(dims)*2*4_8,flags)
+        hipMallocManaged_c4_5_source = hipMallocManaged_(cptr,PRODUCT(int(dims,kind=int64))*2_int64*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):) => tmp
@@ -12096,7 +12232,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_c4_5_c_int
 #endif
       !
-      hipMallocManaged_c4_5_c_int = hipMallocManaged_(cptr,length1*length2*length3*length4*length5*2*4_8,flags)
+      hipMallocManaged_c4_5_c_int = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                           int(length4,kind=int64)*int(length5,kind=int64)*2_int64*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5])
     end function
 
@@ -12120,7 +12257,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_c4_5_c_size_t
 #endif
       !
-      hipMallocManaged_c4_5_c_size_t = hipMallocManaged_(cptr,length1*length2*length3*length4*length5*2*4_8,flags)
+      hipMallocManaged_c4_5_c_size_t = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                              int(length4,kind=int64)*int(length5,kind=int64)*2_int64*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5])
     end function
 
@@ -12135,8 +12273,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       complex(c_float_complex),pointer,dimension(:,:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(6),dims(6)
-      integer(8),intent(in),optional :: lbounds8(6),dims8(6)
+      integer(int32),intent(in),optional :: lbounds(6),dims(6)
+      integer(int64),intent(in),optional :: lbounds8(6),dims8(6)
       complex(c_float_complex),target,dimension(:,:,:,:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags   
       ! 
@@ -12165,21 +12303,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMallocManaged_c4_6_source = hipMallocManaged_(cptr,size(dsource)*2*4_8,flags)
-        hipMallocManaged_c4_6_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*2*4_8,hipMemcpyDeviceToDevice)
+        hipMallocManaged_c4_6_source = hipMallocManaged_(cptr,size(dsource,kind=int64)*2_int64*byte_size(elem_real32),flags)
+        hipMallocManaged_c4_6_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*2_int64*byte_size(elem_real32),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):,LBOUND(dsource,6):) => tmp
       else if ( present(source) ) then
-        hipMallocManaged_c4_6_source = hipMallocManaged_(cptr,size(source)*2*4_8,flags)
-        hipMallocManaged_c4_6_source = hipMemcpy(cptr,c_loc(source),size(source)*2*4_8,hipMemcpyHostToDevice)
+        hipMallocManaged_c4_6_source = hipMallocManaged_(cptr,size(source,kind=int64)*2_int64*byte_size(elem_real32),flags)
+        hipMallocManaged_c4_6_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*2_int64*byte_size(elem_real32),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):,LBOUND(source,6):) => tmp
       else if ( present(mold) ) then
-        hipMallocManaged_c4_6_source = hipMallocManaged_(cptr,size(mold)*2*4_8,flags)
+        hipMallocManaged_c4_6_source = hipMallocManaged_(cptr,size(mold,kind=int64)*2_int64*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):,LBOUND(mold,6):) => tmp
       else if ( present(dims8) ) then
-        hipMallocManaged_c4_6_source = hipMallocManaged_(cptr,PRODUCT(dims8)*2*4_8,flags)
+        hipMallocManaged_c4_6_source = hipMallocManaged_(cptr,PRODUCT(dims8)*2_int64*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):,lbounds8(6):) => tmp
@@ -12187,7 +12325,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMallocManaged_c4_6_source = hipMallocManaged_(cptr,PRODUCT(dims)*2*4_8,flags)
+        hipMallocManaged_c4_6_source = hipMallocManaged_(cptr,PRODUCT(int(dims,kind=int64))*2_int64*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):,lbounds(6):) => tmp
@@ -12217,7 +12355,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_c4_6_c_int
 #endif
       !
-      hipMallocManaged_c4_6_c_int = hipMallocManaged_(cptr,length1*length2*length3*length4*length5*length6*2*4_8,flags)
+      hipMallocManaged_c4_6_c_int = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                           int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*2_int64*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6])
     end function
 
@@ -12241,7 +12380,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_c4_6_c_size_t
 #endif
       !
-      hipMallocManaged_c4_6_c_size_t = hipMallocManaged_(cptr,length1*length2*length3*length4*length5*length6*2*4_8,flags)
+      hipMallocManaged_c4_6_c_size_t = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                              int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*2_int64*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6])
     end function
 
@@ -12256,8 +12396,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       complex(c_float_complex),pointer,dimension(:,:,:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(7),dims(7)
-      integer(8),intent(in),optional :: lbounds8(7),dims8(7)
+      integer(int32),intent(in),optional :: lbounds(7),dims(7)
+      integer(int64),intent(in),optional :: lbounds8(7),dims8(7)
       complex(c_float_complex),target,dimension(:,:,:,:,:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags   
       ! 
@@ -12286,21 +12426,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMallocManaged_c4_7_source = hipMallocManaged_(cptr,size(dsource)*2*4_8,flags)
-        hipMallocManaged_c4_7_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*2*4_8,hipMemcpyDeviceToDevice)
+        hipMallocManaged_c4_7_source = hipMallocManaged_(cptr,size(dsource,kind=int64)*2_int64*byte_size(elem_real32),flags)
+        hipMallocManaged_c4_7_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*2_int64*byte_size(elem_real32),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):,LBOUND(dsource,6):,LBOUND(dsource,7):) => tmp
       else if ( present(source) ) then
-        hipMallocManaged_c4_7_source = hipMallocManaged_(cptr,size(source)*2*4_8,flags)
-        hipMallocManaged_c4_7_source = hipMemcpy(cptr,c_loc(source),size(source)*2*4_8,hipMemcpyHostToDevice)
+        hipMallocManaged_c4_7_source = hipMallocManaged_(cptr,size(source,kind=int64)*2_int64*byte_size(elem_real32),flags)
+        hipMallocManaged_c4_7_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*2_int64*byte_size(elem_real32),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):,LBOUND(source,6):,LBOUND(source,7):) => tmp
       else if ( present(mold) ) then
-        hipMallocManaged_c4_7_source = hipMallocManaged_(cptr,size(mold)*2*4_8,flags)
+        hipMallocManaged_c4_7_source = hipMallocManaged_(cptr,size(mold,kind=int64)*2_int64*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):,LBOUND(mold,6):,LBOUND(mold,7):) => tmp
       else if ( present(dims8) ) then
-        hipMallocManaged_c4_7_source = hipMallocManaged_(cptr,PRODUCT(dims8)*2*4_8,flags)
+        hipMallocManaged_c4_7_source = hipMallocManaged_(cptr,PRODUCT(dims8)*2_int64*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):,lbounds8(6):,lbounds8(7):) => tmp
@@ -12308,7 +12448,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMallocManaged_c4_7_source = hipMallocManaged_(cptr,PRODUCT(dims)*2*4_8,flags)
+        hipMallocManaged_c4_7_source = hipMallocManaged_(cptr,PRODUCT(int(dims,kind=int64))*2_int64*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):,lbounds(6):,lbounds(7):) => tmp
@@ -12338,7 +12478,9 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_c4_7_c_int
 #endif
       !
-      hipMallocManaged_c4_7_c_int = hipMallocManaged_(cptr,length1*length2*length3*length4*length5*length6*length7*2*4_8,flags)
+      hipMallocManaged_c4_7_c_int = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                           int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*&
+                                                           int(length7,kind=int64)*2_int64*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6,length7])
     end function
 
@@ -12362,7 +12504,9 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_c4_7_c_size_t
 #endif
       !
-      hipMallocManaged_c4_7_c_size_t = hipMallocManaged_(cptr,length1*length2*length3*length4*length5*length6*length7*2*4_8,flags)
+      hipMallocManaged_c4_7_c_size_t = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                              int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*&
+                                                              int(length7,kind=int64)*2_int64*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6,length7])
     end function
 
@@ -12395,15 +12539,15 @@ module hipfort_hipmalloc
       if ( nOptArgs > 1 ) ERROR STOP "ERROR: hipMallocManaged (scalar version): Only one optional argument ('dsource','source') must be specified."
     
       if ( present(dsource) ) then
-        hipMallocManaged_c8_0_source = hipMallocManaged_(cptr,2*8_8,flags)
-        hipMallocManaged_c8_0_source = hipMemcpy(cptr,c_loc(dsource),2*8_8,hipMemcpyDeviceToDevice)
+        hipMallocManaged_c8_0_source = hipMallocManaged_(cptr,2_int64*byte_size(elem_real64),flags)
+        hipMallocManaged_c8_0_source = hipMemcpy(cptr,c_loc(dsource),2_int64*byte_size(elem_real64),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,ptr)
       else if ( present(source) ) then
-        hipMallocManaged_c8_0_source = hipMallocManaged_(cptr,2*8_8,flags)
-        hipMallocManaged_c8_0_source = hipMemcpy(cptr,c_loc(source),2*8_8,hipMemcpyHostToDevice)
+        hipMallocManaged_c8_0_source = hipMallocManaged_(cptr,2_int64*byte_size(elem_real64),flags)
+        hipMallocManaged_c8_0_source = hipMemcpy(cptr,c_loc(source),2_int64*byte_size(elem_real64),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,ptr)
       else
-        hipMallocManaged_c8_0_source = hipMallocManaged_(cptr,2*8_8,flags)
+        hipMallocManaged_c8_0_source = hipMallocManaged_(cptr,2_int64*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,ptr)
       end if
     end function
@@ -12420,8 +12564,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       complex(c_double_complex),pointer,dimension(:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(1),dims(1)
-      integer(8),intent(in),optional :: lbounds8(1),dims8(1)
+      integer(int32),intent(in),optional :: lbounds(1),dims(1)
+      integer(int64),intent(in),optional :: lbounds8(1),dims8(1)
       complex(c_double_complex),target,dimension(:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags   
       ! 
@@ -12450,21 +12594,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMallocManaged_c8_1_source = hipMallocManaged_(cptr,size(dsource)*2*8_8,flags)
-        hipMallocManaged_c8_1_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*2*8_8,hipMemcpyDeviceToDevice)
+        hipMallocManaged_c8_1_source = hipMallocManaged_(cptr,size(dsource,kind=int64)*2_int64*byte_size(elem_real64),flags)
+        hipMallocManaged_c8_1_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*2_int64*byte_size(elem_real64),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):) => tmp
       else if ( present(source) ) then
-        hipMallocManaged_c8_1_source = hipMallocManaged_(cptr,size(source)*2*8_8,flags)
-        hipMallocManaged_c8_1_source = hipMemcpy(cptr,c_loc(source),size(source)*2*8_8,hipMemcpyHostToDevice)
+        hipMallocManaged_c8_1_source = hipMallocManaged_(cptr,size(source,kind=int64)*2_int64*byte_size(elem_real64),flags)
+        hipMallocManaged_c8_1_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*2_int64*byte_size(elem_real64),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):) => tmp
       else if ( present(mold) ) then
-        hipMallocManaged_c8_1_source = hipMallocManaged_(cptr,size(mold)*2*8_8,flags)
+        hipMallocManaged_c8_1_source = hipMallocManaged_(cptr,size(mold,kind=int64)*2_int64*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):) => tmp
       else if ( present(dims8) ) then
-        hipMallocManaged_c8_1_source = hipMallocManaged_(cptr,PRODUCT(dims8)*2*8_8,flags)
+        hipMallocManaged_c8_1_source = hipMallocManaged_(cptr,PRODUCT(dims8)*2_int64*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):) => tmp
@@ -12472,7 +12616,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMallocManaged_c8_1_source = hipMallocManaged_(cptr,PRODUCT(dims)*2*8_8,flags)
+        hipMallocManaged_c8_1_source = hipMallocManaged_(cptr,PRODUCT(int(dims,kind=int64))*2_int64*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):) => tmp
@@ -12502,7 +12646,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_c8_1_c_int
 #endif
       !
-      hipMallocManaged_c8_1_c_int = hipMallocManaged_(cptr,length1*2*8_8,flags)
+      hipMallocManaged_c8_1_c_int = hipMallocManaged_(cptr,int(length1,kind=int64)*2_int64*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1])
     end function
 
@@ -12526,7 +12670,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_c8_1_c_size_t
 #endif
       !
-      hipMallocManaged_c8_1_c_size_t = hipMallocManaged_(cptr,length1*2*8_8,flags)
+      hipMallocManaged_c8_1_c_size_t = hipMallocManaged_(cptr,int(length1,kind=int64)*2_int64*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1])
     end function
 
@@ -12541,8 +12685,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       complex(c_double_complex),pointer,dimension(:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(2),dims(2)
-      integer(8),intent(in),optional :: lbounds8(2),dims8(2)
+      integer(int32),intent(in),optional :: lbounds(2),dims(2)
+      integer(int64),intent(in),optional :: lbounds8(2),dims8(2)
       complex(c_double_complex),target,dimension(:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags   
       ! 
@@ -12571,21 +12715,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMallocManaged_c8_2_source = hipMallocManaged_(cptr,size(dsource)*2*8_8,flags)
-        hipMallocManaged_c8_2_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*2*8_8,hipMemcpyDeviceToDevice)
+        hipMallocManaged_c8_2_source = hipMallocManaged_(cptr,size(dsource,kind=int64)*2_int64*byte_size(elem_real64),flags)
+        hipMallocManaged_c8_2_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*2_int64*byte_size(elem_real64),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):) => tmp
       else if ( present(source) ) then
-        hipMallocManaged_c8_2_source = hipMallocManaged_(cptr,size(source)*2*8_8,flags)
-        hipMallocManaged_c8_2_source = hipMemcpy(cptr,c_loc(source),size(source)*2*8_8,hipMemcpyHostToDevice)
+        hipMallocManaged_c8_2_source = hipMallocManaged_(cptr,size(source,kind=int64)*2_int64*byte_size(elem_real64),flags)
+        hipMallocManaged_c8_2_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*2_int64*byte_size(elem_real64),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):) => tmp
       else if ( present(mold) ) then
-        hipMallocManaged_c8_2_source = hipMallocManaged_(cptr,size(mold)*2*8_8,flags)
+        hipMallocManaged_c8_2_source = hipMallocManaged_(cptr,size(mold,kind=int64)*2_int64*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):) => tmp
       else if ( present(dims8) ) then
-        hipMallocManaged_c8_2_source = hipMallocManaged_(cptr,PRODUCT(dims8)*2*8_8,flags)
+        hipMallocManaged_c8_2_source = hipMallocManaged_(cptr,PRODUCT(dims8)*2_int64*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):) => tmp
@@ -12593,7 +12737,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMallocManaged_c8_2_source = hipMallocManaged_(cptr,PRODUCT(dims)*2*8_8,flags)
+        hipMallocManaged_c8_2_source = hipMallocManaged_(cptr,PRODUCT(int(dims,kind=int64))*2_int64*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):) => tmp
@@ -12623,7 +12767,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_c8_2_c_int
 #endif
       !
-      hipMallocManaged_c8_2_c_int = hipMallocManaged_(cptr,length1*length2*2*8_8,flags)
+      hipMallocManaged_c8_2_c_int = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*2_int64*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2])
     end function
 
@@ -12647,7 +12791,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_c8_2_c_size_t
 #endif
       !
-      hipMallocManaged_c8_2_c_size_t = hipMallocManaged_(cptr,length1*length2*2*8_8,flags)
+      hipMallocManaged_c8_2_c_size_t = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*2_int64*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2])
     end function
 
@@ -12662,8 +12806,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       complex(c_double_complex),pointer,dimension(:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(3),dims(3)
-      integer(8),intent(in),optional :: lbounds8(3),dims8(3)
+      integer(int32),intent(in),optional :: lbounds(3),dims(3)
+      integer(int64),intent(in),optional :: lbounds8(3),dims8(3)
       complex(c_double_complex),target,dimension(:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags   
       ! 
@@ -12692,21 +12836,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMallocManaged_c8_3_source = hipMallocManaged_(cptr,size(dsource)*2*8_8,flags)
-        hipMallocManaged_c8_3_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*2*8_8,hipMemcpyDeviceToDevice)
+        hipMallocManaged_c8_3_source = hipMallocManaged_(cptr,size(dsource,kind=int64)*2_int64*byte_size(elem_real64),flags)
+        hipMallocManaged_c8_3_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*2_int64*byte_size(elem_real64),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):) => tmp
       else if ( present(source) ) then
-        hipMallocManaged_c8_3_source = hipMallocManaged_(cptr,size(source)*2*8_8,flags)
-        hipMallocManaged_c8_3_source = hipMemcpy(cptr,c_loc(source),size(source)*2*8_8,hipMemcpyHostToDevice)
+        hipMallocManaged_c8_3_source = hipMallocManaged_(cptr,size(source,kind=int64)*2_int64*byte_size(elem_real64),flags)
+        hipMallocManaged_c8_3_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*2_int64*byte_size(elem_real64),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):) => tmp
       else if ( present(mold) ) then
-        hipMallocManaged_c8_3_source = hipMallocManaged_(cptr,size(mold)*2*8_8,flags)
+        hipMallocManaged_c8_3_source = hipMallocManaged_(cptr,size(mold,kind=int64)*2_int64*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):) => tmp
       else if ( present(dims8) ) then
-        hipMallocManaged_c8_3_source = hipMallocManaged_(cptr,PRODUCT(dims8)*2*8_8,flags)
+        hipMallocManaged_c8_3_source = hipMallocManaged_(cptr,PRODUCT(dims8)*2_int64*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):) => tmp
@@ -12714,7 +12858,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMallocManaged_c8_3_source = hipMallocManaged_(cptr,PRODUCT(dims)*2*8_8,flags)
+        hipMallocManaged_c8_3_source = hipMallocManaged_(cptr,PRODUCT(int(dims,kind=int64))*2_int64*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):) => tmp
@@ -12744,7 +12888,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_c8_3_c_int
 #endif
       !
-      hipMallocManaged_c8_3_c_int = hipMallocManaged_(cptr,length1*length2*length3*2*8_8,flags)
+      hipMallocManaged_c8_3_c_int = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*2_int64*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3])
     end function
 
@@ -12768,7 +12912,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_c8_3_c_size_t
 #endif
       !
-      hipMallocManaged_c8_3_c_size_t = hipMallocManaged_(cptr,length1*length2*length3*2*8_8,flags)
+      hipMallocManaged_c8_3_c_size_t = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*2_int64*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3])
     end function
 
@@ -12783,8 +12927,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       complex(c_double_complex),pointer,dimension(:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(4),dims(4)
-      integer(8),intent(in),optional :: lbounds8(4),dims8(4)
+      integer(int32),intent(in),optional :: lbounds(4),dims(4)
+      integer(int64),intent(in),optional :: lbounds8(4),dims8(4)
       complex(c_double_complex),target,dimension(:,:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags   
       ! 
@@ -12813,21 +12957,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMallocManaged_c8_4_source = hipMallocManaged_(cptr,size(dsource)*2*8_8,flags)
-        hipMallocManaged_c8_4_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*2*8_8,hipMemcpyDeviceToDevice)
+        hipMallocManaged_c8_4_source = hipMallocManaged_(cptr,size(dsource,kind=int64)*2_int64*byte_size(elem_real64),flags)
+        hipMallocManaged_c8_4_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*2_int64*byte_size(elem_real64),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):) => tmp
       else if ( present(source) ) then
-        hipMallocManaged_c8_4_source = hipMallocManaged_(cptr,size(source)*2*8_8,flags)
-        hipMallocManaged_c8_4_source = hipMemcpy(cptr,c_loc(source),size(source)*2*8_8,hipMemcpyHostToDevice)
+        hipMallocManaged_c8_4_source = hipMallocManaged_(cptr,size(source,kind=int64)*2_int64*byte_size(elem_real64),flags)
+        hipMallocManaged_c8_4_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*2_int64*byte_size(elem_real64),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):) => tmp
       else if ( present(mold) ) then
-        hipMallocManaged_c8_4_source = hipMallocManaged_(cptr,size(mold)*2*8_8,flags)
+        hipMallocManaged_c8_4_source = hipMallocManaged_(cptr,size(mold,kind=int64)*2_int64*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):) => tmp
       else if ( present(dims8) ) then
-        hipMallocManaged_c8_4_source = hipMallocManaged_(cptr,PRODUCT(dims8)*2*8_8,flags)
+        hipMallocManaged_c8_4_source = hipMallocManaged_(cptr,PRODUCT(dims8)*2_int64*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):) => tmp
@@ -12835,7 +12979,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMallocManaged_c8_4_source = hipMallocManaged_(cptr,PRODUCT(dims)*2*8_8,flags)
+        hipMallocManaged_c8_4_source = hipMallocManaged_(cptr,PRODUCT(int(dims,kind=int64))*2_int64*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):) => tmp
@@ -12865,7 +13009,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_c8_4_c_int
 #endif
       !
-      hipMallocManaged_c8_4_c_int = hipMallocManaged_(cptr,length1*length2*length3*length4*2*8_8,flags)
+      hipMallocManaged_c8_4_c_int = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                           int(length4,kind=int64)*2_int64*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4])
     end function
 
@@ -12889,7 +13034,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_c8_4_c_size_t
 #endif
       !
-      hipMallocManaged_c8_4_c_size_t = hipMallocManaged_(cptr,length1*length2*length3*length4*2*8_8,flags)
+      hipMallocManaged_c8_4_c_size_t = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                              int(length4,kind=int64)*2_int64*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4])
     end function
 
@@ -12904,8 +13050,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       complex(c_double_complex),pointer,dimension(:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(5),dims(5)
-      integer(8),intent(in),optional :: lbounds8(5),dims8(5)
+      integer(int32),intent(in),optional :: lbounds(5),dims(5)
+      integer(int64),intent(in),optional :: lbounds8(5),dims8(5)
       complex(c_double_complex),target,dimension(:,:,:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags   
       ! 
@@ -12934,21 +13080,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMallocManaged_c8_5_source = hipMallocManaged_(cptr,size(dsource)*2*8_8,flags)
-        hipMallocManaged_c8_5_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*2*8_8,hipMemcpyDeviceToDevice)
+        hipMallocManaged_c8_5_source = hipMallocManaged_(cptr,size(dsource,kind=int64)*2_int64*byte_size(elem_real64),flags)
+        hipMallocManaged_c8_5_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*2_int64*byte_size(elem_real64),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):) => tmp
       else if ( present(source) ) then
-        hipMallocManaged_c8_5_source = hipMallocManaged_(cptr,size(source)*2*8_8,flags)
-        hipMallocManaged_c8_5_source = hipMemcpy(cptr,c_loc(source),size(source)*2*8_8,hipMemcpyHostToDevice)
+        hipMallocManaged_c8_5_source = hipMallocManaged_(cptr,size(source,kind=int64)*2_int64*byte_size(elem_real64),flags)
+        hipMallocManaged_c8_5_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*2_int64*byte_size(elem_real64),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):) => tmp
       else if ( present(mold) ) then
-        hipMallocManaged_c8_5_source = hipMallocManaged_(cptr,size(mold)*2*8_8,flags)
+        hipMallocManaged_c8_5_source = hipMallocManaged_(cptr,size(mold,kind=int64)*2_int64*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):) => tmp
       else if ( present(dims8) ) then
-        hipMallocManaged_c8_5_source = hipMallocManaged_(cptr,PRODUCT(dims8)*2*8_8,flags)
+        hipMallocManaged_c8_5_source = hipMallocManaged_(cptr,PRODUCT(dims8)*2_int64*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):) => tmp
@@ -12956,7 +13102,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMallocManaged_c8_5_source = hipMallocManaged_(cptr,PRODUCT(dims)*2*8_8,flags)
+        hipMallocManaged_c8_5_source = hipMallocManaged_(cptr,PRODUCT(int(dims,kind=int64))*2_int64*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):) => tmp
@@ -12986,7 +13132,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_c8_5_c_int
 #endif
       !
-      hipMallocManaged_c8_5_c_int = hipMallocManaged_(cptr,length1*length2*length3*length4*length5*2*8_8,flags)
+      hipMallocManaged_c8_5_c_int = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                           int(length4,kind=int64)*int(length5,kind=int64)*2_int64*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5])
     end function
 
@@ -13010,7 +13157,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_c8_5_c_size_t
 #endif
       !
-      hipMallocManaged_c8_5_c_size_t = hipMallocManaged_(cptr,length1*length2*length3*length4*length5*2*8_8,flags)
+      hipMallocManaged_c8_5_c_size_t = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                              int(length4,kind=int64)*int(length5,kind=int64)*2_int64*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5])
     end function
 
@@ -13025,8 +13173,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       complex(c_double_complex),pointer,dimension(:,:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(6),dims(6)
-      integer(8),intent(in),optional :: lbounds8(6),dims8(6)
+      integer(int32),intent(in),optional :: lbounds(6),dims(6)
+      integer(int64),intent(in),optional :: lbounds8(6),dims8(6)
       complex(c_double_complex),target,dimension(:,:,:,:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags   
       ! 
@@ -13055,21 +13203,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMallocManaged_c8_6_source = hipMallocManaged_(cptr,size(dsource)*2*8_8,flags)
-        hipMallocManaged_c8_6_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*2*8_8,hipMemcpyDeviceToDevice)
+        hipMallocManaged_c8_6_source = hipMallocManaged_(cptr,size(dsource,kind=int64)*2_int64*byte_size(elem_real64),flags)
+        hipMallocManaged_c8_6_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*2_int64*byte_size(elem_real64),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):,LBOUND(dsource,6):) => tmp
       else if ( present(source) ) then
-        hipMallocManaged_c8_6_source = hipMallocManaged_(cptr,size(source)*2*8_8,flags)
-        hipMallocManaged_c8_6_source = hipMemcpy(cptr,c_loc(source),size(source)*2*8_8,hipMemcpyHostToDevice)
+        hipMallocManaged_c8_6_source = hipMallocManaged_(cptr,size(source,kind=int64)*2_int64*byte_size(elem_real64),flags)
+        hipMallocManaged_c8_6_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*2_int64*byte_size(elem_real64),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):,LBOUND(source,6):) => tmp
       else if ( present(mold) ) then
-        hipMallocManaged_c8_6_source = hipMallocManaged_(cptr,size(mold)*2*8_8,flags)
+        hipMallocManaged_c8_6_source = hipMallocManaged_(cptr,size(mold,kind=int64)*2_int64*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):,LBOUND(mold,6):) => tmp
       else if ( present(dims8) ) then
-        hipMallocManaged_c8_6_source = hipMallocManaged_(cptr,PRODUCT(dims8)*2*8_8,flags)
+        hipMallocManaged_c8_6_source = hipMallocManaged_(cptr,PRODUCT(dims8)*2_int64*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):,lbounds8(6):) => tmp
@@ -13077,7 +13225,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMallocManaged_c8_6_source = hipMallocManaged_(cptr,PRODUCT(dims)*2*8_8,flags)
+        hipMallocManaged_c8_6_source = hipMallocManaged_(cptr,PRODUCT(int(dims,kind=int64))*2_int64*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):,lbounds(6):) => tmp
@@ -13107,7 +13255,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_c8_6_c_int
 #endif
       !
-      hipMallocManaged_c8_6_c_int = hipMallocManaged_(cptr,length1*length2*length3*length4*length5*length6*2*8_8,flags)
+      hipMallocManaged_c8_6_c_int = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                           int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*2_int64*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6])
     end function
 
@@ -13131,7 +13280,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_c8_6_c_size_t
 #endif
       !
-      hipMallocManaged_c8_6_c_size_t = hipMallocManaged_(cptr,length1*length2*length3*length4*length5*length6*2*8_8,flags)
+      hipMallocManaged_c8_6_c_size_t = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                              int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*2_int64*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6])
     end function
 
@@ -13146,8 +13296,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       complex(c_double_complex),pointer,dimension(:,:,:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(7),dims(7)
-      integer(8),intent(in),optional :: lbounds8(7),dims8(7)
+      integer(int32),intent(in),optional :: lbounds(7),dims(7)
+      integer(int64),intent(in),optional :: lbounds8(7),dims8(7)
       complex(c_double_complex),target,dimension(:,:,:,:,:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags   
       ! 
@@ -13176,21 +13326,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipMallocManaged_c8_7_source = hipMallocManaged_(cptr,size(dsource)*2*8_8,flags)
-        hipMallocManaged_c8_7_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*2*8_8,hipMemcpyDeviceToDevice)
+        hipMallocManaged_c8_7_source = hipMallocManaged_(cptr,size(dsource,kind=int64)*2_int64*byte_size(elem_real64),flags)
+        hipMallocManaged_c8_7_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*2_int64*byte_size(elem_real64),hipMemcpyDeviceToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):,LBOUND(dsource,6):,LBOUND(dsource,7):) => tmp
       else if ( present(source) ) then
-        hipMallocManaged_c8_7_source = hipMallocManaged_(cptr,size(source)*2*8_8,flags)
-        hipMallocManaged_c8_7_source = hipMemcpy(cptr,c_loc(source),size(source)*2*8_8,hipMemcpyHostToDevice)
+        hipMallocManaged_c8_7_source = hipMallocManaged_(cptr,size(source,kind=int64)*2_int64*byte_size(elem_real64),flags)
+        hipMallocManaged_c8_7_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*2_int64*byte_size(elem_real64),hipMemcpyHostToDevice)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):,LBOUND(source,6):,LBOUND(source,7):) => tmp
       else if ( present(mold) ) then
-        hipMallocManaged_c8_7_source = hipMallocManaged_(cptr,size(mold)*2*8_8,flags)
+        hipMallocManaged_c8_7_source = hipMallocManaged_(cptr,size(mold,kind=int64)*2_int64*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):,LBOUND(mold,6):,LBOUND(mold,7):) => tmp
       else if ( present(dims8) ) then
-        hipMallocManaged_c8_7_source = hipMallocManaged_(cptr,PRODUCT(dims8)*2*8_8,flags)
+        hipMallocManaged_c8_7_source = hipMallocManaged_(cptr,PRODUCT(dims8)*2_int64*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):,lbounds8(6):,lbounds8(7):) => tmp
@@ -13198,7 +13348,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipMallocManaged_c8_7_source = hipMallocManaged_(cptr,PRODUCT(dims)*2*8_8,flags)
+        hipMallocManaged_c8_7_source = hipMallocManaged_(cptr,PRODUCT(int(dims,kind=int64))*2_int64*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):,lbounds(6):,lbounds(7):) => tmp
@@ -13228,7 +13378,9 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_c8_7_c_int
 #endif
       !
-      hipMallocManaged_c8_7_c_int = hipMallocManaged_(cptr,length1*length2*length3*length4*length5*length6*length7*2*8_8,flags)
+      hipMallocManaged_c8_7_c_int = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                           int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*&
+                                                           int(length7,kind=int64)*2_int64*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6,length7])
     end function
 
@@ -13252,7 +13404,9 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipMallocManaged_c8_7_c_size_t
 #endif
       !
-      hipMallocManaged_c8_7_c_size_t = hipMallocManaged_(cptr,length1*length2*length3*length4*length5*length6*length7*2*8_8,flags)
+      hipMallocManaged_c8_7_c_size_t = hipMallocManaged_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                              int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*&
+                                                              int(length7,kind=int64)*2_int64*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6,length7])
     end function
 
@@ -13286,15 +13440,15 @@ module hipfort_hipmalloc
       if ( nOptArgs > 1 ) ERROR STOP "ERROR: hipHostMalloc (scalar version): Only one optional argument ('dsource','source') must be specified."
 
       if ( present(dsource) ) then
-        hipHostMalloc_l_0_source = hipHostMalloc_(cptr,1_8,flags)
-        hipHostMalloc_l_0_source = hipMemcpy(cptr,c_loc(dsource),1_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_l_0_source = hipHostMalloc_(cptr,1_int64,flags)
+        hipHostMalloc_l_0_source = hipMemcpy(cptr,c_loc(dsource),1_int64,hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,ptr)
       else if ( present(source) ) then
-        hipHostMalloc_l_0_source = hipHostMalloc_(cptr,1_8,flags)
-        hipHostMalloc_l_0_source = hipMemcpy(cptr,c_loc(source),1_8,hipMemcpyHostToHost)
+        hipHostMalloc_l_0_source = hipHostMalloc_(cptr,1_int64,flags)
+        hipHostMalloc_l_0_source = hipMemcpy(cptr,c_loc(source),1_int64,hipMemcpyHostToHost)
         call c_f_pointer(cptr,ptr)
       else
-        hipHostMalloc_l_0_source = hipHostMalloc_(cptr,1_8,flags)
+        hipHostMalloc_l_0_source = hipHostMalloc_(cptr,1_int64,flags)
         call c_f_pointer(cptr,ptr)
       end if
     end function
@@ -13311,8 +13465,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       logical(c_bool),pointer,dimension(:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(1),dims(1)
-      integer(8),intent(in),optional :: lbounds8(1),dims8(1)
+      integer(int32),intent(in),optional :: lbounds(1),dims(1)
+      integer(int64),intent(in),optional :: lbounds8(1),dims8(1)
       logical(c_bool),target,dimension(:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags
       !
@@ -13341,21 +13495,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipHostMalloc_l_1_source = hipHostMalloc_(cptr,size(dsource)*1_8,flags)
-        hipHostMalloc_l_1_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*1_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_l_1_source = hipHostMalloc_(cptr,size(dsource,kind=int64),flags)
+        hipHostMalloc_l_1_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):) => tmp
       else if ( present(source) ) then
-        hipHostMalloc_l_1_source = hipHostMalloc_(cptr,size(source)*1_8,flags)
-        hipHostMalloc_l_1_source = hipMemcpy(cptr,c_loc(source),size(source)*1_8,hipMemcpyHostToHost)
+        hipHostMalloc_l_1_source = hipHostMalloc_(cptr,size(source,kind=int64),flags)
+        hipHostMalloc_l_1_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64),hipMemcpyHostToHost)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):) => tmp
       else if ( present(mold) ) then
-        hipHostMalloc_l_1_source = hipHostMalloc_(cptr,size(mold)*1_8,flags)
+        hipHostMalloc_l_1_source = hipHostMalloc_(cptr,size(mold,kind=int64),flags)
         call c_f_pointer(cptr,ptr,shape=shape(mold))
         ptr(LBOUND(mold,1):) => tmp
       else if ( present(dims8) ) then
-        hipHostMalloc_l_1_source = hipHostMalloc_(cptr,PRODUCT(dims8)*1_8,flags)
+        hipHostMalloc_l_1_source = hipHostMalloc_(cptr,PRODUCT(dims8),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):) => tmp
@@ -13363,7 +13517,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipHostMalloc_l_1_source = hipHostMalloc_(cptr,PRODUCT(dims)*1_8,flags)
+        hipHostMalloc_l_1_source = hipHostMalloc_(cptr,PRODUCT(int(dims,kind=int64)),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):) => tmp
@@ -13392,7 +13546,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_l_1_c_int
 #endif
       !
-      hipHostMalloc_l_1_c_int = hipHostMalloc_(cptr,length1*1_8,flags)
+      hipHostMalloc_l_1_c_int = hipHostMalloc_(cptr,int(length1,kind=int64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1])
     end function
 
@@ -13415,7 +13569,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_l_1_c_size_t
 #endif
       !
-      hipHostMalloc_l_1_c_size_t = hipHostMalloc_(cptr,length1*1_8,flags)
+      hipHostMalloc_l_1_c_size_t = hipHostMalloc_(cptr,int(length1,kind=int64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1])
     end function
 
@@ -13430,8 +13584,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       logical(c_bool),pointer,dimension(:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(2),dims(2)
-      integer(8),intent(in),optional :: lbounds8(2),dims8(2)
+      integer(int32),intent(in),optional :: lbounds(2),dims(2)
+      integer(int64),intent(in),optional :: lbounds8(2),dims8(2)
       logical(c_bool),target,dimension(:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags
       !
@@ -13460,21 +13614,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipHostMalloc_l_2_source = hipHostMalloc_(cptr,size(dsource)*1_8,flags)
-        hipHostMalloc_l_2_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*1_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_l_2_source = hipHostMalloc_(cptr,size(dsource,kind=int64),flags)
+        hipHostMalloc_l_2_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):) => tmp
       else if ( present(source) ) then
-        hipHostMalloc_l_2_source = hipHostMalloc_(cptr,size(source)*1_8,flags)
-        hipHostMalloc_l_2_source = hipMemcpy(cptr,c_loc(source),size(source)*1_8,hipMemcpyHostToHost)
+        hipHostMalloc_l_2_source = hipHostMalloc_(cptr,size(source,kind=int64),flags)
+        hipHostMalloc_l_2_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64),hipMemcpyHostToHost)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):) => tmp
       else if ( present(mold) ) then
-        hipHostMalloc_l_2_source = hipHostMalloc_(cptr,size(mold)*1_8,flags)
+        hipHostMalloc_l_2_source = hipHostMalloc_(cptr,size(mold,kind=int64),flags)
         call c_f_pointer(cptr,ptr,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):) => tmp
       else if ( present(dims8) ) then
-        hipHostMalloc_l_2_source = hipHostMalloc_(cptr,PRODUCT(dims8)*1_8,flags)
+        hipHostMalloc_l_2_source = hipHostMalloc_(cptr,PRODUCT(dims8),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):) => tmp
@@ -13482,7 +13636,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipHostMalloc_l_2_source = hipHostMalloc_(cptr,PRODUCT(dims)*1_8,flags)
+        hipHostMalloc_l_2_source = hipHostMalloc_(cptr,PRODUCT(int(dims,kind=int64)),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):) => tmp
@@ -13511,7 +13665,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_l_2_c_int
 #endif
       !
-      hipHostMalloc_l_2_c_int = hipHostMalloc_(cptr,length1*length2*1_8,flags)
+      hipHostMalloc_l_2_c_int = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2])
     end function
 
@@ -13534,7 +13688,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_l_2_c_size_t
 #endif
       !
-      hipHostMalloc_l_2_c_size_t = hipHostMalloc_(cptr,length1*length2*1_8,flags)
+      hipHostMalloc_l_2_c_size_t = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2])
     end function
 
@@ -13549,8 +13703,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       logical(c_bool),pointer,dimension(:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(3),dims(3)
-      integer(8),intent(in),optional :: lbounds8(3),dims8(3)
+      integer(int32),intent(in),optional :: lbounds(3),dims(3)
+      integer(int64),intent(in),optional :: lbounds8(3),dims8(3)
       logical(c_bool),target,dimension(:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags
       !
@@ -13579,21 +13733,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipHostMalloc_l_3_source = hipHostMalloc_(cptr,size(dsource)*1_8,flags)
-        hipHostMalloc_l_3_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*1_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_l_3_source = hipHostMalloc_(cptr,size(dsource,kind=int64),flags)
+        hipHostMalloc_l_3_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):) => tmp
       else if ( present(source) ) then
-        hipHostMalloc_l_3_source = hipHostMalloc_(cptr,size(source)*1_8,flags)
-        hipHostMalloc_l_3_source = hipMemcpy(cptr,c_loc(source),size(source)*1_8,hipMemcpyHostToHost)
+        hipHostMalloc_l_3_source = hipHostMalloc_(cptr,size(source,kind=int64),flags)
+        hipHostMalloc_l_3_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64),hipMemcpyHostToHost)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):) => tmp
       else if ( present(mold) ) then
-        hipHostMalloc_l_3_source = hipHostMalloc_(cptr,size(mold)*1_8,flags)
+        hipHostMalloc_l_3_source = hipHostMalloc_(cptr,size(mold,kind=int64),flags)
         call c_f_pointer(cptr,ptr,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):) => tmp
       else if ( present(dims8) ) then
-        hipHostMalloc_l_3_source = hipHostMalloc_(cptr,PRODUCT(dims8)*1_8,flags)
+        hipHostMalloc_l_3_source = hipHostMalloc_(cptr,PRODUCT(dims8),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):) => tmp
@@ -13601,7 +13755,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipHostMalloc_l_3_source = hipHostMalloc_(cptr,PRODUCT(dims)*1_8,flags)
+        hipHostMalloc_l_3_source = hipHostMalloc_(cptr,PRODUCT(int(dims,kind=int64)),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):) => tmp
@@ -13630,7 +13784,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_l_3_c_int
 #endif
       !
-      hipHostMalloc_l_3_c_int = hipHostMalloc_(cptr,length1*length2*length3*1_8,flags)
+      hipHostMalloc_l_3_c_int = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3])
     end function
 
@@ -13653,7 +13807,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_l_3_c_size_t
 #endif
       !
-      hipHostMalloc_l_3_c_size_t = hipHostMalloc_(cptr,length1*length2*length3*1_8,flags)
+      hipHostMalloc_l_3_c_size_t = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3])
     end function
 
@@ -13668,8 +13822,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       logical(c_bool),pointer,dimension(:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(4),dims(4)
-      integer(8),intent(in),optional :: lbounds8(4),dims8(4)
+      integer(int32),intent(in),optional :: lbounds(4),dims(4)
+      integer(int64),intent(in),optional :: lbounds8(4),dims8(4)
       logical(c_bool),target,dimension(:,:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags
       !
@@ -13698,21 +13852,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipHostMalloc_l_4_source = hipHostMalloc_(cptr,size(dsource)*1_8,flags)
-        hipHostMalloc_l_4_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*1_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_l_4_source = hipHostMalloc_(cptr,size(dsource,kind=int64),flags)
+        hipHostMalloc_l_4_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):) => tmp
       else if ( present(source) ) then
-        hipHostMalloc_l_4_source = hipHostMalloc_(cptr,size(source)*1_8,flags)
-        hipHostMalloc_l_4_source = hipMemcpy(cptr,c_loc(source),size(source)*1_8,hipMemcpyHostToHost)
+        hipHostMalloc_l_4_source = hipHostMalloc_(cptr,size(source,kind=int64),flags)
+        hipHostMalloc_l_4_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64),hipMemcpyHostToHost)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):) => tmp
       else if ( present(mold) ) then
-        hipHostMalloc_l_4_source = hipHostMalloc_(cptr,size(mold)*1_8,flags)
+        hipHostMalloc_l_4_source = hipHostMalloc_(cptr,size(mold,kind=int64),flags)
         call c_f_pointer(cptr,ptr,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):) => tmp
       else if ( present(dims8) ) then
-        hipHostMalloc_l_4_source = hipHostMalloc_(cptr,PRODUCT(dims8)*1_8,flags)
+        hipHostMalloc_l_4_source = hipHostMalloc_(cptr,PRODUCT(dims8),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):) => tmp
@@ -13720,7 +13874,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipHostMalloc_l_4_source = hipHostMalloc_(cptr,PRODUCT(dims)*1_8,flags)
+        hipHostMalloc_l_4_source = hipHostMalloc_(cptr,PRODUCT(int(dims,kind=int64)),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):) => tmp
@@ -13749,7 +13903,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_l_4_c_int
 #endif
       !
-      hipHostMalloc_l_4_c_int = hipHostMalloc_(cptr,length1*length2*length3*length4*1_8,flags)
+      hipHostMalloc_l_4_c_int = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                    int(length4,kind=int64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4])
     end function
 
@@ -13772,7 +13927,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_l_4_c_size_t
 #endif
       !
-      hipHostMalloc_l_4_c_size_t = hipHostMalloc_(cptr,length1*length2*length3*length4*1_8,flags)
+      hipHostMalloc_l_4_c_size_t = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                       int(length4,kind=int64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4])
     end function
 
@@ -13787,8 +13943,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       logical(c_bool),pointer,dimension(:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(5),dims(5)
-      integer(8),intent(in),optional :: lbounds8(5),dims8(5)
+      integer(int32),intent(in),optional :: lbounds(5),dims(5)
+      integer(int64),intent(in),optional :: lbounds8(5),dims8(5)
       logical(c_bool),target,dimension(:,:,:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags
       !
@@ -13817,21 +13973,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipHostMalloc_l_5_source = hipHostMalloc_(cptr,size(dsource)*1_8,flags)
-        hipHostMalloc_l_5_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*1_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_l_5_source = hipHostMalloc_(cptr,size(dsource,kind=int64),flags)
+        hipHostMalloc_l_5_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):) => tmp
       else if ( present(source) ) then
-        hipHostMalloc_l_5_source = hipHostMalloc_(cptr,size(source)*1_8,flags)
-        hipHostMalloc_l_5_source = hipMemcpy(cptr,c_loc(source),size(source)*1_8,hipMemcpyHostToHost)
+        hipHostMalloc_l_5_source = hipHostMalloc_(cptr,size(source,kind=int64),flags)
+        hipHostMalloc_l_5_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64),hipMemcpyHostToHost)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):) => tmp
       else if ( present(mold) ) then
-        hipHostMalloc_l_5_source = hipHostMalloc_(cptr,size(mold)*1_8,flags)
+        hipHostMalloc_l_5_source = hipHostMalloc_(cptr,size(mold,kind=int64),flags)
         call c_f_pointer(cptr,ptr,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):) => tmp
       else if ( present(dims8) ) then
-        hipHostMalloc_l_5_source = hipHostMalloc_(cptr,PRODUCT(dims8)*1_8,flags)
+        hipHostMalloc_l_5_source = hipHostMalloc_(cptr,PRODUCT(dims8),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):) => tmp
@@ -13839,7 +13995,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipHostMalloc_l_5_source = hipHostMalloc_(cptr,PRODUCT(dims)*1_8,flags)
+        hipHostMalloc_l_5_source = hipHostMalloc_(cptr,PRODUCT(int(dims,kind=int64)),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):) => tmp
@@ -13868,7 +14024,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_l_5_c_int
 #endif
       !
-      hipHostMalloc_l_5_c_int = hipHostMalloc_(cptr,length1*length2*length3*length4*length5*1_8,flags)
+      hipHostMalloc_l_5_c_int = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                    int(length4,kind=int64)*int(length5,kind=int64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5])
     end function
 
@@ -13891,7 +14048,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_l_5_c_size_t
 #endif
       !
-      hipHostMalloc_l_5_c_size_t = hipHostMalloc_(cptr,length1*length2*length3*length4*length5*1_8,flags)
+      hipHostMalloc_l_5_c_size_t = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                       int(length4,kind=int64)*int(length5,kind=int64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5])
     end function
 
@@ -13906,8 +14064,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       logical(c_bool),pointer,dimension(:,:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(6),dims(6)
-      integer(8),intent(in),optional :: lbounds8(6),dims8(6)
+      integer(int32),intent(in),optional :: lbounds(6),dims(6)
+      integer(int64),intent(in),optional :: lbounds8(6),dims8(6)
       logical(c_bool),target,dimension(:,:,:,:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags
       !
@@ -13936,21 +14094,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipHostMalloc_l_6_source = hipHostMalloc_(cptr,size(dsource)*1_8,flags)
-        hipHostMalloc_l_6_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*1_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_l_6_source = hipHostMalloc_(cptr,size(dsource,kind=int64),flags)
+        hipHostMalloc_l_6_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):,LBOUND(dsource,6):) => tmp
       else if ( present(source) ) then
-        hipHostMalloc_l_6_source = hipHostMalloc_(cptr,size(source)*1_8,flags)
-        hipHostMalloc_l_6_source = hipMemcpy(cptr,c_loc(source),size(source)*1_8,hipMemcpyHostToHost)
+        hipHostMalloc_l_6_source = hipHostMalloc_(cptr,size(source,kind=int64),flags)
+        hipHostMalloc_l_6_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64),hipMemcpyHostToHost)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):,LBOUND(source,6):) => tmp
       else if ( present(mold) ) then
-        hipHostMalloc_l_6_source = hipHostMalloc_(cptr,size(mold)*1_8,flags)
+        hipHostMalloc_l_6_source = hipHostMalloc_(cptr,size(mold,kind=int64),flags)
         call c_f_pointer(cptr,ptr,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):,LBOUND(mold,6):) => tmp
       else if ( present(dims8) ) then
-        hipHostMalloc_l_6_source = hipHostMalloc_(cptr,PRODUCT(dims8)*1_8,flags)
+        hipHostMalloc_l_6_source = hipHostMalloc_(cptr,PRODUCT(dims8),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):,lbounds8(6):) => tmp
@@ -13958,7 +14116,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipHostMalloc_l_6_source = hipHostMalloc_(cptr,PRODUCT(dims)*1_8,flags)
+        hipHostMalloc_l_6_source = hipHostMalloc_(cptr,PRODUCT(int(dims,kind=int64)),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):,lbounds(6):) => tmp
@@ -13987,7 +14145,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_l_6_c_int
 #endif
       !
-      hipHostMalloc_l_6_c_int = hipHostMalloc_(cptr,length1*length2*length3*length4*length5*length6*1_8,flags)
+      hipHostMalloc_l_6_c_int = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                    int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6])
     end function
 
@@ -14010,7 +14169,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_l_6_c_size_t
 #endif
       !
-      hipHostMalloc_l_6_c_size_t = hipHostMalloc_(cptr,length1*length2*length3*length4*length5*length6*1_8,flags)
+      hipHostMalloc_l_6_c_size_t = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                       int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6])
     end function
 
@@ -14025,8 +14185,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       logical(c_bool),pointer,dimension(:,:,:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(7),dims(7)
-      integer(8),intent(in),optional :: lbounds8(7),dims8(7)
+      integer(int32),intent(in),optional :: lbounds(7),dims(7)
+      integer(int64),intent(in),optional :: lbounds8(7),dims8(7)
       logical(c_bool),target,dimension(:,:,:,:,:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags
       !
@@ -14055,21 +14215,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipHostMalloc_l_7_source = hipHostMalloc_(cptr,size(dsource)*1_8,flags)
-        hipHostMalloc_l_7_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*1_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_l_7_source = hipHostMalloc_(cptr,size(dsource,kind=int64),flags)
+        hipHostMalloc_l_7_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):,LBOUND(dsource,6):,LBOUND(dsource,7):) => tmp
       else if ( present(source) ) then
-        hipHostMalloc_l_7_source = hipHostMalloc_(cptr,size(source)*1_8,flags)
-        hipHostMalloc_l_7_source = hipMemcpy(cptr,c_loc(source),size(source)*1_8,hipMemcpyHostToHost)
+        hipHostMalloc_l_7_source = hipHostMalloc_(cptr,size(source,kind=int64),flags)
+        hipHostMalloc_l_7_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64),hipMemcpyHostToHost)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):,LBOUND(source,6):,LBOUND(source,7):) => tmp
       else if ( present(mold) ) then
-        hipHostMalloc_l_7_source = hipHostMalloc_(cptr,size(mold)*1_8,flags)
+        hipHostMalloc_l_7_source = hipHostMalloc_(cptr,size(mold,kind=int64),flags)
         call c_f_pointer(cptr,ptr,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):,LBOUND(mold,6):,LBOUND(mold,7):) => tmp
       else if ( present(dims8) ) then
-        hipHostMalloc_l_7_source = hipHostMalloc_(cptr,PRODUCT(dims8)*1_8,flags)
+        hipHostMalloc_l_7_source = hipHostMalloc_(cptr,PRODUCT(dims8),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):,lbounds8(6):,lbounds8(7):) => tmp
@@ -14077,7 +14237,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipHostMalloc_l_7_source = hipHostMalloc_(cptr,PRODUCT(dims)*1_8,flags)
+        hipHostMalloc_l_7_source = hipHostMalloc_(cptr,PRODUCT(int(dims,kind=int64)),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):,lbounds(6):,lbounds(7):) => tmp
@@ -14106,7 +14266,9 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_l_7_c_int
 #endif
       !
-      hipHostMalloc_l_7_c_int = hipHostMalloc_(cptr,length1*length2*length3*length4*length5*length6*length7*1_8,flags)
+      hipHostMalloc_l_7_c_int = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                    int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*&
+                                                    int(length7,kind=int64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6,length7])
     end function
 
@@ -14129,7 +14291,9 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_l_7_c_size_t
 #endif
       !
-      hipHostMalloc_l_7_c_size_t = hipHostMalloc_(cptr,length1*length2*length3*length4*length5*length6*length7*1_8,flags)
+      hipHostMalloc_l_7_c_size_t = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                       int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*&
+                                                       int(length7,kind=int64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6,length7])
     end function
 
@@ -14162,15 +14326,15 @@ module hipfort_hipmalloc
       if ( nOptArgs > 1 ) ERROR STOP "ERROR: hipHostMalloc (scalar version): Only one optional argument ('dsource','source') must be specified."
 
       if ( present(dsource) ) then
-        hipHostMalloc_i4_0_source = hipHostMalloc_(cptr,4_8,flags)
-        hipHostMalloc_i4_0_source = hipMemcpy(cptr,c_loc(dsource),4_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_i4_0_source = hipHostMalloc_(cptr,byte_size(elem_int32),flags)
+        hipHostMalloc_i4_0_source = hipMemcpy(cptr,c_loc(dsource),byte_size(elem_int32),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,ptr)
       else if ( present(source) ) then
-        hipHostMalloc_i4_0_source = hipHostMalloc_(cptr,4_8,flags)
-        hipHostMalloc_i4_0_source = hipMemcpy(cptr,c_loc(source),4_8,hipMemcpyHostToHost)
+        hipHostMalloc_i4_0_source = hipHostMalloc_(cptr,byte_size(elem_int32),flags)
+        hipHostMalloc_i4_0_source = hipMemcpy(cptr,c_loc(source),byte_size(elem_int32),hipMemcpyHostToHost)
         call c_f_pointer(cptr,ptr)
       else
-        hipHostMalloc_i4_0_source = hipHostMalloc_(cptr,4_8,flags)
+        hipHostMalloc_i4_0_source = hipHostMalloc_(cptr,byte_size(elem_int32),flags)
         call c_f_pointer(cptr,ptr)
       end if
     end function
@@ -14187,8 +14351,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       integer(c_int),pointer,dimension(:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(1),dims(1)
-      integer(8),intent(in),optional :: lbounds8(1),dims8(1)
+      integer(int32),intent(in),optional :: lbounds(1),dims(1)
+      integer(int64),intent(in),optional :: lbounds8(1),dims8(1)
       integer(c_int),target,dimension(:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags
       !
@@ -14217,21 +14381,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipHostMalloc_i4_1_source = hipHostMalloc_(cptr,size(dsource)*4_8,flags)
-        hipHostMalloc_i4_1_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*4_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_i4_1_source = hipHostMalloc_(cptr,size(dsource,kind=int64)*byte_size(elem_int32),flags)
+        hipHostMalloc_i4_1_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_int32),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):) => tmp
       else if ( present(source) ) then
-        hipHostMalloc_i4_1_source = hipHostMalloc_(cptr,size(source)*4_8,flags)
-        hipHostMalloc_i4_1_source = hipMemcpy(cptr,c_loc(source),size(source)*4_8,hipMemcpyHostToHost)
+        hipHostMalloc_i4_1_source = hipHostMalloc_(cptr,size(source,kind=int64)*byte_size(elem_int32),flags)
+        hipHostMalloc_i4_1_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_int32),hipMemcpyHostToHost)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):) => tmp
       else if ( present(mold) ) then
-        hipHostMalloc_i4_1_source = hipHostMalloc_(cptr,size(mold)*4_8,flags)
+        hipHostMalloc_i4_1_source = hipHostMalloc_(cptr,size(mold,kind=int64)*byte_size(elem_int32),flags)
         call c_f_pointer(cptr,ptr,shape=shape(mold))
         ptr(LBOUND(mold,1):) => tmp
       else if ( present(dims8) ) then
-        hipHostMalloc_i4_1_source = hipHostMalloc_(cptr,PRODUCT(dims8)*4_8,flags)
+        hipHostMalloc_i4_1_source = hipHostMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_int32),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):) => tmp
@@ -14239,7 +14403,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipHostMalloc_i4_1_source = hipHostMalloc_(cptr,PRODUCT(dims)*4_8,flags)
+        hipHostMalloc_i4_1_source = hipHostMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_int32),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):) => tmp
@@ -14268,7 +14432,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_i4_1_c_int
 #endif
       !
-      hipHostMalloc_i4_1_c_int = hipHostMalloc_(cptr,length1*4_8,flags)
+      hipHostMalloc_i4_1_c_int = hipHostMalloc_(cptr,int(length1,kind=int64)*byte_size(elem_int32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1])
     end function
 
@@ -14291,7 +14455,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_i4_1_c_size_t
 #endif
       !
-      hipHostMalloc_i4_1_c_size_t = hipHostMalloc_(cptr,length1*4_8,flags)
+      hipHostMalloc_i4_1_c_size_t = hipHostMalloc_(cptr,int(length1,kind=int64)*byte_size(elem_int32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1])
     end function
 
@@ -14306,8 +14470,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       integer(c_int),pointer,dimension(:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(2),dims(2)
-      integer(8),intent(in),optional :: lbounds8(2),dims8(2)
+      integer(int32),intent(in),optional :: lbounds(2),dims(2)
+      integer(int64),intent(in),optional :: lbounds8(2),dims8(2)
       integer(c_int),target,dimension(:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags
       !
@@ -14336,21 +14500,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipHostMalloc_i4_2_source = hipHostMalloc_(cptr,size(dsource)*4_8,flags)
-        hipHostMalloc_i4_2_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*4_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_i4_2_source = hipHostMalloc_(cptr,size(dsource,kind=int64)*byte_size(elem_int32),flags)
+        hipHostMalloc_i4_2_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_int32),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):) => tmp
       else if ( present(source) ) then
-        hipHostMalloc_i4_2_source = hipHostMalloc_(cptr,size(source)*4_8,flags)
-        hipHostMalloc_i4_2_source = hipMemcpy(cptr,c_loc(source),size(source)*4_8,hipMemcpyHostToHost)
+        hipHostMalloc_i4_2_source = hipHostMalloc_(cptr,size(source,kind=int64)*byte_size(elem_int32),flags)
+        hipHostMalloc_i4_2_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_int32),hipMemcpyHostToHost)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):) => tmp
       else if ( present(mold) ) then
-        hipHostMalloc_i4_2_source = hipHostMalloc_(cptr,size(mold)*4_8,flags)
+        hipHostMalloc_i4_2_source = hipHostMalloc_(cptr,size(mold,kind=int64)*byte_size(elem_int32),flags)
         call c_f_pointer(cptr,ptr,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):) => tmp
       else if ( present(dims8) ) then
-        hipHostMalloc_i4_2_source = hipHostMalloc_(cptr,PRODUCT(dims8)*4_8,flags)
+        hipHostMalloc_i4_2_source = hipHostMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_int32),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):) => tmp
@@ -14358,7 +14522,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipHostMalloc_i4_2_source = hipHostMalloc_(cptr,PRODUCT(dims)*4_8,flags)
+        hipHostMalloc_i4_2_source = hipHostMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_int32),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):) => tmp
@@ -14387,7 +14551,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_i4_2_c_int
 #endif
       !
-      hipHostMalloc_i4_2_c_int = hipHostMalloc_(cptr,length1*length2*4_8,flags)
+      hipHostMalloc_i4_2_c_int = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*byte_size(elem_int32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2])
     end function
 
@@ -14410,7 +14574,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_i4_2_c_size_t
 #endif
       !
-      hipHostMalloc_i4_2_c_size_t = hipHostMalloc_(cptr,length1*length2*4_8,flags)
+      hipHostMalloc_i4_2_c_size_t = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*byte_size(elem_int32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2])
     end function
 
@@ -14425,8 +14589,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       integer(c_int),pointer,dimension(:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(3),dims(3)
-      integer(8),intent(in),optional :: lbounds8(3),dims8(3)
+      integer(int32),intent(in),optional :: lbounds(3),dims(3)
+      integer(int64),intent(in),optional :: lbounds8(3),dims8(3)
       integer(c_int),target,dimension(:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags
       !
@@ -14455,21 +14619,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipHostMalloc_i4_3_source = hipHostMalloc_(cptr,size(dsource)*4_8,flags)
-        hipHostMalloc_i4_3_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*4_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_i4_3_source = hipHostMalloc_(cptr,size(dsource,kind=int64)*byte_size(elem_int32),flags)
+        hipHostMalloc_i4_3_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_int32),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):) => tmp
       else if ( present(source) ) then
-        hipHostMalloc_i4_3_source = hipHostMalloc_(cptr,size(source)*4_8,flags)
-        hipHostMalloc_i4_3_source = hipMemcpy(cptr,c_loc(source),size(source)*4_8,hipMemcpyHostToHost)
+        hipHostMalloc_i4_3_source = hipHostMalloc_(cptr,size(source,kind=int64)*byte_size(elem_int32),flags)
+        hipHostMalloc_i4_3_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_int32),hipMemcpyHostToHost)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):) => tmp
       else if ( present(mold) ) then
-        hipHostMalloc_i4_3_source = hipHostMalloc_(cptr,size(mold)*4_8,flags)
+        hipHostMalloc_i4_3_source = hipHostMalloc_(cptr,size(mold,kind=int64)*byte_size(elem_int32),flags)
         call c_f_pointer(cptr,ptr,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):) => tmp
       else if ( present(dims8) ) then
-        hipHostMalloc_i4_3_source = hipHostMalloc_(cptr,PRODUCT(dims8)*4_8,flags)
+        hipHostMalloc_i4_3_source = hipHostMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_int32),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):) => tmp
@@ -14477,7 +14641,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipHostMalloc_i4_3_source = hipHostMalloc_(cptr,PRODUCT(dims)*4_8,flags)
+        hipHostMalloc_i4_3_source = hipHostMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_int32),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):) => tmp
@@ -14506,7 +14670,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_i4_3_c_int
 #endif
       !
-      hipHostMalloc_i4_3_c_int = hipHostMalloc_(cptr,length1*length2*length3*4_8,flags)
+      hipHostMalloc_i4_3_c_int = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*byte_size(elem_int32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3])
     end function
 
@@ -14529,7 +14693,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_i4_3_c_size_t
 #endif
       !
-      hipHostMalloc_i4_3_c_size_t = hipHostMalloc_(cptr,length1*length2*length3*4_8,flags)
+      hipHostMalloc_i4_3_c_size_t = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*byte_size(elem_int32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3])
     end function
 
@@ -14544,8 +14708,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       integer(c_int),pointer,dimension(:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(4),dims(4)
-      integer(8),intent(in),optional :: lbounds8(4),dims8(4)
+      integer(int32),intent(in),optional :: lbounds(4),dims(4)
+      integer(int64),intent(in),optional :: lbounds8(4),dims8(4)
       integer(c_int),target,dimension(:,:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags
       !
@@ -14574,21 +14738,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipHostMalloc_i4_4_source = hipHostMalloc_(cptr,size(dsource)*4_8,flags)
-        hipHostMalloc_i4_4_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*4_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_i4_4_source = hipHostMalloc_(cptr,size(dsource,kind=int64)*byte_size(elem_int32),flags)
+        hipHostMalloc_i4_4_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_int32),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):) => tmp
       else if ( present(source) ) then
-        hipHostMalloc_i4_4_source = hipHostMalloc_(cptr,size(source)*4_8,flags)
-        hipHostMalloc_i4_4_source = hipMemcpy(cptr,c_loc(source),size(source)*4_8,hipMemcpyHostToHost)
+        hipHostMalloc_i4_4_source = hipHostMalloc_(cptr,size(source,kind=int64)*byte_size(elem_int32),flags)
+        hipHostMalloc_i4_4_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_int32),hipMemcpyHostToHost)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):) => tmp
       else if ( present(mold) ) then
-        hipHostMalloc_i4_4_source = hipHostMalloc_(cptr,size(mold)*4_8,flags)
+        hipHostMalloc_i4_4_source = hipHostMalloc_(cptr,size(mold,kind=int64)*byte_size(elem_int32),flags)
         call c_f_pointer(cptr,ptr,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):) => tmp
       else if ( present(dims8) ) then
-        hipHostMalloc_i4_4_source = hipHostMalloc_(cptr,PRODUCT(dims8)*4_8,flags)
+        hipHostMalloc_i4_4_source = hipHostMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_int32),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):) => tmp
@@ -14596,7 +14760,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipHostMalloc_i4_4_source = hipHostMalloc_(cptr,PRODUCT(dims)*4_8,flags)
+        hipHostMalloc_i4_4_source = hipHostMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_int32),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):) => tmp
@@ -14625,7 +14789,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_i4_4_c_int
 #endif
       !
-      hipHostMalloc_i4_4_c_int = hipHostMalloc_(cptr,length1*length2*length3*length4*4_8,flags)
+      hipHostMalloc_i4_4_c_int = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                     int(length4,kind=int64)*byte_size(elem_int32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4])
     end function
 
@@ -14648,7 +14813,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_i4_4_c_size_t
 #endif
       !
-      hipHostMalloc_i4_4_c_size_t = hipHostMalloc_(cptr,length1*length2*length3*length4*4_8,flags)
+      hipHostMalloc_i4_4_c_size_t = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                        int(length4,kind=int64)*byte_size(elem_int32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4])
     end function
 
@@ -14663,8 +14829,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       integer(c_int),pointer,dimension(:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(5),dims(5)
-      integer(8),intent(in),optional :: lbounds8(5),dims8(5)
+      integer(int32),intent(in),optional :: lbounds(5),dims(5)
+      integer(int64),intent(in),optional :: lbounds8(5),dims8(5)
       integer(c_int),target,dimension(:,:,:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags
       !
@@ -14693,21 +14859,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipHostMalloc_i4_5_source = hipHostMalloc_(cptr,size(dsource)*4_8,flags)
-        hipHostMalloc_i4_5_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*4_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_i4_5_source = hipHostMalloc_(cptr,size(dsource,kind=int64)*byte_size(elem_int32),flags)
+        hipHostMalloc_i4_5_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_int32),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):) => tmp
       else if ( present(source) ) then
-        hipHostMalloc_i4_5_source = hipHostMalloc_(cptr,size(source)*4_8,flags)
-        hipHostMalloc_i4_5_source = hipMemcpy(cptr,c_loc(source),size(source)*4_8,hipMemcpyHostToHost)
+        hipHostMalloc_i4_5_source = hipHostMalloc_(cptr,size(source,kind=int64)*byte_size(elem_int32),flags)
+        hipHostMalloc_i4_5_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_int32),hipMemcpyHostToHost)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):) => tmp
       else if ( present(mold) ) then
-        hipHostMalloc_i4_5_source = hipHostMalloc_(cptr,size(mold)*4_8,flags)
+        hipHostMalloc_i4_5_source = hipHostMalloc_(cptr,size(mold,kind=int64)*byte_size(elem_int32),flags)
         call c_f_pointer(cptr,ptr,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):) => tmp
       else if ( present(dims8) ) then
-        hipHostMalloc_i4_5_source = hipHostMalloc_(cptr,PRODUCT(dims8)*4_8,flags)
+        hipHostMalloc_i4_5_source = hipHostMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_int32),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):) => tmp
@@ -14715,7 +14881,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipHostMalloc_i4_5_source = hipHostMalloc_(cptr,PRODUCT(dims)*4_8,flags)
+        hipHostMalloc_i4_5_source = hipHostMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_int32),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):) => tmp
@@ -14744,7 +14910,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_i4_5_c_int
 #endif
       !
-      hipHostMalloc_i4_5_c_int = hipHostMalloc_(cptr,length1*length2*length3*length4*length5*4_8,flags)
+      hipHostMalloc_i4_5_c_int = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                     int(length4,kind=int64)*int(length5,kind=int64)*byte_size(elem_int32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5])
     end function
 
@@ -14767,7 +14934,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_i4_5_c_size_t
 #endif
       !
-      hipHostMalloc_i4_5_c_size_t = hipHostMalloc_(cptr,length1*length2*length3*length4*length5*4_8,flags)
+      hipHostMalloc_i4_5_c_size_t = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                        int(length4,kind=int64)*int(length5,kind=int64)*byte_size(elem_int32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5])
     end function
 
@@ -14782,8 +14950,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       integer(c_int),pointer,dimension(:,:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(6),dims(6)
-      integer(8),intent(in),optional :: lbounds8(6),dims8(6)
+      integer(int32),intent(in),optional :: lbounds(6),dims(6)
+      integer(int64),intent(in),optional :: lbounds8(6),dims8(6)
       integer(c_int),target,dimension(:,:,:,:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags
       !
@@ -14812,21 +14980,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipHostMalloc_i4_6_source = hipHostMalloc_(cptr,size(dsource)*4_8,flags)
-        hipHostMalloc_i4_6_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*4_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_i4_6_source = hipHostMalloc_(cptr,size(dsource,kind=int64)*byte_size(elem_int32),flags)
+        hipHostMalloc_i4_6_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_int32),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):,LBOUND(dsource,6):) => tmp
       else if ( present(source) ) then
-        hipHostMalloc_i4_6_source = hipHostMalloc_(cptr,size(source)*4_8,flags)
-        hipHostMalloc_i4_6_source = hipMemcpy(cptr,c_loc(source),size(source)*4_8,hipMemcpyHostToHost)
+        hipHostMalloc_i4_6_source = hipHostMalloc_(cptr,size(source,kind=int64)*byte_size(elem_int32),flags)
+        hipHostMalloc_i4_6_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_int32),hipMemcpyHostToHost)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):,LBOUND(source,6):) => tmp
       else if ( present(mold) ) then
-        hipHostMalloc_i4_6_source = hipHostMalloc_(cptr,size(mold)*4_8,flags)
+        hipHostMalloc_i4_6_source = hipHostMalloc_(cptr,size(mold,kind=int64)*byte_size(elem_int32),flags)
         call c_f_pointer(cptr,ptr,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):,LBOUND(mold,6):) => tmp
       else if ( present(dims8) ) then
-        hipHostMalloc_i4_6_source = hipHostMalloc_(cptr,PRODUCT(dims8)*4_8,flags)
+        hipHostMalloc_i4_6_source = hipHostMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_int32),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):,lbounds8(6):) => tmp
@@ -14834,7 +15002,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipHostMalloc_i4_6_source = hipHostMalloc_(cptr,PRODUCT(dims)*4_8,flags)
+        hipHostMalloc_i4_6_source = hipHostMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_int32),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):,lbounds(6):) => tmp
@@ -14863,7 +15031,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_i4_6_c_int
 #endif
       !
-      hipHostMalloc_i4_6_c_int = hipHostMalloc_(cptr,length1*length2*length3*length4*length5*length6*4_8,flags)
+      hipHostMalloc_i4_6_c_int = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                     int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*byte_size(elem_int32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6])
     end function
 
@@ -14886,7 +15055,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_i4_6_c_size_t
 #endif
       !
-      hipHostMalloc_i4_6_c_size_t = hipHostMalloc_(cptr,length1*length2*length3*length4*length5*length6*4_8,flags)
+      hipHostMalloc_i4_6_c_size_t = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                        int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*byte_size(elem_int32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6])
     end function
 
@@ -14901,8 +15071,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       integer(c_int),pointer,dimension(:,:,:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(7),dims(7)
-      integer(8),intent(in),optional :: lbounds8(7),dims8(7)
+      integer(int32),intent(in),optional :: lbounds(7),dims(7)
+      integer(int64),intent(in),optional :: lbounds8(7),dims8(7)
       integer(c_int),target,dimension(:,:,:,:,:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags
       !
@@ -14931,21 +15101,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipHostMalloc_i4_7_source = hipHostMalloc_(cptr,size(dsource)*4_8,flags)
-        hipHostMalloc_i4_7_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*4_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_i4_7_source = hipHostMalloc_(cptr,size(dsource,kind=int64)*byte_size(elem_int32),flags)
+        hipHostMalloc_i4_7_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_int32),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):,LBOUND(dsource,6):,LBOUND(dsource,7):) => tmp
       else if ( present(source) ) then
-        hipHostMalloc_i4_7_source = hipHostMalloc_(cptr,size(source)*4_8,flags)
-        hipHostMalloc_i4_7_source = hipMemcpy(cptr,c_loc(source),size(source)*4_8,hipMemcpyHostToHost)
+        hipHostMalloc_i4_7_source = hipHostMalloc_(cptr,size(source,kind=int64)*byte_size(elem_int32),flags)
+        hipHostMalloc_i4_7_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_int32),hipMemcpyHostToHost)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):,LBOUND(source,6):,LBOUND(source,7):) => tmp
       else if ( present(mold) ) then
-        hipHostMalloc_i4_7_source = hipHostMalloc_(cptr,size(mold)*4_8,flags)
+        hipHostMalloc_i4_7_source = hipHostMalloc_(cptr,size(mold,kind=int64)*byte_size(elem_int32),flags)
         call c_f_pointer(cptr,ptr,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):,LBOUND(mold,6):,LBOUND(mold,7):) => tmp
       else if ( present(dims8) ) then
-        hipHostMalloc_i4_7_source = hipHostMalloc_(cptr,PRODUCT(dims8)*4_8,flags)
+        hipHostMalloc_i4_7_source = hipHostMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_int32),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):,lbounds8(6):,lbounds8(7):) => tmp
@@ -14953,7 +15123,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipHostMalloc_i4_7_source = hipHostMalloc_(cptr,PRODUCT(dims)*4_8,flags)
+        hipHostMalloc_i4_7_source = hipHostMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_int32),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):,lbounds(6):,lbounds(7):) => tmp
@@ -14982,7 +15152,9 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_i4_7_c_int
 #endif
       !
-      hipHostMalloc_i4_7_c_int = hipHostMalloc_(cptr,length1*length2*length3*length4*length5*length6*length7*4_8,flags)
+      hipHostMalloc_i4_7_c_int = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                     int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*&
+                                                     int(length7,kind=int64)*byte_size(elem_int32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6,length7])
     end function
 
@@ -15005,7 +15177,9 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_i4_7_c_size_t
 #endif
       !
-      hipHostMalloc_i4_7_c_size_t = hipHostMalloc_(cptr,length1*length2*length3*length4*length5*length6*length7*4_8,flags)
+      hipHostMalloc_i4_7_c_size_t = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                        int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*&
+                                                        int(length7,kind=int64)*byte_size(elem_int32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6,length7])
     end function
 
@@ -15038,15 +15212,15 @@ module hipfort_hipmalloc
       if ( nOptArgs > 1 ) ERROR STOP "ERROR: hipHostMalloc (scalar version): Only one optional argument ('dsource','source') must be specified."
 
       if ( present(dsource) ) then
-        hipHostMalloc_i8_0_source = hipHostMalloc_(cptr,8_8,flags)
-        hipHostMalloc_i8_0_source = hipMemcpy(cptr,c_loc(dsource),8_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_i8_0_source = hipHostMalloc_(cptr,byte_size(elem_int64),flags)
+        hipHostMalloc_i8_0_source = hipMemcpy(cptr,c_loc(dsource),byte_size(elem_int64),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,ptr)
       else if ( present(source) ) then
-        hipHostMalloc_i8_0_source = hipHostMalloc_(cptr,8_8,flags)
-        hipHostMalloc_i8_0_source = hipMemcpy(cptr,c_loc(source),8_8,hipMemcpyHostToHost)
+        hipHostMalloc_i8_0_source = hipHostMalloc_(cptr,byte_size(elem_int64),flags)
+        hipHostMalloc_i8_0_source = hipMemcpy(cptr,c_loc(source),byte_size(elem_int64),hipMemcpyHostToHost)
         call c_f_pointer(cptr,ptr)
       else
-        hipHostMalloc_i8_0_source = hipHostMalloc_(cptr,8_8,flags)
+        hipHostMalloc_i8_0_source = hipHostMalloc_(cptr,byte_size(elem_int64),flags)
         call c_f_pointer(cptr,ptr)
       end if
     end function
@@ -15063,8 +15237,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       integer(c_long),pointer,dimension(:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(1),dims(1)
-      integer(8),intent(in),optional :: lbounds8(1),dims8(1)
+      integer(int32),intent(in),optional :: lbounds(1),dims(1)
+      integer(int64),intent(in),optional :: lbounds8(1),dims8(1)
       integer(c_long),target,dimension(:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags
       !
@@ -15093,21 +15267,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipHostMalloc_i8_1_source = hipHostMalloc_(cptr,size(dsource)*8_8,flags)
-        hipHostMalloc_i8_1_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*8_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_i8_1_source = hipHostMalloc_(cptr,size(dsource,kind=int64)*byte_size(elem_int64),flags)
+        hipHostMalloc_i8_1_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_int64),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):) => tmp
       else if ( present(source) ) then
-        hipHostMalloc_i8_1_source = hipHostMalloc_(cptr,size(source)*8_8,flags)
-        hipHostMalloc_i8_1_source = hipMemcpy(cptr,c_loc(source),size(source)*8_8,hipMemcpyHostToHost)
+        hipHostMalloc_i8_1_source = hipHostMalloc_(cptr,size(source,kind=int64)*byte_size(elem_int64),flags)
+        hipHostMalloc_i8_1_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_int64),hipMemcpyHostToHost)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):) => tmp
       else if ( present(mold) ) then
-        hipHostMalloc_i8_1_source = hipHostMalloc_(cptr,size(mold)*8_8,flags)
+        hipHostMalloc_i8_1_source = hipHostMalloc_(cptr,size(mold,kind=int64)*byte_size(elem_int64),flags)
         call c_f_pointer(cptr,ptr,shape=shape(mold))
         ptr(LBOUND(mold,1):) => tmp
       else if ( present(dims8) ) then
-        hipHostMalloc_i8_1_source = hipHostMalloc_(cptr,PRODUCT(dims8)*8_8,flags)
+        hipHostMalloc_i8_1_source = hipHostMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_int64),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):) => tmp
@@ -15115,7 +15289,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipHostMalloc_i8_1_source = hipHostMalloc_(cptr,PRODUCT(dims)*8_8,flags)
+        hipHostMalloc_i8_1_source = hipHostMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_int64),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):) => tmp
@@ -15144,7 +15318,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_i8_1_c_int
 #endif
       !
-      hipHostMalloc_i8_1_c_int = hipHostMalloc_(cptr,length1*8_8,flags)
+      hipHostMalloc_i8_1_c_int = hipHostMalloc_(cptr,int(length1,kind=int64)*byte_size(elem_int64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1])
     end function
 
@@ -15167,7 +15341,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_i8_1_c_size_t
 #endif
       !
-      hipHostMalloc_i8_1_c_size_t = hipHostMalloc_(cptr,length1*8_8,flags)
+      hipHostMalloc_i8_1_c_size_t = hipHostMalloc_(cptr,int(length1,kind=int64)*byte_size(elem_int64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1])
     end function
 
@@ -15182,8 +15356,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       integer(c_long),pointer,dimension(:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(2),dims(2)
-      integer(8),intent(in),optional :: lbounds8(2),dims8(2)
+      integer(int32),intent(in),optional :: lbounds(2),dims(2)
+      integer(int64),intent(in),optional :: lbounds8(2),dims8(2)
       integer(c_long),target,dimension(:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags
       !
@@ -15212,21 +15386,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipHostMalloc_i8_2_source = hipHostMalloc_(cptr,size(dsource)*8_8,flags)
-        hipHostMalloc_i8_2_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*8_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_i8_2_source = hipHostMalloc_(cptr,size(dsource,kind=int64)*byte_size(elem_int64),flags)
+        hipHostMalloc_i8_2_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_int64),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):) => tmp
       else if ( present(source) ) then
-        hipHostMalloc_i8_2_source = hipHostMalloc_(cptr,size(source)*8_8,flags)
-        hipHostMalloc_i8_2_source = hipMemcpy(cptr,c_loc(source),size(source)*8_8,hipMemcpyHostToHost)
+        hipHostMalloc_i8_2_source = hipHostMalloc_(cptr,size(source,kind=int64)*byte_size(elem_int64),flags)
+        hipHostMalloc_i8_2_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_int64),hipMemcpyHostToHost)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):) => tmp
       else if ( present(mold) ) then
-        hipHostMalloc_i8_2_source = hipHostMalloc_(cptr,size(mold)*8_8,flags)
+        hipHostMalloc_i8_2_source = hipHostMalloc_(cptr,size(mold,kind=int64)*byte_size(elem_int64),flags)
         call c_f_pointer(cptr,ptr,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):) => tmp
       else if ( present(dims8) ) then
-        hipHostMalloc_i8_2_source = hipHostMalloc_(cptr,PRODUCT(dims8)*8_8,flags)
+        hipHostMalloc_i8_2_source = hipHostMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_int64),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):) => tmp
@@ -15234,7 +15408,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipHostMalloc_i8_2_source = hipHostMalloc_(cptr,PRODUCT(dims)*8_8,flags)
+        hipHostMalloc_i8_2_source = hipHostMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_int64),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):) => tmp
@@ -15263,7 +15437,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_i8_2_c_int
 #endif
       !
-      hipHostMalloc_i8_2_c_int = hipHostMalloc_(cptr,length1*length2*8_8,flags)
+      hipHostMalloc_i8_2_c_int = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*byte_size(elem_int64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2])
     end function
 
@@ -15286,7 +15460,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_i8_2_c_size_t
 #endif
       !
-      hipHostMalloc_i8_2_c_size_t = hipHostMalloc_(cptr,length1*length2*8_8,flags)
+      hipHostMalloc_i8_2_c_size_t = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*byte_size(elem_int64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2])
     end function
 
@@ -15301,8 +15475,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       integer(c_long),pointer,dimension(:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(3),dims(3)
-      integer(8),intent(in),optional :: lbounds8(3),dims8(3)
+      integer(int32),intent(in),optional :: lbounds(3),dims(3)
+      integer(int64),intent(in),optional :: lbounds8(3),dims8(3)
       integer(c_long),target,dimension(:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags
       !
@@ -15331,21 +15505,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipHostMalloc_i8_3_source = hipHostMalloc_(cptr,size(dsource)*8_8,flags)
-        hipHostMalloc_i8_3_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*8_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_i8_3_source = hipHostMalloc_(cptr,size(dsource,kind=int64)*byte_size(elem_int64),flags)
+        hipHostMalloc_i8_3_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_int64),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):) => tmp
       else if ( present(source) ) then
-        hipHostMalloc_i8_3_source = hipHostMalloc_(cptr,size(source)*8_8,flags)
-        hipHostMalloc_i8_3_source = hipMemcpy(cptr,c_loc(source),size(source)*8_8,hipMemcpyHostToHost)
+        hipHostMalloc_i8_3_source = hipHostMalloc_(cptr,size(source,kind=int64)*byte_size(elem_int64),flags)
+        hipHostMalloc_i8_3_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_int64),hipMemcpyHostToHost)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):) => tmp
       else if ( present(mold) ) then
-        hipHostMalloc_i8_3_source = hipHostMalloc_(cptr,size(mold)*8_8,flags)
+        hipHostMalloc_i8_3_source = hipHostMalloc_(cptr,size(mold,kind=int64)*byte_size(elem_int64),flags)
         call c_f_pointer(cptr,ptr,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):) => tmp
       else if ( present(dims8) ) then
-        hipHostMalloc_i8_3_source = hipHostMalloc_(cptr,PRODUCT(dims8)*8_8,flags)
+        hipHostMalloc_i8_3_source = hipHostMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_int64),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):) => tmp
@@ -15353,7 +15527,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipHostMalloc_i8_3_source = hipHostMalloc_(cptr,PRODUCT(dims)*8_8,flags)
+        hipHostMalloc_i8_3_source = hipHostMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_int64),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):) => tmp
@@ -15382,7 +15556,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_i8_3_c_int
 #endif
       !
-      hipHostMalloc_i8_3_c_int = hipHostMalloc_(cptr,length1*length2*length3*8_8,flags)
+      hipHostMalloc_i8_3_c_int = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*byte_size(elem_int64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3])
     end function
 
@@ -15405,7 +15579,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_i8_3_c_size_t
 #endif
       !
-      hipHostMalloc_i8_3_c_size_t = hipHostMalloc_(cptr,length1*length2*length3*8_8,flags)
+      hipHostMalloc_i8_3_c_size_t = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*byte_size(elem_int64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3])
     end function
 
@@ -15420,8 +15594,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       integer(c_long),pointer,dimension(:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(4),dims(4)
-      integer(8),intent(in),optional :: lbounds8(4),dims8(4)
+      integer(int32),intent(in),optional :: lbounds(4),dims(4)
+      integer(int64),intent(in),optional :: lbounds8(4),dims8(4)
       integer(c_long),target,dimension(:,:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags
       !
@@ -15450,21 +15624,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipHostMalloc_i8_4_source = hipHostMalloc_(cptr,size(dsource)*8_8,flags)
-        hipHostMalloc_i8_4_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*8_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_i8_4_source = hipHostMalloc_(cptr,size(dsource,kind=int64)*byte_size(elem_int64),flags)
+        hipHostMalloc_i8_4_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_int64),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):) => tmp
       else if ( present(source) ) then
-        hipHostMalloc_i8_4_source = hipHostMalloc_(cptr,size(source)*8_8,flags)
-        hipHostMalloc_i8_4_source = hipMemcpy(cptr,c_loc(source),size(source)*8_8,hipMemcpyHostToHost)
+        hipHostMalloc_i8_4_source = hipHostMalloc_(cptr,size(source,kind=int64)*byte_size(elem_int64),flags)
+        hipHostMalloc_i8_4_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_int64),hipMemcpyHostToHost)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):) => tmp
       else if ( present(mold) ) then
-        hipHostMalloc_i8_4_source = hipHostMalloc_(cptr,size(mold)*8_8,flags)
+        hipHostMalloc_i8_4_source = hipHostMalloc_(cptr,size(mold,kind=int64)*byte_size(elem_int64),flags)
         call c_f_pointer(cptr,ptr,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):) => tmp
       else if ( present(dims8) ) then
-        hipHostMalloc_i8_4_source = hipHostMalloc_(cptr,PRODUCT(dims8)*8_8,flags)
+        hipHostMalloc_i8_4_source = hipHostMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_int64),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):) => tmp
@@ -15472,7 +15646,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipHostMalloc_i8_4_source = hipHostMalloc_(cptr,PRODUCT(dims)*8_8,flags)
+        hipHostMalloc_i8_4_source = hipHostMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_int64),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):) => tmp
@@ -15501,7 +15675,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_i8_4_c_int
 #endif
       !
-      hipHostMalloc_i8_4_c_int = hipHostMalloc_(cptr,length1*length2*length3*length4*8_8,flags)
+      hipHostMalloc_i8_4_c_int = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                     int(length4,kind=int64)*byte_size(elem_int64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4])
     end function
 
@@ -15524,7 +15699,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_i8_4_c_size_t
 #endif
       !
-      hipHostMalloc_i8_4_c_size_t = hipHostMalloc_(cptr,length1*length2*length3*length4*8_8,flags)
+      hipHostMalloc_i8_4_c_size_t = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                        int(length4,kind=int64)*byte_size(elem_int64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4])
     end function
 
@@ -15539,8 +15715,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       integer(c_long),pointer,dimension(:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(5),dims(5)
-      integer(8),intent(in),optional :: lbounds8(5),dims8(5)
+      integer(int32),intent(in),optional :: lbounds(5),dims(5)
+      integer(int64),intent(in),optional :: lbounds8(5),dims8(5)
       integer(c_long),target,dimension(:,:,:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags
       !
@@ -15569,21 +15745,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipHostMalloc_i8_5_source = hipHostMalloc_(cptr,size(dsource)*8_8,flags)
-        hipHostMalloc_i8_5_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*8_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_i8_5_source = hipHostMalloc_(cptr,size(dsource,kind=int64)*byte_size(elem_int64),flags)
+        hipHostMalloc_i8_5_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_int64),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):) => tmp
       else if ( present(source) ) then
-        hipHostMalloc_i8_5_source = hipHostMalloc_(cptr,size(source)*8_8,flags)
-        hipHostMalloc_i8_5_source = hipMemcpy(cptr,c_loc(source),size(source)*8_8,hipMemcpyHostToHost)
+        hipHostMalloc_i8_5_source = hipHostMalloc_(cptr,size(source,kind=int64)*byte_size(elem_int64),flags)
+        hipHostMalloc_i8_5_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_int64),hipMemcpyHostToHost)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):) => tmp
       else if ( present(mold) ) then
-        hipHostMalloc_i8_5_source = hipHostMalloc_(cptr,size(mold)*8_8,flags)
+        hipHostMalloc_i8_5_source = hipHostMalloc_(cptr,size(mold,kind=int64)*byte_size(elem_int64),flags)
         call c_f_pointer(cptr,ptr,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):) => tmp
       else if ( present(dims8) ) then
-        hipHostMalloc_i8_5_source = hipHostMalloc_(cptr,PRODUCT(dims8)*8_8,flags)
+        hipHostMalloc_i8_5_source = hipHostMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_int64),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):) => tmp
@@ -15591,7 +15767,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipHostMalloc_i8_5_source = hipHostMalloc_(cptr,PRODUCT(dims)*8_8,flags)
+        hipHostMalloc_i8_5_source = hipHostMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_int64),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):) => tmp
@@ -15620,7 +15796,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_i8_5_c_int
 #endif
       !
-      hipHostMalloc_i8_5_c_int = hipHostMalloc_(cptr,length1*length2*length3*length4*length5*8_8,flags)
+      hipHostMalloc_i8_5_c_int = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                     int(length4,kind=int64)*int(length5,kind=int64)*byte_size(elem_int64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5])
     end function
 
@@ -15643,7 +15820,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_i8_5_c_size_t
 #endif
       !
-      hipHostMalloc_i8_5_c_size_t = hipHostMalloc_(cptr,length1*length2*length3*length4*length5*8_8,flags)
+      hipHostMalloc_i8_5_c_size_t = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                        int(length4,kind=int64)*int(length5,kind=int64)*byte_size(elem_int64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5])
     end function
 
@@ -15658,8 +15836,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       integer(c_long),pointer,dimension(:,:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(6),dims(6)
-      integer(8),intent(in),optional :: lbounds8(6),dims8(6)
+      integer(int32),intent(in),optional :: lbounds(6),dims(6)
+      integer(int64),intent(in),optional :: lbounds8(6),dims8(6)
       integer(c_long),target,dimension(:,:,:,:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags
       !
@@ -15688,21 +15866,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipHostMalloc_i8_6_source = hipHostMalloc_(cptr,size(dsource)*8_8,flags)
-        hipHostMalloc_i8_6_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*8_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_i8_6_source = hipHostMalloc_(cptr,size(dsource,kind=int64)*byte_size(elem_int64),flags)
+        hipHostMalloc_i8_6_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_int64),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):,LBOUND(dsource,6):) => tmp
       else if ( present(source) ) then
-        hipHostMalloc_i8_6_source = hipHostMalloc_(cptr,size(source)*8_8,flags)
-        hipHostMalloc_i8_6_source = hipMemcpy(cptr,c_loc(source),size(source)*8_8,hipMemcpyHostToHost)
+        hipHostMalloc_i8_6_source = hipHostMalloc_(cptr,size(source,kind=int64)*byte_size(elem_int64),flags)
+        hipHostMalloc_i8_6_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_int64),hipMemcpyHostToHost)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):,LBOUND(source,6):) => tmp
       else if ( present(mold) ) then
-        hipHostMalloc_i8_6_source = hipHostMalloc_(cptr,size(mold)*8_8,flags)
+        hipHostMalloc_i8_6_source = hipHostMalloc_(cptr,size(mold,kind=int64)*byte_size(elem_int64),flags)
         call c_f_pointer(cptr,ptr,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):,LBOUND(mold,6):) => tmp
       else if ( present(dims8) ) then
-        hipHostMalloc_i8_6_source = hipHostMalloc_(cptr,PRODUCT(dims8)*8_8,flags)
+        hipHostMalloc_i8_6_source = hipHostMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_int64),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):,lbounds8(6):) => tmp
@@ -15710,7 +15888,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipHostMalloc_i8_6_source = hipHostMalloc_(cptr,PRODUCT(dims)*8_8,flags)
+        hipHostMalloc_i8_6_source = hipHostMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_int64),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):,lbounds(6):) => tmp
@@ -15739,7 +15917,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_i8_6_c_int
 #endif
       !
-      hipHostMalloc_i8_6_c_int = hipHostMalloc_(cptr,length1*length2*length3*length4*length5*length6*8_8,flags)
+      hipHostMalloc_i8_6_c_int = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                     int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*byte_size(elem_int64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6])
     end function
 
@@ -15762,7 +15941,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_i8_6_c_size_t
 #endif
       !
-      hipHostMalloc_i8_6_c_size_t = hipHostMalloc_(cptr,length1*length2*length3*length4*length5*length6*8_8,flags)
+      hipHostMalloc_i8_6_c_size_t = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                        int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*byte_size(elem_int64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6])
     end function
 
@@ -15777,8 +15957,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       integer(c_long),pointer,dimension(:,:,:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(7),dims(7)
-      integer(8),intent(in),optional :: lbounds8(7),dims8(7)
+      integer(int32),intent(in),optional :: lbounds(7),dims(7)
+      integer(int64),intent(in),optional :: lbounds8(7),dims8(7)
       integer(c_long),target,dimension(:,:,:,:,:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags
       !
@@ -15807,21 +15987,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipHostMalloc_i8_7_source = hipHostMalloc_(cptr,size(dsource)*8_8,flags)
-        hipHostMalloc_i8_7_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*8_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_i8_7_source = hipHostMalloc_(cptr,size(dsource,kind=int64)*byte_size(elem_int64),flags)
+        hipHostMalloc_i8_7_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_int64),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):,LBOUND(dsource,6):,LBOUND(dsource,7):) => tmp
       else if ( present(source) ) then
-        hipHostMalloc_i8_7_source = hipHostMalloc_(cptr,size(source)*8_8,flags)
-        hipHostMalloc_i8_7_source = hipMemcpy(cptr,c_loc(source),size(source)*8_8,hipMemcpyHostToHost)
+        hipHostMalloc_i8_7_source = hipHostMalloc_(cptr,size(source,kind=int64)*byte_size(elem_int64),flags)
+        hipHostMalloc_i8_7_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_int64),hipMemcpyHostToHost)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):,LBOUND(source,6):,LBOUND(source,7):) => tmp
       else if ( present(mold) ) then
-        hipHostMalloc_i8_7_source = hipHostMalloc_(cptr,size(mold)*8_8,flags)
+        hipHostMalloc_i8_7_source = hipHostMalloc_(cptr,size(mold,kind=int64)*byte_size(elem_int64),flags)
         call c_f_pointer(cptr,ptr,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):,LBOUND(mold,6):,LBOUND(mold,7):) => tmp
       else if ( present(dims8) ) then
-        hipHostMalloc_i8_7_source = hipHostMalloc_(cptr,PRODUCT(dims8)*8_8,flags)
+        hipHostMalloc_i8_7_source = hipHostMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_int64),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):,lbounds8(6):,lbounds8(7):) => tmp
@@ -15829,7 +16009,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipHostMalloc_i8_7_source = hipHostMalloc_(cptr,PRODUCT(dims)*8_8,flags)
+        hipHostMalloc_i8_7_source = hipHostMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_int64),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):,lbounds(6):,lbounds(7):) => tmp
@@ -15858,7 +16038,9 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_i8_7_c_int
 #endif
       !
-      hipHostMalloc_i8_7_c_int = hipHostMalloc_(cptr,length1*length2*length3*length4*length5*length6*length7*8_8,flags)
+      hipHostMalloc_i8_7_c_int = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                     int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*&
+                                                     int(length7,kind=int64)*byte_size(elem_int64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6,length7])
     end function
 
@@ -15881,7 +16063,9 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_i8_7_c_size_t
 #endif
       !
-      hipHostMalloc_i8_7_c_size_t = hipHostMalloc_(cptr,length1*length2*length3*length4*length5*length6*length7*8_8,flags)
+      hipHostMalloc_i8_7_c_size_t = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                        int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*&
+                                                        int(length7,kind=int64)*byte_size(elem_int64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6,length7])
     end function
 
@@ -15914,15 +16098,15 @@ module hipfort_hipmalloc
       if ( nOptArgs > 1 ) ERROR STOP "ERROR: hipHostMalloc (scalar version): Only one optional argument ('dsource','source') must be specified."
 
       if ( present(dsource) ) then
-        hipHostMalloc_r4_0_source = hipHostMalloc_(cptr,4_8,flags)
-        hipHostMalloc_r4_0_source = hipMemcpy(cptr,c_loc(dsource),4_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_r4_0_source = hipHostMalloc_(cptr,byte_size(elem_real32),flags)
+        hipHostMalloc_r4_0_source = hipMemcpy(cptr,c_loc(dsource),byte_size(elem_real32),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,ptr)
       else if ( present(source) ) then
-        hipHostMalloc_r4_0_source = hipHostMalloc_(cptr,4_8,flags)
-        hipHostMalloc_r4_0_source = hipMemcpy(cptr,c_loc(source),4_8,hipMemcpyHostToHost)
+        hipHostMalloc_r4_0_source = hipHostMalloc_(cptr,byte_size(elem_real32),flags)
+        hipHostMalloc_r4_0_source = hipMemcpy(cptr,c_loc(source),byte_size(elem_real32),hipMemcpyHostToHost)
         call c_f_pointer(cptr,ptr)
       else
-        hipHostMalloc_r4_0_source = hipHostMalloc_(cptr,4_8,flags)
+        hipHostMalloc_r4_0_source = hipHostMalloc_(cptr,byte_size(elem_real32),flags)
         call c_f_pointer(cptr,ptr)
       end if
     end function
@@ -15939,8 +16123,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       real(c_float),pointer,dimension(:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(1),dims(1)
-      integer(8),intent(in),optional :: lbounds8(1),dims8(1)
+      integer(int32),intent(in),optional :: lbounds(1),dims(1)
+      integer(int64),intent(in),optional :: lbounds8(1),dims8(1)
       real(c_float),target,dimension(:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags
       !
@@ -15969,21 +16153,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipHostMalloc_r4_1_source = hipHostMalloc_(cptr,size(dsource)*4_8,flags)
-        hipHostMalloc_r4_1_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*4_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_r4_1_source = hipHostMalloc_(cptr,size(dsource,kind=int64)*byte_size(elem_real32),flags)
+        hipHostMalloc_r4_1_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_real32),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):) => tmp
       else if ( present(source) ) then
-        hipHostMalloc_r4_1_source = hipHostMalloc_(cptr,size(source)*4_8,flags)
-        hipHostMalloc_r4_1_source = hipMemcpy(cptr,c_loc(source),size(source)*4_8,hipMemcpyHostToHost)
+        hipHostMalloc_r4_1_source = hipHostMalloc_(cptr,size(source,kind=int64)*byte_size(elem_real32),flags)
+        hipHostMalloc_r4_1_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_real32),hipMemcpyHostToHost)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):) => tmp
       else if ( present(mold) ) then
-        hipHostMalloc_r4_1_source = hipHostMalloc_(cptr,size(mold)*4_8,flags)
+        hipHostMalloc_r4_1_source = hipHostMalloc_(cptr,size(mold,kind=int64)*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,ptr,shape=shape(mold))
         ptr(LBOUND(mold,1):) => tmp
       else if ( present(dims8) ) then
-        hipHostMalloc_r4_1_source = hipHostMalloc_(cptr,PRODUCT(dims8)*4_8,flags)
+        hipHostMalloc_r4_1_source = hipHostMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):) => tmp
@@ -15991,7 +16175,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipHostMalloc_r4_1_source = hipHostMalloc_(cptr,PRODUCT(dims)*4_8,flags)
+        hipHostMalloc_r4_1_source = hipHostMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):) => tmp
@@ -16020,7 +16204,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_r4_1_c_int
 #endif
       !
-      hipHostMalloc_r4_1_c_int = hipHostMalloc_(cptr,length1*4_8,flags)
+      hipHostMalloc_r4_1_c_int = hipHostMalloc_(cptr,int(length1,kind=int64)*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1])
     end function
 
@@ -16043,7 +16227,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_r4_1_c_size_t
 #endif
       !
-      hipHostMalloc_r4_1_c_size_t = hipHostMalloc_(cptr,length1*4_8,flags)
+      hipHostMalloc_r4_1_c_size_t = hipHostMalloc_(cptr,int(length1,kind=int64)*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1])
     end function
 
@@ -16058,8 +16242,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       real(c_float),pointer,dimension(:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(2),dims(2)
-      integer(8),intent(in),optional :: lbounds8(2),dims8(2)
+      integer(int32),intent(in),optional :: lbounds(2),dims(2)
+      integer(int64),intent(in),optional :: lbounds8(2),dims8(2)
       real(c_float),target,dimension(:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags
       !
@@ -16088,21 +16272,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipHostMalloc_r4_2_source = hipHostMalloc_(cptr,size(dsource)*4_8,flags)
-        hipHostMalloc_r4_2_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*4_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_r4_2_source = hipHostMalloc_(cptr,size(dsource,kind=int64)*byte_size(elem_real32),flags)
+        hipHostMalloc_r4_2_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_real32),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):) => tmp
       else if ( present(source) ) then
-        hipHostMalloc_r4_2_source = hipHostMalloc_(cptr,size(source)*4_8,flags)
-        hipHostMalloc_r4_2_source = hipMemcpy(cptr,c_loc(source),size(source)*4_8,hipMemcpyHostToHost)
+        hipHostMalloc_r4_2_source = hipHostMalloc_(cptr,size(source,kind=int64)*byte_size(elem_real32),flags)
+        hipHostMalloc_r4_2_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_real32),hipMemcpyHostToHost)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):) => tmp
       else if ( present(mold) ) then
-        hipHostMalloc_r4_2_source = hipHostMalloc_(cptr,size(mold)*4_8,flags)
+        hipHostMalloc_r4_2_source = hipHostMalloc_(cptr,size(mold,kind=int64)*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,ptr,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):) => tmp
       else if ( present(dims8) ) then
-        hipHostMalloc_r4_2_source = hipHostMalloc_(cptr,PRODUCT(dims8)*4_8,flags)
+        hipHostMalloc_r4_2_source = hipHostMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):) => tmp
@@ -16110,7 +16294,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipHostMalloc_r4_2_source = hipHostMalloc_(cptr,PRODUCT(dims)*4_8,flags)
+        hipHostMalloc_r4_2_source = hipHostMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):) => tmp
@@ -16139,7 +16323,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_r4_2_c_int
 #endif
       !
-      hipHostMalloc_r4_2_c_int = hipHostMalloc_(cptr,length1*length2*4_8,flags)
+      hipHostMalloc_r4_2_c_int = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2])
     end function
 
@@ -16162,7 +16346,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_r4_2_c_size_t
 #endif
       !
-      hipHostMalloc_r4_2_c_size_t = hipHostMalloc_(cptr,length1*length2*4_8,flags)
+      hipHostMalloc_r4_2_c_size_t = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2])
     end function
 
@@ -16177,8 +16361,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       real(c_float),pointer,dimension(:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(3),dims(3)
-      integer(8),intent(in),optional :: lbounds8(3),dims8(3)
+      integer(int32),intent(in),optional :: lbounds(3),dims(3)
+      integer(int64),intent(in),optional :: lbounds8(3),dims8(3)
       real(c_float),target,dimension(:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags
       !
@@ -16207,21 +16391,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipHostMalloc_r4_3_source = hipHostMalloc_(cptr,size(dsource)*4_8,flags)
-        hipHostMalloc_r4_3_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*4_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_r4_3_source = hipHostMalloc_(cptr,size(dsource,kind=int64)*byte_size(elem_real32),flags)
+        hipHostMalloc_r4_3_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_real32),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):) => tmp
       else if ( present(source) ) then
-        hipHostMalloc_r4_3_source = hipHostMalloc_(cptr,size(source)*4_8,flags)
-        hipHostMalloc_r4_3_source = hipMemcpy(cptr,c_loc(source),size(source)*4_8,hipMemcpyHostToHost)
+        hipHostMalloc_r4_3_source = hipHostMalloc_(cptr,size(source,kind=int64)*byte_size(elem_real32),flags)
+        hipHostMalloc_r4_3_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_real32),hipMemcpyHostToHost)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):) => tmp
       else if ( present(mold) ) then
-        hipHostMalloc_r4_3_source = hipHostMalloc_(cptr,size(mold)*4_8,flags)
+        hipHostMalloc_r4_3_source = hipHostMalloc_(cptr,size(mold,kind=int64)*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,ptr,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):) => tmp
       else if ( present(dims8) ) then
-        hipHostMalloc_r4_3_source = hipHostMalloc_(cptr,PRODUCT(dims8)*4_8,flags)
+        hipHostMalloc_r4_3_source = hipHostMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):) => tmp
@@ -16229,7 +16413,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipHostMalloc_r4_3_source = hipHostMalloc_(cptr,PRODUCT(dims)*4_8,flags)
+        hipHostMalloc_r4_3_source = hipHostMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):) => tmp
@@ -16258,7 +16442,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_r4_3_c_int
 #endif
       !
-      hipHostMalloc_r4_3_c_int = hipHostMalloc_(cptr,length1*length2*length3*4_8,flags)
+      hipHostMalloc_r4_3_c_int = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3])
     end function
 
@@ -16281,7 +16465,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_r4_3_c_size_t
 #endif
       !
-      hipHostMalloc_r4_3_c_size_t = hipHostMalloc_(cptr,length1*length2*length3*4_8,flags)
+      hipHostMalloc_r4_3_c_size_t = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3])
     end function
 
@@ -16296,8 +16480,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       real(c_float),pointer,dimension(:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(4),dims(4)
-      integer(8),intent(in),optional :: lbounds8(4),dims8(4)
+      integer(int32),intent(in),optional :: lbounds(4),dims(4)
+      integer(int64),intent(in),optional :: lbounds8(4),dims8(4)
       real(c_float),target,dimension(:,:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags
       !
@@ -16326,21 +16510,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipHostMalloc_r4_4_source = hipHostMalloc_(cptr,size(dsource)*4_8,flags)
-        hipHostMalloc_r4_4_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*4_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_r4_4_source = hipHostMalloc_(cptr,size(dsource,kind=int64)*byte_size(elem_real32),flags)
+        hipHostMalloc_r4_4_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_real32),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):) => tmp
       else if ( present(source) ) then
-        hipHostMalloc_r4_4_source = hipHostMalloc_(cptr,size(source)*4_8,flags)
-        hipHostMalloc_r4_4_source = hipMemcpy(cptr,c_loc(source),size(source)*4_8,hipMemcpyHostToHost)
+        hipHostMalloc_r4_4_source = hipHostMalloc_(cptr,size(source,kind=int64)*byte_size(elem_real32),flags)
+        hipHostMalloc_r4_4_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_real32),hipMemcpyHostToHost)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):) => tmp
       else if ( present(mold) ) then
-        hipHostMalloc_r4_4_source = hipHostMalloc_(cptr,size(mold)*4_8,flags)
+        hipHostMalloc_r4_4_source = hipHostMalloc_(cptr,size(mold,kind=int64)*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,ptr,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):) => tmp
       else if ( present(dims8) ) then
-        hipHostMalloc_r4_4_source = hipHostMalloc_(cptr,PRODUCT(dims8)*4_8,flags)
+        hipHostMalloc_r4_4_source = hipHostMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):) => tmp
@@ -16348,7 +16532,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipHostMalloc_r4_4_source = hipHostMalloc_(cptr,PRODUCT(dims)*4_8,flags)
+        hipHostMalloc_r4_4_source = hipHostMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):) => tmp
@@ -16377,7 +16561,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_r4_4_c_int
 #endif
       !
-      hipHostMalloc_r4_4_c_int = hipHostMalloc_(cptr,length1*length2*length3*length4*4_8,flags)
+      hipHostMalloc_r4_4_c_int = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                     int(length4,kind=int64)*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4])
     end function
 
@@ -16400,7 +16585,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_r4_4_c_size_t
 #endif
       !
-      hipHostMalloc_r4_4_c_size_t = hipHostMalloc_(cptr,length1*length2*length3*length4*4_8,flags)
+      hipHostMalloc_r4_4_c_size_t = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                        int(length4,kind=int64)*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4])
     end function
 
@@ -16415,8 +16601,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       real(c_float),pointer,dimension(:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(5),dims(5)
-      integer(8),intent(in),optional :: lbounds8(5),dims8(5)
+      integer(int32),intent(in),optional :: lbounds(5),dims(5)
+      integer(int64),intent(in),optional :: lbounds8(5),dims8(5)
       real(c_float),target,dimension(:,:,:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags
       !
@@ -16445,21 +16631,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipHostMalloc_r4_5_source = hipHostMalloc_(cptr,size(dsource)*4_8,flags)
-        hipHostMalloc_r4_5_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*4_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_r4_5_source = hipHostMalloc_(cptr,size(dsource,kind=int64)*byte_size(elem_real32),flags)
+        hipHostMalloc_r4_5_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_real32),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):) => tmp
       else if ( present(source) ) then
-        hipHostMalloc_r4_5_source = hipHostMalloc_(cptr,size(source)*4_8,flags)
-        hipHostMalloc_r4_5_source = hipMemcpy(cptr,c_loc(source),size(source)*4_8,hipMemcpyHostToHost)
+        hipHostMalloc_r4_5_source = hipHostMalloc_(cptr,size(source,kind=int64)*byte_size(elem_real32),flags)
+        hipHostMalloc_r4_5_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_real32),hipMemcpyHostToHost)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):) => tmp
       else if ( present(mold) ) then
-        hipHostMalloc_r4_5_source = hipHostMalloc_(cptr,size(mold)*4_8,flags)
+        hipHostMalloc_r4_5_source = hipHostMalloc_(cptr,size(mold,kind=int64)*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,ptr,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):) => tmp
       else if ( present(dims8) ) then
-        hipHostMalloc_r4_5_source = hipHostMalloc_(cptr,PRODUCT(dims8)*4_8,flags)
+        hipHostMalloc_r4_5_source = hipHostMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):) => tmp
@@ -16467,7 +16653,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipHostMalloc_r4_5_source = hipHostMalloc_(cptr,PRODUCT(dims)*4_8,flags)
+        hipHostMalloc_r4_5_source = hipHostMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):) => tmp
@@ -16496,7 +16682,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_r4_5_c_int
 #endif
       !
-      hipHostMalloc_r4_5_c_int = hipHostMalloc_(cptr,length1*length2*length3*length4*length5*4_8,flags)
+      hipHostMalloc_r4_5_c_int = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                     int(length4,kind=int64)*int(length5,kind=int64)*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5])
     end function
 
@@ -16519,7 +16706,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_r4_5_c_size_t
 #endif
       !
-      hipHostMalloc_r4_5_c_size_t = hipHostMalloc_(cptr,length1*length2*length3*length4*length5*4_8,flags)
+      hipHostMalloc_r4_5_c_size_t = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                        int(length4,kind=int64)*int(length5,kind=int64)*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5])
     end function
 
@@ -16534,8 +16722,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       real(c_float),pointer,dimension(:,:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(6),dims(6)
-      integer(8),intent(in),optional :: lbounds8(6),dims8(6)
+      integer(int32),intent(in),optional :: lbounds(6),dims(6)
+      integer(int64),intent(in),optional :: lbounds8(6),dims8(6)
       real(c_float),target,dimension(:,:,:,:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags
       !
@@ -16564,21 +16752,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipHostMalloc_r4_6_source = hipHostMalloc_(cptr,size(dsource)*4_8,flags)
-        hipHostMalloc_r4_6_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*4_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_r4_6_source = hipHostMalloc_(cptr,size(dsource,kind=int64)*byte_size(elem_real32),flags)
+        hipHostMalloc_r4_6_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_real32),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):,LBOUND(dsource,6):) => tmp
       else if ( present(source) ) then
-        hipHostMalloc_r4_6_source = hipHostMalloc_(cptr,size(source)*4_8,flags)
-        hipHostMalloc_r4_6_source = hipMemcpy(cptr,c_loc(source),size(source)*4_8,hipMemcpyHostToHost)
+        hipHostMalloc_r4_6_source = hipHostMalloc_(cptr,size(source,kind=int64)*byte_size(elem_real32),flags)
+        hipHostMalloc_r4_6_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_real32),hipMemcpyHostToHost)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):,LBOUND(source,6):) => tmp
       else if ( present(mold) ) then
-        hipHostMalloc_r4_6_source = hipHostMalloc_(cptr,size(mold)*4_8,flags)
+        hipHostMalloc_r4_6_source = hipHostMalloc_(cptr,size(mold,kind=int64)*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,ptr,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):,LBOUND(mold,6):) => tmp
       else if ( present(dims8) ) then
-        hipHostMalloc_r4_6_source = hipHostMalloc_(cptr,PRODUCT(dims8)*4_8,flags)
+        hipHostMalloc_r4_6_source = hipHostMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):,lbounds8(6):) => tmp
@@ -16586,7 +16774,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipHostMalloc_r4_6_source = hipHostMalloc_(cptr,PRODUCT(dims)*4_8,flags)
+        hipHostMalloc_r4_6_source = hipHostMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):,lbounds(6):) => tmp
@@ -16615,7 +16803,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_r4_6_c_int
 #endif
       !
-      hipHostMalloc_r4_6_c_int = hipHostMalloc_(cptr,length1*length2*length3*length4*length5*length6*4_8,flags)
+      hipHostMalloc_r4_6_c_int = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                     int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6])
     end function
 
@@ -16638,7 +16827,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_r4_6_c_size_t
 #endif
       !
-      hipHostMalloc_r4_6_c_size_t = hipHostMalloc_(cptr,length1*length2*length3*length4*length5*length6*4_8,flags)
+      hipHostMalloc_r4_6_c_size_t = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                        int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6])
     end function
 
@@ -16653,8 +16843,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       real(c_float),pointer,dimension(:,:,:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(7),dims(7)
-      integer(8),intent(in),optional :: lbounds8(7),dims8(7)
+      integer(int32),intent(in),optional :: lbounds(7),dims(7)
+      integer(int64),intent(in),optional :: lbounds8(7),dims8(7)
       real(c_float),target,dimension(:,:,:,:,:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags
       !
@@ -16683,21 +16873,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipHostMalloc_r4_7_source = hipHostMalloc_(cptr,size(dsource)*4_8,flags)
-        hipHostMalloc_r4_7_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*4_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_r4_7_source = hipHostMalloc_(cptr,size(dsource,kind=int64)*byte_size(elem_real32),flags)
+        hipHostMalloc_r4_7_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_real32),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):,LBOUND(dsource,6):,LBOUND(dsource,7):) => tmp
       else if ( present(source) ) then
-        hipHostMalloc_r4_7_source = hipHostMalloc_(cptr,size(source)*4_8,flags)
-        hipHostMalloc_r4_7_source = hipMemcpy(cptr,c_loc(source),size(source)*4_8,hipMemcpyHostToHost)
+        hipHostMalloc_r4_7_source = hipHostMalloc_(cptr,size(source,kind=int64)*byte_size(elem_real32),flags)
+        hipHostMalloc_r4_7_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_real32),hipMemcpyHostToHost)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):,LBOUND(source,6):,LBOUND(source,7):) => tmp
       else if ( present(mold) ) then
-        hipHostMalloc_r4_7_source = hipHostMalloc_(cptr,size(mold)*4_8,flags)
+        hipHostMalloc_r4_7_source = hipHostMalloc_(cptr,size(mold,kind=int64)*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,ptr,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):,LBOUND(mold,6):,LBOUND(mold,7):) => tmp
       else if ( present(dims8) ) then
-        hipHostMalloc_r4_7_source = hipHostMalloc_(cptr,PRODUCT(dims8)*4_8,flags)
+        hipHostMalloc_r4_7_source = hipHostMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):,lbounds8(6):,lbounds8(7):) => tmp
@@ -16705,7 +16895,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipHostMalloc_r4_7_source = hipHostMalloc_(cptr,PRODUCT(dims)*4_8,flags)
+        hipHostMalloc_r4_7_source = hipHostMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):,lbounds(6):,lbounds(7):) => tmp
@@ -16734,7 +16924,9 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_r4_7_c_int
 #endif
       !
-      hipHostMalloc_r4_7_c_int = hipHostMalloc_(cptr,length1*length2*length3*length4*length5*length6*length7*4_8,flags)
+      hipHostMalloc_r4_7_c_int = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                     int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*&
+                                                     int(length7,kind=int64)*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6,length7])
     end function
 
@@ -16757,7 +16949,9 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_r4_7_c_size_t
 #endif
       !
-      hipHostMalloc_r4_7_c_size_t = hipHostMalloc_(cptr,length1*length2*length3*length4*length5*length6*length7*4_8,flags)
+      hipHostMalloc_r4_7_c_size_t = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                        int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*&
+                                                        int(length7,kind=int64)*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6,length7])
     end function
 
@@ -16790,15 +16984,15 @@ module hipfort_hipmalloc
       if ( nOptArgs > 1 ) ERROR STOP "ERROR: hipHostMalloc (scalar version): Only one optional argument ('dsource','source') must be specified."
 
       if ( present(dsource) ) then
-        hipHostMalloc_r8_0_source = hipHostMalloc_(cptr,8_8,flags)
-        hipHostMalloc_r8_0_source = hipMemcpy(cptr,c_loc(dsource),8_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_r8_0_source = hipHostMalloc_(cptr,byte_size(elem_real64),flags)
+        hipHostMalloc_r8_0_source = hipMemcpy(cptr,c_loc(dsource),byte_size(elem_real64),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,ptr)
       else if ( present(source) ) then
-        hipHostMalloc_r8_0_source = hipHostMalloc_(cptr,8_8,flags)
-        hipHostMalloc_r8_0_source = hipMemcpy(cptr,c_loc(source),8_8,hipMemcpyHostToHost)
+        hipHostMalloc_r8_0_source = hipHostMalloc_(cptr,byte_size(elem_real64),flags)
+        hipHostMalloc_r8_0_source = hipMemcpy(cptr,c_loc(source),byte_size(elem_real64),hipMemcpyHostToHost)
         call c_f_pointer(cptr,ptr)
       else
-        hipHostMalloc_r8_0_source = hipHostMalloc_(cptr,8_8,flags)
+        hipHostMalloc_r8_0_source = hipHostMalloc_(cptr,byte_size(elem_real64),flags)
         call c_f_pointer(cptr,ptr)
       end if
     end function
@@ -16815,8 +17009,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       real(c_double),pointer,dimension(:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(1),dims(1)
-      integer(8),intent(in),optional :: lbounds8(1),dims8(1)
+      integer(int32),intent(in),optional :: lbounds(1),dims(1)
+      integer(int64),intent(in),optional :: lbounds8(1),dims8(1)
       real(c_double),target,dimension(:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags
       !
@@ -16845,21 +17039,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipHostMalloc_r8_1_source = hipHostMalloc_(cptr,size(dsource)*8_8,flags)
-        hipHostMalloc_r8_1_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*8_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_r8_1_source = hipHostMalloc_(cptr,size(dsource,kind=int64)*byte_size(elem_real64),flags)
+        hipHostMalloc_r8_1_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_real64),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):) => tmp
       else if ( present(source) ) then
-        hipHostMalloc_r8_1_source = hipHostMalloc_(cptr,size(source)*8_8,flags)
-        hipHostMalloc_r8_1_source = hipMemcpy(cptr,c_loc(source),size(source)*8_8,hipMemcpyHostToHost)
+        hipHostMalloc_r8_1_source = hipHostMalloc_(cptr,size(source,kind=int64)*byte_size(elem_real64),flags)
+        hipHostMalloc_r8_1_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_real64),hipMemcpyHostToHost)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):) => tmp
       else if ( present(mold) ) then
-        hipHostMalloc_r8_1_source = hipHostMalloc_(cptr,size(mold)*8_8,flags)
+        hipHostMalloc_r8_1_source = hipHostMalloc_(cptr,size(mold,kind=int64)*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,ptr,shape=shape(mold))
         ptr(LBOUND(mold,1):) => tmp
       else if ( present(dims8) ) then
-        hipHostMalloc_r8_1_source = hipHostMalloc_(cptr,PRODUCT(dims8)*8_8,flags)
+        hipHostMalloc_r8_1_source = hipHostMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):) => tmp
@@ -16867,7 +17061,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipHostMalloc_r8_1_source = hipHostMalloc_(cptr,PRODUCT(dims)*8_8,flags)
+        hipHostMalloc_r8_1_source = hipHostMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):) => tmp
@@ -16896,7 +17090,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_r8_1_c_int
 #endif
       !
-      hipHostMalloc_r8_1_c_int = hipHostMalloc_(cptr,length1*8_8,flags)
+      hipHostMalloc_r8_1_c_int = hipHostMalloc_(cptr,int(length1,kind=int64)*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1])
     end function
 
@@ -16919,7 +17113,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_r8_1_c_size_t
 #endif
       !
-      hipHostMalloc_r8_1_c_size_t = hipHostMalloc_(cptr,length1*8_8,flags)
+      hipHostMalloc_r8_1_c_size_t = hipHostMalloc_(cptr,int(length1,kind=int64)*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1])
     end function
 
@@ -16934,8 +17128,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       real(c_double),pointer,dimension(:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(2),dims(2)
-      integer(8),intent(in),optional :: lbounds8(2),dims8(2)
+      integer(int32),intent(in),optional :: lbounds(2),dims(2)
+      integer(int64),intent(in),optional :: lbounds8(2),dims8(2)
       real(c_double),target,dimension(:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags
       !
@@ -16964,21 +17158,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipHostMalloc_r8_2_source = hipHostMalloc_(cptr,size(dsource)*8_8,flags)
-        hipHostMalloc_r8_2_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*8_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_r8_2_source = hipHostMalloc_(cptr,size(dsource,kind=int64)*byte_size(elem_real64),flags)
+        hipHostMalloc_r8_2_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_real64),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):) => tmp
       else if ( present(source) ) then
-        hipHostMalloc_r8_2_source = hipHostMalloc_(cptr,size(source)*8_8,flags)
-        hipHostMalloc_r8_2_source = hipMemcpy(cptr,c_loc(source),size(source)*8_8,hipMemcpyHostToHost)
+        hipHostMalloc_r8_2_source = hipHostMalloc_(cptr,size(source,kind=int64)*byte_size(elem_real64),flags)
+        hipHostMalloc_r8_2_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_real64),hipMemcpyHostToHost)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):) => tmp
       else if ( present(mold) ) then
-        hipHostMalloc_r8_2_source = hipHostMalloc_(cptr,size(mold)*8_8,flags)
+        hipHostMalloc_r8_2_source = hipHostMalloc_(cptr,size(mold,kind=int64)*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,ptr,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):) => tmp
       else if ( present(dims8) ) then
-        hipHostMalloc_r8_2_source = hipHostMalloc_(cptr,PRODUCT(dims8)*8_8,flags)
+        hipHostMalloc_r8_2_source = hipHostMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):) => tmp
@@ -16986,7 +17180,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipHostMalloc_r8_2_source = hipHostMalloc_(cptr,PRODUCT(dims)*8_8,flags)
+        hipHostMalloc_r8_2_source = hipHostMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):) => tmp
@@ -17015,7 +17209,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_r8_2_c_int
 #endif
       !
-      hipHostMalloc_r8_2_c_int = hipHostMalloc_(cptr,length1*length2*8_8,flags)
+      hipHostMalloc_r8_2_c_int = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2])
     end function
 
@@ -17038,7 +17232,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_r8_2_c_size_t
 #endif
       !
-      hipHostMalloc_r8_2_c_size_t = hipHostMalloc_(cptr,length1*length2*8_8,flags)
+      hipHostMalloc_r8_2_c_size_t = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2])
     end function
 
@@ -17053,8 +17247,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       real(c_double),pointer,dimension(:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(3),dims(3)
-      integer(8),intent(in),optional :: lbounds8(3),dims8(3)
+      integer(int32),intent(in),optional :: lbounds(3),dims(3)
+      integer(int64),intent(in),optional :: lbounds8(3),dims8(3)
       real(c_double),target,dimension(:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags
       !
@@ -17083,21 +17277,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipHostMalloc_r8_3_source = hipHostMalloc_(cptr,size(dsource)*8_8,flags)
-        hipHostMalloc_r8_3_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*8_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_r8_3_source = hipHostMalloc_(cptr,size(dsource,kind=int64)*byte_size(elem_real64),flags)
+        hipHostMalloc_r8_3_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_real64),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):) => tmp
       else if ( present(source) ) then
-        hipHostMalloc_r8_3_source = hipHostMalloc_(cptr,size(source)*8_8,flags)
-        hipHostMalloc_r8_3_source = hipMemcpy(cptr,c_loc(source),size(source)*8_8,hipMemcpyHostToHost)
+        hipHostMalloc_r8_3_source = hipHostMalloc_(cptr,size(source,kind=int64)*byte_size(elem_real64),flags)
+        hipHostMalloc_r8_3_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_real64),hipMemcpyHostToHost)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):) => tmp
       else if ( present(mold) ) then
-        hipHostMalloc_r8_3_source = hipHostMalloc_(cptr,size(mold)*8_8,flags)
+        hipHostMalloc_r8_3_source = hipHostMalloc_(cptr,size(mold,kind=int64)*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,ptr,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):) => tmp
       else if ( present(dims8) ) then
-        hipHostMalloc_r8_3_source = hipHostMalloc_(cptr,PRODUCT(dims8)*8_8,flags)
+        hipHostMalloc_r8_3_source = hipHostMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):) => tmp
@@ -17105,7 +17299,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipHostMalloc_r8_3_source = hipHostMalloc_(cptr,PRODUCT(dims)*8_8,flags)
+        hipHostMalloc_r8_3_source = hipHostMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):) => tmp
@@ -17134,7 +17328,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_r8_3_c_int
 #endif
       !
-      hipHostMalloc_r8_3_c_int = hipHostMalloc_(cptr,length1*length2*length3*8_8,flags)
+      hipHostMalloc_r8_3_c_int = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3])
     end function
 
@@ -17157,7 +17351,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_r8_3_c_size_t
 #endif
       !
-      hipHostMalloc_r8_3_c_size_t = hipHostMalloc_(cptr,length1*length2*length3*8_8,flags)
+      hipHostMalloc_r8_3_c_size_t = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3])
     end function
 
@@ -17172,8 +17366,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       real(c_double),pointer,dimension(:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(4),dims(4)
-      integer(8),intent(in),optional :: lbounds8(4),dims8(4)
+      integer(int32),intent(in),optional :: lbounds(4),dims(4)
+      integer(int64),intent(in),optional :: lbounds8(4),dims8(4)
       real(c_double),target,dimension(:,:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags
       !
@@ -17202,21 +17396,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipHostMalloc_r8_4_source = hipHostMalloc_(cptr,size(dsource)*8_8,flags)
-        hipHostMalloc_r8_4_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*8_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_r8_4_source = hipHostMalloc_(cptr,size(dsource,kind=int64)*byte_size(elem_real64),flags)
+        hipHostMalloc_r8_4_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_real64),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):) => tmp
       else if ( present(source) ) then
-        hipHostMalloc_r8_4_source = hipHostMalloc_(cptr,size(source)*8_8,flags)
-        hipHostMalloc_r8_4_source = hipMemcpy(cptr,c_loc(source),size(source)*8_8,hipMemcpyHostToHost)
+        hipHostMalloc_r8_4_source = hipHostMalloc_(cptr,size(source,kind=int64)*byte_size(elem_real64),flags)
+        hipHostMalloc_r8_4_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_real64),hipMemcpyHostToHost)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):) => tmp
       else if ( present(mold) ) then
-        hipHostMalloc_r8_4_source = hipHostMalloc_(cptr,size(mold)*8_8,flags)
+        hipHostMalloc_r8_4_source = hipHostMalloc_(cptr,size(mold,kind=int64)*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,ptr,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):) => tmp
       else if ( present(dims8) ) then
-        hipHostMalloc_r8_4_source = hipHostMalloc_(cptr,PRODUCT(dims8)*8_8,flags)
+        hipHostMalloc_r8_4_source = hipHostMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):) => tmp
@@ -17224,7 +17418,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipHostMalloc_r8_4_source = hipHostMalloc_(cptr,PRODUCT(dims)*8_8,flags)
+        hipHostMalloc_r8_4_source = hipHostMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):) => tmp
@@ -17253,7 +17447,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_r8_4_c_int
 #endif
       !
-      hipHostMalloc_r8_4_c_int = hipHostMalloc_(cptr,length1*length2*length3*length4*8_8,flags)
+      hipHostMalloc_r8_4_c_int = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                     int(length4,kind=int64)*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4])
     end function
 
@@ -17276,7 +17471,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_r8_4_c_size_t
 #endif
       !
-      hipHostMalloc_r8_4_c_size_t = hipHostMalloc_(cptr,length1*length2*length3*length4*8_8,flags)
+      hipHostMalloc_r8_4_c_size_t = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                        int(length4,kind=int64)*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4])
     end function
 
@@ -17291,8 +17487,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       real(c_double),pointer,dimension(:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(5),dims(5)
-      integer(8),intent(in),optional :: lbounds8(5),dims8(5)
+      integer(int32),intent(in),optional :: lbounds(5),dims(5)
+      integer(int64),intent(in),optional :: lbounds8(5),dims8(5)
       real(c_double),target,dimension(:,:,:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags
       !
@@ -17321,21 +17517,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipHostMalloc_r8_5_source = hipHostMalloc_(cptr,size(dsource)*8_8,flags)
-        hipHostMalloc_r8_5_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*8_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_r8_5_source = hipHostMalloc_(cptr,size(dsource,kind=int64)*byte_size(elem_real64),flags)
+        hipHostMalloc_r8_5_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_real64),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):) => tmp
       else if ( present(source) ) then
-        hipHostMalloc_r8_5_source = hipHostMalloc_(cptr,size(source)*8_8,flags)
-        hipHostMalloc_r8_5_source = hipMemcpy(cptr,c_loc(source),size(source)*8_8,hipMemcpyHostToHost)
+        hipHostMalloc_r8_5_source = hipHostMalloc_(cptr,size(source,kind=int64)*byte_size(elem_real64),flags)
+        hipHostMalloc_r8_5_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_real64),hipMemcpyHostToHost)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):) => tmp
       else if ( present(mold) ) then
-        hipHostMalloc_r8_5_source = hipHostMalloc_(cptr,size(mold)*8_8,flags)
+        hipHostMalloc_r8_5_source = hipHostMalloc_(cptr,size(mold,kind=int64)*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,ptr,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):) => tmp
       else if ( present(dims8) ) then
-        hipHostMalloc_r8_5_source = hipHostMalloc_(cptr,PRODUCT(dims8)*8_8,flags)
+        hipHostMalloc_r8_5_source = hipHostMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):) => tmp
@@ -17343,7 +17539,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipHostMalloc_r8_5_source = hipHostMalloc_(cptr,PRODUCT(dims)*8_8,flags)
+        hipHostMalloc_r8_5_source = hipHostMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):) => tmp
@@ -17372,7 +17568,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_r8_5_c_int
 #endif
       !
-      hipHostMalloc_r8_5_c_int = hipHostMalloc_(cptr,length1*length2*length3*length4*length5*8_8,flags)
+      hipHostMalloc_r8_5_c_int = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                     int(length4,kind=int64)*int(length5,kind=int64)*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5])
     end function
 
@@ -17395,7 +17592,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_r8_5_c_size_t
 #endif
       !
-      hipHostMalloc_r8_5_c_size_t = hipHostMalloc_(cptr,length1*length2*length3*length4*length5*8_8,flags)
+      hipHostMalloc_r8_5_c_size_t = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                        int(length4,kind=int64)*int(length5,kind=int64)*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5])
     end function
 
@@ -17410,8 +17608,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       real(c_double),pointer,dimension(:,:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(6),dims(6)
-      integer(8),intent(in),optional :: lbounds8(6),dims8(6)
+      integer(int32),intent(in),optional :: lbounds(6),dims(6)
+      integer(int64),intent(in),optional :: lbounds8(6),dims8(6)
       real(c_double),target,dimension(:,:,:,:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags
       !
@@ -17440,21 +17638,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipHostMalloc_r8_6_source = hipHostMalloc_(cptr,size(dsource)*8_8,flags)
-        hipHostMalloc_r8_6_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*8_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_r8_6_source = hipHostMalloc_(cptr,size(dsource,kind=int64)*byte_size(elem_real64),flags)
+        hipHostMalloc_r8_6_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_real64),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):,LBOUND(dsource,6):) => tmp
       else if ( present(source) ) then
-        hipHostMalloc_r8_6_source = hipHostMalloc_(cptr,size(source)*8_8,flags)
-        hipHostMalloc_r8_6_source = hipMemcpy(cptr,c_loc(source),size(source)*8_8,hipMemcpyHostToHost)
+        hipHostMalloc_r8_6_source = hipHostMalloc_(cptr,size(source,kind=int64)*byte_size(elem_real64),flags)
+        hipHostMalloc_r8_6_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_real64),hipMemcpyHostToHost)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):,LBOUND(source,6):) => tmp
       else if ( present(mold) ) then
-        hipHostMalloc_r8_6_source = hipHostMalloc_(cptr,size(mold)*8_8,flags)
+        hipHostMalloc_r8_6_source = hipHostMalloc_(cptr,size(mold,kind=int64)*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,ptr,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):,LBOUND(mold,6):) => tmp
       else if ( present(dims8) ) then
-        hipHostMalloc_r8_6_source = hipHostMalloc_(cptr,PRODUCT(dims8)*8_8,flags)
+        hipHostMalloc_r8_6_source = hipHostMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):,lbounds8(6):) => tmp
@@ -17462,7 +17660,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipHostMalloc_r8_6_source = hipHostMalloc_(cptr,PRODUCT(dims)*8_8,flags)
+        hipHostMalloc_r8_6_source = hipHostMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):,lbounds(6):) => tmp
@@ -17491,7 +17689,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_r8_6_c_int
 #endif
       !
-      hipHostMalloc_r8_6_c_int = hipHostMalloc_(cptr,length1*length2*length3*length4*length5*length6*8_8,flags)
+      hipHostMalloc_r8_6_c_int = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                     int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6])
     end function
 
@@ -17514,7 +17713,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_r8_6_c_size_t
 #endif
       !
-      hipHostMalloc_r8_6_c_size_t = hipHostMalloc_(cptr,length1*length2*length3*length4*length5*length6*8_8,flags)
+      hipHostMalloc_r8_6_c_size_t = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                        int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6])
     end function
 
@@ -17529,8 +17729,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       real(c_double),pointer,dimension(:,:,:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(7),dims(7)
-      integer(8),intent(in),optional :: lbounds8(7),dims8(7)
+      integer(int32),intent(in),optional :: lbounds(7),dims(7)
+      integer(int64),intent(in),optional :: lbounds8(7),dims8(7)
       real(c_double),target,dimension(:,:,:,:,:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags
       !
@@ -17559,21 +17759,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipHostMalloc_r8_7_source = hipHostMalloc_(cptr,size(dsource)*8_8,flags)
-        hipHostMalloc_r8_7_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*8_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_r8_7_source = hipHostMalloc_(cptr,size(dsource,kind=int64)*byte_size(elem_real64),flags)
+        hipHostMalloc_r8_7_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*byte_size(elem_real64),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):,LBOUND(dsource,6):,LBOUND(dsource,7):) => tmp
       else if ( present(source) ) then
-        hipHostMalloc_r8_7_source = hipHostMalloc_(cptr,size(source)*8_8,flags)
-        hipHostMalloc_r8_7_source = hipMemcpy(cptr,c_loc(source),size(source)*8_8,hipMemcpyHostToHost)
+        hipHostMalloc_r8_7_source = hipHostMalloc_(cptr,size(source,kind=int64)*byte_size(elem_real64),flags)
+        hipHostMalloc_r8_7_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*byte_size(elem_real64),hipMemcpyHostToHost)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):,LBOUND(source,6):,LBOUND(source,7):) => tmp
       else if ( present(mold) ) then
-        hipHostMalloc_r8_7_source = hipHostMalloc_(cptr,size(mold)*8_8,flags)
+        hipHostMalloc_r8_7_source = hipHostMalloc_(cptr,size(mold,kind=int64)*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,ptr,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):,LBOUND(mold,6):,LBOUND(mold,7):) => tmp
       else if ( present(dims8) ) then
-        hipHostMalloc_r8_7_source = hipHostMalloc_(cptr,PRODUCT(dims8)*8_8,flags)
+        hipHostMalloc_r8_7_source = hipHostMalloc_(cptr,PRODUCT(dims8)*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):,lbounds8(6):,lbounds8(7):) => tmp
@@ -17581,7 +17781,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipHostMalloc_r8_7_source = hipHostMalloc_(cptr,PRODUCT(dims)*8_8,flags)
+        hipHostMalloc_r8_7_source = hipHostMalloc_(cptr,PRODUCT(int(dims,kind=int64))*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):,lbounds(6):,lbounds(7):) => tmp
@@ -17610,7 +17810,9 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_r8_7_c_int
 #endif
       !
-      hipHostMalloc_r8_7_c_int = hipHostMalloc_(cptr,length1*length2*length3*length4*length5*length6*length7*8_8,flags)
+      hipHostMalloc_r8_7_c_int = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                     int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*&
+                                                     int(length7,kind=int64)*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6,length7])
     end function
 
@@ -17633,7 +17835,9 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_r8_7_c_size_t
 #endif
       !
-      hipHostMalloc_r8_7_c_size_t = hipHostMalloc_(cptr,length1*length2*length3*length4*length5*length6*length7*8_8,flags)
+      hipHostMalloc_r8_7_c_size_t = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                        int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*&
+                                                        int(length7,kind=int64)*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6,length7])
     end function
 
@@ -17666,15 +17870,15 @@ module hipfort_hipmalloc
       if ( nOptArgs > 1 ) ERROR STOP "ERROR: hipHostMalloc (scalar version): Only one optional argument ('dsource','source') must be specified."
 
       if ( present(dsource) ) then
-        hipHostMalloc_c4_0_source = hipHostMalloc_(cptr,2*4_8,flags)
-        hipHostMalloc_c4_0_source = hipMemcpy(cptr,c_loc(dsource),2*4_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_c4_0_source = hipHostMalloc_(cptr,2_int64*byte_size(elem_real32),flags)
+        hipHostMalloc_c4_0_source = hipMemcpy(cptr,c_loc(dsource),2_int64*byte_size(elem_real32),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,ptr)
       else if ( present(source) ) then
-        hipHostMalloc_c4_0_source = hipHostMalloc_(cptr,2*4_8,flags)
-        hipHostMalloc_c4_0_source = hipMemcpy(cptr,c_loc(source),2*4_8,hipMemcpyHostToHost)
+        hipHostMalloc_c4_0_source = hipHostMalloc_(cptr,2_int64*byte_size(elem_real32),flags)
+        hipHostMalloc_c4_0_source = hipMemcpy(cptr,c_loc(source),2_int64*byte_size(elem_real32),hipMemcpyHostToHost)
         call c_f_pointer(cptr,ptr)
       else
-        hipHostMalloc_c4_0_source = hipHostMalloc_(cptr,2*4_8,flags)
+        hipHostMalloc_c4_0_source = hipHostMalloc_(cptr,2_int64*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,ptr)
       end if
     end function
@@ -17691,8 +17895,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       complex(c_float_complex),pointer,dimension(:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(1),dims(1)
-      integer(8),intent(in),optional :: lbounds8(1),dims8(1)
+      integer(int32),intent(in),optional :: lbounds(1),dims(1)
+      integer(int64),intent(in),optional :: lbounds8(1),dims8(1)
       complex(c_float_complex),target,dimension(:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags
       !
@@ -17721,21 +17925,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipHostMalloc_c4_1_source = hipHostMalloc_(cptr,size(dsource)*2*4_8,flags)
-        hipHostMalloc_c4_1_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*2*4_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_c4_1_source = hipHostMalloc_(cptr,size(dsource,kind=int64)*2_int64*byte_size(elem_real32),flags)
+        hipHostMalloc_c4_1_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*2_int64*byte_size(elem_real32),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):) => tmp
       else if ( present(source) ) then
-        hipHostMalloc_c4_1_source = hipHostMalloc_(cptr,size(source)*2*4_8,flags)
-        hipHostMalloc_c4_1_source = hipMemcpy(cptr,c_loc(source),size(source)*2*4_8,hipMemcpyHostToHost)
+        hipHostMalloc_c4_1_source = hipHostMalloc_(cptr,size(source,kind=int64)*2_int64*byte_size(elem_real32),flags)
+        hipHostMalloc_c4_1_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*2_int64*byte_size(elem_real32),hipMemcpyHostToHost)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):) => tmp
       else if ( present(mold) ) then
-        hipHostMalloc_c4_1_source = hipHostMalloc_(cptr,size(mold)*2*4_8,flags)
+        hipHostMalloc_c4_1_source = hipHostMalloc_(cptr,size(mold,kind=int64)*2_int64*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,ptr,shape=shape(mold))
         ptr(LBOUND(mold,1):) => tmp
       else if ( present(dims8) ) then
-        hipHostMalloc_c4_1_source = hipHostMalloc_(cptr,PRODUCT(dims8)*2*4_8,flags)
+        hipHostMalloc_c4_1_source = hipHostMalloc_(cptr,PRODUCT(dims8)*2_int64*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):) => tmp
@@ -17743,7 +17947,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipHostMalloc_c4_1_source = hipHostMalloc_(cptr,PRODUCT(dims)*2*4_8,flags)
+        hipHostMalloc_c4_1_source = hipHostMalloc_(cptr,PRODUCT(int(dims,kind=int64))*2_int64*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):) => tmp
@@ -17772,7 +17976,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_c4_1_c_int
 #endif
       !
-      hipHostMalloc_c4_1_c_int = hipHostMalloc_(cptr,length1*2*4_8,flags)
+      hipHostMalloc_c4_1_c_int = hipHostMalloc_(cptr,int(length1,kind=int64)*2_int64*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1])
     end function
 
@@ -17795,7 +17999,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_c4_1_c_size_t
 #endif
       !
-      hipHostMalloc_c4_1_c_size_t = hipHostMalloc_(cptr,length1*2*4_8,flags)
+      hipHostMalloc_c4_1_c_size_t = hipHostMalloc_(cptr,int(length1,kind=int64)*2_int64*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1])
     end function
 
@@ -17810,8 +18014,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       complex(c_float_complex),pointer,dimension(:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(2),dims(2)
-      integer(8),intent(in),optional :: lbounds8(2),dims8(2)
+      integer(int32),intent(in),optional :: lbounds(2),dims(2)
+      integer(int64),intent(in),optional :: lbounds8(2),dims8(2)
       complex(c_float_complex),target,dimension(:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags
       !
@@ -17840,21 +18044,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipHostMalloc_c4_2_source = hipHostMalloc_(cptr,size(dsource)*2*4_8,flags)
-        hipHostMalloc_c4_2_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*2*4_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_c4_2_source = hipHostMalloc_(cptr,size(dsource,kind=int64)*2_int64*byte_size(elem_real32),flags)
+        hipHostMalloc_c4_2_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*2_int64*byte_size(elem_real32),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):) => tmp
       else if ( present(source) ) then
-        hipHostMalloc_c4_2_source = hipHostMalloc_(cptr,size(source)*2*4_8,flags)
-        hipHostMalloc_c4_2_source = hipMemcpy(cptr,c_loc(source),size(source)*2*4_8,hipMemcpyHostToHost)
+        hipHostMalloc_c4_2_source = hipHostMalloc_(cptr,size(source,kind=int64)*2_int64*byte_size(elem_real32),flags)
+        hipHostMalloc_c4_2_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*2_int64*byte_size(elem_real32),hipMemcpyHostToHost)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):) => tmp
       else if ( present(mold) ) then
-        hipHostMalloc_c4_2_source = hipHostMalloc_(cptr,size(mold)*2*4_8,flags)
+        hipHostMalloc_c4_2_source = hipHostMalloc_(cptr,size(mold,kind=int64)*2_int64*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,ptr,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):) => tmp
       else if ( present(dims8) ) then
-        hipHostMalloc_c4_2_source = hipHostMalloc_(cptr,PRODUCT(dims8)*2*4_8,flags)
+        hipHostMalloc_c4_2_source = hipHostMalloc_(cptr,PRODUCT(dims8)*2_int64*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):) => tmp
@@ -17862,7 +18066,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipHostMalloc_c4_2_source = hipHostMalloc_(cptr,PRODUCT(dims)*2*4_8,flags)
+        hipHostMalloc_c4_2_source = hipHostMalloc_(cptr,PRODUCT(int(dims,kind=int64))*2_int64*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):) => tmp
@@ -17891,7 +18095,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_c4_2_c_int
 #endif
       !
-      hipHostMalloc_c4_2_c_int = hipHostMalloc_(cptr,length1*length2*2*4_8,flags)
+      hipHostMalloc_c4_2_c_int = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*2_int64*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2])
     end function
 
@@ -17914,7 +18118,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_c4_2_c_size_t
 #endif
       !
-      hipHostMalloc_c4_2_c_size_t = hipHostMalloc_(cptr,length1*length2*2*4_8,flags)
+      hipHostMalloc_c4_2_c_size_t = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*2_int64*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2])
     end function
 
@@ -17929,8 +18133,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       complex(c_float_complex),pointer,dimension(:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(3),dims(3)
-      integer(8),intent(in),optional :: lbounds8(3),dims8(3)
+      integer(int32),intent(in),optional :: lbounds(3),dims(3)
+      integer(int64),intent(in),optional :: lbounds8(3),dims8(3)
       complex(c_float_complex),target,dimension(:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags
       !
@@ -17959,21 +18163,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipHostMalloc_c4_3_source = hipHostMalloc_(cptr,size(dsource)*2*4_8,flags)
-        hipHostMalloc_c4_3_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*2*4_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_c4_3_source = hipHostMalloc_(cptr,size(dsource,kind=int64)*2_int64*byte_size(elem_real32),flags)
+        hipHostMalloc_c4_3_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*2_int64*byte_size(elem_real32),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):) => tmp
       else if ( present(source) ) then
-        hipHostMalloc_c4_3_source = hipHostMalloc_(cptr,size(source)*2*4_8,flags)
-        hipHostMalloc_c4_3_source = hipMemcpy(cptr,c_loc(source),size(source)*2*4_8,hipMemcpyHostToHost)
+        hipHostMalloc_c4_3_source = hipHostMalloc_(cptr,size(source,kind=int64)*2_int64*byte_size(elem_real32),flags)
+        hipHostMalloc_c4_3_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*2_int64*byte_size(elem_real32),hipMemcpyHostToHost)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):) => tmp
       else if ( present(mold) ) then
-        hipHostMalloc_c4_3_source = hipHostMalloc_(cptr,size(mold)*2*4_8,flags)
+        hipHostMalloc_c4_3_source = hipHostMalloc_(cptr,size(mold,kind=int64)*2_int64*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,ptr,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):) => tmp
       else if ( present(dims8) ) then
-        hipHostMalloc_c4_3_source = hipHostMalloc_(cptr,PRODUCT(dims8)*2*4_8,flags)
+        hipHostMalloc_c4_3_source = hipHostMalloc_(cptr,PRODUCT(dims8)*2_int64*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):) => tmp
@@ -17981,7 +18185,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipHostMalloc_c4_3_source = hipHostMalloc_(cptr,PRODUCT(dims)*2*4_8,flags)
+        hipHostMalloc_c4_3_source = hipHostMalloc_(cptr,PRODUCT(int(dims,kind=int64))*2_int64*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):) => tmp
@@ -18010,7 +18214,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_c4_3_c_int
 #endif
       !
-      hipHostMalloc_c4_3_c_int = hipHostMalloc_(cptr,length1*length2*length3*2*4_8,flags)
+      hipHostMalloc_c4_3_c_int = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*2_int64*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3])
     end function
 
@@ -18033,7 +18237,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_c4_3_c_size_t
 #endif
       !
-      hipHostMalloc_c4_3_c_size_t = hipHostMalloc_(cptr,length1*length2*length3*2*4_8,flags)
+      hipHostMalloc_c4_3_c_size_t = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*2_int64*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3])
     end function
 
@@ -18048,8 +18252,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       complex(c_float_complex),pointer,dimension(:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(4),dims(4)
-      integer(8),intent(in),optional :: lbounds8(4),dims8(4)
+      integer(int32),intent(in),optional :: lbounds(4),dims(4)
+      integer(int64),intent(in),optional :: lbounds8(4),dims8(4)
       complex(c_float_complex),target,dimension(:,:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags
       !
@@ -18078,21 +18282,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipHostMalloc_c4_4_source = hipHostMalloc_(cptr,size(dsource)*2*4_8,flags)
-        hipHostMalloc_c4_4_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*2*4_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_c4_4_source = hipHostMalloc_(cptr,size(dsource,kind=int64)*2_int64*byte_size(elem_real32),flags)
+        hipHostMalloc_c4_4_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*2_int64*byte_size(elem_real32),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):) => tmp
       else if ( present(source) ) then
-        hipHostMalloc_c4_4_source = hipHostMalloc_(cptr,size(source)*2*4_8,flags)
-        hipHostMalloc_c4_4_source = hipMemcpy(cptr,c_loc(source),size(source)*2*4_8,hipMemcpyHostToHost)
+        hipHostMalloc_c4_4_source = hipHostMalloc_(cptr,size(source,kind=int64)*2_int64*byte_size(elem_real32),flags)
+        hipHostMalloc_c4_4_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*2_int64*byte_size(elem_real32),hipMemcpyHostToHost)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):) => tmp
       else if ( present(mold) ) then
-        hipHostMalloc_c4_4_source = hipHostMalloc_(cptr,size(mold)*2*4_8,flags)
+        hipHostMalloc_c4_4_source = hipHostMalloc_(cptr,size(mold,kind=int64)*2_int64*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,ptr,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):) => tmp
       else if ( present(dims8) ) then
-        hipHostMalloc_c4_4_source = hipHostMalloc_(cptr,PRODUCT(dims8)*2*4_8,flags)
+        hipHostMalloc_c4_4_source = hipHostMalloc_(cptr,PRODUCT(dims8)*2_int64*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):) => tmp
@@ -18100,7 +18304,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipHostMalloc_c4_4_source = hipHostMalloc_(cptr,PRODUCT(dims)*2*4_8,flags)
+        hipHostMalloc_c4_4_source = hipHostMalloc_(cptr,PRODUCT(int(dims,kind=int64))*2_int64*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):) => tmp
@@ -18129,7 +18333,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_c4_4_c_int
 #endif
       !
-      hipHostMalloc_c4_4_c_int = hipHostMalloc_(cptr,length1*length2*length3*length4*2*4_8,flags)
+      hipHostMalloc_c4_4_c_int = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                     int(length4,kind=int64)*2_int64*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4])
     end function
 
@@ -18152,7 +18357,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_c4_4_c_size_t
 #endif
       !
-      hipHostMalloc_c4_4_c_size_t = hipHostMalloc_(cptr,length1*length2*length3*length4*2*4_8,flags)
+      hipHostMalloc_c4_4_c_size_t = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                        int(length4,kind=int64)*2_int64*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4])
     end function
 
@@ -18167,8 +18373,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       complex(c_float_complex),pointer,dimension(:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(5),dims(5)
-      integer(8),intent(in),optional :: lbounds8(5),dims8(5)
+      integer(int32),intent(in),optional :: lbounds(5),dims(5)
+      integer(int64),intent(in),optional :: lbounds8(5),dims8(5)
       complex(c_float_complex),target,dimension(:,:,:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags
       !
@@ -18197,21 +18403,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipHostMalloc_c4_5_source = hipHostMalloc_(cptr,size(dsource)*2*4_8,flags)
-        hipHostMalloc_c4_5_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*2*4_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_c4_5_source = hipHostMalloc_(cptr,size(dsource,kind=int64)*2_int64*byte_size(elem_real32),flags)
+        hipHostMalloc_c4_5_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*2_int64*byte_size(elem_real32),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):) => tmp
       else if ( present(source) ) then
-        hipHostMalloc_c4_5_source = hipHostMalloc_(cptr,size(source)*2*4_8,flags)
-        hipHostMalloc_c4_5_source = hipMemcpy(cptr,c_loc(source),size(source)*2*4_8,hipMemcpyHostToHost)
+        hipHostMalloc_c4_5_source = hipHostMalloc_(cptr,size(source,kind=int64)*2_int64*byte_size(elem_real32),flags)
+        hipHostMalloc_c4_5_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*2_int64*byte_size(elem_real32),hipMemcpyHostToHost)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):) => tmp
       else if ( present(mold) ) then
-        hipHostMalloc_c4_5_source = hipHostMalloc_(cptr,size(mold)*2*4_8,flags)
+        hipHostMalloc_c4_5_source = hipHostMalloc_(cptr,size(mold,kind=int64)*2_int64*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,ptr,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):) => tmp
       else if ( present(dims8) ) then
-        hipHostMalloc_c4_5_source = hipHostMalloc_(cptr,PRODUCT(dims8)*2*4_8,flags)
+        hipHostMalloc_c4_5_source = hipHostMalloc_(cptr,PRODUCT(dims8)*2_int64*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):) => tmp
@@ -18219,7 +18425,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipHostMalloc_c4_5_source = hipHostMalloc_(cptr,PRODUCT(dims)*2*4_8,flags)
+        hipHostMalloc_c4_5_source = hipHostMalloc_(cptr,PRODUCT(int(dims,kind=int64))*2_int64*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):) => tmp
@@ -18248,7 +18454,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_c4_5_c_int
 #endif
       !
-      hipHostMalloc_c4_5_c_int = hipHostMalloc_(cptr,length1*length2*length3*length4*length5*2*4_8,flags)
+      hipHostMalloc_c4_5_c_int = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                     int(length4,kind=int64)*int(length5,kind=int64)*2_int64*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5])
     end function
 
@@ -18271,7 +18478,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_c4_5_c_size_t
 #endif
       !
-      hipHostMalloc_c4_5_c_size_t = hipHostMalloc_(cptr,length1*length2*length3*length4*length5*2*4_8,flags)
+      hipHostMalloc_c4_5_c_size_t = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                        int(length4,kind=int64)*int(length5,kind=int64)*2_int64*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5])
     end function
 
@@ -18286,8 +18494,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       complex(c_float_complex),pointer,dimension(:,:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(6),dims(6)
-      integer(8),intent(in),optional :: lbounds8(6),dims8(6)
+      integer(int32),intent(in),optional :: lbounds(6),dims(6)
+      integer(int64),intent(in),optional :: lbounds8(6),dims8(6)
       complex(c_float_complex),target,dimension(:,:,:,:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags
       !
@@ -18316,21 +18524,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipHostMalloc_c4_6_source = hipHostMalloc_(cptr,size(dsource)*2*4_8,flags)
-        hipHostMalloc_c4_6_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*2*4_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_c4_6_source = hipHostMalloc_(cptr,size(dsource,kind=int64)*2_int64*byte_size(elem_real32),flags)
+        hipHostMalloc_c4_6_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*2_int64*byte_size(elem_real32),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):,LBOUND(dsource,6):) => tmp
       else if ( present(source) ) then
-        hipHostMalloc_c4_6_source = hipHostMalloc_(cptr,size(source)*2*4_8,flags)
-        hipHostMalloc_c4_6_source = hipMemcpy(cptr,c_loc(source),size(source)*2*4_8,hipMemcpyHostToHost)
+        hipHostMalloc_c4_6_source = hipHostMalloc_(cptr,size(source,kind=int64)*2_int64*byte_size(elem_real32),flags)
+        hipHostMalloc_c4_6_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*2_int64*byte_size(elem_real32),hipMemcpyHostToHost)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):,LBOUND(source,6):) => tmp
       else if ( present(mold) ) then
-        hipHostMalloc_c4_6_source = hipHostMalloc_(cptr,size(mold)*2*4_8,flags)
+        hipHostMalloc_c4_6_source = hipHostMalloc_(cptr,size(mold,kind=int64)*2_int64*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,ptr,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):,LBOUND(mold,6):) => tmp
       else if ( present(dims8) ) then
-        hipHostMalloc_c4_6_source = hipHostMalloc_(cptr,PRODUCT(dims8)*2*4_8,flags)
+        hipHostMalloc_c4_6_source = hipHostMalloc_(cptr,PRODUCT(dims8)*2_int64*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):,lbounds8(6):) => tmp
@@ -18338,7 +18546,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipHostMalloc_c4_6_source = hipHostMalloc_(cptr,PRODUCT(dims)*2*4_8,flags)
+        hipHostMalloc_c4_6_source = hipHostMalloc_(cptr,PRODUCT(int(dims,kind=int64))*2_int64*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):,lbounds(6):) => tmp
@@ -18367,7 +18575,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_c4_6_c_int
 #endif
       !
-      hipHostMalloc_c4_6_c_int = hipHostMalloc_(cptr,length1*length2*length3*length4*length5*length6*2*4_8,flags)
+      hipHostMalloc_c4_6_c_int = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                     int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*2_int64*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6])
     end function
 
@@ -18390,7 +18599,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_c4_6_c_size_t
 #endif
       !
-      hipHostMalloc_c4_6_c_size_t = hipHostMalloc_(cptr,length1*length2*length3*length4*length5*length6*2*4_8,flags)
+      hipHostMalloc_c4_6_c_size_t = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                        int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*2_int64*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6])
     end function
 
@@ -18405,8 +18615,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       complex(c_float_complex),pointer,dimension(:,:,:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(7),dims(7)
-      integer(8),intent(in),optional :: lbounds8(7),dims8(7)
+      integer(int32),intent(in),optional :: lbounds(7),dims(7)
+      integer(int64),intent(in),optional :: lbounds8(7),dims8(7)
       complex(c_float_complex),target,dimension(:,:,:,:,:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags
       !
@@ -18435,21 +18645,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipHostMalloc_c4_7_source = hipHostMalloc_(cptr,size(dsource)*2*4_8,flags)
-        hipHostMalloc_c4_7_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*2*4_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_c4_7_source = hipHostMalloc_(cptr,size(dsource,kind=int64)*2_int64*byte_size(elem_real32),flags)
+        hipHostMalloc_c4_7_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*2_int64*byte_size(elem_real32),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):,LBOUND(dsource,6):,LBOUND(dsource,7):) => tmp
       else if ( present(source) ) then
-        hipHostMalloc_c4_7_source = hipHostMalloc_(cptr,size(source)*2*4_8,flags)
-        hipHostMalloc_c4_7_source = hipMemcpy(cptr,c_loc(source),size(source)*2*4_8,hipMemcpyHostToHost)
+        hipHostMalloc_c4_7_source = hipHostMalloc_(cptr,size(source,kind=int64)*2_int64*byte_size(elem_real32),flags)
+        hipHostMalloc_c4_7_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*2_int64*byte_size(elem_real32),hipMemcpyHostToHost)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):,LBOUND(source,6):,LBOUND(source,7):) => tmp
       else if ( present(mold) ) then
-        hipHostMalloc_c4_7_source = hipHostMalloc_(cptr,size(mold)*2*4_8,flags)
+        hipHostMalloc_c4_7_source = hipHostMalloc_(cptr,size(mold,kind=int64)*2_int64*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,ptr,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):,LBOUND(mold,6):,LBOUND(mold,7):) => tmp
       else if ( present(dims8) ) then
-        hipHostMalloc_c4_7_source = hipHostMalloc_(cptr,PRODUCT(dims8)*2*4_8,flags)
+        hipHostMalloc_c4_7_source = hipHostMalloc_(cptr,PRODUCT(dims8)*2_int64*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):,lbounds8(6):,lbounds8(7):) => tmp
@@ -18457,7 +18667,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipHostMalloc_c4_7_source = hipHostMalloc_(cptr,PRODUCT(dims)*2*4_8,flags)
+        hipHostMalloc_c4_7_source = hipHostMalloc_(cptr,PRODUCT(int(dims,kind=int64))*2_int64*byte_size(elem_real32),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):,lbounds(6):,lbounds(7):) => tmp
@@ -18486,7 +18696,9 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_c4_7_c_int
 #endif
       !
-      hipHostMalloc_c4_7_c_int = hipHostMalloc_(cptr,length1*length2*length3*length4*length5*length6*length7*2*4_8,flags)
+      hipHostMalloc_c4_7_c_int = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                     int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*&
+                                                     int(length7,kind=int64)*2_int64*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6,length7])
     end function
 
@@ -18509,7 +18721,9 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_c4_7_c_size_t
 #endif
       !
-      hipHostMalloc_c4_7_c_size_t = hipHostMalloc_(cptr,length1*length2*length3*length4*length5*length6*length7*2*4_8,flags)
+      hipHostMalloc_c4_7_c_size_t = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                        int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*&
+                                                        int(length7,kind=int64)*2_int64*byte_size(elem_real32),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6,length7])
     end function
 
@@ -18542,15 +18756,15 @@ module hipfort_hipmalloc
       if ( nOptArgs > 1 ) ERROR STOP "ERROR: hipHostMalloc (scalar version): Only one optional argument ('dsource','source') must be specified."
 
       if ( present(dsource) ) then
-        hipHostMalloc_c8_0_source = hipHostMalloc_(cptr,2*8_8,flags)
-        hipHostMalloc_c8_0_source = hipMemcpy(cptr,c_loc(dsource),2*8_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_c8_0_source = hipHostMalloc_(cptr,2_int64*byte_size(elem_real64),flags)
+        hipHostMalloc_c8_0_source = hipMemcpy(cptr,c_loc(dsource),2_int64*byte_size(elem_real64),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,ptr)
       else if ( present(source) ) then
-        hipHostMalloc_c8_0_source = hipHostMalloc_(cptr,2*8_8,flags)
-        hipHostMalloc_c8_0_source = hipMemcpy(cptr,c_loc(source),2*8_8,hipMemcpyHostToHost)
+        hipHostMalloc_c8_0_source = hipHostMalloc_(cptr,2_int64*byte_size(elem_real64),flags)
+        hipHostMalloc_c8_0_source = hipMemcpy(cptr,c_loc(source),2_int64*byte_size(elem_real64),hipMemcpyHostToHost)
         call c_f_pointer(cptr,ptr)
       else
-        hipHostMalloc_c8_0_source = hipHostMalloc_(cptr,2*8_8,flags)
+        hipHostMalloc_c8_0_source = hipHostMalloc_(cptr,2_int64*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,ptr)
       end if
     end function
@@ -18567,8 +18781,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       complex(c_double_complex),pointer,dimension(:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(1),dims(1)
-      integer(8),intent(in),optional :: lbounds8(1),dims8(1)
+      integer(int32),intent(in),optional :: lbounds(1),dims(1)
+      integer(int64),intent(in),optional :: lbounds8(1),dims8(1)
       complex(c_double_complex),target,dimension(:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags
       !
@@ -18597,21 +18811,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipHostMalloc_c8_1_source = hipHostMalloc_(cptr,size(dsource)*2*8_8,flags)
-        hipHostMalloc_c8_1_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*2*8_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_c8_1_source = hipHostMalloc_(cptr,size(dsource,kind=int64)*2_int64*byte_size(elem_real64),flags)
+        hipHostMalloc_c8_1_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*2_int64*byte_size(elem_real64),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):) => tmp
       else if ( present(source) ) then
-        hipHostMalloc_c8_1_source = hipHostMalloc_(cptr,size(source)*2*8_8,flags)
-        hipHostMalloc_c8_1_source = hipMemcpy(cptr,c_loc(source),size(source)*2*8_8,hipMemcpyHostToHost)
+        hipHostMalloc_c8_1_source = hipHostMalloc_(cptr,size(source,kind=int64)*2_int64*byte_size(elem_real64),flags)
+        hipHostMalloc_c8_1_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*2_int64*byte_size(elem_real64),hipMemcpyHostToHost)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):) => tmp
       else if ( present(mold) ) then
-        hipHostMalloc_c8_1_source = hipHostMalloc_(cptr,size(mold)*2*8_8,flags)
+        hipHostMalloc_c8_1_source = hipHostMalloc_(cptr,size(mold,kind=int64)*2_int64*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,ptr,shape=shape(mold))
         ptr(LBOUND(mold,1):) => tmp
       else if ( present(dims8) ) then
-        hipHostMalloc_c8_1_source = hipHostMalloc_(cptr,PRODUCT(dims8)*2*8_8,flags)
+        hipHostMalloc_c8_1_source = hipHostMalloc_(cptr,PRODUCT(dims8)*2_int64*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):) => tmp
@@ -18619,7 +18833,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipHostMalloc_c8_1_source = hipHostMalloc_(cptr,PRODUCT(dims)*2*8_8,flags)
+        hipHostMalloc_c8_1_source = hipHostMalloc_(cptr,PRODUCT(int(dims,kind=int64))*2_int64*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):) => tmp
@@ -18648,7 +18862,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_c8_1_c_int
 #endif
       !
-      hipHostMalloc_c8_1_c_int = hipHostMalloc_(cptr,length1*2*8_8,flags)
+      hipHostMalloc_c8_1_c_int = hipHostMalloc_(cptr,int(length1,kind=int64)*2_int64*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1])
     end function
 
@@ -18671,7 +18885,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_c8_1_c_size_t
 #endif
       !
-      hipHostMalloc_c8_1_c_size_t = hipHostMalloc_(cptr,length1*2*8_8,flags)
+      hipHostMalloc_c8_1_c_size_t = hipHostMalloc_(cptr,int(length1,kind=int64)*2_int64*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1])
     end function
 
@@ -18686,8 +18900,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       complex(c_double_complex),pointer,dimension(:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(2),dims(2)
-      integer(8),intent(in),optional :: lbounds8(2),dims8(2)
+      integer(int32),intent(in),optional :: lbounds(2),dims(2)
+      integer(int64),intent(in),optional :: lbounds8(2),dims8(2)
       complex(c_double_complex),target,dimension(:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags
       !
@@ -18716,21 +18930,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipHostMalloc_c8_2_source = hipHostMalloc_(cptr,size(dsource)*2*8_8,flags)
-        hipHostMalloc_c8_2_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*2*8_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_c8_2_source = hipHostMalloc_(cptr,size(dsource,kind=int64)*2_int64*byte_size(elem_real64),flags)
+        hipHostMalloc_c8_2_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*2_int64*byte_size(elem_real64),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):) => tmp
       else if ( present(source) ) then
-        hipHostMalloc_c8_2_source = hipHostMalloc_(cptr,size(source)*2*8_8,flags)
-        hipHostMalloc_c8_2_source = hipMemcpy(cptr,c_loc(source),size(source)*2*8_8,hipMemcpyHostToHost)
+        hipHostMalloc_c8_2_source = hipHostMalloc_(cptr,size(source,kind=int64)*2_int64*byte_size(elem_real64),flags)
+        hipHostMalloc_c8_2_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*2_int64*byte_size(elem_real64),hipMemcpyHostToHost)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):) => tmp
       else if ( present(mold) ) then
-        hipHostMalloc_c8_2_source = hipHostMalloc_(cptr,size(mold)*2*8_8,flags)
+        hipHostMalloc_c8_2_source = hipHostMalloc_(cptr,size(mold,kind=int64)*2_int64*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,ptr,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):) => tmp
       else if ( present(dims8) ) then
-        hipHostMalloc_c8_2_source = hipHostMalloc_(cptr,PRODUCT(dims8)*2*8_8,flags)
+        hipHostMalloc_c8_2_source = hipHostMalloc_(cptr,PRODUCT(dims8)*2_int64*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):) => tmp
@@ -18738,7 +18952,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipHostMalloc_c8_2_source = hipHostMalloc_(cptr,PRODUCT(dims)*2*8_8,flags)
+        hipHostMalloc_c8_2_source = hipHostMalloc_(cptr,PRODUCT(int(dims,kind=int64))*2_int64*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):) => tmp
@@ -18767,7 +18981,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_c8_2_c_int
 #endif
       !
-      hipHostMalloc_c8_2_c_int = hipHostMalloc_(cptr,length1*length2*2*8_8,flags)
+      hipHostMalloc_c8_2_c_int = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*2_int64*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2])
     end function
 
@@ -18790,7 +19004,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_c8_2_c_size_t
 #endif
       !
-      hipHostMalloc_c8_2_c_size_t = hipHostMalloc_(cptr,length1*length2*2*8_8,flags)
+      hipHostMalloc_c8_2_c_size_t = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*2_int64*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2])
     end function
 
@@ -18805,8 +19019,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       complex(c_double_complex),pointer,dimension(:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(3),dims(3)
-      integer(8),intent(in),optional :: lbounds8(3),dims8(3)
+      integer(int32),intent(in),optional :: lbounds(3),dims(3)
+      integer(int64),intent(in),optional :: lbounds8(3),dims8(3)
       complex(c_double_complex),target,dimension(:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags
       !
@@ -18835,21 +19049,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipHostMalloc_c8_3_source = hipHostMalloc_(cptr,size(dsource)*2*8_8,flags)
-        hipHostMalloc_c8_3_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*2*8_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_c8_3_source = hipHostMalloc_(cptr,size(dsource,kind=int64)*2_int64*byte_size(elem_real64),flags)
+        hipHostMalloc_c8_3_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*2_int64*byte_size(elem_real64),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):) => tmp
       else if ( present(source) ) then
-        hipHostMalloc_c8_3_source = hipHostMalloc_(cptr,size(source)*2*8_8,flags)
-        hipHostMalloc_c8_3_source = hipMemcpy(cptr,c_loc(source),size(source)*2*8_8,hipMemcpyHostToHost)
+        hipHostMalloc_c8_3_source = hipHostMalloc_(cptr,size(source,kind=int64)*2_int64*byte_size(elem_real64),flags)
+        hipHostMalloc_c8_3_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*2_int64*byte_size(elem_real64),hipMemcpyHostToHost)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):) => tmp
       else if ( present(mold) ) then
-        hipHostMalloc_c8_3_source = hipHostMalloc_(cptr,size(mold)*2*8_8,flags)
+        hipHostMalloc_c8_3_source = hipHostMalloc_(cptr,size(mold,kind=int64)*2_int64*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,ptr,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):) => tmp
       else if ( present(dims8) ) then
-        hipHostMalloc_c8_3_source = hipHostMalloc_(cptr,PRODUCT(dims8)*2*8_8,flags)
+        hipHostMalloc_c8_3_source = hipHostMalloc_(cptr,PRODUCT(dims8)*2_int64*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):) => tmp
@@ -18857,7 +19071,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipHostMalloc_c8_3_source = hipHostMalloc_(cptr,PRODUCT(dims)*2*8_8,flags)
+        hipHostMalloc_c8_3_source = hipHostMalloc_(cptr,PRODUCT(int(dims,kind=int64))*2_int64*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):) => tmp
@@ -18886,7 +19100,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_c8_3_c_int
 #endif
       !
-      hipHostMalloc_c8_3_c_int = hipHostMalloc_(cptr,length1*length2*length3*2*8_8,flags)
+      hipHostMalloc_c8_3_c_int = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*2_int64*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3])
     end function
 
@@ -18909,7 +19123,7 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_c8_3_c_size_t
 #endif
       !
-      hipHostMalloc_c8_3_c_size_t = hipHostMalloc_(cptr,length1*length2*length3*2*8_8,flags)
+      hipHostMalloc_c8_3_c_size_t = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*2_int64*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3])
     end function
 
@@ -18924,8 +19138,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       complex(c_double_complex),pointer,dimension(:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(4),dims(4)
-      integer(8),intent(in),optional :: lbounds8(4),dims8(4)
+      integer(int32),intent(in),optional :: lbounds(4),dims(4)
+      integer(int64),intent(in),optional :: lbounds8(4),dims8(4)
       complex(c_double_complex),target,dimension(:,:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags
       !
@@ -18954,21 +19168,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipHostMalloc_c8_4_source = hipHostMalloc_(cptr,size(dsource)*2*8_8,flags)
-        hipHostMalloc_c8_4_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*2*8_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_c8_4_source = hipHostMalloc_(cptr,size(dsource,kind=int64)*2_int64*byte_size(elem_real64),flags)
+        hipHostMalloc_c8_4_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*2_int64*byte_size(elem_real64),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):) => tmp
       else if ( present(source) ) then
-        hipHostMalloc_c8_4_source = hipHostMalloc_(cptr,size(source)*2*8_8,flags)
-        hipHostMalloc_c8_4_source = hipMemcpy(cptr,c_loc(source),size(source)*2*8_8,hipMemcpyHostToHost)
+        hipHostMalloc_c8_4_source = hipHostMalloc_(cptr,size(source,kind=int64)*2_int64*byte_size(elem_real64),flags)
+        hipHostMalloc_c8_4_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*2_int64*byte_size(elem_real64),hipMemcpyHostToHost)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):) => tmp
       else if ( present(mold) ) then
-        hipHostMalloc_c8_4_source = hipHostMalloc_(cptr,size(mold)*2*8_8,flags)
+        hipHostMalloc_c8_4_source = hipHostMalloc_(cptr,size(mold,kind=int64)*2_int64*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,ptr,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):) => tmp
       else if ( present(dims8) ) then
-        hipHostMalloc_c8_4_source = hipHostMalloc_(cptr,PRODUCT(dims8)*2*8_8,flags)
+        hipHostMalloc_c8_4_source = hipHostMalloc_(cptr,PRODUCT(dims8)*2_int64*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):) => tmp
@@ -18976,7 +19190,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipHostMalloc_c8_4_source = hipHostMalloc_(cptr,PRODUCT(dims)*2*8_8,flags)
+        hipHostMalloc_c8_4_source = hipHostMalloc_(cptr,PRODUCT(int(dims,kind=int64))*2_int64*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):) => tmp
@@ -19005,7 +19219,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_c8_4_c_int
 #endif
       !
-      hipHostMalloc_c8_4_c_int = hipHostMalloc_(cptr,length1*length2*length3*length4*2*8_8,flags)
+      hipHostMalloc_c8_4_c_int = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                     int(length4,kind=int64)*2_int64*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4])
     end function
 
@@ -19028,7 +19243,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_c8_4_c_size_t
 #endif
       !
-      hipHostMalloc_c8_4_c_size_t = hipHostMalloc_(cptr,length1*length2*length3*length4*2*8_8,flags)
+      hipHostMalloc_c8_4_c_size_t = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                        int(length4,kind=int64)*2_int64*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4])
     end function
 
@@ -19043,8 +19259,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       complex(c_double_complex),pointer,dimension(:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(5),dims(5)
-      integer(8),intent(in),optional :: lbounds8(5),dims8(5)
+      integer(int32),intent(in),optional :: lbounds(5),dims(5)
+      integer(int64),intent(in),optional :: lbounds8(5),dims8(5)
       complex(c_double_complex),target,dimension(:,:,:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags
       !
@@ -19073,21 +19289,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipHostMalloc_c8_5_source = hipHostMalloc_(cptr,size(dsource)*2*8_8,flags)
-        hipHostMalloc_c8_5_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*2*8_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_c8_5_source = hipHostMalloc_(cptr,size(dsource,kind=int64)*2_int64*byte_size(elem_real64),flags)
+        hipHostMalloc_c8_5_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*2_int64*byte_size(elem_real64),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):) => tmp
       else if ( present(source) ) then
-        hipHostMalloc_c8_5_source = hipHostMalloc_(cptr,size(source)*2*8_8,flags)
-        hipHostMalloc_c8_5_source = hipMemcpy(cptr,c_loc(source),size(source)*2*8_8,hipMemcpyHostToHost)
+        hipHostMalloc_c8_5_source = hipHostMalloc_(cptr,size(source,kind=int64)*2_int64*byte_size(elem_real64),flags)
+        hipHostMalloc_c8_5_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*2_int64*byte_size(elem_real64),hipMemcpyHostToHost)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):) => tmp
       else if ( present(mold) ) then
-        hipHostMalloc_c8_5_source = hipHostMalloc_(cptr,size(mold)*2*8_8,flags)
+        hipHostMalloc_c8_5_source = hipHostMalloc_(cptr,size(mold,kind=int64)*2_int64*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,ptr,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):) => tmp
       else if ( present(dims8) ) then
-        hipHostMalloc_c8_5_source = hipHostMalloc_(cptr,PRODUCT(dims8)*2*8_8,flags)
+        hipHostMalloc_c8_5_source = hipHostMalloc_(cptr,PRODUCT(dims8)*2_int64*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):) => tmp
@@ -19095,7 +19311,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipHostMalloc_c8_5_source = hipHostMalloc_(cptr,PRODUCT(dims)*2*8_8,flags)
+        hipHostMalloc_c8_5_source = hipHostMalloc_(cptr,PRODUCT(int(dims,kind=int64))*2_int64*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):) => tmp
@@ -19124,7 +19340,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_c8_5_c_int
 #endif
       !
-      hipHostMalloc_c8_5_c_int = hipHostMalloc_(cptr,length1*length2*length3*length4*length5*2*8_8,flags)
+      hipHostMalloc_c8_5_c_int = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                     int(length4,kind=int64)*int(length5,kind=int64)*2_int64*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5])
     end function
 
@@ -19147,7 +19364,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_c8_5_c_size_t
 #endif
       !
-      hipHostMalloc_c8_5_c_size_t = hipHostMalloc_(cptr,length1*length2*length3*length4*length5*2*8_8,flags)
+      hipHostMalloc_c8_5_c_size_t = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                        int(length4,kind=int64)*int(length5,kind=int64)*2_int64*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5])
     end function
 
@@ -19162,8 +19380,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       complex(c_double_complex),pointer,dimension(:,:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(6),dims(6)
-      integer(8),intent(in),optional :: lbounds8(6),dims8(6)
+      integer(int32),intent(in),optional :: lbounds(6),dims(6)
+      integer(int64),intent(in),optional :: lbounds8(6),dims8(6)
       complex(c_double_complex),target,dimension(:,:,:,:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags
       !
@@ -19192,21 +19410,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipHostMalloc_c8_6_source = hipHostMalloc_(cptr,size(dsource)*2*8_8,flags)
-        hipHostMalloc_c8_6_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*2*8_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_c8_6_source = hipHostMalloc_(cptr,size(dsource,kind=int64)*2_int64*byte_size(elem_real64),flags)
+        hipHostMalloc_c8_6_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*2_int64*byte_size(elem_real64),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):,LBOUND(dsource,6):) => tmp
       else if ( present(source) ) then
-        hipHostMalloc_c8_6_source = hipHostMalloc_(cptr,size(source)*2*8_8,flags)
-        hipHostMalloc_c8_6_source = hipMemcpy(cptr,c_loc(source),size(source)*2*8_8,hipMemcpyHostToHost)
+        hipHostMalloc_c8_6_source = hipHostMalloc_(cptr,size(source,kind=int64)*2_int64*byte_size(elem_real64),flags)
+        hipHostMalloc_c8_6_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*2_int64*byte_size(elem_real64),hipMemcpyHostToHost)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):,LBOUND(source,6):) => tmp
       else if ( present(mold) ) then
-        hipHostMalloc_c8_6_source = hipHostMalloc_(cptr,size(mold)*2*8_8,flags)
+        hipHostMalloc_c8_6_source = hipHostMalloc_(cptr,size(mold,kind=int64)*2_int64*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,ptr,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):,LBOUND(mold,6):) => tmp
       else if ( present(dims8) ) then
-        hipHostMalloc_c8_6_source = hipHostMalloc_(cptr,PRODUCT(dims8)*2*8_8,flags)
+        hipHostMalloc_c8_6_source = hipHostMalloc_(cptr,PRODUCT(dims8)*2_int64*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):,lbounds8(6):) => tmp
@@ -19214,7 +19432,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipHostMalloc_c8_6_source = hipHostMalloc_(cptr,PRODUCT(dims)*2*8_8,flags)
+        hipHostMalloc_c8_6_source = hipHostMalloc_(cptr,PRODUCT(int(dims,kind=int64))*2_int64*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):,lbounds(6):) => tmp
@@ -19243,7 +19461,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_c8_6_c_int
 #endif
       !
-      hipHostMalloc_c8_6_c_int = hipHostMalloc_(cptr,length1*length2*length3*length4*length5*length6*2*8_8,flags)
+      hipHostMalloc_c8_6_c_int = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                     int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*2_int64*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6])
     end function
 
@@ -19266,7 +19485,8 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_c8_6_c_size_t
 #endif
       !
-      hipHostMalloc_c8_6_c_size_t = hipHostMalloc_(cptr,length1*length2*length3*length4*length5*length6*2*8_8,flags)
+      hipHostMalloc_c8_6_c_size_t = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                        int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*2_int64*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6])
     end function
 
@@ -19281,8 +19501,8 @@ module hipfort_hipmalloc
       use hipfort_hipmemcpy, ONLY: hipMemcpy
       implicit none
       complex(c_double_complex),pointer,dimension(:,:,:,:,:,:,:),intent(inout) :: ptr
-      integer(4),intent(in),optional :: lbounds(7),dims(7)
-      integer(8),intent(in),optional :: lbounds8(7),dims8(7)
+      integer(int32),intent(in),optional :: lbounds(7),dims(7)
+      integer(int64),intent(in),optional :: lbounds8(7),dims8(7)
       complex(c_double_complex),target,dimension(:,:,:,:,:,:,:),intent(in),optional :: dsource,source,mold
       integer(kind=4),intent(in) :: flags
       !
@@ -19311,21 +19531,21 @@ module hipfort_hipmalloc
       endif
 
       if ( present(dsource) ) then
-        hipHostMalloc_c8_7_source = hipHostMalloc_(cptr,size(dsource)*2*8_8,flags)
-        hipHostMalloc_c8_7_source = hipMemcpy(cptr,c_loc(dsource),size(dsource)*2*8_8,hipMemcpyDeviceToHost)
+        hipHostMalloc_c8_7_source = hipHostMalloc_(cptr,size(dsource,kind=int64)*2_int64*byte_size(elem_real64),flags)
+        hipHostMalloc_c8_7_source = hipMemcpy(cptr,c_loc(dsource),size(dsource,kind=int64)*2_int64*byte_size(elem_real64),hipMemcpyDeviceToHost)
         call c_f_pointer(cptr,tmp,shape=shape(dsource))
         ptr(LBOUND(dsource,1):,LBOUND(dsource,2):,LBOUND(dsource,3):,LBOUND(dsource,4):,LBOUND(dsource,5):,LBOUND(dsource,6):,LBOUND(dsource,7):) => tmp
       else if ( present(source) ) then
-        hipHostMalloc_c8_7_source = hipHostMalloc_(cptr,size(source)*2*8_8,flags)
-        hipHostMalloc_c8_7_source = hipMemcpy(cptr,c_loc(source),size(source)*2*8_8,hipMemcpyHostToHost)
+        hipHostMalloc_c8_7_source = hipHostMalloc_(cptr,size(source,kind=int64)*2_int64*byte_size(elem_real64),flags)
+        hipHostMalloc_c8_7_source = hipMemcpy(cptr,c_loc(source),size(source,kind=int64)*2_int64*byte_size(elem_real64),hipMemcpyHostToHost)
         call c_f_pointer(cptr,tmp,shape=shape(source))
         ptr(LBOUND(source,1):,LBOUND(source,2):,LBOUND(source,3):,LBOUND(source,4):,LBOUND(source,5):,LBOUND(source,6):,LBOUND(source,7):) => tmp
       else if ( present(mold) ) then
-        hipHostMalloc_c8_7_source = hipHostMalloc_(cptr,size(mold)*2*8_8,flags)
+        hipHostMalloc_c8_7_source = hipHostMalloc_(cptr,size(mold,kind=int64)*2_int64*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,ptr,shape=shape(mold))
         ptr(LBOUND(mold,1):,LBOUND(mold,2):,LBOUND(mold,3):,LBOUND(mold,4):,LBOUND(mold,5):,LBOUND(mold,6):,LBOUND(mold,7):) => tmp
       else if ( present(dims8) ) then
-        hipHostMalloc_c8_7_source = hipHostMalloc_(cptr,PRODUCT(dims8)*2*8_8,flags)
+        hipHostMalloc_c8_7_source = hipHostMalloc_(cptr,PRODUCT(dims8)*2_int64*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims8)
         if ( present(lbounds8) ) then 
           ptr(lbounds8(1):,lbounds8(2):,lbounds8(3):,lbounds8(4):,lbounds8(5):,lbounds8(6):,lbounds8(7):) => tmp
@@ -19333,7 +19553,7 @@ module hipfort_hipmalloc
           ptr => tmp
         end if
       else if ( present(dims) ) then
-        hipHostMalloc_c8_7_source = hipHostMalloc_(cptr,PRODUCT(dims)*2*8_8,flags)
+        hipHostMalloc_c8_7_source = hipHostMalloc_(cptr,PRODUCT(int(dims,kind=int64))*2_int64*byte_size(elem_real64),flags)
         call c_f_pointer(cptr,tmp,shape=dims)
         if ( present(lbounds) ) then 
           ptr(lbounds(1):,lbounds(2):,lbounds(3):,lbounds(4):,lbounds(5):,lbounds(6):,lbounds(7):) => tmp
@@ -19362,7 +19582,9 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_c8_7_c_int
 #endif
       !
-      hipHostMalloc_c8_7_c_int = hipHostMalloc_(cptr,length1*length2*length3*length4*length5*length6*length7*2*8_8,flags)
+      hipHostMalloc_c8_7_c_int = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                     int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*&
+                                                     int(length7,kind=int64)*2_int64*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6,length7])
     end function
 
@@ -19385,7 +19607,9 @@ module hipfort_hipmalloc
       integer(kind(hipSuccess)) :: hipHostMalloc_c8_7_c_size_t
 #endif
       !
-      hipHostMalloc_c8_7_c_size_t = hipHostMalloc_(cptr,length1*length2*length3*length4*length5*length6*length7*2*8_8,flags)
+      hipHostMalloc_c8_7_c_size_t = hipHostMalloc_(cptr,int(length1,kind=int64)*int(length2,kind=int64)*int(length3,kind=int64)*&
+                                                        int(length4,kind=int64)*int(length5,kind=int64)*int(length6,kind=int64)*&
+                                                        int(length7,kind=int64)*2_int64*byte_size(elem_real64),flags)
       call c_f_pointer(cptr,ptr,shape=[length1,length2,length3,length4,length5,length6,length7])
     end function
 


### PR DESCRIPTION
Concerning hipmalloc interfaces, multiplying the sizes (given by Fortran "size", Fortran "PRODUCT" or dummy length multiplication) by ?_8 doesn't guarantee that the result will be a 64 bit integer. This fix produces all overflow safe sizes.