### PR TITLE
unify cmake_minimum_required versions and allow 4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-CMAKE_MINIMUM_REQUIRED(VERSION 3.18...3.31)
+cmake_minimum_required(VERSION 3.18..4.0 FATAL_ERROR)
 
 #Setting Default value for libdir
 set(CMAKE_INSTALL_LIBDIR "lib" CACHE STRING "Library install directory")

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -1,5 +1,4 @@
-
-cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18..4.0 FATAL_ERROR)
 if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
   project(hipfort-tools)
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,7 +5,7 @@
 # Each test is contained in its own subdirectory of this test directory
 # The Makefile must create a binary with the same name as the directory name.
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.18..4.0 FATAL_ERROR)
 if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
   project(test-hipfort)
 endif()


### PR DESCRIPTION
Fixes #259

cc @amd-jnovotny @bcornille 

## Motivation

Building with CMake 4 should work.

## Technical Details

#222 attempted to implement compatibility with newer CMake versions by bumping the minimum required version, however the cmake_minimum_required calls in subdirs that are intended to support standalone builds were missed.

Unifying these and allowing 4.0 as I've tested that policy version works.

## Test Plan

Rebuild of nixpkgs ROCm package set atop CMake 4.

## Test Result

hipfort builds successfully

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
