### PR TITLE
Fix bash syntax in `Makefile.hipfort` that breaks environment variable inheritance

### DIFF
--- a/bin/Makefile.hipfort
+++ b/bin/Makefile.hipfort
@@ -21,11 +21,11 @@
 HIPFORT_ARCHGPU ?= $(shell $(HIPFORT_HOME)/libexec/hipfort/myarchgpu)
 ARCH = $(firstword $(subst -, ,$(HIPFORT_ARCHGPU)))
 HIPFORT_COMPILER ?= gfortran
-CUDA_PATH=${CUDA_PATH:-/usr/local/cuda}
-ROCM_PATH=${ROCM_PATH:-/opt/rocm}
-DEVICE_LIB_PATH  ?= $(ROCM_PATH)/lib
-HIP_CLANG_PATH   ?= $(ROCM_PATH)/llvm/bin
-HIP_PLATFORM=${HIP_PLATFORM:-amd}
+CUDA_PATH ?= /usr/local/cuda
+ROCM_PATH ?= /opt/rocm
+DEVICE_LIB_PATH ?= $(ROCM_PATH)/lib
+HIP_CLANG_PATH ?= $(ROCM_PATH)/llvm/bin
+HIP_PLATFORM ?= amd
 
 MOD_DIR  = $(HIPFORT_HOME)/include/hipfort/$(ARCH)
 LIB_DIR  = $(HIPFORT_HOME)/lib


### PR DESCRIPTION
## Motivation

The `Makefile.hipfort` uses bash shell parameter expansion syntax (`${VAR:-default}`) for setting default values, which does not work in GNU Make. This causes `ROCM_PATH`, `CUDA_PATH`, and `HIP_PLATFORM` to become empty strings instead of inheriting values from the environment or using their defaults.

This bug prevents users from using hipfort with just `module load rocm` - they must explicitly pass `ROCM_PATH` on the command line as a workaround.

## Technical Details

### `bin/Makefile.hipfort`

Replace bash parameter expansion syntax with proper Make conditional assignment (`?=`):

```diff
-CUDA_PATH=${CUDA_PATH:-/usr/local/cuda}
-ROCM_PATH=${ROCM_PATH:-/opt/rocm}
-HIP_PLATFORM=${HIP_PLATFORM:-amd}
+CUDA_PATH ?= /usr/local/cuda
+ROCM_PATH ?= /opt/rocm
+HIP_PLATFORM ?= amd
```

**Why this matters:**
- `${VAR:-default}` is bash syntax that Make interprets as a variable named `VAR:-default`, which doesn't exist, resulting in an empty string
- `VAR ?= default` is proper Make syntax meaning "set VAR to default only if not already defined"

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

JIRA ID: https://amd-hub.atlassian.net/browse/ROCM-21579