### PR TITLE
Add example CMake toolchain files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@
   `c`, and `z` precisions, along with the `rocsparse_gpsv_interleaved_alg` enum.
 * Added the `hiprandCheck` error-check helper for hipRAND status codes
   (`use hipfort_check`).
+* Added example CMake toolchain files in `cmake/toolchains/` (amdflang, GNU,
+  Intel `ifx`/`ifort`, Cray, and NVHPC), selectable with
+  `-DCMAKE_TOOLCHAIN_FILE`, to build hipfort with different Fortran compilers
+  and backends.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,27 @@ cmake --install build
 ctest --test-dir build
 ```
 
+### Toolchain files
+
+Example CMake toolchain files are provided in [`cmake/toolchains`](cmake/toolchains)
+to select the Fortran compiler and backend without setting cache variables by
+hand. Pass one with `-DCMAKE_TOOLCHAIN_FILE`:
+
+```shell
+cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/amdflang.cmake
+```
+
+| Toolchain file | Compiler | Backend |
+| -------------- | ---------- | ------- |
+| `amdflang.cmake` | `amdflang` (ROCm LLVM Flang) | AMD ROCm (**recommended default**) |
+| `gnu.cmake`    | `gfortran` | AMD ROCm |
+| `intel.cmake`  | `ifx` (Intel LLVM) | AMD ROCm |
+| `intel-classic.cmake` | `ifort` (EOL) | AMD ROCm |
+| `cray.cmake`   | Cray `ftn` | AMD ROCm |
+| `nvhpc.cmake`  | `nvfortran` | NVIDIA/CUDA |
+
+Copy any of these as a starting point for your own site-specific toolchain.
+
 ## Fortran interfaces
 
 `hipfort` provides interfaces to the following HIP and ROCm libraries:

--- a/cmake/Modules/SetFortranFlags.cmake
+++ b/cmake/Modules/SetFortranFlags.cmake
@@ -135,8 +135,5 @@ SET_COMPILE_FLAG(CMAKE_Fortran_FLAGS_RELEASE "${CMAKE_Fortran_FLAGS_RELEASE}"
                          "/Qvec-report0" # Intel Windows
                          "-Mvect"        # Portland Group
                 )
-SET_COMPILE_FLAG(CMAKE_Fortran_FLAGS_RELEASE "${CMAKE_Fortran_FLAGS_RELEASE}"
-                  Fortran "-ffree-line-length-none"
-                  )
 
 ENDIF(NOT CMAKE_Fortran_COMPILER_ID MATCHES "Cray")

--- a/cmake/toolchains/amdflang.cmake
+++ b/cmake/toolchains/amdflang.cmake
@@ -1,0 +1,24 @@
+# AMD toolchain file for hipfort (amdflang, AMD ROCm backend).
+#
+# This is the recommended default: amdflang is the LLVM-based Fortran compiler
+# shipped with ROCm.
+#
+# Usage:
+#   cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/amdflang.cmake
+#
+# By default the ROCm compilers are looked up on PATH. Set ROCM_PATH (below or
+# on the command line) if your ROCm install is elsewhere.
+
+if(NOT DEFINED ROCM_PATH AND DEFINED ENV{ROCM_PATH})
+  set(ROCM_PATH "$ENV{ROCM_PATH}" CACHE PATH "ROCm installation root")
+endif()
+
+set(CMAKE_Fortran_COMPILER amdflang   CACHE FILEPATH "Fortran compiler")
+set(CMAKE_C_COMPILER       amdclang   CACHE FILEPATH "C compiler")
+set(CMAKE_CXX_COMPILER     amdclang++ CACHE FILEPATH "C++ compiler")
+
+# Free-form parsing and C preprocessing are enabled by hipfort itself, via
+# CMAKE_Fortran_FORMAT and CMAKE_Fortran_PREPROCESS in the top-level
+# CMakeLists.txt. CMake emits the preprocessing flag each compiler expects
+# (-cpp for amdflang), so there is no need to add a preprocessing or free-form
+# flag here.

--- a/cmake/toolchains/cray.cmake
+++ b/cmake/toolchains/cray.cmake
@@ -1,0 +1,25 @@
+# HPE Cray toolchain file for hipfort (Cray Fortran via the ftn wrapper).
+#
+# On a Cray system, load the relevant environment modules first (for example
+# PrgEnv-cray and rocm), then configure with:
+#   cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/cray.cmake
+#
+# The Cray compiler drivers (ftn/cc/CC) forward to the underlying compilers and
+# already know about the system headers and libraries.
+
+set(CMAKE_Fortran_COMPILER ftn CACHE FILEPATH "Cray Fortran wrapper")
+set(CMAKE_C_COMPILER       cc  CACHE FILEPATH "Cray C wrapper")
+set(CMAKE_CXX_COMPILER     CC  CACHE FILEPATH "Cray C++ wrapper")
+
+# cmake/Modules/SetFortranFlags.cmake already special-cases the Cray compiler,
+# so no extra Fortran flags are needed here. Ensure ROCM_PATH points at the
+# ROCm install (usually provided by the 'rocm' environment module).
+if(NOT DEFINED ROCM_PATH AND DEFINED ENV{ROCM_PATH})
+  set(ROCM_PATH "$ENV{ROCM_PATH}" CACHE PATH "ROCm installation root")
+endif()
+
+# Free-form parsing and C preprocessing are enabled by hipfort itself, via
+# CMAKE_Fortran_FORMAT and CMAKE_Fortran_PREPROCESS in the top-level
+# CMakeLists.txt. CMake emits the preprocessing flag each compiler expects
+# (-eZ for the Cray compiler), so there is no need to add a preprocessing or
+# free-form flag here.

--- a/cmake/toolchains/gnu.cmake
+++ b/cmake/toolchains/gnu.cmake
@@ -1,0 +1,26 @@
+# GNU toolchain file for hipfort (GNU Fortran, AMD ROCm backend).
+#
+# Usage:
+#   cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/gnu.cmake
+#
+# This is the default configuration used to build hipfort against ROCm.
+
+set(CMAKE_Fortran_COMPILER gfortran CACHE FILEPATH "Fortran compiler")
+
+# find_package(hip) pulls in hip-config.cmake, which requires C and CXX to be
+# enabled. The stock gcc/g++ are sufficient: hipfort builds only Fortran module
+# files, so no device (.hip) sources are compiled here.
+set(CMAKE_C_COMPILER   gcc CACHE FILEPATH "C compiler")
+set(CMAKE_CXX_COMPILER g++ CACHE FILEPATH "C++ compiler")
+
+# Point CMake at your ROCm installation when it is not in the default location
+# (equivalent to passing -DROCM_PATH=... on the command line).
+if(NOT DEFINED ROCM_PATH AND DEFINED ENV{ROCM_PATH})
+  set(ROCM_PATH "$ENV{ROCM_PATH}" CACHE PATH "ROCm installation root")
+endif()
+
+# Free-form parsing and C preprocessing are enabled by hipfort itself, via
+# CMAKE_Fortran_FORMAT and CMAKE_Fortran_PREPROCESS in the top-level
+# CMakeLists.txt. CMake emits the preprocessing flag each compiler expects
+# (-cpp for gfortran), so there is no need to add a preprocessing or free-form
+# flag here.

--- a/cmake/toolchains/intel-classic.cmake
+++ b/cmake/toolchains/intel-classic.cmake
@@ -1,0 +1,22 @@
+# Classic Intel Fortran toolchain file for hipfort (ifort, AMD ROCm backend).
+#
+# Note: the classic ifort compiler is end-of-life; prefer intel.cmake (ifx) for
+# new setups. This file is provided for legacy environments.
+#
+# Usage:
+#   source /opt/intel/oneapi/setvars.sh
+#   cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/intel-classic.cmake
+
+set(CMAKE_Fortran_COMPILER ifort CACHE FILEPATH "Classic Intel Fortran compiler")
+set(CMAKE_C_COMPILER       icx   CACHE FILEPATH "Intel C compiler (LLVM)")
+set(CMAKE_CXX_COMPILER     icpx  CACHE FILEPATH "Intel C++ compiler (LLVM)")
+
+if(NOT DEFINED ROCM_PATH AND DEFINED ENV{ROCM_PATH})
+  set(ROCM_PATH "$ENV{ROCM_PATH}" CACHE PATH "ROCm installation root")
+endif()
+
+# Free-form parsing and C preprocessing are enabled by hipfort itself, via
+# CMAKE_Fortran_FORMAT and CMAKE_Fortran_PREPROCESS in the top-level
+# CMakeLists.txt. CMake emits the preprocessing flag each compiler expects
+# (-fpp for ifort), so there is no need to add a preprocessing or free-form
+# flag here.

--- a/cmake/toolchains/intel.cmake
+++ b/cmake/toolchains/intel.cmake
@@ -1,0 +1,22 @@
+# Intel oneAPI toolchain file for hipfort (ifx, AMD ROCm backend).
+#
+# Uses the LLVM-based Intel compilers (ifx/icx/icpx). For the end-of-life
+# classic ifort compiler, see intel-classic.cmake.
+#
+# Usage:
+#   source /opt/intel/oneapi/setvars.sh
+#   cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/intel.cmake
+
+set(CMAKE_Fortran_COMPILER ifx  CACHE FILEPATH "Intel Fortran compiler (LLVM)")
+set(CMAKE_C_COMPILER       icx  CACHE FILEPATH "Intel C compiler (LLVM)")
+set(CMAKE_CXX_COMPILER     icpx CACHE FILEPATH "Intel C++ compiler (LLVM)")
+
+if(NOT DEFINED ROCM_PATH AND DEFINED ENV{ROCM_PATH})
+  set(ROCM_PATH "$ENV{ROCM_PATH}" CACHE PATH "ROCm installation root")
+endif()
+
+# Free-form parsing and C preprocessing are enabled by hipfort itself, via
+# CMAKE_Fortran_FORMAT and CMAKE_Fortran_PREPROCESS in the top-level
+# CMakeLists.txt. CMake emits the preprocessing flag each compiler expects
+# (-fpp for ifx), so there is no need to add a preprocessing or free-form
+# flag here.

--- a/cmake/toolchains/nvhpc.cmake
+++ b/cmake/toolchains/nvhpc.cmake
@@ -1,0 +1,26 @@
+# NVIDIA HPC SDK toolchain file for hipfort (nvfortran, NVIDIA/CUDA backend).
+#
+# Usage:
+#   cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/nvhpc.cmake
+#
+# NOTE: hipfort selects the NVIDIA code path (USE_CUDA_NAMES) from the platform
+# reported by find_package(hip), *not* from this file. To build the CUDA backend
+# you must have HIP configured for NVIDIA and CUDA available. Set HIP_PLATFORM
+# and ROCM_PATH below (or on the command line) to match your installation.
+
+set(CMAKE_Fortran_COMPILER nvfortran CACHE FILEPATH "NVIDIA Fortran compiler")
+set(CMAKE_C_COMPILER       nvc       CACHE FILEPATH "NVIDIA C compiler")
+set(CMAKE_CXX_COMPILER     nvc++     CACHE FILEPATH "NVIDIA C++ compiler")
+
+# Select the NVIDIA HIP backend. Adjust the paths to your HIP/CUDA install.
+# set(HIP_PLATFORM nvidia    CACHE STRING "HIP platform (amd or nvidia)")
+# set(ROCM_PATH    /opt/rocm CACHE PATH   "HIP installation root")
+
+# nvfortran does not implement -march=native the way GNU does; leave the
+# portable defaults from cmake/Modules/SetFortranFlags.cmake in place.
+
+# Free-form parsing and C preprocessing are enabled by hipfort itself, via
+# CMAKE_Fortran_FORMAT and CMAKE_Fortran_PREPROCESS in the top-level
+# CMakeLists.txt. CMake emits the preprocessing flag each compiler expects
+# (-Mpreprocess for nvfortran), so there is no need to add a preprocessing or
+# free-form flag here.

--- a/docs/install/install.rst
+++ b/docs/install/install.rst
@@ -18,6 +18,7 @@ GFortran version 7.5.0 or newer is the primary tested compiler (see the `GFortra
 also supported. Other standard-conforming compilers such as NVIDIA ``nvfortran``, Intel ``ifx``/``ifort``,
 and the Cray Fortran compiler (for example on LUMI) are not officially supported, but hipFORT should
 build with them too. Please open an issue at https://github.com/ROCm/hipfort/issues if you run into problems.
+Ready-made CMake toolchain files for each of these compilers are provided; see :ref:`hipfort-toolchain-files`.
 
 .. _build-test-hipfort-from-source:
 
@@ -55,6 +56,48 @@ or by setting the CMake cache variables:
 *  ``CMAKE_AR``: Static archive command
 *  ``CMAKE_RANLIB``: The ``ranlib`` used to create the static archive
 *  ``CMAKE_INSTALL_PREFIX``: The install directory
+
+.. _hipfort-toolchain-files:
+
+Toolchain files
+-----------------
+
+Rather than setting the compiler and backend cache variables by hand, you can select a
+ready-made CMake toolchain file from ``cmake/toolchains/`` with ``-DCMAKE_TOOLCHAIN_FILE``:
+
+.. code-block:: shell
+
+   cmake -S . -Bbuild -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/amdflang.cmake
+
+Each file only sets the Fortran, C, and C++ compilers (plus optional ``ROCM_PATH`` and
+``HIP_PLATFORM`` hints), so they compose with the other build options above.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Toolchain file
+     - Compiler
+     - Backend
+   * - ``amdflang.cmake``
+     - ``amdflang`` (ROCm LLVM Flang)
+     - AMD ROCm (recommended default)
+   * - ``gnu.cmake``
+     - ``gfortran``
+     - AMD ROCm
+   * - ``intel.cmake``
+     - ``ifx`` (Intel LLVM)
+     - AMD ROCm
+   * - ``intel-classic.cmake``
+     - ``ifort`` (EOL)
+     - AMD ROCm
+   * - ``cray.cmake``
+     - Cray ``ftn``
+     - AMD ROCm
+   * - ``nvhpc.cmake``
+     - ``nvfortran``
+     - NVIDIA/CUDA
+
+Copy any of these as a starting point for your own site-specific toolchain.
 
 Linking against hipFORT
 ========================

--- a/docs/install/quick-start.rst
+++ b/docs/install/quick-start.rst
@@ -32,3 +32,7 @@ Building and testing hipFORT from source
       cmake --build build
       cmake --install build
       ctest --test-dir build
+
+To build with a specific compiler and backend, pass one of the provided toolchain files, for
+example ``-DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/amdflang.cmake``. See
+:doc:`the detailed install guide <./install>` for the full list.


### PR DESCRIPTION
Addresses #81 (move architecture/compiler-dependent CMake configuration into toolchain files).

## Toolchain files

Adds `cmake/toolchains/` with ready-to-use, commented toolchain files, selectable via `-DCMAKE_TOOLCHAIN_FILE`:

| Toolchain file | Compiler | Backend |
| -------------- | -------- | ------- |
| `amdflang.cmake` | `amdflang` (ROCm LLVM Flang) | AMD ROCm (**recommended default**) |
| `gnu.cmake`   | `gfortran`  | AMD ROCm |
| `intel.cmake` | `ifx` (Intel LLVM) | AMD ROCm |
| `intel-classic.cmake` | `ifort` (EOL) | AMD ROCm |
| `cray.cmake`  | Cray `ftn`  | AMD ROCm |
| `nvhpc.cmake` | `nvfortran` | NVIDIA/CUDA |

Each file only sets the compilers (plus optional `ROCM_PATH`/`HIP_PLATFORM` hints). Free-form parsing and C preprocessing are enabled by hipfort itself (`CMAKE_Fortran_FORMAT`/`CMAKE_Fortran_PREPROCESS`), so no per-compiler flags are needed. Pure CMake toolchain files, no dependency on the removed `hipfc` wrapper.

Documented in the README and the Sphinx install guide, with a CHANGELOG entry.

## Remove the free-form line-length flag

All Fortran sources now fit within 132 columns — the generated bindings, and (since #388) the hand-written `hipMalloc`/`hipMemcpy` interfaces — so the `-ffree-line-length-none` GNU flag is no longer needed and is removed from `SetFortranFlags.cmake`. This also lets the classic Intel `ifort` compiler build hipfort.

## Verified

- `amdflang.cmake` (default) and `gnu.cmake` configure and fully build.
- The whole `lib/hipfort` tree compiles with gfortran without any line-length flag.
- ifx / ifort / Cray `ftn` / nvfortran were not available in the test environment, so those toolchains are provided as documented examples.