### PR TITLE
hipfort 7.0 changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log for hipfort
 
-## hipfort 0.7.0 for ROCm 6.5.0
+## hipfort 0.7.0 for ROCm 7.0.0
 
 ### Added
 


### PR DESCRIPTION
Fixes the hipfort changelog by moving 6.5 content to 7.0.