### PR TITLE
Build docs on ubuntu-24.04 to get Doxygen 1.9.8

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,7 +13,7 @@ python:
    - requirements: docs/sphinx/requirements.txt
 
 build:
-   os: ubuntu-22.04
+   os: ubuntu-24.04
    tools:
       python: "3.10"
    apt_packages:


### PR DESCRIPTION
## Motivation

The documentation build ran Doxygen **1.9.1** (Ubuntu 22.04's system package).
Its Markdown parser mishandles inline code spans containing `[` or `|`: it opens a `<tt>` and never closes it, aborting the build with:
```
error: end of comment block while expecting command </tt> (warning treated as error, aborting now)
```

## Change

Bump `build.os` from `ubuntu-22.04` to `ubuntu-24.04`, which ships **Doxygen 1.9.8**.

Verified locally that 1.9.8 parses the affected docstrings without the `</tt>` error, while 1.9.1 does not. `python`, `apt_packages` (doxygen/gfortran/graphviz) and everything else are unchanged.

I will be able to revert the commit https://github.com/ROCm/hipfort/commit/6a8b0e3c3f1574409c4841ea780f6af12304d576 after this PR.