### PR TITLE
Tests: set Fortran language on .f03 CTest targets for CMake < 3.27

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ Then build, install, and test hipfort from source with the commands below:
 ```shell
 git clone https://github.com/ROCm/hipfort.git
 cd hipfort
-cmake -S. -Bbuild -DCMAKE_INSTALL_PREFIOX=/tmp/hipfort -DBUILD_TESTING=ON
+cmake -S. -Bbuild -DCMAKE_INSTALL_PREFIX=/tmp/hipfort -DBUILD_TESTING=ON
 make -C build
-make -C build check
+make -C build test
 ```
 
 ## Fortran interfaces

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -43,6 +43,8 @@ add_custom_target(all-tests-clean
 
 if(BUILD_TESTING)
   function(hipfort_add_test lib func dir)
+    # CMake < 3.27 does not recognize .f03 as a Fortran source file extension
+    set_source_files_properties(${dir}/${lib}/${func}.f03 PROPERTIES LANGUAGE Fortran)
     add_executable(hipfort_test_${dir}_${lib}_${func} ${dir}/${lib}/${func}.f03)
     target_link_libraries(hipfort_test_${dir}_${lib}_${func} PRIVATE hipfort::${lib} hipfort::hip)
 


### PR DESCRIPTION
## Motivation

Fixes https://github.com/ROCm/hipfort/issues/293

`BUILD_TESTING=ON` fails at generate time on CMake < 3.27 because `.f03` is not treated as Fortran, so CMake cannot infer the linker language for the `hipfort_test_*` executables.

## Technical Details

In `test/CMakeLists.txt`, inside `hipfort_add_test`, add `set_source_files_properties(... PROPERTIES LANGUAGE Fortran)` for each `${dir}/${lib}/${func}.f03` before `add_executable`. An alternative would be raising the minimum CMake version floor which may cause more issues with systems (including CI) with CMake < 3.27 installed.

Also fixed minor typos in `README.md`.

## Test Plan

- Configure with CMake 3.26.5, `-DBUILD_TESTING=ON`, and a ROCm prefix on `CMAKE_PREFIX_PATH` so test targets are all defined
- Reconfigure with CMake 3.28 to confirm no regression

## Test Result

Configuration was successful with both CMake versions.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
