### PR TITLE
[Ex CI] Disabling Azure Pipeline

### DIFF
--- a/.azuredevops/rocm-ci.yml
+++ b/.azuredevops/rocm-ci.yml
@@ -9,34 +9,9 @@ variables:
 - group: common
 - template: /.azuredevops/variables-global.yml@pipelines_repo
 
-trigger:
-  batch: true
-  branches:
-    include:
-    - develop
-    - mainline
-  paths:
-    exclude:
-    - .github
-    - docs
-    - '.*.y*ml'
-    - LICENSE
-    - '*.md'
-
-pr:
-  autoCancel: true
-  branches:
-    include:
-    - develop
-    - mainline
-  paths:
-    exclude:
-    - .github
-    - docs
-    - '.*.y*ml'
-    - LICENSE
-    - '*.md'
-  drafts: false
+# Pipeline disabled: hipfort depends on hipSPARSE and rocSPARSE (disabled)
+trigger: none
+pr: none
 
 jobs:
   - template: ${{ variables.CI_COMPONENT_PATH }}/hipfort.yml@pipelines_repo


### PR DESCRIPTION
## Motivation
Disable Azure pipeline due to rocsparse dependency. hipfort depends on hipSPARSE and rocSPARSE.
Since rocsparse and hipsparse pipelines are being disabled,  this pipeline must also be disabled.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
Set trigger: none and pr: none to disable all pipeline runs.
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
