### PR TITLE
Add f90/F90 to Doxygen files to fix broken link

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,24 @@ gfortran_exe = shutil.which("gfortran")
 if gfortran_exe is None:
     raise RuntimeError("Couldn't find the fortran compiler!")
 
-for filename in glob.glob("../lib/hipfort/*.f"):
+for filename in glob.glob("../lib/hipfort/*.f90"):
+    path = Path(filename)
+    # -P is to disable embedding line information
+    subprocess.check_call(
+        [
+            gfortran_exe,
+            "-E",
+            "-cpp",
+            "-P",
+            "-DUSE_FPOINTER_INTERFACES=1",
+            "-UUSE_CUDA_NAMES",
+            str(path),
+            "-o",
+            str(preprocessed_out_dir / path.name),
+        ]
+    )
+
+for filename in glob.glob("../lib/hipfort/*.F90"):
     path = Path(filename)
     # -P is to disable embedding line information
     subprocess.check_call(

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,24 +28,7 @@ gfortran_exe = shutil.which("gfortran")
 if gfortran_exe is None:
     raise RuntimeError("Couldn't find the fortran compiler!")
 
-for filename in glob.glob("../lib/hipfort/*.f90"):
-    path = Path(filename)
-    # -P is to disable embedding line information
-    subprocess.check_call(
-        [
-            gfortran_exe,
-            "-E",
-            "-cpp",
-            "-P",
-            "-DUSE_FPOINTER_INTERFACES=1",
-            "-UUSE_CUDA_NAMES",
-            str(path),
-            "-o",
-            str(preprocessed_out_dir / path.name),
-        ]
-    )
-
-for filename in glob.glob("../lib/hipfort/*.F90"):
+for filename in glob.glob("../lib/hipfort/*.[fF]90"):
     path = Path(filename)
     # -P is to disable embedding line information
     subprocess.check_call(

--- a/docs/doxygen/Doxyfile
+++ b/docs/doxygen/Doxyfile
@@ -856,6 +856,8 @@ INPUT_ENCODING         = UTF-8
 # *.ucf, *.qsf and *.ice.
 
 FILE_PATTERNS          = *.f \
+                         *.f90 \
+                         *.F90 \
                          *.md
 
 # The RECURSIVE tag can be used to specify whether or not subdirectories should

--- a/docs/doxygen/input/.gitignore
+++ b/docs/doxygen/input/.gitignore
@@ -1,2 +1,4 @@
 # Pre-processed fortran sources
 *.f
+*.f90
+*.F90


### PR DESCRIPTION
When the .f files were renamed to .f90 or .F90, the Doxygen content was no longer being retrieved. This fixes the issue along with a broken link to the modules.