### PR TITLE
Fix Fortran generic resolution (natural _full_rank ranks + pass-through c_ptr for info/result)

### DIFF
--- a/lib/hipfort/hipfort_hipblas.F90
+++ b/lib/hipfort/hipfort_hipblas.F90
@@ -321,13 +321,6 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
       type(c_ptr),value :: myResult
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipblasIsamaxBatched_rank_0,&
-      hipblasIsamaxBatched_rank_1,&
-      hipblasIsamaxBatched_full_rank
-#endif
   end interface
 
   interface hipblasIdamaxBatched
@@ -349,13 +342,6 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
       type(c_ptr),value :: myResult
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipblasIdamaxBatched_rank_0,&
-      hipblasIdamaxBatched_rank_1,&
-      hipblasIdamaxBatched_full_rank
-#endif
   end interface
 
   interface hipblasIcamaxBatched
@@ -377,13 +363,6 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
       type(c_ptr),value :: myResult
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipblasIcamaxBatched_rank_0,&
-      hipblasIcamaxBatched_rank_1,&
-      hipblasIcamaxBatched_full_rank
-#endif
   end interface
 
   interface hipblasIzamaxBatched
@@ -405,13 +384,6 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
       type(c_ptr),value :: myResult
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipblasIzamaxBatched_rank_0,&
-      hipblasIzamaxBatched_rank_1,&
-      hipblasIzamaxBatched_full_rank
-#endif
   end interface
 
   !>     \brief  BLAS Level 1 API
@@ -722,13 +694,6 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
       type(c_ptr),value :: myResult
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipblasIsaminBatched_rank_0,&
-      hipblasIsaminBatched_rank_1,&
-      hipblasIsaminBatched_full_rank
-#endif
   end interface
 
   interface hipblasIdaminBatched
@@ -750,13 +715,6 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
       type(c_ptr),value :: myResult
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipblasIdaminBatched_rank_0,&
-      hipblasIdaminBatched_rank_1,&
-      hipblasIdaminBatched_full_rank
-#endif
   end interface
 
   interface hipblasIcaminBatched
@@ -778,13 +736,6 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
       type(c_ptr),value :: myResult
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipblasIcaminBatched_rank_0,&
-      hipblasIcaminBatched_rank_1,&
-      hipblasIcaminBatched_full_rank
-#endif
   end interface
 
   interface hipblasIzaminBatched
@@ -806,13 +757,6 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
       type(c_ptr),value :: myResult
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipblasIzaminBatched_rank_0,&
-      hipblasIzaminBatched_rank_1,&
-      hipblasIzaminBatched_full_rank
-#endif
   end interface
 
   !>     \brief  BLAS Level 1 API
@@ -1127,13 +1071,6 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
       type(c_ptr),value :: myResult
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipblasSasumBatched_rank_0,&
-      hipblasSasumBatched_rank_1,&
-      hipblasSasumBatched_full_rank
-#endif
   end interface
 
   interface hipblasDasumBatched
@@ -1155,13 +1092,6 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
       type(c_ptr),value :: myResult
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipblasDasumBatched_rank_0,&
-      hipblasDasumBatched_rank_1,&
-      hipblasDasumBatched_full_rank
-#endif
   end interface
 
   interface hipblasScasumBatched
@@ -1183,13 +1113,6 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
       type(c_ptr),value :: myResult
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipblasScasumBatched_rank_0,&
-      hipblasScasumBatched_rank_1,&
-      hipblasScasumBatched_full_rank
-#endif
   end interface
 
   interface hipblasDzasumBatched
@@ -1211,13 +1134,6 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
       type(c_ptr),value :: myResult
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipblasDzasumBatched_rank_0,&
-      hipblasDzasumBatched_rank_1,&
-      hipblasDzasumBatched_full_rank
-#endif
   end interface
 
   !>     \brief  BLAS Level 1 API
@@ -2278,13 +2194,6 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
       type(c_ptr),value :: myResult
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipblasSdotBatched_rank_0,&
-      hipblasSdotBatched_rank_1,&
-      hipblasSdotBatched_full_rank
-#endif
   end interface
 
   interface hipblasDdotBatched
@@ -2308,13 +2217,6 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
       type(c_ptr),value :: myResult
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipblasDdotBatched_rank_0,&
-      hipblasDdotBatched_rank_1,&
-      hipblasDdotBatched_full_rank
-#endif
   end interface
 
   interface hipblasCdotcBatched
@@ -2338,13 +2240,6 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
       type(c_ptr),value :: myResult
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipblasCdotcBatched_rank_0,&
-      hipblasCdotcBatched_rank_1,&
-      hipblasCdotcBatched_full_rank
-#endif
   end interface
 
   interface hipblasCdotuBatched
@@ -2368,13 +2263,6 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
       type(c_ptr),value :: myResult
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipblasCdotuBatched_rank_0,&
-      hipblasCdotuBatched_rank_1,&
-      hipblasCdotuBatched_full_rank
-#endif
   end interface
 
   interface hipblasZdotcBatched
@@ -2398,13 +2286,6 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
       type(c_ptr),value :: myResult
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipblasZdotcBatched_rank_0,&
-      hipblasZdotcBatched_rank_1,&
-      hipblasZdotcBatched_full_rank
-#endif
   end interface
 
   interface hipblasZdotuBatched
@@ -2428,13 +2309,6 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
       type(c_ptr),value :: myResult
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipblasZdotuBatched_rank_0,&
-      hipblasZdotuBatched_rank_1,&
-      hipblasZdotuBatched_full_rank
-#endif
   end interface
 
   interface hipblasSdotStridedBatched
@@ -2806,13 +2680,6 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
       type(c_ptr),value :: myResult
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipblasSnrm2Batched_rank_0,&
-      hipblasSnrm2Batched_rank_1,&
-      hipblasSnrm2Batched_full_rank
-#endif
   end interface
 
   interface hipblasDnrm2Batched
@@ -2834,13 +2701,6 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
       type(c_ptr),value :: myResult
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipblasDnrm2Batched_rank_0,&
-      hipblasDnrm2Batched_rank_1,&
-      hipblasDnrm2Batched_full_rank
-#endif
   end interface
 
   interface hipblasScnrm2Batched
@@ -2862,13 +2722,6 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
       type(c_ptr),value :: myResult
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipblasScnrm2Batched_rank_0,&
-      hipblasScnrm2Batched_rank_1,&
-      hipblasScnrm2Batched_full_rank
-#endif
   end interface
 
   interface hipblasDznrm2Batched
@@ -2890,13 +2743,6 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
       type(c_ptr),value :: myResult
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipblasDznrm2Batched_rank_0,&
-      hipblasDznrm2Batched_rank_1,&
-      hipblasDznrm2Batched_full_rank
-#endif
   end interface
 
   !>     \brief  BLAS Level 1 API
@@ -3299,13 +3145,6 @@ module hipfort_hipblas
       type(c_ptr),value :: s
       integer(c_int),value :: batchCount
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipblasSrotBatched_rank_0,&
-      hipblasSrotBatched_rank_1,&
-      hipblasSrotBatched_full_rank
-#endif
   end interface
 
   interface hipblasDrotBatched
@@ -3330,13 +3169,6 @@ module hipfort_hipblas
       type(c_ptr),value :: s
       integer(c_int),value :: batchCount
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipblasDrotBatched_rank_0,&
-      hipblasDrotBatched_rank_1,&
-      hipblasDrotBatched_full_rank
-#endif
   end interface
 
   interface hipblasCrotBatched
@@ -3361,13 +3193,6 @@ module hipfort_hipblas
       type(c_ptr),value :: s
       integer(c_int),value :: batchCount
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipblasCrotBatched_rank_0,&
-      hipblasCrotBatched_rank_1,&
-      hipblasCrotBatched_full_rank
-#endif
   end interface
 
   interface hipblasCsrotBatched
@@ -3392,13 +3217,6 @@ module hipfort_hipblas
       type(c_ptr),value :: s
       integer(c_int),value :: batchCount
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipblasCsrotBatched_rank_0,&
-      hipblasCsrotBatched_rank_1,&
-      hipblasCsrotBatched_full_rank
-#endif
   end interface
 
   interface hipblasZrotBatched
@@ -3423,13 +3241,6 @@ module hipfort_hipblas
       type(c_ptr),value :: s
       integer(c_int),value :: batchCount
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipblasZrotBatched_rank_0,&
-      hipblasZrotBatched_rank_1,&
-      hipblasZrotBatched_full_rank
-#endif
   end interface
 
   interface hipblasZdrotBatched
@@ -3454,13 +3265,6 @@ module hipfort_hipblas
       type(c_ptr),value :: s
       integer(c_int),value :: batchCount
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipblasZdrotBatched_rank_0,&
-      hipblasZdrotBatched_rank_1,&
-      hipblasZdrotBatched_full_rank
-#endif
   end interface
 
   !>     \brief  BLAS Level 1 API
@@ -24878,13 +24682,6 @@ module hipfort_hipblas
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batchCount
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipblasSgetrfBatched_rank_0,&
-      hipblasSgetrfBatched_rank_1,&
-      hipblasSgetrfBatched_full_rank
-#endif
   end interface
 
   interface hipblasDgetrfBatched
@@ -24907,13 +24704,6 @@ module hipfort_hipblas
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batchCount
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipblasDgetrfBatched_rank_0,&
-      hipblasDgetrfBatched_rank_1,&
-      hipblasDgetrfBatched_full_rank
-#endif
   end interface
 
   interface hipblasCgetrfBatched
@@ -24936,13 +24726,6 @@ module hipfort_hipblas
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batchCount
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipblasCgetrfBatched_rank_0,&
-      hipblasCgetrfBatched_rank_1,&
-      hipblasCgetrfBatched_full_rank
-#endif
   end interface
 
   interface hipblasZgetrfBatched
@@ -24965,13 +24748,6 @@ module hipfort_hipblas
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batchCount
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipblasZgetrfBatched_rank_0,&
-      hipblasZgetrfBatched_rank_1,&
-      hipblasZgetrfBatched_full_rank
-#endif
   end interface
 
   !>     \brief  SOLVER API
@@ -25433,13 +25209,6 @@ module hipfort_hipblas
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batchCount
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipblasSgetrsBatched_rank_0,&
-      hipblasSgetrsBatched_rank_1,&
-      hipblasSgetrsBatched_full_rank
-#endif
   end interface
 
   interface hipblasDgetrsBatched
@@ -25466,13 +25235,6 @@ module hipfort_hipblas
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batchCount
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipblasDgetrsBatched_rank_0,&
-      hipblasDgetrsBatched_rank_1,&
-      hipblasDgetrsBatched_full_rank
-#endif
   end interface
 
   interface hipblasCgetrsBatched
@@ -25499,13 +25261,6 @@ module hipfort_hipblas
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batchCount
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipblasCgetrsBatched_rank_0,&
-      hipblasCgetrsBatched_rank_1,&
-      hipblasCgetrsBatched_full_rank
-#endif
   end interface
 
   interface hipblasZgetrsBatched
@@ -25532,13 +25287,6 @@ module hipfort_hipblas
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batchCount
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipblasZgetrsBatched_rank_0,&
-      hipblasZgetrsBatched_rank_1,&
-      hipblasZgetrsBatched_full_rank
-#endif
   end interface
 
   !>     \brief  SOLVER API
@@ -25839,13 +25587,6 @@ module hipfort_hipblas
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batchCount
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipblasSgetriBatched_rank_0,&
-      hipblasSgetriBatched_rank_1,&
-      hipblasSgetriBatched_full_rank
-#endif
   end interface
 
   interface hipblasDgetriBatched
@@ -25870,13 +25611,6 @@ module hipfort_hipblas
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batchCount
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipblasDgetriBatched_rank_0,&
-      hipblasDgetriBatched_rank_1,&
-      hipblasDgetriBatched_full_rank
-#endif
   end interface
 
   interface hipblasCgetriBatched
@@ -25901,13 +25635,6 @@ module hipfort_hipblas
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batchCount
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipblasCgetriBatched_rank_0,&
-      hipblasCgetriBatched_rank_1,&
-      hipblasCgetriBatched_full_rank
-#endif
   end interface
 
   interface hipblasZgetriBatched
@@ -25932,13 +25659,6 @@ module hipfort_hipblas
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batchCount
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipblasZgetriBatched_rank_0,&
-      hipblasZgetriBatched_rank_1,&
-      hipblasZgetriBatched_full_rank
-#endif
   end interface
 
   !>     \brief  SOLVER API
@@ -26190,13 +25910,6 @@ module hipfort_hipblas
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batchCount
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipblasSgeqrfBatched_rank_0,&
-      hipblasSgeqrfBatched_rank_1,&
-      hipblasSgeqrfBatched_full_rank
-#endif
   end interface
 
   interface hipblasDgeqrfBatched
@@ -26220,13 +25933,6 @@ module hipfort_hipblas
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batchCount
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipblasDgeqrfBatched_rank_0,&
-      hipblasDgeqrfBatched_rank_1,&
-      hipblasDgeqrfBatched_full_rank
-#endif
   end interface
 
   interface hipblasCgeqrfBatched
@@ -26250,13 +25956,6 @@ module hipfort_hipblas
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batchCount
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipblasCgeqrfBatched_rank_0,&
-      hipblasCgeqrfBatched_rank_1,&
-      hipblasCgeqrfBatched_full_rank
-#endif
   end interface
 
   interface hipblasZgeqrfBatched
@@ -26280,13 +25979,6 @@ module hipfort_hipblas
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batchCount
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipblasZgeqrfBatched_rank_0,&
-      hipblasZgeqrfBatched_rank_1,&
-      hipblasZgeqrfBatched_full_rank
-#endif
   end interface
 
   !>     \brief  SOLVER API
@@ -45250,9 +44942,9 @@ module hipfort_hipblas
       integer(c_int) :: n
       real(c_float),target :: x
       integer(c_int) :: incx
-      integer(c_int),target :: myResult
+      type(c_ptr) :: myResult
       !
-      hipblasIsamax_rank_0 = hipblasIsamax_(handle,n,c_loc(x),incx,c_loc(myResult))
+      hipblasIsamax_rank_0 = hipblasIsamax_(handle,n,c_loc(x),incx,myResult)
     end function
 
     function hipblasIsamax_rank_1(handle,n,x,incx,myResult)
@@ -45264,9 +44956,9 @@ module hipfort_hipblas
       integer(c_int) :: n
       real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
-      integer(c_int),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
-      hipblasIsamax_rank_1 = hipblasIsamax_(handle,n,c_loc(x),incx,c_loc(myResult))
+      hipblasIsamax_rank_1 = hipblasIsamax_(handle,n,c_loc(x),incx,myResult)
     end function
 
     function hipblasIdamax_rank_0(handle,n,x,incx,myResult)
@@ -45278,9 +44970,9 @@ module hipfort_hipblas
       integer(c_int) :: n
       real(c_double),target :: x
       integer(c_int) :: incx
-      integer(c_int),target :: myResult
+      type(c_ptr) :: myResult
       !
-      hipblasIdamax_rank_0 = hipblasIdamax_(handle,n,c_loc(x),incx,c_loc(myResult))
+      hipblasIdamax_rank_0 = hipblasIdamax_(handle,n,c_loc(x),incx,myResult)
     end function
 
     function hipblasIdamax_rank_1(handle,n,x,incx,myResult)
@@ -45292,9 +44984,9 @@ module hipfort_hipblas
       integer(c_int) :: n
       real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
-      integer(c_int),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
-      hipblasIdamax_rank_1 = hipblasIdamax_(handle,n,c_loc(x),incx,c_loc(myResult))
+      hipblasIdamax_rank_1 = hipblasIdamax_(handle,n,c_loc(x),incx,myResult)
     end function
 
     function hipblasIcamax_rank_0(handle,n,x,incx,myResult)
@@ -45306,9 +44998,9 @@ module hipfort_hipblas
       integer(c_int) :: n
       complex(c_float_complex),target :: x
       integer(c_int) :: incx
-      integer(c_int),target :: myResult
+      type(c_ptr) :: myResult
       !
-      hipblasIcamax_rank_0 = hipblasIcamax_(handle,n,c_loc(x),incx,c_loc(myResult))
+      hipblasIcamax_rank_0 = hipblasIcamax_(handle,n,c_loc(x),incx,myResult)
     end function
 
     function hipblasIcamax_rank_1(handle,n,x,incx,myResult)
@@ -45320,9 +45012,9 @@ module hipfort_hipblas
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
-      integer(c_int),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
-      hipblasIcamax_rank_1 = hipblasIcamax_(handle,n,c_loc(x),incx,c_loc(myResult))
+      hipblasIcamax_rank_1 = hipblasIcamax_(handle,n,c_loc(x),incx,myResult)
     end function
 
     function hipblasIzamax_rank_0(handle,n,x,incx,myResult)
@@ -45334,9 +45026,9 @@ module hipfort_hipblas
       integer(c_int) :: n
       complex(c_double_complex),target :: x
       integer(c_int) :: incx
-      integer(c_int),target :: myResult
+      type(c_ptr) :: myResult
       !
-      hipblasIzamax_rank_0 = hipblasIzamax_(handle,n,c_loc(x),incx,c_loc(myResult))
+      hipblasIzamax_rank_0 = hipblasIzamax_(handle,n,c_loc(x),incx,myResult)
     end function
 
     function hipblasIzamax_rank_1(handle,n,x,incx,myResult)
@@ -45348,201 +45040,9 @@ module hipfort_hipblas
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
-      integer(c_int),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
-      hipblasIzamax_rank_1 = hipblasIzamax_(handle,n,c_loc(x),incx,c_loc(myResult))
-    end function
-
-    function hipblasIsamaxBatched_rank_0(handle,n,x,incx,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasIsamaxBatched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batchCount
-      integer(c_int),target :: myResult
-      !
-      hipblasIsamaxBatched_rank_0 = hipblasIsamaxBatched_(handle,n,x,incx,batchCount, &
-        c_loc(myResult))
-    end function
-
-    function hipblasIsamaxBatched_rank_1(handle,n,x,incx,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasIsamaxBatched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batchCount
-      integer(c_int),target,dimension(:) :: myResult
-      !
-      hipblasIsamaxBatched_rank_1 = hipblasIsamaxBatched_(handle,n,x,incx,batchCount, &
-        c_loc(myResult))
-    end function
-
-    function hipblasIsamaxBatched_full_rank(handle,n,x,incx,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasIsamaxBatched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batchCount
-      integer(c_int),target,dimension(:,:) :: myResult
-      !
-      hipblasIsamaxBatched_full_rank = hipblasIsamaxBatched_(handle,n,x,incx,batchCount, &
-        c_loc(myResult))
-    end function
-
-    function hipblasIdamaxBatched_rank_0(handle,n,x,incx,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasIdamaxBatched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batchCount
-      integer(c_int),target :: myResult
-      !
-      hipblasIdamaxBatched_rank_0 = hipblasIdamaxBatched_(handle,n,x,incx,batchCount, &
-        c_loc(myResult))
-    end function
-
-    function hipblasIdamaxBatched_rank_1(handle,n,x,incx,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasIdamaxBatched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batchCount
-      integer(c_int),target,dimension(:) :: myResult
-      !
-      hipblasIdamaxBatched_rank_1 = hipblasIdamaxBatched_(handle,n,x,incx,batchCount, &
-        c_loc(myResult))
-    end function
-
-    function hipblasIdamaxBatched_full_rank(handle,n,x,incx,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasIdamaxBatched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batchCount
-      integer(c_int),target,dimension(:,:) :: myResult
-      !
-      hipblasIdamaxBatched_full_rank = hipblasIdamaxBatched_(handle,n,x,incx,batchCount, &
-        c_loc(myResult))
-    end function
-
-    function hipblasIcamaxBatched_rank_0(handle,n,x,incx,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasIcamaxBatched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batchCount
-      integer(c_int),target :: myResult
-      !
-      hipblasIcamaxBatched_rank_0 = hipblasIcamaxBatched_(handle,n,x,incx,batchCount, &
-        c_loc(myResult))
-    end function
-
-    function hipblasIcamaxBatched_rank_1(handle,n,x,incx,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasIcamaxBatched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batchCount
-      integer(c_int),target,dimension(:) :: myResult
-      !
-      hipblasIcamaxBatched_rank_1 = hipblasIcamaxBatched_(handle,n,x,incx,batchCount, &
-        c_loc(myResult))
-    end function
-
-    function hipblasIcamaxBatched_full_rank(handle,n,x,incx,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasIcamaxBatched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batchCount
-      integer(c_int),target,dimension(:,:) :: myResult
-      !
-      hipblasIcamaxBatched_full_rank = hipblasIcamaxBatched_(handle,n,x,incx,batchCount, &
-        c_loc(myResult))
-    end function
-
-    function hipblasIzamaxBatched_rank_0(handle,n,x,incx,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasIzamaxBatched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batchCount
-      integer(c_int),target :: myResult
-      !
-      hipblasIzamaxBatched_rank_0 = hipblasIzamaxBatched_(handle,n,x,incx,batchCount, &
-        c_loc(myResult))
-    end function
-
-    function hipblasIzamaxBatched_rank_1(handle,n,x,incx,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasIzamaxBatched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batchCount
-      integer(c_int),target,dimension(:) :: myResult
-      !
-      hipblasIzamaxBatched_rank_1 = hipblasIzamaxBatched_(handle,n,x,incx,batchCount, &
-        c_loc(myResult))
-    end function
-
-    function hipblasIzamaxBatched_full_rank(handle,n,x,incx,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasIzamaxBatched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batchCount
-      integer(c_int),target,dimension(:,:) :: myResult
-      !
-      hipblasIzamaxBatched_full_rank = hipblasIzamaxBatched_(handle,n,x,incx,batchCount, &
-        c_loc(myResult))
+      hipblasIzamax_rank_1 = hipblasIzamax_(handle,n,c_loc(x),incx,myResult)
     end function
 
     function hipblasIsamaxStridedBatched_rank_0(handle,n,x,incx,stridex,batchCount,myResult)
@@ -45556,10 +45056,10 @@ module hipfort_hipblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batchCount
-      integer(c_int),target :: myResult
+      type(c_ptr) :: myResult
       !
       hipblasIsamaxStridedBatched_rank_0 = hipblasIsamaxStridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,batchCount,c_loc(myResult))
+        stridex,batchCount,myResult)
     end function
 
     function hipblasIsamaxStridedBatched_rank_1(handle,n,x,incx,stridex,batchCount,myResult)
@@ -45573,10 +45073,10 @@ module hipfort_hipblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batchCount
-      integer(c_int),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
       hipblasIsamaxStridedBatched_rank_1 = hipblasIsamaxStridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,batchCount,c_loc(myResult))
+        stridex,batchCount,myResult)
     end function
 
     function hipblasIdamaxStridedBatched_rank_0(handle,n,x,incx,stridex,batchCount,myResult)
@@ -45590,10 +45090,10 @@ module hipfort_hipblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batchCount
-      integer(c_int),target :: myResult
+      type(c_ptr) :: myResult
       !
       hipblasIdamaxStridedBatched_rank_0 = hipblasIdamaxStridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,batchCount,c_loc(myResult))
+        stridex,batchCount,myResult)
     end function
 
     function hipblasIdamaxStridedBatched_rank_1(handle,n,x,incx,stridex,batchCount,myResult)
@@ -45607,10 +45107,10 @@ module hipfort_hipblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batchCount
-      integer(c_int),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
       hipblasIdamaxStridedBatched_rank_1 = hipblasIdamaxStridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,batchCount,c_loc(myResult))
+        stridex,batchCount,myResult)
     end function
 
     function hipblasIcamaxStridedBatched_rank_0(handle,n,x,incx,stridex,batchCount,myResult)
@@ -45624,10 +45124,10 @@ module hipfort_hipblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batchCount
-      integer(c_int),target :: myResult
+      type(c_ptr) :: myResult
       !
       hipblasIcamaxStridedBatched_rank_0 = hipblasIcamaxStridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,batchCount,c_loc(myResult))
+        stridex,batchCount,myResult)
     end function
 
     function hipblasIcamaxStridedBatched_rank_1(handle,n,x,incx,stridex,batchCount,myResult)
@@ -45641,10 +45141,10 @@ module hipfort_hipblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batchCount
-      integer(c_int),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
       hipblasIcamaxStridedBatched_rank_1 = hipblasIcamaxStridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,batchCount,c_loc(myResult))
+        stridex,batchCount,myResult)
     end function
 
     function hipblasIzamaxStridedBatched_rank_0(handle,n,x,incx,stridex,batchCount,myResult)
@@ -45658,10 +45158,10 @@ module hipfort_hipblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batchCount
-      integer(c_int),target :: myResult
+      type(c_ptr) :: myResult
       !
       hipblasIzamaxStridedBatched_rank_0 = hipblasIzamaxStridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,batchCount,c_loc(myResult))
+        stridex,batchCount,myResult)
     end function
 
     function hipblasIzamaxStridedBatched_rank_1(handle,n,x,incx,stridex,batchCount,myResult)
@@ -45675,10 +45175,10 @@ module hipfort_hipblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batchCount
-      integer(c_int),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
       hipblasIzamaxStridedBatched_rank_1 = hipblasIzamaxStridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,batchCount,c_loc(myResult))
+        stridex,batchCount,myResult)
     end function
 
     function hipblasIsamin_rank_0(handle,n,x,incx,myResult)
@@ -45690,9 +45190,9 @@ module hipfort_hipblas
       integer(c_int) :: n
       real(c_float),target :: x
       integer(c_int) :: incx
-      integer(c_int),target :: myResult
+      type(c_ptr) :: myResult
       !
-      hipblasIsamin_rank_0 = hipblasIsamin_(handle,n,c_loc(x),incx,c_loc(myResult))
+      hipblasIsamin_rank_0 = hipblasIsamin_(handle,n,c_loc(x),incx,myResult)
     end function
 
     function hipblasIsamin_rank_1(handle,n,x,incx,myResult)
@@ -45704,9 +45204,9 @@ module hipfort_hipblas
       integer(c_int) :: n
       real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
-      integer(c_int),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
-      hipblasIsamin_rank_1 = hipblasIsamin_(handle,n,c_loc(x),incx,c_loc(myResult))
+      hipblasIsamin_rank_1 = hipblasIsamin_(handle,n,c_loc(x),incx,myResult)
     end function
 
     function hipblasIdamin_rank_0(handle,n,x,incx,myResult)
@@ -45718,9 +45218,9 @@ module hipfort_hipblas
       integer(c_int) :: n
       real(c_double),target :: x
       integer(c_int) :: incx
-      integer(c_int),target :: myResult
+      type(c_ptr) :: myResult
       !
-      hipblasIdamin_rank_0 = hipblasIdamin_(handle,n,c_loc(x),incx,c_loc(myResult))
+      hipblasIdamin_rank_0 = hipblasIdamin_(handle,n,c_loc(x),incx,myResult)
     end function
 
     function hipblasIdamin_rank_1(handle,n,x,incx,myResult)
@@ -45732,9 +45232,9 @@ module hipfort_hipblas
       integer(c_int) :: n
       real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
-      integer(c_int),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
-      hipblasIdamin_rank_1 = hipblasIdamin_(handle,n,c_loc(x),incx,c_loc(myResult))
+      hipblasIdamin_rank_1 = hipblasIdamin_(handle,n,c_loc(x),incx,myResult)
     end function
 
     function hipblasIcamin_rank_0(handle,n,x,incx,myResult)
@@ -45746,9 +45246,9 @@ module hipfort_hipblas
       integer(c_int) :: n
       complex(c_float_complex),target :: x
       integer(c_int) :: incx
-      integer(c_int),target :: myResult
+      type(c_ptr) :: myResult
       !
-      hipblasIcamin_rank_0 = hipblasIcamin_(handle,n,c_loc(x),incx,c_loc(myResult))
+      hipblasIcamin_rank_0 = hipblasIcamin_(handle,n,c_loc(x),incx,myResult)
     end function
 
     function hipblasIcamin_rank_1(handle,n,x,incx,myResult)
@@ -45760,9 +45260,9 @@ module hipfort_hipblas
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
-      integer(c_int),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
-      hipblasIcamin_rank_1 = hipblasIcamin_(handle,n,c_loc(x),incx,c_loc(myResult))
+      hipblasIcamin_rank_1 = hipblasIcamin_(handle,n,c_loc(x),incx,myResult)
     end function
 
     function hipblasIzamin_rank_0(handle,n,x,incx,myResult)
@@ -45774,9 +45274,9 @@ module hipfort_hipblas
       integer(c_int) :: n
       complex(c_double_complex),target :: x
       integer(c_int) :: incx
-      integer(c_int),target :: myResult
+      type(c_ptr) :: myResult
       !
-      hipblasIzamin_rank_0 = hipblasIzamin_(handle,n,c_loc(x),incx,c_loc(myResult))
+      hipblasIzamin_rank_0 = hipblasIzamin_(handle,n,c_loc(x),incx,myResult)
     end function
 
     function hipblasIzamin_rank_1(handle,n,x,incx,myResult)
@@ -45788,201 +45288,9 @@ module hipfort_hipblas
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
-      integer(c_int),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
-      hipblasIzamin_rank_1 = hipblasIzamin_(handle,n,c_loc(x),incx,c_loc(myResult))
-    end function
-
-    function hipblasIsaminBatched_rank_0(handle,n,x,incx,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasIsaminBatched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batchCount
-      integer(c_int),target :: myResult
-      !
-      hipblasIsaminBatched_rank_0 = hipblasIsaminBatched_(handle,n,x,incx,batchCount, &
-        c_loc(myResult))
-    end function
-
-    function hipblasIsaminBatched_rank_1(handle,n,x,incx,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasIsaminBatched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batchCount
-      integer(c_int),target,dimension(:) :: myResult
-      !
-      hipblasIsaminBatched_rank_1 = hipblasIsaminBatched_(handle,n,x,incx,batchCount, &
-        c_loc(myResult))
-    end function
-
-    function hipblasIsaminBatched_full_rank(handle,n,x,incx,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasIsaminBatched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batchCount
-      integer(c_int),target,dimension(:,:) :: myResult
-      !
-      hipblasIsaminBatched_full_rank = hipblasIsaminBatched_(handle,n,x,incx,batchCount, &
-        c_loc(myResult))
-    end function
-
-    function hipblasIdaminBatched_rank_0(handle,n,x,incx,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasIdaminBatched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batchCount
-      integer(c_int),target :: myResult
-      !
-      hipblasIdaminBatched_rank_0 = hipblasIdaminBatched_(handle,n,x,incx,batchCount, &
-        c_loc(myResult))
-    end function
-
-    function hipblasIdaminBatched_rank_1(handle,n,x,incx,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasIdaminBatched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batchCount
-      integer(c_int),target,dimension(:) :: myResult
-      !
-      hipblasIdaminBatched_rank_1 = hipblasIdaminBatched_(handle,n,x,incx,batchCount, &
-        c_loc(myResult))
-    end function
-
-    function hipblasIdaminBatched_full_rank(handle,n,x,incx,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasIdaminBatched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batchCount
-      integer(c_int),target,dimension(:,:) :: myResult
-      !
-      hipblasIdaminBatched_full_rank = hipblasIdaminBatched_(handle,n,x,incx,batchCount, &
-        c_loc(myResult))
-    end function
-
-    function hipblasIcaminBatched_rank_0(handle,n,x,incx,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasIcaminBatched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batchCount
-      integer(c_int),target :: myResult
-      !
-      hipblasIcaminBatched_rank_0 = hipblasIcaminBatched_(handle,n,x,incx,batchCount, &
-        c_loc(myResult))
-    end function
-
-    function hipblasIcaminBatched_rank_1(handle,n,x,incx,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasIcaminBatched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batchCount
-      integer(c_int),target,dimension(:) :: myResult
-      !
-      hipblasIcaminBatched_rank_1 = hipblasIcaminBatched_(handle,n,x,incx,batchCount, &
-        c_loc(myResult))
-    end function
-
-    function hipblasIcaminBatched_full_rank(handle,n,x,incx,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasIcaminBatched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batchCount
-      integer(c_int),target,dimension(:,:) :: myResult
-      !
-      hipblasIcaminBatched_full_rank = hipblasIcaminBatched_(handle,n,x,incx,batchCount, &
-        c_loc(myResult))
-    end function
-
-    function hipblasIzaminBatched_rank_0(handle,n,x,incx,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasIzaminBatched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batchCount
-      integer(c_int),target :: myResult
-      !
-      hipblasIzaminBatched_rank_0 = hipblasIzaminBatched_(handle,n,x,incx,batchCount, &
-        c_loc(myResult))
-    end function
-
-    function hipblasIzaminBatched_rank_1(handle,n,x,incx,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasIzaminBatched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batchCount
-      integer(c_int),target,dimension(:) :: myResult
-      !
-      hipblasIzaminBatched_rank_1 = hipblasIzaminBatched_(handle,n,x,incx,batchCount, &
-        c_loc(myResult))
-    end function
-
-    function hipblasIzaminBatched_full_rank(handle,n,x,incx,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasIzaminBatched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batchCount
-      integer(c_int),target,dimension(:,:) :: myResult
-      !
-      hipblasIzaminBatched_full_rank = hipblasIzaminBatched_(handle,n,x,incx,batchCount, &
-        c_loc(myResult))
+      hipblasIzamin_rank_1 = hipblasIzamin_(handle,n,c_loc(x),incx,myResult)
     end function
 
     function hipblasIsaminStridedBatched_rank_0(handle,n,x,incx,stridex,batchCount,myResult)
@@ -45996,10 +45304,10 @@ module hipfort_hipblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batchCount
-      integer(c_int),target :: myResult
+      type(c_ptr) :: myResult
       !
       hipblasIsaminStridedBatched_rank_0 = hipblasIsaminStridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,batchCount,c_loc(myResult))
+        stridex,batchCount,myResult)
     end function
 
     function hipblasIsaminStridedBatched_rank_1(handle,n,x,incx,stridex,batchCount,myResult)
@@ -46013,10 +45321,10 @@ module hipfort_hipblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batchCount
-      integer(c_int),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
       hipblasIsaminStridedBatched_rank_1 = hipblasIsaminStridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,batchCount,c_loc(myResult))
+        stridex,batchCount,myResult)
     end function
 
     function hipblasIdaminStridedBatched_rank_0(handle,n,x,incx,stridex,batchCount,myResult)
@@ -46030,10 +45338,10 @@ module hipfort_hipblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batchCount
-      integer(c_int),target :: myResult
+      type(c_ptr) :: myResult
       !
       hipblasIdaminStridedBatched_rank_0 = hipblasIdaminStridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,batchCount,c_loc(myResult))
+        stridex,batchCount,myResult)
     end function
 
     function hipblasIdaminStridedBatched_rank_1(handle,n,x,incx,stridex,batchCount,myResult)
@@ -46047,10 +45355,10 @@ module hipfort_hipblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batchCount
-      integer(c_int),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
       hipblasIdaminStridedBatched_rank_1 = hipblasIdaminStridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,batchCount,c_loc(myResult))
+        stridex,batchCount,myResult)
     end function
 
     function hipblasIcaminStridedBatched_rank_0(handle,n,x,incx,stridex,batchCount,myResult)
@@ -46064,10 +45372,10 @@ module hipfort_hipblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batchCount
-      integer(c_int),target :: myResult
+      type(c_ptr) :: myResult
       !
       hipblasIcaminStridedBatched_rank_0 = hipblasIcaminStridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,batchCount,c_loc(myResult))
+        stridex,batchCount,myResult)
     end function
 
     function hipblasIcaminStridedBatched_rank_1(handle,n,x,incx,stridex,batchCount,myResult)
@@ -46081,10 +45389,10 @@ module hipfort_hipblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batchCount
-      integer(c_int),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
       hipblasIcaminStridedBatched_rank_1 = hipblasIcaminStridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,batchCount,c_loc(myResult))
+        stridex,batchCount,myResult)
     end function
 
     function hipblasIzaminStridedBatched_rank_0(handle,n,x,incx,stridex,batchCount,myResult)
@@ -46098,10 +45406,10 @@ module hipfort_hipblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batchCount
-      integer(c_int),target :: myResult
+      type(c_ptr) :: myResult
       !
       hipblasIzaminStridedBatched_rank_0 = hipblasIzaminStridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,batchCount,c_loc(myResult))
+        stridex,batchCount,myResult)
     end function
 
     function hipblasIzaminStridedBatched_rank_1(handle,n,x,incx,stridex,batchCount,myResult)
@@ -46115,10 +45423,10 @@ module hipfort_hipblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batchCount
-      integer(c_int),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
       hipblasIzaminStridedBatched_rank_1 = hipblasIzaminStridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,batchCount,c_loc(myResult))
+        stridex,batchCount,myResult)
     end function
 
     function hipblasSasum_rank_0(handle,n,x,incx,myResult)
@@ -46130,9 +45438,9 @@ module hipfort_hipblas
       integer(c_int) :: n
       real(c_float),target :: x
       integer(c_int) :: incx
-      real(c_float),target :: myResult
+      type(c_ptr) :: myResult
       !
-      hipblasSasum_rank_0 = hipblasSasum_(handle,n,c_loc(x),incx,c_loc(myResult))
+      hipblasSasum_rank_0 = hipblasSasum_(handle,n,c_loc(x),incx,myResult)
     end function
 
     function hipblasSasum_rank_1(handle,n,x,incx,myResult)
@@ -46144,9 +45452,9 @@ module hipfort_hipblas
       integer(c_int) :: n
       real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
-      real(c_float),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
-      hipblasSasum_rank_1 = hipblasSasum_(handle,n,c_loc(x),incx,c_loc(myResult))
+      hipblasSasum_rank_1 = hipblasSasum_(handle,n,c_loc(x),incx,myResult)
     end function
 
     function hipblasDasum_rank_0(handle,n,x,incx,myResult)
@@ -46158,9 +45466,9 @@ module hipfort_hipblas
       integer(c_int) :: n
       real(c_double),target :: x
       integer(c_int) :: incx
-      real(c_double),target :: myResult
+      type(c_ptr) :: myResult
       !
-      hipblasDasum_rank_0 = hipblasDasum_(handle,n,c_loc(x),incx,c_loc(myResult))
+      hipblasDasum_rank_0 = hipblasDasum_(handle,n,c_loc(x),incx,myResult)
     end function
 
     function hipblasDasum_rank_1(handle,n,x,incx,myResult)
@@ -46172,9 +45480,9 @@ module hipfort_hipblas
       integer(c_int) :: n
       real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
-      real(c_double),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
-      hipblasDasum_rank_1 = hipblasDasum_(handle,n,c_loc(x),incx,c_loc(myResult))
+      hipblasDasum_rank_1 = hipblasDasum_(handle,n,c_loc(x),incx,myResult)
     end function
 
     function hipblasScasum_rank_0(handle,n,x,incx,myResult)
@@ -46186,9 +45494,9 @@ module hipfort_hipblas
       integer(c_int) :: n
       complex(c_float_complex),target :: x
       integer(c_int) :: incx
-      real(c_float),target :: myResult
+      type(c_ptr) :: myResult
       !
-      hipblasScasum_rank_0 = hipblasScasum_(handle,n,c_loc(x),incx,c_loc(myResult))
+      hipblasScasum_rank_0 = hipblasScasum_(handle,n,c_loc(x),incx,myResult)
     end function
 
     function hipblasScasum_rank_1(handle,n,x,incx,myResult)
@@ -46200,9 +45508,9 @@ module hipfort_hipblas
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
-      real(c_float),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
-      hipblasScasum_rank_1 = hipblasScasum_(handle,n,c_loc(x),incx,c_loc(myResult))
+      hipblasScasum_rank_1 = hipblasScasum_(handle,n,c_loc(x),incx,myResult)
     end function
 
     function hipblasDzasum_rank_0(handle,n,x,incx,myResult)
@@ -46214,9 +45522,9 @@ module hipfort_hipblas
       integer(c_int) :: n
       complex(c_double_complex),target :: x
       integer(c_int) :: incx
-      real(c_double),target :: myResult
+      type(c_ptr) :: myResult
       !
-      hipblasDzasum_rank_0 = hipblasDzasum_(handle,n,c_loc(x),incx,c_loc(myResult))
+      hipblasDzasum_rank_0 = hipblasDzasum_(handle,n,c_loc(x),incx,myResult)
     end function
 
     function hipblasDzasum_rank_1(handle,n,x,incx,myResult)
@@ -46228,197 +45536,9 @@ module hipfort_hipblas
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
-      real(c_double),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
-      hipblasDzasum_rank_1 = hipblasDzasum_(handle,n,c_loc(x),incx,c_loc(myResult))
-    end function
-
-    function hipblasSasumBatched_rank_0(handle,n,x,incx,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasSasumBatched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batchCount
-      real(c_float),target :: myResult
-      !
-      hipblasSasumBatched_rank_0 = hipblasSasumBatched_(handle,n,x,incx,batchCount,c_loc(myResult))
-    end function
-
-    function hipblasSasumBatched_rank_1(handle,n,x,incx,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasSasumBatched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batchCount
-      real(c_float),target,dimension(:) :: myResult
-      !
-      hipblasSasumBatched_rank_1 = hipblasSasumBatched_(handle,n,x,incx,batchCount,c_loc(myResult))
-    end function
-
-    function hipblasSasumBatched_full_rank(handle,n,x,incx,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasSasumBatched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batchCount
-      real(c_float),target,dimension(:,:) :: myResult
-      !
-      hipblasSasumBatched_full_rank = hipblasSasumBatched_(handle,n,x,incx,batchCount, &
-        c_loc(myResult))
-    end function
-
-    function hipblasDasumBatched_rank_0(handle,n,x,incx,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasDasumBatched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batchCount
-      real(c_double),target :: myResult
-      !
-      hipblasDasumBatched_rank_0 = hipblasDasumBatched_(handle,n,x,incx,batchCount,c_loc(myResult))
-    end function
-
-    function hipblasDasumBatched_rank_1(handle,n,x,incx,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasDasumBatched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batchCount
-      real(c_double),target,dimension(:) :: myResult
-      !
-      hipblasDasumBatched_rank_1 = hipblasDasumBatched_(handle,n,x,incx,batchCount,c_loc(myResult))
-    end function
-
-    function hipblasDasumBatched_full_rank(handle,n,x,incx,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasDasumBatched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batchCount
-      real(c_double),target,dimension(:,:) :: myResult
-      !
-      hipblasDasumBatched_full_rank = hipblasDasumBatched_(handle,n,x,incx,batchCount, &
-        c_loc(myResult))
-    end function
-
-    function hipblasScasumBatched_rank_0(handle,n,x,incx,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasScasumBatched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batchCount
-      real(c_float),target :: myResult
-      !
-      hipblasScasumBatched_rank_0 = hipblasScasumBatched_(handle,n,x,incx,batchCount, &
-        c_loc(myResult))
-    end function
-
-    function hipblasScasumBatched_rank_1(handle,n,x,incx,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasScasumBatched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batchCount
-      real(c_float),target,dimension(:) :: myResult
-      !
-      hipblasScasumBatched_rank_1 = hipblasScasumBatched_(handle,n,x,incx,batchCount, &
-        c_loc(myResult))
-    end function
-
-    function hipblasScasumBatched_full_rank(handle,n,x,incx,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasScasumBatched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batchCount
-      real(c_float),target,dimension(:,:) :: myResult
-      !
-      hipblasScasumBatched_full_rank = hipblasScasumBatched_(handle,n,x,incx,batchCount, &
-        c_loc(myResult))
-    end function
-
-    function hipblasDzasumBatched_rank_0(handle,n,x,incx,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasDzasumBatched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batchCount
-      real(c_double),target :: myResult
-      !
-      hipblasDzasumBatched_rank_0 = hipblasDzasumBatched_(handle,n,x,incx,batchCount, &
-        c_loc(myResult))
-    end function
-
-    function hipblasDzasumBatched_rank_1(handle,n,x,incx,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasDzasumBatched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batchCount
-      real(c_double),target,dimension(:) :: myResult
-      !
-      hipblasDzasumBatched_rank_1 = hipblasDzasumBatched_(handle,n,x,incx,batchCount, &
-        c_loc(myResult))
-    end function
-
-    function hipblasDzasumBatched_full_rank(handle,n,x,incx,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasDzasumBatched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batchCount
-      real(c_double),target,dimension(:,:) :: myResult
-      !
-      hipblasDzasumBatched_full_rank = hipblasDzasumBatched_(handle,n,x,incx,batchCount, &
-        c_loc(myResult))
+      hipblasDzasum_rank_1 = hipblasDzasum_(handle,n,c_loc(x),incx,myResult)
     end function
 
     function hipblasSasumStridedBatched_rank_0(handle,n,x,incx,stridex,batchCount,myResult)
@@ -46432,10 +45552,10 @@ module hipfort_hipblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batchCount
-      real(c_float),target :: myResult
+      type(c_ptr) :: myResult
       !
       hipblasSasumStridedBatched_rank_0 = hipblasSasumStridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,batchCount,c_loc(myResult))
+        stridex,batchCount,myResult)
     end function
 
     function hipblasSasumStridedBatched_rank_1(handle,n,x,incx,stridex,batchCount,myResult)
@@ -46449,10 +45569,10 @@ module hipfort_hipblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batchCount
-      real(c_float),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
       hipblasSasumStridedBatched_rank_1 = hipblasSasumStridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,batchCount,c_loc(myResult))
+        stridex,batchCount,myResult)
     end function
 
     function hipblasDasumStridedBatched_rank_0(handle,n,x,incx,stridex,batchCount,myResult)
@@ -46466,10 +45586,10 @@ module hipfort_hipblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batchCount
-      real(c_double),target :: myResult
+      type(c_ptr) :: myResult
       !
       hipblasDasumStridedBatched_rank_0 = hipblasDasumStridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,batchCount,c_loc(myResult))
+        stridex,batchCount,myResult)
     end function
 
     function hipblasDasumStridedBatched_rank_1(handle,n,x,incx,stridex,batchCount,myResult)
@@ -46483,10 +45603,10 @@ module hipfort_hipblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batchCount
-      real(c_double),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
       hipblasDasumStridedBatched_rank_1 = hipblasDasumStridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,batchCount,c_loc(myResult))
+        stridex,batchCount,myResult)
     end function
 
     function hipblasScasumStridedBatched_rank_0(handle,n,x,incx,stridex,batchCount,myResult)
@@ -46500,10 +45620,10 @@ module hipfort_hipblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batchCount
-      real(c_float),target :: myResult
+      type(c_ptr) :: myResult
       !
       hipblasScasumStridedBatched_rank_0 = hipblasScasumStridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,batchCount,c_loc(myResult))
+        stridex,batchCount,myResult)
     end function
 
     function hipblasScasumStridedBatched_rank_1(handle,n,x,incx,stridex,batchCount,myResult)
@@ -46517,10 +45637,10 @@ module hipfort_hipblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batchCount
-      real(c_float),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
       hipblasScasumStridedBatched_rank_1 = hipblasScasumStridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,batchCount,c_loc(myResult))
+        stridex,batchCount,myResult)
     end function
 
     function hipblasDzasumStridedBatched_rank_0(handle,n,x,incx,stridex,batchCount,myResult)
@@ -46534,10 +45654,10 @@ module hipfort_hipblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batchCount
-      real(c_double),target :: myResult
+      type(c_ptr) :: myResult
       !
       hipblasDzasumStridedBatched_rank_0 = hipblasDzasumStridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,batchCount,c_loc(myResult))
+        stridex,batchCount,myResult)
     end function
 
     function hipblasDzasumStridedBatched_rank_1(handle,n,x,incx,stridex,batchCount,myResult)
@@ -46551,10 +45671,10 @@ module hipfort_hipblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batchCount
-      real(c_double),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
       hipblasDzasumStridedBatched_rank_1 = hipblasDzasumStridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,batchCount,c_loc(myResult))
+        stridex,batchCount,myResult)
     end function
 
     function hipblasSaxpy_rank_0(handle,n,alpha,x,incx,y,incy)
@@ -47136,9 +46256,9 @@ module hipfort_hipblas
       integer(c_int) :: incx
       real(c_float),target :: y
       integer(c_int) :: incy
-      real(c_float),target :: myResult
+      type(c_ptr) :: myResult
       !
-      hipblasSdot_rank_0 = hipblasSdot_(handle,n,c_loc(x),incx,c_loc(y),incy,c_loc(myResult))
+      hipblasSdot_rank_0 = hipblasSdot_(handle,n,c_loc(x),incx,c_loc(y),incy,myResult)
     end function
 
     function hipblasSdot_rank_1(handle,n,x,incx,y,incy,myResult)
@@ -47152,9 +46272,9 @@ module hipfort_hipblas
       integer(c_int) :: incx
       real(c_float),target,dimension(:) :: y
       integer(c_int) :: incy
-      real(c_float),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
-      hipblasSdot_rank_1 = hipblasSdot_(handle,n,c_loc(x),incx,c_loc(y),incy,c_loc(myResult))
+      hipblasSdot_rank_1 = hipblasSdot_(handle,n,c_loc(x),incx,c_loc(y),incy,myResult)
     end function
 
     function hipblasDdot_rank_0(handle,n,x,incx,y,incy,myResult)
@@ -47168,9 +46288,9 @@ module hipfort_hipblas
       integer(c_int) :: incx
       real(c_double),target :: y
       integer(c_int) :: incy
-      real(c_double),target :: myResult
+      type(c_ptr) :: myResult
       !
-      hipblasDdot_rank_0 = hipblasDdot_(handle,n,c_loc(x),incx,c_loc(y),incy,c_loc(myResult))
+      hipblasDdot_rank_0 = hipblasDdot_(handle,n,c_loc(x),incx,c_loc(y),incy,myResult)
     end function
 
     function hipblasDdot_rank_1(handle,n,x,incx,y,incy,myResult)
@@ -47184,9 +46304,9 @@ module hipfort_hipblas
       integer(c_int) :: incx
       real(c_double),target,dimension(:) :: y
       integer(c_int) :: incy
-      real(c_double),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
-      hipblasDdot_rank_1 = hipblasDdot_(handle,n,c_loc(x),incx,c_loc(y),incy,c_loc(myResult))
+      hipblasDdot_rank_1 = hipblasDdot_(handle,n,c_loc(x),incx,c_loc(y),incy,myResult)
     end function
 
     function hipblasCdotc_rank_0(handle,n,x,incx,y,incy,myResult)
@@ -47200,9 +46320,9 @@ module hipfort_hipblas
       integer(c_int) :: incx
       complex(c_float_complex),target :: y
       integer(c_int) :: incy
-      complex(c_float_complex),target :: myResult
+      type(c_ptr) :: myResult
       !
-      hipblasCdotc_rank_0 = hipblasCdotc_(handle,n,c_loc(x),incx,c_loc(y),incy,c_loc(myResult))
+      hipblasCdotc_rank_0 = hipblasCdotc_(handle,n,c_loc(x),incx,c_loc(y),incy,myResult)
     end function
 
     function hipblasCdotc_rank_1(handle,n,x,incx,y,incy,myResult)
@@ -47216,9 +46336,9 @@ module hipfort_hipblas
       integer(c_int) :: incx
       complex(c_float_complex),target,dimension(:) :: y
       integer(c_int) :: incy
-      complex(c_float_complex),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
-      hipblasCdotc_rank_1 = hipblasCdotc_(handle,n,c_loc(x),incx,c_loc(y),incy,c_loc(myResult))
+      hipblasCdotc_rank_1 = hipblasCdotc_(handle,n,c_loc(x),incx,c_loc(y),incy,myResult)
     end function
 
     function hipblasCdotu_rank_0(handle,n,x,incx,y,incy,myResult)
@@ -47232,9 +46352,9 @@ module hipfort_hipblas
       integer(c_int) :: incx
       complex(c_float_complex),target :: y
       integer(c_int) :: incy
-      complex(c_float_complex),target :: myResult
+      type(c_ptr) :: myResult
       !
-      hipblasCdotu_rank_0 = hipblasCdotu_(handle,n,c_loc(x),incx,c_loc(y),incy,c_loc(myResult))
+      hipblasCdotu_rank_0 = hipblasCdotu_(handle,n,c_loc(x),incx,c_loc(y),incy,myResult)
     end function
 
     function hipblasCdotu_rank_1(handle,n,x,incx,y,incy,myResult)
@@ -47248,9 +46368,9 @@ module hipfort_hipblas
       integer(c_int) :: incx
       complex(c_float_complex),target,dimension(:) :: y
       integer(c_int) :: incy
-      complex(c_float_complex),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
-      hipblasCdotu_rank_1 = hipblasCdotu_(handle,n,c_loc(x),incx,c_loc(y),incy,c_loc(myResult))
+      hipblasCdotu_rank_1 = hipblasCdotu_(handle,n,c_loc(x),incx,c_loc(y),incy,myResult)
     end function
 
     function hipblasZdotc_rank_0(handle,n,x,incx,y,incy,myResult)
@@ -47264,9 +46384,9 @@ module hipfort_hipblas
       integer(c_int) :: incx
       complex(c_double_complex),target :: y
       integer(c_int) :: incy
-      complex(c_double_complex),target :: myResult
+      type(c_ptr) :: myResult
       !
-      hipblasZdotc_rank_0 = hipblasZdotc_(handle,n,c_loc(x),incx,c_loc(y),incy,c_loc(myResult))
+      hipblasZdotc_rank_0 = hipblasZdotc_(handle,n,c_loc(x),incx,c_loc(y),incy,myResult)
     end function
 
     function hipblasZdotc_rank_1(handle,n,x,incx,y,incy,myResult)
@@ -47280,9 +46400,9 @@ module hipfort_hipblas
       integer(c_int) :: incx
       complex(c_double_complex),target,dimension(:) :: y
       integer(c_int) :: incy
-      complex(c_double_complex),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
-      hipblasZdotc_rank_1 = hipblasZdotc_(handle,n,c_loc(x),incx,c_loc(y),incy,c_loc(myResult))
+      hipblasZdotc_rank_1 = hipblasZdotc_(handle,n,c_loc(x),incx,c_loc(y),incy,myResult)
     end function
 
     function hipblasZdotu_rank_0(handle,n,x,incx,y,incy,myResult)
@@ -47296,9 +46416,9 @@ module hipfort_hipblas
       integer(c_int) :: incx
       complex(c_double_complex),target :: y
       integer(c_int) :: incy
-      complex(c_double_complex),target :: myResult
+      type(c_ptr) :: myResult
       !
-      hipblasZdotu_rank_0 = hipblasZdotu_(handle,n,c_loc(x),incx,c_loc(y),incy,c_loc(myResult))
+      hipblasZdotu_rank_0 = hipblasZdotu_(handle,n,c_loc(x),incx,c_loc(y),incy,myResult)
     end function
 
     function hipblasZdotu_rank_1(handle,n,x,incx,y,incy,myResult)
@@ -47312,333 +46432,9 @@ module hipfort_hipblas
       integer(c_int) :: incx
       complex(c_double_complex),target,dimension(:) :: y
       integer(c_int) :: incy
-      complex(c_double_complex),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
-      hipblasZdotu_rank_1 = hipblasZdotu_(handle,n,c_loc(x),incx,c_loc(y),incy,c_loc(myResult))
-    end function
-
-    function hipblasSdotBatched_rank_0(handle,n,x,incx,y,incy,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasSdotBatched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      type(c_ptr) :: y
-      integer(c_int) :: incy
-      integer(c_int) :: batchCount
-      real(c_float),target :: myResult
-      !
-      hipblasSdotBatched_rank_0 = hipblasSdotBatched_(handle,n,x,incx,y,incy,batchCount, &
-        c_loc(myResult))
-    end function
-
-    function hipblasSdotBatched_rank_1(handle,n,x,incx,y,incy,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasSdotBatched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      type(c_ptr) :: y
-      integer(c_int) :: incy
-      integer(c_int) :: batchCount
-      real(c_float),target,dimension(:) :: myResult
-      !
-      hipblasSdotBatched_rank_1 = hipblasSdotBatched_(handle,n,x,incx,y,incy,batchCount, &
-        c_loc(myResult))
-    end function
-
-    function hipblasSdotBatched_full_rank(handle,n,x,incx,y,incy,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasSdotBatched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      type(c_ptr) :: y
-      integer(c_int) :: incy
-      integer(c_int) :: batchCount
-      real(c_float),target,dimension(:,:) :: myResult
-      !
-      hipblasSdotBatched_full_rank = hipblasSdotBatched_(handle,n,x,incx,y,incy,batchCount, &
-        c_loc(myResult))
-    end function
-
-    function hipblasDdotBatched_rank_0(handle,n,x,incx,y,incy,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasDdotBatched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      type(c_ptr) :: y
-      integer(c_int) :: incy
-      integer(c_int) :: batchCount
-      real(c_double),target :: myResult
-      !
-      hipblasDdotBatched_rank_0 = hipblasDdotBatched_(handle,n,x,incx,y,incy,batchCount, &
-        c_loc(myResult))
-    end function
-
-    function hipblasDdotBatched_rank_1(handle,n,x,incx,y,incy,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasDdotBatched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      type(c_ptr) :: y
-      integer(c_int) :: incy
-      integer(c_int) :: batchCount
-      real(c_double),target,dimension(:) :: myResult
-      !
-      hipblasDdotBatched_rank_1 = hipblasDdotBatched_(handle,n,x,incx,y,incy,batchCount, &
-        c_loc(myResult))
-    end function
-
-    function hipblasDdotBatched_full_rank(handle,n,x,incx,y,incy,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasDdotBatched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      type(c_ptr) :: y
-      integer(c_int) :: incy
-      integer(c_int) :: batchCount
-      real(c_double),target,dimension(:,:) :: myResult
-      !
-      hipblasDdotBatched_full_rank = hipblasDdotBatched_(handle,n,x,incx,y,incy,batchCount, &
-        c_loc(myResult))
-    end function
-
-    function hipblasCdotcBatched_rank_0(handle,n,x,incx,y,incy,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasCdotcBatched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      type(c_ptr) :: y
-      integer(c_int) :: incy
-      integer(c_int) :: batchCount
-      complex(c_float_complex),target :: myResult
-      !
-      hipblasCdotcBatched_rank_0 = hipblasCdotcBatched_(handle,n,x,incx,y,incy,batchCount, &
-        c_loc(myResult))
-    end function
-
-    function hipblasCdotcBatched_rank_1(handle,n,x,incx,y,incy,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasCdotcBatched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      type(c_ptr) :: y
-      integer(c_int) :: incy
-      integer(c_int) :: batchCount
-      complex(c_float_complex),target,dimension(:) :: myResult
-      !
-      hipblasCdotcBatched_rank_1 = hipblasCdotcBatched_(handle,n,x,incx,y,incy,batchCount, &
-        c_loc(myResult))
-    end function
-
-    function hipblasCdotcBatched_full_rank(handle,n,x,incx,y,incy,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasCdotcBatched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      type(c_ptr) :: y
-      integer(c_int) :: incy
-      integer(c_int) :: batchCount
-      complex(c_float_complex),target,dimension(:,:) :: myResult
-      !
-      hipblasCdotcBatched_full_rank = hipblasCdotcBatched_(handle,n,x,incx,y,incy,batchCount, &
-        c_loc(myResult))
-    end function
-
-    function hipblasCdotuBatched_rank_0(handle,n,x,incx,y,incy,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasCdotuBatched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      type(c_ptr) :: y
-      integer(c_int) :: incy
-      integer(c_int) :: batchCount
-      complex(c_float_complex),target :: myResult
-      !
-      hipblasCdotuBatched_rank_0 = hipblasCdotuBatched_(handle,n,x,incx,y,incy,batchCount, &
-        c_loc(myResult))
-    end function
-
-    function hipblasCdotuBatched_rank_1(handle,n,x,incx,y,incy,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasCdotuBatched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      type(c_ptr) :: y
-      integer(c_int) :: incy
-      integer(c_int) :: batchCount
-      complex(c_float_complex),target,dimension(:) :: myResult
-      !
-      hipblasCdotuBatched_rank_1 = hipblasCdotuBatched_(handle,n,x,incx,y,incy,batchCount, &
-        c_loc(myResult))
-    end function
-
-    function hipblasCdotuBatched_full_rank(handle,n,x,incx,y,incy,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasCdotuBatched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      type(c_ptr) :: y
-      integer(c_int) :: incy
-      integer(c_int) :: batchCount
-      complex(c_float_complex),target,dimension(:,:) :: myResult
-      !
-      hipblasCdotuBatched_full_rank = hipblasCdotuBatched_(handle,n,x,incx,y,incy,batchCount, &
-        c_loc(myResult))
-    end function
-
-    function hipblasZdotcBatched_rank_0(handle,n,x,incx,y,incy,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasZdotcBatched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      type(c_ptr) :: y
-      integer(c_int) :: incy
-      integer(c_int) :: batchCount
-      complex(c_double_complex),target :: myResult
-      !
-      hipblasZdotcBatched_rank_0 = hipblasZdotcBatched_(handle,n,x,incx,y,incy,batchCount, &
-        c_loc(myResult))
-    end function
-
-    function hipblasZdotcBatched_rank_1(handle,n,x,incx,y,incy,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasZdotcBatched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      type(c_ptr) :: y
-      integer(c_int) :: incy
-      integer(c_int) :: batchCount
-      complex(c_double_complex),target,dimension(:) :: myResult
-      !
-      hipblasZdotcBatched_rank_1 = hipblasZdotcBatched_(handle,n,x,incx,y,incy,batchCount, &
-        c_loc(myResult))
-    end function
-
-    function hipblasZdotcBatched_full_rank(handle,n,x,incx,y,incy,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasZdotcBatched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      type(c_ptr) :: y
-      integer(c_int) :: incy
-      integer(c_int) :: batchCount
-      complex(c_double_complex),target,dimension(:,:) :: myResult
-      !
-      hipblasZdotcBatched_full_rank = hipblasZdotcBatched_(handle,n,x,incx,y,incy,batchCount, &
-        c_loc(myResult))
-    end function
-
-    function hipblasZdotuBatched_rank_0(handle,n,x,incx,y,incy,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasZdotuBatched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      type(c_ptr) :: y
-      integer(c_int) :: incy
-      integer(c_int) :: batchCount
-      complex(c_double_complex),target :: myResult
-      !
-      hipblasZdotuBatched_rank_0 = hipblasZdotuBatched_(handle,n,x,incx,y,incy,batchCount, &
-        c_loc(myResult))
-    end function
-
-    function hipblasZdotuBatched_rank_1(handle,n,x,incx,y,incy,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasZdotuBatched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      type(c_ptr) :: y
-      integer(c_int) :: incy
-      integer(c_int) :: batchCount
-      complex(c_double_complex),target,dimension(:) :: myResult
-      !
-      hipblasZdotuBatched_rank_1 = hipblasZdotuBatched_(handle,n,x,incx,y,incy,batchCount, &
-        c_loc(myResult))
-    end function
-
-    function hipblasZdotuBatched_full_rank(handle,n,x,incx,y,incy,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasZdotuBatched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      type(c_ptr) :: y
-      integer(c_int) :: incy
-      integer(c_int) :: batchCount
-      complex(c_double_complex),target,dimension(:,:) :: myResult
-      !
-      hipblasZdotuBatched_full_rank = hipblasZdotuBatched_(handle,n,x,incx,y,incy,batchCount, &
-        c_loc(myResult))
+      hipblasZdotu_rank_1 = hipblasZdotu_(handle,n,c_loc(x),incx,c_loc(y),incy,myResult)
     end function
 
     function hipblasSdotStridedBatched_rank_0(handle,n,x,incx,stridex,y,incy,stridey,batchCount, &
@@ -47656,10 +46452,10 @@ module hipfort_hipblas
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       integer(c_int) :: batchCount
-      real(c_float),target :: myResult
+      type(c_ptr) :: myResult
       !
       hipblasSdotStridedBatched_rank_0 = hipblasSdotStridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,c_loc(y),incy,stridey,batchCount,c_loc(myResult))
+        stridex,c_loc(y),incy,stridey,batchCount,myResult)
     end function
 
     function hipblasSdotStridedBatched_rank_1(handle,n,x,incx,stridex,y,incy,stridey,batchCount, &
@@ -47677,10 +46473,10 @@ module hipfort_hipblas
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       integer(c_int) :: batchCount
-      real(c_float),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
       hipblasSdotStridedBatched_rank_1 = hipblasSdotStridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,c_loc(y),incy,stridey,batchCount,c_loc(myResult))
+        stridex,c_loc(y),incy,stridey,batchCount,myResult)
     end function
 
     function hipblasDdotStridedBatched_rank_0(handle,n,x,incx,stridex,y,incy,stridey,batchCount, &
@@ -47698,10 +46494,10 @@ module hipfort_hipblas
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       integer(c_int) :: batchCount
-      real(c_double),target :: myResult
+      type(c_ptr) :: myResult
       !
       hipblasDdotStridedBatched_rank_0 = hipblasDdotStridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,c_loc(y),incy,stridey,batchCount,c_loc(myResult))
+        stridex,c_loc(y),incy,stridey,batchCount,myResult)
     end function
 
     function hipblasDdotStridedBatched_rank_1(handle,n,x,incx,stridex,y,incy,stridey,batchCount, &
@@ -47719,10 +46515,10 @@ module hipfort_hipblas
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       integer(c_int) :: batchCount
-      real(c_double),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
       hipblasDdotStridedBatched_rank_1 = hipblasDdotStridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,c_loc(y),incy,stridey,batchCount,c_loc(myResult))
+        stridex,c_loc(y),incy,stridey,batchCount,myResult)
     end function
 
     function hipblasCdotcStridedBatched_rank_0(handle,n,x,incx,stridex,y,incy,stridey,batchCount, &
@@ -47740,10 +46536,10 @@ module hipfort_hipblas
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       integer(c_int) :: batchCount
-      complex(c_float_complex),target :: myResult
+      type(c_ptr) :: myResult
       !
       hipblasCdotcStridedBatched_rank_0 = hipblasCdotcStridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,c_loc(y),incy,stridey,batchCount,c_loc(myResult))
+        stridex,c_loc(y),incy,stridey,batchCount,myResult)
     end function
 
     function hipblasCdotcStridedBatched_rank_1(handle,n,x,incx,stridex,y,incy,stridey,batchCount, &
@@ -47761,10 +46557,10 @@ module hipfort_hipblas
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       integer(c_int) :: batchCount
-      complex(c_float_complex),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
       hipblasCdotcStridedBatched_rank_1 = hipblasCdotcStridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,c_loc(y),incy,stridey,batchCount,c_loc(myResult))
+        stridex,c_loc(y),incy,stridey,batchCount,myResult)
     end function
 
     function hipblasCdotuStridedBatched_rank_0(handle,n,x,incx,stridex,y,incy,stridey,batchCount, &
@@ -47782,10 +46578,10 @@ module hipfort_hipblas
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       integer(c_int) :: batchCount
-      complex(c_float_complex),target :: myResult
+      type(c_ptr) :: myResult
       !
       hipblasCdotuStridedBatched_rank_0 = hipblasCdotuStridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,c_loc(y),incy,stridey,batchCount,c_loc(myResult))
+        stridex,c_loc(y),incy,stridey,batchCount,myResult)
     end function
 
     function hipblasCdotuStridedBatched_rank_1(handle,n,x,incx,stridex,y,incy,stridey,batchCount, &
@@ -47803,10 +46599,10 @@ module hipfort_hipblas
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       integer(c_int) :: batchCount
-      complex(c_float_complex),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
       hipblasCdotuStridedBatched_rank_1 = hipblasCdotuStridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,c_loc(y),incy,stridey,batchCount,c_loc(myResult))
+        stridex,c_loc(y),incy,stridey,batchCount,myResult)
     end function
 
     function hipblasZdotcStridedBatched_rank_0(handle,n,x,incx,stridex,y,incy,stridey,batchCount, &
@@ -47824,10 +46620,10 @@ module hipfort_hipblas
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       integer(c_int) :: batchCount
-      complex(c_double_complex),target :: myResult
+      type(c_ptr) :: myResult
       !
       hipblasZdotcStridedBatched_rank_0 = hipblasZdotcStridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,c_loc(y),incy,stridey,batchCount,c_loc(myResult))
+        stridex,c_loc(y),incy,stridey,batchCount,myResult)
     end function
 
     function hipblasZdotcStridedBatched_rank_1(handle,n,x,incx,stridex,y,incy,stridey,batchCount, &
@@ -47845,10 +46641,10 @@ module hipfort_hipblas
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       integer(c_int) :: batchCount
-      complex(c_double_complex),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
       hipblasZdotcStridedBatched_rank_1 = hipblasZdotcStridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,c_loc(y),incy,stridey,batchCount,c_loc(myResult))
+        stridex,c_loc(y),incy,stridey,batchCount,myResult)
     end function
 
     function hipblasZdotuStridedBatched_rank_0(handle,n,x,incx,stridex,y,incy,stridey,batchCount, &
@@ -47866,10 +46662,10 @@ module hipfort_hipblas
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       integer(c_int) :: batchCount
-      complex(c_double_complex),target :: myResult
+      type(c_ptr) :: myResult
       !
       hipblasZdotuStridedBatched_rank_0 = hipblasZdotuStridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,c_loc(y),incy,stridey,batchCount,c_loc(myResult))
+        stridex,c_loc(y),incy,stridey,batchCount,myResult)
     end function
 
     function hipblasZdotuStridedBatched_rank_1(handle,n,x,incx,stridex,y,incy,stridey,batchCount, &
@@ -47887,10 +46683,10 @@ module hipfort_hipblas
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       integer(c_int) :: batchCount
-      complex(c_double_complex),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
       hipblasZdotuStridedBatched_rank_1 = hipblasZdotuStridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,c_loc(y),incy,stridey,batchCount,c_loc(myResult))
+        stridex,c_loc(y),incy,stridey,batchCount,myResult)
     end function
 
     function hipblasSnrm2_rank_0(handle,n,x,incx,myResult)
@@ -47902,9 +46698,9 @@ module hipfort_hipblas
       integer(c_int) :: n
       real(c_float),target :: x
       integer(c_int) :: incx
-      real(c_float),target :: myResult
+      type(c_ptr) :: myResult
       !
-      hipblasSnrm2_rank_0 = hipblasSnrm2_(handle,n,c_loc(x),incx,c_loc(myResult))
+      hipblasSnrm2_rank_0 = hipblasSnrm2_(handle,n,c_loc(x),incx,myResult)
     end function
 
     function hipblasSnrm2_rank_1(handle,n,x,incx,myResult)
@@ -47916,9 +46712,9 @@ module hipfort_hipblas
       integer(c_int) :: n
       real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
-      real(c_float),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
-      hipblasSnrm2_rank_1 = hipblasSnrm2_(handle,n,c_loc(x),incx,c_loc(myResult))
+      hipblasSnrm2_rank_1 = hipblasSnrm2_(handle,n,c_loc(x),incx,myResult)
     end function
 
     function hipblasDnrm2_rank_0(handle,n,x,incx,myResult)
@@ -47930,9 +46726,9 @@ module hipfort_hipblas
       integer(c_int) :: n
       real(c_double),target :: x
       integer(c_int) :: incx
-      real(c_double),target :: myResult
+      type(c_ptr) :: myResult
       !
-      hipblasDnrm2_rank_0 = hipblasDnrm2_(handle,n,c_loc(x),incx,c_loc(myResult))
+      hipblasDnrm2_rank_0 = hipblasDnrm2_(handle,n,c_loc(x),incx,myResult)
     end function
 
     function hipblasDnrm2_rank_1(handle,n,x,incx,myResult)
@@ -47944,9 +46740,9 @@ module hipfort_hipblas
       integer(c_int) :: n
       real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
-      real(c_double),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
-      hipblasDnrm2_rank_1 = hipblasDnrm2_(handle,n,c_loc(x),incx,c_loc(myResult))
+      hipblasDnrm2_rank_1 = hipblasDnrm2_(handle,n,c_loc(x),incx,myResult)
     end function
 
     function hipblasScnrm2_rank_0(handle,n,x,incx,myResult)
@@ -47958,9 +46754,9 @@ module hipfort_hipblas
       integer(c_int) :: n
       complex(c_float_complex),target :: x
       integer(c_int) :: incx
-      real(c_float),target :: myResult
+      type(c_ptr) :: myResult
       !
-      hipblasScnrm2_rank_0 = hipblasScnrm2_(handle,n,c_loc(x),incx,c_loc(myResult))
+      hipblasScnrm2_rank_0 = hipblasScnrm2_(handle,n,c_loc(x),incx,myResult)
     end function
 
     function hipblasScnrm2_rank_1(handle,n,x,incx,myResult)
@@ -47972,9 +46768,9 @@ module hipfort_hipblas
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
-      real(c_float),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
-      hipblasScnrm2_rank_1 = hipblasScnrm2_(handle,n,c_loc(x),incx,c_loc(myResult))
+      hipblasScnrm2_rank_1 = hipblasScnrm2_(handle,n,c_loc(x),incx,myResult)
     end function
 
     function hipblasDznrm2_rank_0(handle,n,x,incx,myResult)
@@ -47986,9 +46782,9 @@ module hipfort_hipblas
       integer(c_int) :: n
       complex(c_double_complex),target :: x
       integer(c_int) :: incx
-      real(c_double),target :: myResult
+      type(c_ptr) :: myResult
       !
-      hipblasDznrm2_rank_0 = hipblasDznrm2_(handle,n,c_loc(x),incx,c_loc(myResult))
+      hipblasDznrm2_rank_0 = hipblasDznrm2_(handle,n,c_loc(x),incx,myResult)
     end function
 
     function hipblasDznrm2_rank_1(handle,n,x,incx,myResult)
@@ -48000,197 +46796,9 @@ module hipfort_hipblas
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
-      real(c_double),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
-      hipblasDznrm2_rank_1 = hipblasDznrm2_(handle,n,c_loc(x),incx,c_loc(myResult))
-    end function
-
-    function hipblasSnrm2Batched_rank_0(handle,n,x,incx,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasSnrm2Batched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batchCount
-      real(c_float),target :: myResult
-      !
-      hipblasSnrm2Batched_rank_0 = hipblasSnrm2Batched_(handle,n,x,incx,batchCount,c_loc(myResult))
-    end function
-
-    function hipblasSnrm2Batched_rank_1(handle,n,x,incx,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasSnrm2Batched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batchCount
-      real(c_float),target,dimension(:) :: myResult
-      !
-      hipblasSnrm2Batched_rank_1 = hipblasSnrm2Batched_(handle,n,x,incx,batchCount,c_loc(myResult))
-    end function
-
-    function hipblasSnrm2Batched_full_rank(handle,n,x,incx,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasSnrm2Batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batchCount
-      real(c_float),target,dimension(:,:) :: myResult
-      !
-      hipblasSnrm2Batched_full_rank = hipblasSnrm2Batched_(handle,n,x,incx,batchCount, &
-        c_loc(myResult))
-    end function
-
-    function hipblasDnrm2Batched_rank_0(handle,n,x,incx,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasDnrm2Batched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batchCount
-      real(c_double),target :: myResult
-      !
-      hipblasDnrm2Batched_rank_0 = hipblasDnrm2Batched_(handle,n,x,incx,batchCount,c_loc(myResult))
-    end function
-
-    function hipblasDnrm2Batched_rank_1(handle,n,x,incx,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasDnrm2Batched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batchCount
-      real(c_double),target,dimension(:) :: myResult
-      !
-      hipblasDnrm2Batched_rank_1 = hipblasDnrm2Batched_(handle,n,x,incx,batchCount,c_loc(myResult))
-    end function
-
-    function hipblasDnrm2Batched_full_rank(handle,n,x,incx,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasDnrm2Batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batchCount
-      real(c_double),target,dimension(:,:) :: myResult
-      !
-      hipblasDnrm2Batched_full_rank = hipblasDnrm2Batched_(handle,n,x,incx,batchCount, &
-        c_loc(myResult))
-    end function
-
-    function hipblasScnrm2Batched_rank_0(handle,n,x,incx,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasScnrm2Batched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batchCount
-      real(c_float),target :: myResult
-      !
-      hipblasScnrm2Batched_rank_0 = hipblasScnrm2Batched_(handle,n,x,incx,batchCount, &
-        c_loc(myResult))
-    end function
-
-    function hipblasScnrm2Batched_rank_1(handle,n,x,incx,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasScnrm2Batched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batchCount
-      real(c_float),target,dimension(:) :: myResult
-      !
-      hipblasScnrm2Batched_rank_1 = hipblasScnrm2Batched_(handle,n,x,incx,batchCount, &
-        c_loc(myResult))
-    end function
-
-    function hipblasScnrm2Batched_full_rank(handle,n,x,incx,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasScnrm2Batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batchCount
-      real(c_float),target,dimension(:,:) :: myResult
-      !
-      hipblasScnrm2Batched_full_rank = hipblasScnrm2Batched_(handle,n,x,incx,batchCount, &
-        c_loc(myResult))
-    end function
-
-    function hipblasDznrm2Batched_rank_0(handle,n,x,incx,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasDznrm2Batched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batchCount
-      real(c_double),target :: myResult
-      !
-      hipblasDznrm2Batched_rank_0 = hipblasDznrm2Batched_(handle,n,x,incx,batchCount, &
-        c_loc(myResult))
-    end function
-
-    function hipblasDznrm2Batched_rank_1(handle,n,x,incx,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasDznrm2Batched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batchCount
-      real(c_double),target,dimension(:) :: myResult
-      !
-      hipblasDznrm2Batched_rank_1 = hipblasDznrm2Batched_(handle,n,x,incx,batchCount, &
-        c_loc(myResult))
-    end function
-
-    function hipblasDznrm2Batched_full_rank(handle,n,x,incx,batchCount,myResult)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasDznrm2Batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batchCount
-      real(c_double),target,dimension(:,:) :: myResult
-      !
-      hipblasDznrm2Batched_full_rank = hipblasDznrm2Batched_(handle,n,x,incx,batchCount, &
-        c_loc(myResult))
+      hipblasDznrm2_rank_1 = hipblasDznrm2_(handle,n,c_loc(x),incx,myResult)
     end function
 
     function hipblasSnrm2StridedBatched_rank_0(handle,n,x,incx,stridex,batchCount,myResult)
@@ -48204,10 +46812,10 @@ module hipfort_hipblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batchCount
-      real(c_float),target :: myResult
+      type(c_ptr) :: myResult
       !
       hipblasSnrm2StridedBatched_rank_0 = hipblasSnrm2StridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,batchCount,c_loc(myResult))
+        stridex,batchCount,myResult)
     end function
 
     function hipblasSnrm2StridedBatched_rank_1(handle,n,x,incx,stridex,batchCount,myResult)
@@ -48221,10 +46829,10 @@ module hipfort_hipblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batchCount
-      real(c_float),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
       hipblasSnrm2StridedBatched_rank_1 = hipblasSnrm2StridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,batchCount,c_loc(myResult))
+        stridex,batchCount,myResult)
     end function
 
     function hipblasDnrm2StridedBatched_rank_0(handle,n,x,incx,stridex,batchCount,myResult)
@@ -48238,10 +46846,10 @@ module hipfort_hipblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batchCount
-      real(c_double),target :: myResult
+      type(c_ptr) :: myResult
       !
       hipblasDnrm2StridedBatched_rank_0 = hipblasDnrm2StridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,batchCount,c_loc(myResult))
+        stridex,batchCount,myResult)
     end function
 
     function hipblasDnrm2StridedBatched_rank_1(handle,n,x,incx,stridex,batchCount,myResult)
@@ -48255,10 +46863,10 @@ module hipfort_hipblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batchCount
-      real(c_double),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
       hipblasDnrm2StridedBatched_rank_1 = hipblasDnrm2StridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,batchCount,c_loc(myResult))
+        stridex,batchCount,myResult)
     end function
 
     function hipblasScnrm2StridedBatched_rank_0(handle,n,x,incx,stridex,batchCount,myResult)
@@ -48272,10 +46880,10 @@ module hipfort_hipblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batchCount
-      real(c_float),target :: myResult
+      type(c_ptr) :: myResult
       !
       hipblasScnrm2StridedBatched_rank_0 = hipblasScnrm2StridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,batchCount,c_loc(myResult))
+        stridex,batchCount,myResult)
     end function
 
     function hipblasScnrm2StridedBatched_rank_1(handle,n,x,incx,stridex,batchCount,myResult)
@@ -48289,10 +46897,10 @@ module hipfort_hipblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batchCount
-      real(c_float),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
       hipblasScnrm2StridedBatched_rank_1 = hipblasScnrm2StridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,batchCount,c_loc(myResult))
+        stridex,batchCount,myResult)
     end function
 
     function hipblasDznrm2StridedBatched_rank_0(handle,n,x,incx,stridex,batchCount,myResult)
@@ -48306,10 +46914,10 @@ module hipfort_hipblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batchCount
-      real(c_double),target :: myResult
+      type(c_ptr) :: myResult
       !
       hipblasDznrm2StridedBatched_rank_0 = hipblasDznrm2StridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,batchCount,c_loc(myResult))
+        stridex,batchCount,myResult)
     end function
 
     function hipblasDznrm2StridedBatched_rank_1(handle,n,x,incx,stridex,batchCount,myResult)
@@ -48323,10 +46931,10 @@ module hipfort_hipblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batchCount
-      real(c_double),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
       hipblasDznrm2StridedBatched_rank_1 = hipblasDznrm2StridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,batchCount,c_loc(myResult))
+        stridex,batchCount,myResult)
     end function
 
     function hipblasSrot_rank_0(handle,n,x,incx,y,incy,c,s)
@@ -48340,10 +46948,10 @@ module hipfort_hipblas
       integer(c_int) :: incx
       real(c_float),target :: y
       integer(c_int) :: incy
-      real(c_float),target :: c
-      real(c_float),target :: s
+      type(c_ptr) :: c
+      type(c_ptr) :: s
       !
-      hipblasSrot_rank_0 = hipblasSrot_(handle,n,c_loc(x),incx,c_loc(y),incy,c_loc(c),c_loc(s))
+      hipblasSrot_rank_0 = hipblasSrot_(handle,n,c_loc(x),incx,c_loc(y),incy,c,s)
     end function
 
     function hipblasSrot_rank_1(handle,n,x,incx,y,incy,c,s)
@@ -48357,10 +46965,10 @@ module hipfort_hipblas
       integer(c_int) :: incx
       real(c_float),target,dimension(:) :: y
       integer(c_int) :: incy
-      real(c_float),target,dimension(:) :: c
-      real(c_float),target,dimension(:) :: s
+      type(c_ptr) :: c
+      type(c_ptr) :: s
       !
-      hipblasSrot_rank_1 = hipblasSrot_(handle,n,c_loc(x),incx,c_loc(y),incy,c_loc(c),c_loc(s))
+      hipblasSrot_rank_1 = hipblasSrot_(handle,n,c_loc(x),incx,c_loc(y),incy,c,s)
     end function
 
     function hipblasDrot_rank_0(handle,n,x,incx,y,incy,c,s)
@@ -48374,10 +46982,10 @@ module hipfort_hipblas
       integer(c_int) :: incx
       real(c_double),target :: y
       integer(c_int) :: incy
-      real(c_double),target :: c
-      real(c_double),target :: s
+      type(c_ptr) :: c
+      type(c_ptr) :: s
       !
-      hipblasDrot_rank_0 = hipblasDrot_(handle,n,c_loc(x),incx,c_loc(y),incy,c_loc(c),c_loc(s))
+      hipblasDrot_rank_0 = hipblasDrot_(handle,n,c_loc(x),incx,c_loc(y),incy,c,s)
     end function
 
     function hipblasDrot_rank_1(handle,n,x,incx,y,incy,c,s)
@@ -48391,10 +46999,10 @@ module hipfort_hipblas
       integer(c_int) :: incx
       real(c_double),target,dimension(:) :: y
       integer(c_int) :: incy
-      real(c_double),target,dimension(:) :: c
-      real(c_double),target,dimension(:) :: s
+      type(c_ptr) :: c
+      type(c_ptr) :: s
       !
-      hipblasDrot_rank_1 = hipblasDrot_(handle,n,c_loc(x),incx,c_loc(y),incy,c_loc(c),c_loc(s))
+      hipblasDrot_rank_1 = hipblasDrot_(handle,n,c_loc(x),incx,c_loc(y),incy,c,s)
     end function
 
     function hipblasCrot_rank_0(handle,n,x,incx,y,incy,c,s)
@@ -48408,10 +47016,10 @@ module hipfort_hipblas
       integer(c_int) :: incx
       complex(c_float_complex),target :: y
       integer(c_int) :: incy
-      real(c_float),target :: c
-      complex(c_float_complex),target :: s
+      type(c_ptr) :: c
+      type(c_ptr) :: s
       !
-      hipblasCrot_rank_0 = hipblasCrot_(handle,n,c_loc(x),incx,c_loc(y),incy,c_loc(c),c_loc(s))
+      hipblasCrot_rank_0 = hipblasCrot_(handle,n,c_loc(x),incx,c_loc(y),incy,c,s)
     end function
 
     function hipblasCrot_rank_1(handle,n,x,incx,y,incy,c,s)
@@ -48425,10 +47033,10 @@ module hipfort_hipblas
       integer(c_int) :: incx
       complex(c_float_complex),target,dimension(:) :: y
       integer(c_int) :: incy
-      real(c_float),target,dimension(:) :: c
-      complex(c_float_complex),target,dimension(:) :: s
+      type(c_ptr) :: c
+      type(c_ptr) :: s
       !
-      hipblasCrot_rank_1 = hipblasCrot_(handle,n,c_loc(x),incx,c_loc(y),incy,c_loc(c),c_loc(s))
+      hipblasCrot_rank_1 = hipblasCrot_(handle,n,c_loc(x),incx,c_loc(y),incy,c,s)
     end function
 
     function hipblasCsrot_rank_0(handle,n,x,incx,y,incy,c,s)
@@ -48442,10 +47050,10 @@ module hipfort_hipblas
       integer(c_int) :: incx
       complex(c_float_complex),target :: y
       integer(c_int) :: incy
-      real(c_float),target :: c
-      real(c_float),target :: s
+      type(c_ptr) :: c
+      type(c_ptr) :: s
       !
-      hipblasCsrot_rank_0 = hipblasCsrot_(handle,n,c_loc(x),incx,c_loc(y),incy,c_loc(c),c_loc(s))
+      hipblasCsrot_rank_0 = hipblasCsrot_(handle,n,c_loc(x),incx,c_loc(y),incy,c,s)
     end function
 
     function hipblasCsrot_rank_1(handle,n,x,incx,y,incy,c,s)
@@ -48459,10 +47067,10 @@ module hipfort_hipblas
       integer(c_int) :: incx
       complex(c_float_complex),target,dimension(:) :: y
       integer(c_int) :: incy
-      real(c_float),target,dimension(:) :: c
-      real(c_float),target,dimension(:) :: s
+      type(c_ptr) :: c
+      type(c_ptr) :: s
       !
-      hipblasCsrot_rank_1 = hipblasCsrot_(handle,n,c_loc(x),incx,c_loc(y),incy,c_loc(c),c_loc(s))
+      hipblasCsrot_rank_1 = hipblasCsrot_(handle,n,c_loc(x),incx,c_loc(y),incy,c,s)
     end function
 
     function hipblasZrot_rank_0(handle,n,x,incx,y,incy,c,s)
@@ -48476,10 +47084,10 @@ module hipfort_hipblas
       integer(c_int) :: incx
       complex(c_double_complex),target :: y
       integer(c_int) :: incy
-      real(c_double),target :: c
-      complex(c_double_complex),target :: s
+      type(c_ptr) :: c
+      type(c_ptr) :: s
       !
-      hipblasZrot_rank_0 = hipblasZrot_(handle,n,c_loc(x),incx,c_loc(y),incy,c_loc(c),c_loc(s))
+      hipblasZrot_rank_0 = hipblasZrot_(handle,n,c_loc(x),incx,c_loc(y),incy,c,s)
     end function
 
     function hipblasZrot_rank_1(handle,n,x,incx,y,incy,c,s)
@@ -48493,10 +47101,10 @@ module hipfort_hipblas
       integer(c_int) :: incx
       complex(c_double_complex),target,dimension(:) :: y
       integer(c_int) :: incy
-      real(c_double),target,dimension(:) :: c
-      complex(c_double_complex),target,dimension(:) :: s
+      type(c_ptr) :: c
+      type(c_ptr) :: s
       !
-      hipblasZrot_rank_1 = hipblasZrot_(handle,n,c_loc(x),incx,c_loc(y),incy,c_loc(c),c_loc(s))
+      hipblasZrot_rank_1 = hipblasZrot_(handle,n,c_loc(x),incx,c_loc(y),incy,c,s)
     end function
 
     function hipblasZdrot_rank_0(handle,n,x,incx,y,incy,c,s)
@@ -48510,10 +47118,10 @@ module hipfort_hipblas
       integer(c_int) :: incx
       complex(c_double_complex),target :: y
       integer(c_int) :: incy
-      real(c_double),target :: c
-      real(c_double),target :: s
+      type(c_ptr) :: c
+      type(c_ptr) :: s
       !
-      hipblasZdrot_rank_0 = hipblasZdrot_(handle,n,c_loc(x),incx,c_loc(y),incy,c_loc(c),c_loc(s))
+      hipblasZdrot_rank_0 = hipblasZdrot_(handle,n,c_loc(x),incx,c_loc(y),incy,c,s)
     end function
 
     function hipblasZdrot_rank_1(handle,n,x,incx,y,incy,c,s)
@@ -48527,352 +47135,10 @@ module hipfort_hipblas
       integer(c_int) :: incx
       complex(c_double_complex),target,dimension(:) :: y
       integer(c_int) :: incy
-      real(c_double),target,dimension(:) :: c
-      real(c_double),target,dimension(:) :: s
+      type(c_ptr) :: c
+      type(c_ptr) :: s
       !
-      hipblasZdrot_rank_1 = hipblasZdrot_(handle,n,c_loc(x),incx,c_loc(y),incy,c_loc(c),c_loc(s))
-    end function
-
-    function hipblasSrotBatched_rank_0(handle,n,x,incx,y,incy,c,s,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasSrotBatched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      type(c_ptr) :: y
-      integer(c_int) :: incy
-      real(c_float),target :: c
-      real(c_float),target :: s
-      integer(c_int) :: batchCount
-      !
-      hipblasSrotBatched_rank_0 = hipblasSrotBatched_(handle,n,x,incx,y,incy,c_loc(c),c_loc(s), &
-        batchCount)
-    end function
-
-    function hipblasSrotBatched_rank_1(handle,n,x,incx,y,incy,c,s,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasSrotBatched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      type(c_ptr) :: y
-      integer(c_int) :: incy
-      real(c_float),target,dimension(:) :: c
-      real(c_float),target,dimension(:) :: s
-      integer(c_int) :: batchCount
-      !
-      hipblasSrotBatched_rank_1 = hipblasSrotBatched_(handle,n,x,incx,y,incy,c_loc(c),c_loc(s), &
-        batchCount)
-    end function
-
-    function hipblasSrotBatched_full_rank(handle,n,x,incx,y,incy,c,s,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasSrotBatched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      type(c_ptr) :: y
-      integer(c_int) :: incy
-      real(c_float),target,dimension(:,:) :: c
-      real(c_float),target,dimension(:,:) :: s
-      integer(c_int) :: batchCount
-      !
-      hipblasSrotBatched_full_rank = hipblasSrotBatched_(handle,n,x,incx,y,incy,c_loc(c),c_loc(s), &
-        batchCount)
-    end function
-
-    function hipblasDrotBatched_rank_0(handle,n,x,incx,y,incy,c,s,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasDrotBatched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      type(c_ptr) :: y
-      integer(c_int) :: incy
-      real(c_double),target :: c
-      real(c_double),target :: s
-      integer(c_int) :: batchCount
-      !
-      hipblasDrotBatched_rank_0 = hipblasDrotBatched_(handle,n,x,incx,y,incy,c_loc(c),c_loc(s), &
-        batchCount)
-    end function
-
-    function hipblasDrotBatched_rank_1(handle,n,x,incx,y,incy,c,s,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasDrotBatched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      type(c_ptr) :: y
-      integer(c_int) :: incy
-      real(c_double),target,dimension(:) :: c
-      real(c_double),target,dimension(:) :: s
-      integer(c_int) :: batchCount
-      !
-      hipblasDrotBatched_rank_1 = hipblasDrotBatched_(handle,n,x,incx,y,incy,c_loc(c),c_loc(s), &
-        batchCount)
-    end function
-
-    function hipblasDrotBatched_full_rank(handle,n,x,incx,y,incy,c,s,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasDrotBatched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      type(c_ptr) :: y
-      integer(c_int) :: incy
-      real(c_double),target,dimension(:,:) :: c
-      real(c_double),target,dimension(:,:) :: s
-      integer(c_int) :: batchCount
-      !
-      hipblasDrotBatched_full_rank = hipblasDrotBatched_(handle,n,x,incx,y,incy,c_loc(c),c_loc(s), &
-        batchCount)
-    end function
-
-    function hipblasCrotBatched_rank_0(handle,n,x,incx,y,incy,c,s,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasCrotBatched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      type(c_ptr) :: y
-      integer(c_int) :: incy
-      real(c_float),target :: c
-      complex(c_float_complex),target :: s
-      integer(c_int) :: batchCount
-      !
-      hipblasCrotBatched_rank_0 = hipblasCrotBatched_(handle,n,x,incx,y,incy,c_loc(c),c_loc(s), &
-        batchCount)
-    end function
-
-    function hipblasCrotBatched_rank_1(handle,n,x,incx,y,incy,c,s,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasCrotBatched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      type(c_ptr) :: y
-      integer(c_int) :: incy
-      real(c_float),target,dimension(:) :: c
-      complex(c_float_complex),target,dimension(:) :: s
-      integer(c_int) :: batchCount
-      !
-      hipblasCrotBatched_rank_1 = hipblasCrotBatched_(handle,n,x,incx,y,incy,c_loc(c),c_loc(s), &
-        batchCount)
-    end function
-
-    function hipblasCrotBatched_full_rank(handle,n,x,incx,y,incy,c,s,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasCrotBatched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      type(c_ptr) :: y
-      integer(c_int) :: incy
-      real(c_float),target,dimension(:,:) :: c
-      complex(c_float_complex),target,dimension(:,:) :: s
-      integer(c_int) :: batchCount
-      !
-      hipblasCrotBatched_full_rank = hipblasCrotBatched_(handle,n,x,incx,y,incy,c_loc(c),c_loc(s), &
-        batchCount)
-    end function
-
-    function hipblasCsrotBatched_rank_0(handle,n,x,incx,y,incy,c,s,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasCsrotBatched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      type(c_ptr) :: y
-      integer(c_int) :: incy
-      real(c_float),target :: c
-      real(c_float),target :: s
-      integer(c_int) :: batchCount
-      !
-      hipblasCsrotBatched_rank_0 = hipblasCsrotBatched_(handle,n,x,incx,y,incy,c_loc(c),c_loc(s), &
-        batchCount)
-    end function
-
-    function hipblasCsrotBatched_rank_1(handle,n,x,incx,y,incy,c,s,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasCsrotBatched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      type(c_ptr) :: y
-      integer(c_int) :: incy
-      real(c_float),target,dimension(:) :: c
-      real(c_float),target,dimension(:) :: s
-      integer(c_int) :: batchCount
-      !
-      hipblasCsrotBatched_rank_1 = hipblasCsrotBatched_(handle,n,x,incx,y,incy,c_loc(c),c_loc(s), &
-        batchCount)
-    end function
-
-    function hipblasCsrotBatched_full_rank(handle,n,x,incx,y,incy,c,s,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasCsrotBatched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      type(c_ptr) :: y
-      integer(c_int) :: incy
-      real(c_float),target,dimension(:,:) :: c
-      real(c_float),target,dimension(:,:) :: s
-      integer(c_int) :: batchCount
-      !
-      hipblasCsrotBatched_full_rank = hipblasCsrotBatched_(handle,n,x,incx,y,incy,c_loc(c), &
-        c_loc(s),batchCount)
-    end function
-
-    function hipblasZrotBatched_rank_0(handle,n,x,incx,y,incy,c,s,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasZrotBatched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      type(c_ptr) :: y
-      integer(c_int) :: incy
-      real(c_double),target :: c
-      complex(c_double_complex),target :: s
-      integer(c_int) :: batchCount
-      !
-      hipblasZrotBatched_rank_0 = hipblasZrotBatched_(handle,n,x,incx,y,incy,c_loc(c),c_loc(s), &
-        batchCount)
-    end function
-
-    function hipblasZrotBatched_rank_1(handle,n,x,incx,y,incy,c,s,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasZrotBatched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      type(c_ptr) :: y
-      integer(c_int) :: incy
-      real(c_double),target,dimension(:) :: c
-      complex(c_double_complex),target,dimension(:) :: s
-      integer(c_int) :: batchCount
-      !
-      hipblasZrotBatched_rank_1 = hipblasZrotBatched_(handle,n,x,incx,y,incy,c_loc(c),c_loc(s), &
-        batchCount)
-    end function
-
-    function hipblasZrotBatched_full_rank(handle,n,x,incx,y,incy,c,s,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasZrotBatched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      type(c_ptr) :: y
-      integer(c_int) :: incy
-      real(c_double),target,dimension(:,:) :: c
-      complex(c_double_complex),target,dimension(:,:) :: s
-      integer(c_int) :: batchCount
-      !
-      hipblasZrotBatched_full_rank = hipblasZrotBatched_(handle,n,x,incx,y,incy,c_loc(c),c_loc(s), &
-        batchCount)
-    end function
-
-    function hipblasZdrotBatched_rank_0(handle,n,x,incx,y,incy,c,s,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasZdrotBatched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      type(c_ptr) :: y
-      integer(c_int) :: incy
-      real(c_double),target :: c
-      real(c_double),target :: s
-      integer(c_int) :: batchCount
-      !
-      hipblasZdrotBatched_rank_0 = hipblasZdrotBatched_(handle,n,x,incx,y,incy,c_loc(c),c_loc(s), &
-        batchCount)
-    end function
-
-    function hipblasZdrotBatched_rank_1(handle,n,x,incx,y,incy,c,s,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasZdrotBatched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      type(c_ptr) :: y
-      integer(c_int) :: incy
-      real(c_double),target,dimension(:) :: c
-      real(c_double),target,dimension(:) :: s
-      integer(c_int) :: batchCount
-      !
-      hipblasZdrotBatched_rank_1 = hipblasZdrotBatched_(handle,n,x,incx,y,incy,c_loc(c),c_loc(s), &
-        batchCount)
-    end function
-
-    function hipblasZdrotBatched_full_rank(handle,n,x,incx,y,incy,c,s,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasZdrotBatched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      type(c_ptr) :: y
-      integer(c_int) :: incy
-      real(c_double),target,dimension(:,:) :: c
-      real(c_double),target,dimension(:,:) :: s
-      integer(c_int) :: batchCount
-      !
-      hipblasZdrotBatched_full_rank = hipblasZdrotBatched_(handle,n,x,incx,y,incy,c_loc(c), &
-        c_loc(s),batchCount)
+      hipblasZdrot_rank_1 = hipblasZdrot_(handle,n,c_loc(x),incx,c_loc(y),incy,c,s)
     end function
 
     function hipblasSrotStridedBatched_rank_0(handle,n,x,incx,stridex,y,incy,stridey,c,s,batchCount)
@@ -48888,12 +47154,12 @@ module hipfort_hipblas
       real(c_float),target :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
-      real(c_float),target :: c
-      real(c_float),target :: s
+      type(c_ptr) :: c
+      type(c_ptr) :: s
       integer(c_int) :: batchCount
       !
       hipblasSrotStridedBatched_rank_0 = hipblasSrotStridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,c_loc(y),incy,stridey,c_loc(c),c_loc(s),batchCount)
+        stridex,c_loc(y),incy,stridey,c,s,batchCount)
     end function
 
     function hipblasSrotStridedBatched_rank_1(handle,n,x,incx,stridex,y,incy,stridey,c,s,batchCount)
@@ -48909,12 +47175,12 @@ module hipfort_hipblas
       real(c_float),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
-      real(c_float),target,dimension(:) :: c
-      real(c_float),target,dimension(:) :: s
+      type(c_ptr) :: c
+      type(c_ptr) :: s
       integer(c_int) :: batchCount
       !
       hipblasSrotStridedBatched_rank_1 = hipblasSrotStridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,c_loc(y),incy,stridey,c_loc(c),c_loc(s),batchCount)
+        stridex,c_loc(y),incy,stridey,c,s,batchCount)
     end function
 
     function hipblasDrotStridedBatched_rank_0(handle,n,x,incx,stridex,y,incy,stridey,c,s,batchCount)
@@ -48930,12 +47196,12 @@ module hipfort_hipblas
       real(c_double),target :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
-      real(c_double),target :: c
-      real(c_double),target :: s
+      type(c_ptr) :: c
+      type(c_ptr) :: s
       integer(c_int) :: batchCount
       !
       hipblasDrotStridedBatched_rank_0 = hipblasDrotStridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,c_loc(y),incy,stridey,c_loc(c),c_loc(s),batchCount)
+        stridex,c_loc(y),incy,stridey,c,s,batchCount)
     end function
 
     function hipblasDrotStridedBatched_rank_1(handle,n,x,incx,stridex,y,incy,stridey,c,s,batchCount)
@@ -48951,12 +47217,12 @@ module hipfort_hipblas
       real(c_double),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
-      real(c_double),target,dimension(:) :: c
-      real(c_double),target,dimension(:) :: s
+      type(c_ptr) :: c
+      type(c_ptr) :: s
       integer(c_int) :: batchCount
       !
       hipblasDrotStridedBatched_rank_1 = hipblasDrotStridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,c_loc(y),incy,stridey,c_loc(c),c_loc(s),batchCount)
+        stridex,c_loc(y),incy,stridey,c,s,batchCount)
     end function
 
     function hipblasCrotStridedBatched_rank_0(handle,n,x,incx,stridex,y,incy,stridey,c,s,batchCount)
@@ -48972,12 +47238,12 @@ module hipfort_hipblas
       complex(c_float_complex),target :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
-      real(c_float),target :: c
-      complex(c_float_complex),target :: s
+      type(c_ptr) :: c
+      type(c_ptr) :: s
       integer(c_int) :: batchCount
       !
       hipblasCrotStridedBatched_rank_0 = hipblasCrotStridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,c_loc(y),incy,stridey,c_loc(c),c_loc(s),batchCount)
+        stridex,c_loc(y),incy,stridey,c,s,batchCount)
     end function
 
     function hipblasCrotStridedBatched_rank_1(handle,n,x,incx,stridex,y,incy,stridey,c,s,batchCount)
@@ -48993,12 +47259,12 @@ module hipfort_hipblas
       complex(c_float_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
-      real(c_float),target,dimension(:) :: c
-      complex(c_float_complex),target,dimension(:) :: s
+      type(c_ptr) :: c
+      type(c_ptr) :: s
       integer(c_int) :: batchCount
       !
       hipblasCrotStridedBatched_rank_1 = hipblasCrotStridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,c_loc(y),incy,stridey,c_loc(c),c_loc(s),batchCount)
+        stridex,c_loc(y),incy,stridey,c,s,batchCount)
     end function
 
     function hipblasCsrotStridedBatched_rank_0(handle,n,x,incx,stridex,y,incy,stridey,c,s, &
@@ -49015,12 +47281,12 @@ module hipfort_hipblas
       complex(c_float_complex),target :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
-      real(c_float),target :: c
-      real(c_float),target :: s
+      type(c_ptr) :: c
+      type(c_ptr) :: s
       integer(c_int) :: batchCount
       !
       hipblasCsrotStridedBatched_rank_0 = hipblasCsrotStridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,c_loc(y),incy,stridey,c_loc(c),c_loc(s),batchCount)
+        stridex,c_loc(y),incy,stridey,c,s,batchCount)
     end function
 
     function hipblasCsrotStridedBatched_rank_1(handle,n,x,incx,stridex,y,incy,stridey,c,s, &
@@ -49037,12 +47303,12 @@ module hipfort_hipblas
       complex(c_float_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
-      real(c_float),target,dimension(:) :: c
-      real(c_float),target,dimension(:) :: s
+      type(c_ptr) :: c
+      type(c_ptr) :: s
       integer(c_int) :: batchCount
       !
       hipblasCsrotStridedBatched_rank_1 = hipblasCsrotStridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,c_loc(y),incy,stridey,c_loc(c),c_loc(s),batchCount)
+        stridex,c_loc(y),incy,stridey,c,s,batchCount)
     end function
 
     function hipblasZrotStridedBatched_rank_0(handle,n,x,incx,stridex,y,incy,stridey,c,s,batchCount)
@@ -49058,12 +47324,12 @@ module hipfort_hipblas
       complex(c_double_complex),target :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
-      real(c_double),target :: c
-      complex(c_double_complex),target :: s
+      type(c_ptr) :: c
+      type(c_ptr) :: s
       integer(c_int) :: batchCount
       !
       hipblasZrotStridedBatched_rank_0 = hipblasZrotStridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,c_loc(y),incy,stridey,c_loc(c),c_loc(s),batchCount)
+        stridex,c_loc(y),incy,stridey,c,s,batchCount)
     end function
 
     function hipblasZrotStridedBatched_rank_1(handle,n,x,incx,stridex,y,incy,stridey,c,s,batchCount)
@@ -49079,12 +47345,12 @@ module hipfort_hipblas
       complex(c_double_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
-      real(c_double),target,dimension(:) :: c
-      complex(c_double_complex),target,dimension(:) :: s
+      type(c_ptr) :: c
+      type(c_ptr) :: s
       integer(c_int) :: batchCount
       !
       hipblasZrotStridedBatched_rank_1 = hipblasZrotStridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,c_loc(y),incy,stridey,c_loc(c),c_loc(s),batchCount)
+        stridex,c_loc(y),incy,stridey,c,s,batchCount)
     end function
 
     function hipblasZdrotStridedBatched_rank_0(handle,n,x,incx,stridex,y,incy,stridey,c,s, &
@@ -49101,12 +47367,12 @@ module hipfort_hipblas
       complex(c_double_complex),target :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
-      real(c_double),target :: c
-      real(c_double),target :: s
+      type(c_ptr) :: c
+      type(c_ptr) :: s
       integer(c_int) :: batchCount
       !
       hipblasZdrotStridedBatched_rank_0 = hipblasZdrotStridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,c_loc(y),incy,stridey,c_loc(c),c_loc(s),batchCount)
+        stridex,c_loc(y),incy,stridey,c,s,batchCount)
     end function
 
     function hipblasZdrotStridedBatched_rank_1(handle,n,x,incx,stridex,y,incy,stridey,c,s, &
@@ -49123,12 +47389,12 @@ module hipfort_hipblas
       complex(c_double_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
-      real(c_double),target,dimension(:) :: c
-      real(c_double),target,dimension(:) :: s
+      type(c_ptr) :: c
+      type(c_ptr) :: s
       integer(c_int) :: batchCount
       !
       hipblasZdrotStridedBatched_rank_1 = hipblasZdrotStridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,c_loc(y),incy,stridey,c_loc(c),c_loc(s),batchCount)
+        stridex,c_loc(y),incy,stridey,c,s,batchCount)
     end function
 
     function hipblasSrotm_rank_0(handle,n,x,incx,y,incy,param)
@@ -49142,9 +47408,9 @@ module hipfort_hipblas
       integer(c_int) :: incx
       real(c_float),target :: y
       integer(c_int) :: incy
-      real(c_float),target :: param
+      type(c_ptr) :: param
       !
-      hipblasSrotm_rank_0 = hipblasSrotm_(handle,n,c_loc(x),incx,c_loc(y),incy,c_loc(param))
+      hipblasSrotm_rank_0 = hipblasSrotm_(handle,n,c_loc(x),incx,c_loc(y),incy,param)
     end function
 
     function hipblasSrotm_rank_1(handle,n,x,incx,y,incy,param)
@@ -49158,9 +47424,9 @@ module hipfort_hipblas
       integer(c_int) :: incx
       real(c_float),target,dimension(:) :: y
       integer(c_int) :: incy
-      real(c_float),target,dimension(:) :: param
+      type(c_ptr) :: param
       !
-      hipblasSrotm_rank_1 = hipblasSrotm_(handle,n,c_loc(x),incx,c_loc(y),incy,c_loc(param))
+      hipblasSrotm_rank_1 = hipblasSrotm_(handle,n,c_loc(x),incx,c_loc(y),incy,param)
     end function
 
     function hipblasDrotm_rank_0(handle,n,x,incx,y,incy,param)
@@ -49174,9 +47440,9 @@ module hipfort_hipblas
       integer(c_int) :: incx
       real(c_double),target :: y
       integer(c_int) :: incy
-      real(c_double),target :: param
+      type(c_ptr) :: param
       !
-      hipblasDrotm_rank_0 = hipblasDrotm_(handle,n,c_loc(x),incx,c_loc(y),incy,c_loc(param))
+      hipblasDrotm_rank_0 = hipblasDrotm_(handle,n,c_loc(x),incx,c_loc(y),incy,param)
     end function
 
     function hipblasDrotm_rank_1(handle,n,x,incx,y,incy,param)
@@ -49190,9 +47456,9 @@ module hipfort_hipblas
       integer(c_int) :: incx
       real(c_double),target,dimension(:) :: y
       integer(c_int) :: incy
-      real(c_double),target,dimension(:) :: param
+      type(c_ptr) :: param
       !
-      hipblasDrotm_rank_1 = hipblasDrotm_(handle,n,c_loc(x),incx,c_loc(y),incy,c_loc(param))
+      hipblasDrotm_rank_1 = hipblasDrotm_(handle,n,c_loc(x),incx,c_loc(y),incy,param)
     end function
 
     function hipblasSrotmStridedBatched_rank_0(handle,n,x,incx,stridex,y,incy,stridey,param, &
@@ -49209,12 +47475,12 @@ module hipfort_hipblas
       real(c_float),target :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
-      real(c_float),target :: param
+      type(c_ptr) :: param
       integer(c_int64_t) :: strideParam
       integer(c_int) :: batchCount
       !
       hipblasSrotmStridedBatched_rank_0 = hipblasSrotmStridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,c_loc(y),incy,stridey,c_loc(param),strideParam,batchCount)
+        stridex,c_loc(y),incy,stridey,param,strideParam,batchCount)
     end function
 
     function hipblasSrotmStridedBatched_rank_1(handle,n,x,incx,stridex,y,incy,stridey,param, &
@@ -49231,12 +47497,12 @@ module hipfort_hipblas
       real(c_float),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
-      real(c_float),target,dimension(:) :: param
+      type(c_ptr) :: param
       integer(c_int64_t) :: strideParam
       integer(c_int) :: batchCount
       !
       hipblasSrotmStridedBatched_rank_1 = hipblasSrotmStridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,c_loc(y),incy,stridey,c_loc(param),strideParam,batchCount)
+        stridex,c_loc(y),incy,stridey,param,strideParam,batchCount)
     end function
 
     function hipblasDrotmStridedBatched_rank_0(handle,n,x,incx,stridex,y,incy,stridey,param, &
@@ -49253,12 +47519,12 @@ module hipfort_hipblas
       real(c_double),target :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
-      real(c_double),target :: param
+      type(c_ptr) :: param
       integer(c_int64_t) :: strideParam
       integer(c_int) :: batchCount
       !
       hipblasDrotmStridedBatched_rank_0 = hipblasDrotmStridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,c_loc(y),incy,stridey,c_loc(param),strideParam,batchCount)
+        stridex,c_loc(y),incy,stridey,param,strideParam,batchCount)
     end function
 
     function hipblasDrotmStridedBatched_rank_1(handle,n,x,incx,stridex,y,incy,stridey,param, &
@@ -49275,12 +47541,12 @@ module hipfort_hipblas
       real(c_double),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
-      real(c_double),target,dimension(:) :: param
+      type(c_ptr) :: param
       integer(c_int64_t) :: strideParam
       integer(c_int) :: batchCount
       !
       hipblasDrotmStridedBatched_rank_1 = hipblasDrotmStridedBatched_(handle,n,c_loc(x),incx, &
-        stridex,c_loc(y),incy,stridey,c_loc(param),strideParam,batchCount)
+        stridex,c_loc(y),incy,stridey,param,strideParam,batchCount)
     end function
 
     function hipblasSscal_rank_0(handle,n,alpha,x,incx)
@@ -49989,10 +48255,10 @@ module hipfort_hipblas
       real(c_float) :: alpha
       real(c_float),target,dimension(:,:) :: AP
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: x
+      real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       real(c_float) :: beta
-      real(c_float),target,dimension(:,:) :: y
+      real(c_float),target,dimension(:) :: y
       integer(c_int) :: incy
       !
       hipblasSgbmv_full_rank = hipblasSgbmv_(handle,trans,m,n,kl,ku,alpha,c_loc(AP),lda,c_loc(x), &
@@ -50061,10 +48327,10 @@ module hipfort_hipblas
       real(c_double) :: alpha
       real(c_double),target,dimension(:,:) :: AP
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: x
+      real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       real(c_double) :: beta
-      real(c_double),target,dimension(:,:) :: y
+      real(c_double),target,dimension(:) :: y
       integer(c_int) :: incy
       !
       hipblasDgbmv_full_rank = hipblasDgbmv_(handle,trans,m,n,kl,ku,alpha,c_loc(AP),lda,c_loc(x), &
@@ -50133,10 +48399,10 @@ module hipfort_hipblas
       complex(c_float_complex) :: alpha
       complex(c_float_complex),target,dimension(:,:) :: AP
       integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       complex(c_float_complex) :: beta
-      complex(c_float_complex),target,dimension(:,:) :: y
+      complex(c_float_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       !
       hipblasCgbmv_full_rank = hipblasCgbmv_(handle,trans,m,n,kl,ku,alpha,c_loc(AP),lda,c_loc(x), &
@@ -50205,10 +48471,10 @@ module hipfort_hipblas
       complex(c_double_complex) :: alpha
       complex(c_double_complex),target,dimension(:,:) :: AP
       integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       complex(c_double_complex) :: beta
-      complex(c_double_complex),target,dimension(:,:) :: y
+      complex(c_double_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       !
       hipblasZgbmv_full_rank = hipblasZgbmv_(handle,trans,m,n,kl,ku,alpha,c_loc(AP),lda,c_loc(x), &
@@ -50289,11 +48555,11 @@ module hipfort_hipblas
       real(c_float),target,dimension(:,:) :: AP
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_float),target,dimension(:,:) :: x
+      real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       real(c_float) :: beta
-      real(c_float),target,dimension(:,:) :: y
+      real(c_float),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       integer(c_int) :: batchCount
@@ -50376,11 +48642,11 @@ module hipfort_hipblas
       real(c_double),target,dimension(:,:) :: AP
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_double),target,dimension(:,:) :: x
+      real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       real(c_double) :: beta
-      real(c_double),target,dimension(:,:) :: y
+      real(c_double),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       integer(c_int) :: batchCount
@@ -50463,11 +48729,11 @@ module hipfort_hipblas
       complex(c_float_complex),target,dimension(:,:) :: AP
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       complex(c_float_complex) :: beta
-      complex(c_float_complex),target,dimension(:,:) :: y
+      complex(c_float_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       integer(c_int) :: batchCount
@@ -50550,11 +48816,11 @@ module hipfort_hipblas
       complex(c_double_complex),target,dimension(:,:) :: AP
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       complex(c_double_complex) :: beta
-      complex(c_double_complex),target,dimension(:,:) :: y
+      complex(c_double_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       integer(c_int) :: batchCount
@@ -50619,10 +48885,10 @@ module hipfort_hipblas
       real(c_float) :: alpha
       real(c_float),target,dimension(:,:) :: AP
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: x
+      real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       real(c_float) :: beta
-      real(c_float),target,dimension(:,:) :: y
+      real(c_float),target,dimension(:) :: y
       integer(c_int) :: incy
       !
       hipblasSgemv_full_rank = hipblasSgemv_(handle,trans,m,n,alpha,c_loc(AP),lda,c_loc(x),incx, &
@@ -50685,10 +48951,10 @@ module hipfort_hipblas
       real(c_double) :: alpha
       real(c_double),target,dimension(:,:) :: AP
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: x
+      real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       real(c_double) :: beta
-      real(c_double),target,dimension(:,:) :: y
+      real(c_double),target,dimension(:) :: y
       integer(c_int) :: incy
       !
       hipblasDgemv_full_rank = hipblasDgemv_(handle,trans,m,n,alpha,c_loc(AP),lda,c_loc(x),incx, &
@@ -50751,10 +49017,10 @@ module hipfort_hipblas
       complex(c_float_complex) :: alpha
       complex(c_float_complex),target,dimension(:,:) :: AP
       integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       complex(c_float_complex) :: beta
-      complex(c_float_complex),target,dimension(:,:) :: y
+      complex(c_float_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       !
       hipblasCgemv_full_rank = hipblasCgemv_(handle,trans,m,n,alpha,c_loc(AP),lda,c_loc(x),incx, &
@@ -50817,10 +49083,10 @@ module hipfort_hipblas
       complex(c_double_complex) :: alpha
       complex(c_double_complex),target,dimension(:,:) :: AP
       integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       complex(c_double_complex) :: beta
-      complex(c_double_complex),target,dimension(:,:) :: y
+      complex(c_double_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       !
       hipblasZgemv_full_rank = hipblasZgemv_(handle,trans,m,n,alpha,c_loc(AP),lda,c_loc(x),incx, &
@@ -50895,11 +49161,11 @@ module hipfort_hipblas
       real(c_float),target,dimension(:,:) :: AP
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_float),target,dimension(:,:) :: x
+      real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       real(c_float) :: beta
-      real(c_float),target,dimension(:,:) :: y
+      real(c_float),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       integer(c_int) :: batchCount
@@ -50976,11 +49242,11 @@ module hipfort_hipblas
       real(c_double),target,dimension(:,:) :: AP
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_double),target,dimension(:,:) :: x
+      real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       real(c_double) :: beta
-      real(c_double),target,dimension(:,:) :: y
+      real(c_double),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       integer(c_int) :: batchCount
@@ -51057,11 +49323,11 @@ module hipfort_hipblas
       complex(c_float_complex),target,dimension(:,:) :: AP
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       complex(c_float_complex) :: beta
-      complex(c_float_complex),target,dimension(:,:) :: y
+      complex(c_float_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       integer(c_int) :: batchCount
@@ -51138,11 +49404,11 @@ module hipfort_hipblas
       complex(c_double_complex),target,dimension(:,:) :: AP
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       complex(c_double_complex) :: beta
-      complex(c_double_complex),target,dimension(:,:) :: y
+      complex(c_double_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       integer(c_int) :: batchCount
@@ -51198,9 +49464,9 @@ module hipfort_hipblas
       integer(c_int) :: m
       integer(c_int) :: n
       real(c_float) :: alpha
-      real(c_float),target,dimension(:,:) :: x
+      real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
-      real(c_float),target,dimension(:,:) :: y
+      real(c_float),target,dimension(:) :: y
       integer(c_int) :: incy
       real(c_float),target,dimension(:,:) :: AP
       integer(c_int) :: lda
@@ -51256,9 +49522,9 @@ module hipfort_hipblas
       integer(c_int) :: m
       integer(c_int) :: n
       real(c_double) :: alpha
-      real(c_double),target,dimension(:,:) :: x
+      real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
-      real(c_double),target,dimension(:,:) :: y
+      real(c_double),target,dimension(:) :: y
       integer(c_int) :: incy
       real(c_double),target,dimension(:,:) :: AP
       integer(c_int) :: lda
@@ -51316,9 +49582,9 @@ module hipfort_hipblas
       integer(c_int) :: m
       integer(c_int) :: n
       complex(c_float_complex) :: alpha
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
-      complex(c_float_complex),target,dimension(:,:) :: y
+      complex(c_float_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       complex(c_float_complex),target,dimension(:,:) :: AP
       integer(c_int) :: lda
@@ -51376,9 +49642,9 @@ module hipfort_hipblas
       integer(c_int) :: m
       integer(c_int) :: n
       complex(c_float_complex) :: alpha
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
-      complex(c_float_complex),target,dimension(:,:) :: y
+      complex(c_float_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       complex(c_float_complex),target,dimension(:,:) :: AP
       integer(c_int) :: lda
@@ -51436,9 +49702,9 @@ module hipfort_hipblas
       integer(c_int) :: m
       integer(c_int) :: n
       complex(c_double_complex) :: alpha
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
-      complex(c_double_complex),target,dimension(:,:) :: y
+      complex(c_double_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       complex(c_double_complex),target,dimension(:,:) :: AP
       integer(c_int) :: lda
@@ -51496,9 +49762,9 @@ module hipfort_hipblas
       integer(c_int) :: m
       integer(c_int) :: n
       complex(c_double_complex) :: alpha
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
-      complex(c_double_complex),target,dimension(:,:) :: y
+      complex(c_double_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       complex(c_double_complex),target,dimension(:,:) :: AP
       integer(c_int) :: lda
@@ -51567,10 +49833,10 @@ module hipfort_hipblas
       integer(c_int) :: m
       integer(c_int) :: n
       real(c_float) :: alpha
-      real(c_float),target,dimension(:,:) :: x
+      real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
-      real(c_float),target,dimension(:,:) :: y
+      real(c_float),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       real(c_float),target,dimension(:,:) :: AP
@@ -51642,10 +49908,10 @@ module hipfort_hipblas
       integer(c_int) :: m
       integer(c_int) :: n
       real(c_double) :: alpha
-      real(c_double),target,dimension(:,:) :: x
+      real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
-      real(c_double),target,dimension(:,:) :: y
+      real(c_double),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       real(c_double),target,dimension(:,:) :: AP
@@ -51717,10 +49983,10 @@ module hipfort_hipblas
       integer(c_int) :: m
       integer(c_int) :: n
       complex(c_float_complex) :: alpha
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
-      complex(c_float_complex),target,dimension(:,:) :: y
+      complex(c_float_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       complex(c_float_complex),target,dimension(:,:) :: AP
@@ -51792,10 +50058,10 @@ module hipfort_hipblas
       integer(c_int) :: m
       integer(c_int) :: n
       complex(c_float_complex) :: alpha
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
-      complex(c_float_complex),target,dimension(:,:) :: y
+      complex(c_float_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       complex(c_float_complex),target,dimension(:,:) :: AP
@@ -51867,10 +50133,10 @@ module hipfort_hipblas
       integer(c_int) :: m
       integer(c_int) :: n
       complex(c_double_complex) :: alpha
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
-      complex(c_double_complex),target,dimension(:,:) :: y
+      complex(c_double_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       complex(c_double_complex),target,dimension(:,:) :: AP
@@ -51942,10 +50208,10 @@ module hipfort_hipblas
       integer(c_int) :: m
       integer(c_int) :: n
       complex(c_double_complex) :: alpha
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
-      complex(c_double_complex),target,dimension(:,:) :: y
+      complex(c_double_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       complex(c_double_complex),target,dimension(:,:) :: AP
@@ -52013,10 +50279,10 @@ module hipfort_hipblas
       complex(c_float_complex) :: alpha
       complex(c_float_complex),target,dimension(:,:) :: AP
       integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       complex(c_float_complex) :: beta
-      complex(c_float_complex),target,dimension(:,:) :: y
+      complex(c_float_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       !
       hipblasChbmv_full_rank = hipblasChbmv_(handle,uplo,n,k,alpha,c_loc(AP),lda,c_loc(x),incx, &
@@ -52079,10 +50345,10 @@ module hipfort_hipblas
       complex(c_double_complex) :: alpha
       complex(c_double_complex),target,dimension(:,:) :: AP
       integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       complex(c_double_complex) :: beta
-      complex(c_double_complex),target,dimension(:,:) :: y
+      complex(c_double_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       !
       hipblasZhbmv_full_rank = hipblasZhbmv_(handle,uplo,n,k,alpha,c_loc(AP),lda,c_loc(x),incx, &
@@ -52157,11 +50423,11 @@ module hipfort_hipblas
       complex(c_float_complex),target,dimension(:,:) :: AP
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       complex(c_float_complex) :: beta
-      complex(c_float_complex),target,dimension(:,:) :: y
+      complex(c_float_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       integer(c_int) :: batchCount
@@ -52238,11 +50504,11 @@ module hipfort_hipblas
       complex(c_double_complex),target,dimension(:,:) :: AP
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       complex(c_double_complex) :: beta
-      complex(c_double_complex),target,dimension(:,:) :: y
+      complex(c_double_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       integer(c_int) :: batchCount
@@ -52304,10 +50570,10 @@ module hipfort_hipblas
       complex(c_float_complex) :: alpha
       complex(c_float_complex),target,dimension(:,:) :: AP
       integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       complex(c_float_complex) :: beta
-      complex(c_float_complex),target,dimension(:,:) :: y
+      complex(c_float_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       !
       hipblasChemv_full_rank = hipblasChemv_(handle,uplo,n,alpha,c_loc(AP),lda,c_loc(x),incx,beta, &
@@ -52367,10 +50633,10 @@ module hipfort_hipblas
       complex(c_double_complex) :: alpha
       complex(c_double_complex),target,dimension(:,:) :: AP
       integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       complex(c_double_complex) :: beta
-      complex(c_double_complex),target,dimension(:,:) :: y
+      complex(c_double_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       !
       hipblasZhemv_full_rank = hipblasZhemv_(handle,uplo,n,alpha,c_loc(AP),lda,c_loc(x),incx,beta, &
@@ -52442,11 +50708,11 @@ module hipfort_hipblas
       complex(c_float_complex),target,dimension(:,:) :: AP
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       complex(c_float_complex) :: beta
-      complex(c_float_complex),target,dimension(:,:) :: y
+      complex(c_float_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       integer(c_int) :: batchCount
@@ -52520,11 +50786,11 @@ module hipfort_hipblas
       complex(c_double_complex),target,dimension(:,:) :: AP
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       complex(c_double_complex) :: beta
-      complex(c_double_complex),target,dimension(:,:) :: y
+      complex(c_double_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       integer(c_int) :: batchCount
@@ -52576,7 +50842,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       real(c_float) :: alpha
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       complex(c_float_complex),target,dimension(:,:) :: AP
       integer(c_int) :: lda
@@ -52627,7 +50893,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       real(c_double) :: alpha
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       complex(c_double_complex),target,dimension(:,:) :: AP
       integer(c_int) :: lda
@@ -52689,7 +50955,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       real(c_float) :: alpha
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       complex(c_float_complex),target,dimension(:,:) :: AP
@@ -52755,7 +51021,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       real(c_double) :: alpha
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       complex(c_double_complex),target,dimension(:,:) :: AP
@@ -52816,9 +51082,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       complex(c_float_complex) :: alpha
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
-      complex(c_float_complex),target,dimension(:,:) :: y
+      complex(c_float_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       complex(c_float_complex),target,dimension(:,:) :: AP
       integer(c_int) :: lda
@@ -52876,9 +51142,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       complex(c_double_complex) :: alpha
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
-      complex(c_double_complex),target,dimension(:,:) :: y
+      complex(c_double_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       complex(c_double_complex),target,dimension(:,:) :: AP
       integer(c_int) :: lda
@@ -52947,10 +51213,10 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       complex(c_float_complex) :: alpha
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
-      complex(c_float_complex),target,dimension(:,:) :: y
+      complex(c_float_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       complex(c_float_complex),target,dimension(:,:) :: AP
@@ -53022,10 +51288,10 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       complex(c_double_complex) :: alpha
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
-      complex(c_double_complex),target,dimension(:,:) :: y
+      complex(c_double_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       complex(c_double_complex),target,dimension(:,:) :: AP
@@ -53046,15 +51312,14 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       complex(c_float_complex) :: alpha
-      complex(c_float_complex),target :: AP
+      type(c_ptr) :: AP
       complex(c_float_complex),target :: x
       integer(c_int) :: incx
       complex(c_float_complex) :: beta
       complex(c_float_complex),target :: y
       integer(c_int) :: incy
       !
-      hipblasChpmv_rank_0 = hipblasChpmv_(handle,uplo,n,alpha,c_loc(AP),c_loc(x),incx,beta, &
-        c_loc(y),incy)
+      hipblasChpmv_rank_0 = hipblasChpmv_(handle,uplo,n,alpha,AP,c_loc(x),incx,beta,c_loc(y),incy)
     end function
 
     function hipblasChpmv_rank_1(handle,uplo,n,alpha,AP,x,incx,beta,y,incy)
@@ -53066,15 +51331,14 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       complex(c_float_complex) :: alpha
-      complex(c_float_complex),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       complex(c_float_complex) :: beta
       complex(c_float_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       !
-      hipblasChpmv_rank_1 = hipblasChpmv_(handle,uplo,n,alpha,c_loc(AP),c_loc(x),incx,beta, &
-        c_loc(y),incy)
+      hipblasChpmv_rank_1 = hipblasChpmv_(handle,uplo,n,alpha,AP,c_loc(x),incx,beta,c_loc(y),incy)
     end function
 
     function hipblasZhpmv_rank_0(handle,uplo,n,alpha,AP,x,incx,beta,y,incy)
@@ -53086,15 +51350,14 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       complex(c_double_complex) :: alpha
-      complex(c_double_complex),target :: AP
+      type(c_ptr) :: AP
       complex(c_double_complex),target :: x
       integer(c_int) :: incx
       complex(c_double_complex) :: beta
       complex(c_double_complex),target :: y
       integer(c_int) :: incy
       !
-      hipblasZhpmv_rank_0 = hipblasZhpmv_(handle,uplo,n,alpha,c_loc(AP),c_loc(x),incx,beta, &
-        c_loc(y),incy)
+      hipblasZhpmv_rank_0 = hipblasZhpmv_(handle,uplo,n,alpha,AP,c_loc(x),incx,beta,c_loc(y),incy)
     end function
 
     function hipblasZhpmv_rank_1(handle,uplo,n,alpha,AP,x,incx,beta,y,incy)
@@ -53106,15 +51369,14 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       complex(c_double_complex) :: alpha
-      complex(c_double_complex),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       complex(c_double_complex) :: beta
       complex(c_double_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       !
-      hipblasZhpmv_rank_1 = hipblasZhpmv_(handle,uplo,n,alpha,c_loc(AP),c_loc(x),incx,beta, &
-        c_loc(y),incy)
+      hipblasZhpmv_rank_1 = hipblasZhpmv_(handle,uplo,n,alpha,AP,c_loc(x),incx,beta,c_loc(y),incy)
     end function
 
     function hipblasChpmvStridedBatched_rank_0(handle,uplo,n,alpha,AP,strideA,x,incx,stridex,beta, &
@@ -53127,7 +51389,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       complex(c_float_complex) :: alpha
-      complex(c_float_complex),target :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: strideA
       complex(c_float_complex),target :: x
       integer(c_int) :: incx
@@ -53138,8 +51400,8 @@ module hipfort_hipblas
       integer(c_int64_t) :: stridey
       integer(c_int) :: batchCount
       !
-      hipblasChpmvStridedBatched_rank_0 = hipblasChpmvStridedBatched_(handle,uplo,n,alpha, &
-        c_loc(AP),strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
+      hipblasChpmvStridedBatched_rank_0 = hipblasChpmvStridedBatched_(handle,uplo,n,alpha,AP, &
+        strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
     end function
 
     function hipblasChpmvStridedBatched_rank_1(handle,uplo,n,alpha,AP,strideA,x,incx,stridex,beta, &
@@ -53152,7 +51414,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       complex(c_float_complex) :: alpha
-      complex(c_float_complex),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: strideA
       complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
@@ -53163,8 +51425,8 @@ module hipfort_hipblas
       integer(c_int64_t) :: stridey
       integer(c_int) :: batchCount
       !
-      hipblasChpmvStridedBatched_rank_1 = hipblasChpmvStridedBatched_(handle,uplo,n,alpha, &
-        c_loc(AP),strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
+      hipblasChpmvStridedBatched_rank_1 = hipblasChpmvStridedBatched_(handle,uplo,n,alpha,AP, &
+        strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
     end function
 
     function hipblasZhpmvStridedBatched_rank_0(handle,uplo,n,alpha,AP,strideA,x,incx,stridex,beta, &
@@ -53177,7 +51439,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       complex(c_double_complex) :: alpha
-      complex(c_double_complex),target :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: strideA
       complex(c_double_complex),target :: x
       integer(c_int) :: incx
@@ -53188,8 +51450,8 @@ module hipfort_hipblas
       integer(c_int64_t) :: stridey
       integer(c_int) :: batchCount
       !
-      hipblasZhpmvStridedBatched_rank_0 = hipblasZhpmvStridedBatched_(handle,uplo,n,alpha, &
-        c_loc(AP),strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
+      hipblasZhpmvStridedBatched_rank_0 = hipblasZhpmvStridedBatched_(handle,uplo,n,alpha,AP, &
+        strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
     end function
 
     function hipblasZhpmvStridedBatched_rank_1(handle,uplo,n,alpha,AP,strideA,x,incx,stridex,beta, &
@@ -53202,7 +51464,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       complex(c_double_complex) :: alpha
-      complex(c_double_complex),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: strideA
       complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
@@ -53213,8 +51475,8 @@ module hipfort_hipblas
       integer(c_int64_t) :: stridey
       integer(c_int) :: batchCount
       !
-      hipblasZhpmvStridedBatched_rank_1 = hipblasZhpmvStridedBatched_(handle,uplo,n,alpha, &
-        c_loc(AP),strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
+      hipblasZhpmvStridedBatched_rank_1 = hipblasZhpmvStridedBatched_(handle,uplo,n,alpha,AP, &
+        strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
     end function
 
     function hipblasChpr_rank_0(handle,uplo,n,alpha,x,incx,AP)
@@ -53228,9 +51490,9 @@ module hipfort_hipblas
       real(c_float) :: alpha
       complex(c_float_complex),target :: x
       integer(c_int) :: incx
-      complex(c_float_complex),target :: AP
+      type(c_ptr) :: AP
       !
-      hipblasChpr_rank_0 = hipblasChpr_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(AP))
+      hipblasChpr_rank_0 = hipblasChpr_(handle,uplo,n,alpha,c_loc(x),incx,AP)
     end function
 
     function hipblasChpr_rank_1(handle,uplo,n,alpha,x,incx,AP)
@@ -53244,9 +51506,9 @@ module hipfort_hipblas
       real(c_float) :: alpha
       complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
-      complex(c_float_complex),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       !
-      hipblasChpr_rank_1 = hipblasChpr_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(AP))
+      hipblasChpr_rank_1 = hipblasChpr_(handle,uplo,n,alpha,c_loc(x),incx,AP)
     end function
 
     function hipblasZhpr_rank_0(handle,uplo,n,alpha,x,incx,AP)
@@ -53260,9 +51522,9 @@ module hipfort_hipblas
       real(c_double) :: alpha
       complex(c_double_complex),target :: x
       integer(c_int) :: incx
-      complex(c_double_complex),target :: AP
+      type(c_ptr) :: AP
       !
-      hipblasZhpr_rank_0 = hipblasZhpr_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(AP))
+      hipblasZhpr_rank_0 = hipblasZhpr_(handle,uplo,n,alpha,c_loc(x),incx,AP)
     end function
 
     function hipblasZhpr_rank_1(handle,uplo,n,alpha,x,incx,AP)
@@ -53276,9 +51538,9 @@ module hipfort_hipblas
       real(c_double) :: alpha
       complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
-      complex(c_double_complex),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       !
-      hipblasZhpr_rank_1 = hipblasZhpr_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(AP))
+      hipblasZhpr_rank_1 = hipblasZhpr_(handle,uplo,n,alpha,c_loc(x),incx,AP)
     end function
 
     function hipblasChprStridedBatched_rank_0(handle,uplo,n,alpha,x,incx,stridex,AP,strideA, &
@@ -53294,12 +51556,12 @@ module hipfort_hipblas
       complex(c_float_complex),target :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
-      complex(c_float_complex),target :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: strideA
       integer(c_int) :: batchCount
       !
       hipblasChprStridedBatched_rank_0 = hipblasChprStridedBatched_(handle,uplo,n,alpha,c_loc(x), &
-        incx,stridex,c_loc(AP),strideA,batchCount)
+        incx,stridex,AP,strideA,batchCount)
     end function
 
     function hipblasChprStridedBatched_rank_1(handle,uplo,n,alpha,x,incx,stridex,AP,strideA, &
@@ -53315,12 +51577,12 @@ module hipfort_hipblas
       complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
-      complex(c_float_complex),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: strideA
       integer(c_int) :: batchCount
       !
       hipblasChprStridedBatched_rank_1 = hipblasChprStridedBatched_(handle,uplo,n,alpha,c_loc(x), &
-        incx,stridex,c_loc(AP),strideA,batchCount)
+        incx,stridex,AP,strideA,batchCount)
     end function
 
     function hipblasZhprStridedBatched_rank_0(handle,uplo,n,alpha,x,incx,stridex,AP,strideA, &
@@ -53336,12 +51598,12 @@ module hipfort_hipblas
       complex(c_double_complex),target :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
-      complex(c_double_complex),target :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: strideA
       integer(c_int) :: batchCount
       !
       hipblasZhprStridedBatched_rank_0 = hipblasZhprStridedBatched_(handle,uplo,n,alpha,c_loc(x), &
-        incx,stridex,c_loc(AP),strideA,batchCount)
+        incx,stridex,AP,strideA,batchCount)
     end function
 
     function hipblasZhprStridedBatched_rank_1(handle,uplo,n,alpha,x,incx,stridex,AP,strideA, &
@@ -53357,12 +51619,12 @@ module hipfort_hipblas
       complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
-      complex(c_double_complex),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: strideA
       integer(c_int) :: batchCount
       !
       hipblasZhprStridedBatched_rank_1 = hipblasZhprStridedBatched_(handle,uplo,n,alpha,c_loc(x), &
-        incx,stridex,c_loc(AP),strideA,batchCount)
+        incx,stridex,AP,strideA,batchCount)
     end function
 
     function hipblasChpr2_rank_0(handle,uplo,n,alpha,x,incx,y,incy,AP)
@@ -53378,9 +51640,9 @@ module hipfort_hipblas
       integer(c_int) :: incx
       complex(c_float_complex),target :: y
       integer(c_int) :: incy
-      complex(c_float_complex),target :: AP
+      type(c_ptr) :: AP
       !
-      hipblasChpr2_rank_0 = hipblasChpr2_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(y),incy,c_loc(AP))
+      hipblasChpr2_rank_0 = hipblasChpr2_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(y),incy,AP)
     end function
 
     function hipblasChpr2_rank_1(handle,uplo,n,alpha,x,incx,y,incy,AP)
@@ -53396,9 +51658,9 @@ module hipfort_hipblas
       integer(c_int) :: incx
       complex(c_float_complex),target,dimension(:) :: y
       integer(c_int) :: incy
-      complex(c_float_complex),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       !
-      hipblasChpr2_rank_1 = hipblasChpr2_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(y),incy,c_loc(AP))
+      hipblasChpr2_rank_1 = hipblasChpr2_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(y),incy,AP)
     end function
 
     function hipblasZhpr2_rank_0(handle,uplo,n,alpha,x,incx,y,incy,AP)
@@ -53414,9 +51676,9 @@ module hipfort_hipblas
       integer(c_int) :: incx
       complex(c_double_complex),target :: y
       integer(c_int) :: incy
-      complex(c_double_complex),target :: AP
+      type(c_ptr) :: AP
       !
-      hipblasZhpr2_rank_0 = hipblasZhpr2_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(y),incy,c_loc(AP))
+      hipblasZhpr2_rank_0 = hipblasZhpr2_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(y),incy,AP)
     end function
 
     function hipblasZhpr2_rank_1(handle,uplo,n,alpha,x,incx,y,incy,AP)
@@ -53432,9 +51694,9 @@ module hipfort_hipblas
       integer(c_int) :: incx
       complex(c_double_complex),target,dimension(:) :: y
       integer(c_int) :: incy
-      complex(c_double_complex),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       !
-      hipblasZhpr2_rank_1 = hipblasZhpr2_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(y),incy,c_loc(AP))
+      hipblasZhpr2_rank_1 = hipblasZhpr2_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(y),incy,AP)
     end function
 
     function hipblasChpr2StridedBatched_rank_0(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey, &
@@ -53453,12 +51715,12 @@ module hipfort_hipblas
       complex(c_float_complex),target :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
-      complex(c_float_complex),target :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: strideA
       integer(c_int) :: batchCount
       !
       hipblasChpr2StridedBatched_rank_0 = hipblasChpr2StridedBatched_(handle,uplo,n,alpha, &
-        c_loc(x),incx,stridex,c_loc(y),incy,stridey,c_loc(AP),strideA,batchCount)
+        c_loc(x),incx,stridex,c_loc(y),incy,stridey,AP,strideA,batchCount)
     end function
 
     function hipblasChpr2StridedBatched_rank_1(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey, &
@@ -53477,12 +51739,12 @@ module hipfort_hipblas
       complex(c_float_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
-      complex(c_float_complex),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: strideA
       integer(c_int) :: batchCount
       !
       hipblasChpr2StridedBatched_rank_1 = hipblasChpr2StridedBatched_(handle,uplo,n,alpha, &
-        c_loc(x),incx,stridex,c_loc(y),incy,stridey,c_loc(AP),strideA,batchCount)
+        c_loc(x),incx,stridex,c_loc(y),incy,stridey,AP,strideA,batchCount)
     end function
 
     function hipblasZhpr2StridedBatched_rank_0(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey, &
@@ -53501,12 +51763,12 @@ module hipfort_hipblas
       complex(c_double_complex),target :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
-      complex(c_double_complex),target :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: strideA
       integer(c_int) :: batchCount
       !
       hipblasZhpr2StridedBatched_rank_0 = hipblasZhpr2StridedBatched_(handle,uplo,n,alpha, &
-        c_loc(x),incx,stridex,c_loc(y),incy,stridey,c_loc(AP),strideA,batchCount)
+        c_loc(x),incx,stridex,c_loc(y),incy,stridey,AP,strideA,batchCount)
     end function
 
     function hipblasZhpr2StridedBatched_rank_1(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey, &
@@ -53525,12 +51787,12 @@ module hipfort_hipblas
       complex(c_double_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
-      complex(c_double_complex),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: strideA
       integer(c_int) :: batchCount
       !
       hipblasZhpr2StridedBatched_rank_1 = hipblasZhpr2StridedBatched_(handle,uplo,n,alpha, &
-        c_loc(x),incx,stridex,c_loc(y),incy,stridey,c_loc(AP),strideA,batchCount)
+        c_loc(x),incx,stridex,c_loc(y),incy,stridey,AP,strideA,batchCount)
     end function
 
     function hipblasSsbmv_rank_0(handle,uplo,n,k,alpha,AP,lda,x,incx,beta,y,incy)
@@ -53589,10 +51851,10 @@ module hipfort_hipblas
       real(c_float) :: alpha
       real(c_float),target,dimension(:,:) :: AP
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: x
+      real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       real(c_float) :: beta
-      real(c_float),target,dimension(:,:) :: y
+      real(c_float),target,dimension(:) :: y
       integer(c_int) :: incy
       !
       hipblasSsbmv_full_rank = hipblasSsbmv_(handle,uplo,n,k,alpha,c_loc(AP),lda,c_loc(x),incx, &
@@ -53655,10 +51917,10 @@ module hipfort_hipblas
       real(c_double) :: alpha
       real(c_double),target,dimension(:,:) :: AP
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: x
+      real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       real(c_double) :: beta
-      real(c_double),target,dimension(:,:) :: y
+      real(c_double),target,dimension(:) :: y
       integer(c_int) :: incy
       !
       hipblasDsbmv_full_rank = hipblasDsbmv_(handle,uplo,n,k,alpha,c_loc(AP),lda,c_loc(x),incx, &
@@ -53733,11 +51995,11 @@ module hipfort_hipblas
       real(c_float),target,dimension(:,:) :: AP
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_float),target,dimension(:,:) :: x
+      real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       real(c_float) :: beta
-      real(c_float),target,dimension(:,:) :: y
+      real(c_float),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       integer(c_int) :: batchCount
@@ -53814,11 +52076,11 @@ module hipfort_hipblas
       real(c_double),target,dimension(:,:) :: AP
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_double),target,dimension(:,:) :: x
+      real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       real(c_double) :: beta
-      real(c_double),target,dimension(:,:) :: y
+      real(c_double),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       integer(c_int) :: batchCount
@@ -53836,15 +52098,14 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       real(c_float) :: alpha
-      real(c_float),target :: AP
+      type(c_ptr) :: AP
       real(c_float),target :: x
       integer(c_int) :: incx
       real(c_float) :: beta
       real(c_float),target :: y
       integer(c_int) :: incy
       !
-      hipblasSspmv_rank_0 = hipblasSspmv_(handle,uplo,n,alpha,c_loc(AP),c_loc(x),incx,beta, &
-        c_loc(y),incy)
+      hipblasSspmv_rank_0 = hipblasSspmv_(handle,uplo,n,alpha,AP,c_loc(x),incx,beta,c_loc(y),incy)
     end function
 
     function hipblasSspmv_rank_1(handle,uplo,n,alpha,AP,x,incx,beta,y,incy)
@@ -53856,15 +52117,14 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       real(c_float) :: alpha
-      real(c_float),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       real(c_float) :: beta
       real(c_float),target,dimension(:) :: y
       integer(c_int) :: incy
       !
-      hipblasSspmv_rank_1 = hipblasSspmv_(handle,uplo,n,alpha,c_loc(AP),c_loc(x),incx,beta, &
-        c_loc(y),incy)
+      hipblasSspmv_rank_1 = hipblasSspmv_(handle,uplo,n,alpha,AP,c_loc(x),incx,beta,c_loc(y),incy)
     end function
 
     function hipblasDspmv_rank_0(handle,uplo,n,alpha,AP,x,incx,beta,y,incy)
@@ -53876,15 +52136,14 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       real(c_double) :: alpha
-      real(c_double),target :: AP
+      type(c_ptr) :: AP
       real(c_double),target :: x
       integer(c_int) :: incx
       real(c_double) :: beta
       real(c_double),target :: y
       integer(c_int) :: incy
       !
-      hipblasDspmv_rank_0 = hipblasDspmv_(handle,uplo,n,alpha,c_loc(AP),c_loc(x),incx,beta, &
-        c_loc(y),incy)
+      hipblasDspmv_rank_0 = hipblasDspmv_(handle,uplo,n,alpha,AP,c_loc(x),incx,beta,c_loc(y),incy)
     end function
 
     function hipblasDspmv_rank_1(handle,uplo,n,alpha,AP,x,incx,beta,y,incy)
@@ -53896,15 +52155,14 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       real(c_double) :: alpha
-      real(c_double),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       real(c_double) :: beta
       real(c_double),target,dimension(:) :: y
       integer(c_int) :: incy
       !
-      hipblasDspmv_rank_1 = hipblasDspmv_(handle,uplo,n,alpha,c_loc(AP),c_loc(x),incx,beta, &
-        c_loc(y),incy)
+      hipblasDspmv_rank_1 = hipblasDspmv_(handle,uplo,n,alpha,AP,c_loc(x),incx,beta,c_loc(y),incy)
     end function
 
     function hipblasSspmvStridedBatched_rank_0(handle,uplo,n,alpha,AP,strideA,x,incx,stridex,beta, &
@@ -53917,7 +52175,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       real(c_float) :: alpha
-      real(c_float),target :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: strideA
       real(c_float),target :: x
       integer(c_int) :: incx
@@ -53928,8 +52186,8 @@ module hipfort_hipblas
       integer(c_int64_t) :: stridey
       integer(c_int) :: batchCount
       !
-      hipblasSspmvStridedBatched_rank_0 = hipblasSspmvStridedBatched_(handle,uplo,n,alpha, &
-        c_loc(AP),strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
+      hipblasSspmvStridedBatched_rank_0 = hipblasSspmvStridedBatched_(handle,uplo,n,alpha,AP, &
+        strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
     end function
 
     function hipblasSspmvStridedBatched_rank_1(handle,uplo,n,alpha,AP,strideA,x,incx,stridex,beta, &
@@ -53942,7 +52200,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       real(c_float) :: alpha
-      real(c_float),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: strideA
       real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
@@ -53953,8 +52211,8 @@ module hipfort_hipblas
       integer(c_int64_t) :: stridey
       integer(c_int) :: batchCount
       !
-      hipblasSspmvStridedBatched_rank_1 = hipblasSspmvStridedBatched_(handle,uplo,n,alpha, &
-        c_loc(AP),strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
+      hipblasSspmvStridedBatched_rank_1 = hipblasSspmvStridedBatched_(handle,uplo,n,alpha,AP, &
+        strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
     end function
 
     function hipblasDspmvStridedBatched_rank_0(handle,uplo,n,alpha,AP,strideA,x,incx,stridex,beta, &
@@ -53967,7 +52225,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       real(c_double) :: alpha
-      real(c_double),target :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: strideA
       real(c_double),target :: x
       integer(c_int) :: incx
@@ -53978,8 +52236,8 @@ module hipfort_hipblas
       integer(c_int64_t) :: stridey
       integer(c_int) :: batchCount
       !
-      hipblasDspmvStridedBatched_rank_0 = hipblasDspmvStridedBatched_(handle,uplo,n,alpha, &
-        c_loc(AP),strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
+      hipblasDspmvStridedBatched_rank_0 = hipblasDspmvStridedBatched_(handle,uplo,n,alpha,AP, &
+        strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
     end function
 
     function hipblasDspmvStridedBatched_rank_1(handle,uplo,n,alpha,AP,strideA,x,incx,stridex,beta, &
@@ -53992,7 +52250,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       real(c_double) :: alpha
-      real(c_double),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: strideA
       real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
@@ -54003,8 +52261,8 @@ module hipfort_hipblas
       integer(c_int64_t) :: stridey
       integer(c_int) :: batchCount
       !
-      hipblasDspmvStridedBatched_rank_1 = hipblasDspmvStridedBatched_(handle,uplo,n,alpha, &
-        c_loc(AP),strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
+      hipblasDspmvStridedBatched_rank_1 = hipblasDspmvStridedBatched_(handle,uplo,n,alpha,AP, &
+        strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
     end function
 
     function hipblasSspr_rank_0(handle,uplo,n,alpha,x,incx,AP)
@@ -54018,9 +52276,9 @@ module hipfort_hipblas
       real(c_float) :: alpha
       real(c_float),target :: x
       integer(c_int) :: incx
-      real(c_float),target :: AP
+      type(c_ptr) :: AP
       !
-      hipblasSspr_rank_0 = hipblasSspr_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(AP))
+      hipblasSspr_rank_0 = hipblasSspr_(handle,uplo,n,alpha,c_loc(x),incx,AP)
     end function
 
     function hipblasSspr_rank_1(handle,uplo,n,alpha,x,incx,AP)
@@ -54034,9 +52292,9 @@ module hipfort_hipblas
       real(c_float) :: alpha
       real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
-      real(c_float),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       !
-      hipblasSspr_rank_1 = hipblasSspr_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(AP))
+      hipblasSspr_rank_1 = hipblasSspr_(handle,uplo,n,alpha,c_loc(x),incx,AP)
     end function
 
     function hipblasDspr_rank_0(handle,uplo,n,alpha,x,incx,AP)
@@ -54050,9 +52308,9 @@ module hipfort_hipblas
       real(c_double) :: alpha
       real(c_double),target :: x
       integer(c_int) :: incx
-      real(c_double),target :: AP
+      type(c_ptr) :: AP
       !
-      hipblasDspr_rank_0 = hipblasDspr_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(AP))
+      hipblasDspr_rank_0 = hipblasDspr_(handle,uplo,n,alpha,c_loc(x),incx,AP)
     end function
 
     function hipblasDspr_rank_1(handle,uplo,n,alpha,x,incx,AP)
@@ -54066,9 +52324,9 @@ module hipfort_hipblas
       real(c_double) :: alpha
       real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
-      real(c_double),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       !
-      hipblasDspr_rank_1 = hipblasDspr_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(AP))
+      hipblasDspr_rank_1 = hipblasDspr_(handle,uplo,n,alpha,c_loc(x),incx,AP)
     end function
 
     function hipblasCspr_rank_0(handle,uplo,n,alpha,x,incx,AP)
@@ -54082,9 +52340,9 @@ module hipfort_hipblas
       complex(c_float_complex) :: alpha
       complex(c_float_complex),target :: x
       integer(c_int) :: incx
-      complex(c_float_complex),target :: AP
+      type(c_ptr) :: AP
       !
-      hipblasCspr_rank_0 = hipblasCspr_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(AP))
+      hipblasCspr_rank_0 = hipblasCspr_(handle,uplo,n,alpha,c_loc(x),incx,AP)
     end function
 
     function hipblasCspr_rank_1(handle,uplo,n,alpha,x,incx,AP)
@@ -54098,9 +52356,9 @@ module hipfort_hipblas
       complex(c_float_complex) :: alpha
       complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
-      complex(c_float_complex),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       !
-      hipblasCspr_rank_1 = hipblasCspr_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(AP))
+      hipblasCspr_rank_1 = hipblasCspr_(handle,uplo,n,alpha,c_loc(x),incx,AP)
     end function
 
     function hipblasZspr_rank_0(handle,uplo,n,alpha,x,incx,AP)
@@ -54114,9 +52372,9 @@ module hipfort_hipblas
       complex(c_double_complex) :: alpha
       complex(c_double_complex),target :: x
       integer(c_int) :: incx
-      complex(c_double_complex),target :: AP
+      type(c_ptr) :: AP
       !
-      hipblasZspr_rank_0 = hipblasZspr_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(AP))
+      hipblasZspr_rank_0 = hipblasZspr_(handle,uplo,n,alpha,c_loc(x),incx,AP)
     end function
 
     function hipblasZspr_rank_1(handle,uplo,n,alpha,x,incx,AP)
@@ -54130,9 +52388,9 @@ module hipfort_hipblas
       complex(c_double_complex) :: alpha
       complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
-      complex(c_double_complex),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       !
-      hipblasZspr_rank_1 = hipblasZspr_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(AP))
+      hipblasZspr_rank_1 = hipblasZspr_(handle,uplo,n,alpha,c_loc(x),incx,AP)
     end function
 
     function hipblasSsprStridedBatched_rank_0(handle,uplo,n,alpha,x,incx,stridex,AP,strideA, &
@@ -54148,12 +52406,12 @@ module hipfort_hipblas
       real(c_float),target :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
-      real(c_float),target :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: strideA
       integer(c_int) :: batchCount
       !
       hipblasSsprStridedBatched_rank_0 = hipblasSsprStridedBatched_(handle,uplo,n,alpha,c_loc(x), &
-        incx,stridex,c_loc(AP),strideA,batchCount)
+        incx,stridex,AP,strideA,batchCount)
     end function
 
     function hipblasSsprStridedBatched_rank_1(handle,uplo,n,alpha,x,incx,stridex,AP,strideA, &
@@ -54169,12 +52427,12 @@ module hipfort_hipblas
       real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
-      real(c_float),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: strideA
       integer(c_int) :: batchCount
       !
       hipblasSsprStridedBatched_rank_1 = hipblasSsprStridedBatched_(handle,uplo,n,alpha,c_loc(x), &
-        incx,stridex,c_loc(AP),strideA,batchCount)
+        incx,stridex,AP,strideA,batchCount)
     end function
 
     function hipblasDsprStridedBatched_rank_0(handle,uplo,n,alpha,x,incx,stridex,AP,strideA, &
@@ -54190,12 +52448,12 @@ module hipfort_hipblas
       real(c_double),target :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
-      real(c_double),target :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: strideA
       integer(c_int) :: batchCount
       !
       hipblasDsprStridedBatched_rank_0 = hipblasDsprStridedBatched_(handle,uplo,n,alpha,c_loc(x), &
-        incx,stridex,c_loc(AP),strideA,batchCount)
+        incx,stridex,AP,strideA,batchCount)
     end function
 
     function hipblasDsprStridedBatched_rank_1(handle,uplo,n,alpha,x,incx,stridex,AP,strideA, &
@@ -54211,12 +52469,12 @@ module hipfort_hipblas
       real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
-      real(c_double),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: strideA
       integer(c_int) :: batchCount
       !
       hipblasDsprStridedBatched_rank_1 = hipblasDsprStridedBatched_(handle,uplo,n,alpha,c_loc(x), &
-        incx,stridex,c_loc(AP),strideA,batchCount)
+        incx,stridex,AP,strideA,batchCount)
     end function
 
     function hipblasCsprStridedBatched_rank_0(handle,uplo,n,alpha,x,incx,stridex,AP,strideA, &
@@ -54232,12 +52490,12 @@ module hipfort_hipblas
       complex(c_float_complex),target :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
-      complex(c_float_complex),target :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: strideA
       integer(c_int) :: batchCount
       !
       hipblasCsprStridedBatched_rank_0 = hipblasCsprStridedBatched_(handle,uplo,n,alpha,c_loc(x), &
-        incx,stridex,c_loc(AP),strideA,batchCount)
+        incx,stridex,AP,strideA,batchCount)
     end function
 
     function hipblasCsprStridedBatched_rank_1(handle,uplo,n,alpha,x,incx,stridex,AP,strideA, &
@@ -54253,12 +52511,12 @@ module hipfort_hipblas
       complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
-      complex(c_float_complex),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: strideA
       integer(c_int) :: batchCount
       !
       hipblasCsprStridedBatched_rank_1 = hipblasCsprStridedBatched_(handle,uplo,n,alpha,c_loc(x), &
-        incx,stridex,c_loc(AP),strideA,batchCount)
+        incx,stridex,AP,strideA,batchCount)
     end function
 
     function hipblasZsprStridedBatched_rank_0(handle,uplo,n,alpha,x,incx,stridex,AP,strideA, &
@@ -54274,12 +52532,12 @@ module hipfort_hipblas
       complex(c_double_complex),target :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
-      complex(c_double_complex),target :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: strideA
       integer(c_int) :: batchCount
       !
       hipblasZsprStridedBatched_rank_0 = hipblasZsprStridedBatched_(handle,uplo,n,alpha,c_loc(x), &
-        incx,stridex,c_loc(AP),strideA,batchCount)
+        incx,stridex,AP,strideA,batchCount)
     end function
 
     function hipblasZsprStridedBatched_rank_1(handle,uplo,n,alpha,x,incx,stridex,AP,strideA, &
@@ -54295,12 +52553,12 @@ module hipfort_hipblas
       complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
-      complex(c_double_complex),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: strideA
       integer(c_int) :: batchCount
       !
       hipblasZsprStridedBatched_rank_1 = hipblasZsprStridedBatched_(handle,uplo,n,alpha,c_loc(x), &
-        incx,stridex,c_loc(AP),strideA,batchCount)
+        incx,stridex,AP,strideA,batchCount)
     end function
 
     function hipblasSspr2_rank_0(handle,uplo,n,alpha,x,incx,y,incy,AP)
@@ -54316,9 +52574,9 @@ module hipfort_hipblas
       integer(c_int) :: incx
       real(c_float),target :: y
       integer(c_int) :: incy
-      real(c_float),target :: AP
+      type(c_ptr) :: AP
       !
-      hipblasSspr2_rank_0 = hipblasSspr2_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(y),incy,c_loc(AP))
+      hipblasSspr2_rank_0 = hipblasSspr2_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(y),incy,AP)
     end function
 
     function hipblasSspr2_rank_1(handle,uplo,n,alpha,x,incx,y,incy,AP)
@@ -54334,9 +52592,9 @@ module hipfort_hipblas
       integer(c_int) :: incx
       real(c_float),target,dimension(:) :: y
       integer(c_int) :: incy
-      real(c_float),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       !
-      hipblasSspr2_rank_1 = hipblasSspr2_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(y),incy,c_loc(AP))
+      hipblasSspr2_rank_1 = hipblasSspr2_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(y),incy,AP)
     end function
 
     function hipblasDspr2_rank_0(handle,uplo,n,alpha,x,incx,y,incy,AP)
@@ -54352,9 +52610,9 @@ module hipfort_hipblas
       integer(c_int) :: incx
       real(c_double),target :: y
       integer(c_int) :: incy
-      real(c_double),target :: AP
+      type(c_ptr) :: AP
       !
-      hipblasDspr2_rank_0 = hipblasDspr2_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(y),incy,c_loc(AP))
+      hipblasDspr2_rank_0 = hipblasDspr2_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(y),incy,AP)
     end function
 
     function hipblasDspr2_rank_1(handle,uplo,n,alpha,x,incx,y,incy,AP)
@@ -54370,9 +52628,9 @@ module hipfort_hipblas
       integer(c_int) :: incx
       real(c_double),target,dimension(:) :: y
       integer(c_int) :: incy
-      real(c_double),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       !
-      hipblasDspr2_rank_1 = hipblasDspr2_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(y),incy,c_loc(AP))
+      hipblasDspr2_rank_1 = hipblasDspr2_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(y),incy,AP)
     end function
 
     function hipblasSspr2StridedBatched_rank_0(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey, &
@@ -54391,12 +52649,12 @@ module hipfort_hipblas
       real(c_float),target :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
-      real(c_float),target :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: strideA
       integer(c_int) :: batchCount
       !
       hipblasSspr2StridedBatched_rank_0 = hipblasSspr2StridedBatched_(handle,uplo,n,alpha, &
-        c_loc(x),incx,stridex,c_loc(y),incy,stridey,c_loc(AP),strideA,batchCount)
+        c_loc(x),incx,stridex,c_loc(y),incy,stridey,AP,strideA,batchCount)
     end function
 
     function hipblasSspr2StridedBatched_rank_1(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey, &
@@ -54415,12 +52673,12 @@ module hipfort_hipblas
       real(c_float),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
-      real(c_float),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: strideA
       integer(c_int) :: batchCount
       !
       hipblasSspr2StridedBatched_rank_1 = hipblasSspr2StridedBatched_(handle,uplo,n,alpha, &
-        c_loc(x),incx,stridex,c_loc(y),incy,stridey,c_loc(AP),strideA,batchCount)
+        c_loc(x),incx,stridex,c_loc(y),incy,stridey,AP,strideA,batchCount)
     end function
 
     function hipblasDspr2StridedBatched_rank_0(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey, &
@@ -54439,12 +52697,12 @@ module hipfort_hipblas
       real(c_double),target :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
-      real(c_double),target :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: strideA
       integer(c_int) :: batchCount
       !
       hipblasDspr2StridedBatched_rank_0 = hipblasDspr2StridedBatched_(handle,uplo,n,alpha, &
-        c_loc(x),incx,stridex,c_loc(y),incy,stridey,c_loc(AP),strideA,batchCount)
+        c_loc(x),incx,stridex,c_loc(y),incy,stridey,AP,strideA,batchCount)
     end function
 
     function hipblasDspr2StridedBatched_rank_1(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey, &
@@ -54463,12 +52721,12 @@ module hipfort_hipblas
       real(c_double),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
-      real(c_double),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: strideA
       integer(c_int) :: batchCount
       !
       hipblasDspr2StridedBatched_rank_1 = hipblasDspr2StridedBatched_(handle,uplo,n,alpha, &
-        c_loc(x),incx,stridex,c_loc(y),incy,stridey,c_loc(AP),strideA,batchCount)
+        c_loc(x),incx,stridex,c_loc(y),incy,stridey,AP,strideA,batchCount)
     end function
 
     function hipblasSsymv_rank_0(handle,uplo,n,alpha,AP,lda,x,incx,beta,y,incy)
@@ -54524,10 +52782,10 @@ module hipfort_hipblas
       real(c_float) :: alpha
       real(c_float),target,dimension(:,:) :: AP
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: x
+      real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       real(c_float) :: beta
-      real(c_float),target,dimension(:,:) :: y
+      real(c_float),target,dimension(:) :: y
       integer(c_int) :: incy
       !
       hipblasSsymv_full_rank = hipblasSsymv_(handle,uplo,n,alpha,c_loc(AP),lda,c_loc(x),incx,beta, &
@@ -54587,10 +52845,10 @@ module hipfort_hipblas
       real(c_double) :: alpha
       real(c_double),target,dimension(:,:) :: AP
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: x
+      real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       real(c_double) :: beta
-      real(c_double),target,dimension(:,:) :: y
+      real(c_double),target,dimension(:) :: y
       integer(c_int) :: incy
       !
       hipblasDsymv_full_rank = hipblasDsymv_(handle,uplo,n,alpha,c_loc(AP),lda,c_loc(x),incx,beta, &
@@ -54650,10 +52908,10 @@ module hipfort_hipblas
       complex(c_float_complex) :: alpha
       complex(c_float_complex),target,dimension(:,:) :: AP
       integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       complex(c_float_complex) :: beta
-      complex(c_float_complex),target,dimension(:,:) :: y
+      complex(c_float_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       !
       hipblasCsymv_full_rank = hipblasCsymv_(handle,uplo,n,alpha,c_loc(AP),lda,c_loc(x),incx,beta, &
@@ -54713,10 +52971,10 @@ module hipfort_hipblas
       complex(c_double_complex) :: alpha
       complex(c_double_complex),target,dimension(:,:) :: AP
       integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       complex(c_double_complex) :: beta
-      complex(c_double_complex),target,dimension(:,:) :: y
+      complex(c_double_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       !
       hipblasZsymv_full_rank = hipblasZsymv_(handle,uplo,n,alpha,c_loc(AP),lda,c_loc(x),incx,beta, &
@@ -54788,11 +53046,11 @@ module hipfort_hipblas
       real(c_float),target,dimension(:,:) :: AP
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_float),target,dimension(:,:) :: x
+      real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       real(c_float) :: beta
-      real(c_float),target,dimension(:,:) :: y
+      real(c_float),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       integer(c_int) :: batchCount
@@ -54866,11 +53124,11 @@ module hipfort_hipblas
       real(c_double),target,dimension(:,:) :: AP
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_double),target,dimension(:,:) :: x
+      real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       real(c_double) :: beta
-      real(c_double),target,dimension(:,:) :: y
+      real(c_double),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       integer(c_int) :: batchCount
@@ -54944,11 +53202,11 @@ module hipfort_hipblas
       complex(c_float_complex),target,dimension(:,:) :: AP
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       complex(c_float_complex) :: beta
-      complex(c_float_complex),target,dimension(:,:) :: y
+      complex(c_float_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       integer(c_int) :: batchCount
@@ -55022,11 +53280,11 @@ module hipfort_hipblas
       complex(c_double_complex),target,dimension(:,:) :: AP
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       complex(c_double_complex) :: beta
-      complex(c_double_complex),target,dimension(:,:) :: y
+      complex(c_double_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       integer(c_int) :: batchCount
@@ -55078,7 +53336,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       real(c_float) :: alpha
-      real(c_float),target,dimension(:,:) :: x
+      real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       real(c_float),target,dimension(:,:) :: AP
       integer(c_int) :: lda
@@ -55129,7 +53387,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       real(c_double) :: alpha
-      real(c_double),target,dimension(:,:) :: x
+      real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       real(c_double),target,dimension(:,:) :: AP
       integer(c_int) :: lda
@@ -55180,7 +53438,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       complex(c_float_complex) :: alpha
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       complex(c_float_complex),target,dimension(:,:) :: AP
       integer(c_int) :: lda
@@ -55231,7 +53489,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       complex(c_double_complex) :: alpha
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       complex(c_double_complex),target,dimension(:,:) :: AP
       integer(c_int) :: lda
@@ -55293,7 +53551,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       real(c_float) :: alpha
-      real(c_float),target,dimension(:,:) :: x
+      real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       real(c_float),target,dimension(:,:) :: AP
@@ -55359,7 +53617,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       real(c_double) :: alpha
-      real(c_double),target,dimension(:,:) :: x
+      real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       real(c_double),target,dimension(:,:) :: AP
@@ -55425,7 +53683,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       complex(c_float_complex) :: alpha
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       complex(c_float_complex),target,dimension(:,:) :: AP
@@ -55491,7 +53749,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       complex(c_double_complex) :: alpha
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       complex(c_double_complex),target,dimension(:,:) :: AP
@@ -55552,9 +53810,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       real(c_float) :: alpha
-      real(c_float),target,dimension(:,:) :: x
+      real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
-      real(c_float),target,dimension(:,:) :: y
+      real(c_float),target,dimension(:) :: y
       integer(c_int) :: incy
       real(c_float),target,dimension(:,:) :: AP
       integer(c_int) :: lda
@@ -55612,9 +53870,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       real(c_double) :: alpha
-      real(c_double),target,dimension(:,:) :: x
+      real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
-      real(c_double),target,dimension(:,:) :: y
+      real(c_double),target,dimension(:) :: y
       integer(c_int) :: incy
       real(c_double),target,dimension(:,:) :: AP
       integer(c_int) :: lda
@@ -55672,9 +53930,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       complex(c_float_complex) :: alpha
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
-      complex(c_float_complex),target,dimension(:,:) :: y
+      complex(c_float_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       complex(c_float_complex),target,dimension(:,:) :: AP
       integer(c_int) :: lda
@@ -55732,9 +53990,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       complex(c_double_complex) :: alpha
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
-      complex(c_double_complex),target,dimension(:,:) :: y
+      complex(c_double_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       complex(c_double_complex),target,dimension(:,:) :: AP
       integer(c_int) :: lda
@@ -55803,10 +54061,10 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       real(c_float) :: alpha
-      real(c_float),target,dimension(:,:) :: x
+      real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
-      real(c_float),target,dimension(:,:) :: y
+      real(c_float),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       real(c_float),target,dimension(:,:) :: AP
@@ -55878,10 +54136,10 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       real(c_double) :: alpha
-      real(c_double),target,dimension(:,:) :: x
+      real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
-      real(c_double),target,dimension(:,:) :: y
+      real(c_double),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       real(c_double),target,dimension(:,:) :: AP
@@ -55953,10 +54211,10 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       complex(c_float_complex) :: alpha
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
-      complex(c_float_complex),target,dimension(:,:) :: y
+      complex(c_float_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       complex(c_float_complex),target,dimension(:,:) :: AP
@@ -56028,10 +54286,10 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       complex(c_double_complex) :: alpha
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
-      complex(c_double_complex),target,dimension(:,:) :: y
+      complex(c_double_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       complex(c_double_complex),target,dimension(:,:) :: AP
@@ -56094,7 +54352,7 @@ module hipfort_hipblas
       integer(c_int) :: k
       real(c_float),target,dimension(:,:) :: AP
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: x
+      real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       !
       hipblasStbmv_full_rank = hipblasStbmv_(handle,uplo,transA,diag,n,k,c_loc(AP),lda,c_loc(x), &
@@ -56152,7 +54410,7 @@ module hipfort_hipblas
       integer(c_int) :: k
       real(c_double),target,dimension(:,:) :: AP
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: x
+      real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       !
       hipblasDtbmv_full_rank = hipblasDtbmv_(handle,uplo,transA,diag,n,k,c_loc(AP),lda,c_loc(x), &
@@ -56210,7 +54468,7 @@ module hipfort_hipblas
       integer(c_int) :: k
       complex(c_float_complex),target,dimension(:,:) :: AP
       integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       !
       hipblasCtbmv_full_rank = hipblasCtbmv_(handle,uplo,transA,diag,n,k,c_loc(AP),lda,c_loc(x), &
@@ -56268,7 +54526,7 @@ module hipfort_hipblas
       integer(c_int) :: k
       complex(c_double_complex),target,dimension(:,:) :: AP
       integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       !
       hipblasZtbmv_full_rank = hipblasZtbmv_(handle,uplo,transA,diag,n,k,c_loc(AP),lda,c_loc(x), &
@@ -56338,7 +54596,7 @@ module hipfort_hipblas
       real(c_float),target,dimension(:,:) :: AP
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_float),target,dimension(:,:) :: x
+      real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batchCount
@@ -56410,7 +54668,7 @@ module hipfort_hipblas
       real(c_double),target,dimension(:,:) :: AP
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_double),target,dimension(:,:) :: x
+      real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batchCount
@@ -56482,7 +54740,7 @@ module hipfort_hipblas
       complex(c_float_complex),target,dimension(:,:) :: AP
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batchCount
@@ -56554,7 +54812,7 @@ module hipfort_hipblas
       complex(c_double_complex),target,dimension(:,:) :: AP
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batchCount
@@ -56614,7 +54872,7 @@ module hipfort_hipblas
       integer(c_int) :: k
       real(c_float),target,dimension(:,:) :: AP
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: x
+      real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       !
       hipblasStbsv_full_rank = hipblasStbsv_(handle,uplo,transA,diag,n,k,c_loc(AP),lda,c_loc(x), &
@@ -56672,7 +54930,7 @@ module hipfort_hipblas
       integer(c_int) :: k
       real(c_double),target,dimension(:,:) :: AP
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: x
+      real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       !
       hipblasDtbsv_full_rank = hipblasDtbsv_(handle,uplo,transA,diag,n,k,c_loc(AP),lda,c_loc(x), &
@@ -56730,7 +54988,7 @@ module hipfort_hipblas
       integer(c_int) :: k
       complex(c_float_complex),target,dimension(:,:) :: AP
       integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       !
       hipblasCtbsv_full_rank = hipblasCtbsv_(handle,uplo,transA,diag,n,k,c_loc(AP),lda,c_loc(x), &
@@ -56788,7 +55046,7 @@ module hipfort_hipblas
       integer(c_int) :: k
       complex(c_double_complex),target,dimension(:,:) :: AP
       integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       !
       hipblasZtbsv_full_rank = hipblasZtbsv_(handle,uplo,transA,diag,n,k,c_loc(AP),lda,c_loc(x), &
@@ -56858,7 +55116,7 @@ module hipfort_hipblas
       real(c_float),target,dimension(:,:) :: AP
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_float),target,dimension(:,:) :: x
+      real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batchCount
@@ -56930,7 +55188,7 @@ module hipfort_hipblas
       real(c_double),target,dimension(:,:) :: AP
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_double),target,dimension(:,:) :: x
+      real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batchCount
@@ -57002,7 +55260,7 @@ module hipfort_hipblas
       complex(c_float_complex),target,dimension(:,:) :: AP
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batchCount
@@ -57074,7 +55332,7 @@ module hipfort_hipblas
       complex(c_double_complex),target,dimension(:,:) :: AP
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batchCount
@@ -57093,11 +55351,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      real(c_float),target :: AP
+      type(c_ptr) :: AP
       real(c_float),target :: x
       integer(c_int) :: incx
       !
-      hipblasStpmv_rank_0 = hipblasStpmv_(handle,uplo,transA,diag,n,c_loc(AP),c_loc(x),incx)
+      hipblasStpmv_rank_0 = hipblasStpmv_(handle,uplo,transA,diag,n,AP,c_loc(x),incx)
     end function
 
     function hipblasStpmv_rank_1(handle,uplo,transA,diag,n,AP,x,incx)
@@ -57110,11 +55368,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      real(c_float),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       !
-      hipblasStpmv_rank_1 = hipblasStpmv_(handle,uplo,transA,diag,n,c_loc(AP),c_loc(x),incx)
+      hipblasStpmv_rank_1 = hipblasStpmv_(handle,uplo,transA,diag,n,AP,c_loc(x),incx)
     end function
 
     function hipblasDtpmv_rank_0(handle,uplo,transA,diag,n,AP,x,incx)
@@ -57127,11 +55385,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      real(c_double),target :: AP
+      type(c_ptr) :: AP
       real(c_double),target :: x
       integer(c_int) :: incx
       !
-      hipblasDtpmv_rank_0 = hipblasDtpmv_(handle,uplo,transA,diag,n,c_loc(AP),c_loc(x),incx)
+      hipblasDtpmv_rank_0 = hipblasDtpmv_(handle,uplo,transA,diag,n,AP,c_loc(x),incx)
     end function
 
     function hipblasDtpmv_rank_1(handle,uplo,transA,diag,n,AP,x,incx)
@@ -57144,11 +55402,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      real(c_double),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       !
-      hipblasDtpmv_rank_1 = hipblasDtpmv_(handle,uplo,transA,diag,n,c_loc(AP),c_loc(x),incx)
+      hipblasDtpmv_rank_1 = hipblasDtpmv_(handle,uplo,transA,diag,n,AP,c_loc(x),incx)
     end function
 
     function hipblasCtpmv_rank_0(handle,uplo,transA,diag,n,AP,x,incx)
@@ -57161,11 +55419,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      complex(c_float_complex),target :: AP
+      type(c_ptr) :: AP
       complex(c_float_complex),target :: x
       integer(c_int) :: incx
       !
-      hipblasCtpmv_rank_0 = hipblasCtpmv_(handle,uplo,transA,diag,n,c_loc(AP),c_loc(x),incx)
+      hipblasCtpmv_rank_0 = hipblasCtpmv_(handle,uplo,transA,diag,n,AP,c_loc(x),incx)
     end function
 
     function hipblasCtpmv_rank_1(handle,uplo,transA,diag,n,AP,x,incx)
@@ -57178,11 +55436,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      complex(c_float_complex),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       !
-      hipblasCtpmv_rank_1 = hipblasCtpmv_(handle,uplo,transA,diag,n,c_loc(AP),c_loc(x),incx)
+      hipblasCtpmv_rank_1 = hipblasCtpmv_(handle,uplo,transA,diag,n,AP,c_loc(x),incx)
     end function
 
     function hipblasZtpmv_rank_0(handle,uplo,transA,diag,n,AP,x,incx)
@@ -57195,11 +55453,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      complex(c_double_complex),target :: AP
+      type(c_ptr) :: AP
       complex(c_double_complex),target :: x
       integer(c_int) :: incx
       !
-      hipblasZtpmv_rank_0 = hipblasZtpmv_(handle,uplo,transA,diag,n,c_loc(AP),c_loc(x),incx)
+      hipblasZtpmv_rank_0 = hipblasZtpmv_(handle,uplo,transA,diag,n,AP,c_loc(x),incx)
     end function
 
     function hipblasZtpmv_rank_1(handle,uplo,transA,diag,n,AP,x,incx)
@@ -57212,11 +55470,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      complex(c_double_complex),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       !
-      hipblasZtpmv_rank_1 = hipblasZtpmv_(handle,uplo,transA,diag,n,c_loc(AP),c_loc(x),incx)
+      hipblasZtpmv_rank_1 = hipblasZtpmv_(handle,uplo,transA,diag,n,AP,c_loc(x),incx)
     end function
 
     function hipblasStpmvStridedBatched_rank_0(handle,uplo,transA,diag,n,AP,strideA,x,incx, &
@@ -57230,7 +55488,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      real(c_float),target :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: strideA
       real(c_float),target :: x
       integer(c_int) :: incx
@@ -57238,7 +55496,7 @@ module hipfort_hipblas
       integer(c_int) :: batchCount
       !
       hipblasStpmvStridedBatched_rank_0 = hipblasStpmvStridedBatched_(handle,uplo,transA,diag,n, &
-        c_loc(AP),strideA,c_loc(x),incx,stridex,batchCount)
+        AP,strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
     function hipblasStpmvStridedBatched_rank_1(handle,uplo,transA,diag,n,AP,strideA,x,incx, &
@@ -57252,7 +55510,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      real(c_float),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: strideA
       real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
@@ -57260,7 +55518,7 @@ module hipfort_hipblas
       integer(c_int) :: batchCount
       !
       hipblasStpmvStridedBatched_rank_1 = hipblasStpmvStridedBatched_(handle,uplo,transA,diag,n, &
-        c_loc(AP),strideA,c_loc(x),incx,stridex,batchCount)
+        AP,strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
     function hipblasDtpmvStridedBatched_rank_0(handle,uplo,transA,diag,n,AP,strideA,x,incx, &
@@ -57274,7 +55532,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      real(c_double),target :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: strideA
       real(c_double),target :: x
       integer(c_int) :: incx
@@ -57282,7 +55540,7 @@ module hipfort_hipblas
       integer(c_int) :: batchCount
       !
       hipblasDtpmvStridedBatched_rank_0 = hipblasDtpmvStridedBatched_(handle,uplo,transA,diag,n, &
-        c_loc(AP),strideA,c_loc(x),incx,stridex,batchCount)
+        AP,strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
     function hipblasDtpmvStridedBatched_rank_1(handle,uplo,transA,diag,n,AP,strideA,x,incx, &
@@ -57296,7 +55554,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      real(c_double),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: strideA
       real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
@@ -57304,7 +55562,7 @@ module hipfort_hipblas
       integer(c_int) :: batchCount
       !
       hipblasDtpmvStridedBatched_rank_1 = hipblasDtpmvStridedBatched_(handle,uplo,transA,diag,n, &
-        c_loc(AP),strideA,c_loc(x),incx,stridex,batchCount)
+        AP,strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
     function hipblasCtpmvStridedBatched_rank_0(handle,uplo,transA,diag,n,AP,strideA,x,incx, &
@@ -57318,7 +55576,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      complex(c_float_complex),target :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: strideA
       complex(c_float_complex),target :: x
       integer(c_int) :: incx
@@ -57326,7 +55584,7 @@ module hipfort_hipblas
       integer(c_int) :: batchCount
       !
       hipblasCtpmvStridedBatched_rank_0 = hipblasCtpmvStridedBatched_(handle,uplo,transA,diag,n, &
-        c_loc(AP),strideA,c_loc(x),incx,stridex,batchCount)
+        AP,strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
     function hipblasCtpmvStridedBatched_rank_1(handle,uplo,transA,diag,n,AP,strideA,x,incx, &
@@ -57340,7 +55598,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      complex(c_float_complex),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: strideA
       complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
@@ -57348,7 +55606,7 @@ module hipfort_hipblas
       integer(c_int) :: batchCount
       !
       hipblasCtpmvStridedBatched_rank_1 = hipblasCtpmvStridedBatched_(handle,uplo,transA,diag,n, &
-        c_loc(AP),strideA,c_loc(x),incx,stridex,batchCount)
+        AP,strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
     function hipblasZtpmvStridedBatched_rank_0(handle,uplo,transA,diag,n,AP,strideA,x,incx, &
@@ -57362,7 +55620,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      complex(c_double_complex),target :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: strideA
       complex(c_double_complex),target :: x
       integer(c_int) :: incx
@@ -57370,7 +55628,7 @@ module hipfort_hipblas
       integer(c_int) :: batchCount
       !
       hipblasZtpmvStridedBatched_rank_0 = hipblasZtpmvStridedBatched_(handle,uplo,transA,diag,n, &
-        c_loc(AP),strideA,c_loc(x),incx,stridex,batchCount)
+        AP,strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
     function hipblasZtpmvStridedBatched_rank_1(handle,uplo,transA,diag,n,AP,strideA,x,incx, &
@@ -57384,7 +55642,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      complex(c_double_complex),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: strideA
       complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
@@ -57392,7 +55650,7 @@ module hipfort_hipblas
       integer(c_int) :: batchCount
       !
       hipblasZtpmvStridedBatched_rank_1 = hipblasZtpmvStridedBatched_(handle,uplo,transA,diag,n, &
-        c_loc(AP),strideA,c_loc(x),incx,stridex,batchCount)
+        AP,strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
     function hipblasStpsv_rank_0(handle,uplo,transA,diag,n,AP,x,incx)
@@ -57405,11 +55663,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      real(c_float),target :: AP
+      type(c_ptr) :: AP
       real(c_float),target :: x
       integer(c_int) :: incx
       !
-      hipblasStpsv_rank_0 = hipblasStpsv_(handle,uplo,transA,diag,n,c_loc(AP),c_loc(x),incx)
+      hipblasStpsv_rank_0 = hipblasStpsv_(handle,uplo,transA,diag,n,AP,c_loc(x),incx)
     end function
 
     function hipblasStpsv_rank_1(handle,uplo,transA,diag,n,AP,x,incx)
@@ -57422,11 +55680,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      real(c_float),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       !
-      hipblasStpsv_rank_1 = hipblasStpsv_(handle,uplo,transA,diag,n,c_loc(AP),c_loc(x),incx)
+      hipblasStpsv_rank_1 = hipblasStpsv_(handle,uplo,transA,diag,n,AP,c_loc(x),incx)
     end function
 
     function hipblasDtpsv_rank_0(handle,uplo,transA,diag,n,AP,x,incx)
@@ -57439,11 +55697,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      real(c_double),target :: AP
+      type(c_ptr) :: AP
       real(c_double),target :: x
       integer(c_int) :: incx
       !
-      hipblasDtpsv_rank_0 = hipblasDtpsv_(handle,uplo,transA,diag,n,c_loc(AP),c_loc(x),incx)
+      hipblasDtpsv_rank_0 = hipblasDtpsv_(handle,uplo,transA,diag,n,AP,c_loc(x),incx)
     end function
 
     function hipblasDtpsv_rank_1(handle,uplo,transA,diag,n,AP,x,incx)
@@ -57456,11 +55714,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      real(c_double),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       !
-      hipblasDtpsv_rank_1 = hipblasDtpsv_(handle,uplo,transA,diag,n,c_loc(AP),c_loc(x),incx)
+      hipblasDtpsv_rank_1 = hipblasDtpsv_(handle,uplo,transA,diag,n,AP,c_loc(x),incx)
     end function
 
     function hipblasCtpsv_rank_0(handle,uplo,transA,diag,n,AP,x,incx)
@@ -57473,11 +55731,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      complex(c_float_complex),target :: AP
+      type(c_ptr) :: AP
       complex(c_float_complex),target :: x
       integer(c_int) :: incx
       !
-      hipblasCtpsv_rank_0 = hipblasCtpsv_(handle,uplo,transA,diag,n,c_loc(AP),c_loc(x),incx)
+      hipblasCtpsv_rank_0 = hipblasCtpsv_(handle,uplo,transA,diag,n,AP,c_loc(x),incx)
     end function
 
     function hipblasCtpsv_rank_1(handle,uplo,transA,diag,n,AP,x,incx)
@@ -57490,11 +55748,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      complex(c_float_complex),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       !
-      hipblasCtpsv_rank_1 = hipblasCtpsv_(handle,uplo,transA,diag,n,c_loc(AP),c_loc(x),incx)
+      hipblasCtpsv_rank_1 = hipblasCtpsv_(handle,uplo,transA,diag,n,AP,c_loc(x),incx)
     end function
 
     function hipblasZtpsv_rank_0(handle,uplo,transA,diag,n,AP,x,incx)
@@ -57507,11 +55765,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      complex(c_double_complex),target :: AP
+      type(c_ptr) :: AP
       complex(c_double_complex),target :: x
       integer(c_int) :: incx
       !
-      hipblasZtpsv_rank_0 = hipblasZtpsv_(handle,uplo,transA,diag,n,c_loc(AP),c_loc(x),incx)
+      hipblasZtpsv_rank_0 = hipblasZtpsv_(handle,uplo,transA,diag,n,AP,c_loc(x),incx)
     end function
 
     function hipblasZtpsv_rank_1(handle,uplo,transA,diag,n,AP,x,incx)
@@ -57524,11 +55782,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      complex(c_double_complex),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       !
-      hipblasZtpsv_rank_1 = hipblasZtpsv_(handle,uplo,transA,diag,n,c_loc(AP),c_loc(x),incx)
+      hipblasZtpsv_rank_1 = hipblasZtpsv_(handle,uplo,transA,diag,n,AP,c_loc(x),incx)
     end function
 
     function hipblasStpsvStridedBatched_rank_0(handle,uplo,transA,diag,n,AP,strideA,x,incx, &
@@ -57542,7 +55800,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      real(c_float),target :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: strideA
       real(c_float),target :: x
       integer(c_int) :: incx
@@ -57550,7 +55808,7 @@ module hipfort_hipblas
       integer(c_int) :: batchCount
       !
       hipblasStpsvStridedBatched_rank_0 = hipblasStpsvStridedBatched_(handle,uplo,transA,diag,n, &
-        c_loc(AP),strideA,c_loc(x),incx,stridex,batchCount)
+        AP,strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
     function hipblasStpsvStridedBatched_rank_1(handle,uplo,transA,diag,n,AP,strideA,x,incx, &
@@ -57564,7 +55822,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      real(c_float),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: strideA
       real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
@@ -57572,7 +55830,7 @@ module hipfort_hipblas
       integer(c_int) :: batchCount
       !
       hipblasStpsvStridedBatched_rank_1 = hipblasStpsvStridedBatched_(handle,uplo,transA,diag,n, &
-        c_loc(AP),strideA,c_loc(x),incx,stridex,batchCount)
+        AP,strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
     function hipblasDtpsvStridedBatched_rank_0(handle,uplo,transA,diag,n,AP,strideA,x,incx, &
@@ -57586,7 +55844,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      real(c_double),target :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: strideA
       real(c_double),target :: x
       integer(c_int) :: incx
@@ -57594,7 +55852,7 @@ module hipfort_hipblas
       integer(c_int) :: batchCount
       !
       hipblasDtpsvStridedBatched_rank_0 = hipblasDtpsvStridedBatched_(handle,uplo,transA,diag,n, &
-        c_loc(AP),strideA,c_loc(x),incx,stridex,batchCount)
+        AP,strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
     function hipblasDtpsvStridedBatched_rank_1(handle,uplo,transA,diag,n,AP,strideA,x,incx, &
@@ -57608,7 +55866,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      real(c_double),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: strideA
       real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
@@ -57616,7 +55874,7 @@ module hipfort_hipblas
       integer(c_int) :: batchCount
       !
       hipblasDtpsvStridedBatched_rank_1 = hipblasDtpsvStridedBatched_(handle,uplo,transA,diag,n, &
-        c_loc(AP),strideA,c_loc(x),incx,stridex,batchCount)
+        AP,strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
     function hipblasCtpsvStridedBatched_rank_0(handle,uplo,transA,diag,n,AP,strideA,x,incx, &
@@ -57630,7 +55888,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      complex(c_float_complex),target :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: strideA
       complex(c_float_complex),target :: x
       integer(c_int) :: incx
@@ -57638,7 +55896,7 @@ module hipfort_hipblas
       integer(c_int) :: batchCount
       !
       hipblasCtpsvStridedBatched_rank_0 = hipblasCtpsvStridedBatched_(handle,uplo,transA,diag,n, &
-        c_loc(AP),strideA,c_loc(x),incx,stridex,batchCount)
+        AP,strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
     function hipblasCtpsvStridedBatched_rank_1(handle,uplo,transA,diag,n,AP,strideA,x,incx, &
@@ -57652,7 +55910,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      complex(c_float_complex),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: strideA
       complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
@@ -57660,7 +55918,7 @@ module hipfort_hipblas
       integer(c_int) :: batchCount
       !
       hipblasCtpsvStridedBatched_rank_1 = hipblasCtpsvStridedBatched_(handle,uplo,transA,diag,n, &
-        c_loc(AP),strideA,c_loc(x),incx,stridex,batchCount)
+        AP,strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
     function hipblasZtpsvStridedBatched_rank_0(handle,uplo,transA,diag,n,AP,strideA,x,incx, &
@@ -57674,7 +55932,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      complex(c_double_complex),target :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: strideA
       complex(c_double_complex),target :: x
       integer(c_int) :: incx
@@ -57682,7 +55940,7 @@ module hipfort_hipblas
       integer(c_int) :: batchCount
       !
       hipblasZtpsvStridedBatched_rank_0 = hipblasZtpsvStridedBatched_(handle,uplo,transA,diag,n, &
-        c_loc(AP),strideA,c_loc(x),incx,stridex,batchCount)
+        AP,strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
     function hipblasZtpsvStridedBatched_rank_1(handle,uplo,transA,diag,n,AP,strideA,x,incx, &
@@ -57696,7 +55954,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      complex(c_double_complex),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: strideA
       complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
@@ -57704,7 +55962,7 @@ module hipfort_hipblas
       integer(c_int) :: batchCount
       !
       hipblasZtpsvStridedBatched_rank_1 = hipblasZtpsvStridedBatched_(handle,uplo,transA,diag,n, &
-        c_loc(AP),strideA,c_loc(x),incx,stridex,batchCount)
+        AP,strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
     function hipblasStrmv_rank_0(handle,uplo,transA,diag,n,AP,lda,x,incx)
@@ -57755,7 +56013,7 @@ module hipfort_hipblas
       integer(c_int) :: n
       real(c_float),target,dimension(:,:) :: AP
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: x
+      real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       !
       hipblasStrmv_full_rank = hipblasStrmv_(handle,uplo,transA,diag,n,c_loc(AP),lda,c_loc(x),incx)
@@ -57809,7 +56067,7 @@ module hipfort_hipblas
       integer(c_int) :: n
       real(c_double),target,dimension(:,:) :: AP
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: x
+      real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       !
       hipblasDtrmv_full_rank = hipblasDtrmv_(handle,uplo,transA,diag,n,c_loc(AP),lda,c_loc(x),incx)
@@ -57863,7 +56121,7 @@ module hipfort_hipblas
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:,:) :: AP
       integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       !
       hipblasCtrmv_full_rank = hipblasCtrmv_(handle,uplo,transA,diag,n,c_loc(AP),lda,c_loc(x),incx)
@@ -57917,7 +56175,7 @@ module hipfort_hipblas
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:,:) :: AP
       integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       !
       hipblasZtrmv_full_rank = hipblasZtrmv_(handle,uplo,transA,diag,n,c_loc(AP),lda,c_loc(x),incx)
@@ -57983,7 +56241,7 @@ module hipfort_hipblas
       real(c_float),target,dimension(:,:) :: AP
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_float),target,dimension(:,:) :: x
+      real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batchCount
@@ -58052,7 +56310,7 @@ module hipfort_hipblas
       real(c_double),target,dimension(:,:) :: AP
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_double),target,dimension(:,:) :: x
+      real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batchCount
@@ -58121,7 +56379,7 @@ module hipfort_hipblas
       complex(c_float_complex),target,dimension(:,:) :: AP
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batchCount
@@ -58190,7 +56448,7 @@ module hipfort_hipblas
       complex(c_double_complex),target,dimension(:,:) :: AP
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batchCount
@@ -58247,7 +56505,7 @@ module hipfort_hipblas
       integer(c_int) :: n
       real(c_float),target,dimension(:,:) :: AP
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: x
+      real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       !
       hipblasStrsv_full_rank = hipblasStrsv_(handle,uplo,transA,diag,n,c_loc(AP),lda,c_loc(x),incx)
@@ -58301,7 +56559,7 @@ module hipfort_hipblas
       integer(c_int) :: n
       real(c_double),target,dimension(:,:) :: AP
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: x
+      real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       !
       hipblasDtrsv_full_rank = hipblasDtrsv_(handle,uplo,transA,diag,n,c_loc(AP),lda,c_loc(x),incx)
@@ -58355,7 +56613,7 @@ module hipfort_hipblas
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:,:) :: AP
       integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       !
       hipblasCtrsv_full_rank = hipblasCtrsv_(handle,uplo,transA,diag,n,c_loc(AP),lda,c_loc(x),incx)
@@ -58409,7 +56667,7 @@ module hipfort_hipblas
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:,:) :: AP
       integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       !
       hipblasZtrsv_full_rank = hipblasZtrsv_(handle,uplo,transA,diag,n,c_loc(AP),lda,c_loc(x),incx)
@@ -58475,7 +56733,7 @@ module hipfort_hipblas
       real(c_float),target,dimension(:,:) :: AP
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_float),target,dimension(:,:) :: x
+      real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batchCount
@@ -58544,7 +56802,7 @@ module hipfort_hipblas
       real(c_double),target,dimension(:,:) :: AP
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_double),target,dimension(:,:) :: x
+      real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batchCount
@@ -58613,7 +56871,7 @@ module hipfort_hipblas
       complex(c_float_complex),target,dimension(:,:) :: AP
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batchCount
@@ -58682,7 +56940,7 @@ module hipfort_hipblas
       complex(c_double_complex),target,dimension(:,:) :: AP
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batchCount
@@ -65250,7 +63508,7 @@ module hipfort_hipblas
       integer(c_int) :: n
       real(c_float),target,dimension(:,:) :: AP
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: x
+      real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       real(c_float),target,dimension(:,:) :: CP
       integer(c_int) :: ldc
@@ -65308,7 +63566,7 @@ module hipfort_hipblas
       integer(c_int) :: n
       real(c_double),target,dimension(:,:) :: AP
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: x
+      real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       real(c_double),target,dimension(:,:) :: CP
       integer(c_int) :: ldc
@@ -65366,7 +63624,7 @@ module hipfort_hipblas
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:,:) :: AP
       integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       complex(c_float_complex),target,dimension(:,:) :: CP
       integer(c_int) :: ldc
@@ -65424,7 +63682,7 @@ module hipfort_hipblas
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:,:) :: AP
       integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       complex(c_double_complex),target,dimension(:,:) :: CP
       integer(c_int) :: ldc
@@ -65496,7 +63754,7 @@ module hipfort_hipblas
       real(c_float),target,dimension(:,:) :: AP
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_float),target,dimension(:,:) :: x
+      real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       real(c_float),target,dimension(:,:) :: CP
@@ -65571,7 +63829,7 @@ module hipfort_hipblas
       real(c_double),target,dimension(:,:) :: AP
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_double),target,dimension(:,:) :: x
+      real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       real(c_double),target,dimension(:,:) :: CP
@@ -65646,7 +63904,7 @@ module hipfort_hipblas
       complex(c_float_complex),target,dimension(:,:) :: AP
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       complex(c_float_complex),target,dimension(:,:) :: CP
@@ -65721,7 +63979,7 @@ module hipfort_hipblas
       complex(c_double_complex),target,dimension(:,:) :: AP
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       complex(c_double_complex),target,dimension(:,:) :: CP
@@ -65742,10 +64000,10 @@ module hipfort_hipblas
       integer(c_int) :: n
       real(c_float),target :: A
       integer(c_int) :: lda
-      integer(c_int),target :: ipiv
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: ipiv
+      type(c_ptr) :: myInfo
       !
-      hipblasSgetrf_rank_0 = hipblasSgetrf_(handle,n,c_loc(A),lda,c_loc(ipiv),c_loc(myInfo))
+      hipblasSgetrf_rank_0 = hipblasSgetrf_(handle,n,c_loc(A),lda,ipiv,myInfo)
     end function
 
     function hipblasSgetrf_rank_1(handle,n,A,lda,ipiv,myInfo)
@@ -65757,10 +64015,10 @@ module hipfort_hipblas
       integer(c_int) :: n
       real(c_float),target,dimension(:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: ipiv
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: ipiv
+      type(c_ptr) :: myInfo
       !
-      hipblasSgetrf_rank_1 = hipblasSgetrf_(handle,n,c_loc(A),lda,c_loc(ipiv),c_loc(myInfo))
+      hipblasSgetrf_rank_1 = hipblasSgetrf_(handle,n,c_loc(A),lda,ipiv,myInfo)
     end function
 
     function hipblasSgetrf_full_rank(handle,n,A,lda,ipiv,myInfo)
@@ -65772,10 +64030,10 @@ module hipfort_hipblas
       integer(c_int) :: n
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: ipiv
+      type(c_ptr) :: myInfo
       !
-      hipblasSgetrf_full_rank = hipblasSgetrf_(handle,n,c_loc(A),lda,c_loc(ipiv),c_loc(myInfo))
+      hipblasSgetrf_full_rank = hipblasSgetrf_(handle,n,c_loc(A),lda,ipiv,myInfo)
     end function
 
     function hipblasDgetrf_rank_0(handle,n,A,lda,ipiv,myInfo)
@@ -65787,10 +64045,10 @@ module hipfort_hipblas
       integer(c_int) :: n
       real(c_double),target :: A
       integer(c_int) :: lda
-      integer(c_int),target :: ipiv
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: ipiv
+      type(c_ptr) :: myInfo
       !
-      hipblasDgetrf_rank_0 = hipblasDgetrf_(handle,n,c_loc(A),lda,c_loc(ipiv),c_loc(myInfo))
+      hipblasDgetrf_rank_0 = hipblasDgetrf_(handle,n,c_loc(A),lda,ipiv,myInfo)
     end function
 
     function hipblasDgetrf_rank_1(handle,n,A,lda,ipiv,myInfo)
@@ -65802,10 +64060,10 @@ module hipfort_hipblas
       integer(c_int) :: n
       real(c_double),target,dimension(:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: ipiv
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: ipiv
+      type(c_ptr) :: myInfo
       !
-      hipblasDgetrf_rank_1 = hipblasDgetrf_(handle,n,c_loc(A),lda,c_loc(ipiv),c_loc(myInfo))
+      hipblasDgetrf_rank_1 = hipblasDgetrf_(handle,n,c_loc(A),lda,ipiv,myInfo)
     end function
 
     function hipblasDgetrf_full_rank(handle,n,A,lda,ipiv,myInfo)
@@ -65817,10 +64075,10 @@ module hipfort_hipblas
       integer(c_int) :: n
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: ipiv
+      type(c_ptr) :: myInfo
       !
-      hipblasDgetrf_full_rank = hipblasDgetrf_(handle,n,c_loc(A),lda,c_loc(ipiv),c_loc(myInfo))
+      hipblasDgetrf_full_rank = hipblasDgetrf_(handle,n,c_loc(A),lda,ipiv,myInfo)
     end function
 
     function hipblasCgetrf_rank_0(handle,n,A,lda,ipiv,myInfo)
@@ -65832,10 +64090,10 @@ module hipfort_hipblas
       integer(c_int) :: n
       complex(c_float_complex),target :: A
       integer(c_int) :: lda
-      integer(c_int),target :: ipiv
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: ipiv
+      type(c_ptr) :: myInfo
       !
-      hipblasCgetrf_rank_0 = hipblasCgetrf_(handle,n,c_loc(A),lda,c_loc(ipiv),c_loc(myInfo))
+      hipblasCgetrf_rank_0 = hipblasCgetrf_(handle,n,c_loc(A),lda,ipiv,myInfo)
     end function
 
     function hipblasCgetrf_rank_1(handle,n,A,lda,ipiv,myInfo)
@@ -65847,10 +64105,10 @@ module hipfort_hipblas
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: ipiv
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: ipiv
+      type(c_ptr) :: myInfo
       !
-      hipblasCgetrf_rank_1 = hipblasCgetrf_(handle,n,c_loc(A),lda,c_loc(ipiv),c_loc(myInfo))
+      hipblasCgetrf_rank_1 = hipblasCgetrf_(handle,n,c_loc(A),lda,ipiv,myInfo)
     end function
 
     function hipblasCgetrf_full_rank(handle,n,A,lda,ipiv,myInfo)
@@ -65862,10 +64120,10 @@ module hipfort_hipblas
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: ipiv
+      type(c_ptr) :: myInfo
       !
-      hipblasCgetrf_full_rank = hipblasCgetrf_(handle,n,c_loc(A),lda,c_loc(ipiv),c_loc(myInfo))
+      hipblasCgetrf_full_rank = hipblasCgetrf_(handle,n,c_loc(A),lda,ipiv,myInfo)
     end function
 
     function hipblasZgetrf_rank_0(handle,n,A,lda,ipiv,myInfo)
@@ -65877,10 +64135,10 @@ module hipfort_hipblas
       integer(c_int) :: n
       complex(c_double_complex),target :: A
       integer(c_int) :: lda
-      integer(c_int),target :: ipiv
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: ipiv
+      type(c_ptr) :: myInfo
       !
-      hipblasZgetrf_rank_0 = hipblasZgetrf_(handle,n,c_loc(A),lda,c_loc(ipiv),c_loc(myInfo))
+      hipblasZgetrf_rank_0 = hipblasZgetrf_(handle,n,c_loc(A),lda,ipiv,myInfo)
     end function
 
     function hipblasZgetrf_rank_1(handle,n,A,lda,ipiv,myInfo)
@@ -65892,10 +64150,10 @@ module hipfort_hipblas
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: ipiv
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: ipiv
+      type(c_ptr) :: myInfo
       !
-      hipblasZgetrf_rank_1 = hipblasZgetrf_(handle,n,c_loc(A),lda,c_loc(ipiv),c_loc(myInfo))
+      hipblasZgetrf_rank_1 = hipblasZgetrf_(handle,n,c_loc(A),lda,ipiv,myInfo)
     end function
 
     function hipblasZgetrf_full_rank(handle,n,A,lda,ipiv,myInfo)
@@ -65907,214 +64165,10 @@ module hipfort_hipblas
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: ipiv
+      type(c_ptr) :: myInfo
       !
-      hipblasZgetrf_full_rank = hipblasZgetrf_(handle,n,c_loc(A),lda,c_loc(ipiv),c_loc(myInfo))
-    end function
-
-    function hipblasSgetrfBatched_rank_0(handle,n,A,lda,ipiv,myInfo,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasSgetrfBatched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target :: ipiv
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batchCount
-      !
-      hipblasSgetrfBatched_rank_0 = hipblasSgetrfBatched_(handle,n,A,lda,c_loc(ipiv), &
-        c_loc(myInfo),batchCount)
-    end function
-
-    function hipblasSgetrfBatched_rank_1(handle,n,A,lda,ipiv,myInfo,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasSgetrfBatched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: ipiv
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batchCount
-      !
-      hipblasSgetrfBatched_rank_1 = hipblasSgetrfBatched_(handle,n,A,lda,c_loc(ipiv), &
-        c_loc(myInfo),batchCount)
-    end function
-
-    function hipblasSgetrfBatched_full_rank(handle,n,A,lda,ipiv,myInfo,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasSgetrfBatched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batchCount
-      !
-      hipblasSgetrfBatched_full_rank = hipblasSgetrfBatched_(handle,n,A,lda,c_loc(ipiv), &
-        c_loc(myInfo),batchCount)
-    end function
-
-    function hipblasDgetrfBatched_rank_0(handle,n,A,lda,ipiv,myInfo,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasDgetrfBatched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target :: ipiv
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batchCount
-      !
-      hipblasDgetrfBatched_rank_0 = hipblasDgetrfBatched_(handle,n,A,lda,c_loc(ipiv), &
-        c_loc(myInfo),batchCount)
-    end function
-
-    function hipblasDgetrfBatched_rank_1(handle,n,A,lda,ipiv,myInfo,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasDgetrfBatched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: ipiv
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batchCount
-      !
-      hipblasDgetrfBatched_rank_1 = hipblasDgetrfBatched_(handle,n,A,lda,c_loc(ipiv), &
-        c_loc(myInfo),batchCount)
-    end function
-
-    function hipblasDgetrfBatched_full_rank(handle,n,A,lda,ipiv,myInfo,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasDgetrfBatched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batchCount
-      !
-      hipblasDgetrfBatched_full_rank = hipblasDgetrfBatched_(handle,n,A,lda,c_loc(ipiv), &
-        c_loc(myInfo),batchCount)
-    end function
-
-    function hipblasCgetrfBatched_rank_0(handle,n,A,lda,ipiv,myInfo,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasCgetrfBatched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target :: ipiv
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batchCount
-      !
-      hipblasCgetrfBatched_rank_0 = hipblasCgetrfBatched_(handle,n,A,lda,c_loc(ipiv), &
-        c_loc(myInfo),batchCount)
-    end function
-
-    function hipblasCgetrfBatched_rank_1(handle,n,A,lda,ipiv,myInfo,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasCgetrfBatched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: ipiv
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batchCount
-      !
-      hipblasCgetrfBatched_rank_1 = hipblasCgetrfBatched_(handle,n,A,lda,c_loc(ipiv), &
-        c_loc(myInfo),batchCount)
-    end function
-
-    function hipblasCgetrfBatched_full_rank(handle,n,A,lda,ipiv,myInfo,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasCgetrfBatched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batchCount
-      !
-      hipblasCgetrfBatched_full_rank = hipblasCgetrfBatched_(handle,n,A,lda,c_loc(ipiv), &
-        c_loc(myInfo),batchCount)
-    end function
-
-    function hipblasZgetrfBatched_rank_0(handle,n,A,lda,ipiv,myInfo,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasZgetrfBatched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target :: ipiv
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batchCount
-      !
-      hipblasZgetrfBatched_rank_0 = hipblasZgetrfBatched_(handle,n,A,lda,c_loc(ipiv), &
-        c_loc(myInfo),batchCount)
-    end function
-
-    function hipblasZgetrfBatched_rank_1(handle,n,A,lda,ipiv,myInfo,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasZgetrfBatched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: ipiv
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batchCount
-      !
-      hipblasZgetrfBatched_rank_1 = hipblasZgetrfBatched_(handle,n,A,lda,c_loc(ipiv), &
-        c_loc(myInfo),batchCount)
-    end function
-
-    function hipblasZgetrfBatched_full_rank(handle,n,A,lda,ipiv,myInfo,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasZgetrfBatched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batchCount
-      !
-      hipblasZgetrfBatched_full_rank = hipblasZgetrfBatched_(handle,n,A,lda,c_loc(ipiv), &
-        c_loc(myInfo),batchCount)
+      hipblasZgetrf_full_rank = hipblasZgetrf_(handle,n,c_loc(A),lda,ipiv,myInfo)
     end function
 
     function hipblasSgetrfStridedBatched_rank_0(handle,n,A,lda,strideA,ipiv,strideP,myInfo, &
@@ -66128,13 +64182,13 @@ module hipfort_hipblas
       real(c_float),target :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target :: ipiv
+      type(c_ptr) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batchCount
       !
       hipblasSgetrfStridedBatched_rank_0 = hipblasSgetrfStridedBatched_(handle,n,c_loc(A),lda, &
-        strideA,c_loc(ipiv),strideP,c_loc(myInfo),batchCount)
+        strideA,ipiv,strideP,myInfo,batchCount)
     end function
 
     function hipblasSgetrfStridedBatched_rank_1(handle,n,A,lda,strideA,ipiv,strideP,myInfo, &
@@ -66148,13 +64202,13 @@ module hipfort_hipblas
       real(c_float),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:) :: ipiv
+      type(c_ptr) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batchCount
       !
       hipblasSgetrfStridedBatched_rank_1 = hipblasSgetrfStridedBatched_(handle,n,c_loc(A),lda, &
-        strideA,c_loc(ipiv),strideP,c_loc(myInfo),batchCount)
+        strideA,ipiv,strideP,myInfo,batchCount)
     end function
 
     function hipblasSgetrfStridedBatched_full_rank(handle,n,A,lda,strideA,ipiv,strideP,myInfo, &
@@ -66168,13 +64222,13 @@ module hipfort_hipblas
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: ipiv
+      type(c_ptr) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batchCount
       !
       hipblasSgetrfStridedBatched_full_rank = hipblasSgetrfStridedBatched_(handle,n,c_loc(A),lda, &
-        strideA,c_loc(ipiv),strideP,c_loc(myInfo),batchCount)
+        strideA,ipiv,strideP,myInfo,batchCount)
     end function
 
     function hipblasDgetrfStridedBatched_rank_0(handle,n,A,lda,strideA,ipiv,strideP,myInfo, &
@@ -66188,13 +64242,13 @@ module hipfort_hipblas
       real(c_double),target :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target :: ipiv
+      type(c_ptr) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batchCount
       !
       hipblasDgetrfStridedBatched_rank_0 = hipblasDgetrfStridedBatched_(handle,n,c_loc(A),lda, &
-        strideA,c_loc(ipiv),strideP,c_loc(myInfo),batchCount)
+        strideA,ipiv,strideP,myInfo,batchCount)
     end function
 
     function hipblasDgetrfStridedBatched_rank_1(handle,n,A,lda,strideA,ipiv,strideP,myInfo, &
@@ -66208,13 +64262,13 @@ module hipfort_hipblas
       real(c_double),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:) :: ipiv
+      type(c_ptr) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batchCount
       !
       hipblasDgetrfStridedBatched_rank_1 = hipblasDgetrfStridedBatched_(handle,n,c_loc(A),lda, &
-        strideA,c_loc(ipiv),strideP,c_loc(myInfo),batchCount)
+        strideA,ipiv,strideP,myInfo,batchCount)
     end function
 
     function hipblasDgetrfStridedBatched_full_rank(handle,n,A,lda,strideA,ipiv,strideP,myInfo, &
@@ -66228,13 +64282,13 @@ module hipfort_hipblas
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: ipiv
+      type(c_ptr) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batchCount
       !
       hipblasDgetrfStridedBatched_full_rank = hipblasDgetrfStridedBatched_(handle,n,c_loc(A),lda, &
-        strideA,c_loc(ipiv),strideP,c_loc(myInfo),batchCount)
+        strideA,ipiv,strideP,myInfo,batchCount)
     end function
 
     function hipblasCgetrfStridedBatched_rank_0(handle,n,A,lda,strideA,ipiv,strideP,myInfo, &
@@ -66248,13 +64302,13 @@ module hipfort_hipblas
       complex(c_float_complex),target :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target :: ipiv
+      type(c_ptr) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batchCount
       !
       hipblasCgetrfStridedBatched_rank_0 = hipblasCgetrfStridedBatched_(handle,n,c_loc(A),lda, &
-        strideA,c_loc(ipiv),strideP,c_loc(myInfo),batchCount)
+        strideA,ipiv,strideP,myInfo,batchCount)
     end function
 
     function hipblasCgetrfStridedBatched_rank_1(handle,n,A,lda,strideA,ipiv,strideP,myInfo, &
@@ -66268,13 +64322,13 @@ module hipfort_hipblas
       complex(c_float_complex),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:) :: ipiv
+      type(c_ptr) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batchCount
       !
       hipblasCgetrfStridedBatched_rank_1 = hipblasCgetrfStridedBatched_(handle,n,c_loc(A),lda, &
-        strideA,c_loc(ipiv),strideP,c_loc(myInfo),batchCount)
+        strideA,ipiv,strideP,myInfo,batchCount)
     end function
 
     function hipblasCgetrfStridedBatched_full_rank(handle,n,A,lda,strideA,ipiv,strideP,myInfo, &
@@ -66288,13 +64342,13 @@ module hipfort_hipblas
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: ipiv
+      type(c_ptr) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batchCount
       !
       hipblasCgetrfStridedBatched_full_rank = hipblasCgetrfStridedBatched_(handle,n,c_loc(A),lda, &
-        strideA,c_loc(ipiv),strideP,c_loc(myInfo),batchCount)
+        strideA,ipiv,strideP,myInfo,batchCount)
     end function
 
     function hipblasZgetrfStridedBatched_rank_0(handle,n,A,lda,strideA,ipiv,strideP,myInfo, &
@@ -66308,13 +64362,13 @@ module hipfort_hipblas
       complex(c_double_complex),target :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target :: ipiv
+      type(c_ptr) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batchCount
       !
       hipblasZgetrfStridedBatched_rank_0 = hipblasZgetrfStridedBatched_(handle,n,c_loc(A),lda, &
-        strideA,c_loc(ipiv),strideP,c_loc(myInfo),batchCount)
+        strideA,ipiv,strideP,myInfo,batchCount)
     end function
 
     function hipblasZgetrfStridedBatched_rank_1(handle,n,A,lda,strideA,ipiv,strideP,myInfo, &
@@ -66328,13 +64382,13 @@ module hipfort_hipblas
       complex(c_double_complex),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:) :: ipiv
+      type(c_ptr) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batchCount
       !
       hipblasZgetrfStridedBatched_rank_1 = hipblasZgetrfStridedBatched_(handle,n,c_loc(A),lda, &
-        strideA,c_loc(ipiv),strideP,c_loc(myInfo),batchCount)
+        strideA,ipiv,strideP,myInfo,batchCount)
     end function
 
     function hipblasZgetrfStridedBatched_full_rank(handle,n,A,lda,strideA,ipiv,strideP,myInfo, &
@@ -66348,13 +64402,13 @@ module hipfort_hipblas
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: ipiv
+      type(c_ptr) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batchCount
       !
       hipblasZgetrfStridedBatched_full_rank = hipblasZgetrfStridedBatched_(handle,n,c_loc(A),lda, &
-        strideA,c_loc(ipiv),strideP,c_loc(myInfo),batchCount)
+        strideA,ipiv,strideP,myInfo,batchCount)
     end function
 
     function hipblasSgetrs_rank_0(handle,trans,n,nrhs,A,lda,ipiv,B,ldb,myInfo)
@@ -66368,13 +64422,13 @@ module hipfort_hipblas
       integer(c_int) :: nrhs
       real(c_float),target :: A
       integer(c_int) :: lda
-      integer(c_int),target :: ipiv
+      type(c_ptr) :: ipiv
       real(c_float),target :: B
       integer(c_int) :: ldb
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      hipblasSgetrs_rank_0 = hipblasSgetrs_(handle,trans,n,nrhs,c_loc(A),lda,c_loc(ipiv),c_loc(B), &
-        ldb,c_loc(myInfo))
+      hipblasSgetrs_rank_0 = hipblasSgetrs_(handle,trans,n,nrhs,c_loc(A),lda,ipiv,c_loc(B),ldb, &
+        myInfo)
     end function
 
     function hipblasSgetrs_rank_1(handle,trans,n,nrhs,A,lda,ipiv,B,ldb,myInfo)
@@ -66388,13 +64442,13 @@ module hipfort_hipblas
       integer(c_int) :: nrhs
       real(c_float),target,dimension(:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: ipiv
+      type(c_ptr) :: ipiv
       real(c_float),target,dimension(:) :: B
       integer(c_int) :: ldb
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      hipblasSgetrs_rank_1 = hipblasSgetrs_(handle,trans,n,nrhs,c_loc(A),lda,c_loc(ipiv),c_loc(B), &
-        ldb,c_loc(myInfo))
+      hipblasSgetrs_rank_1 = hipblasSgetrs_(handle,trans,n,nrhs,c_loc(A),lda,ipiv,c_loc(B),ldb, &
+        myInfo)
     end function
 
     function hipblasSgetrs_full_rank(handle,trans,n,nrhs,A,lda,ipiv,B,ldb,myInfo)
@@ -66408,13 +64462,13 @@ module hipfort_hipblas
       integer(c_int) :: nrhs
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
+      type(c_ptr) :: ipiv
       real(c_float),target,dimension(:,:) :: B
       integer(c_int) :: ldb
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      hipblasSgetrs_full_rank = hipblasSgetrs_(handle,trans,n,nrhs,c_loc(A),lda,c_loc(ipiv), &
-        c_loc(B),ldb,c_loc(myInfo))
+      hipblasSgetrs_full_rank = hipblasSgetrs_(handle,trans,n,nrhs,c_loc(A),lda,ipiv,c_loc(B),ldb, &
+        myInfo)
     end function
 
     function hipblasDgetrs_rank_0(handle,trans,n,nrhs,A,lda,ipiv,B,ldb,myInfo)
@@ -66428,13 +64482,13 @@ module hipfort_hipblas
       integer(c_int) :: nrhs
       real(c_double),target :: A
       integer(c_int) :: lda
-      integer(c_int),target :: ipiv
+      type(c_ptr) :: ipiv
       real(c_double),target :: B
       integer(c_int) :: ldb
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      hipblasDgetrs_rank_0 = hipblasDgetrs_(handle,trans,n,nrhs,c_loc(A),lda,c_loc(ipiv),c_loc(B), &
-        ldb,c_loc(myInfo))
+      hipblasDgetrs_rank_0 = hipblasDgetrs_(handle,trans,n,nrhs,c_loc(A),lda,ipiv,c_loc(B),ldb, &
+        myInfo)
     end function
 
     function hipblasDgetrs_rank_1(handle,trans,n,nrhs,A,lda,ipiv,B,ldb,myInfo)
@@ -66448,13 +64502,13 @@ module hipfort_hipblas
       integer(c_int) :: nrhs
       real(c_double),target,dimension(:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: ipiv
+      type(c_ptr) :: ipiv
       real(c_double),target,dimension(:) :: B
       integer(c_int) :: ldb
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      hipblasDgetrs_rank_1 = hipblasDgetrs_(handle,trans,n,nrhs,c_loc(A),lda,c_loc(ipiv),c_loc(B), &
-        ldb,c_loc(myInfo))
+      hipblasDgetrs_rank_1 = hipblasDgetrs_(handle,trans,n,nrhs,c_loc(A),lda,ipiv,c_loc(B),ldb, &
+        myInfo)
     end function
 
     function hipblasDgetrs_full_rank(handle,trans,n,nrhs,A,lda,ipiv,B,ldb,myInfo)
@@ -66468,13 +64522,13 @@ module hipfort_hipblas
       integer(c_int) :: nrhs
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
+      type(c_ptr) :: ipiv
       real(c_double),target,dimension(:,:) :: B
       integer(c_int) :: ldb
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      hipblasDgetrs_full_rank = hipblasDgetrs_(handle,trans,n,nrhs,c_loc(A),lda,c_loc(ipiv), &
-        c_loc(B),ldb,c_loc(myInfo))
+      hipblasDgetrs_full_rank = hipblasDgetrs_(handle,trans,n,nrhs,c_loc(A),lda,ipiv,c_loc(B),ldb, &
+        myInfo)
     end function
 
     function hipblasCgetrs_rank_0(handle,trans,n,nrhs,A,lda,ipiv,B,ldb,myInfo)
@@ -66488,13 +64542,13 @@ module hipfort_hipblas
       integer(c_int) :: nrhs
       complex(c_float_complex),target :: A
       integer(c_int) :: lda
-      integer(c_int),target :: ipiv
+      type(c_ptr) :: ipiv
       complex(c_float_complex),target :: B
       integer(c_int) :: ldb
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      hipblasCgetrs_rank_0 = hipblasCgetrs_(handle,trans,n,nrhs,c_loc(A),lda,c_loc(ipiv),c_loc(B), &
-        ldb,c_loc(myInfo))
+      hipblasCgetrs_rank_0 = hipblasCgetrs_(handle,trans,n,nrhs,c_loc(A),lda,ipiv,c_loc(B),ldb, &
+        myInfo)
     end function
 
     function hipblasCgetrs_rank_1(handle,trans,n,nrhs,A,lda,ipiv,B,ldb,myInfo)
@@ -66508,13 +64562,13 @@ module hipfort_hipblas
       integer(c_int) :: nrhs
       complex(c_float_complex),target,dimension(:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: ipiv
+      type(c_ptr) :: ipiv
       complex(c_float_complex),target,dimension(:) :: B
       integer(c_int) :: ldb
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      hipblasCgetrs_rank_1 = hipblasCgetrs_(handle,trans,n,nrhs,c_loc(A),lda,c_loc(ipiv),c_loc(B), &
-        ldb,c_loc(myInfo))
+      hipblasCgetrs_rank_1 = hipblasCgetrs_(handle,trans,n,nrhs,c_loc(A),lda,ipiv,c_loc(B),ldb, &
+        myInfo)
     end function
 
     function hipblasCgetrs_full_rank(handle,trans,n,nrhs,A,lda,ipiv,B,ldb,myInfo)
@@ -66528,13 +64582,13 @@ module hipfort_hipblas
       integer(c_int) :: nrhs
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
+      type(c_ptr) :: ipiv
       complex(c_float_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      hipblasCgetrs_full_rank = hipblasCgetrs_(handle,trans,n,nrhs,c_loc(A),lda,c_loc(ipiv), &
-        c_loc(B),ldb,c_loc(myInfo))
+      hipblasCgetrs_full_rank = hipblasCgetrs_(handle,trans,n,nrhs,c_loc(A),lda,ipiv,c_loc(B),ldb, &
+        myInfo)
     end function
 
     function hipblasZgetrs_rank_0(handle,trans,n,nrhs,A,lda,ipiv,B,ldb,myInfo)
@@ -66548,13 +64602,13 @@ module hipfort_hipblas
       integer(c_int) :: nrhs
       complex(c_double_complex),target :: A
       integer(c_int) :: lda
-      integer(c_int),target :: ipiv
+      type(c_ptr) :: ipiv
       complex(c_double_complex),target :: B
       integer(c_int) :: ldb
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      hipblasZgetrs_rank_0 = hipblasZgetrs_(handle,trans,n,nrhs,c_loc(A),lda,c_loc(ipiv),c_loc(B), &
-        ldb,c_loc(myInfo))
+      hipblasZgetrs_rank_0 = hipblasZgetrs_(handle,trans,n,nrhs,c_loc(A),lda,ipiv,c_loc(B),ldb, &
+        myInfo)
     end function
 
     function hipblasZgetrs_rank_1(handle,trans,n,nrhs,A,lda,ipiv,B,ldb,myInfo)
@@ -66568,13 +64622,13 @@ module hipfort_hipblas
       integer(c_int) :: nrhs
       complex(c_double_complex),target,dimension(:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: ipiv
+      type(c_ptr) :: ipiv
       complex(c_double_complex),target,dimension(:) :: B
       integer(c_int) :: ldb
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      hipblasZgetrs_rank_1 = hipblasZgetrs_(handle,trans,n,nrhs,c_loc(A),lda,c_loc(ipiv),c_loc(B), &
-        ldb,c_loc(myInfo))
+      hipblasZgetrs_rank_1 = hipblasZgetrs_(handle,trans,n,nrhs,c_loc(A),lda,ipiv,c_loc(B),ldb, &
+        myInfo)
     end function
 
     function hipblasZgetrs_full_rank(handle,trans,n,nrhs,A,lda,ipiv,B,ldb,myInfo)
@@ -66588,265 +64642,13 @@ module hipfort_hipblas
       integer(c_int) :: nrhs
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
+      type(c_ptr) :: ipiv
       complex(c_double_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      hipblasZgetrs_full_rank = hipblasZgetrs_(handle,trans,n,nrhs,c_loc(A),lda,c_loc(ipiv), &
-        c_loc(B),ldb,c_loc(myInfo))
-    end function
-
-    function hipblasSgetrsBatched_rank_0(handle,trans,n,nrhs,A,lda,ipiv,B,ldb,myInfo,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasSgetrsBatched_rank_0
-      type(c_ptr) :: handle
-      integer(kind(HIPBLAS_OP_N)) :: trans
-      integer(c_int) :: n
-      integer(c_int) :: nrhs
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target :: ipiv
-      type(c_ptr) :: B
-      integer(c_int) :: ldb
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batchCount
-      !
-      hipblasSgetrsBatched_rank_0 = hipblasSgetrsBatched_(handle,trans,n,nrhs,A,lda,c_loc(ipiv),B, &
-        ldb,c_loc(myInfo),batchCount)
-    end function
-
-    function hipblasSgetrsBatched_rank_1(handle,trans,n,nrhs,A,lda,ipiv,B,ldb,myInfo,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasSgetrsBatched_rank_1
-      type(c_ptr) :: handle
-      integer(kind(HIPBLAS_OP_N)) :: trans
-      integer(c_int) :: n
-      integer(c_int) :: nrhs
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: ipiv
-      type(c_ptr) :: B
-      integer(c_int) :: ldb
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batchCount
-      !
-      hipblasSgetrsBatched_rank_1 = hipblasSgetrsBatched_(handle,trans,n,nrhs,A,lda,c_loc(ipiv),B, &
-        ldb,c_loc(myInfo),batchCount)
-    end function
-
-    function hipblasSgetrsBatched_full_rank(handle,trans,n,nrhs,A,lda,ipiv,B,ldb,myInfo,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasSgetrsBatched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(HIPBLAS_OP_N)) :: trans
-      integer(c_int) :: n
-      integer(c_int) :: nrhs
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      type(c_ptr) :: B
-      integer(c_int) :: ldb
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batchCount
-      !
-      hipblasSgetrsBatched_full_rank = hipblasSgetrsBatched_(handle,trans,n,nrhs,A,lda, &
-        c_loc(ipiv),B,ldb,c_loc(myInfo),batchCount)
-    end function
-
-    function hipblasDgetrsBatched_rank_0(handle,trans,n,nrhs,A,lda,ipiv,B,ldb,myInfo,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasDgetrsBatched_rank_0
-      type(c_ptr) :: handle
-      integer(kind(HIPBLAS_OP_N)) :: trans
-      integer(c_int) :: n
-      integer(c_int) :: nrhs
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target :: ipiv
-      type(c_ptr) :: B
-      integer(c_int) :: ldb
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batchCount
-      !
-      hipblasDgetrsBatched_rank_0 = hipblasDgetrsBatched_(handle,trans,n,nrhs,A,lda,c_loc(ipiv),B, &
-        ldb,c_loc(myInfo),batchCount)
-    end function
-
-    function hipblasDgetrsBatched_rank_1(handle,trans,n,nrhs,A,lda,ipiv,B,ldb,myInfo,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasDgetrsBatched_rank_1
-      type(c_ptr) :: handle
-      integer(kind(HIPBLAS_OP_N)) :: trans
-      integer(c_int) :: n
-      integer(c_int) :: nrhs
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: ipiv
-      type(c_ptr) :: B
-      integer(c_int) :: ldb
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batchCount
-      !
-      hipblasDgetrsBatched_rank_1 = hipblasDgetrsBatched_(handle,trans,n,nrhs,A,lda,c_loc(ipiv),B, &
-        ldb,c_loc(myInfo),batchCount)
-    end function
-
-    function hipblasDgetrsBatched_full_rank(handle,trans,n,nrhs,A,lda,ipiv,B,ldb,myInfo,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasDgetrsBatched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(HIPBLAS_OP_N)) :: trans
-      integer(c_int) :: n
-      integer(c_int) :: nrhs
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      type(c_ptr) :: B
-      integer(c_int) :: ldb
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batchCount
-      !
-      hipblasDgetrsBatched_full_rank = hipblasDgetrsBatched_(handle,trans,n,nrhs,A,lda, &
-        c_loc(ipiv),B,ldb,c_loc(myInfo),batchCount)
-    end function
-
-    function hipblasCgetrsBatched_rank_0(handle,trans,n,nrhs,A,lda,ipiv,B,ldb,myInfo,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasCgetrsBatched_rank_0
-      type(c_ptr) :: handle
-      integer(kind(HIPBLAS_OP_N)) :: trans
-      integer(c_int) :: n
-      integer(c_int) :: nrhs
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target :: ipiv
-      type(c_ptr) :: B
-      integer(c_int) :: ldb
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batchCount
-      !
-      hipblasCgetrsBatched_rank_0 = hipblasCgetrsBatched_(handle,trans,n,nrhs,A,lda,c_loc(ipiv),B, &
-        ldb,c_loc(myInfo),batchCount)
-    end function
-
-    function hipblasCgetrsBatched_rank_1(handle,trans,n,nrhs,A,lda,ipiv,B,ldb,myInfo,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasCgetrsBatched_rank_1
-      type(c_ptr) :: handle
-      integer(kind(HIPBLAS_OP_N)) :: trans
-      integer(c_int) :: n
-      integer(c_int) :: nrhs
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: ipiv
-      type(c_ptr) :: B
-      integer(c_int) :: ldb
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batchCount
-      !
-      hipblasCgetrsBatched_rank_1 = hipblasCgetrsBatched_(handle,trans,n,nrhs,A,lda,c_loc(ipiv),B, &
-        ldb,c_loc(myInfo),batchCount)
-    end function
-
-    function hipblasCgetrsBatched_full_rank(handle,trans,n,nrhs,A,lda,ipiv,B,ldb,myInfo,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasCgetrsBatched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(HIPBLAS_OP_N)) :: trans
-      integer(c_int) :: n
-      integer(c_int) :: nrhs
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      type(c_ptr) :: B
-      integer(c_int) :: ldb
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batchCount
-      !
-      hipblasCgetrsBatched_full_rank = hipblasCgetrsBatched_(handle,trans,n,nrhs,A,lda, &
-        c_loc(ipiv),B,ldb,c_loc(myInfo),batchCount)
-    end function
-
-    function hipblasZgetrsBatched_rank_0(handle,trans,n,nrhs,A,lda,ipiv,B,ldb,myInfo,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasZgetrsBatched_rank_0
-      type(c_ptr) :: handle
-      integer(kind(HIPBLAS_OP_N)) :: trans
-      integer(c_int) :: n
-      integer(c_int) :: nrhs
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target :: ipiv
-      type(c_ptr) :: B
-      integer(c_int) :: ldb
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batchCount
-      !
-      hipblasZgetrsBatched_rank_0 = hipblasZgetrsBatched_(handle,trans,n,nrhs,A,lda,c_loc(ipiv),B, &
-        ldb,c_loc(myInfo),batchCount)
-    end function
-
-    function hipblasZgetrsBatched_rank_1(handle,trans,n,nrhs,A,lda,ipiv,B,ldb,myInfo,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasZgetrsBatched_rank_1
-      type(c_ptr) :: handle
-      integer(kind(HIPBLAS_OP_N)) :: trans
-      integer(c_int) :: n
-      integer(c_int) :: nrhs
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: ipiv
-      type(c_ptr) :: B
-      integer(c_int) :: ldb
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batchCount
-      !
-      hipblasZgetrsBatched_rank_1 = hipblasZgetrsBatched_(handle,trans,n,nrhs,A,lda,c_loc(ipiv),B, &
-        ldb,c_loc(myInfo),batchCount)
-    end function
-
-    function hipblasZgetrsBatched_full_rank(handle,trans,n,nrhs,A,lda,ipiv,B,ldb,myInfo,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasZgetrsBatched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(HIPBLAS_OP_N)) :: trans
-      integer(c_int) :: n
-      integer(c_int) :: nrhs
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      type(c_ptr) :: B
-      integer(c_int) :: ldb
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batchCount
-      !
-      hipblasZgetrsBatched_full_rank = hipblasZgetrsBatched_(handle,trans,n,nrhs,A,lda, &
-        c_loc(ipiv),B,ldb,c_loc(myInfo),batchCount)
+      hipblasZgetrs_full_rank = hipblasZgetrs_(handle,trans,n,nrhs,c_loc(A),lda,ipiv,c_loc(B),ldb, &
+        myInfo)
     end function
 
     function hipblasSgetrsStridedBatched_rank_0(handle,trans,n,nrhs,A,lda,strideA,ipiv,strideP,B, &
@@ -66862,16 +64664,16 @@ module hipfort_hipblas
       real(c_float),target :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target :: ipiv
+      type(c_ptr) :: ipiv
       integer(c_int64_t) :: strideP
       real(c_float),target :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batchCount
       !
       hipblasSgetrsStridedBatched_rank_0 = hipblasSgetrsStridedBatched_(handle,trans,n,nrhs, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(B),ldb,strideB,c_loc(myInfo),batchCount)
+        c_loc(A),lda,strideA,ipiv,strideP,c_loc(B),ldb,strideB,myInfo,batchCount)
     end function
 
     function hipblasSgetrsStridedBatched_rank_1(handle,trans,n,nrhs,A,lda,strideA,ipiv,strideP,B, &
@@ -66887,16 +64689,16 @@ module hipfort_hipblas
       real(c_float),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:) :: ipiv
+      type(c_ptr) :: ipiv
       integer(c_int64_t) :: strideP
       real(c_float),target,dimension(:) :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batchCount
       !
       hipblasSgetrsStridedBatched_rank_1 = hipblasSgetrsStridedBatched_(handle,trans,n,nrhs, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(B),ldb,strideB,c_loc(myInfo),batchCount)
+        c_loc(A),lda,strideA,ipiv,strideP,c_loc(B),ldb,strideB,myInfo,batchCount)
     end function
 
     function hipblasSgetrsStridedBatched_full_rank(handle,trans,n,nrhs,A,lda,strideA,ipiv,strideP, &
@@ -66912,16 +64714,16 @@ module hipfort_hipblas
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: ipiv
+      type(c_ptr) :: ipiv
       integer(c_int64_t) :: strideP
       real(c_float),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batchCount
       !
       hipblasSgetrsStridedBatched_full_rank = hipblasSgetrsStridedBatched_(handle,trans,n,nrhs, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(B),ldb,strideB,c_loc(myInfo),batchCount)
+        c_loc(A),lda,strideA,ipiv,strideP,c_loc(B),ldb,strideB,myInfo,batchCount)
     end function
 
     function hipblasDgetrsStridedBatched_rank_0(handle,trans,n,nrhs,A,lda,strideA,ipiv,strideP,B, &
@@ -66937,16 +64739,16 @@ module hipfort_hipblas
       real(c_double),target :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target :: ipiv
+      type(c_ptr) :: ipiv
       integer(c_int64_t) :: strideP
       real(c_double),target :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batchCount
       !
       hipblasDgetrsStridedBatched_rank_0 = hipblasDgetrsStridedBatched_(handle,trans,n,nrhs, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(B),ldb,strideB,c_loc(myInfo),batchCount)
+        c_loc(A),lda,strideA,ipiv,strideP,c_loc(B),ldb,strideB,myInfo,batchCount)
     end function
 
     function hipblasDgetrsStridedBatched_rank_1(handle,trans,n,nrhs,A,lda,strideA,ipiv,strideP,B, &
@@ -66962,16 +64764,16 @@ module hipfort_hipblas
       real(c_double),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:) :: ipiv
+      type(c_ptr) :: ipiv
       integer(c_int64_t) :: strideP
       real(c_double),target,dimension(:) :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batchCount
       !
       hipblasDgetrsStridedBatched_rank_1 = hipblasDgetrsStridedBatched_(handle,trans,n,nrhs, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(B),ldb,strideB,c_loc(myInfo),batchCount)
+        c_loc(A),lda,strideA,ipiv,strideP,c_loc(B),ldb,strideB,myInfo,batchCount)
     end function
 
     function hipblasDgetrsStridedBatched_full_rank(handle,trans,n,nrhs,A,lda,strideA,ipiv,strideP, &
@@ -66987,16 +64789,16 @@ module hipfort_hipblas
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: ipiv
+      type(c_ptr) :: ipiv
       integer(c_int64_t) :: strideP
       real(c_double),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batchCount
       !
       hipblasDgetrsStridedBatched_full_rank = hipblasDgetrsStridedBatched_(handle,trans,n,nrhs, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(B),ldb,strideB,c_loc(myInfo),batchCount)
+        c_loc(A),lda,strideA,ipiv,strideP,c_loc(B),ldb,strideB,myInfo,batchCount)
     end function
 
     function hipblasCgetrsStridedBatched_rank_0(handle,trans,n,nrhs,A,lda,strideA,ipiv,strideP,B, &
@@ -67012,16 +64814,16 @@ module hipfort_hipblas
       complex(c_float_complex),target :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target :: ipiv
+      type(c_ptr) :: ipiv
       integer(c_int64_t) :: strideP
       complex(c_float_complex),target :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batchCount
       !
       hipblasCgetrsStridedBatched_rank_0 = hipblasCgetrsStridedBatched_(handle,trans,n,nrhs, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(B),ldb,strideB,c_loc(myInfo),batchCount)
+        c_loc(A),lda,strideA,ipiv,strideP,c_loc(B),ldb,strideB,myInfo,batchCount)
     end function
 
     function hipblasCgetrsStridedBatched_rank_1(handle,trans,n,nrhs,A,lda,strideA,ipiv,strideP,B, &
@@ -67037,16 +64839,16 @@ module hipfort_hipblas
       complex(c_float_complex),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:) :: ipiv
+      type(c_ptr) :: ipiv
       integer(c_int64_t) :: strideP
       complex(c_float_complex),target,dimension(:) :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batchCount
       !
       hipblasCgetrsStridedBatched_rank_1 = hipblasCgetrsStridedBatched_(handle,trans,n,nrhs, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(B),ldb,strideB,c_loc(myInfo),batchCount)
+        c_loc(A),lda,strideA,ipiv,strideP,c_loc(B),ldb,strideB,myInfo,batchCount)
     end function
 
     function hipblasCgetrsStridedBatched_full_rank(handle,trans,n,nrhs,A,lda,strideA,ipiv,strideP, &
@@ -67062,16 +64864,16 @@ module hipfort_hipblas
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: ipiv
+      type(c_ptr) :: ipiv
       integer(c_int64_t) :: strideP
       complex(c_float_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batchCount
       !
       hipblasCgetrsStridedBatched_full_rank = hipblasCgetrsStridedBatched_(handle,trans,n,nrhs, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(B),ldb,strideB,c_loc(myInfo),batchCount)
+        c_loc(A),lda,strideA,ipiv,strideP,c_loc(B),ldb,strideB,myInfo,batchCount)
     end function
 
     function hipblasZgetrsStridedBatched_rank_0(handle,trans,n,nrhs,A,lda,strideA,ipiv,strideP,B, &
@@ -67087,16 +64889,16 @@ module hipfort_hipblas
       complex(c_double_complex),target :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target :: ipiv
+      type(c_ptr) :: ipiv
       integer(c_int64_t) :: strideP
       complex(c_double_complex),target :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batchCount
       !
       hipblasZgetrsStridedBatched_rank_0 = hipblasZgetrsStridedBatched_(handle,trans,n,nrhs, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(B),ldb,strideB,c_loc(myInfo),batchCount)
+        c_loc(A),lda,strideA,ipiv,strideP,c_loc(B),ldb,strideB,myInfo,batchCount)
     end function
 
     function hipblasZgetrsStridedBatched_rank_1(handle,trans,n,nrhs,A,lda,strideA,ipiv,strideP,B, &
@@ -67112,16 +64914,16 @@ module hipfort_hipblas
       complex(c_double_complex),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:) :: ipiv
+      type(c_ptr) :: ipiv
       integer(c_int64_t) :: strideP
       complex(c_double_complex),target,dimension(:) :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batchCount
       !
       hipblasZgetrsStridedBatched_rank_1 = hipblasZgetrsStridedBatched_(handle,trans,n,nrhs, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(B),ldb,strideB,c_loc(myInfo),batchCount)
+        c_loc(A),lda,strideA,ipiv,strideP,c_loc(B),ldb,strideB,myInfo,batchCount)
     end function
 
     function hipblasZgetrsStridedBatched_full_rank(handle,trans,n,nrhs,A,lda,strideA,ipiv,strideP, &
@@ -67137,244 +64939,16 @@ module hipfort_hipblas
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: ipiv
+      type(c_ptr) :: ipiv
       integer(c_int64_t) :: strideP
       complex(c_double_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batchCount
       !
       hipblasZgetrsStridedBatched_full_rank = hipblasZgetrsStridedBatched_(handle,trans,n,nrhs, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(B),ldb,strideB,c_loc(myInfo),batchCount)
-    end function
-
-    function hipblasSgetriBatched_rank_0(handle,n,A,lda,ipiv,C,ldc,myInfo,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasSgetriBatched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target :: ipiv
-      type(c_ptr) :: C
-      integer(c_int) :: ldc
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batchCount
-      !
-      hipblasSgetriBatched_rank_0 = hipblasSgetriBatched_(handle,n,A,lda,c_loc(ipiv),C,ldc, &
-        c_loc(myInfo),batchCount)
-    end function
-
-    function hipblasSgetriBatched_rank_1(handle,n,A,lda,ipiv,C,ldc,myInfo,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasSgetriBatched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: ipiv
-      type(c_ptr) :: C
-      integer(c_int) :: ldc
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batchCount
-      !
-      hipblasSgetriBatched_rank_1 = hipblasSgetriBatched_(handle,n,A,lda,c_loc(ipiv),C,ldc, &
-        c_loc(myInfo),batchCount)
-    end function
-
-    function hipblasSgetriBatched_full_rank(handle,n,A,lda,ipiv,C,ldc,myInfo,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasSgetriBatched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      type(c_ptr) :: C
-      integer(c_int) :: ldc
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batchCount
-      !
-      hipblasSgetriBatched_full_rank = hipblasSgetriBatched_(handle,n,A,lda,c_loc(ipiv),C,ldc, &
-        c_loc(myInfo),batchCount)
-    end function
-
-    function hipblasDgetriBatched_rank_0(handle,n,A,lda,ipiv,C,ldc,myInfo,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasDgetriBatched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target :: ipiv
-      type(c_ptr) :: C
-      integer(c_int) :: ldc
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batchCount
-      !
-      hipblasDgetriBatched_rank_0 = hipblasDgetriBatched_(handle,n,A,lda,c_loc(ipiv),C,ldc, &
-        c_loc(myInfo),batchCount)
-    end function
-
-    function hipblasDgetriBatched_rank_1(handle,n,A,lda,ipiv,C,ldc,myInfo,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasDgetriBatched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: ipiv
-      type(c_ptr) :: C
-      integer(c_int) :: ldc
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batchCount
-      !
-      hipblasDgetriBatched_rank_1 = hipblasDgetriBatched_(handle,n,A,lda,c_loc(ipiv),C,ldc, &
-        c_loc(myInfo),batchCount)
-    end function
-
-    function hipblasDgetriBatched_full_rank(handle,n,A,lda,ipiv,C,ldc,myInfo,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasDgetriBatched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      type(c_ptr) :: C
-      integer(c_int) :: ldc
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batchCount
-      !
-      hipblasDgetriBatched_full_rank = hipblasDgetriBatched_(handle,n,A,lda,c_loc(ipiv),C,ldc, &
-        c_loc(myInfo),batchCount)
-    end function
-
-    function hipblasCgetriBatched_rank_0(handle,n,A,lda,ipiv,C,ldc,myInfo,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasCgetriBatched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target :: ipiv
-      type(c_ptr) :: C
-      integer(c_int) :: ldc
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batchCount
-      !
-      hipblasCgetriBatched_rank_0 = hipblasCgetriBatched_(handle,n,A,lda,c_loc(ipiv),C,ldc, &
-        c_loc(myInfo),batchCount)
-    end function
-
-    function hipblasCgetriBatched_rank_1(handle,n,A,lda,ipiv,C,ldc,myInfo,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasCgetriBatched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: ipiv
-      type(c_ptr) :: C
-      integer(c_int) :: ldc
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batchCount
-      !
-      hipblasCgetriBatched_rank_1 = hipblasCgetriBatched_(handle,n,A,lda,c_loc(ipiv),C,ldc, &
-        c_loc(myInfo),batchCount)
-    end function
-
-    function hipblasCgetriBatched_full_rank(handle,n,A,lda,ipiv,C,ldc,myInfo,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasCgetriBatched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      type(c_ptr) :: C
-      integer(c_int) :: ldc
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batchCount
-      !
-      hipblasCgetriBatched_full_rank = hipblasCgetriBatched_(handle,n,A,lda,c_loc(ipiv),C,ldc, &
-        c_loc(myInfo),batchCount)
-    end function
-
-    function hipblasZgetriBatched_rank_0(handle,n,A,lda,ipiv,C,ldc,myInfo,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasZgetriBatched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target :: ipiv
-      type(c_ptr) :: C
-      integer(c_int) :: ldc
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batchCount
-      !
-      hipblasZgetriBatched_rank_0 = hipblasZgetriBatched_(handle,n,A,lda,c_loc(ipiv),C,ldc, &
-        c_loc(myInfo),batchCount)
-    end function
-
-    function hipblasZgetriBatched_rank_1(handle,n,A,lda,ipiv,C,ldc,myInfo,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasZgetriBatched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: ipiv
-      type(c_ptr) :: C
-      integer(c_int) :: ldc
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batchCount
-      !
-      hipblasZgetriBatched_rank_1 = hipblasZgetriBatched_(handle,n,A,lda,c_loc(ipiv),C,ldc, &
-        c_loc(myInfo),batchCount)
-    end function
-
-    function hipblasZgetriBatched_full_rank(handle,n,A,lda,ipiv,C,ldc,myInfo,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasZgetriBatched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      type(c_ptr) :: C
-      integer(c_int) :: ldc
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batchCount
-      !
-      hipblasZgetriBatched_full_rank = hipblasZgetriBatched_(handle,n,A,lda,c_loc(ipiv),C,ldc, &
-        c_loc(myInfo),batchCount)
+        c_loc(A),lda,strideA,ipiv,strideP,c_loc(B),ldb,strideB,myInfo,batchCount)
     end function
 
     function hipblasSgeqrf_rank_0(handle,m,n,A,lda,ipiv,myInfo)
@@ -67387,10 +64961,10 @@ module hipfort_hipblas
       integer(c_int) :: n
       real(c_float),target :: A
       integer(c_int) :: lda
-      real(c_float),target :: ipiv
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: ipiv
+      type(c_ptr) :: myInfo
       !
-      hipblasSgeqrf_rank_0 = hipblasSgeqrf_(handle,m,n,c_loc(A),lda,c_loc(ipiv),c_loc(myInfo))
+      hipblasSgeqrf_rank_0 = hipblasSgeqrf_(handle,m,n,c_loc(A),lda,ipiv,myInfo)
     end function
 
     function hipblasSgeqrf_rank_1(handle,m,n,A,lda,ipiv,myInfo)
@@ -67403,10 +64977,10 @@ module hipfort_hipblas
       integer(c_int) :: n
       real(c_float),target,dimension(:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:) :: ipiv
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: ipiv
+      type(c_ptr) :: myInfo
       !
-      hipblasSgeqrf_rank_1 = hipblasSgeqrf_(handle,m,n,c_loc(A),lda,c_loc(ipiv),c_loc(myInfo))
+      hipblasSgeqrf_rank_1 = hipblasSgeqrf_(handle,m,n,c_loc(A),lda,ipiv,myInfo)
     end function
 
     function hipblasSgeqrf_full_rank(handle,m,n,A,lda,ipiv,myInfo)
@@ -67419,10 +64993,10 @@ module hipfort_hipblas
       integer(c_int) :: n
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: ipiv
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: ipiv
+      type(c_ptr) :: myInfo
       !
-      hipblasSgeqrf_full_rank = hipblasSgeqrf_(handle,m,n,c_loc(A),lda,c_loc(ipiv),c_loc(myInfo))
+      hipblasSgeqrf_full_rank = hipblasSgeqrf_(handle,m,n,c_loc(A),lda,ipiv,myInfo)
     end function
 
     function hipblasDgeqrf_rank_0(handle,m,n,A,lda,ipiv,myInfo)
@@ -67435,10 +65009,10 @@ module hipfort_hipblas
       integer(c_int) :: n
       real(c_double),target :: A
       integer(c_int) :: lda
-      real(c_double),target :: ipiv
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: ipiv
+      type(c_ptr) :: myInfo
       !
-      hipblasDgeqrf_rank_0 = hipblasDgeqrf_(handle,m,n,c_loc(A),lda,c_loc(ipiv),c_loc(myInfo))
+      hipblasDgeqrf_rank_0 = hipblasDgeqrf_(handle,m,n,c_loc(A),lda,ipiv,myInfo)
     end function
 
     function hipblasDgeqrf_rank_1(handle,m,n,A,lda,ipiv,myInfo)
@@ -67451,10 +65025,10 @@ module hipfort_hipblas
       integer(c_int) :: n
       real(c_double),target,dimension(:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:) :: ipiv
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: ipiv
+      type(c_ptr) :: myInfo
       !
-      hipblasDgeqrf_rank_1 = hipblasDgeqrf_(handle,m,n,c_loc(A),lda,c_loc(ipiv),c_loc(myInfo))
+      hipblasDgeqrf_rank_1 = hipblasDgeqrf_(handle,m,n,c_loc(A),lda,ipiv,myInfo)
     end function
 
     function hipblasDgeqrf_full_rank(handle,m,n,A,lda,ipiv,myInfo)
@@ -67467,10 +65041,10 @@ module hipfort_hipblas
       integer(c_int) :: n
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: ipiv
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: ipiv
+      type(c_ptr) :: myInfo
       !
-      hipblasDgeqrf_full_rank = hipblasDgeqrf_(handle,m,n,c_loc(A),lda,c_loc(ipiv),c_loc(myInfo))
+      hipblasDgeqrf_full_rank = hipblasDgeqrf_(handle,m,n,c_loc(A),lda,ipiv,myInfo)
     end function
 
     function hipblasCgeqrf_rank_0(handle,m,n,A,lda,ipiv,myInfo)
@@ -67483,10 +65057,10 @@ module hipfort_hipblas
       integer(c_int) :: n
       complex(c_float_complex),target :: A
       integer(c_int) :: lda
-      complex(c_float_complex),target :: ipiv
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: ipiv
+      type(c_ptr) :: myInfo
       !
-      hipblasCgeqrf_rank_0 = hipblasCgeqrf_(handle,m,n,c_loc(A),lda,c_loc(ipiv),c_loc(myInfo))
+      hipblasCgeqrf_rank_0 = hipblasCgeqrf_(handle,m,n,c_loc(A),lda,ipiv,myInfo)
     end function
 
     function hipblasCgeqrf_rank_1(handle,m,n,A,lda,ipiv,myInfo)
@@ -67499,10 +65073,10 @@ module hipfort_hipblas
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:) :: A
       integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:) :: ipiv
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: ipiv
+      type(c_ptr) :: myInfo
       !
-      hipblasCgeqrf_rank_1 = hipblasCgeqrf_(handle,m,n,c_loc(A),lda,c_loc(ipiv),c_loc(myInfo))
+      hipblasCgeqrf_rank_1 = hipblasCgeqrf_(handle,m,n,c_loc(A),lda,ipiv,myInfo)
     end function
 
     function hipblasCgeqrf_full_rank(handle,m,n,A,lda,ipiv,myInfo)
@@ -67515,10 +65089,10 @@ module hipfort_hipblas
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:,:) :: ipiv
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: ipiv
+      type(c_ptr) :: myInfo
       !
-      hipblasCgeqrf_full_rank = hipblasCgeqrf_(handle,m,n,c_loc(A),lda,c_loc(ipiv),c_loc(myInfo))
+      hipblasCgeqrf_full_rank = hipblasCgeqrf_(handle,m,n,c_loc(A),lda,ipiv,myInfo)
     end function
 
     function hipblasZgeqrf_rank_0(handle,m,n,A,lda,ipiv,myInfo)
@@ -67531,10 +65105,10 @@ module hipfort_hipblas
       integer(c_int) :: n
       complex(c_double_complex),target :: A
       integer(c_int) :: lda
-      complex(c_double_complex),target :: ipiv
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: ipiv
+      type(c_ptr) :: myInfo
       !
-      hipblasZgeqrf_rank_0 = hipblasZgeqrf_(handle,m,n,c_loc(A),lda,c_loc(ipiv),c_loc(myInfo))
+      hipblasZgeqrf_rank_0 = hipblasZgeqrf_(handle,m,n,c_loc(A),lda,ipiv,myInfo)
     end function
 
     function hipblasZgeqrf_rank_1(handle,m,n,A,lda,ipiv,myInfo)
@@ -67547,10 +65121,10 @@ module hipfort_hipblas
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:) :: A
       integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:) :: ipiv
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: ipiv
+      type(c_ptr) :: myInfo
       !
-      hipblasZgeqrf_rank_1 = hipblasZgeqrf_(handle,m,n,c_loc(A),lda,c_loc(ipiv),c_loc(myInfo))
+      hipblasZgeqrf_rank_1 = hipblasZgeqrf_(handle,m,n,c_loc(A),lda,ipiv,myInfo)
     end function
 
     function hipblasZgeqrf_full_rank(handle,m,n,A,lda,ipiv,myInfo)
@@ -67563,226 +65137,10 @@ module hipfort_hipblas
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:,:) :: ipiv
-      integer(c_int),target,dimension(:,:) :: myInfo
-      !
-      hipblasZgeqrf_full_rank = hipblasZgeqrf_(handle,m,n,c_loc(A),lda,c_loc(ipiv),c_loc(myInfo))
-    end function
-
-    function hipblasSgeqrfBatched_rank_0(handle,m,n,A,lda,ipiv,myInfo,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasSgeqrfBatched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
       type(c_ptr) :: ipiv
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batchCount
+      type(c_ptr) :: myInfo
       !
-      hipblasSgeqrfBatched_rank_0 = hipblasSgeqrfBatched_(handle,m,n,A,lda,ipiv,c_loc(myInfo), &
-        batchCount)
-    end function
-
-    function hipblasSgeqrfBatched_rank_1(handle,m,n,A,lda,ipiv,myInfo,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasSgeqrfBatched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: ipiv
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batchCount
-      !
-      hipblasSgeqrfBatched_rank_1 = hipblasSgeqrfBatched_(handle,m,n,A,lda,ipiv,c_loc(myInfo), &
-        batchCount)
-    end function
-
-    function hipblasSgeqrfBatched_full_rank(handle,m,n,A,lda,ipiv,myInfo,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasSgeqrfBatched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: ipiv
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batchCount
-      !
-      hipblasSgeqrfBatched_full_rank = hipblasSgeqrfBatched_(handle,m,n,A,lda,ipiv,c_loc(myInfo), &
-        batchCount)
-    end function
-
-    function hipblasDgeqrfBatched_rank_0(handle,m,n,A,lda,ipiv,myInfo,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasDgeqrfBatched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: ipiv
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batchCount
-      !
-      hipblasDgeqrfBatched_rank_0 = hipblasDgeqrfBatched_(handle,m,n,A,lda,ipiv,c_loc(myInfo), &
-        batchCount)
-    end function
-
-    function hipblasDgeqrfBatched_rank_1(handle,m,n,A,lda,ipiv,myInfo,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasDgeqrfBatched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: ipiv
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batchCount
-      !
-      hipblasDgeqrfBatched_rank_1 = hipblasDgeqrfBatched_(handle,m,n,A,lda,ipiv,c_loc(myInfo), &
-        batchCount)
-    end function
-
-    function hipblasDgeqrfBatched_full_rank(handle,m,n,A,lda,ipiv,myInfo,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasDgeqrfBatched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: ipiv
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batchCount
-      !
-      hipblasDgeqrfBatched_full_rank = hipblasDgeqrfBatched_(handle,m,n,A,lda,ipiv,c_loc(myInfo), &
-        batchCount)
-    end function
-
-    function hipblasCgeqrfBatched_rank_0(handle,m,n,A,lda,ipiv,myInfo,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasCgeqrfBatched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: ipiv
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batchCount
-      !
-      hipblasCgeqrfBatched_rank_0 = hipblasCgeqrfBatched_(handle,m,n,A,lda,ipiv,c_loc(myInfo), &
-        batchCount)
-    end function
-
-    function hipblasCgeqrfBatched_rank_1(handle,m,n,A,lda,ipiv,myInfo,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasCgeqrfBatched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: ipiv
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batchCount
-      !
-      hipblasCgeqrfBatched_rank_1 = hipblasCgeqrfBatched_(handle,m,n,A,lda,ipiv,c_loc(myInfo), &
-        batchCount)
-    end function
-
-    function hipblasCgeqrfBatched_full_rank(handle,m,n,A,lda,ipiv,myInfo,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasCgeqrfBatched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: ipiv
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batchCount
-      !
-      hipblasCgeqrfBatched_full_rank = hipblasCgeqrfBatched_(handle,m,n,A,lda,ipiv,c_loc(myInfo), &
-        batchCount)
-    end function
-
-    function hipblasZgeqrfBatched_rank_0(handle,m,n,A,lda,ipiv,myInfo,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasZgeqrfBatched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: ipiv
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batchCount
-      !
-      hipblasZgeqrfBatched_rank_0 = hipblasZgeqrfBatched_(handle,m,n,A,lda,ipiv,c_loc(myInfo), &
-        batchCount)
-    end function
-
-    function hipblasZgeqrfBatched_rank_1(handle,m,n,A,lda,ipiv,myInfo,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasZgeqrfBatched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: ipiv
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batchCount
-      !
-      hipblasZgeqrfBatched_rank_1 = hipblasZgeqrfBatched_(handle,m,n,A,lda,ipiv,c_loc(myInfo), &
-        batchCount)
-    end function
-
-    function hipblasZgeqrfBatched_full_rank(handle,m,n,A,lda,ipiv,myInfo,batchCount)
-      use iso_c_binding
-      use hipfort_hipblas_enums
-      implicit none
-      integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasZgeqrfBatched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: ipiv
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batchCount
-      !
-      hipblasZgeqrfBatched_full_rank = hipblasZgeqrfBatched_(handle,m,n,A,lda,ipiv,c_loc(myInfo), &
-        batchCount)
+      hipblasZgeqrf_full_rank = hipblasZgeqrf_(handle,m,n,c_loc(A),lda,ipiv,myInfo)
     end function
 
     function hipblasSgeqrfStridedBatched_rank_0(handle,m,n,A,lda,strideA,ipiv,strideP,myInfo, &
@@ -67797,13 +65155,13 @@ module hipfort_hipblas
       real(c_float),target :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_float),target :: ipiv
+      type(c_ptr) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batchCount
       !
       hipblasSgeqrfStridedBatched_rank_0 = hipblasSgeqrfStridedBatched_(handle,m,n,c_loc(A),lda, &
-        strideA,c_loc(ipiv),strideP,c_loc(myInfo),batchCount)
+        strideA,ipiv,strideP,myInfo,batchCount)
     end function
 
     function hipblasSgeqrfStridedBatched_rank_1(handle,m,n,A,lda,strideA,ipiv,strideP,myInfo, &
@@ -67818,13 +65176,13 @@ module hipfort_hipblas
       real(c_float),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_float),target,dimension(:) :: ipiv
+      type(c_ptr) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batchCount
       !
       hipblasSgeqrfStridedBatched_rank_1 = hipblasSgeqrfStridedBatched_(handle,m,n,c_loc(A),lda, &
-        strideA,c_loc(ipiv),strideP,c_loc(myInfo),batchCount)
+        strideA,ipiv,strideP,myInfo,batchCount)
     end function
 
     function hipblasSgeqrfStridedBatched_full_rank(handle,m,n,A,lda,strideA,ipiv,strideP,myInfo, &
@@ -67839,13 +65197,13 @@ module hipfort_hipblas
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_float),target,dimension(:,:) :: ipiv
+      type(c_ptr) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batchCount
       !
       hipblasSgeqrfStridedBatched_full_rank = hipblasSgeqrfStridedBatched_(handle,m,n,c_loc(A), &
-        lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batchCount)
+        lda,strideA,ipiv,strideP,myInfo,batchCount)
     end function
 
     function hipblasDgeqrfStridedBatched_rank_0(handle,m,n,A,lda,strideA,ipiv,strideP,myInfo, &
@@ -67860,13 +65218,13 @@ module hipfort_hipblas
       real(c_double),target :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_double),target :: ipiv
+      type(c_ptr) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batchCount
       !
       hipblasDgeqrfStridedBatched_rank_0 = hipblasDgeqrfStridedBatched_(handle,m,n,c_loc(A),lda, &
-        strideA,c_loc(ipiv),strideP,c_loc(myInfo),batchCount)
+        strideA,ipiv,strideP,myInfo,batchCount)
     end function
 
     function hipblasDgeqrfStridedBatched_rank_1(handle,m,n,A,lda,strideA,ipiv,strideP,myInfo, &
@@ -67881,13 +65239,13 @@ module hipfort_hipblas
       real(c_double),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_double),target,dimension(:) :: ipiv
+      type(c_ptr) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batchCount
       !
       hipblasDgeqrfStridedBatched_rank_1 = hipblasDgeqrfStridedBatched_(handle,m,n,c_loc(A),lda, &
-        strideA,c_loc(ipiv),strideP,c_loc(myInfo),batchCount)
+        strideA,ipiv,strideP,myInfo,batchCount)
     end function
 
     function hipblasDgeqrfStridedBatched_full_rank(handle,m,n,A,lda,strideA,ipiv,strideP,myInfo, &
@@ -67902,13 +65260,13 @@ module hipfort_hipblas
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_double),target,dimension(:,:) :: ipiv
+      type(c_ptr) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batchCount
       !
       hipblasDgeqrfStridedBatched_full_rank = hipblasDgeqrfStridedBatched_(handle,m,n,c_loc(A), &
-        lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batchCount)
+        lda,strideA,ipiv,strideP,myInfo,batchCount)
     end function
 
     function hipblasCgeqrfStridedBatched_rank_0(handle,m,n,A,lda,strideA,ipiv,strideP,myInfo, &
@@ -67923,13 +65281,13 @@ module hipfort_hipblas
       complex(c_float_complex),target :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      complex(c_float_complex),target :: ipiv
+      type(c_ptr) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batchCount
       !
       hipblasCgeqrfStridedBatched_rank_0 = hipblasCgeqrfStridedBatched_(handle,m,n,c_loc(A),lda, &
-        strideA,c_loc(ipiv),strideP,c_loc(myInfo),batchCount)
+        strideA,ipiv,strideP,myInfo,batchCount)
     end function
 
     function hipblasCgeqrfStridedBatched_rank_1(handle,m,n,A,lda,strideA,ipiv,strideP,myInfo, &
@@ -67944,13 +65302,13 @@ module hipfort_hipblas
       complex(c_float_complex),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      complex(c_float_complex),target,dimension(:) :: ipiv
+      type(c_ptr) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batchCount
       !
       hipblasCgeqrfStridedBatched_rank_1 = hipblasCgeqrfStridedBatched_(handle,m,n,c_loc(A),lda, &
-        strideA,c_loc(ipiv),strideP,c_loc(myInfo),batchCount)
+        strideA,ipiv,strideP,myInfo,batchCount)
     end function
 
     function hipblasCgeqrfStridedBatched_full_rank(handle,m,n,A,lda,strideA,ipiv,strideP,myInfo, &
@@ -67965,13 +65323,13 @@ module hipfort_hipblas
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      complex(c_float_complex),target,dimension(:,:) :: ipiv
+      type(c_ptr) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batchCount
       !
       hipblasCgeqrfStridedBatched_full_rank = hipblasCgeqrfStridedBatched_(handle,m,n,c_loc(A), &
-        lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batchCount)
+        lda,strideA,ipiv,strideP,myInfo,batchCount)
     end function
 
     function hipblasZgeqrfStridedBatched_rank_0(handle,m,n,A,lda,strideA,ipiv,strideP,myInfo, &
@@ -67986,13 +65344,13 @@ module hipfort_hipblas
       complex(c_double_complex),target :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      complex(c_double_complex),target :: ipiv
+      type(c_ptr) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batchCount
       !
       hipblasZgeqrfStridedBatched_rank_0 = hipblasZgeqrfStridedBatched_(handle,m,n,c_loc(A),lda, &
-        strideA,c_loc(ipiv),strideP,c_loc(myInfo),batchCount)
+        strideA,ipiv,strideP,myInfo,batchCount)
     end function
 
     function hipblasZgeqrfStridedBatched_rank_1(handle,m,n,A,lda,strideA,ipiv,strideP,myInfo, &
@@ -68007,13 +65365,13 @@ module hipfort_hipblas
       complex(c_double_complex),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      complex(c_double_complex),target,dimension(:) :: ipiv
+      type(c_ptr) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batchCount
       !
       hipblasZgeqrfStridedBatched_rank_1 = hipblasZgeqrfStridedBatched_(handle,m,n,c_loc(A),lda, &
-        strideA,c_loc(ipiv),strideP,c_loc(myInfo),batchCount)
+        strideA,ipiv,strideP,myInfo,batchCount)
     end function
 
     function hipblasZgeqrfStridedBatched_full_rank(handle,m,n,A,lda,strideA,ipiv,strideP,myInfo, &
@@ -68028,13 +65386,13 @@ module hipfort_hipblas
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      complex(c_double_complex),target,dimension(:,:) :: ipiv
+      type(c_ptr) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batchCount
       !
       hipblasZgeqrfStridedBatched_full_rank = hipblasZgeqrfStridedBatched_(handle,m,n,c_loc(A), &
-        lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batchCount)
+        lda,strideA,ipiv,strideP,myInfo,batchCount)
     end function
 
 #endif

--- a/lib/hipfort/hipfort_hipsolver.F90
+++ b/lib/hipfort/hipfort_hipsolver.F90
@@ -16996,10 +16996,10 @@ module hipfort_hipsolver
       integer(c_int) :: n
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: D
-      real(c_float),target,dimension(:,:) :: E
-      real(c_float),target,dimension(:,:) :: tauq
-      real(c_float),target,dimension(:,:) :: taup
+      real(c_float),target,dimension(:) :: D
+      real(c_float),target,dimension(:) :: E
+      real(c_float),target,dimension(:) :: tauq
+      real(c_float),target,dimension(:) :: taup
       type(c_ptr) :: work
       integer(c_int) :: lwork
       integer(c_int) :: devInfo
@@ -17062,10 +17062,10 @@ module hipfort_hipsolver
       integer(c_int) :: n
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: D
-      real(c_double),target,dimension(:,:) :: E
-      real(c_double),target,dimension(:,:) :: tauq
-      real(c_double),target,dimension(:,:) :: taup
+      real(c_double),target,dimension(:) :: D
+      real(c_double),target,dimension(:) :: E
+      real(c_double),target,dimension(:) :: tauq
+      real(c_double),target,dimension(:) :: taup
       type(c_ptr) :: work
       integer(c_int) :: lwork
       integer(c_int) :: devInfo
@@ -17128,10 +17128,10 @@ module hipfort_hipsolver
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: D
-      real(c_float),target,dimension(:,:) :: E
-      complex(c_float_complex),target,dimension(:,:) :: tauq
-      complex(c_float_complex),target,dimension(:,:) :: taup
+      real(c_float),target,dimension(:) :: D
+      real(c_float),target,dimension(:) :: E
+      complex(c_float_complex),target,dimension(:) :: tauq
+      complex(c_float_complex),target,dimension(:) :: taup
       type(c_ptr) :: work
       integer(c_int) :: lwork
       integer(c_int) :: devInfo
@@ -17194,10 +17194,10 @@ module hipfort_hipsolver
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: D
-      real(c_double),target,dimension(:,:) :: E
-      complex(c_double_complex),target,dimension(:,:) :: tauq
-      complex(c_double_complex),target,dimension(:,:) :: taup
+      real(c_double),target,dimension(:) :: D
+      real(c_double),target,dimension(:) :: E
+      complex(c_double_complex),target,dimension(:) :: tauq
+      complex(c_double_complex),target,dimension(:) :: taup
       type(c_ptr) :: work
       integer(c_int) :: lwork
       integer(c_int) :: devInfo
@@ -17658,7 +17658,7 @@ module hipfort_hipsolver
       integer(c_int) :: nrhs
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: devIpiv
+      integer(c_int),target,dimension(:) :: devIpiv
       real(c_float),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       real(c_float),target,dimension(:,:) :: X
@@ -17721,7 +17721,7 @@ module hipfort_hipsolver
       integer(c_int) :: nrhs
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: devIpiv
+      integer(c_int),target,dimension(:) :: devIpiv
       real(c_double),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       real(c_double),target,dimension(:,:) :: X
@@ -17784,7 +17784,7 @@ module hipfort_hipsolver
       integer(c_int) :: nrhs
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: devIpiv
+      integer(c_int),target,dimension(:) :: devIpiv
       complex(c_float_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       complex(c_float_complex),target,dimension(:,:) :: X
@@ -17847,7 +17847,7 @@ module hipfort_hipsolver
       integer(c_int) :: nrhs
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: devIpiv
+      integer(c_int),target,dimension(:) :: devIpiv
       complex(c_double_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       complex(c_double_complex),target,dimension(:,:) :: X
@@ -17876,11 +17876,11 @@ module hipfort_hipsolver
       integer(c_int) :: ldx
       type(c_ptr) :: work
       integer(c_size_t) :: lwork
-      integer(c_int),target :: niters
+      type(c_ptr) :: niters
       integer(c_int) :: devInfo
       !
       hipsolverSSgesv_rank_0 = hipsolverSSgesv_(handle,n,nrhs,c_loc(A),lda,c_loc(devIpiv), &
-        c_loc(B),ldb,c_loc(X),ldx,work,lwork,c_loc(niters),devInfo)
+        c_loc(B),ldb,c_loc(X),ldx,work,lwork,niters,devInfo)
     end function
 
     function hipsolverSSgesv_rank_1(handle,n,nrhs,A,lda,devIpiv,B,ldb,X,ldx,work,lwork,niters, &
@@ -17901,11 +17901,11 @@ module hipfort_hipsolver
       integer(c_int) :: ldx
       type(c_ptr) :: work
       integer(c_size_t) :: lwork
-      integer(c_int),target,dimension(:) :: niters
+      type(c_ptr) :: niters
       integer(c_int) :: devInfo
       !
       hipsolverSSgesv_rank_1 = hipsolverSSgesv_(handle,n,nrhs,c_loc(A),lda,c_loc(devIpiv), &
-        c_loc(B),ldb,c_loc(X),ldx,work,lwork,c_loc(niters),devInfo)
+        c_loc(B),ldb,c_loc(X),ldx,work,lwork,niters,devInfo)
     end function
 
     function hipsolverSSgesv_full_rank(handle,n,nrhs,A,lda,devIpiv,B,ldb,X,ldx,work,lwork,niters, &
@@ -17919,18 +17919,18 @@ module hipfort_hipsolver
       integer(c_int) :: nrhs
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: devIpiv
+      integer(c_int),target,dimension(:) :: devIpiv
       real(c_float),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       real(c_float),target,dimension(:,:) :: X
       integer(c_int) :: ldx
       type(c_ptr) :: work
       integer(c_size_t) :: lwork
-      integer(c_int),target,dimension(:,:) :: niters
+      type(c_ptr) :: niters
       integer(c_int) :: devInfo
       !
       hipsolverSSgesv_full_rank = hipsolverSSgesv_(handle,n,nrhs,c_loc(A),lda,c_loc(devIpiv), &
-        c_loc(B),ldb,c_loc(X),ldx,work,lwork,c_loc(niters),devInfo)
+        c_loc(B),ldb,c_loc(X),ldx,work,lwork,niters,devInfo)
     end function
 
     function hipsolverDDgesv_rank_0(handle,n,nrhs,A,lda,devIpiv,B,ldb,X,ldx,work,lwork,niters, &
@@ -17951,11 +17951,11 @@ module hipfort_hipsolver
       integer(c_int) :: ldx
       type(c_ptr) :: work
       integer(c_size_t) :: lwork
-      integer(c_int),target :: niters
+      type(c_ptr) :: niters
       integer(c_int) :: devInfo
       !
       hipsolverDDgesv_rank_0 = hipsolverDDgesv_(handle,n,nrhs,c_loc(A),lda,c_loc(devIpiv), &
-        c_loc(B),ldb,c_loc(X),ldx,work,lwork,c_loc(niters),devInfo)
+        c_loc(B),ldb,c_loc(X),ldx,work,lwork,niters,devInfo)
     end function
 
     function hipsolverDDgesv_rank_1(handle,n,nrhs,A,lda,devIpiv,B,ldb,X,ldx,work,lwork,niters, &
@@ -17976,11 +17976,11 @@ module hipfort_hipsolver
       integer(c_int) :: ldx
       type(c_ptr) :: work
       integer(c_size_t) :: lwork
-      integer(c_int),target,dimension(:) :: niters
+      type(c_ptr) :: niters
       integer(c_int) :: devInfo
       !
       hipsolverDDgesv_rank_1 = hipsolverDDgesv_(handle,n,nrhs,c_loc(A),lda,c_loc(devIpiv), &
-        c_loc(B),ldb,c_loc(X),ldx,work,lwork,c_loc(niters),devInfo)
+        c_loc(B),ldb,c_loc(X),ldx,work,lwork,niters,devInfo)
     end function
 
     function hipsolverDDgesv_full_rank(handle,n,nrhs,A,lda,devIpiv,B,ldb,X,ldx,work,lwork,niters, &
@@ -17994,18 +17994,18 @@ module hipfort_hipsolver
       integer(c_int) :: nrhs
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: devIpiv
+      integer(c_int),target,dimension(:) :: devIpiv
       real(c_double),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       real(c_double),target,dimension(:,:) :: X
       integer(c_int) :: ldx
       type(c_ptr) :: work
       integer(c_size_t) :: lwork
-      integer(c_int),target,dimension(:,:) :: niters
+      type(c_ptr) :: niters
       integer(c_int) :: devInfo
       !
       hipsolverDDgesv_full_rank = hipsolverDDgesv_(handle,n,nrhs,c_loc(A),lda,c_loc(devIpiv), &
-        c_loc(B),ldb,c_loc(X),ldx,work,lwork,c_loc(niters),devInfo)
+        c_loc(B),ldb,c_loc(X),ldx,work,lwork,niters,devInfo)
     end function
 
     function hipsolverCCgesv_rank_0(handle,n,nrhs,A,lda,devIpiv,B,ldb,X,ldx,work,lwork,niters, &
@@ -18026,11 +18026,11 @@ module hipfort_hipsolver
       integer(c_int) :: ldx
       type(c_ptr) :: work
       integer(c_size_t) :: lwork
-      integer(c_int),target :: niters
+      type(c_ptr) :: niters
       integer(c_int) :: devInfo
       !
       hipsolverCCgesv_rank_0 = hipsolverCCgesv_(handle,n,nrhs,c_loc(A),lda,c_loc(devIpiv), &
-        c_loc(B),ldb,c_loc(X),ldx,work,lwork,c_loc(niters),devInfo)
+        c_loc(B),ldb,c_loc(X),ldx,work,lwork,niters,devInfo)
     end function
 
     function hipsolverCCgesv_rank_1(handle,n,nrhs,A,lda,devIpiv,B,ldb,X,ldx,work,lwork,niters, &
@@ -18051,11 +18051,11 @@ module hipfort_hipsolver
       integer(c_int) :: ldx
       type(c_ptr) :: work
       integer(c_size_t) :: lwork
-      integer(c_int),target,dimension(:) :: niters
+      type(c_ptr) :: niters
       integer(c_int) :: devInfo
       !
       hipsolverCCgesv_rank_1 = hipsolverCCgesv_(handle,n,nrhs,c_loc(A),lda,c_loc(devIpiv), &
-        c_loc(B),ldb,c_loc(X),ldx,work,lwork,c_loc(niters),devInfo)
+        c_loc(B),ldb,c_loc(X),ldx,work,lwork,niters,devInfo)
     end function
 
     function hipsolverCCgesv_full_rank(handle,n,nrhs,A,lda,devIpiv,B,ldb,X,ldx,work,lwork,niters, &
@@ -18069,18 +18069,18 @@ module hipfort_hipsolver
       integer(c_int) :: nrhs
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: devIpiv
+      integer(c_int),target,dimension(:) :: devIpiv
       complex(c_float_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       complex(c_float_complex),target,dimension(:,:) :: X
       integer(c_int) :: ldx
       type(c_ptr) :: work
       integer(c_size_t) :: lwork
-      integer(c_int),target,dimension(:,:) :: niters
+      type(c_ptr) :: niters
       integer(c_int) :: devInfo
       !
       hipsolverCCgesv_full_rank = hipsolverCCgesv_(handle,n,nrhs,c_loc(A),lda,c_loc(devIpiv), &
-        c_loc(B),ldb,c_loc(X),ldx,work,lwork,c_loc(niters),devInfo)
+        c_loc(B),ldb,c_loc(X),ldx,work,lwork,niters,devInfo)
     end function
 
     function hipsolverZZgesv_rank_0(handle,n,nrhs,A,lda,devIpiv,B,ldb,X,ldx,work,lwork,niters, &
@@ -18101,11 +18101,11 @@ module hipfort_hipsolver
       integer(c_int) :: ldx
       type(c_ptr) :: work
       integer(c_size_t) :: lwork
-      integer(c_int),target :: niters
+      type(c_ptr) :: niters
       integer(c_int) :: devInfo
       !
       hipsolverZZgesv_rank_0 = hipsolverZZgesv_(handle,n,nrhs,c_loc(A),lda,c_loc(devIpiv), &
-        c_loc(B),ldb,c_loc(X),ldx,work,lwork,c_loc(niters),devInfo)
+        c_loc(B),ldb,c_loc(X),ldx,work,lwork,niters,devInfo)
     end function
 
     function hipsolverZZgesv_rank_1(handle,n,nrhs,A,lda,devIpiv,B,ldb,X,ldx,work,lwork,niters, &
@@ -18126,11 +18126,11 @@ module hipfort_hipsolver
       integer(c_int) :: ldx
       type(c_ptr) :: work
       integer(c_size_t) :: lwork
-      integer(c_int),target,dimension(:) :: niters
+      type(c_ptr) :: niters
       integer(c_int) :: devInfo
       !
       hipsolverZZgesv_rank_1 = hipsolverZZgesv_(handle,n,nrhs,c_loc(A),lda,c_loc(devIpiv), &
-        c_loc(B),ldb,c_loc(X),ldx,work,lwork,c_loc(niters),devInfo)
+        c_loc(B),ldb,c_loc(X),ldx,work,lwork,niters,devInfo)
     end function
 
     function hipsolverZZgesv_full_rank(handle,n,nrhs,A,lda,devIpiv,B,ldb,X,ldx,work,lwork,niters, &
@@ -18144,18 +18144,18 @@ module hipfort_hipsolver
       integer(c_int) :: nrhs
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: devIpiv
+      integer(c_int),target,dimension(:) :: devIpiv
       complex(c_double_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       complex(c_double_complex),target,dimension(:,:) :: X
       integer(c_int) :: ldx
       type(c_ptr) :: work
       integer(c_size_t) :: lwork
-      integer(c_int),target,dimension(:,:) :: niters
+      type(c_ptr) :: niters
       integer(c_int) :: devInfo
       !
       hipsolverZZgesv_full_rank = hipsolverZZgesv_(handle,n,nrhs,c_loc(A),lda,c_loc(devIpiv), &
-        c_loc(B),ldb,c_loc(X),ldx,work,lwork,c_loc(niters),devInfo)
+        c_loc(B),ldb,c_loc(X),ldx,work,lwork,niters,devInfo)
     end function
 
     function hipsolverSgetrf_bufferSize_rank_0(handle,m,n,A,lda,lwork)
@@ -18392,7 +18392,7 @@ module hipfort_hipsolver
       integer(c_int) :: lda
       type(c_ptr) :: work
       integer(c_int) :: lwork
-      integer(c_int),target,dimension(:,:) :: devIpiv
+      integer(c_int),target,dimension(:) :: devIpiv
       integer(c_int) :: devInfo
       !
       hipsolverSgetrf_full_rank = hipsolverSgetrf_(handle,m,n,c_loc(A),lda,work,lwork, &
@@ -18449,7 +18449,7 @@ module hipfort_hipsolver
       integer(c_int) :: lda
       type(c_ptr) :: work
       integer(c_int) :: lwork
-      integer(c_int),target,dimension(:,:) :: devIpiv
+      integer(c_int),target,dimension(:) :: devIpiv
       integer(c_int) :: devInfo
       !
       hipsolverDgetrf_full_rank = hipsolverDgetrf_(handle,m,n,c_loc(A),lda,work,lwork, &
@@ -18506,7 +18506,7 @@ module hipfort_hipsolver
       integer(c_int) :: lda
       type(c_ptr) :: work
       integer(c_int) :: lwork
-      integer(c_int),target,dimension(:,:) :: devIpiv
+      integer(c_int),target,dimension(:) :: devIpiv
       integer(c_int) :: devInfo
       !
       hipsolverCgetrf_full_rank = hipsolverCgetrf_(handle,m,n,c_loc(A),lda,work,lwork, &
@@ -18563,7 +18563,7 @@ module hipfort_hipsolver
       integer(c_int) :: lda
       type(c_ptr) :: work
       integer(c_int) :: lwork
-      integer(c_int),target,dimension(:,:) :: devIpiv
+      integer(c_int),target,dimension(:) :: devIpiv
       integer(c_int) :: devInfo
       !
       hipsolverZgetrf_full_rank = hipsolverZgetrf_(handle,m,n,c_loc(A),lda,work,lwork, &
@@ -18621,7 +18621,7 @@ module hipfort_hipsolver
       integer(c_int) :: nrhs
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: devIpiv
+      integer(c_int),target,dimension(:) :: devIpiv
       real(c_float),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       integer(c_int) :: lwork
@@ -18681,7 +18681,7 @@ module hipfort_hipsolver
       integer(c_int) :: nrhs
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: devIpiv
+      integer(c_int),target,dimension(:) :: devIpiv
       real(c_double),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       integer(c_int) :: lwork
@@ -18741,7 +18741,7 @@ module hipfort_hipsolver
       integer(c_int) :: nrhs
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: devIpiv
+      integer(c_int),target,dimension(:) :: devIpiv
       complex(c_float_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       integer(c_int) :: lwork
@@ -18801,7 +18801,7 @@ module hipfort_hipsolver
       integer(c_int) :: nrhs
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: devIpiv
+      integer(c_int),target,dimension(:) :: devIpiv
       complex(c_double_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       integer(c_int) :: lwork
@@ -18865,7 +18865,7 @@ module hipfort_hipsolver
       integer(c_int) :: nrhs
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: devIpiv
+      integer(c_int),target,dimension(:) :: devIpiv
       real(c_float),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: work
@@ -18931,7 +18931,7 @@ module hipfort_hipsolver
       integer(c_int) :: nrhs
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: devIpiv
+      integer(c_int),target,dimension(:) :: devIpiv
       real(c_double),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: work
@@ -18997,7 +18997,7 @@ module hipfort_hipsolver
       integer(c_int) :: nrhs
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: devIpiv
+      integer(c_int),target,dimension(:) :: devIpiv
       complex(c_float_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: work
@@ -19063,7 +19063,7 @@ module hipfort_hipsolver
       integer(c_int) :: nrhs
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: devIpiv
+      integer(c_int),target,dimension(:) :: devIpiv
       complex(c_double_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: work
@@ -20393,7 +20393,7 @@ module hipfort_hipsolver
       integer(c_int) :: n
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: D
+      real(c_float),target,dimension(:) :: D
       integer(c_int) :: lwork
       !
       hipsolverSsyevd_bufferSize_full_rank = hipsolverSsyevd_bufferSize_(handle,jobz,uplo,n, &
@@ -20447,7 +20447,7 @@ module hipfort_hipsolver
       integer(c_int) :: n
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: D
+      real(c_double),target,dimension(:) :: D
       integer(c_int) :: lwork
       !
       hipsolverDsyevd_bufferSize_full_rank = hipsolverDsyevd_bufferSize_(handle,jobz,uplo,n, &
@@ -20501,7 +20501,7 @@ module hipfort_hipsolver
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: D
+      real(c_float),target,dimension(:) :: D
       integer(c_int) :: lwork
       !
       hipsolverCheevd_bufferSize_full_rank = hipsolverCheevd_bufferSize_(handle,jobz,uplo,n, &
@@ -20555,7 +20555,7 @@ module hipfort_hipsolver
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: D
+      real(c_double),target,dimension(:) :: D
       integer(c_int) :: lwork
       !
       hipsolverZheevd_bufferSize_full_rank = hipsolverZheevd_bufferSize_(handle,jobz,uplo,n, &
@@ -20613,7 +20613,7 @@ module hipfort_hipsolver
       integer(c_int) :: n
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: D
+      real(c_float),target,dimension(:) :: D
       type(c_ptr) :: work
       integer(c_int) :: lwork
       integer(c_int) :: devInfo
@@ -20673,7 +20673,7 @@ module hipfort_hipsolver
       integer(c_int) :: n
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: D
+      real(c_double),target,dimension(:) :: D
       type(c_ptr) :: work
       integer(c_int) :: lwork
       integer(c_int) :: devInfo
@@ -20733,7 +20733,7 @@ module hipfort_hipsolver
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: D
+      real(c_float),target,dimension(:) :: D
       type(c_ptr) :: work
       integer(c_int) :: lwork
       integer(c_int) :: devInfo
@@ -20793,7 +20793,7 @@ module hipfort_hipsolver
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: D
+      real(c_double),target,dimension(:) :: D
       type(c_ptr) :: work
       integer(c_int) :: lwork
       integer(c_int) :: devInfo
@@ -20858,7 +20858,7 @@ module hipfort_hipsolver
       integer(c_int) :: lda
       real(c_float),target,dimension(:,:) :: B
       integer(c_int) :: ldb
-      real(c_float),target,dimension(:,:) :: W
+      real(c_float),target,dimension(:) :: W
       integer(c_int) :: lwork
       !
       hipsolverSsygvd_bufferSize_full_rank = hipsolverSsygvd_bufferSize_(handle,itype,jobz,uplo,n, &
@@ -20921,7 +20921,7 @@ module hipfort_hipsolver
       integer(c_int) :: lda
       real(c_double),target,dimension(:,:) :: B
       integer(c_int) :: ldb
-      real(c_double),target,dimension(:,:) :: W
+      real(c_double),target,dimension(:) :: W
       integer(c_int) :: lwork
       !
       hipsolverDsygvd_bufferSize_full_rank = hipsolverDsygvd_bufferSize_(handle,itype,jobz,uplo,n, &
@@ -20984,7 +20984,7 @@ module hipfort_hipsolver
       integer(c_int) :: lda
       complex(c_float_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
-      real(c_float),target,dimension(:,:) :: W
+      real(c_float),target,dimension(:) :: W
       integer(c_int) :: lwork
       !
       hipsolverChegvd_bufferSize_full_rank = hipsolverChegvd_bufferSize_(handle,itype,jobz,uplo,n, &
@@ -21047,7 +21047,7 @@ module hipfort_hipsolver
       integer(c_int) :: lda
       complex(c_double_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
-      real(c_double),target,dimension(:,:) :: W
+      real(c_double),target,dimension(:) :: W
       integer(c_int) :: lwork
       !
       hipsolverZhegvd_bufferSize_full_rank = hipsolverZhegvd_bufferSize_(handle,itype,jobz,uplo,n, &
@@ -21114,7 +21114,7 @@ module hipfort_hipsolver
       integer(c_int) :: lda
       real(c_float),target,dimension(:,:) :: B
       integer(c_int) :: ldb
-      real(c_float),target,dimension(:,:) :: W
+      real(c_float),target,dimension(:) :: W
       type(c_ptr) :: work
       integer(c_int) :: lwork
       integer(c_int) :: devInfo
@@ -21183,7 +21183,7 @@ module hipfort_hipsolver
       integer(c_int) :: lda
       real(c_double),target,dimension(:,:) :: B
       integer(c_int) :: ldb
-      real(c_double),target,dimension(:,:) :: W
+      real(c_double),target,dimension(:) :: W
       type(c_ptr) :: work
       integer(c_int) :: lwork
       integer(c_int) :: devInfo
@@ -21252,7 +21252,7 @@ module hipfort_hipsolver
       integer(c_int) :: lda
       complex(c_float_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
-      real(c_float),target,dimension(:,:) :: W
+      real(c_float),target,dimension(:) :: W
       type(c_ptr) :: work
       integer(c_int) :: lwork
       integer(c_int) :: devInfo
@@ -21321,7 +21321,7 @@ module hipfort_hipsolver
       integer(c_int) :: lda
       complex(c_double_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
-      real(c_double),target,dimension(:,:) :: W
+      real(c_double),target,dimension(:) :: W
       type(c_ptr) :: work
       integer(c_int) :: lwork
       integer(c_int) :: devInfo
@@ -21378,8 +21378,8 @@ module hipfort_hipsolver
       integer(c_int) :: n
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: D
-      real(c_float),target,dimension(:,:) :: E
+      real(c_float),target,dimension(:) :: D
+      real(c_float),target,dimension(:) :: E
       real(c_float) :: tau
       integer(c_int) :: lwork
       !
@@ -21435,8 +21435,8 @@ module hipfort_hipsolver
       integer(c_int) :: n
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: D
-      real(c_double),target,dimension(:,:) :: E
+      real(c_double),target,dimension(:) :: D
+      real(c_double),target,dimension(:) :: E
       real(c_double) :: tau
       integer(c_int) :: lwork
       !
@@ -21492,8 +21492,8 @@ module hipfort_hipsolver
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: D
-      real(c_float),target,dimension(:,:) :: E
+      real(c_float),target,dimension(:) :: D
+      real(c_float),target,dimension(:) :: E
       complex(c_float_complex) :: tau
       integer(c_int) :: lwork
       !
@@ -21549,8 +21549,8 @@ module hipfort_hipsolver
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: D
-      real(c_double),target,dimension(:,:) :: E
+      real(c_double),target,dimension(:) :: D
+      real(c_double),target,dimension(:) :: E
       complex(c_double_complex) :: tau
       integer(c_int) :: lwork
       !
@@ -21610,8 +21610,8 @@ module hipfort_hipsolver
       integer(c_int) :: n
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: D
-      real(c_float),target,dimension(:,:) :: E
+      real(c_float),target,dimension(:) :: D
+      real(c_float),target,dimension(:) :: E
       real(c_float) :: tau
       type(c_ptr) :: work
       integer(c_int) :: lwork
@@ -21673,8 +21673,8 @@ module hipfort_hipsolver
       integer(c_int) :: n
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: D
-      real(c_double),target,dimension(:,:) :: E
+      real(c_double),target,dimension(:) :: D
+      real(c_double),target,dimension(:) :: E
       real(c_double) :: tau
       type(c_ptr) :: work
       integer(c_int) :: lwork
@@ -21736,8 +21736,8 @@ module hipfort_hipsolver
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: D
-      real(c_float),target,dimension(:,:) :: E
+      real(c_float),target,dimension(:) :: D
+      real(c_float),target,dimension(:) :: E
       complex(c_float_complex) :: tau
       type(c_ptr) :: work
       integer(c_int) :: lwork
@@ -21799,8 +21799,8 @@ module hipfort_hipsolver
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: D
-      real(c_double),target,dimension(:,:) :: E
+      real(c_double),target,dimension(:) :: D
+      real(c_double),target,dimension(:) :: E
       complex(c_double_complex) :: tau
       type(c_ptr) :: work
       integer(c_int) :: lwork
@@ -21992,13 +21992,12 @@ module hipfort_hipsolver
       integer(c_int) :: n
       real(c_float),target :: A
       integer(c_int) :: lda
-      integer(c_int),target :: ipiv
+      type(c_ptr) :: ipiv
       type(c_ptr) :: work
       integer(c_int) :: lwork
       integer(c_int) :: devInfo
       !
-      hipsolverSsytrf_rank_0 = hipsolverSsytrf_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv),work,lwork, &
-        devInfo)
+      hipsolverSsytrf_rank_0 = hipsolverSsytrf_(handle,uplo,n,c_loc(A),lda,ipiv,work,lwork,devInfo)
     end function
 
     function hipsolverSsytrf_rank_1(handle,uplo,n,A,lda,ipiv,work,lwork,devInfo)
@@ -22011,13 +22010,12 @@ module hipfort_hipsolver
       integer(c_int) :: n
       real(c_float),target,dimension(:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: ipiv
+      type(c_ptr) :: ipiv
       type(c_ptr) :: work
       integer(c_int) :: lwork
       integer(c_int) :: devInfo
       !
-      hipsolverSsytrf_rank_1 = hipsolverSsytrf_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv),work,lwork, &
-        devInfo)
+      hipsolverSsytrf_rank_1 = hipsolverSsytrf_(handle,uplo,n,c_loc(A),lda,ipiv,work,lwork,devInfo)
     end function
 
     function hipsolverSsytrf_full_rank(handle,uplo,n,A,lda,ipiv,work,lwork,devInfo)
@@ -22030,13 +22028,13 @@ module hipfort_hipsolver
       integer(c_int) :: n
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
+      type(c_ptr) :: ipiv
       type(c_ptr) :: work
       integer(c_int) :: lwork
       integer(c_int) :: devInfo
       !
-      hipsolverSsytrf_full_rank = hipsolverSsytrf_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv),work, &
-        lwork,devInfo)
+      hipsolverSsytrf_full_rank = hipsolverSsytrf_(handle,uplo,n,c_loc(A),lda,ipiv,work,lwork, &
+        devInfo)
     end function
 
     function hipsolverDsytrf_rank_0(handle,uplo,n,A,lda,ipiv,work,lwork,devInfo)
@@ -22049,13 +22047,12 @@ module hipfort_hipsolver
       integer(c_int) :: n
       real(c_double),target :: A
       integer(c_int) :: lda
-      integer(c_int),target :: ipiv
+      type(c_ptr) :: ipiv
       type(c_ptr) :: work
       integer(c_int) :: lwork
       integer(c_int) :: devInfo
       !
-      hipsolverDsytrf_rank_0 = hipsolverDsytrf_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv),work,lwork, &
-        devInfo)
+      hipsolverDsytrf_rank_0 = hipsolverDsytrf_(handle,uplo,n,c_loc(A),lda,ipiv,work,lwork,devInfo)
     end function
 
     function hipsolverDsytrf_rank_1(handle,uplo,n,A,lda,ipiv,work,lwork,devInfo)
@@ -22068,13 +22065,12 @@ module hipfort_hipsolver
       integer(c_int) :: n
       real(c_double),target,dimension(:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: ipiv
+      type(c_ptr) :: ipiv
       type(c_ptr) :: work
       integer(c_int) :: lwork
       integer(c_int) :: devInfo
       !
-      hipsolverDsytrf_rank_1 = hipsolverDsytrf_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv),work,lwork, &
-        devInfo)
+      hipsolverDsytrf_rank_1 = hipsolverDsytrf_(handle,uplo,n,c_loc(A),lda,ipiv,work,lwork,devInfo)
     end function
 
     function hipsolverDsytrf_full_rank(handle,uplo,n,A,lda,ipiv,work,lwork,devInfo)
@@ -22087,13 +22083,13 @@ module hipfort_hipsolver
       integer(c_int) :: n
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
+      type(c_ptr) :: ipiv
       type(c_ptr) :: work
       integer(c_int) :: lwork
       integer(c_int) :: devInfo
       !
-      hipsolverDsytrf_full_rank = hipsolverDsytrf_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv),work, &
-        lwork,devInfo)
+      hipsolverDsytrf_full_rank = hipsolverDsytrf_(handle,uplo,n,c_loc(A),lda,ipiv,work,lwork, &
+        devInfo)
     end function
 
     function hipsolverCsytrf_rank_0(handle,uplo,n,A,lda,ipiv,work,lwork,devInfo)
@@ -22106,13 +22102,12 @@ module hipfort_hipsolver
       integer(c_int) :: n
       complex(c_float_complex),target :: A
       integer(c_int) :: lda
-      integer(c_int),target :: ipiv
+      type(c_ptr) :: ipiv
       type(c_ptr) :: work
       integer(c_int) :: lwork
       integer(c_int) :: devInfo
       !
-      hipsolverCsytrf_rank_0 = hipsolverCsytrf_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv),work,lwork, &
-        devInfo)
+      hipsolverCsytrf_rank_0 = hipsolverCsytrf_(handle,uplo,n,c_loc(A),lda,ipiv,work,lwork,devInfo)
     end function
 
     function hipsolverCsytrf_rank_1(handle,uplo,n,A,lda,ipiv,work,lwork,devInfo)
@@ -22125,13 +22120,12 @@ module hipfort_hipsolver
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: ipiv
+      type(c_ptr) :: ipiv
       type(c_ptr) :: work
       integer(c_int) :: lwork
       integer(c_int) :: devInfo
       !
-      hipsolverCsytrf_rank_1 = hipsolverCsytrf_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv),work,lwork, &
-        devInfo)
+      hipsolverCsytrf_rank_1 = hipsolverCsytrf_(handle,uplo,n,c_loc(A),lda,ipiv,work,lwork,devInfo)
     end function
 
     function hipsolverCsytrf_full_rank(handle,uplo,n,A,lda,ipiv,work,lwork,devInfo)
@@ -22144,13 +22138,13 @@ module hipfort_hipsolver
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
+      type(c_ptr) :: ipiv
       type(c_ptr) :: work
       integer(c_int) :: lwork
       integer(c_int) :: devInfo
       !
-      hipsolverCsytrf_full_rank = hipsolverCsytrf_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv),work, &
-        lwork,devInfo)
+      hipsolverCsytrf_full_rank = hipsolverCsytrf_(handle,uplo,n,c_loc(A),lda,ipiv,work,lwork, &
+        devInfo)
     end function
 
     function hipsolverZsytrf_rank_0(handle,uplo,n,A,lda,ipiv,work,lwork,devInfo)
@@ -22163,13 +22157,12 @@ module hipfort_hipsolver
       integer(c_int) :: n
       complex(c_double_complex),target :: A
       integer(c_int) :: lda
-      integer(c_int),target :: ipiv
+      type(c_ptr) :: ipiv
       type(c_ptr) :: work
       integer(c_int) :: lwork
       integer(c_int) :: devInfo
       !
-      hipsolverZsytrf_rank_0 = hipsolverZsytrf_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv),work,lwork, &
-        devInfo)
+      hipsolverZsytrf_rank_0 = hipsolverZsytrf_(handle,uplo,n,c_loc(A),lda,ipiv,work,lwork,devInfo)
     end function
 
     function hipsolverZsytrf_rank_1(handle,uplo,n,A,lda,ipiv,work,lwork,devInfo)
@@ -22182,13 +22175,12 @@ module hipfort_hipsolver
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: ipiv
+      type(c_ptr) :: ipiv
       type(c_ptr) :: work
       integer(c_int) :: lwork
       integer(c_int) :: devInfo
       !
-      hipsolverZsytrf_rank_1 = hipsolverZsytrf_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv),work,lwork, &
-        devInfo)
+      hipsolverZsytrf_rank_1 = hipsolverZsytrf_(handle,uplo,n,c_loc(A),lda,ipiv,work,lwork,devInfo)
     end function
 
     function hipsolverZsytrf_full_rank(handle,uplo,n,A,lda,ipiv,work,lwork,devInfo)
@@ -22201,13 +22193,13 @@ module hipfort_hipsolver
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
+      type(c_ptr) :: ipiv
       type(c_ptr) :: work
       integer(c_int) :: lwork
       integer(c_int) :: devInfo
       !
-      hipsolverZsytrf_full_rank = hipsolverZsytrf_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv),work, &
-        lwork,devInfo)
+      hipsolverZsytrf_full_rank = hipsolverZsytrf_(handle,uplo,n,c_loc(A),lda,ipiv,work,lwork, &
+        devInfo)
     end function
 
 #endif

--- a/lib/hipfort/hipfort_hipsparse.F90
+++ b/lib/hipfort/hipfort_hipsparse.F90
@@ -14018,8 +14018,7 @@ module hipfort_hipsparse
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       hipsparseSgpsvInterleavedBatch_bufferSizeExt_rank_0,&
-      hipsparseSgpsvInterleavedBatch_bufferSizeExt_rank_1,&
-      hipsparseSgpsvInterleavedBatch_bufferSizeExt_full_rank
+      hipsparseSgpsvInterleavedBatch_bufferSizeExt_rank_1
 #endif
   end interface
 
@@ -14053,8 +14052,7 @@ module hipfort_hipsparse
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       hipsparseDgpsvInterleavedBatch_bufferSizeExt_rank_0,&
-      hipsparseDgpsvInterleavedBatch_bufferSizeExt_rank_1,&
-      hipsparseDgpsvInterleavedBatch_bufferSizeExt_full_rank
+      hipsparseDgpsvInterleavedBatch_bufferSizeExt_rank_1
 #endif
   end interface
 
@@ -14088,8 +14086,7 @@ module hipfort_hipsparse
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       hipsparseCgpsvInterleavedBatch_bufferSizeExt_rank_0,&
-      hipsparseCgpsvInterleavedBatch_bufferSizeExt_rank_1,&
-      hipsparseCgpsvInterleavedBatch_bufferSizeExt_full_rank
+      hipsparseCgpsvInterleavedBatch_bufferSizeExt_rank_1
 #endif
   end interface
 
@@ -14123,8 +14120,7 @@ module hipfort_hipsparse
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       hipsparseZgpsvInterleavedBatch_bufferSizeExt_rank_0,&
-      hipsparseZgpsvInterleavedBatch_bufferSizeExt_rank_1,&
-      hipsparseZgpsvInterleavedBatch_bufferSizeExt_full_rank
+      hipsparseZgpsvInterleavedBatch_bufferSizeExt_rank_1
 #endif
   end interface
 
@@ -14264,8 +14260,7 @@ module hipfort_hipsparse
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       hipsparseSgpsvInterleavedBatch_rank_0,&
-      hipsparseSgpsvInterleavedBatch_rank_1,&
-      hipsparseSgpsvInterleavedBatch_full_rank
+      hipsparseSgpsvInterleavedBatch_rank_1
 #endif
   end interface
 
@@ -14297,8 +14292,7 @@ module hipfort_hipsparse
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       hipsparseDgpsvInterleavedBatch_rank_0,&
-      hipsparseDgpsvInterleavedBatch_rank_1,&
-      hipsparseDgpsvInterleavedBatch_full_rank
+      hipsparseDgpsvInterleavedBatch_rank_1
 #endif
   end interface
 
@@ -14330,8 +14324,7 @@ module hipfort_hipsparse
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       hipsparseCgpsvInterleavedBatch_rank_0,&
-      hipsparseCgpsvInterleavedBatch_rank_1,&
-      hipsparseCgpsvInterleavedBatch_full_rank
+      hipsparseCgpsvInterleavedBatch_rank_1
 #endif
   end interface
 
@@ -14363,8 +14356,7 @@ module hipfort_hipsparse
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       hipsparseZgpsvInterleavedBatch_rank_0,&
-      hipsparseZgpsvInterleavedBatch_rank_1,&
-      hipsparseZgpsvInterleavedBatch_full_rank
+      hipsparseZgpsvInterleavedBatch_rank_1
 #endif
   end interface
 
@@ -20852,8 +20844,7 @@ module hipfort_hipsparse
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       hipsparseXcsrsort_rank_0,&
-      hipsparseXcsrsort_rank_1,&
-      hipsparseXcsrsort_full_rank
+      hipsparseXcsrsort_rank_1
 #endif
   end interface
 
@@ -20994,8 +20985,7 @@ module hipfort_hipsparse
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       hipsparseXcscsort_rank_0,&
-      hipsparseXcscsort_rank_1,&
-      hipsparseXcscsort_full_rank
+      hipsparseXcscsort_rank_1
 #endif
   end interface
 
@@ -21128,8 +21118,7 @@ module hipfort_hipsparse
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       hipsparseXcoosortByRow_rank_0,&
-      hipsparseXcoosortByRow_rank_1,&
-      hipsparseXcoosortByRow_full_rank
+      hipsparseXcoosortByRow_rank_1
 #endif
   end interface
 
@@ -21204,8 +21193,7 @@ module hipfort_hipsparse
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       hipsparseXcoosortByColumn_rank_0,&
-      hipsparseXcoosortByColumn_rank_1,&
-      hipsparseXcoosortByColumn_full_rank
+      hipsparseXcoosortByColumn_rank_1
 #endif
   end interface
 
@@ -27482,19 +27470,18 @@ module hipfort_hipsparse
       integer(c_int) :: nnzb
       real(c_float) :: alpha
       type(c_ptr) :: descr
-      real(c_float),target :: bsrVal
-      integer(c_int),target :: bsrMaskPtr
-      integer(c_int),target :: bsrRowPtr
-      integer(c_int),target :: bsrEndPtr
-      integer(c_int),target :: bsrColInd
+      type(c_ptr) :: bsrVal
+      type(c_ptr) :: bsrMaskPtr
+      type(c_ptr) :: bsrRowPtr
+      type(c_ptr) :: bsrEndPtr
+      type(c_ptr) :: bsrColInd
       integer(c_int) :: blockDim
       real(c_float),target :: x
       real(c_float) :: beta
       real(c_float),target :: y
       !
       hipsparseSbsrxmv_rank_0 = hipsparseSbsrxmv_(handle,dir,trans,sizeOfMask,mb,nb,nnzb,alpha, &
-        descr,c_loc(bsrVal),c_loc(bsrMaskPtr),c_loc(bsrRowPtr),c_loc(bsrEndPtr),c_loc(bsrColInd), &
-        blockDim,c_loc(x),beta,c_loc(y))
+        descr,bsrVal,bsrMaskPtr,bsrRowPtr,bsrEndPtr,bsrColInd,blockDim,c_loc(x),beta,c_loc(y))
     end function
 
     function hipsparseSbsrxmv_rank_1(handle,dir,trans,sizeOfMask,mb,nb,nnzb,alpha,descr,bsrVal, &
@@ -27512,19 +27499,18 @@ module hipfort_hipsparse
       integer(c_int) :: nnzb
       real(c_float) :: alpha
       type(c_ptr) :: descr
-      real(c_float),target,dimension(:) :: bsrVal
-      integer(c_int),target,dimension(:) :: bsrMaskPtr
-      integer(c_int),target,dimension(:) :: bsrRowPtr
-      integer(c_int),target,dimension(:) :: bsrEndPtr
-      integer(c_int),target,dimension(:) :: bsrColInd
+      type(c_ptr) :: bsrVal
+      type(c_ptr) :: bsrMaskPtr
+      type(c_ptr) :: bsrRowPtr
+      type(c_ptr) :: bsrEndPtr
+      type(c_ptr) :: bsrColInd
       integer(c_int) :: blockDim
       real(c_float),target,dimension(:) :: x
       real(c_float) :: beta
       real(c_float),target,dimension(:) :: y
       !
       hipsparseSbsrxmv_rank_1 = hipsparseSbsrxmv_(handle,dir,trans,sizeOfMask,mb,nb,nnzb,alpha, &
-        descr,c_loc(bsrVal),c_loc(bsrMaskPtr),c_loc(bsrRowPtr),c_loc(bsrEndPtr),c_loc(bsrColInd), &
-        blockDim,c_loc(x),beta,c_loc(y))
+        descr,bsrVal,bsrMaskPtr,bsrRowPtr,bsrEndPtr,bsrColInd,blockDim,c_loc(x),beta,c_loc(y))
     end function
 
     function hipsparseDbsrxmv_rank_0(handle,dir,trans,sizeOfMask,mb,nb,nnzb,alpha,descr,bsrVal, &
@@ -27542,19 +27528,18 @@ module hipfort_hipsparse
       integer(c_int) :: nnzb
       real(c_double) :: alpha
       type(c_ptr) :: descr
-      real(c_double),target :: bsrVal
-      integer(c_int),target :: bsrMaskPtr
-      integer(c_int),target :: bsrRowPtr
-      integer(c_int),target :: bsrEndPtr
-      integer(c_int),target :: bsrColInd
+      type(c_ptr) :: bsrVal
+      type(c_ptr) :: bsrMaskPtr
+      type(c_ptr) :: bsrRowPtr
+      type(c_ptr) :: bsrEndPtr
+      type(c_ptr) :: bsrColInd
       integer(c_int) :: blockDim
       real(c_double),target :: x
       real(c_double) :: beta
       real(c_double),target :: y
       !
       hipsparseDbsrxmv_rank_0 = hipsparseDbsrxmv_(handle,dir,trans,sizeOfMask,mb,nb,nnzb,alpha, &
-        descr,c_loc(bsrVal),c_loc(bsrMaskPtr),c_loc(bsrRowPtr),c_loc(bsrEndPtr),c_loc(bsrColInd), &
-        blockDim,c_loc(x),beta,c_loc(y))
+        descr,bsrVal,bsrMaskPtr,bsrRowPtr,bsrEndPtr,bsrColInd,blockDim,c_loc(x),beta,c_loc(y))
     end function
 
     function hipsparseDbsrxmv_rank_1(handle,dir,trans,sizeOfMask,mb,nb,nnzb,alpha,descr,bsrVal, &
@@ -27572,19 +27557,18 @@ module hipfort_hipsparse
       integer(c_int) :: nnzb
       real(c_double) :: alpha
       type(c_ptr) :: descr
-      real(c_double),target,dimension(:) :: bsrVal
-      integer(c_int),target,dimension(:) :: bsrMaskPtr
-      integer(c_int),target,dimension(:) :: bsrRowPtr
-      integer(c_int),target,dimension(:) :: bsrEndPtr
-      integer(c_int),target,dimension(:) :: bsrColInd
+      type(c_ptr) :: bsrVal
+      type(c_ptr) :: bsrMaskPtr
+      type(c_ptr) :: bsrRowPtr
+      type(c_ptr) :: bsrEndPtr
+      type(c_ptr) :: bsrColInd
       integer(c_int) :: blockDim
       real(c_double),target,dimension(:) :: x
       real(c_double) :: beta
       real(c_double),target,dimension(:) :: y
       !
       hipsparseDbsrxmv_rank_1 = hipsparseDbsrxmv_(handle,dir,trans,sizeOfMask,mb,nb,nnzb,alpha, &
-        descr,c_loc(bsrVal),c_loc(bsrMaskPtr),c_loc(bsrRowPtr),c_loc(bsrEndPtr),c_loc(bsrColInd), &
-        blockDim,c_loc(x),beta,c_loc(y))
+        descr,bsrVal,bsrMaskPtr,bsrRowPtr,bsrEndPtr,bsrColInd,blockDim,c_loc(x),beta,c_loc(y))
     end function
 
     function hipsparseCbsrxmv_rank_0(handle,dir,trans,sizeOfMask,mb,nb,nnzb,alpha,descr,bsrVal, &
@@ -27602,19 +27586,18 @@ module hipfort_hipsparse
       integer(c_int) :: nnzb
       complex(c_float_complex) :: alpha
       type(c_ptr) :: descr
-      complex(c_float_complex),target :: bsrVal
-      integer(c_int),target :: bsrMaskPtr
-      integer(c_int),target :: bsrRowPtr
-      integer(c_int),target :: bsrEndPtr
-      integer(c_int),target :: bsrColInd
+      type(c_ptr) :: bsrVal
+      type(c_ptr) :: bsrMaskPtr
+      type(c_ptr) :: bsrRowPtr
+      type(c_ptr) :: bsrEndPtr
+      type(c_ptr) :: bsrColInd
       integer(c_int) :: blockDim
       complex(c_float_complex),target :: x
       complex(c_float_complex) :: beta
       complex(c_float_complex),target :: y
       !
       hipsparseCbsrxmv_rank_0 = hipsparseCbsrxmv_(handle,dir,trans,sizeOfMask,mb,nb,nnzb,alpha, &
-        descr,c_loc(bsrVal),c_loc(bsrMaskPtr),c_loc(bsrRowPtr),c_loc(bsrEndPtr),c_loc(bsrColInd), &
-        blockDim,c_loc(x),beta,c_loc(y))
+        descr,bsrVal,bsrMaskPtr,bsrRowPtr,bsrEndPtr,bsrColInd,blockDim,c_loc(x),beta,c_loc(y))
     end function
 
     function hipsparseCbsrxmv_rank_1(handle,dir,trans,sizeOfMask,mb,nb,nnzb,alpha,descr,bsrVal, &
@@ -27632,19 +27615,18 @@ module hipfort_hipsparse
       integer(c_int) :: nnzb
       complex(c_float_complex) :: alpha
       type(c_ptr) :: descr
-      complex(c_float_complex),target,dimension(:) :: bsrVal
-      integer(c_int),target,dimension(:) :: bsrMaskPtr
-      integer(c_int),target,dimension(:) :: bsrRowPtr
-      integer(c_int),target,dimension(:) :: bsrEndPtr
-      integer(c_int),target,dimension(:) :: bsrColInd
+      type(c_ptr) :: bsrVal
+      type(c_ptr) :: bsrMaskPtr
+      type(c_ptr) :: bsrRowPtr
+      type(c_ptr) :: bsrEndPtr
+      type(c_ptr) :: bsrColInd
       integer(c_int) :: blockDim
       complex(c_float_complex),target,dimension(:) :: x
       complex(c_float_complex) :: beta
       complex(c_float_complex),target,dimension(:) :: y
       !
       hipsparseCbsrxmv_rank_1 = hipsparseCbsrxmv_(handle,dir,trans,sizeOfMask,mb,nb,nnzb,alpha, &
-        descr,c_loc(bsrVal),c_loc(bsrMaskPtr),c_loc(bsrRowPtr),c_loc(bsrEndPtr),c_loc(bsrColInd), &
-        blockDim,c_loc(x),beta,c_loc(y))
+        descr,bsrVal,bsrMaskPtr,bsrRowPtr,bsrEndPtr,bsrColInd,blockDim,c_loc(x),beta,c_loc(y))
     end function
 
     function hipsparseZbsrxmv_rank_0(handle,dir,trans,sizeOfMask,mb,nb,nnzb,alpha,descr,bsrVal, &
@@ -27662,19 +27644,18 @@ module hipfort_hipsparse
       integer(c_int) :: nnzb
       complex(c_double_complex) :: alpha
       type(c_ptr) :: descr
-      complex(c_double_complex),target :: bsrVal
-      integer(c_int),target :: bsrMaskPtr
-      integer(c_int),target :: bsrRowPtr
-      integer(c_int),target :: bsrEndPtr
-      integer(c_int),target :: bsrColInd
+      type(c_ptr) :: bsrVal
+      type(c_ptr) :: bsrMaskPtr
+      type(c_ptr) :: bsrRowPtr
+      type(c_ptr) :: bsrEndPtr
+      type(c_ptr) :: bsrColInd
       integer(c_int) :: blockDim
       complex(c_double_complex),target :: x
       complex(c_double_complex) :: beta
       complex(c_double_complex),target :: y
       !
       hipsparseZbsrxmv_rank_0 = hipsparseZbsrxmv_(handle,dir,trans,sizeOfMask,mb,nb,nnzb,alpha, &
-        descr,c_loc(bsrVal),c_loc(bsrMaskPtr),c_loc(bsrRowPtr),c_loc(bsrEndPtr),c_loc(bsrColInd), &
-        blockDim,c_loc(x),beta,c_loc(y))
+        descr,bsrVal,bsrMaskPtr,bsrRowPtr,bsrEndPtr,bsrColInd,blockDim,c_loc(x),beta,c_loc(y))
     end function
 
     function hipsparseZbsrxmv_rank_1(handle,dir,trans,sizeOfMask,mb,nb,nnzb,alpha,descr,bsrVal, &
@@ -27692,19 +27673,18 @@ module hipfort_hipsparse
       integer(c_int) :: nnzb
       complex(c_double_complex) :: alpha
       type(c_ptr) :: descr
-      complex(c_double_complex),target,dimension(:) :: bsrVal
-      integer(c_int),target,dimension(:) :: bsrMaskPtr
-      integer(c_int),target,dimension(:) :: bsrRowPtr
-      integer(c_int),target,dimension(:) :: bsrEndPtr
-      integer(c_int),target,dimension(:) :: bsrColInd
+      type(c_ptr) :: bsrVal
+      type(c_ptr) :: bsrMaskPtr
+      type(c_ptr) :: bsrRowPtr
+      type(c_ptr) :: bsrEndPtr
+      type(c_ptr) :: bsrColInd
       integer(c_int) :: blockDim
       complex(c_double_complex),target,dimension(:) :: x
       complex(c_double_complex) :: beta
       complex(c_double_complex),target,dimension(:) :: y
       !
       hipsparseZbsrxmv_rank_1 = hipsparseZbsrxmv_(handle,dir,trans,sizeOfMask,mb,nb,nnzb,alpha, &
-        descr,c_loc(bsrVal),c_loc(bsrMaskPtr),c_loc(bsrRowPtr),c_loc(bsrEndPtr),c_loc(bsrColInd), &
-        blockDim,c_loc(x),beta,c_loc(y))
+        descr,bsrVal,bsrMaskPtr,bsrRowPtr,bsrEndPtr,bsrColInd,blockDim,c_loc(x),beta,c_loc(y))
     end function
 
     function hipsparseSbsrsv2_bufferSize_rank_0(handle,dirA,transA,mb,nnzb,descrA,bsrSortedValA, &
@@ -28577,10 +28557,10 @@ module hipfort_hipsparse
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int) :: nnz
-      real(c_float),target,dimension(:,:) :: x
-      integer(c_int),target,dimension(:,:) :: xInd
+      real(c_float),target,dimension(:) :: x
+      integer(c_int),target,dimension(:) :: xInd
       real(c_float) :: beta
-      real(c_float),target,dimension(:,:) :: y
+      real(c_float),target,dimension(:) :: y
       integer(kind(HIPSPARSE_INDEX_BASE_ZERO)) :: idxBase
       type(c_ptr) :: pBuffer
       !
@@ -28650,10 +28630,10 @@ module hipfort_hipsparse
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int) :: nnz
-      real(c_double),target,dimension(:,:) :: x
-      integer(c_int),target,dimension(:,:) :: xInd
+      real(c_double),target,dimension(:) :: x
+      integer(c_int),target,dimension(:) :: xInd
       real(c_double) :: beta
-      real(c_double),target,dimension(:,:) :: y
+      real(c_double),target,dimension(:) :: y
       integer(kind(HIPSPARSE_INDEX_BASE_ZERO)) :: idxBase
       type(c_ptr) :: pBuffer
       !
@@ -28723,10 +28703,10 @@ module hipfort_hipsparse
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int) :: nnz
-      complex(c_float_complex),target,dimension(:,:) :: x
-      integer(c_int),target,dimension(:,:) :: xInd
+      complex(c_float_complex),target,dimension(:) :: x
+      integer(c_int),target,dimension(:) :: xInd
       complex(c_float_complex) :: beta
-      complex(c_float_complex),target,dimension(:,:) :: y
+      complex(c_float_complex),target,dimension(:) :: y
       integer(kind(HIPSPARSE_INDEX_BASE_ZERO)) :: idxBase
       type(c_ptr) :: pBuffer
       !
@@ -28796,10 +28776,10 @@ module hipfort_hipsparse
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int) :: nnz
-      complex(c_double_complex),target,dimension(:,:) :: x
-      integer(c_int),target,dimension(:,:) :: xInd
+      complex(c_double_complex),target,dimension(:) :: x
+      integer(c_int),target,dimension(:) :: xInd
       complex(c_double_complex) :: beta
-      complex(c_double_complex),target,dimension(:,:) :: y
+      complex(c_double_complex),target,dimension(:) :: y
       integer(kind(HIPSPARSE_INDEX_BASE_ZERO)) :: idxBase
       type(c_ptr) :: pBuffer
       !
@@ -28885,9 +28865,9 @@ module hipfort_hipsparse
       integer(c_int) :: nnzb
       real(c_float) :: alpha
       type(c_ptr) :: descrA
-      real(c_float),target,dimension(:,:) :: bsrValA
-      integer(c_int),target,dimension(:,:) :: bsrRowPtrA
-      integer(c_int),target,dimension(:,:) :: bsrColIndA
+      real(c_float),target,dimension(:) :: bsrValA
+      integer(c_int),target,dimension(:) :: bsrRowPtrA
+      integer(c_int),target,dimension(:) :: bsrColIndA
       integer(c_int) :: blockDim
       real(c_float),target,dimension(:,:) :: B
       integer(c_int) :: ldb
@@ -28978,9 +28958,9 @@ module hipfort_hipsparse
       integer(c_int) :: nnzb
       real(c_double) :: alpha
       type(c_ptr) :: descrA
-      real(c_double),target,dimension(:,:) :: bsrValA
-      integer(c_int),target,dimension(:,:) :: bsrRowPtrA
-      integer(c_int),target,dimension(:,:) :: bsrColIndA
+      real(c_double),target,dimension(:) :: bsrValA
+      integer(c_int),target,dimension(:) :: bsrRowPtrA
+      integer(c_int),target,dimension(:) :: bsrColIndA
       integer(c_int) :: blockDim
       real(c_double),target,dimension(:,:) :: B
       integer(c_int) :: ldb
@@ -29071,9 +29051,9 @@ module hipfort_hipsparse
       integer(c_int) :: nnzb
       complex(c_float_complex) :: alpha
       type(c_ptr) :: descrA
-      complex(c_float_complex),target,dimension(:,:) :: bsrValA
-      integer(c_int),target,dimension(:,:) :: bsrRowPtrA
-      integer(c_int),target,dimension(:,:) :: bsrColIndA
+      complex(c_float_complex),target,dimension(:) :: bsrValA
+      integer(c_int),target,dimension(:) :: bsrRowPtrA
+      integer(c_int),target,dimension(:) :: bsrColIndA
       integer(c_int) :: blockDim
       complex(c_float_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
@@ -29164,9 +29144,9 @@ module hipfort_hipsparse
       integer(c_int) :: nnzb
       complex(c_double_complex) :: alpha
       type(c_ptr) :: descrA
-      complex(c_double_complex),target,dimension(:,:) :: bsrValA
-      integer(c_int),target,dimension(:,:) :: bsrRowPtrA
-      integer(c_int),target,dimension(:,:) :: bsrColIndA
+      complex(c_double_complex),target,dimension(:) :: bsrValA
+      integer(c_int),target,dimension(:) :: bsrRowPtrA
+      integer(c_int),target,dimension(:) :: bsrColIndA
       integer(c_int) :: blockDim
       complex(c_double_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
@@ -29249,9 +29229,9 @@ module hipfort_hipsparse
       integer(c_int) :: nnz
       real(c_float) :: alpha
       type(c_ptr) :: descrA
-      real(c_float),target,dimension(:,:) :: csrSortedValA
-      integer(c_int),target,dimension(:,:) :: csrSortedRowPtrA
-      integer(c_int),target,dimension(:,:) :: csrSortedColIndA
+      real(c_float),target,dimension(:) :: csrSortedValA
+      integer(c_int),target,dimension(:) :: csrSortedRowPtrA
+      integer(c_int),target,dimension(:) :: csrSortedColIndA
       real(c_float),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       real(c_float) :: beta
@@ -29333,9 +29313,9 @@ module hipfort_hipsparse
       integer(c_int) :: nnz
       real(c_double) :: alpha
       type(c_ptr) :: descrA
-      real(c_double),target,dimension(:,:) :: csrSortedValA
-      integer(c_int),target,dimension(:,:) :: csrSortedRowPtrA
-      integer(c_int),target,dimension(:,:) :: csrSortedColIndA
+      real(c_double),target,dimension(:) :: csrSortedValA
+      integer(c_int),target,dimension(:) :: csrSortedRowPtrA
+      integer(c_int),target,dimension(:) :: csrSortedColIndA
       real(c_double),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       real(c_double) :: beta
@@ -29417,9 +29397,9 @@ module hipfort_hipsparse
       integer(c_int) :: nnz
       complex(c_float_complex) :: alpha
       type(c_ptr) :: descrA
-      complex(c_float_complex),target,dimension(:,:) :: csrSortedValA
-      integer(c_int),target,dimension(:,:) :: csrSortedRowPtrA
-      integer(c_int),target,dimension(:,:) :: csrSortedColIndA
+      complex(c_float_complex),target,dimension(:) :: csrSortedValA
+      integer(c_int),target,dimension(:) :: csrSortedRowPtrA
+      integer(c_int),target,dimension(:) :: csrSortedColIndA
       complex(c_float_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       complex(c_float_complex) :: beta
@@ -29501,9 +29481,9 @@ module hipfort_hipsparse
       integer(c_int) :: nnz
       complex(c_double_complex) :: alpha
       type(c_ptr) :: descrA
-      complex(c_double_complex),target,dimension(:,:) :: csrSortedValA
-      integer(c_int),target,dimension(:,:) :: csrSortedRowPtrA
-      integer(c_int),target,dimension(:,:) :: csrSortedColIndA
+      complex(c_double_complex),target,dimension(:) :: csrSortedValA
+      integer(c_int),target,dimension(:) :: csrSortedRowPtrA
+      integer(c_int),target,dimension(:) :: csrSortedColIndA
       complex(c_double_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       complex(c_double_complex) :: beta
@@ -29588,9 +29568,9 @@ module hipfort_hipsparse
       integer(c_int) :: nnz
       real(c_float) :: alpha
       type(c_ptr) :: descrA
-      real(c_float),target,dimension(:,:) :: csrSortedValA
-      integer(c_int),target,dimension(:,:) :: csrSortedRowPtrA
-      integer(c_int),target,dimension(:,:) :: csrSortedColIndA
+      real(c_float),target,dimension(:) :: csrSortedValA
+      integer(c_int),target,dimension(:) :: csrSortedRowPtrA
+      integer(c_int),target,dimension(:) :: csrSortedColIndA
       real(c_float),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       real(c_float) :: beta
@@ -29675,9 +29655,9 @@ module hipfort_hipsparse
       integer(c_int) :: nnz
       real(c_double) :: alpha
       type(c_ptr) :: descrA
-      real(c_double),target,dimension(:,:) :: csrSortedValA
-      integer(c_int),target,dimension(:,:) :: csrSortedRowPtrA
-      integer(c_int),target,dimension(:,:) :: csrSortedColIndA
+      real(c_double),target,dimension(:) :: csrSortedValA
+      integer(c_int),target,dimension(:) :: csrSortedRowPtrA
+      integer(c_int),target,dimension(:) :: csrSortedColIndA
       real(c_double),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       real(c_double) :: beta
@@ -29762,9 +29742,9 @@ module hipfort_hipsparse
       integer(c_int) :: nnz
       complex(c_float_complex) :: alpha
       type(c_ptr) :: descrA
-      complex(c_float_complex),target,dimension(:,:) :: csrSortedValA
-      integer(c_int),target,dimension(:,:) :: csrSortedRowPtrA
-      integer(c_int),target,dimension(:,:) :: csrSortedColIndA
+      complex(c_float_complex),target,dimension(:) :: csrSortedValA
+      integer(c_int),target,dimension(:) :: csrSortedRowPtrA
+      integer(c_int),target,dimension(:) :: csrSortedColIndA
       complex(c_float_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       complex(c_float_complex) :: beta
@@ -29849,9 +29829,9 @@ module hipfort_hipsparse
       integer(c_int) :: nnz
       complex(c_double_complex) :: alpha
       type(c_ptr) :: descrA
-      complex(c_double_complex),target,dimension(:,:) :: csrSortedValA
-      integer(c_int),target,dimension(:,:) :: csrSortedRowPtrA
-      integer(c_int),target,dimension(:,:) :: csrSortedColIndA
+      complex(c_double_complex),target,dimension(:) :: csrSortedValA
+      integer(c_int),target,dimension(:) :: csrSortedRowPtrA
+      integer(c_int),target,dimension(:) :: csrSortedColIndA
       complex(c_double_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       complex(c_double_complex) :: beta
@@ -30309,14 +30289,14 @@ module hipfort_hipsparse
       type(c_ptr) :: myInfo
       real(c_float),target :: B
       integer(c_int) :: ldb
-      real(c_float),target :: X
+      type(c_ptr) :: X
       integer(c_int) :: ldx
       integer(kind(HIPSPARSE_SOLVE_POLICY_NO_LEVEL)) :: policy
       type(c_ptr) :: pBuffer
       !
       hipsparseSbsrsm2_solve_rank_0 = hipsparseSbsrsm2_solve_(handle,dirA,transA,transX,mb,nrhs, &
         nnzb,alpha,descrA,c_loc(bsrSortedValA),c_loc(bsrSortedRowPtrA),c_loc(bsrSortedColIndA), &
-        blockDim,myInfo,c_loc(B),ldb,c_loc(X),ldx,policy,pBuffer)
+        blockDim,myInfo,c_loc(B),ldb,X,ldx,policy,pBuffer)
     end function
 
     function hipsparseSbsrsm2_solve_rank_1(handle,dirA,transA,transX,mb,nrhs,nnzb,alpha,descrA, &
@@ -30341,14 +30321,14 @@ module hipfort_hipsparse
       type(c_ptr) :: myInfo
       real(c_float),target,dimension(:) :: B
       integer(c_int) :: ldb
-      real(c_float),target,dimension(:) :: X
+      type(c_ptr) :: X
       integer(c_int) :: ldx
       integer(kind(HIPSPARSE_SOLVE_POLICY_NO_LEVEL)) :: policy
       type(c_ptr) :: pBuffer
       !
       hipsparseSbsrsm2_solve_rank_1 = hipsparseSbsrsm2_solve_(handle,dirA,transA,transX,mb,nrhs, &
         nnzb,alpha,descrA,c_loc(bsrSortedValA),c_loc(bsrSortedRowPtrA),c_loc(bsrSortedColIndA), &
-        blockDim,myInfo,c_loc(B),ldb,c_loc(X),ldx,policy,pBuffer)
+        blockDim,myInfo,c_loc(B),ldb,X,ldx,policy,pBuffer)
     end function
 
     function hipsparseSbsrsm2_solve_full_rank(handle,dirA,transA,transX,mb,nrhs,nnzb,alpha,descrA, &
@@ -30366,21 +30346,21 @@ module hipfort_hipsparse
       integer(c_int) :: nnzb
       real(c_float) :: alpha
       type(c_ptr) :: descrA
-      real(c_float),target,dimension(:,:) :: bsrSortedValA
-      integer(c_int),target,dimension(:,:) :: bsrSortedRowPtrA
-      integer(c_int),target,dimension(:,:) :: bsrSortedColIndA
+      real(c_float),target,dimension(:) :: bsrSortedValA
+      integer(c_int),target,dimension(:) :: bsrSortedRowPtrA
+      integer(c_int),target,dimension(:) :: bsrSortedColIndA
       integer(c_int) :: blockDim
       type(c_ptr) :: myInfo
       real(c_float),target,dimension(:,:) :: B
       integer(c_int) :: ldb
-      real(c_float),target,dimension(:,:) :: X
+      type(c_ptr) :: X
       integer(c_int) :: ldx
       integer(kind(HIPSPARSE_SOLVE_POLICY_NO_LEVEL)) :: policy
       type(c_ptr) :: pBuffer
       !
       hipsparseSbsrsm2_solve_full_rank = hipsparseSbsrsm2_solve_(handle,dirA,transA,transX,mb, &
         nrhs,nnzb,alpha,descrA,c_loc(bsrSortedValA),c_loc(bsrSortedRowPtrA), &
-        c_loc(bsrSortedColIndA),blockDim,myInfo,c_loc(B),ldb,c_loc(X),ldx,policy,pBuffer)
+        c_loc(bsrSortedColIndA),blockDim,myInfo,c_loc(B),ldb,X,ldx,policy,pBuffer)
     end function
 
     function hipsparseDbsrsm2_solve_rank_0(handle,dirA,transA,transX,mb,nrhs,nnzb,alpha,descrA, &
@@ -30405,14 +30385,14 @@ module hipfort_hipsparse
       type(c_ptr) :: myInfo
       real(c_double),target :: B
       integer(c_int) :: ldb
-      real(c_double),target :: X
+      type(c_ptr) :: X
       integer(c_int) :: ldx
       integer(kind(HIPSPARSE_SOLVE_POLICY_NO_LEVEL)) :: policy
       type(c_ptr) :: pBuffer
       !
       hipsparseDbsrsm2_solve_rank_0 = hipsparseDbsrsm2_solve_(handle,dirA,transA,transX,mb,nrhs, &
         nnzb,alpha,descrA,c_loc(bsrSortedValA),c_loc(bsrSortedRowPtrA),c_loc(bsrSortedColIndA), &
-        blockDim,myInfo,c_loc(B),ldb,c_loc(X),ldx,policy,pBuffer)
+        blockDim,myInfo,c_loc(B),ldb,X,ldx,policy,pBuffer)
     end function
 
     function hipsparseDbsrsm2_solve_rank_1(handle,dirA,transA,transX,mb,nrhs,nnzb,alpha,descrA, &
@@ -30437,14 +30417,14 @@ module hipfort_hipsparse
       type(c_ptr) :: myInfo
       real(c_double),target,dimension(:) :: B
       integer(c_int) :: ldb
-      real(c_double),target,dimension(:) :: X
+      type(c_ptr) :: X
       integer(c_int) :: ldx
       integer(kind(HIPSPARSE_SOLVE_POLICY_NO_LEVEL)) :: policy
       type(c_ptr) :: pBuffer
       !
       hipsparseDbsrsm2_solve_rank_1 = hipsparseDbsrsm2_solve_(handle,dirA,transA,transX,mb,nrhs, &
         nnzb,alpha,descrA,c_loc(bsrSortedValA),c_loc(bsrSortedRowPtrA),c_loc(bsrSortedColIndA), &
-        blockDim,myInfo,c_loc(B),ldb,c_loc(X),ldx,policy,pBuffer)
+        blockDim,myInfo,c_loc(B),ldb,X,ldx,policy,pBuffer)
     end function
 
     function hipsparseDbsrsm2_solve_full_rank(handle,dirA,transA,transX,mb,nrhs,nnzb,alpha,descrA, &
@@ -30462,21 +30442,21 @@ module hipfort_hipsparse
       integer(c_int) :: nnzb
       real(c_double) :: alpha
       type(c_ptr) :: descrA
-      real(c_double),target,dimension(:,:) :: bsrSortedValA
-      integer(c_int),target,dimension(:,:) :: bsrSortedRowPtrA
-      integer(c_int),target,dimension(:,:) :: bsrSortedColIndA
+      real(c_double),target,dimension(:) :: bsrSortedValA
+      integer(c_int),target,dimension(:) :: bsrSortedRowPtrA
+      integer(c_int),target,dimension(:) :: bsrSortedColIndA
       integer(c_int) :: blockDim
       type(c_ptr) :: myInfo
       real(c_double),target,dimension(:,:) :: B
       integer(c_int) :: ldb
-      real(c_double),target,dimension(:,:) :: X
+      type(c_ptr) :: X
       integer(c_int) :: ldx
       integer(kind(HIPSPARSE_SOLVE_POLICY_NO_LEVEL)) :: policy
       type(c_ptr) :: pBuffer
       !
       hipsparseDbsrsm2_solve_full_rank = hipsparseDbsrsm2_solve_(handle,dirA,transA,transX,mb, &
         nrhs,nnzb,alpha,descrA,c_loc(bsrSortedValA),c_loc(bsrSortedRowPtrA), &
-        c_loc(bsrSortedColIndA),blockDim,myInfo,c_loc(B),ldb,c_loc(X),ldx,policy,pBuffer)
+        c_loc(bsrSortedColIndA),blockDim,myInfo,c_loc(B),ldb,X,ldx,policy,pBuffer)
     end function
 
     function hipsparseCbsrsm2_solve_rank_0(handle,dirA,transA,transX,mb,nrhs,nnzb,alpha,descrA, &
@@ -30501,14 +30481,14 @@ module hipfort_hipsparse
       type(c_ptr) :: myInfo
       complex(c_float_complex),target :: B
       integer(c_int) :: ldb
-      complex(c_float_complex),target :: X
+      type(c_ptr) :: X
       integer(c_int) :: ldx
       integer(kind(HIPSPARSE_SOLVE_POLICY_NO_LEVEL)) :: policy
       type(c_ptr) :: pBuffer
       !
       hipsparseCbsrsm2_solve_rank_0 = hipsparseCbsrsm2_solve_(handle,dirA,transA,transX,mb,nrhs, &
         nnzb,alpha,descrA,c_loc(bsrSortedValA),c_loc(bsrSortedRowPtrA),c_loc(bsrSortedColIndA), &
-        blockDim,myInfo,c_loc(B),ldb,c_loc(X),ldx,policy,pBuffer)
+        blockDim,myInfo,c_loc(B),ldb,X,ldx,policy,pBuffer)
     end function
 
     function hipsparseCbsrsm2_solve_rank_1(handle,dirA,transA,transX,mb,nrhs,nnzb,alpha,descrA, &
@@ -30533,14 +30513,14 @@ module hipfort_hipsparse
       type(c_ptr) :: myInfo
       complex(c_float_complex),target,dimension(:) :: B
       integer(c_int) :: ldb
-      complex(c_float_complex),target,dimension(:) :: X
+      type(c_ptr) :: X
       integer(c_int) :: ldx
       integer(kind(HIPSPARSE_SOLVE_POLICY_NO_LEVEL)) :: policy
       type(c_ptr) :: pBuffer
       !
       hipsparseCbsrsm2_solve_rank_1 = hipsparseCbsrsm2_solve_(handle,dirA,transA,transX,mb,nrhs, &
         nnzb,alpha,descrA,c_loc(bsrSortedValA),c_loc(bsrSortedRowPtrA),c_loc(bsrSortedColIndA), &
-        blockDim,myInfo,c_loc(B),ldb,c_loc(X),ldx,policy,pBuffer)
+        blockDim,myInfo,c_loc(B),ldb,X,ldx,policy,pBuffer)
     end function
 
     function hipsparseCbsrsm2_solve_full_rank(handle,dirA,transA,transX,mb,nrhs,nnzb,alpha,descrA, &
@@ -30558,21 +30538,21 @@ module hipfort_hipsparse
       integer(c_int) :: nnzb
       complex(c_float_complex) :: alpha
       type(c_ptr) :: descrA
-      complex(c_float_complex),target,dimension(:,:) :: bsrSortedValA
-      integer(c_int),target,dimension(:,:) :: bsrSortedRowPtrA
-      integer(c_int),target,dimension(:,:) :: bsrSortedColIndA
+      complex(c_float_complex),target,dimension(:) :: bsrSortedValA
+      integer(c_int),target,dimension(:) :: bsrSortedRowPtrA
+      integer(c_int),target,dimension(:) :: bsrSortedColIndA
       integer(c_int) :: blockDim
       type(c_ptr) :: myInfo
       complex(c_float_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
-      complex(c_float_complex),target,dimension(:,:) :: X
+      type(c_ptr) :: X
       integer(c_int) :: ldx
       integer(kind(HIPSPARSE_SOLVE_POLICY_NO_LEVEL)) :: policy
       type(c_ptr) :: pBuffer
       !
       hipsparseCbsrsm2_solve_full_rank = hipsparseCbsrsm2_solve_(handle,dirA,transA,transX,mb, &
         nrhs,nnzb,alpha,descrA,c_loc(bsrSortedValA),c_loc(bsrSortedRowPtrA), &
-        c_loc(bsrSortedColIndA),blockDim,myInfo,c_loc(B),ldb,c_loc(X),ldx,policy,pBuffer)
+        c_loc(bsrSortedColIndA),blockDim,myInfo,c_loc(B),ldb,X,ldx,policy,pBuffer)
     end function
 
     function hipsparseZbsrsm2_solve_rank_0(handle,dirA,transA,transX,mb,nrhs,nnzb,alpha,descrA, &
@@ -30597,14 +30577,14 @@ module hipfort_hipsparse
       type(c_ptr) :: myInfo
       complex(c_double_complex),target :: B
       integer(c_int) :: ldb
-      complex(c_double_complex),target :: X
+      type(c_ptr) :: X
       integer(c_int) :: ldx
       integer(kind(HIPSPARSE_SOLVE_POLICY_NO_LEVEL)) :: policy
       type(c_ptr) :: pBuffer
       !
       hipsparseZbsrsm2_solve_rank_0 = hipsparseZbsrsm2_solve_(handle,dirA,transA,transX,mb,nrhs, &
         nnzb,alpha,descrA,c_loc(bsrSortedValA),c_loc(bsrSortedRowPtrA),c_loc(bsrSortedColIndA), &
-        blockDim,myInfo,c_loc(B),ldb,c_loc(X),ldx,policy,pBuffer)
+        blockDim,myInfo,c_loc(B),ldb,X,ldx,policy,pBuffer)
     end function
 
     function hipsparseZbsrsm2_solve_rank_1(handle,dirA,transA,transX,mb,nrhs,nnzb,alpha,descrA, &
@@ -30629,14 +30609,14 @@ module hipfort_hipsparse
       type(c_ptr) :: myInfo
       complex(c_double_complex),target,dimension(:) :: B
       integer(c_int) :: ldb
-      complex(c_double_complex),target,dimension(:) :: X
+      type(c_ptr) :: X
       integer(c_int) :: ldx
       integer(kind(HIPSPARSE_SOLVE_POLICY_NO_LEVEL)) :: policy
       type(c_ptr) :: pBuffer
       !
       hipsparseZbsrsm2_solve_rank_1 = hipsparseZbsrsm2_solve_(handle,dirA,transA,transX,mb,nrhs, &
         nnzb,alpha,descrA,c_loc(bsrSortedValA),c_loc(bsrSortedRowPtrA),c_loc(bsrSortedColIndA), &
-        blockDim,myInfo,c_loc(B),ldb,c_loc(X),ldx,policy,pBuffer)
+        blockDim,myInfo,c_loc(B),ldb,X,ldx,policy,pBuffer)
     end function
 
     function hipsparseZbsrsm2_solve_full_rank(handle,dirA,transA,transX,mb,nrhs,nnzb,alpha,descrA, &
@@ -30654,21 +30634,21 @@ module hipfort_hipsparse
       integer(c_int) :: nnzb
       complex(c_double_complex) :: alpha
       type(c_ptr) :: descrA
-      complex(c_double_complex),target,dimension(:,:) :: bsrSortedValA
-      integer(c_int),target,dimension(:,:) :: bsrSortedRowPtrA
-      integer(c_int),target,dimension(:,:) :: bsrSortedColIndA
+      complex(c_double_complex),target,dimension(:) :: bsrSortedValA
+      integer(c_int),target,dimension(:) :: bsrSortedRowPtrA
+      integer(c_int),target,dimension(:) :: bsrSortedColIndA
       integer(c_int) :: blockDim
       type(c_ptr) :: myInfo
       complex(c_double_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
-      complex(c_double_complex),target,dimension(:,:) :: X
+      type(c_ptr) :: X
       integer(c_int) :: ldx
       integer(kind(HIPSPARSE_SOLVE_POLICY_NO_LEVEL)) :: policy
       type(c_ptr) :: pBuffer
       !
       hipsparseZbsrsm2_solve_full_rank = hipsparseZbsrsm2_solve_(handle,dirA,transA,transX,mb, &
         nrhs,nnzb,alpha,descrA,c_loc(bsrSortedValA),c_loc(bsrSortedRowPtrA), &
-        c_loc(bsrSortedColIndA),blockDim,myInfo,c_loc(B),ldb,c_loc(X),ldx,policy,pBuffer)
+        c_loc(bsrSortedColIndA),blockDim,myInfo,c_loc(B),ldb,X,ldx,policy,pBuffer)
     end function
 
     function hipsparseScsrsm2_bufferSizeExt_rank_0(handle,algo,transA,transB,m,nrhs,nnz,alpha, &
@@ -30747,14 +30727,14 @@ module hipfort_hipsparse
       integer(c_int) :: nnz
       real(c_float) :: alpha
       type(c_ptr) :: descrA
-      real(c_float),target,dimension(:,:) :: csrSortedValA
-      integer(c_int),target,dimension(:,:) :: csrSortedRowPtrA
-      integer(c_int),target,dimension(:,:) :: csrSortedColIndA
+      real(c_float),target,dimension(:) :: csrSortedValA
+      integer(c_int),target,dimension(:) :: csrSortedRowPtrA
+      integer(c_int),target,dimension(:) :: csrSortedColIndA
       real(c_float),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: myInfo
       integer(kind(HIPSPARSE_SOLVE_POLICY_NO_LEVEL)) :: policy
-      integer(c_size_t),target,dimension(:,:) :: pBufferSizeInBytes
+      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
       !
       hipsparseScsrsm2_bufferSizeExt_full_rank = hipsparseScsrsm2_bufferSizeExt_(handle,algo, &
         transA,transB,m,nrhs,nnz,alpha,descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA), &
@@ -30837,14 +30817,14 @@ module hipfort_hipsparse
       integer(c_int) :: nnz
       real(c_double) :: alpha
       type(c_ptr) :: descrA
-      real(c_double),target,dimension(:,:) :: csrSortedValA
-      integer(c_int),target,dimension(:,:) :: csrSortedRowPtrA
-      integer(c_int),target,dimension(:,:) :: csrSortedColIndA
+      real(c_double),target,dimension(:) :: csrSortedValA
+      integer(c_int),target,dimension(:) :: csrSortedRowPtrA
+      integer(c_int),target,dimension(:) :: csrSortedColIndA
       real(c_double),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: myInfo
       integer(kind(HIPSPARSE_SOLVE_POLICY_NO_LEVEL)) :: policy
-      integer(c_size_t),target,dimension(:,:) :: pBufferSizeInBytes
+      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
       !
       hipsparseDcsrsm2_bufferSizeExt_full_rank = hipsparseDcsrsm2_bufferSizeExt_(handle,algo, &
         transA,transB,m,nrhs,nnz,alpha,descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA), &
@@ -30927,14 +30907,14 @@ module hipfort_hipsparse
       integer(c_int) :: nnz
       complex(c_float_complex) :: alpha
       type(c_ptr) :: descrA
-      complex(c_float_complex),target,dimension(:,:) :: csrSortedValA
-      integer(c_int),target,dimension(:,:) :: csrSortedRowPtrA
-      integer(c_int),target,dimension(:,:) :: csrSortedColIndA
+      complex(c_float_complex),target,dimension(:) :: csrSortedValA
+      integer(c_int),target,dimension(:) :: csrSortedRowPtrA
+      integer(c_int),target,dimension(:) :: csrSortedColIndA
       complex(c_float_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: myInfo
       integer(kind(HIPSPARSE_SOLVE_POLICY_NO_LEVEL)) :: policy
-      integer(c_size_t),target,dimension(:,:) :: pBufferSizeInBytes
+      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
       !
       hipsparseCcsrsm2_bufferSizeExt_full_rank = hipsparseCcsrsm2_bufferSizeExt_(handle,algo, &
         transA,transB,m,nrhs,nnz,alpha,descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA), &
@@ -31017,14 +30997,14 @@ module hipfort_hipsparse
       integer(c_int) :: nnz
       complex(c_double_complex) :: alpha
       type(c_ptr) :: descrA
-      complex(c_double_complex),target,dimension(:,:) :: csrSortedValA
-      integer(c_int),target,dimension(:,:) :: csrSortedRowPtrA
-      integer(c_int),target,dimension(:,:) :: csrSortedColIndA
+      complex(c_double_complex),target,dimension(:) :: csrSortedValA
+      integer(c_int),target,dimension(:) :: csrSortedRowPtrA
+      integer(c_int),target,dimension(:) :: csrSortedColIndA
       complex(c_double_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: myInfo
       integer(kind(HIPSPARSE_SOLVE_POLICY_NO_LEVEL)) :: policy
-      integer(c_size_t),target,dimension(:,:) :: pBufferSizeInBytes
+      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
       !
       hipsparseZcsrsm2_bufferSizeExt_full_rank = hipsparseZcsrsm2_bufferSizeExt_(handle,algo, &
         transA,transB,m,nrhs,nnz,alpha,descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA), &
@@ -31104,9 +31084,9 @@ module hipfort_hipsparse
       integer(c_int) :: nnz
       real(c_float) :: alpha
       type(c_ptr) :: descrA
-      real(c_float),target,dimension(:,:) :: csrSortedValA
-      integer(c_int),target,dimension(:,:) :: csrSortedRowPtrA
-      integer(c_int),target,dimension(:,:) :: csrSortedColIndA
+      real(c_float),target,dimension(:) :: csrSortedValA
+      integer(c_int),target,dimension(:) :: csrSortedRowPtrA
+      integer(c_int),target,dimension(:) :: csrSortedColIndA
       real(c_float),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: myInfo
@@ -31191,9 +31171,9 @@ module hipfort_hipsparse
       integer(c_int) :: nnz
       real(c_double) :: alpha
       type(c_ptr) :: descrA
-      real(c_double),target,dimension(:,:) :: csrSortedValA
-      integer(c_int),target,dimension(:,:) :: csrSortedRowPtrA
-      integer(c_int),target,dimension(:,:) :: csrSortedColIndA
+      real(c_double),target,dimension(:) :: csrSortedValA
+      integer(c_int),target,dimension(:) :: csrSortedRowPtrA
+      integer(c_int),target,dimension(:) :: csrSortedColIndA
       real(c_double),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: myInfo
@@ -31278,9 +31258,9 @@ module hipfort_hipsparse
       integer(c_int) :: nnz
       complex(c_float_complex) :: alpha
       type(c_ptr) :: descrA
-      complex(c_float_complex),target,dimension(:,:) :: csrSortedValA
-      integer(c_int),target,dimension(:,:) :: csrSortedRowPtrA
-      integer(c_int),target,dimension(:,:) :: csrSortedColIndA
+      complex(c_float_complex),target,dimension(:) :: csrSortedValA
+      integer(c_int),target,dimension(:) :: csrSortedRowPtrA
+      integer(c_int),target,dimension(:) :: csrSortedColIndA
       complex(c_float_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: myInfo
@@ -31365,9 +31345,9 @@ module hipfort_hipsparse
       integer(c_int) :: nnz
       complex(c_double_complex) :: alpha
       type(c_ptr) :: descrA
-      complex(c_double_complex),target,dimension(:,:) :: csrSortedValA
-      integer(c_int),target,dimension(:,:) :: csrSortedRowPtrA
-      integer(c_int),target,dimension(:,:) :: csrSortedColIndA
+      complex(c_double_complex),target,dimension(:) :: csrSortedValA
+      integer(c_int),target,dimension(:) :: csrSortedRowPtrA
+      integer(c_int),target,dimension(:) :: csrSortedColIndA
       complex(c_double_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: myInfo
@@ -31452,9 +31432,9 @@ module hipfort_hipsparse
       integer(c_int) :: nnz
       real(c_float) :: alpha
       type(c_ptr) :: descrA
-      real(c_float),target,dimension(:,:) :: csrSortedValA
-      integer(c_int),target,dimension(:,:) :: csrSortedRowPtrA
-      integer(c_int),target,dimension(:,:) :: csrSortedColIndA
+      real(c_float),target,dimension(:) :: csrSortedValA
+      integer(c_int),target,dimension(:) :: csrSortedRowPtrA
+      integer(c_int),target,dimension(:) :: csrSortedColIndA
       real(c_float),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: myInfo
@@ -31539,9 +31519,9 @@ module hipfort_hipsparse
       integer(c_int) :: nnz
       real(c_double) :: alpha
       type(c_ptr) :: descrA
-      real(c_double),target,dimension(:,:) :: csrSortedValA
-      integer(c_int),target,dimension(:,:) :: csrSortedRowPtrA
-      integer(c_int),target,dimension(:,:) :: csrSortedColIndA
+      real(c_double),target,dimension(:) :: csrSortedValA
+      integer(c_int),target,dimension(:) :: csrSortedRowPtrA
+      integer(c_int),target,dimension(:) :: csrSortedColIndA
       real(c_double),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: myInfo
@@ -31626,9 +31606,9 @@ module hipfort_hipsparse
       integer(c_int) :: nnz
       complex(c_float_complex) :: alpha
       type(c_ptr) :: descrA
-      complex(c_float_complex),target,dimension(:,:) :: csrSortedValA
-      integer(c_int),target,dimension(:,:) :: csrSortedRowPtrA
-      integer(c_int),target,dimension(:,:) :: csrSortedColIndA
+      complex(c_float_complex),target,dimension(:) :: csrSortedValA
+      integer(c_int),target,dimension(:) :: csrSortedRowPtrA
+      integer(c_int),target,dimension(:) :: csrSortedColIndA
       complex(c_float_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: myInfo
@@ -31713,9 +31693,9 @@ module hipfort_hipsparse
       integer(c_int) :: nnz
       complex(c_double_complex) :: alpha
       type(c_ptr) :: descrA
-      complex(c_double_complex),target,dimension(:,:) :: csrSortedValA
-      integer(c_int),target,dimension(:,:) :: csrSortedRowPtrA
-      integer(c_int),target,dimension(:,:) :: csrSortedColIndA
+      complex(c_double_complex),target,dimension(:) :: csrSortedValA
+      integer(c_int),target,dimension(:) :: csrSortedRowPtrA
+      integer(c_int),target,dimension(:) :: csrSortedColIndA
       complex(c_double_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: myInfo
@@ -31791,9 +31771,9 @@ module hipfort_hipsparse
       real(c_float) :: alpha
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: cscValB
-      integer(c_int),target,dimension(:,:) :: cscColPtrB
-      integer(c_int),target,dimension(:,:) :: cscRowIndB
+      real(c_float),target,dimension(:) :: cscValB
+      integer(c_int),target,dimension(:) :: cscColPtrB
+      integer(c_int),target,dimension(:) :: cscRowIndB
       real(c_float) :: beta
       real(c_float),target,dimension(:,:) :: C
       integer(c_int) :: ldc
@@ -31866,9 +31846,9 @@ module hipfort_hipsparse
       real(c_double) :: alpha
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: cscValB
-      integer(c_int),target,dimension(:,:) :: cscColPtrB
-      integer(c_int),target,dimension(:,:) :: cscRowIndB
+      real(c_double),target,dimension(:) :: cscValB
+      integer(c_int),target,dimension(:) :: cscColPtrB
+      integer(c_int),target,dimension(:) :: cscRowIndB
       real(c_double) :: beta
       real(c_double),target,dimension(:,:) :: C
       integer(c_int) :: ldc
@@ -31941,9 +31921,9 @@ module hipfort_hipsparse
       complex(c_float_complex) :: alpha
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:,:) :: cscValB
-      integer(c_int),target,dimension(:,:) :: cscColPtrB
-      integer(c_int),target,dimension(:,:) :: cscRowIndB
+      complex(c_float_complex),target,dimension(:) :: cscValB
+      integer(c_int),target,dimension(:) :: cscColPtrB
+      integer(c_int),target,dimension(:) :: cscRowIndB
       complex(c_float_complex) :: beta
       complex(c_float_complex),target,dimension(:,:) :: C
       integer(c_int) :: ldc
@@ -32016,9 +31996,9 @@ module hipfort_hipsparse
       complex(c_double_complex) :: alpha
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:,:) :: cscValB
-      integer(c_int),target,dimension(:,:) :: cscColPtrB
-      integer(c_int),target,dimension(:,:) :: cscRowIndB
+      complex(c_double_complex),target,dimension(:) :: cscValB
+      integer(c_int),target,dimension(:) :: cscColPtrB
+      integer(c_int),target,dimension(:) :: cscRowIndB
       complex(c_double_complex) :: beta
       complex(c_double_complex),target,dimension(:,:) :: C
       integer(c_int) :: ldc
@@ -36407,15 +36387,15 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      real(c_float),target :: dl
-      real(c_float),target :: d
-      real(c_float),target :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_float),target :: B
       integer(c_int) :: ldb
       integer(c_size_t) :: pBufferSizeInBytes
       !
-      hipsparseSgtsv2_bufferSizeExt_rank_0 = hipsparseSgtsv2_bufferSizeExt_(handle,m,n,c_loc(dl), &
-        c_loc(d),c_loc(du),c_loc(B),ldb,pBufferSizeInBytes)
+      hipsparseSgtsv2_bufferSizeExt_rank_0 = hipsparseSgtsv2_bufferSizeExt_(handle,m,n,dl,d,du, &
+        c_loc(B),ldb,pBufferSizeInBytes)
     end function
 
     function hipsparseSgtsv2_bufferSizeExt_rank_1(handle,m,n,dl,d,du,B,ldb,pBufferSizeInBytes)
@@ -36426,15 +36406,15 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      real(c_float),target,dimension(:) :: dl
-      real(c_float),target,dimension(:) :: d
-      real(c_float),target,dimension(:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_float),target,dimension(:) :: B
       integer(c_int) :: ldb
       integer(c_size_t) :: pBufferSizeInBytes
       !
-      hipsparseSgtsv2_bufferSizeExt_rank_1 = hipsparseSgtsv2_bufferSizeExt_(handle,m,n,c_loc(dl), &
-        c_loc(d),c_loc(du),c_loc(B),ldb,pBufferSizeInBytes)
+      hipsparseSgtsv2_bufferSizeExt_rank_1 = hipsparseSgtsv2_bufferSizeExt_(handle,m,n,dl,d,du, &
+        c_loc(B),ldb,pBufferSizeInBytes)
     end function
 
     function hipsparseSgtsv2_bufferSizeExt_full_rank(handle,m,n,dl,d,du,B,ldb,pBufferSizeInBytes)
@@ -36445,15 +36425,15 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      real(c_float),target,dimension(:,:) :: dl
-      real(c_float),target,dimension(:,:) :: d
-      real(c_float),target,dimension(:,:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_float),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       integer(c_size_t) :: pBufferSizeInBytes
       !
-      hipsparseSgtsv2_bufferSizeExt_full_rank = hipsparseSgtsv2_bufferSizeExt_(handle,m,n, &
-        c_loc(dl),c_loc(d),c_loc(du),c_loc(B),ldb,pBufferSizeInBytes)
+      hipsparseSgtsv2_bufferSizeExt_full_rank = hipsparseSgtsv2_bufferSizeExt_(handle,m,n,dl,d,du, &
+        c_loc(B),ldb,pBufferSizeInBytes)
     end function
 
     function hipsparseDgtsv2_bufferSizeExt_rank_0(handle,m,n,dl,d,du,B,ldb,pBufferSizeInBytes)
@@ -36464,15 +36444,15 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      real(c_double),target :: dl
-      real(c_double),target :: d
-      real(c_double),target :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_double),target :: B
       integer(c_int) :: ldb
       integer(c_size_t) :: pBufferSizeInBytes
       !
-      hipsparseDgtsv2_bufferSizeExt_rank_0 = hipsparseDgtsv2_bufferSizeExt_(handle,m,n,c_loc(dl), &
-        c_loc(d),c_loc(du),c_loc(B),ldb,pBufferSizeInBytes)
+      hipsparseDgtsv2_bufferSizeExt_rank_0 = hipsparseDgtsv2_bufferSizeExt_(handle,m,n,dl,d,du, &
+        c_loc(B),ldb,pBufferSizeInBytes)
     end function
 
     function hipsparseDgtsv2_bufferSizeExt_rank_1(handle,m,n,dl,d,du,B,ldb,pBufferSizeInBytes)
@@ -36483,15 +36463,15 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      real(c_double),target,dimension(:) :: dl
-      real(c_double),target,dimension(:) :: d
-      real(c_double),target,dimension(:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_double),target,dimension(:) :: B
       integer(c_int) :: ldb
       integer(c_size_t) :: pBufferSizeInBytes
       !
-      hipsparseDgtsv2_bufferSizeExt_rank_1 = hipsparseDgtsv2_bufferSizeExt_(handle,m,n,c_loc(dl), &
-        c_loc(d),c_loc(du),c_loc(B),ldb,pBufferSizeInBytes)
+      hipsparseDgtsv2_bufferSizeExt_rank_1 = hipsparseDgtsv2_bufferSizeExt_(handle,m,n,dl,d,du, &
+        c_loc(B),ldb,pBufferSizeInBytes)
     end function
 
     function hipsparseDgtsv2_bufferSizeExt_full_rank(handle,m,n,dl,d,du,B,ldb,pBufferSizeInBytes)
@@ -36502,15 +36482,15 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      real(c_double),target,dimension(:,:) :: dl
-      real(c_double),target,dimension(:,:) :: d
-      real(c_double),target,dimension(:,:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_double),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       integer(c_size_t) :: pBufferSizeInBytes
       !
-      hipsparseDgtsv2_bufferSizeExt_full_rank = hipsparseDgtsv2_bufferSizeExt_(handle,m,n, &
-        c_loc(dl),c_loc(d),c_loc(du),c_loc(B),ldb,pBufferSizeInBytes)
+      hipsparseDgtsv2_bufferSizeExt_full_rank = hipsparseDgtsv2_bufferSizeExt_(handle,m,n,dl,d,du, &
+        c_loc(B),ldb,pBufferSizeInBytes)
     end function
 
     function hipsparseCgtsv2_bufferSizeExt_rank_0(handle,m,n,dl,d,du,B,ldb,pBufferSizeInBytes)
@@ -36521,15 +36501,15 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      complex(c_float_complex),target :: dl
-      complex(c_float_complex),target :: d
-      complex(c_float_complex),target :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_float_complex),target :: B
       integer(c_int) :: ldb
       integer(c_size_t) :: pBufferSizeInBytes
       !
-      hipsparseCgtsv2_bufferSizeExt_rank_0 = hipsparseCgtsv2_bufferSizeExt_(handle,m,n,c_loc(dl), &
-        c_loc(d),c_loc(du),c_loc(B),ldb,pBufferSizeInBytes)
+      hipsparseCgtsv2_bufferSizeExt_rank_0 = hipsparseCgtsv2_bufferSizeExt_(handle,m,n,dl,d,du, &
+        c_loc(B),ldb,pBufferSizeInBytes)
     end function
 
     function hipsparseCgtsv2_bufferSizeExt_rank_1(handle,m,n,dl,d,du,B,ldb,pBufferSizeInBytes)
@@ -36540,15 +36520,15 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      complex(c_float_complex),target,dimension(:) :: dl
-      complex(c_float_complex),target,dimension(:) :: d
-      complex(c_float_complex),target,dimension(:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_float_complex),target,dimension(:) :: B
       integer(c_int) :: ldb
       integer(c_size_t) :: pBufferSizeInBytes
       !
-      hipsparseCgtsv2_bufferSizeExt_rank_1 = hipsparseCgtsv2_bufferSizeExt_(handle,m,n,c_loc(dl), &
-        c_loc(d),c_loc(du),c_loc(B),ldb,pBufferSizeInBytes)
+      hipsparseCgtsv2_bufferSizeExt_rank_1 = hipsparseCgtsv2_bufferSizeExt_(handle,m,n,dl,d,du, &
+        c_loc(B),ldb,pBufferSizeInBytes)
     end function
 
     function hipsparseCgtsv2_bufferSizeExt_full_rank(handle,m,n,dl,d,du,B,ldb,pBufferSizeInBytes)
@@ -36559,15 +36539,15 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      complex(c_float_complex),target,dimension(:,:) :: dl
-      complex(c_float_complex),target,dimension(:,:) :: d
-      complex(c_float_complex),target,dimension(:,:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_float_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       integer(c_size_t) :: pBufferSizeInBytes
       !
-      hipsparseCgtsv2_bufferSizeExt_full_rank = hipsparseCgtsv2_bufferSizeExt_(handle,m,n, &
-        c_loc(dl),c_loc(d),c_loc(du),c_loc(B),ldb,pBufferSizeInBytes)
+      hipsparseCgtsv2_bufferSizeExt_full_rank = hipsparseCgtsv2_bufferSizeExt_(handle,m,n,dl,d,du, &
+        c_loc(B),ldb,pBufferSizeInBytes)
     end function
 
     function hipsparseZgtsv2_bufferSizeExt_rank_0(handle,m,n,dl,d,du,B,ldb,pBufferSizeInBytes)
@@ -36578,15 +36558,15 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      complex(c_double_complex),target :: dl
-      complex(c_double_complex),target :: d
-      complex(c_double_complex),target :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_double_complex),target :: B
       integer(c_int) :: ldb
       integer(c_size_t) :: pBufferSizeInBytes
       !
-      hipsparseZgtsv2_bufferSizeExt_rank_0 = hipsparseZgtsv2_bufferSizeExt_(handle,m,n,c_loc(dl), &
-        c_loc(d),c_loc(du),c_loc(B),ldb,pBufferSizeInBytes)
+      hipsparseZgtsv2_bufferSizeExt_rank_0 = hipsparseZgtsv2_bufferSizeExt_(handle,m,n,dl,d,du, &
+        c_loc(B),ldb,pBufferSizeInBytes)
     end function
 
     function hipsparseZgtsv2_bufferSizeExt_rank_1(handle,m,n,dl,d,du,B,ldb,pBufferSizeInBytes)
@@ -36597,15 +36577,15 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      complex(c_double_complex),target,dimension(:) :: dl
-      complex(c_double_complex),target,dimension(:) :: d
-      complex(c_double_complex),target,dimension(:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_double_complex),target,dimension(:) :: B
       integer(c_int) :: ldb
       integer(c_size_t) :: pBufferSizeInBytes
       !
-      hipsparseZgtsv2_bufferSizeExt_rank_1 = hipsparseZgtsv2_bufferSizeExt_(handle,m,n,c_loc(dl), &
-        c_loc(d),c_loc(du),c_loc(B),ldb,pBufferSizeInBytes)
+      hipsparseZgtsv2_bufferSizeExt_rank_1 = hipsparseZgtsv2_bufferSizeExt_(handle,m,n,dl,d,du, &
+        c_loc(B),ldb,pBufferSizeInBytes)
     end function
 
     function hipsparseZgtsv2_bufferSizeExt_full_rank(handle,m,n,dl,d,du,B,ldb,pBufferSizeInBytes)
@@ -36616,15 +36596,15 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      complex(c_double_complex),target,dimension(:,:) :: dl
-      complex(c_double_complex),target,dimension(:,:) :: d
-      complex(c_double_complex),target,dimension(:,:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_double_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       integer(c_size_t) :: pBufferSizeInBytes
       !
-      hipsparseZgtsv2_bufferSizeExt_full_rank = hipsparseZgtsv2_bufferSizeExt_(handle,m,n, &
-        c_loc(dl),c_loc(d),c_loc(du),c_loc(B),ldb,pBufferSizeInBytes)
+      hipsparseZgtsv2_bufferSizeExt_full_rank = hipsparseZgtsv2_bufferSizeExt_(handle,m,n,dl,d,du, &
+        c_loc(B),ldb,pBufferSizeInBytes)
     end function
 
     function hipsparseSgtsv2_rank_0(handle,m,n,dl,d,du,B,ldb,pBuffer)
@@ -36635,15 +36615,14 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      real(c_float),target :: dl
-      real(c_float),target :: d
-      real(c_float),target :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_float),target :: B
       integer(c_int) :: ldb
       type(c_ptr) :: pBuffer
       !
-      hipsparseSgtsv2_rank_0 = hipsparseSgtsv2_(handle,m,n,c_loc(dl),c_loc(d),c_loc(du),c_loc(B), &
-        ldb,pBuffer)
+      hipsparseSgtsv2_rank_0 = hipsparseSgtsv2_(handle,m,n,dl,d,du,c_loc(B),ldb,pBuffer)
     end function
 
     function hipsparseSgtsv2_rank_1(handle,m,n,dl,d,du,B,ldb,pBuffer)
@@ -36654,15 +36633,14 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      real(c_float),target,dimension(:) :: dl
-      real(c_float),target,dimension(:) :: d
-      real(c_float),target,dimension(:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_float),target,dimension(:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: pBuffer
       !
-      hipsparseSgtsv2_rank_1 = hipsparseSgtsv2_(handle,m,n,c_loc(dl),c_loc(d),c_loc(du),c_loc(B), &
-        ldb,pBuffer)
+      hipsparseSgtsv2_rank_1 = hipsparseSgtsv2_(handle,m,n,dl,d,du,c_loc(B),ldb,pBuffer)
     end function
 
     function hipsparseSgtsv2_full_rank(handle,m,n,dl,d,du,B,ldb,pBuffer)
@@ -36673,15 +36651,14 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      real(c_float),target,dimension(:,:) :: dl
-      real(c_float),target,dimension(:,:) :: d
-      real(c_float),target,dimension(:,:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_float),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: pBuffer
       !
-      hipsparseSgtsv2_full_rank = hipsparseSgtsv2_(handle,m,n,c_loc(dl),c_loc(d),c_loc(du), &
-        c_loc(B),ldb,pBuffer)
+      hipsparseSgtsv2_full_rank = hipsparseSgtsv2_(handle,m,n,dl,d,du,c_loc(B),ldb,pBuffer)
     end function
 
     function hipsparseDgtsv2_rank_0(handle,m,n,dl,d,du,B,ldb,pBuffer)
@@ -36692,15 +36669,14 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      real(c_double),target :: dl
-      real(c_double),target :: d
-      real(c_double),target :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_double),target :: B
       integer(c_int) :: ldb
       type(c_ptr) :: pBuffer
       !
-      hipsparseDgtsv2_rank_0 = hipsparseDgtsv2_(handle,m,n,c_loc(dl),c_loc(d),c_loc(du),c_loc(B), &
-        ldb,pBuffer)
+      hipsparseDgtsv2_rank_0 = hipsparseDgtsv2_(handle,m,n,dl,d,du,c_loc(B),ldb,pBuffer)
     end function
 
     function hipsparseDgtsv2_rank_1(handle,m,n,dl,d,du,B,ldb,pBuffer)
@@ -36711,15 +36687,14 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      real(c_double),target,dimension(:) :: dl
-      real(c_double),target,dimension(:) :: d
-      real(c_double),target,dimension(:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_double),target,dimension(:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: pBuffer
       !
-      hipsparseDgtsv2_rank_1 = hipsparseDgtsv2_(handle,m,n,c_loc(dl),c_loc(d),c_loc(du),c_loc(B), &
-        ldb,pBuffer)
+      hipsparseDgtsv2_rank_1 = hipsparseDgtsv2_(handle,m,n,dl,d,du,c_loc(B),ldb,pBuffer)
     end function
 
     function hipsparseDgtsv2_full_rank(handle,m,n,dl,d,du,B,ldb,pBuffer)
@@ -36730,15 +36705,14 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      real(c_double),target,dimension(:,:) :: dl
-      real(c_double),target,dimension(:,:) :: d
-      real(c_double),target,dimension(:,:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_double),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: pBuffer
       !
-      hipsparseDgtsv2_full_rank = hipsparseDgtsv2_(handle,m,n,c_loc(dl),c_loc(d),c_loc(du), &
-        c_loc(B),ldb,pBuffer)
+      hipsparseDgtsv2_full_rank = hipsparseDgtsv2_(handle,m,n,dl,d,du,c_loc(B),ldb,pBuffer)
     end function
 
     function hipsparseCgtsv2_rank_0(handle,m,n,dl,d,du,B,ldb,pBuffer)
@@ -36749,15 +36723,14 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      complex(c_float_complex),target :: dl
-      complex(c_float_complex),target :: d
-      complex(c_float_complex),target :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_float_complex),target :: B
       integer(c_int) :: ldb
       type(c_ptr) :: pBuffer
       !
-      hipsparseCgtsv2_rank_0 = hipsparseCgtsv2_(handle,m,n,c_loc(dl),c_loc(d),c_loc(du),c_loc(B), &
-        ldb,pBuffer)
+      hipsparseCgtsv2_rank_0 = hipsparseCgtsv2_(handle,m,n,dl,d,du,c_loc(B),ldb,pBuffer)
     end function
 
     function hipsparseCgtsv2_rank_1(handle,m,n,dl,d,du,B,ldb,pBuffer)
@@ -36768,15 +36741,14 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      complex(c_float_complex),target,dimension(:) :: dl
-      complex(c_float_complex),target,dimension(:) :: d
-      complex(c_float_complex),target,dimension(:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_float_complex),target,dimension(:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: pBuffer
       !
-      hipsparseCgtsv2_rank_1 = hipsparseCgtsv2_(handle,m,n,c_loc(dl),c_loc(d),c_loc(du),c_loc(B), &
-        ldb,pBuffer)
+      hipsparseCgtsv2_rank_1 = hipsparseCgtsv2_(handle,m,n,dl,d,du,c_loc(B),ldb,pBuffer)
     end function
 
     function hipsparseCgtsv2_full_rank(handle,m,n,dl,d,du,B,ldb,pBuffer)
@@ -36787,15 +36759,14 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      complex(c_float_complex),target,dimension(:,:) :: dl
-      complex(c_float_complex),target,dimension(:,:) :: d
-      complex(c_float_complex),target,dimension(:,:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_float_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: pBuffer
       !
-      hipsparseCgtsv2_full_rank = hipsparseCgtsv2_(handle,m,n,c_loc(dl),c_loc(d),c_loc(du), &
-        c_loc(B),ldb,pBuffer)
+      hipsparseCgtsv2_full_rank = hipsparseCgtsv2_(handle,m,n,dl,d,du,c_loc(B),ldb,pBuffer)
     end function
 
     function hipsparseZgtsv2_rank_0(handle,m,n,dl,d,du,B,ldb,pBuffer)
@@ -36806,15 +36777,14 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      complex(c_double_complex),target :: dl
-      complex(c_double_complex),target :: d
-      complex(c_double_complex),target :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_double_complex),target :: B
       integer(c_int) :: ldb
       type(c_ptr) :: pBuffer
       !
-      hipsparseZgtsv2_rank_0 = hipsparseZgtsv2_(handle,m,n,c_loc(dl),c_loc(d),c_loc(du),c_loc(B), &
-        ldb,pBuffer)
+      hipsparseZgtsv2_rank_0 = hipsparseZgtsv2_(handle,m,n,dl,d,du,c_loc(B),ldb,pBuffer)
     end function
 
     function hipsparseZgtsv2_rank_1(handle,m,n,dl,d,du,B,ldb,pBuffer)
@@ -36825,15 +36795,14 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      complex(c_double_complex),target,dimension(:) :: dl
-      complex(c_double_complex),target,dimension(:) :: d
-      complex(c_double_complex),target,dimension(:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_double_complex),target,dimension(:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: pBuffer
       !
-      hipsparseZgtsv2_rank_1 = hipsparseZgtsv2_(handle,m,n,c_loc(dl),c_loc(d),c_loc(du),c_loc(B), &
-        ldb,pBuffer)
+      hipsparseZgtsv2_rank_1 = hipsparseZgtsv2_(handle,m,n,dl,d,du,c_loc(B),ldb,pBuffer)
     end function
 
     function hipsparseZgtsv2_full_rank(handle,m,n,dl,d,du,B,ldb,pBuffer)
@@ -36844,15 +36813,14 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      complex(c_double_complex),target,dimension(:,:) :: dl
-      complex(c_double_complex),target,dimension(:,:) :: d
-      complex(c_double_complex),target,dimension(:,:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_double_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: pBuffer
       !
-      hipsparseZgtsv2_full_rank = hipsparseZgtsv2_(handle,m,n,c_loc(dl),c_loc(d),c_loc(du), &
-        c_loc(B),ldb,pBuffer)
+      hipsparseZgtsv2_full_rank = hipsparseZgtsv2_(handle,m,n,dl,d,du,c_loc(B),ldb,pBuffer)
     end function
 
     function hipsparseSgtsv2_nopivot_bufferSizeExt_rank_0(handle,m,n,dl,d,du,B,ldb, &
@@ -36864,15 +36832,15 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      real(c_float),target :: dl
-      real(c_float),target :: d
-      real(c_float),target :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_float),target :: B
       integer(c_int) :: ldb
       integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseSgtsv2_nopivot_bufferSizeExt_rank_0 = hipsparseSgtsv2_nopivot_bufferSizeExt_( &
-        handle,m,n,c_loc(dl),c_loc(d),c_loc(du),c_loc(B),ldb,pBufferSizeInBytes)
+        handle,m,n,dl,d,du,c_loc(B),ldb,pBufferSizeInBytes)
     end function
 
     function hipsparseSgtsv2_nopivot_bufferSizeExt_rank_1(handle,m,n,dl,d,du,B,ldb, &
@@ -36884,15 +36852,15 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      real(c_float),target,dimension(:) :: dl
-      real(c_float),target,dimension(:) :: d
-      real(c_float),target,dimension(:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_float),target,dimension(:) :: B
       integer(c_int) :: ldb
       integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseSgtsv2_nopivot_bufferSizeExt_rank_1 = hipsparseSgtsv2_nopivot_bufferSizeExt_( &
-        handle,m,n,c_loc(dl),c_loc(d),c_loc(du),c_loc(B),ldb,pBufferSizeInBytes)
+        handle,m,n,dl,d,du,c_loc(B),ldb,pBufferSizeInBytes)
     end function
 
     function hipsparseSgtsv2_nopivot_bufferSizeExt_full_rank(handle,m,n,dl,d,du,B,ldb, &
@@ -36904,15 +36872,15 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      real(c_float),target,dimension(:,:) :: dl
-      real(c_float),target,dimension(:,:) :: d
-      real(c_float),target,dimension(:,:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_float),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseSgtsv2_nopivot_bufferSizeExt_full_rank = hipsparseSgtsv2_nopivot_bufferSizeExt_( &
-        handle,m,n,c_loc(dl),c_loc(d),c_loc(du),c_loc(B),ldb,pBufferSizeInBytes)
+        handle,m,n,dl,d,du,c_loc(B),ldb,pBufferSizeInBytes)
     end function
 
     function hipsparseDgtsv2_nopivot_bufferSizeExt_rank_0(handle,m,n,dl,d,du,B,ldb, &
@@ -36924,15 +36892,15 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      real(c_double),target :: dl
-      real(c_double),target :: d
-      real(c_double),target :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_double),target :: B
       integer(c_int) :: ldb
       integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseDgtsv2_nopivot_bufferSizeExt_rank_0 = hipsparseDgtsv2_nopivot_bufferSizeExt_( &
-        handle,m,n,c_loc(dl),c_loc(d),c_loc(du),c_loc(B),ldb,pBufferSizeInBytes)
+        handle,m,n,dl,d,du,c_loc(B),ldb,pBufferSizeInBytes)
     end function
 
     function hipsparseDgtsv2_nopivot_bufferSizeExt_rank_1(handle,m,n,dl,d,du,B,ldb, &
@@ -36944,15 +36912,15 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      real(c_double),target,dimension(:) :: dl
-      real(c_double),target,dimension(:) :: d
-      real(c_double),target,dimension(:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_double),target,dimension(:) :: B
       integer(c_int) :: ldb
       integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseDgtsv2_nopivot_bufferSizeExt_rank_1 = hipsparseDgtsv2_nopivot_bufferSizeExt_( &
-        handle,m,n,c_loc(dl),c_loc(d),c_loc(du),c_loc(B),ldb,pBufferSizeInBytes)
+        handle,m,n,dl,d,du,c_loc(B),ldb,pBufferSizeInBytes)
     end function
 
     function hipsparseDgtsv2_nopivot_bufferSizeExt_full_rank(handle,m,n,dl,d,du,B,ldb, &
@@ -36964,15 +36932,15 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      real(c_double),target,dimension(:,:) :: dl
-      real(c_double),target,dimension(:,:) :: d
-      real(c_double),target,dimension(:,:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_double),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseDgtsv2_nopivot_bufferSizeExt_full_rank = hipsparseDgtsv2_nopivot_bufferSizeExt_( &
-        handle,m,n,c_loc(dl),c_loc(d),c_loc(du),c_loc(B),ldb,pBufferSizeInBytes)
+        handle,m,n,dl,d,du,c_loc(B),ldb,pBufferSizeInBytes)
     end function
 
     function hipsparseCgtsv2_nopivot_bufferSizeExt_rank_0(handle,m,n,dl,d,du,B,ldb, &
@@ -36984,15 +36952,15 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      complex(c_float_complex),target :: dl
-      complex(c_float_complex),target :: d
-      complex(c_float_complex),target :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_float_complex),target :: B
       integer(c_int) :: ldb
       integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseCgtsv2_nopivot_bufferSizeExt_rank_0 = hipsparseCgtsv2_nopivot_bufferSizeExt_( &
-        handle,m,n,c_loc(dl),c_loc(d),c_loc(du),c_loc(B),ldb,pBufferSizeInBytes)
+        handle,m,n,dl,d,du,c_loc(B),ldb,pBufferSizeInBytes)
     end function
 
     function hipsparseCgtsv2_nopivot_bufferSizeExt_rank_1(handle,m,n,dl,d,du,B,ldb, &
@@ -37004,15 +36972,15 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      complex(c_float_complex),target,dimension(:) :: dl
-      complex(c_float_complex),target,dimension(:) :: d
-      complex(c_float_complex),target,dimension(:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_float_complex),target,dimension(:) :: B
       integer(c_int) :: ldb
       integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseCgtsv2_nopivot_bufferSizeExt_rank_1 = hipsparseCgtsv2_nopivot_bufferSizeExt_( &
-        handle,m,n,c_loc(dl),c_loc(d),c_loc(du),c_loc(B),ldb,pBufferSizeInBytes)
+        handle,m,n,dl,d,du,c_loc(B),ldb,pBufferSizeInBytes)
     end function
 
     function hipsparseCgtsv2_nopivot_bufferSizeExt_full_rank(handle,m,n,dl,d,du,B,ldb, &
@@ -37024,15 +36992,15 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      complex(c_float_complex),target,dimension(:,:) :: dl
-      complex(c_float_complex),target,dimension(:,:) :: d
-      complex(c_float_complex),target,dimension(:,:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_float_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseCgtsv2_nopivot_bufferSizeExt_full_rank = hipsparseCgtsv2_nopivot_bufferSizeExt_( &
-        handle,m,n,c_loc(dl),c_loc(d),c_loc(du),c_loc(B),ldb,pBufferSizeInBytes)
+        handle,m,n,dl,d,du,c_loc(B),ldb,pBufferSizeInBytes)
     end function
 
     function hipsparseZgtsv2_nopivot_bufferSizeExt_rank_0(handle,m,n,dl,d,du,B,ldb, &
@@ -37044,15 +37012,15 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      complex(c_double_complex),target :: dl
-      complex(c_double_complex),target :: d
-      complex(c_double_complex),target :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_double_complex),target :: B
       integer(c_int) :: ldb
       integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseZgtsv2_nopivot_bufferSizeExt_rank_0 = hipsparseZgtsv2_nopivot_bufferSizeExt_( &
-        handle,m,n,c_loc(dl),c_loc(d),c_loc(du),c_loc(B),ldb,pBufferSizeInBytes)
+        handle,m,n,dl,d,du,c_loc(B),ldb,pBufferSizeInBytes)
     end function
 
     function hipsparseZgtsv2_nopivot_bufferSizeExt_rank_1(handle,m,n,dl,d,du,B,ldb, &
@@ -37064,15 +37032,15 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      complex(c_double_complex),target,dimension(:) :: dl
-      complex(c_double_complex),target,dimension(:) :: d
-      complex(c_double_complex),target,dimension(:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_double_complex),target,dimension(:) :: B
       integer(c_int) :: ldb
       integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseZgtsv2_nopivot_bufferSizeExt_rank_1 = hipsparseZgtsv2_nopivot_bufferSizeExt_( &
-        handle,m,n,c_loc(dl),c_loc(d),c_loc(du),c_loc(B),ldb,pBufferSizeInBytes)
+        handle,m,n,dl,d,du,c_loc(B),ldb,pBufferSizeInBytes)
     end function
 
     function hipsparseZgtsv2_nopivot_bufferSizeExt_full_rank(handle,m,n,dl,d,du,B,ldb, &
@@ -37084,15 +37052,15 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      complex(c_double_complex),target,dimension(:,:) :: dl
-      complex(c_double_complex),target,dimension(:,:) :: d
-      complex(c_double_complex),target,dimension(:,:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_double_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseZgtsv2_nopivot_bufferSizeExt_full_rank = hipsparseZgtsv2_nopivot_bufferSizeExt_( &
-        handle,m,n,c_loc(dl),c_loc(d),c_loc(du),c_loc(B),ldb,pBufferSizeInBytes)
+        handle,m,n,dl,d,du,c_loc(B),ldb,pBufferSizeInBytes)
     end function
 
     function hipsparseSgtsv2_nopivot_rank_0(handle,m,n,dl,d,du,B,ldb,pBuffer)
@@ -37103,15 +37071,15 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      real(c_float),target :: dl
-      real(c_float),target :: d
-      real(c_float),target :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_float),target :: B
       integer(c_int) :: ldb
       type(c_ptr) :: pBuffer
       !
-      hipsparseSgtsv2_nopivot_rank_0 = hipsparseSgtsv2_nopivot_(handle,m,n,c_loc(dl),c_loc(d), &
-        c_loc(du),c_loc(B),ldb,pBuffer)
+      hipsparseSgtsv2_nopivot_rank_0 = hipsparseSgtsv2_nopivot_(handle,m,n,dl,d,du,c_loc(B),ldb, &
+        pBuffer)
     end function
 
     function hipsparseSgtsv2_nopivot_rank_1(handle,m,n,dl,d,du,B,ldb,pBuffer)
@@ -37122,15 +37090,15 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      real(c_float),target,dimension(:) :: dl
-      real(c_float),target,dimension(:) :: d
-      real(c_float),target,dimension(:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_float),target,dimension(:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: pBuffer
       !
-      hipsparseSgtsv2_nopivot_rank_1 = hipsparseSgtsv2_nopivot_(handle,m,n,c_loc(dl),c_loc(d), &
-        c_loc(du),c_loc(B),ldb,pBuffer)
+      hipsparseSgtsv2_nopivot_rank_1 = hipsparseSgtsv2_nopivot_(handle,m,n,dl,d,du,c_loc(B),ldb, &
+        pBuffer)
     end function
 
     function hipsparseSgtsv2_nopivot_full_rank(handle,m,n,dl,d,du,B,ldb,pBuffer)
@@ -37141,15 +37109,15 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      real(c_float),target,dimension(:,:) :: dl
-      real(c_float),target,dimension(:,:) :: d
-      real(c_float),target,dimension(:,:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_float),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: pBuffer
       !
-      hipsparseSgtsv2_nopivot_full_rank = hipsparseSgtsv2_nopivot_(handle,m,n,c_loc(dl),c_loc(d), &
-        c_loc(du),c_loc(B),ldb,pBuffer)
+      hipsparseSgtsv2_nopivot_full_rank = hipsparseSgtsv2_nopivot_(handle,m,n,dl,d,du,c_loc(B), &
+        ldb,pBuffer)
     end function
 
     function hipsparseDgtsv2_nopivot_rank_0(handle,m,n,dl,d,du,B,ldb,pBuffer)
@@ -37160,15 +37128,15 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      real(c_double),target :: dl
-      real(c_double),target :: d
-      real(c_double),target :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_double),target :: B
       integer(c_int) :: ldb
       type(c_ptr) :: pBuffer
       !
-      hipsparseDgtsv2_nopivot_rank_0 = hipsparseDgtsv2_nopivot_(handle,m,n,c_loc(dl),c_loc(d), &
-        c_loc(du),c_loc(B),ldb,pBuffer)
+      hipsparseDgtsv2_nopivot_rank_0 = hipsparseDgtsv2_nopivot_(handle,m,n,dl,d,du,c_loc(B),ldb, &
+        pBuffer)
     end function
 
     function hipsparseDgtsv2_nopivot_rank_1(handle,m,n,dl,d,du,B,ldb,pBuffer)
@@ -37179,15 +37147,15 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      real(c_double),target,dimension(:) :: dl
-      real(c_double),target,dimension(:) :: d
-      real(c_double),target,dimension(:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_double),target,dimension(:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: pBuffer
       !
-      hipsparseDgtsv2_nopivot_rank_1 = hipsparseDgtsv2_nopivot_(handle,m,n,c_loc(dl),c_loc(d), &
-        c_loc(du),c_loc(B),ldb,pBuffer)
+      hipsparseDgtsv2_nopivot_rank_1 = hipsparseDgtsv2_nopivot_(handle,m,n,dl,d,du,c_loc(B),ldb, &
+        pBuffer)
     end function
 
     function hipsparseDgtsv2_nopivot_full_rank(handle,m,n,dl,d,du,B,ldb,pBuffer)
@@ -37198,15 +37166,15 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      real(c_double),target,dimension(:,:) :: dl
-      real(c_double),target,dimension(:,:) :: d
-      real(c_double),target,dimension(:,:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_double),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: pBuffer
       !
-      hipsparseDgtsv2_nopivot_full_rank = hipsparseDgtsv2_nopivot_(handle,m,n,c_loc(dl),c_loc(d), &
-        c_loc(du),c_loc(B),ldb,pBuffer)
+      hipsparseDgtsv2_nopivot_full_rank = hipsparseDgtsv2_nopivot_(handle,m,n,dl,d,du,c_loc(B), &
+        ldb,pBuffer)
     end function
 
     function hipsparseCgtsv2_nopivot_rank_0(handle,m,n,dl,d,du,B,ldb,pBuffer)
@@ -37217,15 +37185,15 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      complex(c_float_complex),target :: dl
-      complex(c_float_complex),target :: d
-      complex(c_float_complex),target :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_float_complex),target :: B
       integer(c_int) :: ldb
       type(c_ptr) :: pBuffer
       !
-      hipsparseCgtsv2_nopivot_rank_0 = hipsparseCgtsv2_nopivot_(handle,m,n,c_loc(dl),c_loc(d), &
-        c_loc(du),c_loc(B),ldb,pBuffer)
+      hipsparseCgtsv2_nopivot_rank_0 = hipsparseCgtsv2_nopivot_(handle,m,n,dl,d,du,c_loc(B),ldb, &
+        pBuffer)
     end function
 
     function hipsparseCgtsv2_nopivot_rank_1(handle,m,n,dl,d,du,B,ldb,pBuffer)
@@ -37236,15 +37204,15 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      complex(c_float_complex),target,dimension(:) :: dl
-      complex(c_float_complex),target,dimension(:) :: d
-      complex(c_float_complex),target,dimension(:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_float_complex),target,dimension(:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: pBuffer
       !
-      hipsparseCgtsv2_nopivot_rank_1 = hipsparseCgtsv2_nopivot_(handle,m,n,c_loc(dl),c_loc(d), &
-        c_loc(du),c_loc(B),ldb,pBuffer)
+      hipsparseCgtsv2_nopivot_rank_1 = hipsparseCgtsv2_nopivot_(handle,m,n,dl,d,du,c_loc(B),ldb, &
+        pBuffer)
     end function
 
     function hipsparseCgtsv2_nopivot_full_rank(handle,m,n,dl,d,du,B,ldb,pBuffer)
@@ -37255,15 +37223,15 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      complex(c_float_complex),target,dimension(:,:) :: dl
-      complex(c_float_complex),target,dimension(:,:) :: d
-      complex(c_float_complex),target,dimension(:,:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_float_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: pBuffer
       !
-      hipsparseCgtsv2_nopivot_full_rank = hipsparseCgtsv2_nopivot_(handle,m,n,c_loc(dl),c_loc(d), &
-        c_loc(du),c_loc(B),ldb,pBuffer)
+      hipsparseCgtsv2_nopivot_full_rank = hipsparseCgtsv2_nopivot_(handle,m,n,dl,d,du,c_loc(B), &
+        ldb,pBuffer)
     end function
 
     function hipsparseZgtsv2_nopivot_rank_0(handle,m,n,dl,d,du,B,ldb,pBuffer)
@@ -37274,15 +37242,15 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      complex(c_double_complex),target :: dl
-      complex(c_double_complex),target :: d
-      complex(c_double_complex),target :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_double_complex),target :: B
       integer(c_int) :: ldb
       type(c_ptr) :: pBuffer
       !
-      hipsparseZgtsv2_nopivot_rank_0 = hipsparseZgtsv2_nopivot_(handle,m,n,c_loc(dl),c_loc(d), &
-        c_loc(du),c_loc(B),ldb,pBuffer)
+      hipsparseZgtsv2_nopivot_rank_0 = hipsparseZgtsv2_nopivot_(handle,m,n,dl,d,du,c_loc(B),ldb, &
+        pBuffer)
     end function
 
     function hipsparseZgtsv2_nopivot_rank_1(handle,m,n,dl,d,du,B,ldb,pBuffer)
@@ -37293,15 +37261,15 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      complex(c_double_complex),target,dimension(:) :: dl
-      complex(c_double_complex),target,dimension(:) :: d
-      complex(c_double_complex),target,dimension(:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_double_complex),target,dimension(:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: pBuffer
       !
-      hipsparseZgtsv2_nopivot_rank_1 = hipsparseZgtsv2_nopivot_(handle,m,n,c_loc(dl),c_loc(d), &
-        c_loc(du),c_loc(B),ldb,pBuffer)
+      hipsparseZgtsv2_nopivot_rank_1 = hipsparseZgtsv2_nopivot_(handle,m,n,dl,d,du,c_loc(B),ldb, &
+        pBuffer)
     end function
 
     function hipsparseZgtsv2_nopivot_full_rank(handle,m,n,dl,d,du,B,ldb,pBuffer)
@@ -37312,15 +37280,15 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      complex(c_double_complex),target,dimension(:,:) :: dl
-      complex(c_double_complex),target,dimension(:,:) :: d
-      complex(c_double_complex),target,dimension(:,:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_double_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: pBuffer
       !
-      hipsparseZgtsv2_nopivot_full_rank = hipsparseZgtsv2_nopivot_(handle,m,n,c_loc(dl),c_loc(d), &
-        c_loc(du),c_loc(B),ldb,pBuffer)
+      hipsparseZgtsv2_nopivot_full_rank = hipsparseZgtsv2_nopivot_(handle,m,n,dl,d,du,c_loc(B), &
+        ldb,pBuffer)
     end function
 
     function hipsparseSgtsv2StridedBatch_bufferSizeExt_rank_0(handle,m,dl,d,du,x,batchCount, &
@@ -37331,17 +37299,17 @@ module hipfort_hipsparse
       integer(kind(HIPSPARSE_STATUS_SUCCESS)) :: hipsparseSgtsv2StridedBatch_bufferSizeExt_rank_0
       type(c_ptr) :: handle
       integer(c_int) :: m
-      real(c_float),target :: dl
-      real(c_float),target :: d
-      real(c_float),target :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_float),target :: x
       integer(c_int) :: batchCount
       integer(c_int) :: batchStride
       integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseSgtsv2StridedBatch_bufferSizeExt_rank_0 = &
-        hipsparseSgtsv2StridedBatch_bufferSizeExt_(handle,m,c_loc(dl),c_loc(d),c_loc(du),c_loc(x), &
-        batchCount,batchStride,pBufferSizeInBytes)
+        hipsparseSgtsv2StridedBatch_bufferSizeExt_(handle,m,dl,d,du,c_loc(x),batchCount, &
+        batchStride,pBufferSizeInBytes)
     end function
 
     function hipsparseSgtsv2StridedBatch_bufferSizeExt_rank_1(handle,m,dl,d,du,x,batchCount, &
@@ -37352,17 +37320,17 @@ module hipfort_hipsparse
       integer(kind(HIPSPARSE_STATUS_SUCCESS)) :: hipsparseSgtsv2StridedBatch_bufferSizeExt_rank_1
       type(c_ptr) :: handle
       integer(c_int) :: m
-      real(c_float),target,dimension(:) :: dl
-      real(c_float),target,dimension(:) :: d
-      real(c_float),target,dimension(:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_float),target,dimension(:) :: x
       integer(c_int) :: batchCount
       integer(c_int) :: batchStride
       integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseSgtsv2StridedBatch_bufferSizeExt_rank_1 = &
-        hipsparseSgtsv2StridedBatch_bufferSizeExt_(handle,m,c_loc(dl),c_loc(d),c_loc(du),c_loc(x), &
-        batchCount,batchStride,pBufferSizeInBytes)
+        hipsparseSgtsv2StridedBatch_bufferSizeExt_(handle,m,dl,d,du,c_loc(x),batchCount, &
+        batchStride,pBufferSizeInBytes)
     end function
 
     function hipsparseDgtsv2StridedBatch_bufferSizeExt_rank_0(handle,m,dl,d,du,x,batchCount, &
@@ -37373,17 +37341,17 @@ module hipfort_hipsparse
       integer(kind(HIPSPARSE_STATUS_SUCCESS)) :: hipsparseDgtsv2StridedBatch_bufferSizeExt_rank_0
       type(c_ptr) :: handle
       integer(c_int) :: m
-      real(c_double),target :: dl
-      real(c_double),target :: d
-      real(c_double),target :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_double),target :: x
       integer(c_int) :: batchCount
       integer(c_int) :: batchStride
       integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseDgtsv2StridedBatch_bufferSizeExt_rank_0 = &
-        hipsparseDgtsv2StridedBatch_bufferSizeExt_(handle,m,c_loc(dl),c_loc(d),c_loc(du),c_loc(x), &
-        batchCount,batchStride,pBufferSizeInBytes)
+        hipsparseDgtsv2StridedBatch_bufferSizeExt_(handle,m,dl,d,du,c_loc(x),batchCount, &
+        batchStride,pBufferSizeInBytes)
     end function
 
     function hipsparseDgtsv2StridedBatch_bufferSizeExt_rank_1(handle,m,dl,d,du,x,batchCount, &
@@ -37394,17 +37362,17 @@ module hipfort_hipsparse
       integer(kind(HIPSPARSE_STATUS_SUCCESS)) :: hipsparseDgtsv2StridedBatch_bufferSizeExt_rank_1
       type(c_ptr) :: handle
       integer(c_int) :: m
-      real(c_double),target,dimension(:) :: dl
-      real(c_double),target,dimension(:) :: d
-      real(c_double),target,dimension(:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_double),target,dimension(:) :: x
       integer(c_int) :: batchCount
       integer(c_int) :: batchStride
       integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseDgtsv2StridedBatch_bufferSizeExt_rank_1 = &
-        hipsparseDgtsv2StridedBatch_bufferSizeExt_(handle,m,c_loc(dl),c_loc(d),c_loc(du),c_loc(x), &
-        batchCount,batchStride,pBufferSizeInBytes)
+        hipsparseDgtsv2StridedBatch_bufferSizeExt_(handle,m,dl,d,du,c_loc(x),batchCount, &
+        batchStride,pBufferSizeInBytes)
     end function
 
     function hipsparseCgtsv2StridedBatch_bufferSizeExt_rank_0(handle,m,dl,d,du,x,batchCount, &
@@ -37415,17 +37383,17 @@ module hipfort_hipsparse
       integer(kind(HIPSPARSE_STATUS_SUCCESS)) :: hipsparseCgtsv2StridedBatch_bufferSizeExt_rank_0
       type(c_ptr) :: handle
       integer(c_int) :: m
-      complex(c_float_complex),target :: dl
-      complex(c_float_complex),target :: d
-      complex(c_float_complex),target :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_float_complex),target :: x
       integer(c_int) :: batchCount
       integer(c_int) :: batchStride
       integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseCgtsv2StridedBatch_bufferSizeExt_rank_0 = &
-        hipsparseCgtsv2StridedBatch_bufferSizeExt_(handle,m,c_loc(dl),c_loc(d),c_loc(du),c_loc(x), &
-        batchCount,batchStride,pBufferSizeInBytes)
+        hipsparseCgtsv2StridedBatch_bufferSizeExt_(handle,m,dl,d,du,c_loc(x),batchCount, &
+        batchStride,pBufferSizeInBytes)
     end function
 
     function hipsparseCgtsv2StridedBatch_bufferSizeExt_rank_1(handle,m,dl,d,du,x,batchCount, &
@@ -37436,17 +37404,17 @@ module hipfort_hipsparse
       integer(kind(HIPSPARSE_STATUS_SUCCESS)) :: hipsparseCgtsv2StridedBatch_bufferSizeExt_rank_1
       type(c_ptr) :: handle
       integer(c_int) :: m
-      complex(c_float_complex),target,dimension(:) :: dl
-      complex(c_float_complex),target,dimension(:) :: d
-      complex(c_float_complex),target,dimension(:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: batchCount
       integer(c_int) :: batchStride
       integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseCgtsv2StridedBatch_bufferSizeExt_rank_1 = &
-        hipsparseCgtsv2StridedBatch_bufferSizeExt_(handle,m,c_loc(dl),c_loc(d),c_loc(du),c_loc(x), &
-        batchCount,batchStride,pBufferSizeInBytes)
+        hipsparseCgtsv2StridedBatch_bufferSizeExt_(handle,m,dl,d,du,c_loc(x),batchCount, &
+        batchStride,pBufferSizeInBytes)
     end function
 
     function hipsparseZgtsv2StridedBatch_bufferSizeExt_rank_0(handle,m,dl,d,du,x,batchCount, &
@@ -37457,17 +37425,17 @@ module hipfort_hipsparse
       integer(kind(HIPSPARSE_STATUS_SUCCESS)) :: hipsparseZgtsv2StridedBatch_bufferSizeExt_rank_0
       type(c_ptr) :: handle
       integer(c_int) :: m
-      complex(c_double_complex),target :: dl
-      complex(c_double_complex),target :: d
-      complex(c_double_complex),target :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_double_complex),target :: x
       integer(c_int) :: batchCount
       integer(c_int) :: batchStride
       integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseZgtsv2StridedBatch_bufferSizeExt_rank_0 = &
-        hipsparseZgtsv2StridedBatch_bufferSizeExt_(handle,m,c_loc(dl),c_loc(d),c_loc(du),c_loc(x), &
-        batchCount,batchStride,pBufferSizeInBytes)
+        hipsparseZgtsv2StridedBatch_bufferSizeExt_(handle,m,dl,d,du,c_loc(x),batchCount, &
+        batchStride,pBufferSizeInBytes)
     end function
 
     function hipsparseZgtsv2StridedBatch_bufferSizeExt_rank_1(handle,m,dl,d,du,x,batchCount, &
@@ -37478,17 +37446,17 @@ module hipfort_hipsparse
       integer(kind(HIPSPARSE_STATUS_SUCCESS)) :: hipsparseZgtsv2StridedBatch_bufferSizeExt_rank_1
       type(c_ptr) :: handle
       integer(c_int) :: m
-      complex(c_double_complex),target,dimension(:) :: dl
-      complex(c_double_complex),target,dimension(:) :: d
-      complex(c_double_complex),target,dimension(:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: batchCount
       integer(c_int) :: batchStride
       integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseZgtsv2StridedBatch_bufferSizeExt_rank_1 = &
-        hipsparseZgtsv2StridedBatch_bufferSizeExt_(handle,m,c_loc(dl),c_loc(d),c_loc(du),c_loc(x), &
-        batchCount,batchStride,pBufferSizeInBytes)
+        hipsparseZgtsv2StridedBatch_bufferSizeExt_(handle,m,dl,d,du,c_loc(x),batchCount, &
+        batchStride,pBufferSizeInBytes)
     end function
 
     function hipsparseSgtsv2StridedBatch_rank_0(handle,m,dl,d,du,x,batchCount,batchStride,pBuffer)
@@ -37498,16 +37466,16 @@ module hipfort_hipsparse
       integer(kind(HIPSPARSE_STATUS_SUCCESS)) :: hipsparseSgtsv2StridedBatch_rank_0
       type(c_ptr) :: handle
       integer(c_int) :: m
-      real(c_float),target :: dl
-      real(c_float),target :: d
-      real(c_float),target :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_float),target :: x
       integer(c_int) :: batchCount
       integer(c_int) :: batchStride
       type(c_ptr) :: pBuffer
       !
-      hipsparseSgtsv2StridedBatch_rank_0 = hipsparseSgtsv2StridedBatch_(handle,m,c_loc(dl), &
-        c_loc(d),c_loc(du),c_loc(x),batchCount,batchStride,pBuffer)
+      hipsparseSgtsv2StridedBatch_rank_0 = hipsparseSgtsv2StridedBatch_(handle,m,dl,d,du,c_loc(x), &
+        batchCount,batchStride,pBuffer)
     end function
 
     function hipsparseSgtsv2StridedBatch_rank_1(handle,m,dl,d,du,x,batchCount,batchStride,pBuffer)
@@ -37517,16 +37485,16 @@ module hipfort_hipsparse
       integer(kind(HIPSPARSE_STATUS_SUCCESS)) :: hipsparseSgtsv2StridedBatch_rank_1
       type(c_ptr) :: handle
       integer(c_int) :: m
-      real(c_float),target,dimension(:) :: dl
-      real(c_float),target,dimension(:) :: d
-      real(c_float),target,dimension(:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_float),target,dimension(:) :: x
       integer(c_int) :: batchCount
       integer(c_int) :: batchStride
       type(c_ptr) :: pBuffer
       !
-      hipsparseSgtsv2StridedBatch_rank_1 = hipsparseSgtsv2StridedBatch_(handle,m,c_loc(dl), &
-        c_loc(d),c_loc(du),c_loc(x),batchCount,batchStride,pBuffer)
+      hipsparseSgtsv2StridedBatch_rank_1 = hipsparseSgtsv2StridedBatch_(handle,m,dl,d,du,c_loc(x), &
+        batchCount,batchStride,pBuffer)
     end function
 
     function hipsparseDgtsv2StridedBatch_rank_0(handle,m,dl,d,du,x,batchCount,batchStride,pBuffer)
@@ -37536,16 +37504,16 @@ module hipfort_hipsparse
       integer(kind(HIPSPARSE_STATUS_SUCCESS)) :: hipsparseDgtsv2StridedBatch_rank_0
       type(c_ptr) :: handle
       integer(c_int) :: m
-      real(c_double),target :: dl
-      real(c_double),target :: d
-      real(c_double),target :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_double),target :: x
       integer(c_int) :: batchCount
       integer(c_int) :: batchStride
       type(c_ptr) :: pBuffer
       !
-      hipsparseDgtsv2StridedBatch_rank_0 = hipsparseDgtsv2StridedBatch_(handle,m,c_loc(dl), &
-        c_loc(d),c_loc(du),c_loc(x),batchCount,batchStride,pBuffer)
+      hipsparseDgtsv2StridedBatch_rank_0 = hipsparseDgtsv2StridedBatch_(handle,m,dl,d,du,c_loc(x), &
+        batchCount,batchStride,pBuffer)
     end function
 
     function hipsparseDgtsv2StridedBatch_rank_1(handle,m,dl,d,du,x,batchCount,batchStride,pBuffer)
@@ -37555,16 +37523,16 @@ module hipfort_hipsparse
       integer(kind(HIPSPARSE_STATUS_SUCCESS)) :: hipsparseDgtsv2StridedBatch_rank_1
       type(c_ptr) :: handle
       integer(c_int) :: m
-      real(c_double),target,dimension(:) :: dl
-      real(c_double),target,dimension(:) :: d
-      real(c_double),target,dimension(:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_double),target,dimension(:) :: x
       integer(c_int) :: batchCount
       integer(c_int) :: batchStride
       type(c_ptr) :: pBuffer
       !
-      hipsparseDgtsv2StridedBatch_rank_1 = hipsparseDgtsv2StridedBatch_(handle,m,c_loc(dl), &
-        c_loc(d),c_loc(du),c_loc(x),batchCount,batchStride,pBuffer)
+      hipsparseDgtsv2StridedBatch_rank_1 = hipsparseDgtsv2StridedBatch_(handle,m,dl,d,du,c_loc(x), &
+        batchCount,batchStride,pBuffer)
     end function
 
     function hipsparseCgtsv2StridedBatch_rank_0(handle,m,dl,d,du,x,batchCount,batchStride,pBuffer)
@@ -37574,16 +37542,16 @@ module hipfort_hipsparse
       integer(kind(HIPSPARSE_STATUS_SUCCESS)) :: hipsparseCgtsv2StridedBatch_rank_0
       type(c_ptr) :: handle
       integer(c_int) :: m
-      complex(c_float_complex),target :: dl
-      complex(c_float_complex),target :: d
-      complex(c_float_complex),target :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_float_complex),target :: x
       integer(c_int) :: batchCount
       integer(c_int) :: batchStride
       type(c_ptr) :: pBuffer
       !
-      hipsparseCgtsv2StridedBatch_rank_0 = hipsparseCgtsv2StridedBatch_(handle,m,c_loc(dl), &
-        c_loc(d),c_loc(du),c_loc(x),batchCount,batchStride,pBuffer)
+      hipsparseCgtsv2StridedBatch_rank_0 = hipsparseCgtsv2StridedBatch_(handle,m,dl,d,du,c_loc(x), &
+        batchCount,batchStride,pBuffer)
     end function
 
     function hipsparseCgtsv2StridedBatch_rank_1(handle,m,dl,d,du,x,batchCount,batchStride,pBuffer)
@@ -37593,16 +37561,16 @@ module hipfort_hipsparse
       integer(kind(HIPSPARSE_STATUS_SUCCESS)) :: hipsparseCgtsv2StridedBatch_rank_1
       type(c_ptr) :: handle
       integer(c_int) :: m
-      complex(c_float_complex),target,dimension(:) :: dl
-      complex(c_float_complex),target,dimension(:) :: d
-      complex(c_float_complex),target,dimension(:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: batchCount
       integer(c_int) :: batchStride
       type(c_ptr) :: pBuffer
       !
-      hipsparseCgtsv2StridedBatch_rank_1 = hipsparseCgtsv2StridedBatch_(handle,m,c_loc(dl), &
-        c_loc(d),c_loc(du),c_loc(x),batchCount,batchStride,pBuffer)
+      hipsparseCgtsv2StridedBatch_rank_1 = hipsparseCgtsv2StridedBatch_(handle,m,dl,d,du,c_loc(x), &
+        batchCount,batchStride,pBuffer)
     end function
 
     function hipsparseZgtsv2StridedBatch_rank_0(handle,m,dl,d,du,x,batchCount,batchStride,pBuffer)
@@ -37612,16 +37580,16 @@ module hipfort_hipsparse
       integer(kind(HIPSPARSE_STATUS_SUCCESS)) :: hipsparseZgtsv2StridedBatch_rank_0
       type(c_ptr) :: handle
       integer(c_int) :: m
-      complex(c_double_complex),target :: dl
-      complex(c_double_complex),target :: d
-      complex(c_double_complex),target :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_double_complex),target :: x
       integer(c_int) :: batchCount
       integer(c_int) :: batchStride
       type(c_ptr) :: pBuffer
       !
-      hipsparseZgtsv2StridedBatch_rank_0 = hipsparseZgtsv2StridedBatch_(handle,m,c_loc(dl), &
-        c_loc(d),c_loc(du),c_loc(x),batchCount,batchStride,pBuffer)
+      hipsparseZgtsv2StridedBatch_rank_0 = hipsparseZgtsv2StridedBatch_(handle,m,dl,d,du,c_loc(x), &
+        batchCount,batchStride,pBuffer)
     end function
 
     function hipsparseZgtsv2StridedBatch_rank_1(handle,m,dl,d,du,x,batchCount,batchStride,pBuffer)
@@ -37631,16 +37599,16 @@ module hipfort_hipsparse
       integer(kind(HIPSPARSE_STATUS_SUCCESS)) :: hipsparseZgtsv2StridedBatch_rank_1
       type(c_ptr) :: handle
       integer(c_int) :: m
-      complex(c_double_complex),target,dimension(:) :: dl
-      complex(c_double_complex),target,dimension(:) :: d
-      complex(c_double_complex),target,dimension(:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: batchCount
       integer(c_int) :: batchStride
       type(c_ptr) :: pBuffer
       !
-      hipsparseZgtsv2StridedBatch_rank_1 = hipsparseZgtsv2StridedBatch_(handle,m,c_loc(dl), &
-        c_loc(d),c_loc(du),c_loc(x),batchCount,batchStride,pBuffer)
+      hipsparseZgtsv2StridedBatch_rank_1 = hipsparseZgtsv2StridedBatch_(handle,m,dl,d,du,c_loc(x), &
+        batchCount,batchStride,pBuffer)
     end function
 
     function hipsparseSgpsvInterleavedBatch_bufferSizeExt_rank_0(handle,algo,m,ds,dl,d,du,dw,x, &
@@ -37652,18 +37620,18 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: algo
       integer(c_int) :: m
-      real(c_float),target :: ds
-      real(c_float),target :: dl
-      real(c_float),target :: d
-      real(c_float),target :: du
-      real(c_float),target :: dw
+      type(c_ptr) :: ds
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
+      type(c_ptr) :: dw
       real(c_float),target :: x
       integer(c_int) :: batchCount
       integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseSgpsvInterleavedBatch_bufferSizeExt_rank_0 = &
-        hipsparseSgpsvInterleavedBatch_bufferSizeExt_(handle,algo,m,c_loc(ds),c_loc(dl),c_loc(d), &
-        c_loc(du),c_loc(dw),c_loc(x),batchCount,pBufferSizeInBytes)
+        hipsparseSgpsvInterleavedBatch_bufferSizeExt_(handle,algo,m,ds,dl,d,du,dw,c_loc(x), &
+        batchCount,pBufferSizeInBytes)
     end function
 
     function hipsparseSgpsvInterleavedBatch_bufferSizeExt_rank_1(handle,algo,m,ds,dl,d,du,dw,x, &
@@ -37675,41 +37643,18 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: algo
       integer(c_int) :: m
-      real(c_float),target,dimension(:) :: ds
-      real(c_float),target,dimension(:) :: dl
-      real(c_float),target,dimension(:) :: d
-      real(c_float),target,dimension(:) :: du
-      real(c_float),target,dimension(:) :: dw
+      type(c_ptr) :: ds
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
+      type(c_ptr) :: dw
       real(c_float),target,dimension(:) :: x
       integer(c_int) :: batchCount
       integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseSgpsvInterleavedBatch_bufferSizeExt_rank_1 = &
-        hipsparseSgpsvInterleavedBatch_bufferSizeExt_(handle,algo,m,c_loc(ds),c_loc(dl),c_loc(d), &
-        c_loc(du),c_loc(dw),c_loc(x),batchCount,pBufferSizeInBytes)
-    end function
-
-    function hipsparseSgpsvInterleavedBatch_bufferSizeExt_full_rank(handle,algo,m,ds,dl,d,du,dw,x, &
+        hipsparseSgpsvInterleavedBatch_bufferSizeExt_(handle,algo,m,ds,dl,d,du,dw,c_loc(x), &
         batchCount,pBufferSizeInBytes)
-      use iso_c_binding
-      use hipfort_hipsparse_enums
-      implicit none
-      integer(kind(HIPSPARSE_STATUS_SUCCESS)) :: hipsparseSgpsvInterleavedBatch_bufferSizeExt_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: algo
-      integer(c_int) :: m
-      real(c_float),target,dimension(:,:) :: ds
-      real(c_float),target,dimension(:,:) :: dl
-      real(c_float),target,dimension(:,:) :: d
-      real(c_float),target,dimension(:,:) :: du
-      real(c_float),target,dimension(:,:) :: dw
-      real(c_float),target,dimension(:,:) :: x
-      integer(c_int) :: batchCount
-      integer(c_size_t) :: pBufferSizeInBytes
-      !
-      hipsparseSgpsvInterleavedBatch_bufferSizeExt_full_rank = &
-        hipsparseSgpsvInterleavedBatch_bufferSizeExt_(handle,algo,m,c_loc(ds),c_loc(dl),c_loc(d), &
-        c_loc(du),c_loc(dw),c_loc(x),batchCount,pBufferSizeInBytes)
     end function
 
     function hipsparseDgpsvInterleavedBatch_bufferSizeExt_rank_0(handle,algo,m,ds,dl,d,du,dw,x, &
@@ -37721,18 +37666,18 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: algo
       integer(c_int) :: m
-      real(c_double),target :: ds
-      real(c_double),target :: dl
-      real(c_double),target :: d
-      real(c_double),target :: du
-      real(c_double),target :: dw
+      type(c_ptr) :: ds
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
+      type(c_ptr) :: dw
       real(c_double),target :: x
       integer(c_int) :: batchCount
       integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseDgpsvInterleavedBatch_bufferSizeExt_rank_0 = &
-        hipsparseDgpsvInterleavedBatch_bufferSizeExt_(handle,algo,m,c_loc(ds),c_loc(dl),c_loc(d), &
-        c_loc(du),c_loc(dw),c_loc(x),batchCount,pBufferSizeInBytes)
+        hipsparseDgpsvInterleavedBatch_bufferSizeExt_(handle,algo,m,ds,dl,d,du,dw,c_loc(x), &
+        batchCount,pBufferSizeInBytes)
     end function
 
     function hipsparseDgpsvInterleavedBatch_bufferSizeExt_rank_1(handle,algo,m,ds,dl,d,du,dw,x, &
@@ -37744,41 +37689,18 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: algo
       integer(c_int) :: m
-      real(c_double),target,dimension(:) :: ds
-      real(c_double),target,dimension(:) :: dl
-      real(c_double),target,dimension(:) :: d
-      real(c_double),target,dimension(:) :: du
-      real(c_double),target,dimension(:) :: dw
+      type(c_ptr) :: ds
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
+      type(c_ptr) :: dw
       real(c_double),target,dimension(:) :: x
       integer(c_int) :: batchCount
       integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseDgpsvInterleavedBatch_bufferSizeExt_rank_1 = &
-        hipsparseDgpsvInterleavedBatch_bufferSizeExt_(handle,algo,m,c_loc(ds),c_loc(dl),c_loc(d), &
-        c_loc(du),c_loc(dw),c_loc(x),batchCount,pBufferSizeInBytes)
-    end function
-
-    function hipsparseDgpsvInterleavedBatch_bufferSizeExt_full_rank(handle,algo,m,ds,dl,d,du,dw,x, &
+        hipsparseDgpsvInterleavedBatch_bufferSizeExt_(handle,algo,m,ds,dl,d,du,dw,c_loc(x), &
         batchCount,pBufferSizeInBytes)
-      use iso_c_binding
-      use hipfort_hipsparse_enums
-      implicit none
-      integer(kind(HIPSPARSE_STATUS_SUCCESS)) :: hipsparseDgpsvInterleavedBatch_bufferSizeExt_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: algo
-      integer(c_int) :: m
-      real(c_double),target,dimension(:,:) :: ds
-      real(c_double),target,dimension(:,:) :: dl
-      real(c_double),target,dimension(:,:) :: d
-      real(c_double),target,dimension(:,:) :: du
-      real(c_double),target,dimension(:,:) :: dw
-      real(c_double),target,dimension(:,:) :: x
-      integer(c_int) :: batchCount
-      integer(c_size_t) :: pBufferSizeInBytes
-      !
-      hipsparseDgpsvInterleavedBatch_bufferSizeExt_full_rank = &
-        hipsparseDgpsvInterleavedBatch_bufferSizeExt_(handle,algo,m,c_loc(ds),c_loc(dl),c_loc(d), &
-        c_loc(du),c_loc(dw),c_loc(x),batchCount,pBufferSizeInBytes)
     end function
 
     function hipsparseCgpsvInterleavedBatch_bufferSizeExt_rank_0(handle,algo,m,ds,dl,d,du,dw,x, &
@@ -37790,18 +37712,18 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: algo
       integer(c_int) :: m
-      complex(c_float_complex),target :: ds
-      complex(c_float_complex),target :: dl
-      complex(c_float_complex),target :: d
-      complex(c_float_complex),target :: du
-      complex(c_float_complex),target :: dw
+      type(c_ptr) :: ds
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
+      type(c_ptr) :: dw
       complex(c_float_complex),target :: x
       integer(c_int) :: batchCount
       integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseCgpsvInterleavedBatch_bufferSizeExt_rank_0 = &
-        hipsparseCgpsvInterleavedBatch_bufferSizeExt_(handle,algo,m,c_loc(ds),c_loc(dl),c_loc(d), &
-        c_loc(du),c_loc(dw),c_loc(x),batchCount,pBufferSizeInBytes)
+        hipsparseCgpsvInterleavedBatch_bufferSizeExt_(handle,algo,m,ds,dl,d,du,dw,c_loc(x), &
+        batchCount,pBufferSizeInBytes)
     end function
 
     function hipsparseCgpsvInterleavedBatch_bufferSizeExt_rank_1(handle,algo,m,ds,dl,d,du,dw,x, &
@@ -37813,41 +37735,18 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: algo
       integer(c_int) :: m
-      complex(c_float_complex),target,dimension(:) :: ds
-      complex(c_float_complex),target,dimension(:) :: dl
-      complex(c_float_complex),target,dimension(:) :: d
-      complex(c_float_complex),target,dimension(:) :: du
-      complex(c_float_complex),target,dimension(:) :: dw
+      type(c_ptr) :: ds
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
+      type(c_ptr) :: dw
       complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: batchCount
       integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseCgpsvInterleavedBatch_bufferSizeExt_rank_1 = &
-        hipsparseCgpsvInterleavedBatch_bufferSizeExt_(handle,algo,m,c_loc(ds),c_loc(dl),c_loc(d), &
-        c_loc(du),c_loc(dw),c_loc(x),batchCount,pBufferSizeInBytes)
-    end function
-
-    function hipsparseCgpsvInterleavedBatch_bufferSizeExt_full_rank(handle,algo,m,ds,dl,d,du,dw,x, &
+        hipsparseCgpsvInterleavedBatch_bufferSizeExt_(handle,algo,m,ds,dl,d,du,dw,c_loc(x), &
         batchCount,pBufferSizeInBytes)
-      use iso_c_binding
-      use hipfort_hipsparse_enums
-      implicit none
-      integer(kind(HIPSPARSE_STATUS_SUCCESS)) :: hipsparseCgpsvInterleavedBatch_bufferSizeExt_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: algo
-      integer(c_int) :: m
-      complex(c_float_complex),target,dimension(:,:) :: ds
-      complex(c_float_complex),target,dimension(:,:) :: dl
-      complex(c_float_complex),target,dimension(:,:) :: d
-      complex(c_float_complex),target,dimension(:,:) :: du
-      complex(c_float_complex),target,dimension(:,:) :: dw
-      complex(c_float_complex),target,dimension(:,:) :: x
-      integer(c_int) :: batchCount
-      integer(c_size_t) :: pBufferSizeInBytes
-      !
-      hipsparseCgpsvInterleavedBatch_bufferSizeExt_full_rank = &
-        hipsparseCgpsvInterleavedBatch_bufferSizeExt_(handle,algo,m,c_loc(ds),c_loc(dl),c_loc(d), &
-        c_loc(du),c_loc(dw),c_loc(x),batchCount,pBufferSizeInBytes)
     end function
 
     function hipsparseZgpsvInterleavedBatch_bufferSizeExt_rank_0(handle,algo,m,ds,dl,d,du,dw,x, &
@@ -37859,18 +37758,18 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: algo
       integer(c_int) :: m
-      complex(c_double_complex),target :: ds
-      complex(c_double_complex),target :: dl
-      complex(c_double_complex),target :: d
-      complex(c_double_complex),target :: du
-      complex(c_double_complex),target :: dw
+      type(c_ptr) :: ds
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
+      type(c_ptr) :: dw
       complex(c_double_complex),target :: x
       integer(c_int) :: batchCount
       integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseZgpsvInterleavedBatch_bufferSizeExt_rank_0 = &
-        hipsparseZgpsvInterleavedBatch_bufferSizeExt_(handle,algo,m,c_loc(ds),c_loc(dl),c_loc(d), &
-        c_loc(du),c_loc(dw),c_loc(x),batchCount,pBufferSizeInBytes)
+        hipsparseZgpsvInterleavedBatch_bufferSizeExt_(handle,algo,m,ds,dl,d,du,dw,c_loc(x), &
+        batchCount,pBufferSizeInBytes)
     end function
 
     function hipsparseZgpsvInterleavedBatch_bufferSizeExt_rank_1(handle,algo,m,ds,dl,d,du,dw,x, &
@@ -37882,41 +37781,18 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: algo
       integer(c_int) :: m
-      complex(c_double_complex),target,dimension(:) :: ds
-      complex(c_double_complex),target,dimension(:) :: dl
-      complex(c_double_complex),target,dimension(:) :: d
-      complex(c_double_complex),target,dimension(:) :: du
-      complex(c_double_complex),target,dimension(:) :: dw
+      type(c_ptr) :: ds
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
+      type(c_ptr) :: dw
       complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: batchCount
       integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseZgpsvInterleavedBatch_bufferSizeExt_rank_1 = &
-        hipsparseZgpsvInterleavedBatch_bufferSizeExt_(handle,algo,m,c_loc(ds),c_loc(dl),c_loc(d), &
-        c_loc(du),c_loc(dw),c_loc(x),batchCount,pBufferSizeInBytes)
-    end function
-
-    function hipsparseZgpsvInterleavedBatch_bufferSizeExt_full_rank(handle,algo,m,ds,dl,d,du,dw,x, &
+        hipsparseZgpsvInterleavedBatch_bufferSizeExt_(handle,algo,m,ds,dl,d,du,dw,c_loc(x), &
         batchCount,pBufferSizeInBytes)
-      use iso_c_binding
-      use hipfort_hipsparse_enums
-      implicit none
-      integer(kind(HIPSPARSE_STATUS_SUCCESS)) :: hipsparseZgpsvInterleavedBatch_bufferSizeExt_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: algo
-      integer(c_int) :: m
-      complex(c_double_complex),target,dimension(:,:) :: ds
-      complex(c_double_complex),target,dimension(:,:) :: dl
-      complex(c_double_complex),target,dimension(:,:) :: d
-      complex(c_double_complex),target,dimension(:,:) :: du
-      complex(c_double_complex),target,dimension(:,:) :: dw
-      complex(c_double_complex),target,dimension(:,:) :: x
-      integer(c_int) :: batchCount
-      integer(c_size_t) :: pBufferSizeInBytes
-      !
-      hipsparseZgpsvInterleavedBatch_bufferSizeExt_full_rank = &
-        hipsparseZgpsvInterleavedBatch_bufferSizeExt_(handle,algo,m,c_loc(ds),c_loc(dl),c_loc(d), &
-        c_loc(du),c_loc(dw),c_loc(x),batchCount,pBufferSizeInBytes)
     end function
 
     function hipsparseSgpsvInterleavedBatch_rank_0(handle,algo,m,ds,dl,d,du,dw,x,batchCount,pBuffer)
@@ -37927,17 +37803,17 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: algo
       integer(c_int) :: m
-      real(c_float),target :: ds
-      real(c_float),target :: dl
-      real(c_float),target :: d
-      real(c_float),target :: du
-      real(c_float),target :: dw
+      type(c_ptr) :: ds
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
+      type(c_ptr) :: dw
       real(c_float),target :: x
       integer(c_int) :: batchCount
       type(c_ptr) :: pBuffer
       !
-      hipsparseSgpsvInterleavedBatch_rank_0 = hipsparseSgpsvInterleavedBatch_(handle,algo,m, &
-        c_loc(ds),c_loc(dl),c_loc(d),c_loc(du),c_loc(dw),c_loc(x),batchCount,pBuffer)
+      hipsparseSgpsvInterleavedBatch_rank_0 = hipsparseSgpsvInterleavedBatch_(handle,algo,m,ds,dl, &
+        d,du,dw,c_loc(x),batchCount,pBuffer)
     end function
 
     function hipsparseSgpsvInterleavedBatch_rank_1(handle,algo,m,ds,dl,d,du,dw,x,batchCount,pBuffer)
@@ -37948,39 +37824,17 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: algo
       integer(c_int) :: m
-      real(c_float),target,dimension(:) :: ds
-      real(c_float),target,dimension(:) :: dl
-      real(c_float),target,dimension(:) :: d
-      real(c_float),target,dimension(:) :: du
-      real(c_float),target,dimension(:) :: dw
+      type(c_ptr) :: ds
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
+      type(c_ptr) :: dw
       real(c_float),target,dimension(:) :: x
       integer(c_int) :: batchCount
       type(c_ptr) :: pBuffer
       !
-      hipsparseSgpsvInterleavedBatch_rank_1 = hipsparseSgpsvInterleavedBatch_(handle,algo,m, &
-        c_loc(ds),c_loc(dl),c_loc(d),c_loc(du),c_loc(dw),c_loc(x),batchCount,pBuffer)
-    end function
-
-    function hipsparseSgpsvInterleavedBatch_full_rank(handle,algo,m,ds,dl,d,du,dw,x,batchCount, &
-        pBuffer)
-      use iso_c_binding
-      use hipfort_hipsparse_enums
-      implicit none
-      integer(kind(HIPSPARSE_STATUS_SUCCESS)) :: hipsparseSgpsvInterleavedBatch_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: algo
-      integer(c_int) :: m
-      real(c_float),target,dimension(:,:) :: ds
-      real(c_float),target,dimension(:,:) :: dl
-      real(c_float),target,dimension(:,:) :: d
-      real(c_float),target,dimension(:,:) :: du
-      real(c_float),target,dimension(:,:) :: dw
-      real(c_float),target,dimension(:,:) :: x
-      integer(c_int) :: batchCount
-      type(c_ptr) :: pBuffer
-      !
-      hipsparseSgpsvInterleavedBatch_full_rank = hipsparseSgpsvInterleavedBatch_(handle,algo,m, &
-        c_loc(ds),c_loc(dl),c_loc(d),c_loc(du),c_loc(dw),c_loc(x),batchCount,pBuffer)
+      hipsparseSgpsvInterleavedBatch_rank_1 = hipsparseSgpsvInterleavedBatch_(handle,algo,m,ds,dl, &
+        d,du,dw,c_loc(x),batchCount,pBuffer)
     end function
 
     function hipsparseDgpsvInterleavedBatch_rank_0(handle,algo,m,ds,dl,d,du,dw,x,batchCount,pBuffer)
@@ -37991,17 +37845,17 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: algo
       integer(c_int) :: m
-      real(c_double),target :: ds
-      real(c_double),target :: dl
-      real(c_double),target :: d
-      real(c_double),target :: du
-      real(c_double),target :: dw
+      type(c_ptr) :: ds
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
+      type(c_ptr) :: dw
       real(c_double),target :: x
       integer(c_int) :: batchCount
       type(c_ptr) :: pBuffer
       !
-      hipsparseDgpsvInterleavedBatch_rank_0 = hipsparseDgpsvInterleavedBatch_(handle,algo,m, &
-        c_loc(ds),c_loc(dl),c_loc(d),c_loc(du),c_loc(dw),c_loc(x),batchCount,pBuffer)
+      hipsparseDgpsvInterleavedBatch_rank_0 = hipsparseDgpsvInterleavedBatch_(handle,algo,m,ds,dl, &
+        d,du,dw,c_loc(x),batchCount,pBuffer)
     end function
 
     function hipsparseDgpsvInterleavedBatch_rank_1(handle,algo,m,ds,dl,d,du,dw,x,batchCount,pBuffer)
@@ -38012,39 +37866,17 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: algo
       integer(c_int) :: m
-      real(c_double),target,dimension(:) :: ds
-      real(c_double),target,dimension(:) :: dl
-      real(c_double),target,dimension(:) :: d
-      real(c_double),target,dimension(:) :: du
-      real(c_double),target,dimension(:) :: dw
+      type(c_ptr) :: ds
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
+      type(c_ptr) :: dw
       real(c_double),target,dimension(:) :: x
       integer(c_int) :: batchCount
       type(c_ptr) :: pBuffer
       !
-      hipsparseDgpsvInterleavedBatch_rank_1 = hipsparseDgpsvInterleavedBatch_(handle,algo,m, &
-        c_loc(ds),c_loc(dl),c_loc(d),c_loc(du),c_loc(dw),c_loc(x),batchCount,pBuffer)
-    end function
-
-    function hipsparseDgpsvInterleavedBatch_full_rank(handle,algo,m,ds,dl,d,du,dw,x,batchCount, &
-        pBuffer)
-      use iso_c_binding
-      use hipfort_hipsparse_enums
-      implicit none
-      integer(kind(HIPSPARSE_STATUS_SUCCESS)) :: hipsparseDgpsvInterleavedBatch_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: algo
-      integer(c_int) :: m
-      real(c_double),target,dimension(:,:) :: ds
-      real(c_double),target,dimension(:,:) :: dl
-      real(c_double),target,dimension(:,:) :: d
-      real(c_double),target,dimension(:,:) :: du
-      real(c_double),target,dimension(:,:) :: dw
-      real(c_double),target,dimension(:,:) :: x
-      integer(c_int) :: batchCount
-      type(c_ptr) :: pBuffer
-      !
-      hipsparseDgpsvInterleavedBatch_full_rank = hipsparseDgpsvInterleavedBatch_(handle,algo,m, &
-        c_loc(ds),c_loc(dl),c_loc(d),c_loc(du),c_loc(dw),c_loc(x),batchCount,pBuffer)
+      hipsparseDgpsvInterleavedBatch_rank_1 = hipsparseDgpsvInterleavedBatch_(handle,algo,m,ds,dl, &
+        d,du,dw,c_loc(x),batchCount,pBuffer)
     end function
 
     function hipsparseCgpsvInterleavedBatch_rank_0(handle,algo,m,ds,dl,d,du,dw,x,batchCount,pBuffer)
@@ -38055,17 +37887,17 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: algo
       integer(c_int) :: m
-      complex(c_float_complex),target :: ds
-      complex(c_float_complex),target :: dl
-      complex(c_float_complex),target :: d
-      complex(c_float_complex),target :: du
-      complex(c_float_complex),target :: dw
+      type(c_ptr) :: ds
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
+      type(c_ptr) :: dw
       complex(c_float_complex),target :: x
       integer(c_int) :: batchCount
       type(c_ptr) :: pBuffer
       !
-      hipsparseCgpsvInterleavedBatch_rank_0 = hipsparseCgpsvInterleavedBatch_(handle,algo,m, &
-        c_loc(ds),c_loc(dl),c_loc(d),c_loc(du),c_loc(dw),c_loc(x),batchCount,pBuffer)
+      hipsparseCgpsvInterleavedBatch_rank_0 = hipsparseCgpsvInterleavedBatch_(handle,algo,m,ds,dl, &
+        d,du,dw,c_loc(x),batchCount,pBuffer)
     end function
 
     function hipsparseCgpsvInterleavedBatch_rank_1(handle,algo,m,ds,dl,d,du,dw,x,batchCount,pBuffer)
@@ -38076,39 +37908,17 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: algo
       integer(c_int) :: m
-      complex(c_float_complex),target,dimension(:) :: ds
-      complex(c_float_complex),target,dimension(:) :: dl
-      complex(c_float_complex),target,dimension(:) :: d
-      complex(c_float_complex),target,dimension(:) :: du
-      complex(c_float_complex),target,dimension(:) :: dw
+      type(c_ptr) :: ds
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
+      type(c_ptr) :: dw
       complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: batchCount
       type(c_ptr) :: pBuffer
       !
-      hipsparseCgpsvInterleavedBatch_rank_1 = hipsparseCgpsvInterleavedBatch_(handle,algo,m, &
-        c_loc(ds),c_loc(dl),c_loc(d),c_loc(du),c_loc(dw),c_loc(x),batchCount,pBuffer)
-    end function
-
-    function hipsparseCgpsvInterleavedBatch_full_rank(handle,algo,m,ds,dl,d,du,dw,x,batchCount, &
-        pBuffer)
-      use iso_c_binding
-      use hipfort_hipsparse_enums
-      implicit none
-      integer(kind(HIPSPARSE_STATUS_SUCCESS)) :: hipsparseCgpsvInterleavedBatch_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: algo
-      integer(c_int) :: m
-      complex(c_float_complex),target,dimension(:,:) :: ds
-      complex(c_float_complex),target,dimension(:,:) :: dl
-      complex(c_float_complex),target,dimension(:,:) :: d
-      complex(c_float_complex),target,dimension(:,:) :: du
-      complex(c_float_complex),target,dimension(:,:) :: dw
-      complex(c_float_complex),target,dimension(:,:) :: x
-      integer(c_int) :: batchCount
-      type(c_ptr) :: pBuffer
-      !
-      hipsparseCgpsvInterleavedBatch_full_rank = hipsparseCgpsvInterleavedBatch_(handle,algo,m, &
-        c_loc(ds),c_loc(dl),c_loc(d),c_loc(du),c_loc(dw),c_loc(x),batchCount,pBuffer)
+      hipsparseCgpsvInterleavedBatch_rank_1 = hipsparseCgpsvInterleavedBatch_(handle,algo,m,ds,dl, &
+        d,du,dw,c_loc(x),batchCount,pBuffer)
     end function
 
     function hipsparseZgpsvInterleavedBatch_rank_0(handle,algo,m,ds,dl,d,du,dw,x,batchCount,pBuffer)
@@ -38119,17 +37929,17 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: algo
       integer(c_int) :: m
-      complex(c_double_complex),target :: ds
-      complex(c_double_complex),target :: dl
-      complex(c_double_complex),target :: d
-      complex(c_double_complex),target :: du
-      complex(c_double_complex),target :: dw
+      type(c_ptr) :: ds
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
+      type(c_ptr) :: dw
       complex(c_double_complex),target :: x
       integer(c_int) :: batchCount
       type(c_ptr) :: pBuffer
       !
-      hipsparseZgpsvInterleavedBatch_rank_0 = hipsparseZgpsvInterleavedBatch_(handle,algo,m, &
-        c_loc(ds),c_loc(dl),c_loc(d),c_loc(du),c_loc(dw),c_loc(x),batchCount,pBuffer)
+      hipsparseZgpsvInterleavedBatch_rank_0 = hipsparseZgpsvInterleavedBatch_(handle,algo,m,ds,dl, &
+        d,du,dw,c_loc(x),batchCount,pBuffer)
     end function
 
     function hipsparseZgpsvInterleavedBatch_rank_1(handle,algo,m,ds,dl,d,du,dw,x,batchCount,pBuffer)
@@ -38140,39 +37950,17 @@ module hipfort_hipsparse
       type(c_ptr) :: handle
       integer(c_int) :: algo
       integer(c_int) :: m
-      complex(c_double_complex),target,dimension(:) :: ds
-      complex(c_double_complex),target,dimension(:) :: dl
-      complex(c_double_complex),target,dimension(:) :: d
-      complex(c_double_complex),target,dimension(:) :: du
-      complex(c_double_complex),target,dimension(:) :: dw
+      type(c_ptr) :: ds
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
+      type(c_ptr) :: dw
       complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: batchCount
       type(c_ptr) :: pBuffer
       !
-      hipsparseZgpsvInterleavedBatch_rank_1 = hipsparseZgpsvInterleavedBatch_(handle,algo,m, &
-        c_loc(ds),c_loc(dl),c_loc(d),c_loc(du),c_loc(dw),c_loc(x),batchCount,pBuffer)
-    end function
-
-    function hipsparseZgpsvInterleavedBatch_full_rank(handle,algo,m,ds,dl,d,du,dw,x,batchCount, &
-        pBuffer)
-      use iso_c_binding
-      use hipfort_hipsparse_enums
-      implicit none
-      integer(kind(HIPSPARSE_STATUS_SUCCESS)) :: hipsparseZgpsvInterleavedBatch_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: algo
-      integer(c_int) :: m
-      complex(c_double_complex),target,dimension(:,:) :: ds
-      complex(c_double_complex),target,dimension(:,:) :: dl
-      complex(c_double_complex),target,dimension(:,:) :: d
-      complex(c_double_complex),target,dimension(:,:) :: du
-      complex(c_double_complex),target,dimension(:,:) :: dw
-      complex(c_double_complex),target,dimension(:,:) :: x
-      integer(c_int) :: batchCount
-      type(c_ptr) :: pBuffer
-      !
-      hipsparseZgpsvInterleavedBatch_full_rank = hipsparseZgpsvInterleavedBatch_(handle,algo,m, &
-        c_loc(ds),c_loc(dl),c_loc(d),c_loc(du),c_loc(dw),c_loc(x),batchCount,pBuffer)
+      hipsparseZgpsvInterleavedBatch_rank_1 = hipsparseZgpsvInterleavedBatch_(handle,algo,m,ds,dl, &
+        d,du,dw,c_loc(x),batchCount,pBuffer)
     end function
 
     function hipsparseSnnz_rank_0(handle,dirA,m,n,descrA,A,lda,nnzPerRowColumn,nnzTotalDevHostPtr)
@@ -38226,7 +38014,7 @@ module hipfort_hipsparse
       type(c_ptr) :: descrA
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: nnzPerRowColumn
+      integer(c_int),target,dimension(:) :: nnzPerRowColumn
       integer(c_int) :: nnzTotalDevHostPtr
       !
       hipsparseSnnz_full_rank = hipsparseSnnz_(handle,dirA,m,n,descrA,c_loc(A),lda, &
@@ -38284,7 +38072,7 @@ module hipfort_hipsparse
       type(c_ptr) :: descrA
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: nnzPerRowColumn
+      integer(c_int),target,dimension(:) :: nnzPerRowColumn
       integer(c_int) :: nnzTotalDevHostPtr
       !
       hipsparseDnnz_full_rank = hipsparseDnnz_(handle,dirA,m,n,descrA,c_loc(A),lda, &
@@ -38342,7 +38130,7 @@ module hipfort_hipsparse
       type(c_ptr) :: descrA
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: nnzPerRowColumn
+      integer(c_int),target,dimension(:) :: nnzPerRowColumn
       integer(c_int) :: nnzTotalDevHostPtr
       !
       hipsparseCnnz_full_rank = hipsparseCnnz_(handle,dirA,m,n,descrA,c_loc(A),lda, &
@@ -38400,7 +38188,7 @@ module hipfort_hipsparse
       type(c_ptr) :: descrA
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: nnzPerRowColumn
+      integer(c_int),target,dimension(:) :: nnzPerRowColumn
       integer(c_int) :: nnzTotalDevHostPtr
       !
       hipsparseZnnz_full_rank = hipsparseZnnz_(handle,dirA,m,n,descrA,c_loc(A),lda, &
@@ -38459,10 +38247,10 @@ module hipfort_hipsparse
       type(c_ptr) :: descr
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: ld
-      integer(c_int),target,dimension(:,:) :: nnzPerRow
-      real(c_float),target,dimension(:,:) :: csrVal
-      integer(c_int),target,dimension(:,:) :: csrRowPtr
-      integer(c_int),target,dimension(:,:) :: csrColInd
+      integer(c_int),target,dimension(:) :: nnzPerRow
+      real(c_float),target,dimension(:) :: csrVal
+      integer(c_int),target,dimension(:) :: csrRowPtr
+      integer(c_int),target,dimension(:) :: csrColInd
       !
       hipsparseSdense2csr_full_rank = hipsparseSdense2csr_(handle,m,n,descr,c_loc(A),ld, &
         c_loc(nnzPerRow),c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd))
@@ -38520,10 +38308,10 @@ module hipfort_hipsparse
       type(c_ptr) :: descr
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: ld
-      integer(c_int),target,dimension(:,:) :: nnzPerRow
-      real(c_double),target,dimension(:,:) :: csrVal
-      integer(c_int),target,dimension(:,:) :: csrRowPtr
-      integer(c_int),target,dimension(:,:) :: csrColInd
+      integer(c_int),target,dimension(:) :: nnzPerRow
+      real(c_double),target,dimension(:) :: csrVal
+      integer(c_int),target,dimension(:) :: csrRowPtr
+      integer(c_int),target,dimension(:) :: csrColInd
       !
       hipsparseDdense2csr_full_rank = hipsparseDdense2csr_(handle,m,n,descr,c_loc(A),ld, &
         c_loc(nnzPerRow),c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd))
@@ -38581,10 +38369,10 @@ module hipfort_hipsparse
       type(c_ptr) :: descr
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: ld
-      integer(c_int),target,dimension(:,:) :: nnzPerRow
-      complex(c_float_complex),target,dimension(:,:) :: csrVal
-      integer(c_int),target,dimension(:,:) :: csrRowPtr
-      integer(c_int),target,dimension(:,:) :: csrColInd
+      integer(c_int),target,dimension(:) :: nnzPerRow
+      complex(c_float_complex),target,dimension(:) :: csrVal
+      integer(c_int),target,dimension(:) :: csrRowPtr
+      integer(c_int),target,dimension(:) :: csrColInd
       !
       hipsparseCdense2csr_full_rank = hipsparseCdense2csr_(handle,m,n,descr,c_loc(A),ld, &
         c_loc(nnzPerRow),c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd))
@@ -38642,10 +38430,10 @@ module hipfort_hipsparse
       type(c_ptr) :: descr
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: ld
-      integer(c_int),target,dimension(:,:) :: nnzPerRow
-      complex(c_double_complex),target,dimension(:,:) :: csrVal
-      integer(c_int),target,dimension(:,:) :: csrRowPtr
-      integer(c_int),target,dimension(:,:) :: csrColInd
+      integer(c_int),target,dimension(:) :: nnzPerRow
+      complex(c_double_complex),target,dimension(:) :: csrVal
+      integer(c_int),target,dimension(:) :: csrRowPtr
+      integer(c_int),target,dimension(:) :: csrColInd
       !
       hipsparseZdense2csr_full_rank = hipsparseZdense2csr_(handle,m,n,descr,c_loc(A),ld, &
         c_loc(nnzPerRow),c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd))
@@ -38710,10 +38498,10 @@ module hipfort_hipsparse
       integer(c_int) :: lda
       real(c_float) :: threshold
       type(c_ptr) :: descr
-      real(c_float),target,dimension(:,:) :: csrVal
-      integer(c_int),target,dimension(:,:) :: csrRowPtr
-      integer(c_int),target,dimension(:,:) :: csrColInd
-      integer(c_size_t),target,dimension(:,:) :: pBufferSizeInBytes
+      real(c_float),target,dimension(:) :: csrVal
+      integer(c_int),target,dimension(:) :: csrRowPtr
+      integer(c_int),target,dimension(:) :: csrColInd
+      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
       !
       hipsparseSpruneDense2csr_bufferSize_full_rank = hipsparseSpruneDense2csr_bufferSize_(handle, &
         m,n,c_loc(A),lda,threshold,descr,c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd), &
@@ -38779,10 +38567,10 @@ module hipfort_hipsparse
       integer(c_int) :: lda
       real(c_double) :: threshold
       type(c_ptr) :: descr
-      real(c_double),target,dimension(:,:) :: csrVal
-      integer(c_int),target,dimension(:,:) :: csrRowPtr
-      integer(c_int),target,dimension(:,:) :: csrColInd
-      integer(c_size_t),target,dimension(:,:) :: pBufferSizeInBytes
+      real(c_double),target,dimension(:) :: csrVal
+      integer(c_int),target,dimension(:) :: csrRowPtr
+      integer(c_int),target,dimension(:) :: csrColInd
+      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
       !
       hipsparseDpruneDense2csr_bufferSize_full_rank = hipsparseDpruneDense2csr_bufferSize_(handle, &
         m,n,c_loc(A),lda,threshold,descr,c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd), &
@@ -38848,10 +38636,10 @@ module hipfort_hipsparse
       integer(c_int) :: lda
       real(c_float) :: threshold
       type(c_ptr) :: descr
-      real(c_float),target,dimension(:,:) :: csrVal
-      integer(c_int),target,dimension(:,:) :: csrRowPtr
-      integer(c_int),target,dimension(:,:) :: csrColInd
-      integer(c_size_t),target,dimension(:,:) :: pBufferSizeInBytes
+      real(c_float),target,dimension(:) :: csrVal
+      integer(c_int),target,dimension(:) :: csrRowPtr
+      integer(c_int),target,dimension(:) :: csrColInd
+      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
       !
       hipsparseSpruneDense2csr_bufferSizeExt_full_rank = hipsparseSpruneDense2csr_bufferSizeExt_( &
         handle,m,n,c_loc(A),lda,threshold,descr,c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd), &
@@ -38917,10 +38705,10 @@ module hipfort_hipsparse
       integer(c_int) :: lda
       real(c_double) :: threshold
       type(c_ptr) :: descr
-      real(c_double),target,dimension(:,:) :: csrVal
-      integer(c_int),target,dimension(:,:) :: csrRowPtr
-      integer(c_int),target,dimension(:,:) :: csrColInd
-      integer(c_size_t),target,dimension(:,:) :: pBufferSizeInBytes
+      real(c_double),target,dimension(:) :: csrVal
+      integer(c_int),target,dimension(:) :: csrRowPtr
+      integer(c_int),target,dimension(:) :: csrColInd
+      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
       !
       hipsparseDpruneDense2csr_bufferSizeExt_full_rank = hipsparseDpruneDense2csr_bufferSizeExt_( &
         handle,m,n,c_loc(A),lda,threshold,descr,c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd), &
@@ -38982,7 +38770,7 @@ module hipfort_hipsparse
       integer(c_int) :: lda
       real(c_float) :: threshold
       type(c_ptr) :: descr
-      integer(c_int),target,dimension(:,:) :: csrRowPtr
+      integer(c_int),target,dimension(:) :: csrRowPtr
       integer(c_int) :: nnzTotalDevHostPtr
       type(c_ptr) :: buffer
       !
@@ -39045,7 +38833,7 @@ module hipfort_hipsparse
       integer(c_int) :: lda
       real(c_double) :: threshold
       type(c_ptr) :: descr
-      integer(c_int),target,dimension(:,:) :: csrRowPtr
+      integer(c_int),target,dimension(:) :: csrRowPtr
       integer(c_int) :: nnzTotalDevHostPtr
       type(c_ptr) :: buffer
       !
@@ -39110,9 +38898,9 @@ module hipfort_hipsparse
       integer(c_int) :: lda
       real(c_float) :: threshold
       type(c_ptr) :: descr
-      real(c_float),target,dimension(:,:) :: csrVal
-      integer(c_int),target,dimension(:,:) :: csrRowPtr
-      integer(c_int),target,dimension(:,:) :: csrColInd
+      real(c_float),target,dimension(:) :: csrVal
+      integer(c_int),target,dimension(:) :: csrRowPtr
+      integer(c_int),target,dimension(:) :: csrColInd
       type(c_ptr) :: buffer
       !
       hipsparseSpruneDense2csr_full_rank = hipsparseSpruneDense2csr_(handle,m,n,c_loc(A),lda, &
@@ -39176,9 +38964,9 @@ module hipfort_hipsparse
       integer(c_int) :: lda
       real(c_double) :: threshold
       type(c_ptr) :: descr
-      real(c_double),target,dimension(:,:) :: csrVal
-      integer(c_int),target,dimension(:,:) :: csrRowPtr
-      integer(c_int),target,dimension(:,:) :: csrColInd
+      real(c_double),target,dimension(:) :: csrVal
+      integer(c_int),target,dimension(:) :: csrRowPtr
+      integer(c_int),target,dimension(:) :: csrColInd
       type(c_ptr) :: buffer
       !
       hipsparseDpruneDense2csr_full_rank = hipsparseDpruneDense2csr_(handle,m,n,c_loc(A),lda, &
@@ -39246,11 +39034,11 @@ module hipfort_hipsparse
       integer(c_int) :: lda
       real(c_float) :: percentage
       type(c_ptr) :: descr
-      real(c_float),target,dimension(:,:) :: csrVal
-      integer(c_int),target,dimension(:,:) :: csrRowPtr
-      integer(c_int),target,dimension(:,:) :: csrColInd
+      real(c_float),target,dimension(:) :: csrVal
+      integer(c_int),target,dimension(:) :: csrRowPtr
+      integer(c_int),target,dimension(:) :: csrColInd
       type(c_ptr) :: myInfo
-      integer(c_size_t),target,dimension(:,:) :: pBufferSizeInBytes
+      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
       !
       hipsparseSpruneDense2csrByPercentage_bufferSize_full_rank = &
         hipsparseSpruneDense2csrByPercentage_bufferSize_(handle,m,n,c_loc(A),lda,percentage,descr, &
@@ -39318,11 +39106,11 @@ module hipfort_hipsparse
       integer(c_int) :: lda
       real(c_double) :: percentage
       type(c_ptr) :: descr
-      real(c_double),target,dimension(:,:) :: csrVal
-      integer(c_int),target,dimension(:,:) :: csrRowPtr
-      integer(c_int),target,dimension(:,:) :: csrColInd
+      real(c_double),target,dimension(:) :: csrVal
+      integer(c_int),target,dimension(:) :: csrRowPtr
+      integer(c_int),target,dimension(:) :: csrColInd
       type(c_ptr) :: myInfo
-      integer(c_size_t),target,dimension(:,:) :: pBufferSizeInBytes
+      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
       !
       hipsparseDpruneDense2csrByPercentage_bufferSize_full_rank = &
         hipsparseDpruneDense2csrByPercentage_bufferSize_(handle,m,n,c_loc(A),lda,percentage,descr, &
@@ -39390,11 +39178,11 @@ module hipfort_hipsparse
       integer(c_int) :: lda
       real(c_float) :: percentage
       type(c_ptr) :: descr
-      real(c_float),target,dimension(:,:) :: csrVal
-      integer(c_int),target,dimension(:,:) :: csrRowPtr
-      integer(c_int),target,dimension(:,:) :: csrColInd
+      real(c_float),target,dimension(:) :: csrVal
+      integer(c_int),target,dimension(:) :: csrRowPtr
+      integer(c_int),target,dimension(:) :: csrColInd
       type(c_ptr) :: myInfo
-      integer(c_size_t),target,dimension(:,:) :: pBufferSizeInBytes
+      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
       !
       hipsparseSpruneDense2csrByPercentage_bufferSizeExt_full_rank = &
         hipsparseSpruneDense2csrByPercentage_bufferSizeExt_(handle,m,n,c_loc(A),lda,percentage, &
@@ -39462,11 +39250,11 @@ module hipfort_hipsparse
       integer(c_int) :: lda
       real(c_double) :: percentage
       type(c_ptr) :: descr
-      real(c_double),target,dimension(:,:) :: csrVal
-      integer(c_int),target,dimension(:,:) :: csrRowPtr
-      integer(c_int),target,dimension(:,:) :: csrColInd
+      real(c_double),target,dimension(:) :: csrVal
+      integer(c_int),target,dimension(:) :: csrRowPtr
+      integer(c_int),target,dimension(:) :: csrColInd
       type(c_ptr) :: myInfo
-      integer(c_size_t),target,dimension(:,:) :: pBufferSizeInBytes
+      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
       !
       hipsparseDpruneDense2csrByPercentage_bufferSizeExt_full_rank = &
         hipsparseDpruneDense2csrByPercentage_bufferSizeExt_(handle,m,n,c_loc(A),lda,percentage, &
@@ -39530,7 +39318,7 @@ module hipfort_hipsparse
       integer(c_int) :: lda
       real(c_float) :: percentage
       type(c_ptr) :: descr
-      integer(c_int),target,dimension(:,:) :: csrRowPtr
+      integer(c_int),target,dimension(:) :: csrRowPtr
       integer(c_int) :: nnzTotalDevHostPtr
       type(c_ptr) :: myInfo
       type(c_ptr) :: buffer
@@ -39597,7 +39385,7 @@ module hipfort_hipsparse
       integer(c_int) :: lda
       real(c_double) :: percentage
       type(c_ptr) :: descr
-      integer(c_int),target,dimension(:,:) :: csrRowPtr
+      integer(c_int),target,dimension(:) :: csrRowPtr
       integer(c_int) :: nnzTotalDevHostPtr
       type(c_ptr) :: myInfo
       type(c_ptr) :: buffer
@@ -39668,9 +39456,9 @@ module hipfort_hipsparse
       integer(c_int) :: lda
       real(c_float) :: percentage
       type(c_ptr) :: descr
-      real(c_float),target,dimension(:,:) :: csrVal
-      integer(c_int),target,dimension(:,:) :: csrRowPtr
-      integer(c_int),target,dimension(:,:) :: csrColInd
+      real(c_float),target,dimension(:) :: csrVal
+      integer(c_int),target,dimension(:) :: csrRowPtr
+      integer(c_int),target,dimension(:) :: csrColInd
       type(c_ptr) :: myInfo
       type(c_ptr) :: buffer
       !
@@ -39740,9 +39528,9 @@ module hipfort_hipsparse
       integer(c_int) :: lda
       real(c_double) :: percentage
       type(c_ptr) :: descr
-      real(c_double),target,dimension(:,:) :: csrVal
-      integer(c_int),target,dimension(:,:) :: csrRowPtr
-      integer(c_int),target,dimension(:,:) :: csrColInd
+      real(c_double),target,dimension(:) :: csrVal
+      integer(c_int),target,dimension(:) :: csrRowPtr
+      integer(c_int),target,dimension(:) :: csrColInd
       type(c_ptr) :: myInfo
       type(c_ptr) :: buffer
       !
@@ -39805,10 +39593,10 @@ module hipfort_hipsparse
       type(c_ptr) :: descr
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: ld
-      integer(c_int),target,dimension(:,:) :: nnzPerColumn
-      real(c_float),target,dimension(:,:) :: cscVal
-      integer(c_int),target,dimension(:,:) :: cscRowInd
-      integer(c_int),target,dimension(:,:) :: cscColPtr
+      integer(c_int),target,dimension(:) :: nnzPerColumn
+      real(c_float),target,dimension(:) :: cscVal
+      integer(c_int),target,dimension(:) :: cscRowInd
+      integer(c_int),target,dimension(:) :: cscColPtr
       !
       hipsparseSdense2csc_full_rank = hipsparseSdense2csc_(handle,m,n,descr,c_loc(A),ld, &
         c_loc(nnzPerColumn),c_loc(cscVal),c_loc(cscRowInd),c_loc(cscColPtr))
@@ -39868,10 +39656,10 @@ module hipfort_hipsparse
       type(c_ptr) :: descr
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: ld
-      integer(c_int),target,dimension(:,:) :: nnzPerColumn
-      real(c_double),target,dimension(:,:) :: cscVal
-      integer(c_int),target,dimension(:,:) :: cscRowInd
-      integer(c_int),target,dimension(:,:) :: cscColPtr
+      integer(c_int),target,dimension(:) :: nnzPerColumn
+      real(c_double),target,dimension(:) :: cscVal
+      integer(c_int),target,dimension(:) :: cscRowInd
+      integer(c_int),target,dimension(:) :: cscColPtr
       !
       hipsparseDdense2csc_full_rank = hipsparseDdense2csc_(handle,m,n,descr,c_loc(A),ld, &
         c_loc(nnzPerColumn),c_loc(cscVal),c_loc(cscRowInd),c_loc(cscColPtr))
@@ -39931,10 +39719,10 @@ module hipfort_hipsparse
       type(c_ptr) :: descr
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: ld
-      integer(c_int),target,dimension(:,:) :: nnzPerColumn
-      complex(c_float_complex),target,dimension(:,:) :: cscVal
-      integer(c_int),target,dimension(:,:) :: cscRowInd
-      integer(c_int),target,dimension(:,:) :: cscColPtr
+      integer(c_int),target,dimension(:) :: nnzPerColumn
+      complex(c_float_complex),target,dimension(:) :: cscVal
+      integer(c_int),target,dimension(:) :: cscRowInd
+      integer(c_int),target,dimension(:) :: cscColPtr
       !
       hipsparseCdense2csc_full_rank = hipsparseCdense2csc_(handle,m,n,descr,c_loc(A),ld, &
         c_loc(nnzPerColumn),c_loc(cscVal),c_loc(cscRowInd),c_loc(cscColPtr))
@@ -39994,10 +39782,10 @@ module hipfort_hipsparse
       type(c_ptr) :: descr
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: ld
-      integer(c_int),target,dimension(:,:) :: nnzPerColumn
-      complex(c_double_complex),target,dimension(:,:) :: cscVal
-      integer(c_int),target,dimension(:,:) :: cscRowInd
-      integer(c_int),target,dimension(:,:) :: cscColPtr
+      integer(c_int),target,dimension(:) :: nnzPerColumn
+      complex(c_double_complex),target,dimension(:) :: cscVal
+      integer(c_int),target,dimension(:) :: cscRowInd
+      integer(c_int),target,dimension(:) :: cscColPtr
       !
       hipsparseZdense2csc_full_rank = hipsparseZdense2csc_(handle,m,n,descr,c_loc(A),ld, &
         c_loc(nnzPerColumn),c_loc(cscVal),c_loc(cscRowInd),c_loc(cscColPtr))
@@ -40050,9 +39838,9 @@ module hipfort_hipsparse
       integer(c_int) :: m
       integer(c_int) :: n
       type(c_ptr) :: descr
-      real(c_float),target,dimension(:,:) :: csrVal
-      integer(c_int),target,dimension(:,:) :: csrRowPtr
-      integer(c_int),target,dimension(:,:) :: csrColInd
+      real(c_float),target,dimension(:) :: csrVal
+      integer(c_int),target,dimension(:) :: csrRowPtr
+      integer(c_int),target,dimension(:) :: csrColInd
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: ld
       !
@@ -40107,9 +39895,9 @@ module hipfort_hipsparse
       integer(c_int) :: m
       integer(c_int) :: n
       type(c_ptr) :: descr
-      real(c_double),target,dimension(:,:) :: csrVal
-      integer(c_int),target,dimension(:,:) :: csrRowPtr
-      integer(c_int),target,dimension(:,:) :: csrColInd
+      real(c_double),target,dimension(:) :: csrVal
+      integer(c_int),target,dimension(:) :: csrRowPtr
+      integer(c_int),target,dimension(:) :: csrColInd
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: ld
       !
@@ -40164,9 +39952,9 @@ module hipfort_hipsparse
       integer(c_int) :: m
       integer(c_int) :: n
       type(c_ptr) :: descr
-      complex(c_float_complex),target,dimension(:,:) :: csrVal
-      integer(c_int),target,dimension(:,:) :: csrRowPtr
-      integer(c_int),target,dimension(:,:) :: csrColInd
+      complex(c_float_complex),target,dimension(:) :: csrVal
+      integer(c_int),target,dimension(:) :: csrRowPtr
+      integer(c_int),target,dimension(:) :: csrColInd
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: ld
       !
@@ -40221,9 +40009,9 @@ module hipfort_hipsparse
       integer(c_int) :: m
       integer(c_int) :: n
       type(c_ptr) :: descr
-      complex(c_double_complex),target,dimension(:,:) :: csrVal
-      integer(c_int),target,dimension(:,:) :: csrRowPtr
-      integer(c_int),target,dimension(:,:) :: csrColInd
+      complex(c_double_complex),target,dimension(:) :: csrVal
+      integer(c_int),target,dimension(:) :: csrRowPtr
+      integer(c_int),target,dimension(:) :: csrColInd
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: ld
       !
@@ -40278,9 +40066,9 @@ module hipfort_hipsparse
       integer(c_int) :: m
       integer(c_int) :: n
       type(c_ptr) :: descr
-      real(c_float),target,dimension(:,:) :: cscVal
-      integer(c_int),target,dimension(:,:) :: cscRowInd
-      integer(c_int),target,dimension(:,:) :: cscColPtr
+      real(c_float),target,dimension(:) :: cscVal
+      integer(c_int),target,dimension(:) :: cscRowInd
+      integer(c_int),target,dimension(:) :: cscColPtr
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: ld
       !
@@ -40335,9 +40123,9 @@ module hipfort_hipsparse
       integer(c_int) :: m
       integer(c_int) :: n
       type(c_ptr) :: descr
-      real(c_double),target,dimension(:,:) :: cscVal
-      integer(c_int),target,dimension(:,:) :: cscRowInd
-      integer(c_int),target,dimension(:,:) :: cscColPtr
+      real(c_double),target,dimension(:) :: cscVal
+      integer(c_int),target,dimension(:) :: cscRowInd
+      integer(c_int),target,dimension(:) :: cscColPtr
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: ld
       !
@@ -40392,9 +40180,9 @@ module hipfort_hipsparse
       integer(c_int) :: m
       integer(c_int) :: n
       type(c_ptr) :: descr
-      complex(c_float_complex),target,dimension(:,:) :: cscVal
-      integer(c_int),target,dimension(:,:) :: cscRowInd
-      integer(c_int),target,dimension(:,:) :: cscColPtr
+      complex(c_float_complex),target,dimension(:) :: cscVal
+      integer(c_int),target,dimension(:) :: cscRowInd
+      integer(c_int),target,dimension(:) :: cscColPtr
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: ld
       !
@@ -40449,9 +40237,9 @@ module hipfort_hipsparse
       integer(c_int) :: m
       integer(c_int) :: n
       type(c_ptr) :: descr
-      complex(c_double_complex),target,dimension(:,:) :: cscVal
-      integer(c_int),target,dimension(:,:) :: cscRowInd
-      integer(c_int),target,dimension(:,:) :: cscColPtr
+      complex(c_double_complex),target,dimension(:) :: cscVal
+      integer(c_int),target,dimension(:) :: cscRowInd
+      integer(c_int),target,dimension(:) :: cscColPtr
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: ld
       !
@@ -43421,25 +43209,6 @@ module hipfort_hipsparse
         c_loc(csrColInd),c_loc(P),pBuffer)
     end function
 
-    function hipsparseXcsrsort_full_rank(handle,m,n,nnz,descrA,csrRowPtr,csrColInd,P,pBuffer)
-      use iso_c_binding
-      use hipfort_hipsparse_enums
-      implicit none
-      integer(kind(HIPSPARSE_STATUS_SUCCESS)) :: hipsparseXcsrsort_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      integer(c_int) :: nnz
-      type(c_ptr) :: descrA
-      integer(c_int),target,dimension(:,:) :: csrRowPtr
-      integer(c_int),target,dimension(:,:) :: csrColInd
-      integer(c_int),target,dimension(:,:) :: P
-      type(c_ptr) :: pBuffer
-      !
-      hipsparseXcsrsort_full_rank = hipsparseXcsrsort_(handle,m,n,nnz,descrA,c_loc(csrRowPtr), &
-        c_loc(csrColInd),c_loc(P),pBuffer)
-    end function
-
     function hipsparseXcscsort_bufferSizeExt_rank_0(handle,m,n,nnz,cscColPtr,cscRowInd, &
         pBufferSizeInBytes)
       use iso_c_binding
@@ -43511,25 +43280,6 @@ module hipfort_hipsparse
       type(c_ptr) :: pBuffer
       !
       hipsparseXcscsort_rank_1 = hipsparseXcscsort_(handle,m,n,nnz,descrA,c_loc(cscColPtr), &
-        c_loc(cscRowInd),c_loc(P),pBuffer)
-    end function
-
-    function hipsparseXcscsort_full_rank(handle,m,n,nnz,descrA,cscColPtr,cscRowInd,P,pBuffer)
-      use iso_c_binding
-      use hipfort_hipsparse_enums
-      implicit none
-      integer(kind(HIPSPARSE_STATUS_SUCCESS)) :: hipsparseXcscsort_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      integer(c_int) :: nnz
-      type(c_ptr) :: descrA
-      integer(c_int),target,dimension(:,:) :: cscColPtr
-      integer(c_int),target,dimension(:,:) :: cscRowInd
-      integer(c_int),target,dimension(:,:) :: P
-      type(c_ptr) :: pBuffer
-      !
-      hipsparseXcscsort_full_rank = hipsparseXcscsort_(handle,m,n,nnz,descrA,c_loc(cscColPtr), &
         c_loc(cscRowInd),c_loc(P),pBuffer)
     end function
 
@@ -43605,24 +43355,6 @@ module hipfort_hipsparse
         c_loc(cooCols),c_loc(P),pBuffer)
     end function
 
-    function hipsparseXcoosortByRow_full_rank(handle,m,n,nnz,cooRows,cooCols,P,pBuffer)
-      use iso_c_binding
-      use hipfort_hipsparse_enums
-      implicit none
-      integer(kind(HIPSPARSE_STATUS_SUCCESS)) :: hipsparseXcoosortByRow_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      integer(c_int) :: nnz
-      integer(c_int),target,dimension(:,:) :: cooRows
-      integer(c_int),target,dimension(:,:) :: cooCols
-      integer(c_int),target,dimension(:,:) :: P
-      type(c_ptr) :: pBuffer
-      !
-      hipsparseXcoosortByRow_full_rank = hipsparseXcoosortByRow_(handle,m,n,nnz,c_loc(cooRows), &
-        c_loc(cooCols),c_loc(P),pBuffer)
-    end function
-
     function hipsparseXcoosortByColumn_rank_0(handle,m,n,nnz,cooRows,cooCols,P,pBuffer)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -43657,24 +43389,6 @@ module hipfort_hipsparse
       !
       hipsparseXcoosortByColumn_rank_1 = hipsparseXcoosortByColumn_(handle,m,n,nnz,c_loc(cooRows), &
         c_loc(cooCols),c_loc(P),pBuffer)
-    end function
-
-    function hipsparseXcoosortByColumn_full_rank(handle,m,n,nnz,cooRows,cooCols,P,pBuffer)
-      use iso_c_binding
-      use hipfort_hipsparse_enums
-      implicit none
-      integer(kind(HIPSPARSE_STATUS_SUCCESS)) :: hipsparseXcoosortByColumn_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      integer(c_int) :: nnz
-      integer(c_int),target,dimension(:,:) :: cooRows
-      integer(c_int),target,dimension(:,:) :: cooCols
-      integer(c_int),target,dimension(:,:) :: P
-      type(c_ptr) :: pBuffer
-      !
-      hipsparseXcoosortByColumn_full_rank = hipsparseXcoosortByColumn_(handle,m,n,nnz, &
-        c_loc(cooRows),c_loc(cooCols),c_loc(P),pBuffer)
     end function
 
     function hipsparseSgebsr2gebsr_bufferSize_rank_0(handle,dirA,mb,nb,nnzb,descrA,bsrValA, &
@@ -44708,15 +44422,14 @@ module hipfort_hipsparse
       real(c_float),target :: csrValA
       integer(c_int),target :: csrRowPtrA
       integer(c_int),target :: csrColIndA
-      real(c_float),target :: fractionToColor
+      type(c_ptr) :: fractionToColor
       integer(c_int) :: ncolors
       integer(c_int) :: coloring
       integer(c_int) :: reordering
       type(c_ptr) :: myInfo
       !
       hipsparseScsrcolor_rank_0 = hipsparseScsrcolor_(handle,m,nnz,descrA,c_loc(csrValA), &
-        c_loc(csrRowPtrA),c_loc(csrColIndA),c_loc(fractionToColor),ncolors,coloring,reordering, &
-        myInfo)
+        c_loc(csrRowPtrA),c_loc(csrColIndA),fractionToColor,ncolors,coloring,reordering,myInfo)
     end function
 
     function hipsparseScsrcolor_rank_1(handle,m,nnz,descrA,csrValA,csrRowPtrA,csrColIndA, &
@@ -44732,15 +44445,14 @@ module hipfort_hipsparse
       real(c_float),target,dimension(:) :: csrValA
       integer(c_int),target,dimension(:) :: csrRowPtrA
       integer(c_int),target,dimension(:) :: csrColIndA
-      real(c_float),target,dimension(:) :: fractionToColor
+      type(c_ptr) :: fractionToColor
       integer(c_int) :: ncolors
       integer(c_int) :: coloring
       integer(c_int) :: reordering
       type(c_ptr) :: myInfo
       !
       hipsparseScsrcolor_rank_1 = hipsparseScsrcolor_(handle,m,nnz,descrA,c_loc(csrValA), &
-        c_loc(csrRowPtrA),c_loc(csrColIndA),c_loc(fractionToColor),ncolors,coloring,reordering, &
-        myInfo)
+        c_loc(csrRowPtrA),c_loc(csrColIndA),fractionToColor,ncolors,coloring,reordering,myInfo)
     end function
 
     function hipsparseDcsrcolor_rank_0(handle,m,nnz,descrA,csrValA,csrRowPtrA,csrColIndA, &
@@ -44756,15 +44468,14 @@ module hipfort_hipsparse
       real(c_double),target :: csrValA
       integer(c_int),target :: csrRowPtrA
       integer(c_int),target :: csrColIndA
-      real(c_double),target :: fractionToColor
+      type(c_ptr) :: fractionToColor
       integer(c_int) :: ncolors
       integer(c_int) :: coloring
       integer(c_int) :: reordering
       type(c_ptr) :: myInfo
       !
       hipsparseDcsrcolor_rank_0 = hipsparseDcsrcolor_(handle,m,nnz,descrA,c_loc(csrValA), &
-        c_loc(csrRowPtrA),c_loc(csrColIndA),c_loc(fractionToColor),ncolors,coloring,reordering, &
-        myInfo)
+        c_loc(csrRowPtrA),c_loc(csrColIndA),fractionToColor,ncolors,coloring,reordering,myInfo)
     end function
 
     function hipsparseDcsrcolor_rank_1(handle,m,nnz,descrA,csrValA,csrRowPtrA,csrColIndA, &
@@ -44780,15 +44491,14 @@ module hipfort_hipsparse
       real(c_double),target,dimension(:) :: csrValA
       integer(c_int),target,dimension(:) :: csrRowPtrA
       integer(c_int),target,dimension(:) :: csrColIndA
-      real(c_double),target,dimension(:) :: fractionToColor
+      type(c_ptr) :: fractionToColor
       integer(c_int) :: ncolors
       integer(c_int) :: coloring
       integer(c_int) :: reordering
       type(c_ptr) :: myInfo
       !
       hipsparseDcsrcolor_rank_1 = hipsparseDcsrcolor_(handle,m,nnz,descrA,c_loc(csrValA), &
-        c_loc(csrRowPtrA),c_loc(csrColIndA),c_loc(fractionToColor),ncolors,coloring,reordering, &
-        myInfo)
+        c_loc(csrRowPtrA),c_loc(csrColIndA),fractionToColor,ncolors,coloring,reordering,myInfo)
     end function
 
     function hipsparseCcsrcolor_rank_0(handle,m,nnz,descrA,csrValA,csrRowPtrA,csrColIndA, &
@@ -44804,15 +44514,14 @@ module hipfort_hipsparse
       complex(c_float_complex),target :: csrValA
       integer(c_int),target :: csrRowPtrA
       integer(c_int),target :: csrColIndA
-      real(c_float),target :: fractionToColor
+      type(c_ptr) :: fractionToColor
       integer(c_int) :: ncolors
       integer(c_int) :: coloring
       integer(c_int) :: reordering
       type(c_ptr) :: myInfo
       !
       hipsparseCcsrcolor_rank_0 = hipsparseCcsrcolor_(handle,m,nnz,descrA,c_loc(csrValA), &
-        c_loc(csrRowPtrA),c_loc(csrColIndA),c_loc(fractionToColor),ncolors,coloring,reordering, &
-        myInfo)
+        c_loc(csrRowPtrA),c_loc(csrColIndA),fractionToColor,ncolors,coloring,reordering,myInfo)
     end function
 
     function hipsparseCcsrcolor_rank_1(handle,m,nnz,descrA,csrValA,csrRowPtrA,csrColIndA, &
@@ -44828,15 +44537,14 @@ module hipfort_hipsparse
       complex(c_float_complex),target,dimension(:) :: csrValA
       integer(c_int),target,dimension(:) :: csrRowPtrA
       integer(c_int),target,dimension(:) :: csrColIndA
-      real(c_float),target,dimension(:) :: fractionToColor
+      type(c_ptr) :: fractionToColor
       integer(c_int) :: ncolors
       integer(c_int) :: coloring
       integer(c_int) :: reordering
       type(c_ptr) :: myInfo
       !
       hipsparseCcsrcolor_rank_1 = hipsparseCcsrcolor_(handle,m,nnz,descrA,c_loc(csrValA), &
-        c_loc(csrRowPtrA),c_loc(csrColIndA),c_loc(fractionToColor),ncolors,coloring,reordering, &
-        myInfo)
+        c_loc(csrRowPtrA),c_loc(csrColIndA),fractionToColor,ncolors,coloring,reordering,myInfo)
     end function
 
     function hipsparseZcsrcolor_rank_0(handle,m,nnz,descrA,csrValA,csrRowPtrA,csrColIndA, &
@@ -44852,15 +44560,14 @@ module hipfort_hipsparse
       complex(c_double_complex),target :: csrValA
       integer(c_int),target :: csrRowPtrA
       integer(c_int),target :: csrColIndA
-      real(c_double),target :: fractionToColor
+      type(c_ptr) :: fractionToColor
       integer(c_int) :: ncolors
       integer(c_int) :: coloring
       integer(c_int) :: reordering
       type(c_ptr) :: myInfo
       !
       hipsparseZcsrcolor_rank_0 = hipsparseZcsrcolor_(handle,m,nnz,descrA,c_loc(csrValA), &
-        c_loc(csrRowPtrA),c_loc(csrColIndA),c_loc(fractionToColor),ncolors,coloring,reordering, &
-        myInfo)
+        c_loc(csrRowPtrA),c_loc(csrColIndA),fractionToColor,ncolors,coloring,reordering,myInfo)
     end function
 
     function hipsparseZcsrcolor_rank_1(handle,m,nnz,descrA,csrValA,csrRowPtrA,csrColIndA, &
@@ -44876,15 +44583,14 @@ module hipfort_hipsparse
       complex(c_double_complex),target,dimension(:) :: csrValA
       integer(c_int),target,dimension(:) :: csrRowPtrA
       integer(c_int),target,dimension(:) :: csrColIndA
-      real(c_double),target,dimension(:) :: fractionToColor
+      type(c_ptr) :: fractionToColor
       integer(c_int) :: ncolors
       integer(c_int) :: coloring
       integer(c_int) :: reordering
       type(c_ptr) :: myInfo
       !
       hipsparseZcsrcolor_rank_1 = hipsparseZcsrcolor_(handle,m,nnz,descrA,c_loc(csrValA), &
-        c_loc(csrRowPtrA),c_loc(csrColIndA),c_loc(fractionToColor),ncolors,coloring,reordering, &
-        myInfo)
+        c_loc(csrRowPtrA),c_loc(csrColIndA),fractionToColor,ncolors,coloring,reordering,myInfo)
     end function
 
     function hipsparseSparseToDense_bufferSize_rank_0(handle,matA,matB,alg,pBufferSizeInBytes)

--- a/lib/hipfort/hipfort_rocblas.F90
+++ b/lib/hipfort/hipfort_rocblas.F90
@@ -1047,13 +1047,6 @@ module hipfort_rocblas
       integer(c_int),value :: batch_count
       type(c_ptr),value :: myResult
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocblas_sdot_batched_rank_0,&
-      rocblas_sdot_batched_rank_1,&
-      rocblas_sdot_batched_full_rank
-#endif
   end interface
 
   interface rocblas_ddot_batched
@@ -1072,13 +1065,6 @@ module hipfort_rocblas
       integer(c_int),value :: batch_count
       type(c_ptr),value :: myResult
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocblas_ddot_batched_rank_0,&
-      rocblas_ddot_batched_rank_1,&
-      rocblas_ddot_batched_full_rank
-#endif
   end interface
 
   interface rocblas_hdot_batched
@@ -1133,13 +1119,6 @@ module hipfort_rocblas
       integer(c_int),value :: batch_count
       type(c_ptr),value :: myResult
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocblas_cdotu_batched_rank_0,&
-      rocblas_cdotu_batched_rank_1,&
-      rocblas_cdotu_batched_full_rank
-#endif
   end interface
 
   interface rocblas_zdotu_batched
@@ -1158,13 +1137,6 @@ module hipfort_rocblas
       integer(c_int),value :: batch_count
       type(c_ptr),value :: myResult
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocblas_zdotu_batched_rank_0,&
-      rocblas_zdotu_batched_rank_1,&
-      rocblas_zdotu_batched_full_rank
-#endif
   end interface
 
   interface rocblas_cdotc_batched
@@ -1183,13 +1155,6 @@ module hipfort_rocblas
       integer(c_int),value :: batch_count
       type(c_ptr),value :: myResult
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocblas_cdotc_batched_rank_0,&
-      rocblas_cdotc_batched_rank_1,&
-      rocblas_cdotc_batched_full_rank
-#endif
   end interface
 
   interface rocblas_zdotc_batched
@@ -1208,13 +1173,6 @@ module hipfort_rocblas
       integer(c_int),value :: batch_count
       type(c_ptr),value :: myResult
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocblas_zdotc_batched_rank_0,&
-      rocblas_zdotc_batched_rank_1,&
-      rocblas_zdotc_batched_full_rank
-#endif
   end interface
 
   !>     \brief  BLAS Level 1 API
@@ -2338,13 +2296,6 @@ module hipfort_rocblas
       integer(c_int),value :: batch_count
       type(c_ptr),value :: results
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocblas_sasum_batched_rank_0,&
-      rocblas_sasum_batched_rank_1,&
-      rocblas_sasum_batched_full_rank
-#endif
   end interface
 
   interface rocblas_dasum_batched
@@ -2361,13 +2312,6 @@ module hipfort_rocblas
       integer(c_int),value :: batch_count
       type(c_ptr),value :: results
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocblas_dasum_batched_rank_0,&
-      rocblas_dasum_batched_rank_1,&
-      rocblas_dasum_batched_full_rank
-#endif
   end interface
 
   interface rocblas_scasum_batched
@@ -2384,13 +2328,6 @@ module hipfort_rocblas
       integer(c_int),value :: batch_count
       type(c_ptr),value :: results
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocblas_scasum_batched_rank_0,&
-      rocblas_scasum_batched_rank_1,&
-      rocblas_scasum_batched_full_rank
-#endif
   end interface
 
   interface rocblas_dzasum_batched
@@ -2407,13 +2344,6 @@ module hipfort_rocblas
       integer(c_int),value :: batch_count
       type(c_ptr),value :: results
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocblas_dzasum_batched_rank_0,&
-      rocblas_dzasum_batched_rank_1,&
-      rocblas_dzasum_batched_full_rank
-#endif
   end interface
 
   !>     \brief  BLAS Level 1 API
@@ -2674,13 +2604,6 @@ module hipfort_rocblas
       integer(c_int),value :: batch_count
       type(c_ptr),value :: results
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocblas_snrm2_batched_rank_0,&
-      rocblas_snrm2_batched_rank_1,&
-      rocblas_snrm2_batched_full_rank
-#endif
   end interface
 
   interface rocblas_dnrm2_batched
@@ -2697,13 +2620,6 @@ module hipfort_rocblas
       integer(c_int),value :: batch_count
       type(c_ptr),value :: results
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocblas_dnrm2_batched_rank_0,&
-      rocblas_dnrm2_batched_rank_1,&
-      rocblas_dnrm2_batched_full_rank
-#endif
   end interface
 
   interface rocblas_scnrm2_batched
@@ -2720,13 +2636,6 @@ module hipfort_rocblas
       integer(c_int),value :: batch_count
       type(c_ptr),value :: results
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocblas_scnrm2_batched_rank_0,&
-      rocblas_scnrm2_batched_rank_1,&
-      rocblas_scnrm2_batched_full_rank
-#endif
   end interface
 
   interface rocblas_dznrm2_batched
@@ -2743,13 +2652,6 @@ module hipfort_rocblas
       integer(c_int),value :: batch_count
       type(c_ptr),value :: results
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocblas_dznrm2_batched_rank_0,&
-      rocblas_dznrm2_batched_rank_1,&
-      rocblas_dznrm2_batched_full_rank
-#endif
   end interface
 
   !>     \brief  BLAS Level 1 API
@@ -3005,13 +2907,6 @@ module hipfort_rocblas
       integer(c_int),value :: batch_count
       type(c_ptr),value :: myResult
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocblas_isamax_batched_rank_0,&
-      rocblas_isamax_batched_rank_1,&
-      rocblas_isamax_batched_full_rank
-#endif
   end interface
 
   interface rocblas_idamax_batched
@@ -3028,13 +2923,6 @@ module hipfort_rocblas
       integer(c_int),value :: batch_count
       type(c_ptr),value :: myResult
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocblas_idamax_batched_rank_0,&
-      rocblas_idamax_batched_rank_1,&
-      rocblas_idamax_batched_full_rank
-#endif
   end interface
 
   interface rocblas_icamax_batched
@@ -3051,13 +2939,6 @@ module hipfort_rocblas
       integer(c_int),value :: batch_count
       type(c_ptr),value :: myResult
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocblas_icamax_batched_rank_0,&
-      rocblas_icamax_batched_rank_1,&
-      rocblas_icamax_batched_full_rank
-#endif
   end interface
 
   interface rocblas_izamax_batched
@@ -3074,13 +2955,6 @@ module hipfort_rocblas
       integer(c_int),value :: batch_count
       type(c_ptr),value :: myResult
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocblas_izamax_batched_rank_0,&
-      rocblas_izamax_batched_rank_1,&
-      rocblas_izamax_batched_full_rank
-#endif
   end interface
 
   !>     \brief  BLAS Level 1 API
@@ -3329,13 +3203,6 @@ module hipfort_rocblas
       integer(c_int),value :: batch_count
       type(c_ptr),value :: myResult
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocblas_isamin_batched_rank_0,&
-      rocblas_isamin_batched_rank_1,&
-      rocblas_isamin_batched_full_rank
-#endif
   end interface
 
   interface rocblas_idamin_batched
@@ -3352,13 +3219,6 @@ module hipfort_rocblas
       integer(c_int),value :: batch_count
       type(c_ptr),value :: myResult
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocblas_idamin_batched_rank_0,&
-      rocblas_idamin_batched_rank_1,&
-      rocblas_idamin_batched_full_rank
-#endif
   end interface
 
   interface rocblas_icamin_batched
@@ -3375,13 +3235,6 @@ module hipfort_rocblas
       integer(c_int),value :: batch_count
       type(c_ptr),value :: myResult
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocblas_icamin_batched_rank_0,&
-      rocblas_icamin_batched_rank_1,&
-      rocblas_icamin_batched_full_rank
-#endif
   end interface
 
   interface rocblas_izamin_batched
@@ -3398,13 +3251,6 @@ module hipfort_rocblas
       integer(c_int),value :: batch_count
       type(c_ptr),value :: myResult
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocblas_izamin_batched_rank_0,&
-      rocblas_izamin_batched_rank_1,&
-      rocblas_izamin_batched_full_rank
-#endif
   end interface
 
   !>     \brief  BLAS Level 1 API
@@ -39359,9 +39205,9 @@ module hipfort_rocblas
       integer(c_int) :: incx
       real(c_float),target :: y
       integer(c_int) :: incy
-      real(c_float),target :: myResult
+      type(c_ptr) :: myResult
       !
-      rocblas_sdot_rank_0 = rocblas_sdot_(handle,n,c_loc(x),incx,c_loc(y),incy,c_loc(myResult))
+      rocblas_sdot_rank_0 = rocblas_sdot_(handle,n,c_loc(x),incx,c_loc(y),incy,myResult)
     end function
 
     function rocblas_sdot_rank_1(handle,n,x,incx,y,incy,myResult)
@@ -39375,9 +39221,9 @@ module hipfort_rocblas
       integer(c_int) :: incx
       real(c_float),target,dimension(:) :: y
       integer(c_int) :: incy
-      real(c_float),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
-      rocblas_sdot_rank_1 = rocblas_sdot_(handle,n,c_loc(x),incx,c_loc(y),incy,c_loc(myResult))
+      rocblas_sdot_rank_1 = rocblas_sdot_(handle,n,c_loc(x),incx,c_loc(y),incy,myResult)
     end function
 
     function rocblas_ddot_rank_0(handle,n,x,incx,y,incy,myResult)
@@ -39391,9 +39237,9 @@ module hipfort_rocblas
       integer(c_int) :: incx
       real(c_double),target :: y
       integer(c_int) :: incy
-      real(c_double),target :: myResult
+      type(c_ptr) :: myResult
       !
-      rocblas_ddot_rank_0 = rocblas_ddot_(handle,n,c_loc(x),incx,c_loc(y),incy,c_loc(myResult))
+      rocblas_ddot_rank_0 = rocblas_ddot_(handle,n,c_loc(x),incx,c_loc(y),incy,myResult)
     end function
 
     function rocblas_ddot_rank_1(handle,n,x,incx,y,incy,myResult)
@@ -39407,9 +39253,9 @@ module hipfort_rocblas
       integer(c_int) :: incx
       real(c_double),target,dimension(:) :: y
       integer(c_int) :: incy
-      real(c_double),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
-      rocblas_ddot_rank_1 = rocblas_ddot_(handle,n,c_loc(x),incx,c_loc(y),incy,c_loc(myResult))
+      rocblas_ddot_rank_1 = rocblas_ddot_(handle,n,c_loc(x),incx,c_loc(y),incy,myResult)
     end function
 
     function rocblas_cdotu_rank_0(handle,n,x,incx,y,incy,myResult)
@@ -39423,9 +39269,9 @@ module hipfort_rocblas
       integer(c_int) :: incx
       complex(c_float_complex),target :: y
       integer(c_int) :: incy
-      complex(c_float_complex),target :: myResult
+      type(c_ptr) :: myResult
       !
-      rocblas_cdotu_rank_0 = rocblas_cdotu_(handle,n,c_loc(x),incx,c_loc(y),incy,c_loc(myResult))
+      rocblas_cdotu_rank_0 = rocblas_cdotu_(handle,n,c_loc(x),incx,c_loc(y),incy,myResult)
     end function
 
     function rocblas_cdotu_rank_1(handle,n,x,incx,y,incy,myResult)
@@ -39439,9 +39285,9 @@ module hipfort_rocblas
       integer(c_int) :: incx
       complex(c_float_complex),target,dimension(:) :: y
       integer(c_int) :: incy
-      complex(c_float_complex),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
-      rocblas_cdotu_rank_1 = rocblas_cdotu_(handle,n,c_loc(x),incx,c_loc(y),incy,c_loc(myResult))
+      rocblas_cdotu_rank_1 = rocblas_cdotu_(handle,n,c_loc(x),incx,c_loc(y),incy,myResult)
     end function
 
     function rocblas_zdotu_rank_0(handle,n,x,incx,y,incy,myResult)
@@ -39455,9 +39301,9 @@ module hipfort_rocblas
       integer(c_int) :: incx
       complex(c_double_complex),target :: y
       integer(c_int) :: incy
-      complex(c_double_complex),target :: myResult
+      type(c_ptr) :: myResult
       !
-      rocblas_zdotu_rank_0 = rocblas_zdotu_(handle,n,c_loc(x),incx,c_loc(y),incy,c_loc(myResult))
+      rocblas_zdotu_rank_0 = rocblas_zdotu_(handle,n,c_loc(x),incx,c_loc(y),incy,myResult)
     end function
 
     function rocblas_zdotu_rank_1(handle,n,x,incx,y,incy,myResult)
@@ -39471,9 +39317,9 @@ module hipfort_rocblas
       integer(c_int) :: incx
       complex(c_double_complex),target,dimension(:) :: y
       integer(c_int) :: incy
-      complex(c_double_complex),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
-      rocblas_zdotu_rank_1 = rocblas_zdotu_(handle,n,c_loc(x),incx,c_loc(y),incy,c_loc(myResult))
+      rocblas_zdotu_rank_1 = rocblas_zdotu_(handle,n,c_loc(x),incx,c_loc(y),incy,myResult)
     end function
 
     function rocblas_cdotc_rank_0(handle,n,x,incx,y,incy,myResult)
@@ -39487,9 +39333,9 @@ module hipfort_rocblas
       integer(c_int) :: incx
       complex(c_float_complex),target :: y
       integer(c_int) :: incy
-      complex(c_float_complex),target :: myResult
+      type(c_ptr) :: myResult
       !
-      rocblas_cdotc_rank_0 = rocblas_cdotc_(handle,n,c_loc(x),incx,c_loc(y),incy,c_loc(myResult))
+      rocblas_cdotc_rank_0 = rocblas_cdotc_(handle,n,c_loc(x),incx,c_loc(y),incy,myResult)
     end function
 
     function rocblas_cdotc_rank_1(handle,n,x,incx,y,incy,myResult)
@@ -39503,9 +39349,9 @@ module hipfort_rocblas
       integer(c_int) :: incx
       complex(c_float_complex),target,dimension(:) :: y
       integer(c_int) :: incy
-      complex(c_float_complex),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
-      rocblas_cdotc_rank_1 = rocblas_cdotc_(handle,n,c_loc(x),incx,c_loc(y),incy,c_loc(myResult))
+      rocblas_cdotc_rank_1 = rocblas_cdotc_(handle,n,c_loc(x),incx,c_loc(y),incy,myResult)
     end function
 
     function rocblas_zdotc_rank_0(handle,n,x,incx,y,incy,myResult)
@@ -39519,9 +39365,9 @@ module hipfort_rocblas
       integer(c_int) :: incx
       complex(c_double_complex),target :: y
       integer(c_int) :: incy
-      complex(c_double_complex),target :: myResult
+      type(c_ptr) :: myResult
       !
-      rocblas_zdotc_rank_0 = rocblas_zdotc_(handle,n,c_loc(x),incx,c_loc(y),incy,c_loc(myResult))
+      rocblas_zdotc_rank_0 = rocblas_zdotc_(handle,n,c_loc(x),incx,c_loc(y),incy,myResult)
     end function
 
     function rocblas_zdotc_rank_1(handle,n,x,incx,y,incy,myResult)
@@ -39535,333 +39381,9 @@ module hipfort_rocblas
       integer(c_int) :: incx
       complex(c_double_complex),target,dimension(:) :: y
       integer(c_int) :: incy
-      complex(c_double_complex),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
-      rocblas_zdotc_rank_1 = rocblas_zdotc_(handle,n,c_loc(x),incx,c_loc(y),incy,c_loc(myResult))
-    end function
-
-    function rocblas_sdot_batched_rank_0(handle,n,x,incx,y,incy,batch_count,myResult)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_sdot_batched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      type(c_ptr) :: y
-      integer(c_int) :: incy
-      integer(c_int) :: batch_count
-      real(c_float),target :: myResult
-      !
-      rocblas_sdot_batched_rank_0 = rocblas_sdot_batched_(handle,n,x,incx,y,incy,batch_count, &
-        c_loc(myResult))
-    end function
-
-    function rocblas_sdot_batched_rank_1(handle,n,x,incx,y,incy,batch_count,myResult)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_sdot_batched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      type(c_ptr) :: y
-      integer(c_int) :: incy
-      integer(c_int) :: batch_count
-      real(c_float),target,dimension(:) :: myResult
-      !
-      rocblas_sdot_batched_rank_1 = rocblas_sdot_batched_(handle,n,x,incx,y,incy,batch_count, &
-        c_loc(myResult))
-    end function
-
-    function rocblas_sdot_batched_full_rank(handle,n,x,incx,y,incy,batch_count,myResult)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_sdot_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      type(c_ptr) :: y
-      integer(c_int) :: incy
-      integer(c_int) :: batch_count
-      real(c_float),target,dimension(:,:) :: myResult
-      !
-      rocblas_sdot_batched_full_rank = rocblas_sdot_batched_(handle,n,x,incx,y,incy,batch_count, &
-        c_loc(myResult))
-    end function
-
-    function rocblas_ddot_batched_rank_0(handle,n,x,incx,y,incy,batch_count,myResult)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_ddot_batched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      type(c_ptr) :: y
-      integer(c_int) :: incy
-      integer(c_int) :: batch_count
-      real(c_double),target :: myResult
-      !
-      rocblas_ddot_batched_rank_0 = rocblas_ddot_batched_(handle,n,x,incx,y,incy,batch_count, &
-        c_loc(myResult))
-    end function
-
-    function rocblas_ddot_batched_rank_1(handle,n,x,incx,y,incy,batch_count,myResult)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_ddot_batched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      type(c_ptr) :: y
-      integer(c_int) :: incy
-      integer(c_int) :: batch_count
-      real(c_double),target,dimension(:) :: myResult
-      !
-      rocblas_ddot_batched_rank_1 = rocblas_ddot_batched_(handle,n,x,incx,y,incy,batch_count, &
-        c_loc(myResult))
-    end function
-
-    function rocblas_ddot_batched_full_rank(handle,n,x,incx,y,incy,batch_count,myResult)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_ddot_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      type(c_ptr) :: y
-      integer(c_int) :: incy
-      integer(c_int) :: batch_count
-      real(c_double),target,dimension(:,:) :: myResult
-      !
-      rocblas_ddot_batched_full_rank = rocblas_ddot_batched_(handle,n,x,incx,y,incy,batch_count, &
-        c_loc(myResult))
-    end function
-
-    function rocblas_cdotu_batched_rank_0(handle,n,x,incx,y,incy,batch_count,myResult)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_cdotu_batched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      type(c_ptr) :: y
-      integer(c_int) :: incy
-      integer(c_int) :: batch_count
-      complex(c_float_complex),target :: myResult
-      !
-      rocblas_cdotu_batched_rank_0 = rocblas_cdotu_batched_(handle,n,x,incx,y,incy,batch_count, &
-        c_loc(myResult))
-    end function
-
-    function rocblas_cdotu_batched_rank_1(handle,n,x,incx,y,incy,batch_count,myResult)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_cdotu_batched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      type(c_ptr) :: y
-      integer(c_int) :: incy
-      integer(c_int) :: batch_count
-      complex(c_float_complex),target,dimension(:) :: myResult
-      !
-      rocblas_cdotu_batched_rank_1 = rocblas_cdotu_batched_(handle,n,x,incx,y,incy,batch_count, &
-        c_loc(myResult))
-    end function
-
-    function rocblas_cdotu_batched_full_rank(handle,n,x,incx,y,incy,batch_count,myResult)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_cdotu_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      type(c_ptr) :: y
-      integer(c_int) :: incy
-      integer(c_int) :: batch_count
-      complex(c_float_complex),target,dimension(:,:) :: myResult
-      !
-      rocblas_cdotu_batched_full_rank = rocblas_cdotu_batched_(handle,n,x,incx,y,incy,batch_count, &
-        c_loc(myResult))
-    end function
-
-    function rocblas_zdotu_batched_rank_0(handle,n,x,incx,y,incy,batch_count,myResult)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_zdotu_batched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      type(c_ptr) :: y
-      integer(c_int) :: incy
-      integer(c_int) :: batch_count
-      complex(c_double_complex),target :: myResult
-      !
-      rocblas_zdotu_batched_rank_0 = rocblas_zdotu_batched_(handle,n,x,incx,y,incy,batch_count, &
-        c_loc(myResult))
-    end function
-
-    function rocblas_zdotu_batched_rank_1(handle,n,x,incx,y,incy,batch_count,myResult)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_zdotu_batched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      type(c_ptr) :: y
-      integer(c_int) :: incy
-      integer(c_int) :: batch_count
-      complex(c_double_complex),target,dimension(:) :: myResult
-      !
-      rocblas_zdotu_batched_rank_1 = rocblas_zdotu_batched_(handle,n,x,incx,y,incy,batch_count, &
-        c_loc(myResult))
-    end function
-
-    function rocblas_zdotu_batched_full_rank(handle,n,x,incx,y,incy,batch_count,myResult)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_zdotu_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      type(c_ptr) :: y
-      integer(c_int) :: incy
-      integer(c_int) :: batch_count
-      complex(c_double_complex),target,dimension(:,:) :: myResult
-      !
-      rocblas_zdotu_batched_full_rank = rocblas_zdotu_batched_(handle,n,x,incx,y,incy,batch_count, &
-        c_loc(myResult))
-    end function
-
-    function rocblas_cdotc_batched_rank_0(handle,n,x,incx,y,incy,batch_count,myResult)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_cdotc_batched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      type(c_ptr) :: y
-      integer(c_int) :: incy
-      integer(c_int) :: batch_count
-      complex(c_float_complex),target :: myResult
-      !
-      rocblas_cdotc_batched_rank_0 = rocblas_cdotc_batched_(handle,n,x,incx,y,incy,batch_count, &
-        c_loc(myResult))
-    end function
-
-    function rocblas_cdotc_batched_rank_1(handle,n,x,incx,y,incy,batch_count,myResult)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_cdotc_batched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      type(c_ptr) :: y
-      integer(c_int) :: incy
-      integer(c_int) :: batch_count
-      complex(c_float_complex),target,dimension(:) :: myResult
-      !
-      rocblas_cdotc_batched_rank_1 = rocblas_cdotc_batched_(handle,n,x,incx,y,incy,batch_count, &
-        c_loc(myResult))
-    end function
-
-    function rocblas_cdotc_batched_full_rank(handle,n,x,incx,y,incy,batch_count,myResult)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_cdotc_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      type(c_ptr) :: y
-      integer(c_int) :: incy
-      integer(c_int) :: batch_count
-      complex(c_float_complex),target,dimension(:,:) :: myResult
-      !
-      rocblas_cdotc_batched_full_rank = rocblas_cdotc_batched_(handle,n,x,incx,y,incy,batch_count, &
-        c_loc(myResult))
-    end function
-
-    function rocblas_zdotc_batched_rank_0(handle,n,x,incx,y,incy,batch_count,myResult)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_zdotc_batched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      type(c_ptr) :: y
-      integer(c_int) :: incy
-      integer(c_int) :: batch_count
-      complex(c_double_complex),target :: myResult
-      !
-      rocblas_zdotc_batched_rank_0 = rocblas_zdotc_batched_(handle,n,x,incx,y,incy,batch_count, &
-        c_loc(myResult))
-    end function
-
-    function rocblas_zdotc_batched_rank_1(handle,n,x,incx,y,incy,batch_count,myResult)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_zdotc_batched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      type(c_ptr) :: y
-      integer(c_int) :: incy
-      integer(c_int) :: batch_count
-      complex(c_double_complex),target,dimension(:) :: myResult
-      !
-      rocblas_zdotc_batched_rank_1 = rocblas_zdotc_batched_(handle,n,x,incx,y,incy,batch_count, &
-        c_loc(myResult))
-    end function
-
-    function rocblas_zdotc_batched_full_rank(handle,n,x,incx,y,incy,batch_count,myResult)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_zdotc_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      type(c_ptr) :: y
-      integer(c_int) :: incy
-      integer(c_int) :: batch_count
-      complex(c_double_complex),target,dimension(:,:) :: myResult
-      !
-      rocblas_zdotc_batched_full_rank = rocblas_zdotc_batched_(handle,n,x,incx,y,incy,batch_count, &
-        c_loc(myResult))
+      rocblas_zdotc_rank_1 = rocblas_zdotc_(handle,n,c_loc(x),incx,c_loc(y),incy,myResult)
     end function
 
     function rocblas_sdot_strided_batched_rank_0(handle,n,x,incx,stridex,y,incy,stridey, &
@@ -39879,10 +39401,10 @@ module hipfort_rocblas
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       integer(c_int) :: batch_count
-      real(c_float),target :: myResult
+      type(c_ptr) :: myResult
       !
       rocblas_sdot_strided_batched_rank_0 = rocblas_sdot_strided_batched_(handle,n,c_loc(x),incx, &
-        stridex,c_loc(y),incy,stridey,batch_count,c_loc(myResult))
+        stridex,c_loc(y),incy,stridey,batch_count,myResult)
     end function
 
     function rocblas_sdot_strided_batched_rank_1(handle,n,x,incx,stridex,y,incy,stridey, &
@@ -39900,10 +39422,10 @@ module hipfort_rocblas
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       integer(c_int) :: batch_count
-      real(c_float),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
       rocblas_sdot_strided_batched_rank_1 = rocblas_sdot_strided_batched_(handle,n,c_loc(x),incx, &
-        stridex,c_loc(y),incy,stridey,batch_count,c_loc(myResult))
+        stridex,c_loc(y),incy,stridey,batch_count,myResult)
     end function
 
     function rocblas_ddot_strided_batched_rank_0(handle,n,x,incx,stridex,y,incy,stridey, &
@@ -39921,10 +39443,10 @@ module hipfort_rocblas
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       integer(c_int) :: batch_count
-      real(c_double),target :: myResult
+      type(c_ptr) :: myResult
       !
       rocblas_ddot_strided_batched_rank_0 = rocblas_ddot_strided_batched_(handle,n,c_loc(x),incx, &
-        stridex,c_loc(y),incy,stridey,batch_count,c_loc(myResult))
+        stridex,c_loc(y),incy,stridey,batch_count,myResult)
     end function
 
     function rocblas_ddot_strided_batched_rank_1(handle,n,x,incx,stridex,y,incy,stridey, &
@@ -39942,10 +39464,10 @@ module hipfort_rocblas
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       integer(c_int) :: batch_count
-      real(c_double),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
       rocblas_ddot_strided_batched_rank_1 = rocblas_ddot_strided_batched_(handle,n,c_loc(x),incx, &
-        stridex,c_loc(y),incy,stridey,batch_count,c_loc(myResult))
+        stridex,c_loc(y),incy,stridey,batch_count,myResult)
     end function
 
     function rocblas_cdotu_strided_batched_rank_0(handle,n,x,incx,stridex,y,incy,stridey, &
@@ -39963,10 +39485,10 @@ module hipfort_rocblas
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       integer(c_int) :: batch_count
-      complex(c_float_complex),target :: myResult
+      type(c_ptr) :: myResult
       !
       rocblas_cdotu_strided_batched_rank_0 = rocblas_cdotu_strided_batched_(handle,n,c_loc(x), &
-        incx,stridex,c_loc(y),incy,stridey,batch_count,c_loc(myResult))
+        incx,stridex,c_loc(y),incy,stridey,batch_count,myResult)
     end function
 
     function rocblas_cdotu_strided_batched_rank_1(handle,n,x,incx,stridex,y,incy,stridey, &
@@ -39984,10 +39506,10 @@ module hipfort_rocblas
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       integer(c_int) :: batch_count
-      complex(c_float_complex),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
       rocblas_cdotu_strided_batched_rank_1 = rocblas_cdotu_strided_batched_(handle,n,c_loc(x), &
-        incx,stridex,c_loc(y),incy,stridey,batch_count,c_loc(myResult))
+        incx,stridex,c_loc(y),incy,stridey,batch_count,myResult)
     end function
 
     function rocblas_zdotu_strided_batched_rank_0(handle,n,x,incx,stridex,y,incy,stridey, &
@@ -40005,10 +39527,10 @@ module hipfort_rocblas
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       integer(c_int) :: batch_count
-      complex(c_double_complex),target :: myResult
+      type(c_ptr) :: myResult
       !
       rocblas_zdotu_strided_batched_rank_0 = rocblas_zdotu_strided_batched_(handle,n,c_loc(x), &
-        incx,stridex,c_loc(y),incy,stridey,batch_count,c_loc(myResult))
+        incx,stridex,c_loc(y),incy,stridey,batch_count,myResult)
     end function
 
     function rocblas_zdotu_strided_batched_rank_1(handle,n,x,incx,stridex,y,incy,stridey, &
@@ -40026,10 +39548,10 @@ module hipfort_rocblas
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       integer(c_int) :: batch_count
-      complex(c_double_complex),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
       rocblas_zdotu_strided_batched_rank_1 = rocblas_zdotu_strided_batched_(handle,n,c_loc(x), &
-        incx,stridex,c_loc(y),incy,stridey,batch_count,c_loc(myResult))
+        incx,stridex,c_loc(y),incy,stridey,batch_count,myResult)
     end function
 
     function rocblas_cdotc_strided_batched_rank_0(handle,n,x,incx,stridex,y,incy,stridey, &
@@ -40047,10 +39569,10 @@ module hipfort_rocblas
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       integer(c_int) :: batch_count
-      complex(c_float_complex),target :: myResult
+      type(c_ptr) :: myResult
       !
       rocblas_cdotc_strided_batched_rank_0 = rocblas_cdotc_strided_batched_(handle,n,c_loc(x), &
-        incx,stridex,c_loc(y),incy,stridey,batch_count,c_loc(myResult))
+        incx,stridex,c_loc(y),incy,stridey,batch_count,myResult)
     end function
 
     function rocblas_cdotc_strided_batched_rank_1(handle,n,x,incx,stridex,y,incy,stridey, &
@@ -40068,10 +39590,10 @@ module hipfort_rocblas
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       integer(c_int) :: batch_count
-      complex(c_float_complex),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
       rocblas_cdotc_strided_batched_rank_1 = rocblas_cdotc_strided_batched_(handle,n,c_loc(x), &
-        incx,stridex,c_loc(y),incy,stridey,batch_count,c_loc(myResult))
+        incx,stridex,c_loc(y),incy,stridey,batch_count,myResult)
     end function
 
     function rocblas_zdotc_strided_batched_rank_0(handle,n,x,incx,stridex,y,incy,stridey, &
@@ -40089,10 +39611,10 @@ module hipfort_rocblas
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       integer(c_int) :: batch_count
-      complex(c_double_complex),target :: myResult
+      type(c_ptr) :: myResult
       !
       rocblas_zdotc_strided_batched_rank_0 = rocblas_zdotc_strided_batched_(handle,n,c_loc(x), &
-        incx,stridex,c_loc(y),incy,stridey,batch_count,c_loc(myResult))
+        incx,stridex,c_loc(y),incy,stridey,batch_count,myResult)
     end function
 
     function rocblas_zdotc_strided_batched_rank_1(handle,n,x,incx,stridex,y,incy,stridey, &
@@ -40110,10 +39632,10 @@ module hipfort_rocblas
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       integer(c_int) :: batch_count
-      complex(c_double_complex),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
       rocblas_zdotc_strided_batched_rank_1 = rocblas_zdotc_strided_batched_(handle,n,c_loc(x), &
-        incx,stridex,c_loc(y),incy,stridey,batch_count,c_loc(myResult))
+        incx,stridex,c_loc(y),incy,stridey,batch_count,myResult)
     end function
 
     function rocblas_cswap_rank_0(handle,n,x,incx,y,incy)
@@ -40641,9 +40163,9 @@ module hipfort_rocblas
       integer(c_int) :: n
       complex(c_float_complex),target :: x
       integer(c_int) :: incx
-      real(c_float),target :: myResult
+      type(c_ptr) :: myResult
       !
-      rocblas_scasum_rank_0 = rocblas_scasum_(handle,n,c_loc(x),incx,c_loc(myResult))
+      rocblas_scasum_rank_0 = rocblas_scasum_(handle,n,c_loc(x),incx,myResult)
     end function
 
     function rocblas_scasum_rank_1(handle,n,x,incx,myResult)
@@ -40655,9 +40177,9 @@ module hipfort_rocblas
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
-      real(c_float),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
-      rocblas_scasum_rank_1 = rocblas_scasum_(handle,n,c_loc(x),incx,c_loc(myResult))
+      rocblas_scasum_rank_1 = rocblas_scasum_(handle,n,c_loc(x),incx,myResult)
     end function
 
     function rocblas_dzasum_rank_0(handle,n,x,incx,myResult)
@@ -40669,9 +40191,9 @@ module hipfort_rocblas
       integer(c_int) :: n
       complex(c_double_complex),target :: x
       integer(c_int) :: incx
-      real(c_double),target :: myResult
+      type(c_ptr) :: myResult
       !
-      rocblas_dzasum_rank_0 = rocblas_dzasum_(handle,n,c_loc(x),incx,c_loc(myResult))
+      rocblas_dzasum_rank_0 = rocblas_dzasum_(handle,n,c_loc(x),incx,myResult)
     end function
 
     function rocblas_dzasum_rank_1(handle,n,x,incx,myResult)
@@ -40683,201 +40205,9 @@ module hipfort_rocblas
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
-      real(c_double),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
-      rocblas_dzasum_rank_1 = rocblas_dzasum_(handle,n,c_loc(x),incx,c_loc(myResult))
-    end function
-
-    function rocblas_sasum_batched_rank_0(handle,n,x,incx,batch_count,results)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_sasum_batched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batch_count
-      real(c_float),target :: results
-      !
-      rocblas_sasum_batched_rank_0 = rocblas_sasum_batched_(handle,n,x,incx,batch_count, &
-        c_loc(results))
-    end function
-
-    function rocblas_sasum_batched_rank_1(handle,n,x,incx,batch_count,results)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_sasum_batched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batch_count
-      real(c_float),target,dimension(:) :: results
-      !
-      rocblas_sasum_batched_rank_1 = rocblas_sasum_batched_(handle,n,x,incx,batch_count, &
-        c_loc(results))
-    end function
-
-    function rocblas_sasum_batched_full_rank(handle,n,x,incx,batch_count,results)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_sasum_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batch_count
-      real(c_float),target,dimension(:,:) :: results
-      !
-      rocblas_sasum_batched_full_rank = rocblas_sasum_batched_(handle,n,x,incx,batch_count, &
-        c_loc(results))
-    end function
-
-    function rocblas_dasum_batched_rank_0(handle,n,x,incx,batch_count,results)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_dasum_batched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batch_count
-      real(c_double),target :: results
-      !
-      rocblas_dasum_batched_rank_0 = rocblas_dasum_batched_(handle,n,x,incx,batch_count, &
-        c_loc(results))
-    end function
-
-    function rocblas_dasum_batched_rank_1(handle,n,x,incx,batch_count,results)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_dasum_batched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batch_count
-      real(c_double),target,dimension(:) :: results
-      !
-      rocblas_dasum_batched_rank_1 = rocblas_dasum_batched_(handle,n,x,incx,batch_count, &
-        c_loc(results))
-    end function
-
-    function rocblas_dasum_batched_full_rank(handle,n,x,incx,batch_count,results)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_dasum_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batch_count
-      real(c_double),target,dimension(:,:) :: results
-      !
-      rocblas_dasum_batched_full_rank = rocblas_dasum_batched_(handle,n,x,incx,batch_count, &
-        c_loc(results))
-    end function
-
-    function rocblas_scasum_batched_rank_0(handle,n,x,incx,batch_count,results)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_scasum_batched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batch_count
-      real(c_float),target :: results
-      !
-      rocblas_scasum_batched_rank_0 = rocblas_scasum_batched_(handle,n,x,incx,batch_count, &
-        c_loc(results))
-    end function
-
-    function rocblas_scasum_batched_rank_1(handle,n,x,incx,batch_count,results)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_scasum_batched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batch_count
-      real(c_float),target,dimension(:) :: results
-      !
-      rocblas_scasum_batched_rank_1 = rocblas_scasum_batched_(handle,n,x,incx,batch_count, &
-        c_loc(results))
-    end function
-
-    function rocblas_scasum_batched_full_rank(handle,n,x,incx,batch_count,results)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_scasum_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batch_count
-      real(c_float),target,dimension(:,:) :: results
-      !
-      rocblas_scasum_batched_full_rank = rocblas_scasum_batched_(handle,n,x,incx,batch_count, &
-        c_loc(results))
-    end function
-
-    function rocblas_dzasum_batched_rank_0(handle,n,x,incx,batch_count,results)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_dzasum_batched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batch_count
-      real(c_double),target :: results
-      !
-      rocblas_dzasum_batched_rank_0 = rocblas_dzasum_batched_(handle,n,x,incx,batch_count, &
-        c_loc(results))
-    end function
-
-    function rocblas_dzasum_batched_rank_1(handle,n,x,incx,batch_count,results)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_dzasum_batched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batch_count
-      real(c_double),target,dimension(:) :: results
-      !
-      rocblas_dzasum_batched_rank_1 = rocblas_dzasum_batched_(handle,n,x,incx,batch_count, &
-        c_loc(results))
-    end function
-
-    function rocblas_dzasum_batched_full_rank(handle,n,x,incx,batch_count,results)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_dzasum_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batch_count
-      real(c_double),target,dimension(:,:) :: results
-      !
-      rocblas_dzasum_batched_full_rank = rocblas_dzasum_batched_(handle,n,x,incx,batch_count, &
-        c_loc(results))
+      rocblas_dzasum_rank_1 = rocblas_dzasum_(handle,n,c_loc(x),incx,myResult)
     end function
 
     function rocblas_sasum_strided_batched_rank_0(handle,n,x,incx,stridex,batch_count,results)
@@ -40891,10 +40221,10 @@ module hipfort_rocblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batch_count
-      real(c_float),target :: results
+      type(c_ptr) :: results
       !
       rocblas_sasum_strided_batched_rank_0 = rocblas_sasum_strided_batched_(handle,n,c_loc(x), &
-        incx,stridex,batch_count,c_loc(results))
+        incx,stridex,batch_count,results)
     end function
 
     function rocblas_sasum_strided_batched_rank_1(handle,n,x,incx,stridex,batch_count,results)
@@ -40908,10 +40238,10 @@ module hipfort_rocblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batch_count
-      real(c_float),target,dimension(:) :: results
+      type(c_ptr) :: results
       !
       rocblas_sasum_strided_batched_rank_1 = rocblas_sasum_strided_batched_(handle,n,c_loc(x), &
-        incx,stridex,batch_count,c_loc(results))
+        incx,stridex,batch_count,results)
     end function
 
     function rocblas_dasum_strided_batched_rank_0(handle,n,x,incx,stridex,batch_count,results)
@@ -40925,10 +40255,10 @@ module hipfort_rocblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batch_count
-      real(c_double),target :: results
+      type(c_ptr) :: results
       !
       rocblas_dasum_strided_batched_rank_0 = rocblas_dasum_strided_batched_(handle,n,c_loc(x), &
-        incx,stridex,batch_count,c_loc(results))
+        incx,stridex,batch_count,results)
     end function
 
     function rocblas_dasum_strided_batched_rank_1(handle,n,x,incx,stridex,batch_count,results)
@@ -40942,10 +40272,10 @@ module hipfort_rocblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batch_count
-      real(c_double),target,dimension(:) :: results
+      type(c_ptr) :: results
       !
       rocblas_dasum_strided_batched_rank_1 = rocblas_dasum_strided_batched_(handle,n,c_loc(x), &
-        incx,stridex,batch_count,c_loc(results))
+        incx,stridex,batch_count,results)
     end function
 
     function rocblas_scasum_strided_batched_rank_0(handle,n,x,incx,stridex,batch_count,results)
@@ -40959,10 +40289,10 @@ module hipfort_rocblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batch_count
-      real(c_float),target :: results
+      type(c_ptr) :: results
       !
       rocblas_scasum_strided_batched_rank_0 = rocblas_scasum_strided_batched_(handle,n,c_loc(x), &
-        incx,stridex,batch_count,c_loc(results))
+        incx,stridex,batch_count,results)
     end function
 
     function rocblas_scasum_strided_batched_rank_1(handle,n,x,incx,stridex,batch_count,results)
@@ -40976,10 +40306,10 @@ module hipfort_rocblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batch_count
-      real(c_float),target,dimension(:) :: results
+      type(c_ptr) :: results
       !
       rocblas_scasum_strided_batched_rank_1 = rocblas_scasum_strided_batched_(handle,n,c_loc(x), &
-        incx,stridex,batch_count,c_loc(results))
+        incx,stridex,batch_count,results)
     end function
 
     function rocblas_dzasum_strided_batched_rank_0(handle,n,x,incx,stridex,batch_count,results)
@@ -40993,10 +40323,10 @@ module hipfort_rocblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batch_count
-      real(c_double),target :: results
+      type(c_ptr) :: results
       !
       rocblas_dzasum_strided_batched_rank_0 = rocblas_dzasum_strided_batched_(handle,n,c_loc(x), &
-        incx,stridex,batch_count,c_loc(results))
+        incx,stridex,batch_count,results)
     end function
 
     function rocblas_dzasum_strided_batched_rank_1(handle,n,x,incx,stridex,batch_count,results)
@@ -41010,10 +40340,10 @@ module hipfort_rocblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batch_count
-      real(c_double),target,dimension(:) :: results
+      type(c_ptr) :: results
       !
       rocblas_dzasum_strided_batched_rank_1 = rocblas_dzasum_strided_batched_(handle,n,c_loc(x), &
-        incx,stridex,batch_count,c_loc(results))
+        incx,stridex,batch_count,results)
     end function
 
     function rocblas_scnrm2_rank_0(handle,n,x,incx,myResult)
@@ -41025,9 +40355,9 @@ module hipfort_rocblas
       integer(c_int) :: n
       complex(c_float_complex),target :: x
       integer(c_int) :: incx
-      real(c_float),target :: myResult
+      type(c_ptr) :: myResult
       !
-      rocblas_scnrm2_rank_0 = rocblas_scnrm2_(handle,n,c_loc(x),incx,c_loc(myResult))
+      rocblas_scnrm2_rank_0 = rocblas_scnrm2_(handle,n,c_loc(x),incx,myResult)
     end function
 
     function rocblas_scnrm2_rank_1(handle,n,x,incx,myResult)
@@ -41039,9 +40369,9 @@ module hipfort_rocblas
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
-      real(c_float),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
-      rocblas_scnrm2_rank_1 = rocblas_scnrm2_(handle,n,c_loc(x),incx,c_loc(myResult))
+      rocblas_scnrm2_rank_1 = rocblas_scnrm2_(handle,n,c_loc(x),incx,myResult)
     end function
 
     function rocblas_dznrm2_rank_0(handle,n,x,incx,myResult)
@@ -41053,9 +40383,9 @@ module hipfort_rocblas
       integer(c_int) :: n
       complex(c_double_complex),target :: x
       integer(c_int) :: incx
-      real(c_double),target :: myResult
+      type(c_ptr) :: myResult
       !
-      rocblas_dznrm2_rank_0 = rocblas_dznrm2_(handle,n,c_loc(x),incx,c_loc(myResult))
+      rocblas_dznrm2_rank_0 = rocblas_dznrm2_(handle,n,c_loc(x),incx,myResult)
     end function
 
     function rocblas_dznrm2_rank_1(handle,n,x,incx,myResult)
@@ -41067,201 +40397,9 @@ module hipfort_rocblas
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
-      real(c_double),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
-      rocblas_dznrm2_rank_1 = rocblas_dznrm2_(handle,n,c_loc(x),incx,c_loc(myResult))
-    end function
-
-    function rocblas_snrm2_batched_rank_0(handle,n,x,incx,batch_count,results)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_snrm2_batched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batch_count
-      real(c_float),target :: results
-      !
-      rocblas_snrm2_batched_rank_0 = rocblas_snrm2_batched_(handle,n,x,incx,batch_count, &
-        c_loc(results))
-    end function
-
-    function rocblas_snrm2_batched_rank_1(handle,n,x,incx,batch_count,results)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_snrm2_batched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batch_count
-      real(c_float),target,dimension(:) :: results
-      !
-      rocblas_snrm2_batched_rank_1 = rocblas_snrm2_batched_(handle,n,x,incx,batch_count, &
-        c_loc(results))
-    end function
-
-    function rocblas_snrm2_batched_full_rank(handle,n,x,incx,batch_count,results)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_snrm2_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batch_count
-      real(c_float),target,dimension(:,:) :: results
-      !
-      rocblas_snrm2_batched_full_rank = rocblas_snrm2_batched_(handle,n,x,incx,batch_count, &
-        c_loc(results))
-    end function
-
-    function rocblas_dnrm2_batched_rank_0(handle,n,x,incx,batch_count,results)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_dnrm2_batched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batch_count
-      real(c_double),target :: results
-      !
-      rocblas_dnrm2_batched_rank_0 = rocblas_dnrm2_batched_(handle,n,x,incx,batch_count, &
-        c_loc(results))
-    end function
-
-    function rocblas_dnrm2_batched_rank_1(handle,n,x,incx,batch_count,results)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_dnrm2_batched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batch_count
-      real(c_double),target,dimension(:) :: results
-      !
-      rocblas_dnrm2_batched_rank_1 = rocblas_dnrm2_batched_(handle,n,x,incx,batch_count, &
-        c_loc(results))
-    end function
-
-    function rocblas_dnrm2_batched_full_rank(handle,n,x,incx,batch_count,results)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_dnrm2_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batch_count
-      real(c_double),target,dimension(:,:) :: results
-      !
-      rocblas_dnrm2_batched_full_rank = rocblas_dnrm2_batched_(handle,n,x,incx,batch_count, &
-        c_loc(results))
-    end function
-
-    function rocblas_scnrm2_batched_rank_0(handle,n,x,incx,batch_count,results)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_scnrm2_batched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batch_count
-      real(c_float),target :: results
-      !
-      rocblas_scnrm2_batched_rank_0 = rocblas_scnrm2_batched_(handle,n,x,incx,batch_count, &
-        c_loc(results))
-    end function
-
-    function rocblas_scnrm2_batched_rank_1(handle,n,x,incx,batch_count,results)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_scnrm2_batched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batch_count
-      real(c_float),target,dimension(:) :: results
-      !
-      rocblas_scnrm2_batched_rank_1 = rocblas_scnrm2_batched_(handle,n,x,incx,batch_count, &
-        c_loc(results))
-    end function
-
-    function rocblas_scnrm2_batched_full_rank(handle,n,x,incx,batch_count,results)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_scnrm2_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batch_count
-      real(c_float),target,dimension(:,:) :: results
-      !
-      rocblas_scnrm2_batched_full_rank = rocblas_scnrm2_batched_(handle,n,x,incx,batch_count, &
-        c_loc(results))
-    end function
-
-    function rocblas_dznrm2_batched_rank_0(handle,n,x,incx,batch_count,results)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_dznrm2_batched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batch_count
-      real(c_double),target :: results
-      !
-      rocblas_dznrm2_batched_rank_0 = rocblas_dznrm2_batched_(handle,n,x,incx,batch_count, &
-        c_loc(results))
-    end function
-
-    function rocblas_dznrm2_batched_rank_1(handle,n,x,incx,batch_count,results)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_dznrm2_batched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batch_count
-      real(c_double),target,dimension(:) :: results
-      !
-      rocblas_dznrm2_batched_rank_1 = rocblas_dznrm2_batched_(handle,n,x,incx,batch_count, &
-        c_loc(results))
-    end function
-
-    function rocblas_dznrm2_batched_full_rank(handle,n,x,incx,batch_count,results)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_dznrm2_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batch_count
-      real(c_double),target,dimension(:,:) :: results
-      !
-      rocblas_dznrm2_batched_full_rank = rocblas_dznrm2_batched_(handle,n,x,incx,batch_count, &
-        c_loc(results))
+      rocblas_dznrm2_rank_1 = rocblas_dznrm2_(handle,n,c_loc(x),incx,myResult)
     end function
 
     function rocblas_snrm2_strided_batched_rank_0(handle,n,x,incx,stridex,batch_count,results)
@@ -41275,10 +40413,10 @@ module hipfort_rocblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batch_count
-      real(c_float),target :: results
+      type(c_ptr) :: results
       !
       rocblas_snrm2_strided_batched_rank_0 = rocblas_snrm2_strided_batched_(handle,n,c_loc(x), &
-        incx,stridex,batch_count,c_loc(results))
+        incx,stridex,batch_count,results)
     end function
 
     function rocblas_snrm2_strided_batched_rank_1(handle,n,x,incx,stridex,batch_count,results)
@@ -41292,10 +40430,10 @@ module hipfort_rocblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batch_count
-      real(c_float),target,dimension(:) :: results
+      type(c_ptr) :: results
       !
       rocblas_snrm2_strided_batched_rank_1 = rocblas_snrm2_strided_batched_(handle,n,c_loc(x), &
-        incx,stridex,batch_count,c_loc(results))
+        incx,stridex,batch_count,results)
     end function
 
     function rocblas_dnrm2_strided_batched_rank_0(handle,n,x,incx,stridex,batch_count,results)
@@ -41309,10 +40447,10 @@ module hipfort_rocblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batch_count
-      real(c_double),target :: results
+      type(c_ptr) :: results
       !
       rocblas_dnrm2_strided_batched_rank_0 = rocblas_dnrm2_strided_batched_(handle,n,c_loc(x), &
-        incx,stridex,batch_count,c_loc(results))
+        incx,stridex,batch_count,results)
     end function
 
     function rocblas_dnrm2_strided_batched_rank_1(handle,n,x,incx,stridex,batch_count,results)
@@ -41326,10 +40464,10 @@ module hipfort_rocblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batch_count
-      real(c_double),target,dimension(:) :: results
+      type(c_ptr) :: results
       !
       rocblas_dnrm2_strided_batched_rank_1 = rocblas_dnrm2_strided_batched_(handle,n,c_loc(x), &
-        incx,stridex,batch_count,c_loc(results))
+        incx,stridex,batch_count,results)
     end function
 
     function rocblas_scnrm2_strided_batched_rank_0(handle,n,x,incx,stridex,batch_count,results)
@@ -41343,10 +40481,10 @@ module hipfort_rocblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batch_count
-      real(c_float),target :: results
+      type(c_ptr) :: results
       !
       rocblas_scnrm2_strided_batched_rank_0 = rocblas_scnrm2_strided_batched_(handle,n,c_loc(x), &
-        incx,stridex,batch_count,c_loc(results))
+        incx,stridex,batch_count,results)
     end function
 
     function rocblas_scnrm2_strided_batched_rank_1(handle,n,x,incx,stridex,batch_count,results)
@@ -41360,10 +40498,10 @@ module hipfort_rocblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batch_count
-      real(c_float),target,dimension(:) :: results
+      type(c_ptr) :: results
       !
       rocblas_scnrm2_strided_batched_rank_1 = rocblas_scnrm2_strided_batched_(handle,n,c_loc(x), &
-        incx,stridex,batch_count,c_loc(results))
+        incx,stridex,batch_count,results)
     end function
 
     function rocblas_dznrm2_strided_batched_rank_0(handle,n,x,incx,stridex,batch_count,results)
@@ -41377,10 +40515,10 @@ module hipfort_rocblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batch_count
-      real(c_double),target :: results
+      type(c_ptr) :: results
       !
       rocblas_dznrm2_strided_batched_rank_0 = rocblas_dznrm2_strided_batched_(handle,n,c_loc(x), &
-        incx,stridex,batch_count,c_loc(results))
+        incx,stridex,batch_count,results)
     end function
 
     function rocblas_dznrm2_strided_batched_rank_1(handle,n,x,incx,stridex,batch_count,results)
@@ -41394,10 +40532,10 @@ module hipfort_rocblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batch_count
-      real(c_double),target,dimension(:) :: results
+      type(c_ptr) :: results
       !
       rocblas_dznrm2_strided_batched_rank_1 = rocblas_dznrm2_strided_batched_(handle,n,c_loc(x), &
-        incx,stridex,batch_count,c_loc(results))
+        incx,stridex,batch_count,results)
     end function
 
     function rocblas_icamax_rank_0(handle,n,x,incx,myResult)
@@ -41409,9 +40547,9 @@ module hipfort_rocblas
       integer(c_int) :: n
       complex(c_float_complex),target :: x
       integer(c_int) :: incx
-      integer(c_int),target :: myResult
+      type(c_ptr) :: myResult
       !
-      rocblas_icamax_rank_0 = rocblas_icamax_(handle,n,c_loc(x),incx,c_loc(myResult))
+      rocblas_icamax_rank_0 = rocblas_icamax_(handle,n,c_loc(x),incx,myResult)
     end function
 
     function rocblas_icamax_rank_1(handle,n,x,incx,myResult)
@@ -41423,9 +40561,9 @@ module hipfort_rocblas
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
-      integer(c_int),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
-      rocblas_icamax_rank_1 = rocblas_icamax_(handle,n,c_loc(x),incx,c_loc(myResult))
+      rocblas_icamax_rank_1 = rocblas_icamax_(handle,n,c_loc(x),incx,myResult)
     end function
 
     function rocblas_izamax_rank_0(handle,n,x,incx,myResult)
@@ -41437,9 +40575,9 @@ module hipfort_rocblas
       integer(c_int) :: n
       complex(c_double_complex),target :: x
       integer(c_int) :: incx
-      integer(c_int),target :: myResult
+      type(c_ptr) :: myResult
       !
-      rocblas_izamax_rank_0 = rocblas_izamax_(handle,n,c_loc(x),incx,c_loc(myResult))
+      rocblas_izamax_rank_0 = rocblas_izamax_(handle,n,c_loc(x),incx,myResult)
     end function
 
     function rocblas_izamax_rank_1(handle,n,x,incx,myResult)
@@ -41451,201 +40589,9 @@ module hipfort_rocblas
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
-      integer(c_int),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
-      rocblas_izamax_rank_1 = rocblas_izamax_(handle,n,c_loc(x),incx,c_loc(myResult))
-    end function
-
-    function rocblas_isamax_batched_rank_0(handle,n,x,incx,batch_count,myResult)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_isamax_batched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batch_count
-      integer(c_int),target :: myResult
-      !
-      rocblas_isamax_batched_rank_0 = rocblas_isamax_batched_(handle,n,x,incx,batch_count, &
-        c_loc(myResult))
-    end function
-
-    function rocblas_isamax_batched_rank_1(handle,n,x,incx,batch_count,myResult)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_isamax_batched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batch_count
-      integer(c_int),target,dimension(:) :: myResult
-      !
-      rocblas_isamax_batched_rank_1 = rocblas_isamax_batched_(handle,n,x,incx,batch_count, &
-        c_loc(myResult))
-    end function
-
-    function rocblas_isamax_batched_full_rank(handle,n,x,incx,batch_count,myResult)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_isamax_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batch_count
-      integer(c_int),target,dimension(:,:) :: myResult
-      !
-      rocblas_isamax_batched_full_rank = rocblas_isamax_batched_(handle,n,x,incx,batch_count, &
-        c_loc(myResult))
-    end function
-
-    function rocblas_idamax_batched_rank_0(handle,n,x,incx,batch_count,myResult)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_idamax_batched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batch_count
-      integer(c_int),target :: myResult
-      !
-      rocblas_idamax_batched_rank_0 = rocblas_idamax_batched_(handle,n,x,incx,batch_count, &
-        c_loc(myResult))
-    end function
-
-    function rocblas_idamax_batched_rank_1(handle,n,x,incx,batch_count,myResult)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_idamax_batched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batch_count
-      integer(c_int),target,dimension(:) :: myResult
-      !
-      rocblas_idamax_batched_rank_1 = rocblas_idamax_batched_(handle,n,x,incx,batch_count, &
-        c_loc(myResult))
-    end function
-
-    function rocblas_idamax_batched_full_rank(handle,n,x,incx,batch_count,myResult)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_idamax_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batch_count
-      integer(c_int),target,dimension(:,:) :: myResult
-      !
-      rocblas_idamax_batched_full_rank = rocblas_idamax_batched_(handle,n,x,incx,batch_count, &
-        c_loc(myResult))
-    end function
-
-    function rocblas_icamax_batched_rank_0(handle,n,x,incx,batch_count,myResult)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_icamax_batched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batch_count
-      integer(c_int),target :: myResult
-      !
-      rocblas_icamax_batched_rank_0 = rocblas_icamax_batched_(handle,n,x,incx,batch_count, &
-        c_loc(myResult))
-    end function
-
-    function rocblas_icamax_batched_rank_1(handle,n,x,incx,batch_count,myResult)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_icamax_batched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batch_count
-      integer(c_int),target,dimension(:) :: myResult
-      !
-      rocblas_icamax_batched_rank_1 = rocblas_icamax_batched_(handle,n,x,incx,batch_count, &
-        c_loc(myResult))
-    end function
-
-    function rocblas_icamax_batched_full_rank(handle,n,x,incx,batch_count,myResult)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_icamax_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batch_count
-      integer(c_int),target,dimension(:,:) :: myResult
-      !
-      rocblas_icamax_batched_full_rank = rocblas_icamax_batched_(handle,n,x,incx,batch_count, &
-        c_loc(myResult))
-    end function
-
-    function rocblas_izamax_batched_rank_0(handle,n,x,incx,batch_count,myResult)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_izamax_batched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batch_count
-      integer(c_int),target :: myResult
-      !
-      rocblas_izamax_batched_rank_0 = rocblas_izamax_batched_(handle,n,x,incx,batch_count, &
-        c_loc(myResult))
-    end function
-
-    function rocblas_izamax_batched_rank_1(handle,n,x,incx,batch_count,myResult)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_izamax_batched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batch_count
-      integer(c_int),target,dimension(:) :: myResult
-      !
-      rocblas_izamax_batched_rank_1 = rocblas_izamax_batched_(handle,n,x,incx,batch_count, &
-        c_loc(myResult))
-    end function
-
-    function rocblas_izamax_batched_full_rank(handle,n,x,incx,batch_count,myResult)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_izamax_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batch_count
-      integer(c_int),target,dimension(:,:) :: myResult
-      !
-      rocblas_izamax_batched_full_rank = rocblas_izamax_batched_(handle,n,x,incx,batch_count, &
-        c_loc(myResult))
+      rocblas_izamax_rank_1 = rocblas_izamax_(handle,n,c_loc(x),incx,myResult)
     end function
 
     function rocblas_isamax_strided_batched_rank_0(handle,n,x,incx,stridex,batch_count,myResult)
@@ -41659,10 +40605,10 @@ module hipfort_rocblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batch_count
-      integer(c_int),target :: myResult
+      type(c_ptr) :: myResult
       !
       rocblas_isamax_strided_batched_rank_0 = rocblas_isamax_strided_batched_(handle,n,c_loc(x), &
-        incx,stridex,batch_count,c_loc(myResult))
+        incx,stridex,batch_count,myResult)
     end function
 
     function rocblas_isamax_strided_batched_rank_1(handle,n,x,incx,stridex,batch_count,myResult)
@@ -41676,10 +40622,10 @@ module hipfort_rocblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batch_count
-      integer(c_int),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
       rocblas_isamax_strided_batched_rank_1 = rocblas_isamax_strided_batched_(handle,n,c_loc(x), &
-        incx,stridex,batch_count,c_loc(myResult))
+        incx,stridex,batch_count,myResult)
     end function
 
     function rocblas_idamax_strided_batched_rank_0(handle,n,x,incx,stridex,batch_count,myResult)
@@ -41693,10 +40639,10 @@ module hipfort_rocblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batch_count
-      integer(c_int),target :: myResult
+      type(c_ptr) :: myResult
       !
       rocblas_idamax_strided_batched_rank_0 = rocblas_idamax_strided_batched_(handle,n,c_loc(x), &
-        incx,stridex,batch_count,c_loc(myResult))
+        incx,stridex,batch_count,myResult)
     end function
 
     function rocblas_idamax_strided_batched_rank_1(handle,n,x,incx,stridex,batch_count,myResult)
@@ -41710,10 +40656,10 @@ module hipfort_rocblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batch_count
-      integer(c_int),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
       rocblas_idamax_strided_batched_rank_1 = rocblas_idamax_strided_batched_(handle,n,c_loc(x), &
-        incx,stridex,batch_count,c_loc(myResult))
+        incx,stridex,batch_count,myResult)
     end function
 
     function rocblas_icamax_strided_batched_rank_0(handle,n,x,incx,stridex,batch_count,myResult)
@@ -41727,10 +40673,10 @@ module hipfort_rocblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batch_count
-      integer(c_int),target :: myResult
+      type(c_ptr) :: myResult
       !
       rocblas_icamax_strided_batched_rank_0 = rocblas_icamax_strided_batched_(handle,n,c_loc(x), &
-        incx,stridex,batch_count,c_loc(myResult))
+        incx,stridex,batch_count,myResult)
     end function
 
     function rocblas_icamax_strided_batched_rank_1(handle,n,x,incx,stridex,batch_count,myResult)
@@ -41744,10 +40690,10 @@ module hipfort_rocblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batch_count
-      integer(c_int),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
       rocblas_icamax_strided_batched_rank_1 = rocblas_icamax_strided_batched_(handle,n,c_loc(x), &
-        incx,stridex,batch_count,c_loc(myResult))
+        incx,stridex,batch_count,myResult)
     end function
 
     function rocblas_izamax_strided_batched_rank_0(handle,n,x,incx,stridex,batch_count,myResult)
@@ -41761,10 +40707,10 @@ module hipfort_rocblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batch_count
-      integer(c_int),target :: myResult
+      type(c_ptr) :: myResult
       !
       rocblas_izamax_strided_batched_rank_0 = rocblas_izamax_strided_batched_(handle,n,c_loc(x), &
-        incx,stridex,batch_count,c_loc(myResult))
+        incx,stridex,batch_count,myResult)
     end function
 
     function rocblas_izamax_strided_batched_rank_1(handle,n,x,incx,stridex,batch_count,myResult)
@@ -41778,10 +40724,10 @@ module hipfort_rocblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batch_count
-      integer(c_int),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
       rocblas_izamax_strided_batched_rank_1 = rocblas_izamax_strided_batched_(handle,n,c_loc(x), &
-        incx,stridex,batch_count,c_loc(myResult))
+        incx,stridex,batch_count,myResult)
     end function
 
     function rocblas_icamin_rank_0(handle,n,x,incx,myResult)
@@ -41793,9 +40739,9 @@ module hipfort_rocblas
       integer(c_int) :: n
       complex(c_float_complex),target :: x
       integer(c_int) :: incx
-      integer(c_int),target :: myResult
+      type(c_ptr) :: myResult
       !
-      rocblas_icamin_rank_0 = rocblas_icamin_(handle,n,c_loc(x),incx,c_loc(myResult))
+      rocblas_icamin_rank_0 = rocblas_icamin_(handle,n,c_loc(x),incx,myResult)
     end function
 
     function rocblas_icamin_rank_1(handle,n,x,incx,myResult)
@@ -41807,9 +40753,9 @@ module hipfort_rocblas
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
-      integer(c_int),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
-      rocblas_icamin_rank_1 = rocblas_icamin_(handle,n,c_loc(x),incx,c_loc(myResult))
+      rocblas_icamin_rank_1 = rocblas_icamin_(handle,n,c_loc(x),incx,myResult)
     end function
 
     function rocblas_izamin_rank_0(handle,n,x,incx,myResult)
@@ -41821,9 +40767,9 @@ module hipfort_rocblas
       integer(c_int) :: n
       complex(c_double_complex),target :: x
       integer(c_int) :: incx
-      integer(c_int),target :: myResult
+      type(c_ptr) :: myResult
       !
-      rocblas_izamin_rank_0 = rocblas_izamin_(handle,n,c_loc(x),incx,c_loc(myResult))
+      rocblas_izamin_rank_0 = rocblas_izamin_(handle,n,c_loc(x),incx,myResult)
     end function
 
     function rocblas_izamin_rank_1(handle,n,x,incx,myResult)
@@ -41835,201 +40781,9 @@ module hipfort_rocblas
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
-      integer(c_int),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
-      rocblas_izamin_rank_1 = rocblas_izamin_(handle,n,c_loc(x),incx,c_loc(myResult))
-    end function
-
-    function rocblas_isamin_batched_rank_0(handle,n,x,incx,batch_count,myResult)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_isamin_batched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batch_count
-      integer(c_int),target :: myResult
-      !
-      rocblas_isamin_batched_rank_0 = rocblas_isamin_batched_(handle,n,x,incx,batch_count, &
-        c_loc(myResult))
-    end function
-
-    function rocblas_isamin_batched_rank_1(handle,n,x,incx,batch_count,myResult)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_isamin_batched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batch_count
-      integer(c_int),target,dimension(:) :: myResult
-      !
-      rocblas_isamin_batched_rank_1 = rocblas_isamin_batched_(handle,n,x,incx,batch_count, &
-        c_loc(myResult))
-    end function
-
-    function rocblas_isamin_batched_full_rank(handle,n,x,incx,batch_count,myResult)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_isamin_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batch_count
-      integer(c_int),target,dimension(:,:) :: myResult
-      !
-      rocblas_isamin_batched_full_rank = rocblas_isamin_batched_(handle,n,x,incx,batch_count, &
-        c_loc(myResult))
-    end function
-
-    function rocblas_idamin_batched_rank_0(handle,n,x,incx,batch_count,myResult)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_idamin_batched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batch_count
-      integer(c_int),target :: myResult
-      !
-      rocblas_idamin_batched_rank_0 = rocblas_idamin_batched_(handle,n,x,incx,batch_count, &
-        c_loc(myResult))
-    end function
-
-    function rocblas_idamin_batched_rank_1(handle,n,x,incx,batch_count,myResult)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_idamin_batched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batch_count
-      integer(c_int),target,dimension(:) :: myResult
-      !
-      rocblas_idamin_batched_rank_1 = rocblas_idamin_batched_(handle,n,x,incx,batch_count, &
-        c_loc(myResult))
-    end function
-
-    function rocblas_idamin_batched_full_rank(handle,n,x,incx,batch_count,myResult)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_idamin_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batch_count
-      integer(c_int),target,dimension(:,:) :: myResult
-      !
-      rocblas_idamin_batched_full_rank = rocblas_idamin_batched_(handle,n,x,incx,batch_count, &
-        c_loc(myResult))
-    end function
-
-    function rocblas_icamin_batched_rank_0(handle,n,x,incx,batch_count,myResult)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_icamin_batched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batch_count
-      integer(c_int),target :: myResult
-      !
-      rocblas_icamin_batched_rank_0 = rocblas_icamin_batched_(handle,n,x,incx,batch_count, &
-        c_loc(myResult))
-    end function
-
-    function rocblas_icamin_batched_rank_1(handle,n,x,incx,batch_count,myResult)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_icamin_batched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batch_count
-      integer(c_int),target,dimension(:) :: myResult
-      !
-      rocblas_icamin_batched_rank_1 = rocblas_icamin_batched_(handle,n,x,incx,batch_count, &
-        c_loc(myResult))
-    end function
-
-    function rocblas_icamin_batched_full_rank(handle,n,x,incx,batch_count,myResult)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_icamin_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batch_count
-      integer(c_int),target,dimension(:,:) :: myResult
-      !
-      rocblas_icamin_batched_full_rank = rocblas_icamin_batched_(handle,n,x,incx,batch_count, &
-        c_loc(myResult))
-    end function
-
-    function rocblas_izamin_batched_rank_0(handle,n,x,incx,batch_count,myResult)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_izamin_batched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batch_count
-      integer(c_int),target :: myResult
-      !
-      rocblas_izamin_batched_rank_0 = rocblas_izamin_batched_(handle,n,x,incx,batch_count, &
-        c_loc(myResult))
-    end function
-
-    function rocblas_izamin_batched_rank_1(handle,n,x,incx,batch_count,myResult)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_izamin_batched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batch_count
-      integer(c_int),target,dimension(:) :: myResult
-      !
-      rocblas_izamin_batched_rank_1 = rocblas_izamin_batched_(handle,n,x,incx,batch_count, &
-        c_loc(myResult))
-    end function
-
-    function rocblas_izamin_batched_full_rank(handle,n,x,incx,batch_count,myResult)
-      use iso_c_binding
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocblas_izamin_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: x
-      integer(c_int) :: incx
-      integer(c_int) :: batch_count
-      integer(c_int),target,dimension(:,:) :: myResult
-      !
-      rocblas_izamin_batched_full_rank = rocblas_izamin_batched_(handle,n,x,incx,batch_count, &
-        c_loc(myResult))
+      rocblas_izamin_rank_1 = rocblas_izamin_(handle,n,c_loc(x),incx,myResult)
     end function
 
     function rocblas_isamin_strided_batched_rank_0(handle,n,x,incx,stridex,batch_count,myResult)
@@ -42043,10 +40797,10 @@ module hipfort_rocblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batch_count
-      integer(c_int),target :: myResult
+      type(c_ptr) :: myResult
       !
       rocblas_isamin_strided_batched_rank_0 = rocblas_isamin_strided_batched_(handle,n,c_loc(x), &
-        incx,stridex,batch_count,c_loc(myResult))
+        incx,stridex,batch_count,myResult)
     end function
 
     function rocblas_isamin_strided_batched_rank_1(handle,n,x,incx,stridex,batch_count,myResult)
@@ -42060,10 +40814,10 @@ module hipfort_rocblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batch_count
-      integer(c_int),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
       rocblas_isamin_strided_batched_rank_1 = rocblas_isamin_strided_batched_(handle,n,c_loc(x), &
-        incx,stridex,batch_count,c_loc(myResult))
+        incx,stridex,batch_count,myResult)
     end function
 
     function rocblas_idamin_strided_batched_rank_0(handle,n,x,incx,stridex,batch_count,myResult)
@@ -42077,10 +40831,10 @@ module hipfort_rocblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batch_count
-      integer(c_int),target :: myResult
+      type(c_ptr) :: myResult
       !
       rocblas_idamin_strided_batched_rank_0 = rocblas_idamin_strided_batched_(handle,n,c_loc(x), &
-        incx,stridex,batch_count,c_loc(myResult))
+        incx,stridex,batch_count,myResult)
     end function
 
     function rocblas_idamin_strided_batched_rank_1(handle,n,x,incx,stridex,batch_count,myResult)
@@ -42094,10 +40848,10 @@ module hipfort_rocblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batch_count
-      integer(c_int),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
       rocblas_idamin_strided_batched_rank_1 = rocblas_idamin_strided_batched_(handle,n,c_loc(x), &
-        incx,stridex,batch_count,c_loc(myResult))
+        incx,stridex,batch_count,myResult)
     end function
 
     function rocblas_icamin_strided_batched_rank_0(handle,n,x,incx,stridex,batch_count,myResult)
@@ -42111,10 +40865,10 @@ module hipfort_rocblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batch_count
-      integer(c_int),target :: myResult
+      type(c_ptr) :: myResult
       !
       rocblas_icamin_strided_batched_rank_0 = rocblas_icamin_strided_batched_(handle,n,c_loc(x), &
-        incx,stridex,batch_count,c_loc(myResult))
+        incx,stridex,batch_count,myResult)
     end function
 
     function rocblas_icamin_strided_batched_rank_1(handle,n,x,incx,stridex,batch_count,myResult)
@@ -42128,10 +40882,10 @@ module hipfort_rocblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batch_count
-      integer(c_int),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
       rocblas_icamin_strided_batched_rank_1 = rocblas_icamin_strided_batched_(handle,n,c_loc(x), &
-        incx,stridex,batch_count,c_loc(myResult))
+        incx,stridex,batch_count,myResult)
     end function
 
     function rocblas_izamin_strided_batched_rank_0(handle,n,x,incx,stridex,batch_count,myResult)
@@ -42145,10 +40899,10 @@ module hipfort_rocblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batch_count
-      integer(c_int),target :: myResult
+      type(c_ptr) :: myResult
       !
       rocblas_izamin_strided_batched_rank_0 = rocblas_izamin_strided_batched_(handle,n,c_loc(x), &
-        incx,stridex,batch_count,c_loc(myResult))
+        incx,stridex,batch_count,myResult)
     end function
 
     function rocblas_izamin_strided_batched_rank_1(handle,n,x,incx,stridex,batch_count,myResult)
@@ -42162,10 +40916,10 @@ module hipfort_rocblas
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       integer(c_int) :: batch_count
-      integer(c_int),target,dimension(:) :: myResult
+      type(c_ptr) :: myResult
       !
       rocblas_izamin_strided_batched_rank_1 = rocblas_izamin_strided_batched_(handle,n,c_loc(x), &
-        incx,stridex,batch_count,c_loc(myResult))
+        incx,stridex,batch_count,myResult)
     end function
 
     function rocblas_srot_rank_0(handle,n,x,incx,y,incy,c,s)
@@ -42647,9 +41401,9 @@ module hipfort_rocblas
       integer(c_int) :: incx
       real(c_float),target :: y
       integer(c_int) :: incy
-      real(c_float),target :: param
+      type(c_ptr) :: param
       !
-      rocblas_srotm_rank_0 = rocblas_srotm_(handle,n,c_loc(x),incx,c_loc(y),incy,c_loc(param))
+      rocblas_srotm_rank_0 = rocblas_srotm_(handle,n,c_loc(x),incx,c_loc(y),incy,param)
     end function
 
     function rocblas_srotm_rank_1(handle,n,x,incx,y,incy,param)
@@ -42663,9 +41417,9 @@ module hipfort_rocblas
       integer(c_int) :: incx
       real(c_float),target,dimension(:) :: y
       integer(c_int) :: incy
-      real(c_float),target,dimension(:) :: param
+      type(c_ptr) :: param
       !
-      rocblas_srotm_rank_1 = rocblas_srotm_(handle,n,c_loc(x),incx,c_loc(y),incy,c_loc(param))
+      rocblas_srotm_rank_1 = rocblas_srotm_(handle,n,c_loc(x),incx,c_loc(y),incy,param)
     end function
 
     function rocblas_drotm_rank_0(handle,n,x,incx,y,incy,param)
@@ -42679,9 +41433,9 @@ module hipfort_rocblas
       integer(c_int) :: incx
       real(c_double),target :: y
       integer(c_int) :: incy
-      real(c_double),target :: param
+      type(c_ptr) :: param
       !
-      rocblas_drotm_rank_0 = rocblas_drotm_(handle,n,c_loc(x),incx,c_loc(y),incy,c_loc(param))
+      rocblas_drotm_rank_0 = rocblas_drotm_(handle,n,c_loc(x),incx,c_loc(y),incy,param)
     end function
 
     function rocblas_drotm_rank_1(handle,n,x,incx,y,incy,param)
@@ -42695,9 +41449,9 @@ module hipfort_rocblas
       integer(c_int) :: incx
       real(c_double),target,dimension(:) :: y
       integer(c_int) :: incy
-      real(c_double),target,dimension(:) :: param
+      type(c_ptr) :: param
       !
-      rocblas_drotm_rank_1 = rocblas_drotm_(handle,n,c_loc(x),incx,c_loc(y),incy,c_loc(param))
+      rocblas_drotm_rank_1 = rocblas_drotm_(handle,n,c_loc(x),incx,c_loc(y),incy,param)
     end function
 
     function rocblas_srotm_strided_batched_rank_0(handle,n,x,incx,stride_x,y,incy,stride_y,param, &
@@ -42714,12 +41468,12 @@ module hipfort_rocblas
       real(c_float),target :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stride_y
-      real(c_float),target :: param
+      type(c_ptr) :: param
       integer(c_int64_t) :: stride_param
       integer(c_int) :: batch_count
       !
       rocblas_srotm_strided_batched_rank_0 = rocblas_srotm_strided_batched_(handle,n,c_loc(x), &
-        incx,stride_x,c_loc(y),incy,stride_y,c_loc(param),stride_param,batch_count)
+        incx,stride_x,c_loc(y),incy,stride_y,param,stride_param,batch_count)
     end function
 
     function rocblas_srotm_strided_batched_rank_1(handle,n,x,incx,stride_x,y,incy,stride_y,param, &
@@ -42736,12 +41490,12 @@ module hipfort_rocblas
       real(c_float),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stride_y
-      real(c_float),target,dimension(:) :: param
+      type(c_ptr) :: param
       integer(c_int64_t) :: stride_param
       integer(c_int) :: batch_count
       !
       rocblas_srotm_strided_batched_rank_1 = rocblas_srotm_strided_batched_(handle,n,c_loc(x), &
-        incx,stride_x,c_loc(y),incy,stride_y,c_loc(param),stride_param,batch_count)
+        incx,stride_x,c_loc(y),incy,stride_y,param,stride_param,batch_count)
     end function
 
     function rocblas_drotm_strided_batched_rank_0(handle,n,x,incx,stride_x,y,incy,stride_y,param, &
@@ -42758,12 +41512,12 @@ module hipfort_rocblas
       real(c_double),target :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stride_y
-      real(c_double),target :: param
+      type(c_ptr) :: param
       integer(c_int64_t) :: stride_param
       integer(c_int) :: batch_count
       !
       rocblas_drotm_strided_batched_rank_0 = rocblas_drotm_strided_batched_(handle,n,c_loc(x), &
-        incx,stride_x,c_loc(y),incy,stride_y,c_loc(param),stride_param,batch_count)
+        incx,stride_x,c_loc(y),incy,stride_y,param,stride_param,batch_count)
     end function
 
     function rocblas_drotm_strided_batched_rank_1(handle,n,x,incx,stride_x,y,incy,stride_y,param, &
@@ -42780,12 +41534,12 @@ module hipfort_rocblas
       real(c_double),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stride_y
-      real(c_double),target,dimension(:) :: param
+      type(c_ptr) :: param
       integer(c_int64_t) :: stride_param
       integer(c_int) :: batch_count
       !
       rocblas_drotm_strided_batched_rank_1 = rocblas_drotm_strided_batched_(handle,n,c_loc(x), &
-        incx,stride_x,c_loc(y),incy,stride_y,c_loc(param),stride_param,batch_count)
+        incx,stride_x,c_loc(y),incy,stride_y,param,stride_param,batch_count)
     end function
 
     function rocblas_sgbmv_rank_0(handle,trans,m,n,kl,ku,alpha,A,lda,x,incx,beta,y,incy)
@@ -42850,10 +41604,10 @@ module hipfort_rocblas
       real(c_float) :: alpha
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: x
+      real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       real(c_float) :: beta
-      real(c_float),target,dimension(:,:) :: y
+      real(c_float),target,dimension(:) :: y
       integer(c_int) :: incy
       !
       rocblas_sgbmv_full_rank = rocblas_sgbmv_(handle,trans,m,n,kl,ku,alpha,c_loc(A),lda,c_loc(x), &
@@ -42922,10 +41676,10 @@ module hipfort_rocblas
       real(c_double) :: alpha
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: x
+      real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       real(c_double) :: beta
-      real(c_double),target,dimension(:,:) :: y
+      real(c_double),target,dimension(:) :: y
       integer(c_int) :: incy
       !
       rocblas_dgbmv_full_rank = rocblas_dgbmv_(handle,trans,m,n,kl,ku,alpha,c_loc(A),lda,c_loc(x), &
@@ -42994,10 +41748,10 @@ module hipfort_rocblas
       complex(c_float_complex) :: alpha
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       complex(c_float_complex) :: beta
-      complex(c_float_complex),target,dimension(:,:) :: y
+      complex(c_float_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       !
       rocblas_cgbmv_full_rank = rocblas_cgbmv_(handle,trans,m,n,kl,ku,alpha,c_loc(A),lda,c_loc(x), &
@@ -43066,10 +41820,10 @@ module hipfort_rocblas
       complex(c_double_complex) :: alpha
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       complex(c_double_complex) :: beta
-      complex(c_double_complex),target,dimension(:,:) :: y
+      complex(c_double_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       !
       rocblas_zgbmv_full_rank = rocblas_zgbmv_(handle,trans,m,n,kl,ku,alpha,c_loc(A),lda,c_loc(x), &
@@ -43152,11 +41906,11 @@ module hipfort_rocblas
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: stride_A
-      real(c_float),target,dimension(:,:) :: x
+      real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stride_x
       real(c_float) :: beta
-      real(c_float),target,dimension(:,:) :: y
+      real(c_float),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stride_y
       integer(c_int) :: batch_count
@@ -43242,11 +41996,11 @@ module hipfort_rocblas
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: stride_A
-      real(c_double),target,dimension(:,:) :: x
+      real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stride_x
       real(c_double) :: beta
-      real(c_double),target,dimension(:,:) :: y
+      real(c_double),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stride_y
       integer(c_int) :: batch_count
@@ -43332,11 +42086,11 @@ module hipfort_rocblas
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: stride_A
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stride_x
       complex(c_float_complex) :: beta
-      complex(c_float_complex),target,dimension(:,:) :: y
+      complex(c_float_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stride_y
       integer(c_int) :: batch_count
@@ -43422,11 +42176,11 @@ module hipfort_rocblas
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: stride_A
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stride_x
       complex(c_double_complex) :: beta
-      complex(c_double_complex),target,dimension(:,:) :: y
+      complex(c_double_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stride_y
       integer(c_int) :: batch_count
@@ -43492,10 +42246,10 @@ module hipfort_rocblas
       real(c_float) :: alpha
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: x
+      real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       real(c_float) :: beta
-      real(c_float),target,dimension(:,:) :: y
+      real(c_float),target,dimension(:) :: y
       integer(c_int) :: incy
       !
       rocblas_sgemv_full_rank = rocblas_sgemv_(handle,trans,m,n,alpha,c_loc(A),lda,c_loc(x),incx, &
@@ -43558,10 +42312,10 @@ module hipfort_rocblas
       real(c_double) :: alpha
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: x
+      real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       real(c_double) :: beta
-      real(c_double),target,dimension(:,:) :: y
+      real(c_double),target,dimension(:) :: y
       integer(c_int) :: incy
       !
       rocblas_dgemv_full_rank = rocblas_dgemv_(handle,trans,m,n,alpha,c_loc(A),lda,c_loc(x),incx, &
@@ -43624,10 +42378,10 @@ module hipfort_rocblas
       complex(c_float_complex) :: alpha
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       complex(c_float_complex) :: beta
-      complex(c_float_complex),target,dimension(:,:) :: y
+      complex(c_float_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       !
       rocblas_cgemv_full_rank = rocblas_cgemv_(handle,trans,m,n,alpha,c_loc(A),lda,c_loc(x),incx, &
@@ -43690,10 +42444,10 @@ module hipfort_rocblas
       complex(c_double_complex) :: alpha
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       complex(c_double_complex) :: beta
-      complex(c_double_complex),target,dimension(:,:) :: y
+      complex(c_double_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       !
       rocblas_zgemv_full_rank = rocblas_zgemv_(handle,trans,m,n,alpha,c_loc(A),lda,c_loc(x),incx, &
@@ -43768,11 +42522,11 @@ module hipfort_rocblas
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_float),target,dimension(:,:) :: x
+      real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       real(c_float) :: beta
-      real(c_float),target,dimension(:,:) :: y
+      real(c_float),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       integer(c_int) :: batch_count
@@ -43849,11 +42603,11 @@ module hipfort_rocblas
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_double),target,dimension(:,:) :: x
+      real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       real(c_double) :: beta
-      real(c_double),target,dimension(:,:) :: y
+      real(c_double),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       integer(c_int) :: batch_count
@@ -43930,11 +42684,11 @@ module hipfort_rocblas
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       complex(c_float_complex) :: beta
-      complex(c_float_complex),target,dimension(:,:) :: y
+      complex(c_float_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       integer(c_int) :: batch_count
@@ -44011,11 +42765,11 @@ module hipfort_rocblas
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       complex(c_double_complex) :: beta
-      complex(c_double_complex),target,dimension(:,:) :: y
+      complex(c_double_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       integer(c_int) :: batch_count
@@ -44080,10 +42834,10 @@ module hipfort_rocblas
       complex(c_float_complex) :: alpha
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       complex(c_float_complex) :: beta
-      complex(c_float_complex),target,dimension(:,:) :: y
+      complex(c_float_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       !
       rocblas_chbmv_full_rank = rocblas_chbmv_(handle,uplo,n,k,alpha,c_loc(A),lda,c_loc(x),incx, &
@@ -44146,10 +42900,10 @@ module hipfort_rocblas
       complex(c_double_complex) :: alpha
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       complex(c_double_complex) :: beta
-      complex(c_double_complex),target,dimension(:,:) :: y
+      complex(c_double_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       !
       rocblas_zhbmv_full_rank = rocblas_zhbmv_(handle,uplo,n,k,alpha,c_loc(A),lda,c_loc(x),incx, &
@@ -44224,11 +42978,11 @@ module hipfort_rocblas
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: stride_A
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stride_x
       complex(c_float_complex) :: beta
-      complex(c_float_complex),target,dimension(:,:) :: y
+      complex(c_float_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stride_y
       integer(c_int) :: batch_count
@@ -44305,11 +43059,11 @@ module hipfort_rocblas
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: stride_A
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stride_x
       complex(c_double_complex) :: beta
-      complex(c_double_complex),target,dimension(:,:) :: y
+      complex(c_double_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stride_y
       integer(c_int) :: batch_count
@@ -44371,10 +43125,10 @@ module hipfort_rocblas
       complex(c_float_complex) :: alpha
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       complex(c_float_complex) :: beta
-      complex(c_float_complex),target,dimension(:,:) :: y
+      complex(c_float_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       !
       rocblas_chemv_full_rank = rocblas_chemv_(handle,uplo,n,alpha,c_loc(A),lda,c_loc(x),incx, &
@@ -44434,10 +43188,10 @@ module hipfort_rocblas
       complex(c_double_complex) :: alpha
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       complex(c_double_complex) :: beta
-      complex(c_double_complex),target,dimension(:,:) :: y
+      complex(c_double_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       !
       rocblas_zhemv_full_rank = rocblas_zhemv_(handle,uplo,n,alpha,c_loc(A),lda,c_loc(x),incx, &
@@ -44509,11 +43263,11 @@ module hipfort_rocblas
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: stride_A
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stride_x
       complex(c_float_complex) :: beta
-      complex(c_float_complex),target,dimension(:,:) :: y
+      complex(c_float_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stride_y
       integer(c_int) :: batch_count
@@ -44587,11 +43341,11 @@ module hipfort_rocblas
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: stride_A
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stride_x
       complex(c_double_complex) :: beta
-      complex(c_double_complex),target,dimension(:,:) :: y
+      complex(c_double_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stride_y
       integer(c_int) :: batch_count
@@ -44643,7 +43397,7 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)) :: uplo
       integer(c_int) :: n
       real(c_float) :: alpha
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
@@ -44694,7 +43448,7 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)) :: uplo
       integer(c_int) :: n
       real(c_double) :: alpha
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
@@ -44756,7 +43510,7 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)) :: uplo
       integer(c_int) :: n
       real(c_float) :: alpha
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stride_x
       complex(c_float_complex),target,dimension(:,:) :: A
@@ -44822,7 +43576,7 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)) :: uplo
       integer(c_int) :: n
       real(c_double) :: alpha
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stride_x
       complex(c_double_complex),target,dimension(:,:) :: A
@@ -44883,9 +43637,9 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)) :: uplo
       integer(c_int) :: n
       complex(c_float_complex) :: alpha
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
-      complex(c_float_complex),target,dimension(:,:) :: y
+      complex(c_float_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
@@ -44943,9 +43697,9 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)) :: uplo
       integer(c_int) :: n
       complex(c_double_complex) :: alpha
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
-      complex(c_double_complex),target,dimension(:,:) :: y
+      complex(c_double_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
@@ -45014,10 +43768,10 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)) :: uplo
       integer(c_int) :: n
       complex(c_float_complex) :: alpha
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stride_x
-      complex(c_float_complex),target,dimension(:,:) :: y
+      complex(c_float_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stride_y
       complex(c_float_complex),target,dimension(:,:) :: A
@@ -45089,10 +43843,10 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)) :: uplo
       integer(c_int) :: n
       complex(c_double_complex) :: alpha
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stride_x
-      complex(c_double_complex),target,dimension(:,:) :: y
+      complex(c_double_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stride_y
       complex(c_double_complex),target,dimension(:,:) :: A
@@ -45113,15 +43867,14 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)) :: uplo
       integer(c_int) :: n
       complex(c_float_complex) :: alpha
-      complex(c_float_complex),target :: AP
+      type(c_ptr) :: AP
       complex(c_float_complex),target :: x
       integer(c_int) :: incx
       complex(c_float_complex) :: beta
       complex(c_float_complex),target :: y
       integer(c_int) :: incy
       !
-      rocblas_chpmv_rank_0 = rocblas_chpmv_(handle,uplo,n,alpha,c_loc(AP),c_loc(x),incx,beta, &
-        c_loc(y),incy)
+      rocblas_chpmv_rank_0 = rocblas_chpmv_(handle,uplo,n,alpha,AP,c_loc(x),incx,beta,c_loc(y),incy)
     end function
 
     function rocblas_chpmv_rank_1(handle,uplo,n,alpha,AP,x,incx,beta,y,incy)
@@ -45133,15 +43886,14 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)) :: uplo
       integer(c_int) :: n
       complex(c_float_complex) :: alpha
-      complex(c_float_complex),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       complex(c_float_complex) :: beta
       complex(c_float_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       !
-      rocblas_chpmv_rank_1 = rocblas_chpmv_(handle,uplo,n,alpha,c_loc(AP),c_loc(x),incx,beta, &
-        c_loc(y),incy)
+      rocblas_chpmv_rank_1 = rocblas_chpmv_(handle,uplo,n,alpha,AP,c_loc(x),incx,beta,c_loc(y),incy)
     end function
 
     function rocblas_zhpmv_rank_0(handle,uplo,n,alpha,AP,x,incx,beta,y,incy)
@@ -45153,15 +43905,14 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)) :: uplo
       integer(c_int) :: n
       complex(c_double_complex) :: alpha
-      complex(c_double_complex),target :: AP
+      type(c_ptr) :: AP
       complex(c_double_complex),target :: x
       integer(c_int) :: incx
       complex(c_double_complex) :: beta
       complex(c_double_complex),target :: y
       integer(c_int) :: incy
       !
-      rocblas_zhpmv_rank_0 = rocblas_zhpmv_(handle,uplo,n,alpha,c_loc(AP),c_loc(x),incx,beta, &
-        c_loc(y),incy)
+      rocblas_zhpmv_rank_0 = rocblas_zhpmv_(handle,uplo,n,alpha,AP,c_loc(x),incx,beta,c_loc(y),incy)
     end function
 
     function rocblas_zhpmv_rank_1(handle,uplo,n,alpha,AP,x,incx,beta,y,incy)
@@ -45173,15 +43924,14 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)) :: uplo
       integer(c_int) :: n
       complex(c_double_complex) :: alpha
-      complex(c_double_complex),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       complex(c_double_complex) :: beta
       complex(c_double_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       !
-      rocblas_zhpmv_rank_1 = rocblas_zhpmv_(handle,uplo,n,alpha,c_loc(AP),c_loc(x),incx,beta, &
-        c_loc(y),incy)
+      rocblas_zhpmv_rank_1 = rocblas_zhpmv_(handle,uplo,n,alpha,AP,c_loc(x),incx,beta,c_loc(y),incy)
     end function
 
     function rocblas_chpmv_strided_batched_rank_0(handle,uplo,n,alpha,AP,stride_A,x,incx,stride_x, &
@@ -45194,7 +43944,7 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)) :: uplo
       integer(c_int) :: n
       complex(c_float_complex) :: alpha
-      complex(c_float_complex),target :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: stride_A
       complex(c_float_complex),target :: x
       integer(c_int) :: incx
@@ -45206,7 +43956,7 @@ module hipfort_rocblas
       integer(c_int) :: batch_count
       !
       rocblas_chpmv_strided_batched_rank_0 = rocblas_chpmv_strided_batched_(handle,uplo,n,alpha, &
-        c_loc(AP),stride_A,c_loc(x),incx,stride_x,beta,c_loc(y),incy,stride_y,batch_count)
+        AP,stride_A,c_loc(x),incx,stride_x,beta,c_loc(y),incy,stride_y,batch_count)
     end function
 
     function rocblas_chpmv_strided_batched_rank_1(handle,uplo,n,alpha,AP,stride_A,x,incx,stride_x, &
@@ -45219,7 +43969,7 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)) :: uplo
       integer(c_int) :: n
       complex(c_float_complex) :: alpha
-      complex(c_float_complex),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: stride_A
       complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
@@ -45231,7 +43981,7 @@ module hipfort_rocblas
       integer(c_int) :: batch_count
       !
       rocblas_chpmv_strided_batched_rank_1 = rocblas_chpmv_strided_batched_(handle,uplo,n,alpha, &
-        c_loc(AP),stride_A,c_loc(x),incx,stride_x,beta,c_loc(y),incy,stride_y,batch_count)
+        AP,stride_A,c_loc(x),incx,stride_x,beta,c_loc(y),incy,stride_y,batch_count)
     end function
 
     function rocblas_zhpmv_strided_batched_rank_0(handle,uplo,n,alpha,AP,stride_A,x,incx,stride_x, &
@@ -45244,7 +43994,7 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)) :: uplo
       integer(c_int) :: n
       complex(c_double_complex) :: alpha
-      complex(c_double_complex),target :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: stride_A
       complex(c_double_complex),target :: x
       integer(c_int) :: incx
@@ -45256,7 +44006,7 @@ module hipfort_rocblas
       integer(c_int) :: batch_count
       !
       rocblas_zhpmv_strided_batched_rank_0 = rocblas_zhpmv_strided_batched_(handle,uplo,n,alpha, &
-        c_loc(AP),stride_A,c_loc(x),incx,stride_x,beta,c_loc(y),incy,stride_y,batch_count)
+        AP,stride_A,c_loc(x),incx,stride_x,beta,c_loc(y),incy,stride_y,batch_count)
     end function
 
     function rocblas_zhpmv_strided_batched_rank_1(handle,uplo,n,alpha,AP,stride_A,x,incx,stride_x, &
@@ -45269,7 +44019,7 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)) :: uplo
       integer(c_int) :: n
       complex(c_double_complex) :: alpha
-      complex(c_double_complex),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: stride_A
       complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
@@ -45281,7 +44031,7 @@ module hipfort_rocblas
       integer(c_int) :: batch_count
       !
       rocblas_zhpmv_strided_batched_rank_1 = rocblas_zhpmv_strided_batched_(handle,uplo,n,alpha, &
-        c_loc(AP),stride_A,c_loc(x),incx,stride_x,beta,c_loc(y),incy,stride_y,batch_count)
+        AP,stride_A,c_loc(x),incx,stride_x,beta,c_loc(y),incy,stride_y,batch_count)
     end function
 
     function rocblas_chpr_rank_0(handle,uplo,n,alpha,x,incx,AP)
@@ -45295,9 +44045,9 @@ module hipfort_rocblas
       real(c_float) :: alpha
       complex(c_float_complex),target :: x
       integer(c_int) :: incx
-      complex(c_float_complex),target :: AP
+      type(c_ptr) :: AP
       !
-      rocblas_chpr_rank_0 = rocblas_chpr_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(AP))
+      rocblas_chpr_rank_0 = rocblas_chpr_(handle,uplo,n,alpha,c_loc(x),incx,AP)
     end function
 
     function rocblas_chpr_rank_1(handle,uplo,n,alpha,x,incx,AP)
@@ -45311,9 +44061,9 @@ module hipfort_rocblas
       real(c_float) :: alpha
       complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
-      complex(c_float_complex),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       !
-      rocblas_chpr_rank_1 = rocblas_chpr_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(AP))
+      rocblas_chpr_rank_1 = rocblas_chpr_(handle,uplo,n,alpha,c_loc(x),incx,AP)
     end function
 
     function rocblas_zhpr_rank_0(handle,uplo,n,alpha,x,incx,AP)
@@ -45327,9 +44077,9 @@ module hipfort_rocblas
       real(c_double) :: alpha
       complex(c_double_complex),target :: x
       integer(c_int) :: incx
-      complex(c_double_complex),target :: AP
+      type(c_ptr) :: AP
       !
-      rocblas_zhpr_rank_0 = rocblas_zhpr_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(AP))
+      rocblas_zhpr_rank_0 = rocblas_zhpr_(handle,uplo,n,alpha,c_loc(x),incx,AP)
     end function
 
     function rocblas_zhpr_rank_1(handle,uplo,n,alpha,x,incx,AP)
@@ -45343,9 +44093,9 @@ module hipfort_rocblas
       real(c_double) :: alpha
       complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
-      complex(c_double_complex),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       !
-      rocblas_zhpr_rank_1 = rocblas_zhpr_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(AP))
+      rocblas_zhpr_rank_1 = rocblas_zhpr_(handle,uplo,n,alpha,c_loc(x),incx,AP)
     end function
 
     function rocblas_chpr_strided_batched_rank_0(handle,uplo,n,alpha,x,incx,stride_x,AP,stride_A, &
@@ -45361,12 +44111,12 @@ module hipfort_rocblas
       complex(c_float_complex),target :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stride_x
-      complex(c_float_complex),target :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: stride_A
       integer(c_int) :: batch_count
       !
       rocblas_chpr_strided_batched_rank_0 = rocblas_chpr_strided_batched_(handle,uplo,n,alpha, &
-        c_loc(x),incx,stride_x,c_loc(AP),stride_A,batch_count)
+        c_loc(x),incx,stride_x,AP,stride_A,batch_count)
     end function
 
     function rocblas_chpr_strided_batched_rank_1(handle,uplo,n,alpha,x,incx,stride_x,AP,stride_A, &
@@ -45382,12 +44132,12 @@ module hipfort_rocblas
       complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stride_x
-      complex(c_float_complex),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: stride_A
       integer(c_int) :: batch_count
       !
       rocblas_chpr_strided_batched_rank_1 = rocblas_chpr_strided_batched_(handle,uplo,n,alpha, &
-        c_loc(x),incx,stride_x,c_loc(AP),stride_A,batch_count)
+        c_loc(x),incx,stride_x,AP,stride_A,batch_count)
     end function
 
     function rocblas_zhpr_strided_batched_rank_0(handle,uplo,n,alpha,x,incx,stride_x,AP,stride_A, &
@@ -45403,12 +44153,12 @@ module hipfort_rocblas
       complex(c_double_complex),target :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stride_x
-      complex(c_double_complex),target :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: stride_A
       integer(c_int) :: batch_count
       !
       rocblas_zhpr_strided_batched_rank_0 = rocblas_zhpr_strided_batched_(handle,uplo,n,alpha, &
-        c_loc(x),incx,stride_x,c_loc(AP),stride_A,batch_count)
+        c_loc(x),incx,stride_x,AP,stride_A,batch_count)
     end function
 
     function rocblas_zhpr_strided_batched_rank_1(handle,uplo,n,alpha,x,incx,stride_x,AP,stride_A, &
@@ -45424,12 +44174,12 @@ module hipfort_rocblas
       complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stride_x
-      complex(c_double_complex),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: stride_A
       integer(c_int) :: batch_count
       !
       rocblas_zhpr_strided_batched_rank_1 = rocblas_zhpr_strided_batched_(handle,uplo,n,alpha, &
-        c_loc(x),incx,stride_x,c_loc(AP),stride_A,batch_count)
+        c_loc(x),incx,stride_x,AP,stride_A,batch_count)
     end function
 
     function rocblas_chpr2_rank_0(handle,uplo,n,alpha,x,incx,y,incy,AP)
@@ -45445,10 +44195,9 @@ module hipfort_rocblas
       integer(c_int) :: incx
       complex(c_float_complex),target :: y
       integer(c_int) :: incy
-      complex(c_float_complex),target :: AP
+      type(c_ptr) :: AP
       !
-      rocblas_chpr2_rank_0 = rocblas_chpr2_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(y),incy, &
-        c_loc(AP))
+      rocblas_chpr2_rank_0 = rocblas_chpr2_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(y),incy,AP)
     end function
 
     function rocblas_chpr2_rank_1(handle,uplo,n,alpha,x,incx,y,incy,AP)
@@ -45464,10 +44213,9 @@ module hipfort_rocblas
       integer(c_int) :: incx
       complex(c_float_complex),target,dimension(:) :: y
       integer(c_int) :: incy
-      complex(c_float_complex),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       !
-      rocblas_chpr2_rank_1 = rocblas_chpr2_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(y),incy, &
-        c_loc(AP))
+      rocblas_chpr2_rank_1 = rocblas_chpr2_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(y),incy,AP)
     end function
 
     function rocblas_zhpr2_rank_0(handle,uplo,n,alpha,x,incx,y,incy,AP)
@@ -45483,10 +44231,9 @@ module hipfort_rocblas
       integer(c_int) :: incx
       complex(c_double_complex),target :: y
       integer(c_int) :: incy
-      complex(c_double_complex),target :: AP
+      type(c_ptr) :: AP
       !
-      rocblas_zhpr2_rank_0 = rocblas_zhpr2_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(y),incy, &
-        c_loc(AP))
+      rocblas_zhpr2_rank_0 = rocblas_zhpr2_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(y),incy,AP)
     end function
 
     function rocblas_zhpr2_rank_1(handle,uplo,n,alpha,x,incx,y,incy,AP)
@@ -45502,10 +44249,9 @@ module hipfort_rocblas
       integer(c_int) :: incx
       complex(c_double_complex),target,dimension(:) :: y
       integer(c_int) :: incy
-      complex(c_double_complex),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       !
-      rocblas_zhpr2_rank_1 = rocblas_zhpr2_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(y),incy, &
-        c_loc(AP))
+      rocblas_zhpr2_rank_1 = rocblas_zhpr2_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(y),incy,AP)
     end function
 
     function rocblas_chpr2_strided_batched_rank_0(handle,uplo,n,alpha,x,incx,stride_x,y,incy, &
@@ -45524,12 +44270,12 @@ module hipfort_rocblas
       complex(c_float_complex),target :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stride_y
-      complex(c_float_complex),target :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: stride_A
       integer(c_int) :: batch_count
       !
       rocblas_chpr2_strided_batched_rank_0 = rocblas_chpr2_strided_batched_(handle,uplo,n,alpha, &
-        c_loc(x),incx,stride_x,c_loc(y),incy,stride_y,c_loc(AP),stride_A,batch_count)
+        c_loc(x),incx,stride_x,c_loc(y),incy,stride_y,AP,stride_A,batch_count)
     end function
 
     function rocblas_chpr2_strided_batched_rank_1(handle,uplo,n,alpha,x,incx,stride_x,y,incy, &
@@ -45548,12 +44294,12 @@ module hipfort_rocblas
       complex(c_float_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stride_y
-      complex(c_float_complex),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: stride_A
       integer(c_int) :: batch_count
       !
       rocblas_chpr2_strided_batched_rank_1 = rocblas_chpr2_strided_batched_(handle,uplo,n,alpha, &
-        c_loc(x),incx,stride_x,c_loc(y),incy,stride_y,c_loc(AP),stride_A,batch_count)
+        c_loc(x),incx,stride_x,c_loc(y),incy,stride_y,AP,stride_A,batch_count)
     end function
 
     function rocblas_zhpr2_strided_batched_rank_0(handle,uplo,n,alpha,x,incx,stride_x,y,incy, &
@@ -45572,12 +44318,12 @@ module hipfort_rocblas
       complex(c_double_complex),target :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stride_y
-      complex(c_double_complex),target :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: stride_A
       integer(c_int) :: batch_count
       !
       rocblas_zhpr2_strided_batched_rank_0 = rocblas_zhpr2_strided_batched_(handle,uplo,n,alpha, &
-        c_loc(x),incx,stride_x,c_loc(y),incy,stride_y,c_loc(AP),stride_A,batch_count)
+        c_loc(x),incx,stride_x,c_loc(y),incy,stride_y,AP,stride_A,batch_count)
     end function
 
     function rocblas_zhpr2_strided_batched_rank_1(handle,uplo,n,alpha,x,incx,stride_x,y,incy, &
@@ -45596,12 +44342,12 @@ module hipfort_rocblas
       complex(c_double_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stride_y
-      complex(c_double_complex),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: stride_A
       integer(c_int) :: batch_count
       !
       rocblas_zhpr2_strided_batched_rank_1 = rocblas_zhpr2_strided_batched_(handle,uplo,n,alpha, &
-        c_loc(x),incx,stride_x,c_loc(y),incy,stride_y,c_loc(AP),stride_A,batch_count)
+        c_loc(x),incx,stride_x,c_loc(y),incy,stride_y,AP,stride_A,batch_count)
     end function
 
     function rocblas_strmv_rank_0(handle,uplo,transA,diag,n,A,lda,x,incx)
@@ -45652,7 +44398,7 @@ module hipfort_rocblas
       integer(c_int) :: n
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: x
+      real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       !
       rocblas_strmv_full_rank = rocblas_strmv_(handle,uplo,transA,diag,n,c_loc(A),lda,c_loc(x),incx)
@@ -45706,7 +44452,7 @@ module hipfort_rocblas
       integer(c_int) :: n
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: x
+      real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       !
       rocblas_dtrmv_full_rank = rocblas_dtrmv_(handle,uplo,transA,diag,n,c_loc(A),lda,c_loc(x),incx)
@@ -45760,7 +44506,7 @@ module hipfort_rocblas
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       !
       rocblas_ctrmv_full_rank = rocblas_ctrmv_(handle,uplo,transA,diag,n,c_loc(A),lda,c_loc(x),incx)
@@ -45814,7 +44560,7 @@ module hipfort_rocblas
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       !
       rocblas_ztrmv_full_rank = rocblas_ztrmv_(handle,uplo,transA,diag,n,c_loc(A),lda,c_loc(x),incx)
@@ -45880,7 +44626,7 @@ module hipfort_rocblas
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: stride_A
-      real(c_float),target,dimension(:,:) :: x
+      real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stride_x
       integer(c_int) :: batch_count
@@ -45949,7 +44695,7 @@ module hipfort_rocblas
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: stride_A
-      real(c_double),target,dimension(:,:) :: x
+      real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stride_x
       integer(c_int) :: batch_count
@@ -46018,7 +44764,7 @@ module hipfort_rocblas
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: stride_A
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stride_x
       integer(c_int) :: batch_count
@@ -46087,7 +44833,7 @@ module hipfort_rocblas
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: stride_A
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stride_x
       integer(c_int) :: batch_count
@@ -46459,7 +45205,7 @@ module hipfort_rocblas
       integer(c_int) :: k
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: x
+      real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       !
       rocblas_stbmv_full_rank = rocblas_stbmv_(handle,uplo,trans,diag,n,k,c_loc(A),lda,c_loc(x), &
@@ -46517,7 +45263,7 @@ module hipfort_rocblas
       integer(c_int) :: k
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: x
+      real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       !
       rocblas_dtbmv_full_rank = rocblas_dtbmv_(handle,uplo,trans,diag,n,k,c_loc(A),lda,c_loc(x), &
@@ -46575,7 +45321,7 @@ module hipfort_rocblas
       integer(c_int) :: k
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       !
       rocblas_ctbmv_full_rank = rocblas_ctbmv_(handle,uplo,trans,diag,n,k,c_loc(A),lda,c_loc(x), &
@@ -46633,7 +45379,7 @@ module hipfort_rocblas
       integer(c_int) :: k
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       !
       rocblas_ztbmv_full_rank = rocblas_ztbmv_(handle,uplo,trans,diag,n,k,c_loc(A),lda,c_loc(x), &
@@ -46703,7 +45449,7 @@ module hipfort_rocblas
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: stride_A
-      real(c_float),target,dimension(:,:) :: x
+      real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stride_x
       integer(c_int) :: batch_count
@@ -46775,7 +45521,7 @@ module hipfort_rocblas
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: stride_A
-      real(c_double),target,dimension(:,:) :: x
+      real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stride_x
       integer(c_int) :: batch_count
@@ -46847,7 +45593,7 @@ module hipfort_rocblas
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: stride_A
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stride_x
       integer(c_int) :: batch_count
@@ -46919,7 +45665,7 @@ module hipfort_rocblas
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: stride_A
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stride_x
       integer(c_int) :: batch_count
@@ -46979,7 +45725,7 @@ module hipfort_rocblas
       integer(c_int) :: k
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: x
+      real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       !
       rocblas_stbsv_full_rank = rocblas_stbsv_(handle,uplo,transA,diag,n,k,c_loc(A),lda,c_loc(x), &
@@ -47037,7 +45783,7 @@ module hipfort_rocblas
       integer(c_int) :: k
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: x
+      real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       !
       rocblas_dtbsv_full_rank = rocblas_dtbsv_(handle,uplo,transA,diag,n,k,c_loc(A),lda,c_loc(x), &
@@ -47095,7 +45841,7 @@ module hipfort_rocblas
       integer(c_int) :: k
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       !
       rocblas_ctbsv_full_rank = rocblas_ctbsv_(handle,uplo,transA,diag,n,k,c_loc(A),lda,c_loc(x), &
@@ -47153,7 +45899,7 @@ module hipfort_rocblas
       integer(c_int) :: k
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       !
       rocblas_ztbsv_full_rank = rocblas_ztbsv_(handle,uplo,transA,diag,n,k,c_loc(A),lda,c_loc(x), &
@@ -47223,7 +45969,7 @@ module hipfort_rocblas
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: stride_A
-      real(c_float),target,dimension(:,:) :: x
+      real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stride_x
       integer(c_int) :: batch_count
@@ -47295,7 +46041,7 @@ module hipfort_rocblas
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: stride_A
-      real(c_double),target,dimension(:,:) :: x
+      real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stride_x
       integer(c_int) :: batch_count
@@ -47367,7 +46113,7 @@ module hipfort_rocblas
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: stride_A
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stride_x
       integer(c_int) :: batch_count
@@ -47439,7 +46185,7 @@ module hipfort_rocblas
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: stride_A
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stride_x
       integer(c_int) :: batch_count
@@ -47496,7 +46242,7 @@ module hipfort_rocblas
       integer(c_int) :: n
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: x
+      real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       !
       rocblas_strsv_full_rank = rocblas_strsv_(handle,uplo,transA,diag,n,c_loc(A),lda,c_loc(x),incx)
@@ -47550,7 +46296,7 @@ module hipfort_rocblas
       integer(c_int) :: n
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: x
+      real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       !
       rocblas_dtrsv_full_rank = rocblas_dtrsv_(handle,uplo,transA,diag,n,c_loc(A),lda,c_loc(x),incx)
@@ -47604,7 +46350,7 @@ module hipfort_rocblas
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       !
       rocblas_ctrsv_full_rank = rocblas_ctrsv_(handle,uplo,transA,diag,n,c_loc(A),lda,c_loc(x),incx)
@@ -47658,7 +46404,7 @@ module hipfort_rocblas
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       !
       rocblas_ztrsv_full_rank = rocblas_ztrsv_(handle,uplo,transA,diag,n,c_loc(A),lda,c_loc(x),incx)
@@ -47724,7 +46470,7 @@ module hipfort_rocblas
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: stride_A
-      real(c_float),target,dimension(:,:) :: x
+      real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stride_x
       integer(c_int) :: batch_count
@@ -47793,7 +46539,7 @@ module hipfort_rocblas
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: stride_A
-      real(c_double),target,dimension(:,:) :: x
+      real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stride_x
       integer(c_int) :: batch_count
@@ -47862,7 +46608,7 @@ module hipfort_rocblas
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: stride_A
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stride_x
       integer(c_int) :: batch_count
@@ -47931,7 +46677,7 @@ module hipfort_rocblas
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: stride_A
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stride_x
       integer(c_int) :: batch_count
@@ -47950,11 +46696,11 @@ module hipfort_rocblas
       integer(kind(rocblas_operation_none)) :: transA
       integer(kind(rocblas_diagonal_non_unit)) :: diag
       integer(c_int) :: n
-      real(c_float),target :: AP
+      type(c_ptr) :: AP
       real(c_float),target :: x
       integer(c_int) :: incx
       !
-      rocblas_stpsv_rank_0 = rocblas_stpsv_(handle,uplo,transA,diag,n,c_loc(AP),c_loc(x),incx)
+      rocblas_stpsv_rank_0 = rocblas_stpsv_(handle,uplo,transA,diag,n,AP,c_loc(x),incx)
     end function
 
     function rocblas_stpsv_rank_1(handle,uplo,transA,diag,n,AP,x,incx)
@@ -47967,11 +46713,11 @@ module hipfort_rocblas
       integer(kind(rocblas_operation_none)) :: transA
       integer(kind(rocblas_diagonal_non_unit)) :: diag
       integer(c_int) :: n
-      real(c_float),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       !
-      rocblas_stpsv_rank_1 = rocblas_stpsv_(handle,uplo,transA,diag,n,c_loc(AP),c_loc(x),incx)
+      rocblas_stpsv_rank_1 = rocblas_stpsv_(handle,uplo,transA,diag,n,AP,c_loc(x),incx)
     end function
 
     function rocblas_dtpsv_rank_0(handle,uplo,transA,diag,n,AP,x,incx)
@@ -47984,11 +46730,11 @@ module hipfort_rocblas
       integer(kind(rocblas_operation_none)) :: transA
       integer(kind(rocblas_diagonal_non_unit)) :: diag
       integer(c_int) :: n
-      real(c_double),target :: AP
+      type(c_ptr) :: AP
       real(c_double),target :: x
       integer(c_int) :: incx
       !
-      rocblas_dtpsv_rank_0 = rocblas_dtpsv_(handle,uplo,transA,diag,n,c_loc(AP),c_loc(x),incx)
+      rocblas_dtpsv_rank_0 = rocblas_dtpsv_(handle,uplo,transA,diag,n,AP,c_loc(x),incx)
     end function
 
     function rocblas_dtpsv_rank_1(handle,uplo,transA,diag,n,AP,x,incx)
@@ -48001,11 +46747,11 @@ module hipfort_rocblas
       integer(kind(rocblas_operation_none)) :: transA
       integer(kind(rocblas_diagonal_non_unit)) :: diag
       integer(c_int) :: n
-      real(c_double),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       !
-      rocblas_dtpsv_rank_1 = rocblas_dtpsv_(handle,uplo,transA,diag,n,c_loc(AP),c_loc(x),incx)
+      rocblas_dtpsv_rank_1 = rocblas_dtpsv_(handle,uplo,transA,diag,n,AP,c_loc(x),incx)
     end function
 
     function rocblas_ctpsv_rank_0(handle,uplo,transA,diag,n,AP,x,incx)
@@ -48018,11 +46764,11 @@ module hipfort_rocblas
       integer(kind(rocblas_operation_none)) :: transA
       integer(kind(rocblas_diagonal_non_unit)) :: diag
       integer(c_int) :: n
-      complex(c_float_complex),target :: AP
+      type(c_ptr) :: AP
       complex(c_float_complex),target :: x
       integer(c_int) :: incx
       !
-      rocblas_ctpsv_rank_0 = rocblas_ctpsv_(handle,uplo,transA,diag,n,c_loc(AP),c_loc(x),incx)
+      rocblas_ctpsv_rank_0 = rocblas_ctpsv_(handle,uplo,transA,diag,n,AP,c_loc(x),incx)
     end function
 
     function rocblas_ctpsv_rank_1(handle,uplo,transA,diag,n,AP,x,incx)
@@ -48035,11 +46781,11 @@ module hipfort_rocblas
       integer(kind(rocblas_operation_none)) :: transA
       integer(kind(rocblas_diagonal_non_unit)) :: diag
       integer(c_int) :: n
-      complex(c_float_complex),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       !
-      rocblas_ctpsv_rank_1 = rocblas_ctpsv_(handle,uplo,transA,diag,n,c_loc(AP),c_loc(x),incx)
+      rocblas_ctpsv_rank_1 = rocblas_ctpsv_(handle,uplo,transA,diag,n,AP,c_loc(x),incx)
     end function
 
     function rocblas_ztpsv_rank_0(handle,uplo,transA,diag,n,AP,x,incx)
@@ -48052,11 +46798,11 @@ module hipfort_rocblas
       integer(kind(rocblas_operation_none)) :: transA
       integer(kind(rocblas_diagonal_non_unit)) :: diag
       integer(c_int) :: n
-      complex(c_double_complex),target :: AP
+      type(c_ptr) :: AP
       complex(c_double_complex),target :: x
       integer(c_int) :: incx
       !
-      rocblas_ztpsv_rank_0 = rocblas_ztpsv_(handle,uplo,transA,diag,n,c_loc(AP),c_loc(x),incx)
+      rocblas_ztpsv_rank_0 = rocblas_ztpsv_(handle,uplo,transA,diag,n,AP,c_loc(x),incx)
     end function
 
     function rocblas_ztpsv_rank_1(handle,uplo,transA,diag,n,AP,x,incx)
@@ -48069,11 +46815,11 @@ module hipfort_rocblas
       integer(kind(rocblas_operation_none)) :: transA
       integer(kind(rocblas_diagonal_non_unit)) :: diag
       integer(c_int) :: n
-      complex(c_double_complex),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       !
-      rocblas_ztpsv_rank_1 = rocblas_ztpsv_(handle,uplo,transA,diag,n,c_loc(AP),c_loc(x),incx)
+      rocblas_ztpsv_rank_1 = rocblas_ztpsv_(handle,uplo,transA,diag,n,AP,c_loc(x),incx)
     end function
 
     function rocblas_stpsv_strided_batched_rank_0(handle,uplo,transA,diag,n,AP,stride_A,x,incx, &
@@ -48087,7 +46833,7 @@ module hipfort_rocblas
       integer(kind(rocblas_operation_none)) :: transA
       integer(kind(rocblas_diagonal_non_unit)) :: diag
       integer(c_int) :: n
-      real(c_float),target :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: stride_A
       real(c_float),target :: x
       integer(c_int) :: incx
@@ -48095,7 +46841,7 @@ module hipfort_rocblas
       integer(c_int) :: batch_count
       !
       rocblas_stpsv_strided_batched_rank_0 = rocblas_stpsv_strided_batched_(handle,uplo,transA, &
-        diag,n,c_loc(AP),stride_A,c_loc(x),incx,stride_x,batch_count)
+        diag,n,AP,stride_A,c_loc(x),incx,stride_x,batch_count)
     end function
 
     function rocblas_stpsv_strided_batched_rank_1(handle,uplo,transA,diag,n,AP,stride_A,x,incx, &
@@ -48109,7 +46855,7 @@ module hipfort_rocblas
       integer(kind(rocblas_operation_none)) :: transA
       integer(kind(rocblas_diagonal_non_unit)) :: diag
       integer(c_int) :: n
-      real(c_float),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: stride_A
       real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
@@ -48117,7 +46863,7 @@ module hipfort_rocblas
       integer(c_int) :: batch_count
       !
       rocblas_stpsv_strided_batched_rank_1 = rocblas_stpsv_strided_batched_(handle,uplo,transA, &
-        diag,n,c_loc(AP),stride_A,c_loc(x),incx,stride_x,batch_count)
+        diag,n,AP,stride_A,c_loc(x),incx,stride_x,batch_count)
     end function
 
     function rocblas_dtpsv_strided_batched_rank_0(handle,uplo,transA,diag,n,AP,stride_A,x,incx, &
@@ -48131,7 +46877,7 @@ module hipfort_rocblas
       integer(kind(rocblas_operation_none)) :: transA
       integer(kind(rocblas_diagonal_non_unit)) :: diag
       integer(c_int) :: n
-      real(c_double),target :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: stride_A
       real(c_double),target :: x
       integer(c_int) :: incx
@@ -48139,7 +46885,7 @@ module hipfort_rocblas
       integer(c_int) :: batch_count
       !
       rocblas_dtpsv_strided_batched_rank_0 = rocblas_dtpsv_strided_batched_(handle,uplo,transA, &
-        diag,n,c_loc(AP),stride_A,c_loc(x),incx,stride_x,batch_count)
+        diag,n,AP,stride_A,c_loc(x),incx,stride_x,batch_count)
     end function
 
     function rocblas_dtpsv_strided_batched_rank_1(handle,uplo,transA,diag,n,AP,stride_A,x,incx, &
@@ -48153,7 +46899,7 @@ module hipfort_rocblas
       integer(kind(rocblas_operation_none)) :: transA
       integer(kind(rocblas_diagonal_non_unit)) :: diag
       integer(c_int) :: n
-      real(c_double),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: stride_A
       real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
@@ -48161,7 +46907,7 @@ module hipfort_rocblas
       integer(c_int) :: batch_count
       !
       rocblas_dtpsv_strided_batched_rank_1 = rocblas_dtpsv_strided_batched_(handle,uplo,transA, &
-        diag,n,c_loc(AP),stride_A,c_loc(x),incx,stride_x,batch_count)
+        diag,n,AP,stride_A,c_loc(x),incx,stride_x,batch_count)
     end function
 
     function rocblas_ctpsv_strided_batched_rank_0(handle,uplo,transA,diag,n,AP,stride_A,x,incx, &
@@ -48175,7 +46921,7 @@ module hipfort_rocblas
       integer(kind(rocblas_operation_none)) :: transA
       integer(kind(rocblas_diagonal_non_unit)) :: diag
       integer(c_int) :: n
-      complex(c_float_complex),target :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: stride_A
       complex(c_float_complex),target :: x
       integer(c_int) :: incx
@@ -48183,7 +46929,7 @@ module hipfort_rocblas
       integer(c_int) :: batch_count
       !
       rocblas_ctpsv_strided_batched_rank_0 = rocblas_ctpsv_strided_batched_(handle,uplo,transA, &
-        diag,n,c_loc(AP),stride_A,c_loc(x),incx,stride_x,batch_count)
+        diag,n,AP,stride_A,c_loc(x),incx,stride_x,batch_count)
     end function
 
     function rocblas_ctpsv_strided_batched_rank_1(handle,uplo,transA,diag,n,AP,stride_A,x,incx, &
@@ -48197,7 +46943,7 @@ module hipfort_rocblas
       integer(kind(rocblas_operation_none)) :: transA
       integer(kind(rocblas_diagonal_non_unit)) :: diag
       integer(c_int) :: n
-      complex(c_float_complex),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: stride_A
       complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
@@ -48205,7 +46951,7 @@ module hipfort_rocblas
       integer(c_int) :: batch_count
       !
       rocblas_ctpsv_strided_batched_rank_1 = rocblas_ctpsv_strided_batched_(handle,uplo,transA, &
-        diag,n,c_loc(AP),stride_A,c_loc(x),incx,stride_x,batch_count)
+        diag,n,AP,stride_A,c_loc(x),incx,stride_x,batch_count)
     end function
 
     function rocblas_ztpsv_strided_batched_rank_0(handle,uplo,transA,diag,n,AP,stride_A,x,incx, &
@@ -48219,7 +46965,7 @@ module hipfort_rocblas
       integer(kind(rocblas_operation_none)) :: transA
       integer(kind(rocblas_diagonal_non_unit)) :: diag
       integer(c_int) :: n
-      complex(c_double_complex),target :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: stride_A
       complex(c_double_complex),target :: x
       integer(c_int) :: incx
@@ -48227,7 +46973,7 @@ module hipfort_rocblas
       integer(c_int) :: batch_count
       !
       rocblas_ztpsv_strided_batched_rank_0 = rocblas_ztpsv_strided_batched_(handle,uplo,transA, &
-        diag,n,c_loc(AP),stride_A,c_loc(x),incx,stride_x,batch_count)
+        diag,n,AP,stride_A,c_loc(x),incx,stride_x,batch_count)
     end function
 
     function rocblas_ztpsv_strided_batched_rank_1(handle,uplo,transA,diag,n,AP,stride_A,x,incx, &
@@ -48241,7 +46987,7 @@ module hipfort_rocblas
       integer(kind(rocblas_operation_none)) :: transA
       integer(kind(rocblas_diagonal_non_unit)) :: diag
       integer(c_int) :: n
-      complex(c_double_complex),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: stride_A
       complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
@@ -48249,7 +46995,7 @@ module hipfort_rocblas
       integer(c_int) :: batch_count
       !
       rocblas_ztpsv_strided_batched_rank_1 = rocblas_ztpsv_strided_batched_(handle,uplo,transA, &
-        diag,n,c_loc(AP),stride_A,c_loc(x),incx,stride_x,batch_count)
+        diag,n,AP,stride_A,c_loc(x),incx,stride_x,batch_count)
     end function
 
     function rocblas_ssymv_rank_0(handle,uplo,n,alpha,A,lda,x,incx,beta,y,incy)
@@ -48305,10 +47051,10 @@ module hipfort_rocblas
       real(c_float) :: alpha
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: x
+      real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       real(c_float) :: beta
-      real(c_float),target,dimension(:,:) :: y
+      real(c_float),target,dimension(:) :: y
       integer(c_int) :: incy
       !
       rocblas_ssymv_full_rank = rocblas_ssymv_(handle,uplo,n,alpha,c_loc(A),lda,c_loc(x),incx, &
@@ -48368,10 +47114,10 @@ module hipfort_rocblas
       real(c_double) :: alpha
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: x
+      real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       real(c_double) :: beta
-      real(c_double),target,dimension(:,:) :: y
+      real(c_double),target,dimension(:) :: y
       integer(c_int) :: incy
       !
       rocblas_dsymv_full_rank = rocblas_dsymv_(handle,uplo,n,alpha,c_loc(A),lda,c_loc(x),incx, &
@@ -48431,10 +47177,10 @@ module hipfort_rocblas
       complex(c_float_complex) :: alpha
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       complex(c_float_complex) :: beta
-      complex(c_float_complex),target,dimension(:,:) :: y
+      complex(c_float_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       !
       rocblas_csymv_full_rank = rocblas_csymv_(handle,uplo,n,alpha,c_loc(A),lda,c_loc(x),incx, &
@@ -48494,10 +47240,10 @@ module hipfort_rocblas
       complex(c_double_complex) :: alpha
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       complex(c_double_complex) :: beta
-      complex(c_double_complex),target,dimension(:,:) :: y
+      complex(c_double_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       !
       rocblas_zsymv_full_rank = rocblas_zsymv_(handle,uplo,n,alpha,c_loc(A),lda,c_loc(x),incx, &
@@ -48569,11 +47315,11 @@ module hipfort_rocblas
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_float),target,dimension(:,:) :: x
+      real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       real(c_float) :: beta
-      real(c_float),target,dimension(:,:) :: y
+      real(c_float),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       integer(c_int) :: batch_count
@@ -48647,11 +47393,11 @@ module hipfort_rocblas
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_double),target,dimension(:,:) :: x
+      real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       real(c_double) :: beta
-      real(c_double),target,dimension(:,:) :: y
+      real(c_double),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       integer(c_int) :: batch_count
@@ -48725,11 +47471,11 @@ module hipfort_rocblas
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       complex(c_float_complex) :: beta
-      complex(c_float_complex),target,dimension(:,:) :: y
+      complex(c_float_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       integer(c_int) :: batch_count
@@ -48803,11 +47549,11 @@ module hipfort_rocblas
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       complex(c_double_complex) :: beta
-      complex(c_double_complex),target,dimension(:,:) :: y
+      complex(c_double_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       integer(c_int) :: batch_count
@@ -49052,10 +47798,10 @@ module hipfort_rocblas
       real(c_float) :: alpha
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: x
+      real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       real(c_float) :: beta
-      real(c_float),target,dimension(:,:) :: y
+      real(c_float),target,dimension(:) :: y
       integer(c_int) :: incy
       !
       rocblas_ssbmv_full_rank = rocblas_ssbmv_(handle,uplo,n,k,alpha,c_loc(A),lda,c_loc(x),incx, &
@@ -49118,10 +47864,10 @@ module hipfort_rocblas
       real(c_double) :: alpha
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: x
+      real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       real(c_double) :: beta
-      real(c_double),target,dimension(:,:) :: y
+      real(c_double),target,dimension(:) :: y
       integer(c_int) :: incy
       !
       rocblas_dsbmv_full_rank = rocblas_dsbmv_(handle,uplo,n,k,alpha,c_loc(A),lda,c_loc(x),incx, &
@@ -49196,11 +47942,11 @@ module hipfort_rocblas
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_float),target,dimension(:,:) :: x
+      real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       real(c_float) :: beta
-      real(c_float),target,dimension(:,:) :: y
+      real(c_float),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       integer(c_int) :: batch_count
@@ -49277,11 +48023,11 @@ module hipfort_rocblas
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_double),target,dimension(:,:) :: x
+      real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       real(c_double) :: beta
-      real(c_double),target,dimension(:,:) :: y
+      real(c_double),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       integer(c_int) :: batch_count
@@ -49337,9 +48083,9 @@ module hipfort_rocblas
       integer(c_int) :: m
       integer(c_int) :: n
       real(c_float) :: alpha
-      real(c_float),target,dimension(:,:) :: x
+      real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
-      real(c_float),target,dimension(:,:) :: y
+      real(c_float),target,dimension(:) :: y
       integer(c_int) :: incy
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
@@ -49395,9 +48141,9 @@ module hipfort_rocblas
       integer(c_int) :: m
       integer(c_int) :: n
       real(c_double) :: alpha
-      real(c_double),target,dimension(:,:) :: x
+      real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
-      real(c_double),target,dimension(:,:) :: y
+      real(c_double),target,dimension(:) :: y
       integer(c_int) :: incy
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
@@ -49455,9 +48201,9 @@ module hipfort_rocblas
       integer(c_int) :: m
       integer(c_int) :: n
       complex(c_float_complex) :: alpha
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
-      complex(c_float_complex),target,dimension(:,:) :: y
+      complex(c_float_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
@@ -49515,9 +48261,9 @@ module hipfort_rocblas
       integer(c_int) :: m
       integer(c_int) :: n
       complex(c_double_complex) :: alpha
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
-      complex(c_double_complex),target,dimension(:,:) :: y
+      complex(c_double_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
@@ -49575,9 +48321,9 @@ module hipfort_rocblas
       integer(c_int) :: m
       integer(c_int) :: n
       complex(c_float_complex) :: alpha
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
-      complex(c_float_complex),target,dimension(:,:) :: y
+      complex(c_float_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
@@ -49635,9 +48381,9 @@ module hipfort_rocblas
       integer(c_int) :: m
       integer(c_int) :: n
       complex(c_double_complex) :: alpha
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
-      complex(c_double_complex),target,dimension(:,:) :: y
+      complex(c_double_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
@@ -49706,10 +48452,10 @@ module hipfort_rocblas
       integer(c_int) :: m
       integer(c_int) :: n
       real(c_float) :: alpha
-      real(c_float),target,dimension(:,:) :: x
+      real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
-      real(c_float),target,dimension(:,:) :: y
+      real(c_float),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       real(c_float),target,dimension(:,:) :: A
@@ -49781,10 +48527,10 @@ module hipfort_rocblas
       integer(c_int) :: m
       integer(c_int) :: n
       real(c_double) :: alpha
-      real(c_double),target,dimension(:,:) :: x
+      real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
-      real(c_double),target,dimension(:,:) :: y
+      real(c_double),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       real(c_double),target,dimension(:,:) :: A
@@ -49856,10 +48602,10 @@ module hipfort_rocblas
       integer(c_int) :: m
       integer(c_int) :: n
       complex(c_float_complex) :: alpha
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
-      complex(c_float_complex),target,dimension(:,:) :: y
+      complex(c_float_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       complex(c_float_complex),target,dimension(:,:) :: A
@@ -49931,10 +48677,10 @@ module hipfort_rocblas
       integer(c_int) :: m
       integer(c_int) :: n
       complex(c_double_complex) :: alpha
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
-      complex(c_double_complex),target,dimension(:,:) :: y
+      complex(c_double_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       complex(c_double_complex),target,dimension(:,:) :: A
@@ -50006,10 +48752,10 @@ module hipfort_rocblas
       integer(c_int) :: m
       integer(c_int) :: n
       complex(c_float_complex) :: alpha
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
-      complex(c_float_complex),target,dimension(:,:) :: y
+      complex(c_float_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       complex(c_float_complex),target,dimension(:,:) :: A
@@ -50081,10 +48827,10 @@ module hipfort_rocblas
       integer(c_int) :: m
       integer(c_int) :: n
       complex(c_double_complex) :: alpha
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
-      complex(c_double_complex),target,dimension(:,:) :: y
+      complex(c_double_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       complex(c_double_complex),target,dimension(:,:) :: A
@@ -50107,9 +48853,9 @@ module hipfort_rocblas
       real(c_float) :: alpha
       real(c_float),target :: x
       integer(c_int) :: incx
-      real(c_float),target :: AP
+      type(c_ptr) :: AP
       !
-      rocblas_sspr_rank_0 = rocblas_sspr_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(AP))
+      rocblas_sspr_rank_0 = rocblas_sspr_(handle,uplo,n,alpha,c_loc(x),incx,AP)
     end function
 
     function rocblas_sspr_rank_1(handle,uplo,n,alpha,x,incx,AP)
@@ -50123,9 +48869,9 @@ module hipfort_rocblas
       real(c_float) :: alpha
       real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
-      real(c_float),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       !
-      rocblas_sspr_rank_1 = rocblas_sspr_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(AP))
+      rocblas_sspr_rank_1 = rocblas_sspr_(handle,uplo,n,alpha,c_loc(x),incx,AP)
     end function
 
     function rocblas_dspr_rank_0(handle,uplo,n,alpha,x,incx,AP)
@@ -50139,9 +48885,9 @@ module hipfort_rocblas
       real(c_double) :: alpha
       real(c_double),target :: x
       integer(c_int) :: incx
-      real(c_double),target :: AP
+      type(c_ptr) :: AP
       !
-      rocblas_dspr_rank_0 = rocblas_dspr_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(AP))
+      rocblas_dspr_rank_0 = rocblas_dspr_(handle,uplo,n,alpha,c_loc(x),incx,AP)
     end function
 
     function rocblas_dspr_rank_1(handle,uplo,n,alpha,x,incx,AP)
@@ -50155,9 +48901,9 @@ module hipfort_rocblas
       real(c_double) :: alpha
       real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
-      real(c_double),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       !
-      rocblas_dspr_rank_1 = rocblas_dspr_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(AP))
+      rocblas_dspr_rank_1 = rocblas_dspr_(handle,uplo,n,alpha,c_loc(x),incx,AP)
     end function
 
     function rocblas_cspr_rank_0(handle,uplo,n,alpha,x,incx,AP)
@@ -50171,9 +48917,9 @@ module hipfort_rocblas
       complex(c_float_complex) :: alpha
       complex(c_float_complex),target :: x
       integer(c_int) :: incx
-      complex(c_float_complex),target :: AP
+      type(c_ptr) :: AP
       !
-      rocblas_cspr_rank_0 = rocblas_cspr_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(AP))
+      rocblas_cspr_rank_0 = rocblas_cspr_(handle,uplo,n,alpha,c_loc(x),incx,AP)
     end function
 
     function rocblas_cspr_rank_1(handle,uplo,n,alpha,x,incx,AP)
@@ -50187,9 +48933,9 @@ module hipfort_rocblas
       complex(c_float_complex) :: alpha
       complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
-      complex(c_float_complex),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       !
-      rocblas_cspr_rank_1 = rocblas_cspr_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(AP))
+      rocblas_cspr_rank_1 = rocblas_cspr_(handle,uplo,n,alpha,c_loc(x),incx,AP)
     end function
 
     function rocblas_zspr_rank_0(handle,uplo,n,alpha,x,incx,AP)
@@ -50203,9 +48949,9 @@ module hipfort_rocblas
       complex(c_double_complex) :: alpha
       complex(c_double_complex),target :: x
       integer(c_int) :: incx
-      complex(c_double_complex),target :: AP
+      type(c_ptr) :: AP
       !
-      rocblas_zspr_rank_0 = rocblas_zspr_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(AP))
+      rocblas_zspr_rank_0 = rocblas_zspr_(handle,uplo,n,alpha,c_loc(x),incx,AP)
     end function
 
     function rocblas_zspr_rank_1(handle,uplo,n,alpha,x,incx,AP)
@@ -50219,9 +48965,9 @@ module hipfort_rocblas
       complex(c_double_complex) :: alpha
       complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
-      complex(c_double_complex),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       !
-      rocblas_zspr_rank_1 = rocblas_zspr_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(AP))
+      rocblas_zspr_rank_1 = rocblas_zspr_(handle,uplo,n,alpha,c_loc(x),incx,AP)
     end function
 
     function rocblas_sspr_strided_batched_rank_0(handle,uplo,n,alpha,x,incx,stride_x,AP,stride_A, &
@@ -50237,12 +48983,12 @@ module hipfort_rocblas
       real(c_float),target :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stride_x
-      real(c_float),target :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: stride_A
       integer(c_int) :: batch_count
       !
       rocblas_sspr_strided_batched_rank_0 = rocblas_sspr_strided_batched_(handle,uplo,n,alpha, &
-        c_loc(x),incx,stride_x,c_loc(AP),stride_A,batch_count)
+        c_loc(x),incx,stride_x,AP,stride_A,batch_count)
     end function
 
     function rocblas_sspr_strided_batched_rank_1(handle,uplo,n,alpha,x,incx,stride_x,AP,stride_A, &
@@ -50258,12 +49004,12 @@ module hipfort_rocblas
       real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stride_x
-      real(c_float),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: stride_A
       integer(c_int) :: batch_count
       !
       rocblas_sspr_strided_batched_rank_1 = rocblas_sspr_strided_batched_(handle,uplo,n,alpha, &
-        c_loc(x),incx,stride_x,c_loc(AP),stride_A,batch_count)
+        c_loc(x),incx,stride_x,AP,stride_A,batch_count)
     end function
 
     function rocblas_dspr_strided_batched_rank_0(handle,uplo,n,alpha,x,incx,stride_x,AP,stride_A, &
@@ -50279,12 +49025,12 @@ module hipfort_rocblas
       real(c_double),target :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stride_x
-      real(c_double),target :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: stride_A
       integer(c_int) :: batch_count
       !
       rocblas_dspr_strided_batched_rank_0 = rocblas_dspr_strided_batched_(handle,uplo,n,alpha, &
-        c_loc(x),incx,stride_x,c_loc(AP),stride_A,batch_count)
+        c_loc(x),incx,stride_x,AP,stride_A,batch_count)
     end function
 
     function rocblas_dspr_strided_batched_rank_1(handle,uplo,n,alpha,x,incx,stride_x,AP,stride_A, &
@@ -50300,12 +49046,12 @@ module hipfort_rocblas
       real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stride_x
-      real(c_double),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: stride_A
       integer(c_int) :: batch_count
       !
       rocblas_dspr_strided_batched_rank_1 = rocblas_dspr_strided_batched_(handle,uplo,n,alpha, &
-        c_loc(x),incx,stride_x,c_loc(AP),stride_A,batch_count)
+        c_loc(x),incx,stride_x,AP,stride_A,batch_count)
     end function
 
     function rocblas_cspr_strided_batched_rank_0(handle,uplo,n,alpha,x,incx,stride_x,AP,stride_A, &
@@ -50321,12 +49067,12 @@ module hipfort_rocblas
       complex(c_float_complex),target :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stride_x
-      complex(c_float_complex),target :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: stride_A
       integer(c_int) :: batch_count
       !
       rocblas_cspr_strided_batched_rank_0 = rocblas_cspr_strided_batched_(handle,uplo,n,alpha, &
-        c_loc(x),incx,stride_x,c_loc(AP),stride_A,batch_count)
+        c_loc(x),incx,stride_x,AP,stride_A,batch_count)
     end function
 
     function rocblas_cspr_strided_batched_rank_1(handle,uplo,n,alpha,x,incx,stride_x,AP,stride_A, &
@@ -50342,12 +49088,12 @@ module hipfort_rocblas
       complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stride_x
-      complex(c_float_complex),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: stride_A
       integer(c_int) :: batch_count
       !
       rocblas_cspr_strided_batched_rank_1 = rocblas_cspr_strided_batched_(handle,uplo,n,alpha, &
-        c_loc(x),incx,stride_x,c_loc(AP),stride_A,batch_count)
+        c_loc(x),incx,stride_x,AP,stride_A,batch_count)
     end function
 
     function rocblas_zspr_strided_batched_rank_0(handle,uplo,n,alpha,x,incx,stride_x,AP,stride_A, &
@@ -50363,12 +49109,12 @@ module hipfort_rocblas
       complex(c_double_complex),target :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stride_x
-      complex(c_double_complex),target :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: stride_A
       integer(c_int) :: batch_count
       !
       rocblas_zspr_strided_batched_rank_0 = rocblas_zspr_strided_batched_(handle,uplo,n,alpha, &
-        c_loc(x),incx,stride_x,c_loc(AP),stride_A,batch_count)
+        c_loc(x),incx,stride_x,AP,stride_A,batch_count)
     end function
 
     function rocblas_zspr_strided_batched_rank_1(handle,uplo,n,alpha,x,incx,stride_x,AP,stride_A, &
@@ -50384,12 +49130,12 @@ module hipfort_rocblas
       complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stride_x
-      complex(c_double_complex),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: stride_A
       integer(c_int) :: batch_count
       !
       rocblas_zspr_strided_batched_rank_1 = rocblas_zspr_strided_batched_(handle,uplo,n,alpha, &
-        c_loc(x),incx,stride_x,c_loc(AP),stride_A,batch_count)
+        c_loc(x),incx,stride_x,AP,stride_A,batch_count)
     end function
 
     function rocblas_sspr2_rank_0(handle,uplo,n,alpha,x,incx,y,incy,AP)
@@ -50405,10 +49151,9 @@ module hipfort_rocblas
       integer(c_int) :: incx
       real(c_float),target :: y
       integer(c_int) :: incy
-      real(c_float),target :: AP
+      type(c_ptr) :: AP
       !
-      rocblas_sspr2_rank_0 = rocblas_sspr2_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(y),incy, &
-        c_loc(AP))
+      rocblas_sspr2_rank_0 = rocblas_sspr2_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(y),incy,AP)
     end function
 
     function rocblas_sspr2_rank_1(handle,uplo,n,alpha,x,incx,y,incy,AP)
@@ -50424,10 +49169,9 @@ module hipfort_rocblas
       integer(c_int) :: incx
       real(c_float),target,dimension(:) :: y
       integer(c_int) :: incy
-      real(c_float),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       !
-      rocblas_sspr2_rank_1 = rocblas_sspr2_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(y),incy, &
-        c_loc(AP))
+      rocblas_sspr2_rank_1 = rocblas_sspr2_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(y),incy,AP)
     end function
 
     function rocblas_dspr2_rank_0(handle,uplo,n,alpha,x,incx,y,incy,AP)
@@ -50443,10 +49187,9 @@ module hipfort_rocblas
       integer(c_int) :: incx
       real(c_double),target :: y
       integer(c_int) :: incy
-      real(c_double),target :: AP
+      type(c_ptr) :: AP
       !
-      rocblas_dspr2_rank_0 = rocblas_dspr2_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(y),incy, &
-        c_loc(AP))
+      rocblas_dspr2_rank_0 = rocblas_dspr2_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(y),incy,AP)
     end function
 
     function rocblas_dspr2_rank_1(handle,uplo,n,alpha,x,incx,y,incy,AP)
@@ -50462,10 +49205,9 @@ module hipfort_rocblas
       integer(c_int) :: incx
       real(c_double),target,dimension(:) :: y
       integer(c_int) :: incy
-      real(c_double),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       !
-      rocblas_dspr2_rank_1 = rocblas_dspr2_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(y),incy, &
-        c_loc(AP))
+      rocblas_dspr2_rank_1 = rocblas_dspr2_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(y),incy,AP)
     end function
 
     function rocblas_sspr2_strided_batched_rank_0(handle,uplo,n,alpha,x,incx,stride_x,y,incy, &
@@ -50484,12 +49226,12 @@ module hipfort_rocblas
       real(c_float),target :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stride_y
-      real(c_float),target :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: stride_A
       integer(c_int) :: batch_count
       !
       rocblas_sspr2_strided_batched_rank_0 = rocblas_sspr2_strided_batched_(handle,uplo,n,alpha, &
-        c_loc(x),incx,stride_x,c_loc(y),incy,stride_y,c_loc(AP),stride_A,batch_count)
+        c_loc(x),incx,stride_x,c_loc(y),incy,stride_y,AP,stride_A,batch_count)
     end function
 
     function rocblas_sspr2_strided_batched_rank_1(handle,uplo,n,alpha,x,incx,stride_x,y,incy, &
@@ -50508,12 +49250,12 @@ module hipfort_rocblas
       real(c_float),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stride_y
-      real(c_float),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: stride_A
       integer(c_int) :: batch_count
       !
       rocblas_sspr2_strided_batched_rank_1 = rocblas_sspr2_strided_batched_(handle,uplo,n,alpha, &
-        c_loc(x),incx,stride_x,c_loc(y),incy,stride_y,c_loc(AP),stride_A,batch_count)
+        c_loc(x),incx,stride_x,c_loc(y),incy,stride_y,AP,stride_A,batch_count)
     end function
 
     function rocblas_dspr2_strided_batched_rank_0(handle,uplo,n,alpha,x,incx,stride_x,y,incy, &
@@ -50532,12 +49274,12 @@ module hipfort_rocblas
       real(c_double),target :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stride_y
-      real(c_double),target :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: stride_A
       integer(c_int) :: batch_count
       !
       rocblas_dspr2_strided_batched_rank_0 = rocblas_dspr2_strided_batched_(handle,uplo,n,alpha, &
-        c_loc(x),incx,stride_x,c_loc(y),incy,stride_y,c_loc(AP),stride_A,batch_count)
+        c_loc(x),incx,stride_x,c_loc(y),incy,stride_y,AP,stride_A,batch_count)
     end function
 
     function rocblas_dspr2_strided_batched_rank_1(handle,uplo,n,alpha,x,incx,stride_x,y,incy, &
@@ -50556,12 +49298,12 @@ module hipfort_rocblas
       real(c_double),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stride_y
-      real(c_double),target,dimension(:) :: AP
+      type(c_ptr) :: AP
       integer(c_int64_t) :: stride_A
       integer(c_int) :: batch_count
       !
       rocblas_dspr2_strided_batched_rank_1 = rocblas_dspr2_strided_batched_(handle,uplo,n,alpha, &
-        c_loc(x),incx,stride_x,c_loc(y),incy,stride_y,c_loc(AP),stride_A,batch_count)
+        c_loc(x),incx,stride_x,c_loc(y),incy,stride_y,AP,stride_A,batch_count)
     end function
 
     function rocblas_ssyr_rank_0(handle,uplo,n,alpha,x,incx,A,lda)
@@ -50607,7 +49349,7 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)) :: uplo
       integer(c_int) :: n
       real(c_float) :: alpha
-      real(c_float),target,dimension(:,:) :: x
+      real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
@@ -50658,7 +49400,7 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)) :: uplo
       integer(c_int) :: n
       real(c_double) :: alpha
-      real(c_double),target,dimension(:,:) :: x
+      real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
@@ -50709,7 +49451,7 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)) :: uplo
       integer(c_int) :: n
       complex(c_float_complex) :: alpha
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
@@ -50760,7 +49502,7 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)) :: uplo
       integer(c_int) :: n
       complex(c_double_complex) :: alpha
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
@@ -50822,7 +49564,7 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)) :: uplo
       integer(c_int) :: n
       real(c_float) :: alpha
-      real(c_float),target,dimension(:,:) :: x
+      real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       real(c_float),target,dimension(:,:) :: A
@@ -50888,7 +49630,7 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)) :: uplo
       integer(c_int) :: n
       real(c_double) :: alpha
-      real(c_double),target,dimension(:,:) :: x
+      real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       real(c_double),target,dimension(:,:) :: A
@@ -50954,7 +49696,7 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)) :: uplo
       integer(c_int) :: n
       complex(c_float_complex) :: alpha
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       complex(c_float_complex),target,dimension(:,:) :: A
@@ -51020,7 +49762,7 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)) :: uplo
       integer(c_int) :: n
       complex(c_double_complex) :: alpha
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
       complex(c_double_complex),target,dimension(:,:) :: A
@@ -51081,9 +49823,9 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)) :: uplo
       integer(c_int) :: n
       real(c_float) :: alpha
-      real(c_float),target,dimension(:,:) :: x
+      real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
-      real(c_float),target,dimension(:,:) :: y
+      real(c_float),target,dimension(:) :: y
       integer(c_int) :: incy
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
@@ -51141,9 +49883,9 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)) :: uplo
       integer(c_int) :: n
       real(c_double) :: alpha
-      real(c_double),target,dimension(:,:) :: x
+      real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
-      real(c_double),target,dimension(:,:) :: y
+      real(c_double),target,dimension(:) :: y
       integer(c_int) :: incy
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
@@ -51201,9 +49943,9 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)) :: uplo
       integer(c_int) :: n
       complex(c_float_complex) :: alpha
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
-      complex(c_float_complex),target,dimension(:,:) :: y
+      complex(c_float_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
@@ -51261,9 +50003,9 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)) :: uplo
       integer(c_int) :: n
       complex(c_double_complex) :: alpha
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
-      complex(c_double_complex),target,dimension(:,:) :: y
+      complex(c_double_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
@@ -51332,10 +50074,10 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)) :: uplo
       integer(c_int) :: n
       real(c_float) :: alpha
-      real(c_float),target,dimension(:,:) :: x
+      real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
-      real(c_float),target,dimension(:,:) :: y
+      real(c_float),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       real(c_float),target,dimension(:,:) :: A
@@ -51407,10 +50149,10 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)) :: uplo
       integer(c_int) :: n
       real(c_double) :: alpha
-      real(c_double),target,dimension(:,:) :: x
+      real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
-      real(c_double),target,dimension(:,:) :: y
+      real(c_double),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       real(c_double),target,dimension(:,:) :: A
@@ -51482,10 +50224,10 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)) :: uplo
       integer(c_int) :: n
       complex(c_float_complex) :: alpha
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
-      complex(c_float_complex),target,dimension(:,:) :: y
+      complex(c_float_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       complex(c_float_complex),target,dimension(:,:) :: A
@@ -51557,10 +50299,10 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)) :: uplo
       integer(c_int) :: n
       complex(c_double_complex) :: alpha
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
-      complex(c_double_complex),target,dimension(:,:) :: y
+      complex(c_double_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
       complex(c_double_complex),target,dimension(:,:) :: A
@@ -57195,7 +55937,7 @@ module hipfort_rocblas
       integer(c_int) :: n
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: x
+      real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       real(c_float),target,dimension(:,:) :: C
       integer(c_int) :: ldc
@@ -57253,7 +55995,7 @@ module hipfort_rocblas
       integer(c_int) :: n
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: x
+      real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       real(c_double),target,dimension(:,:) :: C
       integer(c_int) :: ldc
@@ -57311,7 +56053,7 @@ module hipfort_rocblas
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       complex(c_float_complex),target,dimension(:,:) :: C
       integer(c_int) :: ldc
@@ -57369,7 +56111,7 @@ module hipfort_rocblas
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       complex(c_double_complex),target,dimension(:,:) :: C
       integer(c_int) :: ldc
@@ -57441,7 +56183,7 @@ module hipfort_rocblas
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: stride_A
-      real(c_float),target,dimension(:,:) :: x
+      real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stride_x
       real(c_float),target,dimension(:,:) :: C
@@ -57516,7 +56258,7 @@ module hipfort_rocblas
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: stride_A
-      real(c_double),target,dimension(:,:) :: x
+      real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stride_x
       real(c_double),target,dimension(:,:) :: C
@@ -57591,7 +56333,7 @@ module hipfort_rocblas
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: stride_A
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stride_x
       complex(c_float_complex),target,dimension(:,:) :: C
@@ -57666,7 +56408,7 @@ module hipfort_rocblas
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: stride_A
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stride_x
       complex(c_double_complex),target,dimension(:,:) :: C

--- a/lib/hipfort/hipfort_rocsolver.F90
+++ b/lib/hipfort/hipfort_rocsolver.F90
@@ -5984,13 +5984,6 @@ module hipfort_rocsolver
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocsolver_sgetf2_npvt_batched_rank_0,&
-      rocsolver_sgetf2_npvt_batched_rank_1,&
-      rocsolver_sgetf2_npvt_batched_full_rank
-#endif
   end interface
 
   interface rocsolver_dgetf2_npvt_batched
@@ -6009,13 +6002,6 @@ module hipfort_rocsolver
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocsolver_dgetf2_npvt_batched_rank_0,&
-      rocsolver_dgetf2_npvt_batched_rank_1,&
-      rocsolver_dgetf2_npvt_batched_full_rank
-#endif
   end interface
 
   interface rocsolver_cgetf2_npvt_batched
@@ -6034,13 +6020,6 @@ module hipfort_rocsolver
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocsolver_cgetf2_npvt_batched_rank_0,&
-      rocsolver_cgetf2_npvt_batched_rank_1,&
-      rocsolver_cgetf2_npvt_batched_full_rank
-#endif
   end interface
 
   interface rocsolver_zgetf2_npvt_batched
@@ -6059,13 +6038,6 @@ module hipfort_rocsolver
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocsolver_zgetf2_npvt_batched_rank_0,&
-      rocsolver_zgetf2_npvt_batched_rank_1,&
-      rocsolver_zgetf2_npvt_batched_full_rank
-#endif
   end interface
 
   !>     \brief The GETF2_NPVT_STRIDED_BATCHED functions compute the LU factorization of a batch
@@ -6435,13 +6407,6 @@ module hipfort_rocsolver
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocsolver_sgetrf_npvt_batched_rank_0,&
-      rocsolver_sgetrf_npvt_batched_rank_1,&
-      rocsolver_sgetrf_npvt_batched_full_rank
-#endif
   end interface
 
   interface rocsolver_dgetrf_npvt_batched
@@ -6460,13 +6425,6 @@ module hipfort_rocsolver
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocsolver_dgetrf_npvt_batched_rank_0,&
-      rocsolver_dgetrf_npvt_batched_rank_1,&
-      rocsolver_dgetrf_npvt_batched_full_rank
-#endif
   end interface
 
   interface rocsolver_cgetrf_npvt_batched
@@ -6485,13 +6443,6 @@ module hipfort_rocsolver
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocsolver_cgetrf_npvt_batched_rank_0,&
-      rocsolver_cgetrf_npvt_batched_rank_1,&
-      rocsolver_cgetrf_npvt_batched_full_rank
-#endif
   end interface
 
   interface rocsolver_zgetrf_npvt_batched
@@ -6510,13 +6461,6 @@ module hipfort_rocsolver
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocsolver_zgetrf_npvt_batched_rank_0,&
-      rocsolver_zgetrf_npvt_batched_rank_1,&
-      rocsolver_zgetrf_npvt_batched_full_rank
-#endif
   end interface
 
   !>     \brief The GETRF_NPVT_STRIDED_BATCHED functions compute the LU factorization of a batch
@@ -6900,8 +6844,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_sgetf2_batched_rank_0,&
-      rocsolver_sgetf2_batched_rank_1,&
-      rocsolver_sgetf2_batched_full_rank
+      rocsolver_sgetf2_batched_rank_1
 #endif
   end interface
 
@@ -6927,8 +6870,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_dgetf2_batched_rank_0,&
-      rocsolver_dgetf2_batched_rank_1,&
-      rocsolver_dgetf2_batched_full_rank
+      rocsolver_dgetf2_batched_rank_1
 #endif
   end interface
 
@@ -6954,8 +6896,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_cgetf2_batched_rank_0,&
-      rocsolver_cgetf2_batched_rank_1,&
-      rocsolver_cgetf2_batched_full_rank
+      rocsolver_cgetf2_batched_rank_1
 #endif
   end interface
 
@@ -6981,8 +6922,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_zgetf2_batched_rank_0,&
-      rocsolver_zgetf2_batched_rank_1,&
-      rocsolver_zgetf2_batched_full_rank
+      rocsolver_zgetf2_batched_rank_1
 #endif
   end interface
 
@@ -7384,8 +7324,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_sgetrf_batched_rank_0,&
-      rocsolver_sgetrf_batched_rank_1,&
-      rocsolver_sgetrf_batched_full_rank
+      rocsolver_sgetrf_batched_rank_1
 #endif
   end interface
 
@@ -7411,8 +7350,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_dgetrf_batched_rank_0,&
-      rocsolver_dgetrf_batched_rank_1,&
-      rocsolver_dgetrf_batched_full_rank
+      rocsolver_dgetrf_batched_rank_1
 #endif
   end interface
 
@@ -7438,8 +7376,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_cgetrf_batched_rank_0,&
-      rocsolver_cgetrf_batched_rank_1,&
-      rocsolver_cgetrf_batched_full_rank
+      rocsolver_cgetrf_batched_rank_1
 #endif
   end interface
 
@@ -7465,8 +7402,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_zgetrf_batched_rank_0,&
-      rocsolver_zgetrf_batched_rank_1,&
-      rocsolver_zgetrf_batched_full_rank
+      rocsolver_zgetrf_batched_rank_1
 #endif
   end interface
 
@@ -7872,8 +7808,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_sgeqr2_batched_rank_0,&
-      rocsolver_sgeqr2_batched_rank_1,&
-      rocsolver_sgeqr2_batched_full_rank
+      rocsolver_sgeqr2_batched_rank_1
 #endif
   end interface
 
@@ -7898,8 +7833,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_dgeqr2_batched_rank_0,&
-      rocsolver_dgeqr2_batched_rank_1,&
-      rocsolver_dgeqr2_batched_full_rank
+      rocsolver_dgeqr2_batched_rank_1
 #endif
   end interface
 
@@ -7924,8 +7858,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_cgeqr2_batched_rank_0,&
-      rocsolver_cgeqr2_batched_rank_1,&
-      rocsolver_cgeqr2_batched_full_rank
+      rocsolver_cgeqr2_batched_rank_1
 #endif
   end interface
 
@@ -7950,8 +7883,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_zgeqr2_batched_rank_0,&
-      rocsolver_zgeqr2_batched_rank_1,&
-      rocsolver_zgeqr2_batched_full_rank
+      rocsolver_zgeqr2_batched_rank_1
 #endif
   end interface
 
@@ -8353,8 +8285,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_sgerq2_batched_rank_0,&
-      rocsolver_sgerq2_batched_rank_1,&
-      rocsolver_sgerq2_batched_full_rank
+      rocsolver_sgerq2_batched_rank_1
 #endif
   end interface
 
@@ -8379,8 +8310,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_dgerq2_batched_rank_0,&
-      rocsolver_dgerq2_batched_rank_1,&
-      rocsolver_dgerq2_batched_full_rank
+      rocsolver_dgerq2_batched_rank_1
 #endif
   end interface
 
@@ -8405,8 +8335,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_cgerq2_batched_rank_0,&
-      rocsolver_cgerq2_batched_rank_1,&
-      rocsolver_cgerq2_batched_full_rank
+      rocsolver_cgerq2_batched_rank_1
 #endif
   end interface
 
@@ -8431,8 +8360,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_zgerq2_batched_rank_0,&
-      rocsolver_zgerq2_batched_rank_1,&
-      rocsolver_zgerq2_batched_full_rank
+      rocsolver_zgerq2_batched_rank_1
 #endif
   end interface
 
@@ -8836,8 +8764,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_sgeql2_batched_rank_0,&
-      rocsolver_sgeql2_batched_rank_1,&
-      rocsolver_sgeql2_batched_full_rank
+      rocsolver_sgeql2_batched_rank_1
 #endif
   end interface
 
@@ -8862,8 +8789,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_dgeql2_batched_rank_0,&
-      rocsolver_dgeql2_batched_rank_1,&
-      rocsolver_dgeql2_batched_full_rank
+      rocsolver_dgeql2_batched_rank_1
 #endif
   end interface
 
@@ -8888,8 +8814,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_cgeql2_batched_rank_0,&
-      rocsolver_cgeql2_batched_rank_1,&
-      rocsolver_cgeql2_batched_full_rank
+      rocsolver_cgeql2_batched_rank_1
 #endif
   end interface
 
@@ -8914,8 +8839,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_zgeql2_batched_rank_0,&
-      rocsolver_zgeql2_batched_rank_1,&
-      rocsolver_zgeql2_batched_full_rank
+      rocsolver_zgeql2_batched_rank_1
 #endif
   end interface
 
@@ -9316,8 +9240,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_sgelq2_batched_rank_0,&
-      rocsolver_sgelq2_batched_rank_1,&
-      rocsolver_sgelq2_batched_full_rank
+      rocsolver_sgelq2_batched_rank_1
 #endif
   end interface
 
@@ -9342,8 +9265,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_dgelq2_batched_rank_0,&
-      rocsolver_dgelq2_batched_rank_1,&
-      rocsolver_dgelq2_batched_full_rank
+      rocsolver_dgelq2_batched_rank_1
 #endif
   end interface
 
@@ -9368,8 +9290,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_cgelq2_batched_rank_0,&
-      rocsolver_cgelq2_batched_rank_1,&
-      rocsolver_cgelq2_batched_full_rank
+      rocsolver_cgelq2_batched_rank_1
 #endif
   end interface
 
@@ -9394,8 +9315,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_zgelq2_batched_rank_0,&
-      rocsolver_zgelq2_batched_rank_1,&
-      rocsolver_zgelq2_batched_full_rank
+      rocsolver_zgelq2_batched_rank_1
 #endif
   end interface
 
@@ -9796,8 +9716,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_sgeqrf_batched_rank_0,&
-      rocsolver_sgeqrf_batched_rank_1,&
-      rocsolver_sgeqrf_batched_full_rank
+      rocsolver_sgeqrf_batched_rank_1
 #endif
   end interface
 
@@ -9822,8 +9741,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_dgeqrf_batched_rank_0,&
-      rocsolver_dgeqrf_batched_rank_1,&
-      rocsolver_dgeqrf_batched_full_rank
+      rocsolver_dgeqrf_batched_rank_1
 #endif
   end interface
 
@@ -9848,8 +9766,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_cgeqrf_batched_rank_0,&
-      rocsolver_cgeqrf_batched_rank_1,&
-      rocsolver_cgeqrf_batched_full_rank
+      rocsolver_cgeqrf_batched_rank_1
 #endif
   end interface
 
@@ -9874,8 +9791,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_zgeqrf_batched_rank_0,&
-      rocsolver_zgeqrf_batched_rank_1,&
-      rocsolver_zgeqrf_batched_full_rank
+      rocsolver_zgeqrf_batched_rank_1
 #endif
   end interface
 
@@ -10277,8 +10193,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_sgerqf_batched_rank_0,&
-      rocsolver_sgerqf_batched_rank_1,&
-      rocsolver_sgerqf_batched_full_rank
+      rocsolver_sgerqf_batched_rank_1
 #endif
   end interface
 
@@ -10303,8 +10218,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_dgerqf_batched_rank_0,&
-      rocsolver_dgerqf_batched_rank_1,&
-      rocsolver_dgerqf_batched_full_rank
+      rocsolver_dgerqf_batched_rank_1
 #endif
   end interface
 
@@ -10329,8 +10243,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_cgerqf_batched_rank_0,&
-      rocsolver_cgerqf_batched_rank_1,&
-      rocsolver_cgerqf_batched_full_rank
+      rocsolver_cgerqf_batched_rank_1
 #endif
   end interface
 
@@ -10355,8 +10268,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_zgerqf_batched_rank_0,&
-      rocsolver_zgerqf_batched_rank_1,&
-      rocsolver_zgerqf_batched_full_rank
+      rocsolver_zgerqf_batched_rank_1
 #endif
   end interface
 
@@ -10760,8 +10672,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_sgeqlf_batched_rank_0,&
-      rocsolver_sgeqlf_batched_rank_1,&
-      rocsolver_sgeqlf_batched_full_rank
+      rocsolver_sgeqlf_batched_rank_1
 #endif
   end interface
 
@@ -10786,8 +10697,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_dgeqlf_batched_rank_0,&
-      rocsolver_dgeqlf_batched_rank_1,&
-      rocsolver_dgeqlf_batched_full_rank
+      rocsolver_dgeqlf_batched_rank_1
 #endif
   end interface
 
@@ -10812,8 +10722,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_cgeqlf_batched_rank_0,&
-      rocsolver_cgeqlf_batched_rank_1,&
-      rocsolver_cgeqlf_batched_full_rank
+      rocsolver_cgeqlf_batched_rank_1
 #endif
   end interface
 
@@ -10838,8 +10747,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_zgeqlf_batched_rank_0,&
-      rocsolver_zgeqlf_batched_rank_1,&
-      rocsolver_zgeqlf_batched_full_rank
+      rocsolver_zgeqlf_batched_rank_1
 #endif
   end interface
 
@@ -11240,8 +11148,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_sgelqf_batched_rank_0,&
-      rocsolver_sgelqf_batched_rank_1,&
-      rocsolver_sgelqf_batched_full_rank
+      rocsolver_sgelqf_batched_rank_1
 #endif
   end interface
 
@@ -11266,8 +11173,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_dgelqf_batched_rank_0,&
-      rocsolver_dgelqf_batched_rank_1,&
-      rocsolver_dgelqf_batched_full_rank
+      rocsolver_dgelqf_batched_rank_1
 #endif
   end interface
 
@@ -11292,8 +11198,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_cgelqf_batched_rank_0,&
-      rocsolver_cgelqf_batched_rank_1,&
-      rocsolver_cgelqf_batched_full_rank
+      rocsolver_cgelqf_batched_rank_1
 #endif
   end interface
 
@@ -11318,8 +11223,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_zgelqf_batched_rank_0,&
-      rocsolver_zgelqf_batched_rank_1,&
-      rocsolver_zgelqf_batched_full_rank
+      rocsolver_zgelqf_batched_rank_1
 #endif
   end interface
 
@@ -11807,8 +11711,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_sgebd2_batched_rank_0,&
-      rocsolver_sgebd2_batched_rank_1,&
-      rocsolver_sgebd2_batched_full_rank
+      rocsolver_sgebd2_batched_rank_1
 #endif
   end interface
 
@@ -11840,8 +11743,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_dgebd2_batched_rank_0,&
-      rocsolver_dgebd2_batched_rank_1,&
-      rocsolver_dgebd2_batched_full_rank
+      rocsolver_dgebd2_batched_rank_1
 #endif
   end interface
 
@@ -11873,8 +11775,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_cgebd2_batched_rank_0,&
-      rocsolver_cgebd2_batched_rank_1,&
-      rocsolver_cgebd2_batched_full_rank
+      rocsolver_cgebd2_batched_rank_1
 #endif
   end interface
 
@@ -11906,8 +11807,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_zgebd2_batched_rank_0,&
-      rocsolver_zgebd2_batched_rank_1,&
-      rocsolver_zgebd2_batched_full_rank
+      rocsolver_zgebd2_batched_rank_1
 #endif
   end interface
 
@@ -12467,8 +12367,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_sgebrd_batched_rank_0,&
-      rocsolver_sgebrd_batched_rank_1,&
-      rocsolver_sgebrd_batched_full_rank
+      rocsolver_sgebrd_batched_rank_1
 #endif
   end interface
 
@@ -12500,8 +12399,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_dgebrd_batched_rank_0,&
-      rocsolver_dgebrd_batched_rank_1,&
-      rocsolver_dgebrd_batched_full_rank
+      rocsolver_dgebrd_batched_rank_1
 #endif
   end interface
 
@@ -12533,8 +12431,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_cgebrd_batched_rank_0,&
-      rocsolver_cgebrd_batched_rank_1,&
-      rocsolver_cgebrd_batched_full_rank
+      rocsolver_cgebrd_batched_rank_1
 #endif
   end interface
 
@@ -12566,8 +12463,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_zgebrd_batched_rank_0,&
-      rocsolver_zgebrd_batched_rank_1,&
-      rocsolver_zgebrd_batched_full_rank
+      rocsolver_zgebrd_batched_rank_1
 #endif
   end interface
 
@@ -13052,8 +12948,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_sgetrs_batched_rank_0,&
-      rocsolver_sgetrs_batched_rank_1,&
-      rocsolver_sgetrs_batched_full_rank
+      rocsolver_sgetrs_batched_rank_1
 #endif
   end interface
 
@@ -13081,8 +12976,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_dgetrs_batched_rank_0,&
-      rocsolver_dgetrs_batched_rank_1,&
-      rocsolver_dgetrs_batched_full_rank
+      rocsolver_dgetrs_batched_rank_1
 #endif
   end interface
 
@@ -13110,8 +13004,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_cgetrs_batched_rank_0,&
-      rocsolver_cgetrs_batched_rank_1,&
-      rocsolver_cgetrs_batched_full_rank
+      rocsolver_cgetrs_batched_rank_1
 #endif
   end interface
 
@@ -13139,8 +13032,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_zgetrs_batched_rank_0,&
-      rocsolver_zgetrs_batched_rank_1,&
-      rocsolver_zgetrs_batched_full_rank
+      rocsolver_zgetrs_batched_rank_1
 #endif
   end interface
 
@@ -13576,8 +13468,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_sgesv_batched_rank_0,&
-      rocsolver_sgesv_batched_rank_1,&
-      rocsolver_sgesv_batched_full_rank
+      rocsolver_sgesv_batched_rank_1
 #endif
   end interface
 
@@ -13605,8 +13496,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_dgesv_batched_rank_0,&
-      rocsolver_dgesv_batched_rank_1,&
-      rocsolver_dgesv_batched_full_rank
+      rocsolver_dgesv_batched_rank_1
 #endif
   end interface
 
@@ -13634,8 +13524,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_cgesv_batched_rank_0,&
-      rocsolver_cgesv_batched_rank_1,&
-      rocsolver_cgesv_batched_full_rank
+      rocsolver_cgesv_batched_rank_1
 #endif
   end interface
 
@@ -13663,8 +13552,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_zgesv_batched_rank_0,&
-      rocsolver_zgesv_batched_rank_1,&
-      rocsolver_zgesv_batched_full_rank
+      rocsolver_zgesv_batched_rank_1
 #endif
   end interface
 
@@ -14056,8 +13944,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_sgetri_batched_rank_0,&
-      rocsolver_sgetri_batched_rank_1,&
-      rocsolver_sgetri_batched_full_rank
+      rocsolver_sgetri_batched_rank_1
 #endif
   end interface
 
@@ -14082,8 +13969,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_dgetri_batched_rank_0,&
-      rocsolver_dgetri_batched_rank_1,&
-      rocsolver_dgetri_batched_full_rank
+      rocsolver_dgetri_batched_rank_1
 #endif
   end interface
 
@@ -14108,8 +13994,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_cgetri_batched_rank_0,&
-      rocsolver_cgetri_batched_rank_1,&
-      rocsolver_cgetri_batched_full_rank
+      rocsolver_cgetri_batched_rank_1
 #endif
   end interface
 
@@ -14134,8 +14019,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_zgetri_batched_rank_0,&
-      rocsolver_zgetri_batched_rank_1,&
-      rocsolver_zgetri_batched_full_rank
+      rocsolver_zgetri_batched_rank_1
 #endif
   end interface
 
@@ -14472,13 +14356,6 @@ module hipfort_rocsolver
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocsolver_sgetri_npvt_batched_rank_0,&
-      rocsolver_sgetri_npvt_batched_rank_1,&
-      rocsolver_sgetri_npvt_batched_full_rank
-#endif
   end interface
 
   interface rocsolver_dgetri_npvt_batched
@@ -14496,13 +14373,6 @@ module hipfort_rocsolver
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocsolver_dgetri_npvt_batched_rank_0,&
-      rocsolver_dgetri_npvt_batched_rank_1,&
-      rocsolver_dgetri_npvt_batched_full_rank
-#endif
   end interface
 
   interface rocsolver_cgetri_npvt_batched
@@ -14520,13 +14390,6 @@ module hipfort_rocsolver
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocsolver_cgetri_npvt_batched_rank_0,&
-      rocsolver_cgetri_npvt_batched_rank_1,&
-      rocsolver_cgetri_npvt_batched_full_rank
-#endif
   end interface
 
   interface rocsolver_zgetri_npvt_batched
@@ -14544,13 +14407,6 @@ module hipfort_rocsolver
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocsolver_zgetri_npvt_batched_rank_0,&
-      rocsolver_zgetri_npvt_batched_rank_1,&
-      rocsolver_zgetri_npvt_batched_full_rank
-#endif
   end interface
 
   !>     \brief The GETRI_NPVT_STRIDED_BATCHED functions invert a batch of general ``n`` -by-``n``
@@ -14967,13 +14823,6 @@ module hipfort_rocsolver
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocsolver_sgels_batched_rank_0,&
-      rocsolver_sgels_batched_rank_1,&
-      rocsolver_sgels_batched_full_rank
-#endif
   end interface
 
   interface rocsolver_dgels_batched
@@ -14996,13 +14845,6 @@ module hipfort_rocsolver
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocsolver_dgels_batched_rank_0,&
-      rocsolver_dgels_batched_rank_1,&
-      rocsolver_dgels_batched_full_rank
-#endif
   end interface
 
   interface rocsolver_cgels_batched
@@ -15025,13 +14867,6 @@ module hipfort_rocsolver
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocsolver_cgels_batched_rank_0,&
-      rocsolver_cgels_batched_rank_1,&
-      rocsolver_cgels_batched_full_rank
-#endif
   end interface
 
   interface rocsolver_zgels_batched
@@ -15054,13 +14889,6 @@ module hipfort_rocsolver
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocsolver_zgels_batched_rank_0,&
-      rocsolver_zgels_batched_rank_1,&
-      rocsolver_zgels_batched_full_rank
-#endif
   end interface
 
   !>     \brief The GELS_STRIDED_BATCHED functions solve a batch of overdetermined (or
@@ -15466,13 +15294,6 @@ module hipfort_rocsolver
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocsolver_spotf2_batched_rank_0,&
-      rocsolver_spotf2_batched_rank_1,&
-      rocsolver_spotf2_batched_full_rank
-#endif
   end interface
 
   interface rocsolver_dpotf2_batched
@@ -15491,13 +15312,6 @@ module hipfort_rocsolver
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocsolver_dpotf2_batched_rank_0,&
-      rocsolver_dpotf2_batched_rank_1,&
-      rocsolver_dpotf2_batched_full_rank
-#endif
   end interface
 
   interface rocsolver_cpotf2_batched
@@ -15516,13 +15330,6 @@ module hipfort_rocsolver
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocsolver_cpotf2_batched_rank_0,&
-      rocsolver_cpotf2_batched_rank_1,&
-      rocsolver_cpotf2_batched_full_rank
-#endif
   end interface
 
   interface rocsolver_zpotf2_batched
@@ -15541,13 +15348,6 @@ module hipfort_rocsolver
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocsolver_zpotf2_batched_rank_0,&
-      rocsolver_zpotf2_batched_rank_1,&
-      rocsolver_zpotf2_batched_full_rank
-#endif
   end interface
 
   !>     \brief The POTF2_STRIDED_BATCHED functions compute the Cholesky factorization of a
@@ -15892,13 +15692,6 @@ module hipfort_rocsolver
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocsolver_spotrf_batched_rank_0,&
-      rocsolver_spotrf_batched_rank_1,&
-      rocsolver_spotrf_batched_full_rank
-#endif
   end interface
 
   interface rocsolver_dpotrf_batched
@@ -15917,13 +15710,6 @@ module hipfort_rocsolver
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocsolver_dpotrf_batched_rank_0,&
-      rocsolver_dpotrf_batched_rank_1,&
-      rocsolver_dpotrf_batched_full_rank
-#endif
   end interface
 
   interface rocsolver_cpotrf_batched
@@ -15942,13 +15728,6 @@ module hipfort_rocsolver
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocsolver_cpotrf_batched_rank_0,&
-      rocsolver_cpotrf_batched_rank_1,&
-      rocsolver_cpotrf_batched_full_rank
-#endif
   end interface
 
   interface rocsolver_zpotrf_batched
@@ -15967,13 +15746,6 @@ module hipfort_rocsolver
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocsolver_zpotrf_batched_rank_0,&
-      rocsolver_zpotrf_batched_rank_1,&
-      rocsolver_zpotrf_batched_full_rank
-#endif
   end interface
 
   !>     \brief The POTRF_STRIDED_BATCHED functions computes the Cholesky factorization of a
@@ -16833,13 +16605,6 @@ module hipfort_rocsolver
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocsolver_sposv_batched_rank_0,&
-      rocsolver_sposv_batched_rank_1,&
-      rocsolver_sposv_batched_full_rank
-#endif
   end interface
 
   interface rocsolver_dposv_batched
@@ -16861,13 +16626,6 @@ module hipfort_rocsolver
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocsolver_dposv_batched_rank_0,&
-      rocsolver_dposv_batched_rank_1,&
-      rocsolver_dposv_batched_full_rank
-#endif
   end interface
 
   interface rocsolver_cposv_batched
@@ -16889,13 +16647,6 @@ module hipfort_rocsolver
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocsolver_cposv_batched_rank_0,&
-      rocsolver_cposv_batched_rank_1,&
-      rocsolver_cposv_batched_full_rank
-#endif
   end interface
 
   interface rocsolver_zposv_batched
@@ -16917,13 +16668,6 @@ module hipfort_rocsolver
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocsolver_zposv_batched_rank_0,&
-      rocsolver_zposv_batched_rank_1,&
-      rocsolver_zposv_batched_full_rank
-#endif
   end interface
 
   !>     \brief The POSV_STRIDED_BATCHED functions solve a batch of symmetric/Hermitian systems of
@@ -17307,13 +17051,6 @@ module hipfort_rocsolver
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocsolver_spotri_batched_rank_0,&
-      rocsolver_spotri_batched_rank_1,&
-      rocsolver_spotri_batched_full_rank
-#endif
   end interface
 
   interface rocsolver_dpotri_batched
@@ -17332,13 +17069,6 @@ module hipfort_rocsolver
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocsolver_dpotri_batched_rank_0,&
-      rocsolver_dpotri_batched_rank_1,&
-      rocsolver_dpotri_batched_full_rank
-#endif
   end interface
 
   interface rocsolver_cpotri_batched
@@ -17357,13 +17087,6 @@ module hipfort_rocsolver
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocsolver_cpotri_batched_rank_0,&
-      rocsolver_cpotri_batched_rank_1,&
-      rocsolver_cpotri_batched_full_rank
-#endif
   end interface
 
   interface rocsolver_zpotri_batched
@@ -17382,13 +17105,6 @@ module hipfort_rocsolver
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocsolver_zpotri_batched_rank_0,&
-      rocsolver_zpotri_batched_rank_1,&
-      rocsolver_zpotri_batched_full_rank
-#endif
   end interface
 
   !>     \brief The POTRI_STRIDED_BATCHED functions invert a batch of symmetric/Hermitian positive
@@ -18747,8 +18463,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_ssytd2_batched_rank_0,&
-      rocsolver_ssytd2_batched_rank_1,&
-      rocsolver_ssytd2_batched_full_rank
+      rocsolver_ssytd2_batched_rank_1
 #endif
   end interface
 
@@ -18778,8 +18493,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_dsytd2_batched_rank_0,&
-      rocsolver_dsytd2_batched_rank_1,&
-      rocsolver_dsytd2_batched_full_rank
+      rocsolver_dsytd2_batched_rank_1
 #endif
   end interface
 
@@ -18897,8 +18611,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_chetd2_batched_rank_0,&
-      rocsolver_chetd2_batched_rank_1,&
-      rocsolver_chetd2_batched_full_rank
+      rocsolver_chetd2_batched_rank_1
 #endif
   end interface
 
@@ -18928,8 +18641,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_zhetd2_batched_rank_0,&
-      rocsolver_zhetd2_batched_rank_1,&
-      rocsolver_zhetd2_batched_full_rank
+      rocsolver_zhetd2_batched_rank_1
 #endif
   end interface
 
@@ -19592,8 +19304,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_ssytrd_batched_rank_0,&
-      rocsolver_ssytrd_batched_rank_1,&
-      rocsolver_ssytrd_batched_full_rank
+      rocsolver_ssytrd_batched_rank_1
 #endif
   end interface
 
@@ -19623,8 +19334,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_dsytrd_batched_rank_0,&
-      rocsolver_dsytrd_batched_rank_1,&
-      rocsolver_dsytrd_batched_full_rank
+      rocsolver_dsytrd_batched_rank_1
 #endif
   end interface
 
@@ -19742,8 +19452,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_chetrd_batched_rank_0,&
-      rocsolver_chetrd_batched_rank_1,&
-      rocsolver_chetrd_batched_full_rank
+      rocsolver_chetrd_batched_rank_1
 #endif
   end interface
 
@@ -19773,8 +19482,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_zhetrd_batched_rank_0,&
-      rocsolver_zhetrd_batched_rank_1,&
-      rocsolver_zhetrd_batched_full_rank
+      rocsolver_zhetrd_batched_rank_1
 #endif
   end interface
 
@@ -21913,8 +21621,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_ssyev_batched_rank_0,&
-      rocsolver_ssyev_batched_rank_1,&
-      rocsolver_ssyev_batched_full_rank
+      rocsolver_ssyev_batched_rank_1
 #endif
   end interface
 
@@ -21944,8 +21651,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_dsyev_batched_rank_0,&
-      rocsolver_dsyev_batched_rank_1,&
-      rocsolver_dsyev_batched_full_rank
+      rocsolver_dsyev_batched_rank_1
 #endif
   end interface
 
@@ -22043,8 +21749,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_cheev_batched_rank_0,&
-      rocsolver_cheev_batched_rank_1,&
-      rocsolver_cheev_batched_full_rank
+      rocsolver_cheev_batched_rank_1
 #endif
   end interface
 
@@ -22074,8 +21779,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_zheev_batched_rank_0,&
-      rocsolver_zheev_batched_rank_1,&
-      rocsolver_zheev_batched_full_rank
+      rocsolver_zheev_batched_rank_1
 #endif
   end interface
 
@@ -22678,8 +22382,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_ssyevd_batched_rank_0,&
-      rocsolver_ssyevd_batched_rank_1,&
-      rocsolver_ssyevd_batched_full_rank
+      rocsolver_ssyevd_batched_rank_1
 #endif
   end interface
 
@@ -22709,8 +22412,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_dsyevd_batched_rank_0,&
-      rocsolver_dsyevd_batched_rank_1,&
-      rocsolver_dsyevd_batched_full_rank
+      rocsolver_dsyevd_batched_rank_1
 #endif
   end interface
 
@@ -22814,8 +22516,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_cheevd_batched_rank_0,&
-      rocsolver_cheevd_batched_rank_1,&
-      rocsolver_cheevd_batched_full_rank
+      rocsolver_cheevd_batched_rank_1
 #endif
   end interface
 
@@ -22845,8 +22546,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_zheevd_batched_rank_0,&
-      rocsolver_zheevd_batched_rank_1,&
-      rocsolver_zheevd_batched_full_rank
+      rocsolver_zheevd_batched_rank_1
 #endif
   end interface
 
@@ -23543,8 +23243,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_ssygv_batched_rank_0,&
-      rocsolver_ssygv_batched_rank_1,&
-      rocsolver_ssygv_batched_full_rank
+      rocsolver_ssygv_batched_rank_1
 #endif
   end interface
 
@@ -23577,8 +23276,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_dsygv_batched_rank_0,&
-      rocsolver_dsygv_batched_rank_1,&
-      rocsolver_dsygv_batched_full_rank
+      rocsolver_dsygv_batched_rank_1
 #endif
   end interface
 
@@ -23705,8 +23403,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_chegv_batched_rank_0,&
-      rocsolver_chegv_batched_rank_1,&
-      rocsolver_chegv_batched_full_rank
+      rocsolver_chegv_batched_rank_1
 #endif
   end interface
 
@@ -23739,8 +23436,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_zhegv_batched_rank_0,&
-      rocsolver_zhegv_batched_rank_1,&
-      rocsolver_zhegv_batched_full_rank
+      rocsolver_zhegv_batched_rank_1
 #endif
   end interface
 
@@ -24524,8 +24220,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_ssygvd_batched_rank_0,&
-      rocsolver_ssygvd_batched_rank_1,&
-      rocsolver_ssygvd_batched_full_rank
+      rocsolver_ssygvd_batched_rank_1
 #endif
   end interface
 
@@ -24558,8 +24253,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_dsygvd_batched_rank_0,&
-      rocsolver_dsygvd_batched_rank_1,&
-      rocsolver_dsygvd_batched_full_rank
+      rocsolver_dsygvd_batched_rank_1
 #endif
   end interface
 
@@ -24697,8 +24391,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_chegvd_batched_rank_0,&
-      rocsolver_chegvd_batched_rank_1,&
-      rocsolver_chegvd_batched_full_rank
+      rocsolver_chegvd_batched_rank_1
 #endif
   end interface
 
@@ -24731,8 +24424,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_zhegvd_batched_rank_0,&
-      rocsolver_zhegvd_batched_rank_1,&
-      rocsolver_zhegvd_batched_full_rank
+      rocsolver_zhegvd_batched_rank_1
 #endif
   end interface
 
@@ -25518,8 +25210,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_sgetri_outofplace_batched_rank_0,&
-      rocsolver_sgetri_outofplace_batched_rank_1,&
-      rocsolver_sgetri_outofplace_batched_full_rank
+      rocsolver_sgetri_outofplace_batched_rank_1
 #endif
   end interface
 
@@ -25547,8 +25238,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_dgetri_outofplace_batched_rank_0,&
-      rocsolver_dgetri_outofplace_batched_rank_1,&
-      rocsolver_dgetri_outofplace_batched_full_rank
+      rocsolver_dgetri_outofplace_batched_rank_1
 #endif
   end interface
 
@@ -25576,8 +25266,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_cgetri_outofplace_batched_rank_0,&
-      rocsolver_cgetri_outofplace_batched_rank_1,&
-      rocsolver_cgetri_outofplace_batched_full_rank
+      rocsolver_cgetri_outofplace_batched_rank_1
 #endif
   end interface
 
@@ -25605,8 +25294,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_zgetri_outofplace_batched_rank_0,&
-      rocsolver_zgetri_outofplace_batched_rank_1,&
-      rocsolver_zgetri_outofplace_batched_full_rank
+      rocsolver_zgetri_outofplace_batched_rank_1
 #endif
   end interface
 
@@ -25982,13 +25670,6 @@ module hipfort_rocsolver
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocsolver_sgetri_npvt_outofplace_batched_rank_0,&
-      rocsolver_sgetri_npvt_outofplace_batched_rank_1,&
-      rocsolver_sgetri_npvt_outofplace_batched_full_rank
-#endif
   end interface
 
   interface rocsolver_dgetri_npvt_outofplace_batched
@@ -26008,13 +25689,6 @@ module hipfort_rocsolver
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocsolver_dgetri_npvt_outofplace_batched_rank_0,&
-      rocsolver_dgetri_npvt_outofplace_batched_rank_1,&
-      rocsolver_dgetri_npvt_outofplace_batched_full_rank
-#endif
   end interface
 
   interface rocsolver_cgetri_npvt_outofplace_batched
@@ -26034,13 +25708,6 @@ module hipfort_rocsolver
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocsolver_cgetri_npvt_outofplace_batched_rank_0,&
-      rocsolver_cgetri_npvt_outofplace_batched_rank_1,&
-      rocsolver_cgetri_npvt_outofplace_batched_full_rank
-#endif
   end interface
 
   interface rocsolver_zgetri_npvt_outofplace_batched
@@ -26060,13 +25727,6 @@ module hipfort_rocsolver
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocsolver_zgetri_npvt_outofplace_batched_rank_0,&
-      rocsolver_zgetri_npvt_outofplace_batched_rank_1,&
-      rocsolver_zgetri_npvt_outofplace_batched_full_rank
-#endif
   end interface
 
   !>     \brief The GETRI_NPVT_OUTOFPLACE_STRIDED_BATCHED functions compute the inverse \f$C_l^{} =
@@ -26418,13 +26078,6 @@ module hipfort_rocsolver
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocsolver_strtri_batched_rank_0,&
-      rocsolver_strtri_batched_rank_1,&
-      rocsolver_strtri_batched_full_rank
-#endif
   end interface
 
   interface rocsolver_dtrtri_batched
@@ -26444,13 +26097,6 @@ module hipfort_rocsolver
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocsolver_dtrtri_batched_rank_0,&
-      rocsolver_dtrtri_batched_rank_1,&
-      rocsolver_dtrtri_batched_full_rank
-#endif
   end interface
 
   interface rocsolver_ctrtri_batched
@@ -26470,13 +26116,6 @@ module hipfort_rocsolver
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocsolver_ctrtri_batched_rank_0,&
-      rocsolver_ctrtri_batched_rank_1,&
-      rocsolver_ctrtri_batched_full_rank
-#endif
   end interface
 
   interface rocsolver_ztrtri_batched
@@ -26496,13 +26135,6 @@ module hipfort_rocsolver
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      rocsolver_ztrtri_batched_rank_0,&
-      rocsolver_ztrtri_batched_rank_1,&
-      rocsolver_ztrtri_batched_full_rank
-#endif
   end interface
 
   !>     \brief The TRTRI_STRIDED_BATCHED functions invert a batch of triangular ``n`` -by-``n``
@@ -26980,8 +26612,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_ssytf2_batched_rank_0,&
-      rocsolver_ssytf2_batched_rank_1,&
-      rocsolver_ssytf2_batched_full_rank
+      rocsolver_ssytf2_batched_rank_1
 #endif
   end interface
 
@@ -27007,8 +26638,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_dsytf2_batched_rank_0,&
-      rocsolver_dsytf2_batched_rank_1,&
-      rocsolver_dsytf2_batched_full_rank
+      rocsolver_dsytf2_batched_rank_1
 #endif
   end interface
 
@@ -27034,8 +26664,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_csytf2_batched_rank_0,&
-      rocsolver_csytf2_batched_rank_1,&
-      rocsolver_csytf2_batched_full_rank
+      rocsolver_csytf2_batched_rank_1
 #endif
   end interface
 
@@ -27061,8 +26690,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_zsytf2_batched_rank_0,&
-      rocsolver_zsytf2_batched_rank_1,&
-      rocsolver_zsytf2_batched_full_rank
+      rocsolver_zsytf2_batched_rank_1
 #endif
   end interface
 
@@ -27612,8 +27240,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_ssytrf_batched_rank_0,&
-      rocsolver_ssytrf_batched_rank_1,&
-      rocsolver_ssytrf_batched_full_rank
+      rocsolver_ssytrf_batched_rank_1
 #endif
   end interface
 
@@ -27639,8 +27266,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_dsytrf_batched_rank_0,&
-      rocsolver_dsytrf_batched_rank_1,&
-      rocsolver_dsytrf_batched_full_rank
+      rocsolver_dsytrf_batched_rank_1
 #endif
   end interface
 
@@ -27666,8 +27292,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_csytrf_batched_rank_0,&
-      rocsolver_csytrf_batched_rank_1,&
-      rocsolver_csytrf_batched_full_rank
+      rocsolver_csytrf_batched_rank_1
 #endif
   end interface
 
@@ -27693,8 +27318,7 @@ module hipfort_rocsolver
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsolver_zsytrf_batched_rank_0,&
-      rocsolver_zsytrf_batched_rank_1,&
-      rocsolver_zsytrf_batched_full_rank
+      rocsolver_zsytrf_batched_rank_1
 #endif
   end interface
 
@@ -45766,7 +45390,7 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       integer(c_int) :: k1
       integer(c_int) :: k2
-      integer(c_int),target,dimension(:,:) :: ipiv
+      integer(c_int),target,dimension(:) :: ipiv
       integer(c_int) :: incx
       !
       rocsolver_slaswp_full_rank = rocsolver_slaswp_(handle,n,c_loc(A),lda,k1,k2,c_loc(ipiv),incx)
@@ -45820,7 +45444,7 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       integer(c_int) :: k1
       integer(c_int) :: k2
-      integer(c_int),target,dimension(:,:) :: ipiv
+      integer(c_int),target,dimension(:) :: ipiv
       integer(c_int) :: incx
       !
       rocsolver_dlaswp_full_rank = rocsolver_dlaswp_(handle,n,c_loc(A),lda,k1,k2,c_loc(ipiv),incx)
@@ -45874,7 +45498,7 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       integer(c_int) :: k1
       integer(c_int) :: k2
-      integer(c_int),target,dimension(:,:) :: ipiv
+      integer(c_int),target,dimension(:) :: ipiv
       integer(c_int) :: incx
       !
       rocsolver_claswp_full_rank = rocsolver_claswp_(handle,n,c_loc(A),lda,k1,k2,c_loc(ipiv),incx)
@@ -45928,7 +45552,7 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       integer(c_int) :: k1
       integer(c_int) :: k2
-      integer(c_int),target,dimension(:,:) :: ipiv
+      integer(c_int),target,dimension(:) :: ipiv
       integer(c_int) :: incx
       !
       rocsolver_zlaswp_full_rank = rocsolver_zlaswp_(handle,n,c_loc(A),lda,k1,k2,c_loc(ipiv),incx)
@@ -46362,7 +45986,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_side_left)) :: side
       integer(c_int) :: m
       integer(c_int) :: n
-      real(c_float),target,dimension(:,:) :: x
+      real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       real(c_float) :: alpha
       real(c_float),target,dimension(:,:) :: A
@@ -46419,7 +46043,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_side_left)) :: side
       integer(c_int) :: m
       integer(c_int) :: n
-      real(c_double),target,dimension(:,:) :: x
+      real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       real(c_double) :: alpha
       real(c_double),target,dimension(:,:) :: A
@@ -46476,7 +46100,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_side_left)) :: side
       integer(c_int) :: m
       integer(c_int) :: n
-      complex(c_float_complex),target,dimension(:,:) :: x
+      complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       complex(c_float_complex) :: alpha
       complex(c_float_complex),target,dimension(:,:) :: A
@@ -46533,7 +46157,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_side_left)) :: side
       integer(c_int) :: m
       integer(c_int) :: n
-      complex(c_double_complex),target,dimension(:,:) :: x
+      complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       complex(c_double_complex) :: alpha
       complex(c_double_complex),target,dimension(:,:) :: A
@@ -46904,10 +46528,10 @@ module hipfort_rocsolver
       integer(c_int) :: k
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: D
-      real(c_float),target,dimension(:,:) :: E
-      real(c_float),target,dimension(:,:) :: tauq
-      real(c_float),target,dimension(:,:) :: taup
+      real(c_float),target,dimension(:) :: D
+      real(c_float),target,dimension(:) :: E
+      real(c_float),target,dimension(:) :: tauq
+      real(c_float),target,dimension(:) :: taup
       real(c_float),target,dimension(:,:) :: X
       integer(c_int) :: ldx
       real(c_float),target,dimension(:,:) :: Y
@@ -46979,10 +46603,10 @@ module hipfort_rocsolver
       integer(c_int) :: k
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: D
-      real(c_double),target,dimension(:,:) :: E
-      real(c_double),target,dimension(:,:) :: tauq
-      real(c_double),target,dimension(:,:) :: taup
+      real(c_double),target,dimension(:) :: D
+      real(c_double),target,dimension(:) :: E
+      real(c_double),target,dimension(:) :: tauq
+      real(c_double),target,dimension(:) :: taup
       real(c_double),target,dimension(:,:) :: X
       integer(c_int) :: ldx
       real(c_double),target,dimension(:,:) :: Y
@@ -47054,10 +46678,10 @@ module hipfort_rocsolver
       integer(c_int) :: k
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: D
-      real(c_float),target,dimension(:,:) :: E
-      complex(c_float_complex),target,dimension(:,:) :: tauq
-      complex(c_float_complex),target,dimension(:,:) :: taup
+      real(c_float),target,dimension(:) :: D
+      real(c_float),target,dimension(:) :: E
+      complex(c_float_complex),target,dimension(:) :: tauq
+      complex(c_float_complex),target,dimension(:) :: taup
       complex(c_float_complex),target,dimension(:,:) :: X
       integer(c_int) :: ldx
       complex(c_float_complex),target,dimension(:,:) :: Y
@@ -47129,10 +46753,10 @@ module hipfort_rocsolver
       integer(c_int) :: k
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: D
-      real(c_double),target,dimension(:,:) :: E
-      complex(c_double_complex),target,dimension(:,:) :: tauq
-      complex(c_double_complex),target,dimension(:,:) :: taup
+      real(c_double),target,dimension(:) :: D
+      real(c_double),target,dimension(:) :: E
+      complex(c_double_complex),target,dimension(:) :: tauq
+      complex(c_double_complex),target,dimension(:) :: taup
       complex(c_double_complex),target,dimension(:,:) :: X
       integer(c_int) :: ldx
       complex(c_double_complex),target,dimension(:,:) :: Y
@@ -47156,11 +46780,10 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       real(c_float),target :: E
       real(c_float) :: tau
-      real(c_float),target :: W
+      type(c_ptr) :: W
       integer(c_int) :: ldw
       !
-      rocsolver_slatrd_rank_0 = rocsolver_slatrd_(handle,uplo,n,k,c_loc(A),lda,c_loc(E),tau, &
-        c_loc(W),ldw)
+      rocsolver_slatrd_rank_0 = rocsolver_slatrd_(handle,uplo,n,k,c_loc(A),lda,c_loc(E),tau,W,ldw)
     end function
 
     function rocsolver_slatrd_rank_1(handle,uplo,n,k,A,lda,E,tau,W,ldw)
@@ -47177,11 +46800,10 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       real(c_float),target,dimension(:) :: E
       real(c_float) :: tau
-      real(c_float),target,dimension(:) :: W
+      type(c_ptr) :: W
       integer(c_int) :: ldw
       !
-      rocsolver_slatrd_rank_1 = rocsolver_slatrd_(handle,uplo,n,k,c_loc(A),lda,c_loc(E),tau, &
-        c_loc(W),ldw)
+      rocsolver_slatrd_rank_1 = rocsolver_slatrd_(handle,uplo,n,k,c_loc(A),lda,c_loc(E),tau,W,ldw)
     end function
 
     function rocsolver_slatrd_full_rank(handle,uplo,n,k,A,lda,E,tau,W,ldw)
@@ -47196,13 +46818,13 @@ module hipfort_rocsolver
       integer(c_int) :: k
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: E
+      real(c_float),target,dimension(:) :: E
       real(c_float) :: tau
-      real(c_float),target,dimension(:,:) :: W
+      type(c_ptr) :: W
       integer(c_int) :: ldw
       !
-      rocsolver_slatrd_full_rank = rocsolver_slatrd_(handle,uplo,n,k,c_loc(A),lda,c_loc(E),tau, &
-        c_loc(W),ldw)
+      rocsolver_slatrd_full_rank = rocsolver_slatrd_(handle,uplo,n,k,c_loc(A),lda,c_loc(E),tau,W, &
+        ldw)
     end function
 
     function rocsolver_dlatrd_rank_0(handle,uplo,n,k,A,lda,E,tau,W,ldw)
@@ -47219,11 +46841,10 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       real(c_double),target :: E
       real(c_double) :: tau
-      real(c_double),target :: W
+      type(c_ptr) :: W
       integer(c_int) :: ldw
       !
-      rocsolver_dlatrd_rank_0 = rocsolver_dlatrd_(handle,uplo,n,k,c_loc(A),lda,c_loc(E),tau, &
-        c_loc(W),ldw)
+      rocsolver_dlatrd_rank_0 = rocsolver_dlatrd_(handle,uplo,n,k,c_loc(A),lda,c_loc(E),tau,W,ldw)
     end function
 
     function rocsolver_dlatrd_rank_1(handle,uplo,n,k,A,lda,E,tau,W,ldw)
@@ -47240,11 +46861,10 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       real(c_double),target,dimension(:) :: E
       real(c_double) :: tau
-      real(c_double),target,dimension(:) :: W
+      type(c_ptr) :: W
       integer(c_int) :: ldw
       !
-      rocsolver_dlatrd_rank_1 = rocsolver_dlatrd_(handle,uplo,n,k,c_loc(A),lda,c_loc(E),tau, &
-        c_loc(W),ldw)
+      rocsolver_dlatrd_rank_1 = rocsolver_dlatrd_(handle,uplo,n,k,c_loc(A),lda,c_loc(E),tau,W,ldw)
     end function
 
     function rocsolver_dlatrd_full_rank(handle,uplo,n,k,A,lda,E,tau,W,ldw)
@@ -47259,13 +46879,13 @@ module hipfort_rocsolver
       integer(c_int) :: k
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: E
+      real(c_double),target,dimension(:) :: E
       real(c_double) :: tau
-      real(c_double),target,dimension(:,:) :: W
+      type(c_ptr) :: W
       integer(c_int) :: ldw
       !
-      rocsolver_dlatrd_full_rank = rocsolver_dlatrd_(handle,uplo,n,k,c_loc(A),lda,c_loc(E),tau, &
-        c_loc(W),ldw)
+      rocsolver_dlatrd_full_rank = rocsolver_dlatrd_(handle,uplo,n,k,c_loc(A),lda,c_loc(E),tau,W, &
+        ldw)
     end function
 
     function rocsolver_clatrd_rank_0(handle,uplo,n,k,A,lda,E,tau,W,ldw)
@@ -47282,11 +46902,10 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       real(c_float),target :: E
       complex(c_float_complex) :: tau
-      complex(c_float_complex),target :: W
+      type(c_ptr) :: W
       integer(c_int) :: ldw
       !
-      rocsolver_clatrd_rank_0 = rocsolver_clatrd_(handle,uplo,n,k,c_loc(A),lda,c_loc(E),tau, &
-        c_loc(W),ldw)
+      rocsolver_clatrd_rank_0 = rocsolver_clatrd_(handle,uplo,n,k,c_loc(A),lda,c_loc(E),tau,W,ldw)
     end function
 
     function rocsolver_clatrd_rank_1(handle,uplo,n,k,A,lda,E,tau,W,ldw)
@@ -47303,11 +46922,10 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       real(c_float),target,dimension(:) :: E
       complex(c_float_complex) :: tau
-      complex(c_float_complex),target,dimension(:) :: W
+      type(c_ptr) :: W
       integer(c_int) :: ldw
       !
-      rocsolver_clatrd_rank_1 = rocsolver_clatrd_(handle,uplo,n,k,c_loc(A),lda,c_loc(E),tau, &
-        c_loc(W),ldw)
+      rocsolver_clatrd_rank_1 = rocsolver_clatrd_(handle,uplo,n,k,c_loc(A),lda,c_loc(E),tau,W,ldw)
     end function
 
     function rocsolver_clatrd_full_rank(handle,uplo,n,k,A,lda,E,tau,W,ldw)
@@ -47322,13 +46940,13 @@ module hipfort_rocsolver
       integer(c_int) :: k
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: E
+      real(c_float),target,dimension(:) :: E
       complex(c_float_complex) :: tau
-      complex(c_float_complex),target,dimension(:,:) :: W
+      type(c_ptr) :: W
       integer(c_int) :: ldw
       !
-      rocsolver_clatrd_full_rank = rocsolver_clatrd_(handle,uplo,n,k,c_loc(A),lda,c_loc(E),tau, &
-        c_loc(W),ldw)
+      rocsolver_clatrd_full_rank = rocsolver_clatrd_(handle,uplo,n,k,c_loc(A),lda,c_loc(E),tau,W, &
+        ldw)
     end function
 
     function rocsolver_zlatrd_rank_0(handle,uplo,n,k,A,lda,E,tau,W,ldw)
@@ -47345,11 +46963,10 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       real(c_double),target :: E
       complex(c_double_complex) :: tau
-      complex(c_double_complex),target :: W
+      type(c_ptr) :: W
       integer(c_int) :: ldw
       !
-      rocsolver_zlatrd_rank_0 = rocsolver_zlatrd_(handle,uplo,n,k,c_loc(A),lda,c_loc(E),tau, &
-        c_loc(W),ldw)
+      rocsolver_zlatrd_rank_0 = rocsolver_zlatrd_(handle,uplo,n,k,c_loc(A),lda,c_loc(E),tau,W,ldw)
     end function
 
     function rocsolver_zlatrd_rank_1(handle,uplo,n,k,A,lda,E,tau,W,ldw)
@@ -47366,11 +46983,10 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       real(c_double),target,dimension(:) :: E
       complex(c_double_complex) :: tau
-      complex(c_double_complex),target,dimension(:) :: W
+      type(c_ptr) :: W
       integer(c_int) :: ldw
       !
-      rocsolver_zlatrd_rank_1 = rocsolver_zlatrd_(handle,uplo,n,k,c_loc(A),lda,c_loc(E),tau, &
-        c_loc(W),ldw)
+      rocsolver_zlatrd_rank_1 = rocsolver_zlatrd_(handle,uplo,n,k,c_loc(A),lda,c_loc(E),tau,W,ldw)
     end function
 
     function rocsolver_zlatrd_full_rank(handle,uplo,n,k,A,lda,E,tau,W,ldw)
@@ -47385,13 +47001,13 @@ module hipfort_rocsolver
       integer(c_int) :: k
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: E
+      real(c_double),target,dimension(:) :: E
       complex(c_double_complex) :: tau
-      complex(c_double_complex),target,dimension(:,:) :: W
+      type(c_ptr) :: W
       integer(c_int) :: ldw
       !
-      rocsolver_zlatrd_full_rank = rocsolver_zlatrd_(handle,uplo,n,k,c_loc(A),lda,c_loc(E),tau, &
-        c_loc(W),ldw)
+      rocsolver_zlatrd_full_rank = rocsolver_zlatrd_(handle,uplo,n,k,c_loc(A),lda,c_loc(E),tau,W, &
+        ldw)
     end function
 
     function rocsolver_slasyf_rank_0(handle,uplo,n,nb,kb,A,lda,ipiv,myInfo)
@@ -47404,14 +47020,14 @@ module hipfort_rocsolver
       integer(kind(rocblas_fill_upper)) :: uplo
       integer(c_int) :: n
       integer(c_int) :: nb
-      integer(c_int),target :: kb
+      type(c_ptr) :: kb
       real(c_float),target :: A
       integer(c_int) :: lda
       integer(c_int),target :: ipiv
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_slasyf_rank_0 = rocsolver_slasyf_(handle,uplo,n,nb,c_loc(kb),c_loc(A),lda, &
-        c_loc(ipiv),c_loc(myInfo))
+      rocsolver_slasyf_rank_0 = rocsolver_slasyf_(handle,uplo,n,nb,kb,c_loc(A),lda,c_loc(ipiv), &
+        myInfo)
     end function
 
     function rocsolver_slasyf_rank_1(handle,uplo,n,nb,kb,A,lda,ipiv,myInfo)
@@ -47424,14 +47040,14 @@ module hipfort_rocsolver
       integer(kind(rocblas_fill_upper)) :: uplo
       integer(c_int) :: n
       integer(c_int) :: nb
-      integer(c_int),target,dimension(:) :: kb
+      type(c_ptr) :: kb
       real(c_float),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int),target,dimension(:) :: ipiv
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_slasyf_rank_1 = rocsolver_slasyf_(handle,uplo,n,nb,c_loc(kb),c_loc(A),lda, &
-        c_loc(ipiv),c_loc(myInfo))
+      rocsolver_slasyf_rank_1 = rocsolver_slasyf_(handle,uplo,n,nb,kb,c_loc(A),lda,c_loc(ipiv), &
+        myInfo)
     end function
 
     function rocsolver_slasyf_full_rank(handle,uplo,n,nb,kb,A,lda,ipiv,myInfo)
@@ -47444,14 +47060,14 @@ module hipfort_rocsolver
       integer(kind(rocblas_fill_upper)) :: uplo
       integer(c_int) :: n
       integer(c_int) :: nb
-      integer(c_int),target,dimension(:,:) :: kb
+      type(c_ptr) :: kb
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int),target,dimension(:,:) :: myInfo
+      integer(c_int),target,dimension(:) :: ipiv
+      type(c_ptr) :: myInfo
       !
-      rocsolver_slasyf_full_rank = rocsolver_slasyf_(handle,uplo,n,nb,c_loc(kb),c_loc(A),lda, &
-        c_loc(ipiv),c_loc(myInfo))
+      rocsolver_slasyf_full_rank = rocsolver_slasyf_(handle,uplo,n,nb,kb,c_loc(A),lda,c_loc(ipiv), &
+        myInfo)
     end function
 
     function rocsolver_dlasyf_rank_0(handle,uplo,n,nb,kb,A,lda,ipiv,myInfo)
@@ -47464,14 +47080,14 @@ module hipfort_rocsolver
       integer(kind(rocblas_fill_upper)) :: uplo
       integer(c_int) :: n
       integer(c_int) :: nb
-      integer(c_int),target :: kb
+      type(c_ptr) :: kb
       real(c_double),target :: A
       integer(c_int) :: lda
       integer(c_int),target :: ipiv
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_dlasyf_rank_0 = rocsolver_dlasyf_(handle,uplo,n,nb,c_loc(kb),c_loc(A),lda, &
-        c_loc(ipiv),c_loc(myInfo))
+      rocsolver_dlasyf_rank_0 = rocsolver_dlasyf_(handle,uplo,n,nb,kb,c_loc(A),lda,c_loc(ipiv), &
+        myInfo)
     end function
 
     function rocsolver_dlasyf_rank_1(handle,uplo,n,nb,kb,A,lda,ipiv,myInfo)
@@ -47484,14 +47100,14 @@ module hipfort_rocsolver
       integer(kind(rocblas_fill_upper)) :: uplo
       integer(c_int) :: n
       integer(c_int) :: nb
-      integer(c_int),target,dimension(:) :: kb
+      type(c_ptr) :: kb
       real(c_double),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int),target,dimension(:) :: ipiv
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_dlasyf_rank_1 = rocsolver_dlasyf_(handle,uplo,n,nb,c_loc(kb),c_loc(A),lda, &
-        c_loc(ipiv),c_loc(myInfo))
+      rocsolver_dlasyf_rank_1 = rocsolver_dlasyf_(handle,uplo,n,nb,kb,c_loc(A),lda,c_loc(ipiv), &
+        myInfo)
     end function
 
     function rocsolver_dlasyf_full_rank(handle,uplo,n,nb,kb,A,lda,ipiv,myInfo)
@@ -47504,14 +47120,14 @@ module hipfort_rocsolver
       integer(kind(rocblas_fill_upper)) :: uplo
       integer(c_int) :: n
       integer(c_int) :: nb
-      integer(c_int),target,dimension(:,:) :: kb
+      type(c_ptr) :: kb
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int),target,dimension(:,:) :: myInfo
+      integer(c_int),target,dimension(:) :: ipiv
+      type(c_ptr) :: myInfo
       !
-      rocsolver_dlasyf_full_rank = rocsolver_dlasyf_(handle,uplo,n,nb,c_loc(kb),c_loc(A),lda, &
-        c_loc(ipiv),c_loc(myInfo))
+      rocsolver_dlasyf_full_rank = rocsolver_dlasyf_(handle,uplo,n,nb,kb,c_loc(A),lda,c_loc(ipiv), &
+        myInfo)
     end function
 
     function rocsolver_clasyf_rank_0(handle,uplo,n,nb,kb,A,lda,ipiv,myInfo)
@@ -47524,14 +47140,14 @@ module hipfort_rocsolver
       integer(kind(rocblas_fill_upper)) :: uplo
       integer(c_int) :: n
       integer(c_int) :: nb
-      integer(c_int),target :: kb
+      type(c_ptr) :: kb
       complex(c_float_complex),target :: A
       integer(c_int) :: lda
       integer(c_int),target :: ipiv
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_clasyf_rank_0 = rocsolver_clasyf_(handle,uplo,n,nb,c_loc(kb),c_loc(A),lda, &
-        c_loc(ipiv),c_loc(myInfo))
+      rocsolver_clasyf_rank_0 = rocsolver_clasyf_(handle,uplo,n,nb,kb,c_loc(A),lda,c_loc(ipiv), &
+        myInfo)
     end function
 
     function rocsolver_clasyf_rank_1(handle,uplo,n,nb,kb,A,lda,ipiv,myInfo)
@@ -47544,14 +47160,14 @@ module hipfort_rocsolver
       integer(kind(rocblas_fill_upper)) :: uplo
       integer(c_int) :: n
       integer(c_int) :: nb
-      integer(c_int),target,dimension(:) :: kb
+      type(c_ptr) :: kb
       complex(c_float_complex),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int),target,dimension(:) :: ipiv
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_clasyf_rank_1 = rocsolver_clasyf_(handle,uplo,n,nb,c_loc(kb),c_loc(A),lda, &
-        c_loc(ipiv),c_loc(myInfo))
+      rocsolver_clasyf_rank_1 = rocsolver_clasyf_(handle,uplo,n,nb,kb,c_loc(A),lda,c_loc(ipiv), &
+        myInfo)
     end function
 
     function rocsolver_clasyf_full_rank(handle,uplo,n,nb,kb,A,lda,ipiv,myInfo)
@@ -47564,14 +47180,14 @@ module hipfort_rocsolver
       integer(kind(rocblas_fill_upper)) :: uplo
       integer(c_int) :: n
       integer(c_int) :: nb
-      integer(c_int),target,dimension(:,:) :: kb
+      type(c_ptr) :: kb
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int),target,dimension(:,:) :: myInfo
+      integer(c_int),target,dimension(:) :: ipiv
+      type(c_ptr) :: myInfo
       !
-      rocsolver_clasyf_full_rank = rocsolver_clasyf_(handle,uplo,n,nb,c_loc(kb),c_loc(A),lda, &
-        c_loc(ipiv),c_loc(myInfo))
+      rocsolver_clasyf_full_rank = rocsolver_clasyf_(handle,uplo,n,nb,kb,c_loc(A),lda,c_loc(ipiv), &
+        myInfo)
     end function
 
     function rocsolver_zlasyf_rank_0(handle,uplo,n,nb,kb,A,lda,ipiv,myInfo)
@@ -47584,14 +47200,14 @@ module hipfort_rocsolver
       integer(kind(rocblas_fill_upper)) :: uplo
       integer(c_int) :: n
       integer(c_int) :: nb
-      integer(c_int),target :: kb
+      type(c_ptr) :: kb
       complex(c_double_complex),target :: A
       integer(c_int) :: lda
       integer(c_int),target :: ipiv
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_zlasyf_rank_0 = rocsolver_zlasyf_(handle,uplo,n,nb,c_loc(kb),c_loc(A),lda, &
-        c_loc(ipiv),c_loc(myInfo))
+      rocsolver_zlasyf_rank_0 = rocsolver_zlasyf_(handle,uplo,n,nb,kb,c_loc(A),lda,c_loc(ipiv), &
+        myInfo)
     end function
 
     function rocsolver_zlasyf_rank_1(handle,uplo,n,nb,kb,A,lda,ipiv,myInfo)
@@ -47604,14 +47220,14 @@ module hipfort_rocsolver
       integer(kind(rocblas_fill_upper)) :: uplo
       integer(c_int) :: n
       integer(c_int) :: nb
-      integer(c_int),target,dimension(:) :: kb
+      type(c_ptr) :: kb
       complex(c_double_complex),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int),target,dimension(:) :: ipiv
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_zlasyf_rank_1 = rocsolver_zlasyf_(handle,uplo,n,nb,c_loc(kb),c_loc(A),lda, &
-        c_loc(ipiv),c_loc(myInfo))
+      rocsolver_zlasyf_rank_1 = rocsolver_zlasyf_(handle,uplo,n,nb,kb,c_loc(A),lda,c_loc(ipiv), &
+        myInfo)
     end function
 
     function rocsolver_zlasyf_full_rank(handle,uplo,n,nb,kb,A,lda,ipiv,myInfo)
@@ -47624,14 +47240,14 @@ module hipfort_rocsolver
       integer(kind(rocblas_fill_upper)) :: uplo
       integer(c_int) :: n
       integer(c_int) :: nb
-      integer(c_int),target,dimension(:,:) :: kb
+      type(c_ptr) :: kb
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int),target,dimension(:,:) :: myInfo
+      integer(c_int),target,dimension(:) :: ipiv
+      type(c_ptr) :: myInfo
       !
-      rocsolver_zlasyf_full_rank = rocsolver_zlasyf_(handle,uplo,n,nb,c_loc(kb),c_loc(A),lda, &
-        c_loc(ipiv),c_loc(myInfo))
+      rocsolver_zlasyf_full_rank = rocsolver_zlasyf_(handle,uplo,n,nb,kb,c_loc(A),lda,c_loc(ipiv), &
+        myInfo)
     end function
 
     function rocsolver_sorg2r_rank_0(handle,m,n,k,A,lda,ipiv)
@@ -47680,7 +47296,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: ipiv
+      real(c_float),target,dimension(:) :: ipiv
       !
       rocsolver_sorg2r_full_rank = rocsolver_sorg2r_(handle,m,n,k,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -47731,7 +47347,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: ipiv
+      real(c_double),target,dimension(:) :: ipiv
       !
       rocsolver_dorg2r_full_rank = rocsolver_dorg2r_(handle,m,n,k,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -47782,7 +47398,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:,:) :: ipiv
+      complex(c_float_complex),target,dimension(:) :: ipiv
       !
       rocsolver_cung2r_full_rank = rocsolver_cung2r_(handle,m,n,k,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -47833,7 +47449,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:,:) :: ipiv
+      complex(c_double_complex),target,dimension(:) :: ipiv
       !
       rocsolver_zung2r_full_rank = rocsolver_zung2r_(handle,m,n,k,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -47884,7 +47500,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: ipiv
+      real(c_float),target,dimension(:) :: ipiv
       !
       rocsolver_sorgqr_full_rank = rocsolver_sorgqr_(handle,m,n,k,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -47935,7 +47551,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: ipiv
+      real(c_double),target,dimension(:) :: ipiv
       !
       rocsolver_dorgqr_full_rank = rocsolver_dorgqr_(handle,m,n,k,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -47986,7 +47602,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:,:) :: ipiv
+      complex(c_float_complex),target,dimension(:) :: ipiv
       !
       rocsolver_cungqr_full_rank = rocsolver_cungqr_(handle,m,n,k,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -48037,7 +47653,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:,:) :: ipiv
+      complex(c_double_complex),target,dimension(:) :: ipiv
       !
       rocsolver_zungqr_full_rank = rocsolver_zungqr_(handle,m,n,k,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -48088,7 +47704,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: ipiv
+      real(c_float),target,dimension(:) :: ipiv
       !
       rocsolver_sorgl2_full_rank = rocsolver_sorgl2_(handle,m,n,k,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -48139,7 +47755,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: ipiv
+      real(c_double),target,dimension(:) :: ipiv
       !
       rocsolver_dorgl2_full_rank = rocsolver_dorgl2_(handle,m,n,k,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -48190,7 +47806,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:,:) :: ipiv
+      complex(c_float_complex),target,dimension(:) :: ipiv
       !
       rocsolver_cungl2_full_rank = rocsolver_cungl2_(handle,m,n,k,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -48241,7 +47857,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:,:) :: ipiv
+      complex(c_double_complex),target,dimension(:) :: ipiv
       !
       rocsolver_zungl2_full_rank = rocsolver_zungl2_(handle,m,n,k,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -48292,7 +47908,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: ipiv
+      real(c_float),target,dimension(:) :: ipiv
       !
       rocsolver_sorglq_full_rank = rocsolver_sorglq_(handle,m,n,k,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -48343,7 +47959,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: ipiv
+      real(c_double),target,dimension(:) :: ipiv
       !
       rocsolver_dorglq_full_rank = rocsolver_dorglq_(handle,m,n,k,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -48394,7 +48010,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:,:) :: ipiv
+      complex(c_float_complex),target,dimension(:) :: ipiv
       !
       rocsolver_cunglq_full_rank = rocsolver_cunglq_(handle,m,n,k,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -48445,7 +48061,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:,:) :: ipiv
+      complex(c_double_complex),target,dimension(:) :: ipiv
       !
       rocsolver_zunglq_full_rank = rocsolver_zunglq_(handle,m,n,k,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -48496,7 +48112,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: ipiv
+      real(c_float),target,dimension(:) :: ipiv
       !
       rocsolver_sorg2l_full_rank = rocsolver_sorg2l_(handle,m,n,k,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -48547,7 +48163,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: ipiv
+      real(c_double),target,dimension(:) :: ipiv
       !
       rocsolver_dorg2l_full_rank = rocsolver_dorg2l_(handle,m,n,k,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -48598,7 +48214,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:,:) :: ipiv
+      complex(c_float_complex),target,dimension(:) :: ipiv
       !
       rocsolver_cung2l_full_rank = rocsolver_cung2l_(handle,m,n,k,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -48649,7 +48265,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:,:) :: ipiv
+      complex(c_double_complex),target,dimension(:) :: ipiv
       !
       rocsolver_zung2l_full_rank = rocsolver_zung2l_(handle,m,n,k,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -48700,7 +48316,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: ipiv
+      real(c_float),target,dimension(:) :: ipiv
       !
       rocsolver_sorgql_full_rank = rocsolver_sorgql_(handle,m,n,k,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -48751,7 +48367,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: ipiv
+      real(c_double),target,dimension(:) :: ipiv
       !
       rocsolver_dorgql_full_rank = rocsolver_dorgql_(handle,m,n,k,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -48802,7 +48418,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:,:) :: ipiv
+      complex(c_float_complex),target,dimension(:) :: ipiv
       !
       rocsolver_cungql_full_rank = rocsolver_cungql_(handle,m,n,k,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -48853,7 +48469,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:,:) :: ipiv
+      complex(c_double_complex),target,dimension(:) :: ipiv
       !
       rocsolver_zungql_full_rank = rocsolver_zungql_(handle,m,n,k,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -48907,7 +48523,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: ipiv
+      real(c_float),target,dimension(:) :: ipiv
       !
       rocsolver_sorgbr_full_rank = rocsolver_sorgbr_(handle,storev,m,n,k,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -48961,7 +48577,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: ipiv
+      real(c_double),target,dimension(:) :: ipiv
       !
       rocsolver_dorgbr_full_rank = rocsolver_dorgbr_(handle,storev,m,n,k,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -49015,7 +48631,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:,:) :: ipiv
+      complex(c_float_complex),target,dimension(:) :: ipiv
       !
       rocsolver_cungbr_full_rank = rocsolver_cungbr_(handle,storev,m,n,k,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -49069,7 +48685,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:,:) :: ipiv
+      complex(c_double_complex),target,dimension(:) :: ipiv
       !
       rocsolver_zungbr_full_rank = rocsolver_zungbr_(handle,storev,m,n,k,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -49117,7 +48733,7 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: ipiv
+      real(c_float),target,dimension(:) :: ipiv
       !
       rocsolver_sorgtr_full_rank = rocsolver_sorgtr_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -49165,7 +48781,7 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: ipiv
+      real(c_double),target,dimension(:) :: ipiv
       !
       rocsolver_dorgtr_full_rank = rocsolver_dorgtr_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -49213,7 +48829,7 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:,:) :: ipiv
+      complex(c_float_complex),target,dimension(:) :: ipiv
       !
       rocsolver_cungtr_full_rank = rocsolver_cungtr_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -49261,7 +48877,7 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:,:) :: ipiv
+      complex(c_double_complex),target,dimension(:) :: ipiv
       !
       rocsolver_zungtr_full_rank = rocsolver_zungtr_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -49324,7 +48940,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: ipiv
+      real(c_float),target,dimension(:) :: ipiv
       real(c_float),target,dimension(:,:) :: C
       integer(c_int) :: ldc
       !
@@ -49390,7 +49006,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: ipiv
+      real(c_double),target,dimension(:) :: ipiv
       real(c_double),target,dimension(:,:) :: C
       integer(c_int) :: ldc
       !
@@ -49456,7 +49072,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:,:) :: ipiv
+      complex(c_float_complex),target,dimension(:) :: ipiv
       complex(c_float_complex),target,dimension(:,:) :: C
       integer(c_int) :: ldc
       !
@@ -49522,7 +49138,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:,:) :: ipiv
+      complex(c_double_complex),target,dimension(:) :: ipiv
       complex(c_double_complex),target,dimension(:,:) :: C
       integer(c_int) :: ldc
       !
@@ -49588,7 +49204,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: ipiv
+      real(c_float),target,dimension(:) :: ipiv
       real(c_float),target,dimension(:,:) :: C
       integer(c_int) :: ldc
       !
@@ -49654,7 +49270,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: ipiv
+      real(c_double),target,dimension(:) :: ipiv
       real(c_double),target,dimension(:,:) :: C
       integer(c_int) :: ldc
       !
@@ -49720,7 +49336,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:,:) :: ipiv
+      complex(c_float_complex),target,dimension(:) :: ipiv
       complex(c_float_complex),target,dimension(:,:) :: C
       integer(c_int) :: ldc
       !
@@ -49786,7 +49402,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:,:) :: ipiv
+      complex(c_double_complex),target,dimension(:) :: ipiv
       complex(c_double_complex),target,dimension(:,:) :: C
       integer(c_int) :: ldc
       !
@@ -49852,7 +49468,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: ipiv
+      real(c_float),target,dimension(:) :: ipiv
       real(c_float),target,dimension(:,:) :: C
       integer(c_int) :: ldc
       !
@@ -49918,7 +49534,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: ipiv
+      real(c_double),target,dimension(:) :: ipiv
       real(c_double),target,dimension(:,:) :: C
       integer(c_int) :: ldc
       !
@@ -49984,7 +49600,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:,:) :: ipiv
+      complex(c_float_complex),target,dimension(:) :: ipiv
       complex(c_float_complex),target,dimension(:,:) :: C
       integer(c_int) :: ldc
       !
@@ -50050,7 +49666,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:,:) :: ipiv
+      complex(c_double_complex),target,dimension(:) :: ipiv
       complex(c_double_complex),target,dimension(:,:) :: C
       integer(c_int) :: ldc
       !
@@ -50116,7 +49732,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: ipiv
+      real(c_float),target,dimension(:) :: ipiv
       real(c_float),target,dimension(:,:) :: C
       integer(c_int) :: ldc
       !
@@ -50182,7 +49798,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: ipiv
+      real(c_double),target,dimension(:) :: ipiv
       real(c_double),target,dimension(:,:) :: C
       integer(c_int) :: ldc
       !
@@ -50248,7 +49864,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:,:) :: ipiv
+      complex(c_float_complex),target,dimension(:) :: ipiv
       complex(c_float_complex),target,dimension(:,:) :: C
       integer(c_int) :: ldc
       !
@@ -50314,7 +49930,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:,:) :: ipiv
+      complex(c_double_complex),target,dimension(:) :: ipiv
       complex(c_double_complex),target,dimension(:,:) :: C
       integer(c_int) :: ldc
       !
@@ -50380,7 +49996,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: ipiv
+      real(c_float),target,dimension(:) :: ipiv
       real(c_float),target,dimension(:,:) :: C
       integer(c_int) :: ldc
       !
@@ -50446,7 +50062,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: ipiv
+      real(c_double),target,dimension(:) :: ipiv
       real(c_double),target,dimension(:,:) :: C
       integer(c_int) :: ldc
       !
@@ -50512,7 +50128,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:,:) :: ipiv
+      complex(c_float_complex),target,dimension(:) :: ipiv
       complex(c_float_complex),target,dimension(:,:) :: C
       integer(c_int) :: ldc
       !
@@ -50578,7 +50194,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:,:) :: ipiv
+      complex(c_double_complex),target,dimension(:) :: ipiv
       complex(c_double_complex),target,dimension(:,:) :: C
       integer(c_int) :: ldc
       !
@@ -50644,7 +50260,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: ipiv
+      real(c_float),target,dimension(:) :: ipiv
       real(c_float),target,dimension(:,:) :: C
       integer(c_int) :: ldc
       !
@@ -50710,7 +50326,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: ipiv
+      real(c_double),target,dimension(:) :: ipiv
       real(c_double),target,dimension(:,:) :: C
       integer(c_int) :: ldc
       !
@@ -50776,7 +50392,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:,:) :: ipiv
+      complex(c_float_complex),target,dimension(:) :: ipiv
       complex(c_float_complex),target,dimension(:,:) :: C
       integer(c_int) :: ldc
       !
@@ -50842,7 +50458,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:,:) :: ipiv
+      complex(c_double_complex),target,dimension(:) :: ipiv
       complex(c_double_complex),target,dimension(:,:) :: C
       integer(c_int) :: ldc
       !
@@ -50911,7 +50527,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: ipiv
+      real(c_float),target,dimension(:) :: ipiv
       real(c_float),target,dimension(:,:) :: C
       integer(c_int) :: ldc
       !
@@ -50980,7 +50596,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: ipiv
+      real(c_double),target,dimension(:) :: ipiv
       real(c_double),target,dimension(:,:) :: C
       integer(c_int) :: ldc
       !
@@ -51049,7 +50665,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:,:) :: ipiv
+      complex(c_float_complex),target,dimension(:) :: ipiv
       complex(c_float_complex),target,dimension(:,:) :: C
       integer(c_int) :: ldc
       !
@@ -51118,7 +50734,7 @@ module hipfort_rocsolver
       integer(c_int) :: k
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:,:) :: ipiv
+      complex(c_double_complex),target,dimension(:) :: ipiv
       complex(c_double_complex),target,dimension(:,:) :: C
       integer(c_int) :: ldc
       !
@@ -51184,7 +50800,7 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: ipiv
+      real(c_float),target,dimension(:) :: ipiv
       real(c_float),target,dimension(:,:) :: C
       integer(c_int) :: ldc
       !
@@ -51250,7 +50866,7 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: ipiv
+      real(c_double),target,dimension(:) :: ipiv
       real(c_double),target,dimension(:,:) :: C
       integer(c_int) :: ldc
       !
@@ -51316,7 +50932,7 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:,:) :: ipiv
+      complex(c_float_complex),target,dimension(:) :: ipiv
       complex(c_float_complex),target,dimension(:,:) :: C
       integer(c_int) :: ldc
       !
@@ -51382,7 +50998,7 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:,:) :: ipiv
+      complex(c_double_complex),target,dimension(:) :: ipiv
       complex(c_double_complex),target,dimension(:,:) :: C
       integer(c_int) :: ldc
       !
@@ -51410,10 +51026,10 @@ module hipfort_rocsolver
       integer(c_int) :: ldu
       real(c_float),target :: C
       integer(c_int) :: ldc
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_sbdsqr_rank_0 = rocsolver_sbdsqr_(handle,uplo,n,nv,nu,nc,c_loc(D),c_loc(E), &
-        c_loc(V),ldv,c_loc(U),ldu,c_loc(C),ldc,c_loc(myInfo))
+        c_loc(V),ldv,c_loc(U),ldu,c_loc(C),ldc,myInfo)
     end function
 
     function rocsolver_sbdsqr_rank_1(handle,uplo,n,nv,nu,nc,D,E,V,ldv,U,ldu,C,ldc,myInfo)
@@ -51436,10 +51052,10 @@ module hipfort_rocsolver
       integer(c_int) :: ldu
       real(c_float),target,dimension(:) :: C
       integer(c_int) :: ldc
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_sbdsqr_rank_1 = rocsolver_sbdsqr_(handle,uplo,n,nv,nu,nc,c_loc(D),c_loc(E), &
-        c_loc(V),ldv,c_loc(U),ldu,c_loc(C),ldc,c_loc(myInfo))
+        c_loc(V),ldv,c_loc(U),ldu,c_loc(C),ldc,myInfo)
     end function
 
     function rocsolver_sbdsqr_full_rank(handle,uplo,n,nv,nu,nc,D,E,V,ldv,U,ldu,C,ldc,myInfo)
@@ -51454,18 +51070,18 @@ module hipfort_rocsolver
       integer(c_int) :: nv
       integer(c_int) :: nu
       integer(c_int) :: nc
-      real(c_float),target,dimension(:,:) :: D
-      real(c_float),target,dimension(:,:) :: E
+      real(c_float),target,dimension(:) :: D
+      real(c_float),target,dimension(:) :: E
       real(c_float),target,dimension(:,:) :: V
       integer(c_int) :: ldv
       real(c_float),target,dimension(:,:) :: U
       integer(c_int) :: ldu
       real(c_float),target,dimension(:,:) :: C
       integer(c_int) :: ldc
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_sbdsqr_full_rank = rocsolver_sbdsqr_(handle,uplo,n,nv,nu,nc,c_loc(D),c_loc(E), &
-        c_loc(V),ldv,c_loc(U),ldu,c_loc(C),ldc,c_loc(myInfo))
+        c_loc(V),ldv,c_loc(U),ldu,c_loc(C),ldc,myInfo)
     end function
 
     function rocsolver_dbdsqr_rank_0(handle,uplo,n,nv,nu,nc,D,E,V,ldv,U,ldu,C,ldc,myInfo)
@@ -51488,10 +51104,10 @@ module hipfort_rocsolver
       integer(c_int) :: ldu
       real(c_double),target :: C
       integer(c_int) :: ldc
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_dbdsqr_rank_0 = rocsolver_dbdsqr_(handle,uplo,n,nv,nu,nc,c_loc(D),c_loc(E), &
-        c_loc(V),ldv,c_loc(U),ldu,c_loc(C),ldc,c_loc(myInfo))
+        c_loc(V),ldv,c_loc(U),ldu,c_loc(C),ldc,myInfo)
     end function
 
     function rocsolver_dbdsqr_rank_1(handle,uplo,n,nv,nu,nc,D,E,V,ldv,U,ldu,C,ldc,myInfo)
@@ -51514,10 +51130,10 @@ module hipfort_rocsolver
       integer(c_int) :: ldu
       real(c_double),target,dimension(:) :: C
       integer(c_int) :: ldc
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_dbdsqr_rank_1 = rocsolver_dbdsqr_(handle,uplo,n,nv,nu,nc,c_loc(D),c_loc(E), &
-        c_loc(V),ldv,c_loc(U),ldu,c_loc(C),ldc,c_loc(myInfo))
+        c_loc(V),ldv,c_loc(U),ldu,c_loc(C),ldc,myInfo)
     end function
 
     function rocsolver_dbdsqr_full_rank(handle,uplo,n,nv,nu,nc,D,E,V,ldv,U,ldu,C,ldc,myInfo)
@@ -51532,18 +51148,18 @@ module hipfort_rocsolver
       integer(c_int) :: nv
       integer(c_int) :: nu
       integer(c_int) :: nc
-      real(c_double),target,dimension(:,:) :: D
-      real(c_double),target,dimension(:,:) :: E
+      real(c_double),target,dimension(:) :: D
+      real(c_double),target,dimension(:) :: E
       real(c_double),target,dimension(:,:) :: V
       integer(c_int) :: ldv
       real(c_double),target,dimension(:,:) :: U
       integer(c_int) :: ldu
       real(c_double),target,dimension(:,:) :: C
       integer(c_int) :: ldc
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_dbdsqr_full_rank = rocsolver_dbdsqr_(handle,uplo,n,nv,nu,nc,c_loc(D),c_loc(E), &
-        c_loc(V),ldv,c_loc(U),ldu,c_loc(C),ldc,c_loc(myInfo))
+        c_loc(V),ldv,c_loc(U),ldu,c_loc(C),ldc,myInfo)
     end function
 
     function rocsolver_cbdsqr_rank_0(handle,uplo,n,nv,nu,nc,D,E,V,ldv,U,ldu,C,ldc,myInfo)
@@ -51566,10 +51182,10 @@ module hipfort_rocsolver
       integer(c_int) :: ldu
       complex(c_float_complex),target :: C
       integer(c_int) :: ldc
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_cbdsqr_rank_0 = rocsolver_cbdsqr_(handle,uplo,n,nv,nu,nc,c_loc(D),c_loc(E), &
-        c_loc(V),ldv,c_loc(U),ldu,c_loc(C),ldc,c_loc(myInfo))
+        c_loc(V),ldv,c_loc(U),ldu,c_loc(C),ldc,myInfo)
     end function
 
     function rocsolver_cbdsqr_rank_1(handle,uplo,n,nv,nu,nc,D,E,V,ldv,U,ldu,C,ldc,myInfo)
@@ -51592,10 +51208,10 @@ module hipfort_rocsolver
       integer(c_int) :: ldu
       complex(c_float_complex),target,dimension(:) :: C
       integer(c_int) :: ldc
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_cbdsqr_rank_1 = rocsolver_cbdsqr_(handle,uplo,n,nv,nu,nc,c_loc(D),c_loc(E), &
-        c_loc(V),ldv,c_loc(U),ldu,c_loc(C),ldc,c_loc(myInfo))
+        c_loc(V),ldv,c_loc(U),ldu,c_loc(C),ldc,myInfo)
     end function
 
     function rocsolver_cbdsqr_full_rank(handle,uplo,n,nv,nu,nc,D,E,V,ldv,U,ldu,C,ldc,myInfo)
@@ -51610,18 +51226,18 @@ module hipfort_rocsolver
       integer(c_int) :: nv
       integer(c_int) :: nu
       integer(c_int) :: nc
-      real(c_float),target,dimension(:,:) :: D
-      real(c_float),target,dimension(:,:) :: E
+      real(c_float),target,dimension(:) :: D
+      real(c_float),target,dimension(:) :: E
       complex(c_float_complex),target,dimension(:,:) :: V
       integer(c_int) :: ldv
       complex(c_float_complex),target,dimension(:,:) :: U
       integer(c_int) :: ldu
       complex(c_float_complex),target,dimension(:,:) :: C
       integer(c_int) :: ldc
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_cbdsqr_full_rank = rocsolver_cbdsqr_(handle,uplo,n,nv,nu,nc,c_loc(D),c_loc(E), &
-        c_loc(V),ldv,c_loc(U),ldu,c_loc(C),ldc,c_loc(myInfo))
+        c_loc(V),ldv,c_loc(U),ldu,c_loc(C),ldc,myInfo)
     end function
 
     function rocsolver_zbdsqr_rank_0(handle,uplo,n,nv,nu,nc,D,E,V,ldv,U,ldu,C,ldc,myInfo)
@@ -51644,10 +51260,10 @@ module hipfort_rocsolver
       integer(c_int) :: ldu
       complex(c_double_complex),target :: C
       integer(c_int) :: ldc
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_zbdsqr_rank_0 = rocsolver_zbdsqr_(handle,uplo,n,nv,nu,nc,c_loc(D),c_loc(E), &
-        c_loc(V),ldv,c_loc(U),ldu,c_loc(C),ldc,c_loc(myInfo))
+        c_loc(V),ldv,c_loc(U),ldu,c_loc(C),ldc,myInfo)
     end function
 
     function rocsolver_zbdsqr_rank_1(handle,uplo,n,nv,nu,nc,D,E,V,ldv,U,ldu,C,ldc,myInfo)
@@ -51670,10 +51286,10 @@ module hipfort_rocsolver
       integer(c_int) :: ldu
       complex(c_double_complex),target,dimension(:) :: C
       integer(c_int) :: ldc
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_zbdsqr_rank_1 = rocsolver_zbdsqr_(handle,uplo,n,nv,nu,nc,c_loc(D),c_loc(E), &
-        c_loc(V),ldv,c_loc(U),ldu,c_loc(C),ldc,c_loc(myInfo))
+        c_loc(V),ldv,c_loc(U),ldu,c_loc(C),ldc,myInfo)
     end function
 
     function rocsolver_zbdsqr_full_rank(handle,uplo,n,nv,nu,nc,D,E,V,ldv,U,ldu,C,ldc,myInfo)
@@ -51688,18 +51304,18 @@ module hipfort_rocsolver
       integer(c_int) :: nv
       integer(c_int) :: nu
       integer(c_int) :: nc
-      real(c_double),target,dimension(:,:) :: D
-      real(c_double),target,dimension(:,:) :: E
+      real(c_double),target,dimension(:) :: D
+      real(c_double),target,dimension(:) :: E
       complex(c_double_complex),target,dimension(:,:) :: V
       integer(c_int) :: ldv
       complex(c_double_complex),target,dimension(:,:) :: U
       integer(c_int) :: ldu
       complex(c_double_complex),target,dimension(:,:) :: C
       integer(c_int) :: ldc
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_zbdsqr_full_rank = rocsolver_zbdsqr_(handle,uplo,n,nv,nu,nc,c_loc(D),c_loc(E), &
-        c_loc(V),ldv,c_loc(U),ldu,c_loc(C),ldc,c_loc(myInfo))
+        c_loc(V),ldv,c_loc(U),ldu,c_loc(C),ldc,myInfo)
     end function
 
     function rocsolver_ssterf_rank_0(handle,n,D,E,myInfo)
@@ -51712,9 +51328,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_float),target :: D
       real(c_float),target :: E
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_ssterf_rank_0 = rocsolver_ssterf_(handle,n,c_loc(D),c_loc(E),c_loc(myInfo))
+      rocsolver_ssterf_rank_0 = rocsolver_ssterf_(handle,n,c_loc(D),c_loc(E),myInfo)
     end function
 
     function rocsolver_ssterf_rank_1(handle,n,D,E,myInfo)
@@ -51727,9 +51343,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_float),target,dimension(:) :: D
       real(c_float),target,dimension(:) :: E
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_ssterf_rank_1 = rocsolver_ssterf_(handle,n,c_loc(D),c_loc(E),c_loc(myInfo))
+      rocsolver_ssterf_rank_1 = rocsolver_ssterf_(handle,n,c_loc(D),c_loc(E),myInfo)
     end function
 
     function rocsolver_dsterf_rank_0(handle,n,D,E,myInfo)
@@ -51742,9 +51358,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_double),target :: D
       real(c_double),target :: E
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_dsterf_rank_0 = rocsolver_dsterf_(handle,n,c_loc(D),c_loc(E),c_loc(myInfo))
+      rocsolver_dsterf_rank_0 = rocsolver_dsterf_(handle,n,c_loc(D),c_loc(E),myInfo)
     end function
 
     function rocsolver_dsterf_rank_1(handle,n,D,E,myInfo)
@@ -51757,9 +51373,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_double),target,dimension(:) :: D
       real(c_double),target,dimension(:) :: E
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_dsterf_rank_1 = rocsolver_dsterf_(handle,n,c_loc(D),c_loc(E),c_loc(myInfo))
+      rocsolver_dsterf_rank_1 = rocsolver_dsterf_(handle,n,c_loc(D),c_loc(E),myInfo)
     end function
 
     function rocsolver_ssteqr_rank_0(handle,evect,n,D,E,C,ldc,myInfo)
@@ -51775,10 +51391,10 @@ module hipfort_rocsolver
       real(c_float),target :: E
       real(c_float),target :: C
       integer(c_int) :: ldc
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_ssteqr_rank_0 = rocsolver_ssteqr_(handle,evect,n,c_loc(D),c_loc(E),c_loc(C),ldc, &
-        c_loc(myInfo))
+        myInfo)
     end function
 
     function rocsolver_ssteqr_rank_1(handle,evect,n,D,E,C,ldc,myInfo)
@@ -51794,10 +51410,10 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:) :: E
       real(c_float),target,dimension(:) :: C
       integer(c_int) :: ldc
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_ssteqr_rank_1 = rocsolver_ssteqr_(handle,evect,n,c_loc(D),c_loc(E),c_loc(C),ldc, &
-        c_loc(myInfo))
+        myInfo)
     end function
 
     function rocsolver_ssteqr_full_rank(handle,evect,n,D,E,C,ldc,myInfo)
@@ -51809,14 +51425,14 @@ module hipfort_rocsolver
       type(c_ptr) :: handle
       integer(kind(rocblas_evect_original)) :: evect
       integer(c_int) :: n
-      real(c_float),target,dimension(:,:) :: D
-      real(c_float),target,dimension(:,:) :: E
+      real(c_float),target,dimension(:) :: D
+      real(c_float),target,dimension(:) :: E
       real(c_float),target,dimension(:,:) :: C
       integer(c_int) :: ldc
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_ssteqr_full_rank = rocsolver_ssteqr_(handle,evect,n,c_loc(D),c_loc(E),c_loc(C), &
-        ldc,c_loc(myInfo))
+        ldc,myInfo)
     end function
 
     function rocsolver_dsteqr_rank_0(handle,evect,n,D,E,C,ldc,myInfo)
@@ -51832,10 +51448,10 @@ module hipfort_rocsolver
       real(c_double),target :: E
       real(c_double),target :: C
       integer(c_int) :: ldc
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_dsteqr_rank_0 = rocsolver_dsteqr_(handle,evect,n,c_loc(D),c_loc(E),c_loc(C),ldc, &
-        c_loc(myInfo))
+        myInfo)
     end function
 
     function rocsolver_dsteqr_rank_1(handle,evect,n,D,E,C,ldc,myInfo)
@@ -51851,10 +51467,10 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:) :: E
       real(c_double),target,dimension(:) :: C
       integer(c_int) :: ldc
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_dsteqr_rank_1 = rocsolver_dsteqr_(handle,evect,n,c_loc(D),c_loc(E),c_loc(C),ldc, &
-        c_loc(myInfo))
+        myInfo)
     end function
 
     function rocsolver_dsteqr_full_rank(handle,evect,n,D,E,C,ldc,myInfo)
@@ -51866,14 +51482,14 @@ module hipfort_rocsolver
       type(c_ptr) :: handle
       integer(kind(rocblas_evect_original)) :: evect
       integer(c_int) :: n
-      real(c_double),target,dimension(:,:) :: D
-      real(c_double),target,dimension(:,:) :: E
+      real(c_double),target,dimension(:) :: D
+      real(c_double),target,dimension(:) :: E
       real(c_double),target,dimension(:,:) :: C
       integer(c_int) :: ldc
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_dsteqr_full_rank = rocsolver_dsteqr_(handle,evect,n,c_loc(D),c_loc(E),c_loc(C), &
-        ldc,c_loc(myInfo))
+        ldc,myInfo)
     end function
 
     function rocsolver_csteqr_rank_0(handle,evect,n,D,E,C,ldc,myInfo)
@@ -51889,10 +51505,10 @@ module hipfort_rocsolver
       real(c_float),target :: E
       complex(c_float_complex),target :: C
       integer(c_int) :: ldc
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_csteqr_rank_0 = rocsolver_csteqr_(handle,evect,n,c_loc(D),c_loc(E),c_loc(C),ldc, &
-        c_loc(myInfo))
+        myInfo)
     end function
 
     function rocsolver_csteqr_rank_1(handle,evect,n,D,E,C,ldc,myInfo)
@@ -51908,10 +51524,10 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:) :: E
       complex(c_float_complex),target,dimension(:) :: C
       integer(c_int) :: ldc
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_csteqr_rank_1 = rocsolver_csteqr_(handle,evect,n,c_loc(D),c_loc(E),c_loc(C),ldc, &
-        c_loc(myInfo))
+        myInfo)
     end function
 
     function rocsolver_csteqr_full_rank(handle,evect,n,D,E,C,ldc,myInfo)
@@ -51923,14 +51539,14 @@ module hipfort_rocsolver
       type(c_ptr) :: handle
       integer(kind(rocblas_evect_original)) :: evect
       integer(c_int) :: n
-      real(c_float),target,dimension(:,:) :: D
-      real(c_float),target,dimension(:,:) :: E
+      real(c_float),target,dimension(:) :: D
+      real(c_float),target,dimension(:) :: E
       complex(c_float_complex),target,dimension(:,:) :: C
       integer(c_int) :: ldc
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_csteqr_full_rank = rocsolver_csteqr_(handle,evect,n,c_loc(D),c_loc(E),c_loc(C), &
-        ldc,c_loc(myInfo))
+        ldc,myInfo)
     end function
 
     function rocsolver_zsteqr_rank_0(handle,evect,n,D,E,C,ldc,myInfo)
@@ -51946,10 +51562,10 @@ module hipfort_rocsolver
       real(c_double),target :: E
       complex(c_double_complex),target :: C
       integer(c_int) :: ldc
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_zsteqr_rank_0 = rocsolver_zsteqr_(handle,evect,n,c_loc(D),c_loc(E),c_loc(C),ldc, &
-        c_loc(myInfo))
+        myInfo)
     end function
 
     function rocsolver_zsteqr_rank_1(handle,evect,n,D,E,C,ldc,myInfo)
@@ -51965,10 +51581,10 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:) :: E
       complex(c_double_complex),target,dimension(:) :: C
       integer(c_int) :: ldc
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_zsteqr_rank_1 = rocsolver_zsteqr_(handle,evect,n,c_loc(D),c_loc(E),c_loc(C),ldc, &
-        c_loc(myInfo))
+        myInfo)
     end function
 
     function rocsolver_zsteqr_full_rank(handle,evect,n,D,E,C,ldc,myInfo)
@@ -51980,14 +51596,14 @@ module hipfort_rocsolver
       type(c_ptr) :: handle
       integer(kind(rocblas_evect_original)) :: evect
       integer(c_int) :: n
-      real(c_double),target,dimension(:,:) :: D
-      real(c_double),target,dimension(:,:) :: E
+      real(c_double),target,dimension(:) :: D
+      real(c_double),target,dimension(:) :: E
       complex(c_double_complex),target,dimension(:,:) :: C
       integer(c_int) :: ldc
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_zsteqr_full_rank = rocsolver_zsteqr_(handle,evect,n,c_loc(D),c_loc(E),c_loc(C), &
-        ldc,c_loc(myInfo))
+        ldc,myInfo)
     end function
 
     function rocsolver_sstedc_rank_0(handle,evect,n,D,E,C,ldc,myInfo)
@@ -52003,10 +51619,10 @@ module hipfort_rocsolver
       real(c_float),target :: E
       real(c_float),target :: C
       integer(c_int) :: ldc
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_sstedc_rank_0 = rocsolver_sstedc_(handle,evect,n,c_loc(D),c_loc(E),c_loc(C),ldc, &
-        c_loc(myInfo))
+        myInfo)
     end function
 
     function rocsolver_sstedc_rank_1(handle,evect,n,D,E,C,ldc,myInfo)
@@ -52022,10 +51638,10 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:) :: E
       real(c_float),target,dimension(:) :: C
       integer(c_int) :: ldc
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_sstedc_rank_1 = rocsolver_sstedc_(handle,evect,n,c_loc(D),c_loc(E),c_loc(C),ldc, &
-        c_loc(myInfo))
+        myInfo)
     end function
 
     function rocsolver_sstedc_full_rank(handle,evect,n,D,E,C,ldc,myInfo)
@@ -52037,14 +51653,14 @@ module hipfort_rocsolver
       type(c_ptr) :: handle
       integer(kind(rocblas_evect_original)) :: evect
       integer(c_int) :: n
-      real(c_float),target,dimension(:,:) :: D
-      real(c_float),target,dimension(:,:) :: E
+      real(c_float),target,dimension(:) :: D
+      real(c_float),target,dimension(:) :: E
       real(c_float),target,dimension(:,:) :: C
       integer(c_int) :: ldc
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_sstedc_full_rank = rocsolver_sstedc_(handle,evect,n,c_loc(D),c_loc(E),c_loc(C), &
-        ldc,c_loc(myInfo))
+        ldc,myInfo)
     end function
 
     function rocsolver_dstedc_rank_0(handle,evect,n,D,E,C,ldc,myInfo)
@@ -52060,10 +51676,10 @@ module hipfort_rocsolver
       real(c_double),target :: E
       real(c_double),target :: C
       integer(c_int) :: ldc
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_dstedc_rank_0 = rocsolver_dstedc_(handle,evect,n,c_loc(D),c_loc(E),c_loc(C),ldc, &
-        c_loc(myInfo))
+        myInfo)
     end function
 
     function rocsolver_dstedc_rank_1(handle,evect,n,D,E,C,ldc,myInfo)
@@ -52079,10 +51695,10 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:) :: E
       real(c_double),target,dimension(:) :: C
       integer(c_int) :: ldc
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_dstedc_rank_1 = rocsolver_dstedc_(handle,evect,n,c_loc(D),c_loc(E),c_loc(C),ldc, &
-        c_loc(myInfo))
+        myInfo)
     end function
 
     function rocsolver_dstedc_full_rank(handle,evect,n,D,E,C,ldc,myInfo)
@@ -52094,14 +51710,14 @@ module hipfort_rocsolver
       type(c_ptr) :: handle
       integer(kind(rocblas_evect_original)) :: evect
       integer(c_int) :: n
-      real(c_double),target,dimension(:,:) :: D
-      real(c_double),target,dimension(:,:) :: E
+      real(c_double),target,dimension(:) :: D
+      real(c_double),target,dimension(:) :: E
       real(c_double),target,dimension(:,:) :: C
       integer(c_int) :: ldc
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_dstedc_full_rank = rocsolver_dstedc_(handle,evect,n,c_loc(D),c_loc(E),c_loc(C), &
-        ldc,c_loc(myInfo))
+        ldc,myInfo)
     end function
 
     function rocsolver_cstedc_rank_0(handle,evect,n,D,E,C,ldc,myInfo)
@@ -52117,10 +51733,10 @@ module hipfort_rocsolver
       real(c_float),target :: E
       complex(c_float_complex),target :: C
       integer(c_int) :: ldc
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_cstedc_rank_0 = rocsolver_cstedc_(handle,evect,n,c_loc(D),c_loc(E),c_loc(C),ldc, &
-        c_loc(myInfo))
+        myInfo)
     end function
 
     function rocsolver_cstedc_rank_1(handle,evect,n,D,E,C,ldc,myInfo)
@@ -52136,10 +51752,10 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:) :: E
       complex(c_float_complex),target,dimension(:) :: C
       integer(c_int) :: ldc
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_cstedc_rank_1 = rocsolver_cstedc_(handle,evect,n,c_loc(D),c_loc(E),c_loc(C),ldc, &
-        c_loc(myInfo))
+        myInfo)
     end function
 
     function rocsolver_cstedc_full_rank(handle,evect,n,D,E,C,ldc,myInfo)
@@ -52151,14 +51767,14 @@ module hipfort_rocsolver
       type(c_ptr) :: handle
       integer(kind(rocblas_evect_original)) :: evect
       integer(c_int) :: n
-      real(c_float),target,dimension(:,:) :: D
-      real(c_float),target,dimension(:,:) :: E
+      real(c_float),target,dimension(:) :: D
+      real(c_float),target,dimension(:) :: E
       complex(c_float_complex),target,dimension(:,:) :: C
       integer(c_int) :: ldc
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_cstedc_full_rank = rocsolver_cstedc_(handle,evect,n,c_loc(D),c_loc(E),c_loc(C), &
-        ldc,c_loc(myInfo))
+        ldc,myInfo)
     end function
 
     function rocsolver_zstedc_rank_0(handle,evect,n,D,E,C,ldc,myInfo)
@@ -52174,10 +51790,10 @@ module hipfort_rocsolver
       real(c_double),target :: E
       complex(c_double_complex),target :: C
       integer(c_int) :: ldc
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_zstedc_rank_0 = rocsolver_zstedc_(handle,evect,n,c_loc(D),c_loc(E),c_loc(C),ldc, &
-        c_loc(myInfo))
+        myInfo)
     end function
 
     function rocsolver_zstedc_rank_1(handle,evect,n,D,E,C,ldc,myInfo)
@@ -52193,10 +51809,10 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:) :: E
       complex(c_double_complex),target,dimension(:) :: C
       integer(c_int) :: ldc
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_zstedc_rank_1 = rocsolver_zstedc_(handle,evect,n,c_loc(D),c_loc(E),c_loc(C),ldc, &
-        c_loc(myInfo))
+        myInfo)
     end function
 
     function rocsolver_zstedc_full_rank(handle,evect,n,D,E,C,ldc,myInfo)
@@ -52208,14 +51824,14 @@ module hipfort_rocsolver
       type(c_ptr) :: handle
       integer(kind(rocblas_evect_original)) :: evect
       integer(c_int) :: n
-      real(c_double),target,dimension(:,:) :: D
-      real(c_double),target,dimension(:,:) :: E
+      real(c_double),target,dimension(:) :: D
+      real(c_double),target,dimension(:) :: E
       complex(c_double_complex),target,dimension(:,:) :: C
       integer(c_int) :: ldc
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_zstedc_full_rank = rocsolver_zstedc_(handle,evect,n,c_loc(D),c_loc(E),c_loc(C), &
-        ldc,c_loc(myInfo))
+        ldc,myInfo)
     end function
 
     function rocsolver_sgetf2_npvt_rank_0(handle,m,n,A,lda,myInfo)
@@ -52229,9 +51845,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_float),target :: A
       integer(c_int) :: lda
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_sgetf2_npvt_rank_0 = rocsolver_sgetf2_npvt_(handle,m,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_sgetf2_npvt_rank_0 = rocsolver_sgetf2_npvt_(handle,m,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_sgetf2_npvt_rank_1(handle,m,n,A,lda,myInfo)
@@ -52245,9 +51861,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_float),target,dimension(:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_sgetf2_npvt_rank_1 = rocsolver_sgetf2_npvt_(handle,m,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_sgetf2_npvt_rank_1 = rocsolver_sgetf2_npvt_(handle,m,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_sgetf2_npvt_full_rank(handle,m,n,A,lda,myInfo)
@@ -52261,10 +51877,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_sgetf2_npvt_full_rank = rocsolver_sgetf2_npvt_(handle,m,n,c_loc(A),lda, &
-        c_loc(myInfo))
+      rocsolver_sgetf2_npvt_full_rank = rocsolver_sgetf2_npvt_(handle,m,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_dgetf2_npvt_rank_0(handle,m,n,A,lda,myInfo)
@@ -52278,9 +51893,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_double),target :: A
       integer(c_int) :: lda
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_dgetf2_npvt_rank_0 = rocsolver_dgetf2_npvt_(handle,m,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_dgetf2_npvt_rank_0 = rocsolver_dgetf2_npvt_(handle,m,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_dgetf2_npvt_rank_1(handle,m,n,A,lda,myInfo)
@@ -52294,9 +51909,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_double),target,dimension(:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_dgetf2_npvt_rank_1 = rocsolver_dgetf2_npvt_(handle,m,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_dgetf2_npvt_rank_1 = rocsolver_dgetf2_npvt_(handle,m,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_dgetf2_npvt_full_rank(handle,m,n,A,lda,myInfo)
@@ -52310,10 +51925,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_dgetf2_npvt_full_rank = rocsolver_dgetf2_npvt_(handle,m,n,c_loc(A),lda, &
-        c_loc(myInfo))
+      rocsolver_dgetf2_npvt_full_rank = rocsolver_dgetf2_npvt_(handle,m,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_cgetf2_npvt_rank_0(handle,m,n,A,lda,myInfo)
@@ -52327,9 +51941,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_float_complex),target :: A
       integer(c_int) :: lda
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_cgetf2_npvt_rank_0 = rocsolver_cgetf2_npvt_(handle,m,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_cgetf2_npvt_rank_0 = rocsolver_cgetf2_npvt_(handle,m,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_cgetf2_npvt_rank_1(handle,m,n,A,lda,myInfo)
@@ -52343,9 +51957,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_cgetf2_npvt_rank_1 = rocsolver_cgetf2_npvt_(handle,m,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_cgetf2_npvt_rank_1 = rocsolver_cgetf2_npvt_(handle,m,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_cgetf2_npvt_full_rank(handle,m,n,A,lda,myInfo)
@@ -52359,10 +51973,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_cgetf2_npvt_full_rank = rocsolver_cgetf2_npvt_(handle,m,n,c_loc(A),lda, &
-        c_loc(myInfo))
+      rocsolver_cgetf2_npvt_full_rank = rocsolver_cgetf2_npvt_(handle,m,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_zgetf2_npvt_rank_0(handle,m,n,A,lda,myInfo)
@@ -52376,9 +51989,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_double_complex),target :: A
       integer(c_int) :: lda
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_zgetf2_npvt_rank_0 = rocsolver_zgetf2_npvt_(handle,m,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_zgetf2_npvt_rank_0 = rocsolver_zgetf2_npvt_(handle,m,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_zgetf2_npvt_rank_1(handle,m,n,A,lda,myInfo)
@@ -52392,9 +52005,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_zgetf2_npvt_rank_1 = rocsolver_zgetf2_npvt_(handle,m,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_zgetf2_npvt_rank_1 = rocsolver_zgetf2_npvt_(handle,m,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_zgetf2_npvt_full_rank(handle,m,n,A,lda,myInfo)
@@ -52408,226 +52021,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_zgetf2_npvt_full_rank = rocsolver_zgetf2_npvt_(handle,m,n,c_loc(A),lda, &
-        c_loc(myInfo))
-    end function
-
-    function rocsolver_sgetf2_npvt_batched_rank_0(handle,m,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_sgetf2_npvt_batched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_sgetf2_npvt_batched_rank_0 = rocsolver_sgetf2_npvt_batched_(handle,m,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_sgetf2_npvt_batched_rank_1(handle,m,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_sgetf2_npvt_batched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_sgetf2_npvt_batched_rank_1 = rocsolver_sgetf2_npvt_batched_(handle,m,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_sgetf2_npvt_batched_full_rank(handle,m,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_sgetf2_npvt_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_sgetf2_npvt_batched_full_rank = rocsolver_sgetf2_npvt_batched_(handle,m,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_dgetf2_npvt_batched_rank_0(handle,m,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_dgetf2_npvt_batched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_dgetf2_npvt_batched_rank_0 = rocsolver_dgetf2_npvt_batched_(handle,m,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_dgetf2_npvt_batched_rank_1(handle,m,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_dgetf2_npvt_batched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_dgetf2_npvt_batched_rank_1 = rocsolver_dgetf2_npvt_batched_(handle,m,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_dgetf2_npvt_batched_full_rank(handle,m,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_dgetf2_npvt_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_dgetf2_npvt_batched_full_rank = rocsolver_dgetf2_npvt_batched_(handle,m,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_cgetf2_npvt_batched_rank_0(handle,m,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_cgetf2_npvt_batched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_cgetf2_npvt_batched_rank_0 = rocsolver_cgetf2_npvt_batched_(handle,m,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_cgetf2_npvt_batched_rank_1(handle,m,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_cgetf2_npvt_batched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_cgetf2_npvt_batched_rank_1 = rocsolver_cgetf2_npvt_batched_(handle,m,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_cgetf2_npvt_batched_full_rank(handle,m,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_cgetf2_npvt_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_cgetf2_npvt_batched_full_rank = rocsolver_cgetf2_npvt_batched_(handle,m,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_zgetf2_npvt_batched_rank_0(handle,m,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_zgetf2_npvt_batched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_zgetf2_npvt_batched_rank_0 = rocsolver_zgetf2_npvt_batched_(handle,m,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_zgetf2_npvt_batched_rank_1(handle,m,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_zgetf2_npvt_batched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_zgetf2_npvt_batched_rank_1 = rocsolver_zgetf2_npvt_batched_(handle,m,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_zgetf2_npvt_batched_full_rank(handle,m,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_zgetf2_npvt_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_zgetf2_npvt_batched_full_rank = rocsolver_zgetf2_npvt_batched_(handle,m,n,A,lda, &
-        c_loc(myInfo),batch_count)
+      rocsolver_zgetf2_npvt_full_rank = rocsolver_zgetf2_npvt_(handle,m,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_sgetf2_npvt_strided_batched_rank_0(handle,m,n,A,lda,strideA,myInfo, &
@@ -52643,11 +52039,11 @@ module hipfort_rocsolver
       real(c_float),target :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_sgetf2_npvt_strided_batched_rank_0 = rocsolver_sgetf2_npvt_strided_batched_( &
-        handle,m,n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        handle,m,n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_sgetf2_npvt_strided_batched_rank_1(handle,m,n,A,lda,strideA,myInfo, &
@@ -52663,11 +52059,11 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_sgetf2_npvt_strided_batched_rank_1 = rocsolver_sgetf2_npvt_strided_batched_( &
-        handle,m,n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        handle,m,n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_sgetf2_npvt_strided_batched_full_rank(handle,m,n,A,lda,strideA,myInfo, &
@@ -52683,11 +52079,11 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_sgetf2_npvt_strided_batched_full_rank = rocsolver_sgetf2_npvt_strided_batched_( &
-        handle,m,n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        handle,m,n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_dgetf2_npvt_strided_batched_rank_0(handle,m,n,A,lda,strideA,myInfo, &
@@ -52703,11 +52099,11 @@ module hipfort_rocsolver
       real(c_double),target :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dgetf2_npvt_strided_batched_rank_0 = rocsolver_dgetf2_npvt_strided_batched_( &
-        handle,m,n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        handle,m,n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_dgetf2_npvt_strided_batched_rank_1(handle,m,n,A,lda,strideA,myInfo, &
@@ -52723,11 +52119,11 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dgetf2_npvt_strided_batched_rank_1 = rocsolver_dgetf2_npvt_strided_batched_( &
-        handle,m,n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        handle,m,n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_dgetf2_npvt_strided_batched_full_rank(handle,m,n,A,lda,strideA,myInfo, &
@@ -52743,11 +52139,11 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dgetf2_npvt_strided_batched_full_rank = rocsolver_dgetf2_npvt_strided_batched_( &
-        handle,m,n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        handle,m,n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_cgetf2_npvt_strided_batched_rank_0(handle,m,n,A,lda,strideA,myInfo, &
@@ -52763,11 +52159,11 @@ module hipfort_rocsolver
       complex(c_float_complex),target :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cgetf2_npvt_strided_batched_rank_0 = rocsolver_cgetf2_npvt_strided_batched_( &
-        handle,m,n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        handle,m,n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_cgetf2_npvt_strided_batched_rank_1(handle,m,n,A,lda,strideA,myInfo, &
@@ -52783,11 +52179,11 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cgetf2_npvt_strided_batched_rank_1 = rocsolver_cgetf2_npvt_strided_batched_( &
-        handle,m,n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        handle,m,n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_cgetf2_npvt_strided_batched_full_rank(handle,m,n,A,lda,strideA,myInfo, &
@@ -52803,11 +52199,11 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cgetf2_npvt_strided_batched_full_rank = rocsolver_cgetf2_npvt_strided_batched_( &
-        handle,m,n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        handle,m,n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_zgetf2_npvt_strided_batched_rank_0(handle,m,n,A,lda,strideA,myInfo, &
@@ -52823,11 +52219,11 @@ module hipfort_rocsolver
       complex(c_double_complex),target :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zgetf2_npvt_strided_batched_rank_0 = rocsolver_zgetf2_npvt_strided_batched_( &
-        handle,m,n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        handle,m,n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_zgetf2_npvt_strided_batched_rank_1(handle,m,n,A,lda,strideA,myInfo, &
@@ -52843,11 +52239,11 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zgetf2_npvt_strided_batched_rank_1 = rocsolver_zgetf2_npvt_strided_batched_( &
-        handle,m,n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        handle,m,n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_zgetf2_npvt_strided_batched_full_rank(handle,m,n,A,lda,strideA,myInfo, &
@@ -52863,11 +52259,11 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zgetf2_npvt_strided_batched_full_rank = rocsolver_zgetf2_npvt_strided_batched_( &
-        handle,m,n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        handle,m,n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_sgetrf_npvt_rank_0(handle,m,n,A,lda,myInfo)
@@ -52881,9 +52277,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_float),target :: A
       integer(c_int) :: lda
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_sgetrf_npvt_rank_0 = rocsolver_sgetrf_npvt_(handle,m,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_sgetrf_npvt_rank_0 = rocsolver_sgetrf_npvt_(handle,m,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_sgetrf_npvt_rank_1(handle,m,n,A,lda,myInfo)
@@ -52897,9 +52293,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_float),target,dimension(:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_sgetrf_npvt_rank_1 = rocsolver_sgetrf_npvt_(handle,m,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_sgetrf_npvt_rank_1 = rocsolver_sgetrf_npvt_(handle,m,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_sgetrf_npvt_full_rank(handle,m,n,A,lda,myInfo)
@@ -52913,10 +52309,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_sgetrf_npvt_full_rank = rocsolver_sgetrf_npvt_(handle,m,n,c_loc(A),lda, &
-        c_loc(myInfo))
+      rocsolver_sgetrf_npvt_full_rank = rocsolver_sgetrf_npvt_(handle,m,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_dgetrf_npvt_rank_0(handle,m,n,A,lda,myInfo)
@@ -52930,9 +52325,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_double),target :: A
       integer(c_int) :: lda
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_dgetrf_npvt_rank_0 = rocsolver_dgetrf_npvt_(handle,m,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_dgetrf_npvt_rank_0 = rocsolver_dgetrf_npvt_(handle,m,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_dgetrf_npvt_rank_1(handle,m,n,A,lda,myInfo)
@@ -52946,9 +52341,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_double),target,dimension(:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_dgetrf_npvt_rank_1 = rocsolver_dgetrf_npvt_(handle,m,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_dgetrf_npvt_rank_1 = rocsolver_dgetrf_npvt_(handle,m,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_dgetrf_npvt_full_rank(handle,m,n,A,lda,myInfo)
@@ -52962,10 +52357,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_dgetrf_npvt_full_rank = rocsolver_dgetrf_npvt_(handle,m,n,c_loc(A),lda, &
-        c_loc(myInfo))
+      rocsolver_dgetrf_npvt_full_rank = rocsolver_dgetrf_npvt_(handle,m,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_cgetrf_npvt_rank_0(handle,m,n,A,lda,myInfo)
@@ -52979,9 +52373,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_float_complex),target :: A
       integer(c_int) :: lda
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_cgetrf_npvt_rank_0 = rocsolver_cgetrf_npvt_(handle,m,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_cgetrf_npvt_rank_0 = rocsolver_cgetrf_npvt_(handle,m,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_cgetrf_npvt_rank_1(handle,m,n,A,lda,myInfo)
@@ -52995,9 +52389,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_cgetrf_npvt_rank_1 = rocsolver_cgetrf_npvt_(handle,m,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_cgetrf_npvt_rank_1 = rocsolver_cgetrf_npvt_(handle,m,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_cgetrf_npvt_full_rank(handle,m,n,A,lda,myInfo)
@@ -53011,10 +52405,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_cgetrf_npvt_full_rank = rocsolver_cgetrf_npvt_(handle,m,n,c_loc(A),lda, &
-        c_loc(myInfo))
+      rocsolver_cgetrf_npvt_full_rank = rocsolver_cgetrf_npvt_(handle,m,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_zgetrf_npvt_rank_0(handle,m,n,A,lda,myInfo)
@@ -53028,9 +52421,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_double_complex),target :: A
       integer(c_int) :: lda
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_zgetrf_npvt_rank_0 = rocsolver_zgetrf_npvt_(handle,m,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_zgetrf_npvt_rank_0 = rocsolver_zgetrf_npvt_(handle,m,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_zgetrf_npvt_rank_1(handle,m,n,A,lda,myInfo)
@@ -53044,9 +52437,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_zgetrf_npvt_rank_1 = rocsolver_zgetrf_npvt_(handle,m,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_zgetrf_npvt_rank_1 = rocsolver_zgetrf_npvt_(handle,m,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_zgetrf_npvt_full_rank(handle,m,n,A,lda,myInfo)
@@ -53060,226 +52453,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_zgetrf_npvt_full_rank = rocsolver_zgetrf_npvt_(handle,m,n,c_loc(A),lda, &
-        c_loc(myInfo))
-    end function
-
-    function rocsolver_sgetrf_npvt_batched_rank_0(handle,m,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_sgetrf_npvt_batched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_sgetrf_npvt_batched_rank_0 = rocsolver_sgetrf_npvt_batched_(handle,m,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_sgetrf_npvt_batched_rank_1(handle,m,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_sgetrf_npvt_batched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_sgetrf_npvt_batched_rank_1 = rocsolver_sgetrf_npvt_batched_(handle,m,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_sgetrf_npvt_batched_full_rank(handle,m,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_sgetrf_npvt_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_sgetrf_npvt_batched_full_rank = rocsolver_sgetrf_npvt_batched_(handle,m,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_dgetrf_npvt_batched_rank_0(handle,m,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_dgetrf_npvt_batched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_dgetrf_npvt_batched_rank_0 = rocsolver_dgetrf_npvt_batched_(handle,m,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_dgetrf_npvt_batched_rank_1(handle,m,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_dgetrf_npvt_batched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_dgetrf_npvt_batched_rank_1 = rocsolver_dgetrf_npvt_batched_(handle,m,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_dgetrf_npvt_batched_full_rank(handle,m,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_dgetrf_npvt_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_dgetrf_npvt_batched_full_rank = rocsolver_dgetrf_npvt_batched_(handle,m,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_cgetrf_npvt_batched_rank_0(handle,m,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_cgetrf_npvt_batched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_cgetrf_npvt_batched_rank_0 = rocsolver_cgetrf_npvt_batched_(handle,m,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_cgetrf_npvt_batched_rank_1(handle,m,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_cgetrf_npvt_batched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_cgetrf_npvt_batched_rank_1 = rocsolver_cgetrf_npvt_batched_(handle,m,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_cgetrf_npvt_batched_full_rank(handle,m,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_cgetrf_npvt_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_cgetrf_npvt_batched_full_rank = rocsolver_cgetrf_npvt_batched_(handle,m,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_zgetrf_npvt_batched_rank_0(handle,m,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_zgetrf_npvt_batched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_zgetrf_npvt_batched_rank_0 = rocsolver_zgetrf_npvt_batched_(handle,m,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_zgetrf_npvt_batched_rank_1(handle,m,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_zgetrf_npvt_batched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_zgetrf_npvt_batched_rank_1 = rocsolver_zgetrf_npvt_batched_(handle,m,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_zgetrf_npvt_batched_full_rank(handle,m,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_zgetrf_npvt_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_zgetrf_npvt_batched_full_rank = rocsolver_zgetrf_npvt_batched_(handle,m,n,A,lda, &
-        c_loc(myInfo),batch_count)
+      rocsolver_zgetrf_npvt_full_rank = rocsolver_zgetrf_npvt_(handle,m,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_sgetrf_npvt_strided_batched_rank_0(handle,m,n,A,lda,strideA,myInfo, &
@@ -53295,11 +52471,11 @@ module hipfort_rocsolver
       real(c_float),target :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_sgetrf_npvt_strided_batched_rank_0 = rocsolver_sgetrf_npvt_strided_batched_( &
-        handle,m,n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        handle,m,n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_sgetrf_npvt_strided_batched_rank_1(handle,m,n,A,lda,strideA,myInfo, &
@@ -53315,11 +52491,11 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_sgetrf_npvt_strided_batched_rank_1 = rocsolver_sgetrf_npvt_strided_batched_( &
-        handle,m,n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        handle,m,n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_sgetrf_npvt_strided_batched_full_rank(handle,m,n,A,lda,strideA,myInfo, &
@@ -53335,11 +52511,11 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_sgetrf_npvt_strided_batched_full_rank = rocsolver_sgetrf_npvt_strided_batched_( &
-        handle,m,n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        handle,m,n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_dgetrf_npvt_strided_batched_rank_0(handle,m,n,A,lda,strideA,myInfo, &
@@ -53355,11 +52531,11 @@ module hipfort_rocsolver
       real(c_double),target :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dgetrf_npvt_strided_batched_rank_0 = rocsolver_dgetrf_npvt_strided_batched_( &
-        handle,m,n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        handle,m,n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_dgetrf_npvt_strided_batched_rank_1(handle,m,n,A,lda,strideA,myInfo, &
@@ -53375,11 +52551,11 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dgetrf_npvt_strided_batched_rank_1 = rocsolver_dgetrf_npvt_strided_batched_( &
-        handle,m,n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        handle,m,n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_dgetrf_npvt_strided_batched_full_rank(handle,m,n,A,lda,strideA,myInfo, &
@@ -53395,11 +52571,11 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dgetrf_npvt_strided_batched_full_rank = rocsolver_dgetrf_npvt_strided_batched_( &
-        handle,m,n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        handle,m,n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_cgetrf_npvt_strided_batched_rank_0(handle,m,n,A,lda,strideA,myInfo, &
@@ -53415,11 +52591,11 @@ module hipfort_rocsolver
       complex(c_float_complex),target :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cgetrf_npvt_strided_batched_rank_0 = rocsolver_cgetrf_npvt_strided_batched_( &
-        handle,m,n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        handle,m,n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_cgetrf_npvt_strided_batched_rank_1(handle,m,n,A,lda,strideA,myInfo, &
@@ -53435,11 +52611,11 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cgetrf_npvt_strided_batched_rank_1 = rocsolver_cgetrf_npvt_strided_batched_( &
-        handle,m,n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        handle,m,n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_cgetrf_npvt_strided_batched_full_rank(handle,m,n,A,lda,strideA,myInfo, &
@@ -53455,11 +52631,11 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cgetrf_npvt_strided_batched_full_rank = rocsolver_cgetrf_npvt_strided_batched_( &
-        handle,m,n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        handle,m,n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_zgetrf_npvt_strided_batched_rank_0(handle,m,n,A,lda,strideA,myInfo, &
@@ -53475,11 +52651,11 @@ module hipfort_rocsolver
       complex(c_double_complex),target :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zgetrf_npvt_strided_batched_rank_0 = rocsolver_zgetrf_npvt_strided_batched_( &
-        handle,m,n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        handle,m,n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_zgetrf_npvt_strided_batched_rank_1(handle,m,n,A,lda,strideA,myInfo, &
@@ -53495,11 +52671,11 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zgetrf_npvt_strided_batched_rank_1 = rocsolver_zgetrf_npvt_strided_batched_( &
-        handle,m,n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        handle,m,n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_zgetrf_npvt_strided_batched_full_rank(handle,m,n,A,lda,strideA,myInfo, &
@@ -53515,11 +52691,11 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zgetrf_npvt_strided_batched_full_rank = rocsolver_zgetrf_npvt_strided_batched_( &
-        handle,m,n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        handle,m,n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_sgetf2_rank_0(handle,m,n,A,lda,ipiv,myInfo)
@@ -53534,9 +52710,9 @@ module hipfort_rocsolver
       real(c_float),target :: A
       integer(c_int) :: lda
       integer(c_int),target :: ipiv
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_sgetf2_rank_0 = rocsolver_sgetf2_(handle,m,n,c_loc(A),lda,c_loc(ipiv),c_loc(myInfo))
+      rocsolver_sgetf2_rank_0 = rocsolver_sgetf2_(handle,m,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_sgetf2_rank_1(handle,m,n,A,lda,ipiv,myInfo)
@@ -53551,9 +52727,9 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int),target,dimension(:) :: ipiv
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_sgetf2_rank_1 = rocsolver_sgetf2_(handle,m,n,c_loc(A),lda,c_loc(ipiv),c_loc(myInfo))
+      rocsolver_sgetf2_rank_1 = rocsolver_sgetf2_(handle,m,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_sgetf2_full_rank(handle,m,n,A,lda,ipiv,myInfo)
@@ -53567,11 +52743,10 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int),target,dimension(:,:) :: myInfo
+      integer(c_int),target,dimension(:) :: ipiv
+      type(c_ptr) :: myInfo
       !
-      rocsolver_sgetf2_full_rank = rocsolver_sgetf2_(handle,m,n,c_loc(A),lda,c_loc(ipiv), &
-        c_loc(myInfo))
+      rocsolver_sgetf2_full_rank = rocsolver_sgetf2_(handle,m,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_dgetf2_rank_0(handle,m,n,A,lda,ipiv,myInfo)
@@ -53586,9 +52761,9 @@ module hipfort_rocsolver
       real(c_double),target :: A
       integer(c_int) :: lda
       integer(c_int),target :: ipiv
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_dgetf2_rank_0 = rocsolver_dgetf2_(handle,m,n,c_loc(A),lda,c_loc(ipiv),c_loc(myInfo))
+      rocsolver_dgetf2_rank_0 = rocsolver_dgetf2_(handle,m,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_dgetf2_rank_1(handle,m,n,A,lda,ipiv,myInfo)
@@ -53603,9 +52778,9 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int),target,dimension(:) :: ipiv
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_dgetf2_rank_1 = rocsolver_dgetf2_(handle,m,n,c_loc(A),lda,c_loc(ipiv),c_loc(myInfo))
+      rocsolver_dgetf2_rank_1 = rocsolver_dgetf2_(handle,m,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_dgetf2_full_rank(handle,m,n,A,lda,ipiv,myInfo)
@@ -53619,11 +52794,10 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int),target,dimension(:,:) :: myInfo
+      integer(c_int),target,dimension(:) :: ipiv
+      type(c_ptr) :: myInfo
       !
-      rocsolver_dgetf2_full_rank = rocsolver_dgetf2_(handle,m,n,c_loc(A),lda,c_loc(ipiv), &
-        c_loc(myInfo))
+      rocsolver_dgetf2_full_rank = rocsolver_dgetf2_(handle,m,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_cgetf2_rank_0(handle,m,n,A,lda,ipiv,myInfo)
@@ -53638,9 +52812,9 @@ module hipfort_rocsolver
       complex(c_float_complex),target :: A
       integer(c_int) :: lda
       integer(c_int),target :: ipiv
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_cgetf2_rank_0 = rocsolver_cgetf2_(handle,m,n,c_loc(A),lda,c_loc(ipiv),c_loc(myInfo))
+      rocsolver_cgetf2_rank_0 = rocsolver_cgetf2_(handle,m,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_cgetf2_rank_1(handle,m,n,A,lda,ipiv,myInfo)
@@ -53655,9 +52829,9 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int),target,dimension(:) :: ipiv
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_cgetf2_rank_1 = rocsolver_cgetf2_(handle,m,n,c_loc(A),lda,c_loc(ipiv),c_loc(myInfo))
+      rocsolver_cgetf2_rank_1 = rocsolver_cgetf2_(handle,m,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_cgetf2_full_rank(handle,m,n,A,lda,ipiv,myInfo)
@@ -53671,11 +52845,10 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int),target,dimension(:,:) :: myInfo
+      integer(c_int),target,dimension(:) :: ipiv
+      type(c_ptr) :: myInfo
       !
-      rocsolver_cgetf2_full_rank = rocsolver_cgetf2_(handle,m,n,c_loc(A),lda,c_loc(ipiv), &
-        c_loc(myInfo))
+      rocsolver_cgetf2_full_rank = rocsolver_cgetf2_(handle,m,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_zgetf2_rank_0(handle,m,n,A,lda,ipiv,myInfo)
@@ -53690,9 +52863,9 @@ module hipfort_rocsolver
       complex(c_double_complex),target :: A
       integer(c_int) :: lda
       integer(c_int),target :: ipiv
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_zgetf2_rank_0 = rocsolver_zgetf2_(handle,m,n,c_loc(A),lda,c_loc(ipiv),c_loc(myInfo))
+      rocsolver_zgetf2_rank_0 = rocsolver_zgetf2_(handle,m,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_zgetf2_rank_1(handle,m,n,A,lda,ipiv,myInfo)
@@ -53707,9 +52880,9 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int),target,dimension(:) :: ipiv
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_zgetf2_rank_1 = rocsolver_zgetf2_(handle,m,n,c_loc(A),lda,c_loc(ipiv),c_loc(myInfo))
+      rocsolver_zgetf2_rank_1 = rocsolver_zgetf2_(handle,m,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_zgetf2_full_rank(handle,m,n,A,lda,ipiv,myInfo)
@@ -53723,11 +52896,10 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int),target,dimension(:,:) :: myInfo
+      integer(c_int),target,dimension(:) :: ipiv
+      type(c_ptr) :: myInfo
       !
-      rocsolver_zgetf2_full_rank = rocsolver_zgetf2_(handle,m,n,c_loc(A),lda,c_loc(ipiv), &
-        c_loc(myInfo))
+      rocsolver_zgetf2_full_rank = rocsolver_zgetf2_(handle,m,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_sgetf2_batched_rank_0(handle,m,n,A,lda,ipiv,strideP,myInfo,batch_count)
@@ -53743,11 +52915,11 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       integer(c_int),target :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_sgetf2_batched_rank_0 = rocsolver_sgetf2_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,c_loc(myInfo),batch_count)
+        strideP,myInfo,batch_count)
     end function
 
     function rocsolver_sgetf2_batched_rank_1(handle,m,n,A,lda,ipiv,strideP,myInfo,batch_count)
@@ -53763,31 +52935,11 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_sgetf2_batched_rank_1 = rocsolver_sgetf2_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_sgetf2_batched_full_rank(handle,m,n,A,lda,ipiv,strideP,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_sgetf2_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_sgetf2_batched_full_rank = rocsolver_sgetf2_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,c_loc(myInfo),batch_count)
+        strideP,myInfo,batch_count)
     end function
 
     function rocsolver_dgetf2_batched_rank_0(handle,m,n,A,lda,ipiv,strideP,myInfo,batch_count)
@@ -53803,11 +52955,11 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       integer(c_int),target :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dgetf2_batched_rank_0 = rocsolver_dgetf2_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,c_loc(myInfo),batch_count)
+        strideP,myInfo,batch_count)
     end function
 
     function rocsolver_dgetf2_batched_rank_1(handle,m,n,A,lda,ipiv,strideP,myInfo,batch_count)
@@ -53823,31 +52975,11 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dgetf2_batched_rank_1 = rocsolver_dgetf2_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_dgetf2_batched_full_rank(handle,m,n,A,lda,ipiv,strideP,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_dgetf2_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_dgetf2_batched_full_rank = rocsolver_dgetf2_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,c_loc(myInfo),batch_count)
+        strideP,myInfo,batch_count)
     end function
 
     function rocsolver_cgetf2_batched_rank_0(handle,m,n,A,lda,ipiv,strideP,myInfo,batch_count)
@@ -53863,11 +52995,11 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       integer(c_int),target :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cgetf2_batched_rank_0 = rocsolver_cgetf2_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,c_loc(myInfo),batch_count)
+        strideP,myInfo,batch_count)
     end function
 
     function rocsolver_cgetf2_batched_rank_1(handle,m,n,A,lda,ipiv,strideP,myInfo,batch_count)
@@ -53883,31 +53015,11 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cgetf2_batched_rank_1 = rocsolver_cgetf2_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_cgetf2_batched_full_rank(handle,m,n,A,lda,ipiv,strideP,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_cgetf2_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_cgetf2_batched_full_rank = rocsolver_cgetf2_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,c_loc(myInfo),batch_count)
+        strideP,myInfo,batch_count)
     end function
 
     function rocsolver_zgetf2_batched_rank_0(handle,m,n,A,lda,ipiv,strideP,myInfo,batch_count)
@@ -53923,11 +53035,11 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       integer(c_int),target :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zgetf2_batched_rank_0 = rocsolver_zgetf2_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,c_loc(myInfo),batch_count)
+        strideP,myInfo,batch_count)
     end function
 
     function rocsolver_zgetf2_batched_rank_1(handle,m,n,A,lda,ipiv,strideP,myInfo,batch_count)
@@ -53943,31 +53055,11 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zgetf2_batched_rank_1 = rocsolver_zgetf2_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_zgetf2_batched_full_rank(handle,m,n,A,lda,ipiv,strideP,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_zgetf2_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_zgetf2_batched_full_rank = rocsolver_zgetf2_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,c_loc(myInfo),batch_count)
+        strideP,myInfo,batch_count)
     end function
 
     function rocsolver_sgetf2_strided_batched_rank_0(handle,m,n,A,lda,strideA,ipiv,strideP,myInfo, &
@@ -53985,11 +53077,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideA
       integer(c_int),target :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_sgetf2_strided_batched_rank_0 = rocsolver_sgetf2_strided_batched_(handle,m,n, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_sgetf2_strided_batched_rank_1(handle,m,n,A,lda,strideA,ipiv,strideP,myInfo, &
@@ -54007,11 +53099,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideA
       integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_sgetf2_strided_batched_rank_1 = rocsolver_sgetf2_strided_batched_(handle,m,n, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_sgetf2_strided_batched_full_rank(handle,m,n,A,lda,strideA,ipiv,strideP, &
@@ -54027,13 +53119,13 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: ipiv
+      integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_sgetf2_strided_batched_full_rank = rocsolver_sgetf2_strided_batched_(handle,m,n, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_dgetf2_strided_batched_rank_0(handle,m,n,A,lda,strideA,ipiv,strideP,myInfo, &
@@ -54051,11 +53143,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideA
       integer(c_int),target :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dgetf2_strided_batched_rank_0 = rocsolver_dgetf2_strided_batched_(handle,m,n, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_dgetf2_strided_batched_rank_1(handle,m,n,A,lda,strideA,ipiv,strideP,myInfo, &
@@ -54073,11 +53165,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideA
       integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dgetf2_strided_batched_rank_1 = rocsolver_dgetf2_strided_batched_(handle,m,n, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_dgetf2_strided_batched_full_rank(handle,m,n,A,lda,strideA,ipiv,strideP, &
@@ -54093,13 +53185,13 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: ipiv
+      integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dgetf2_strided_batched_full_rank = rocsolver_dgetf2_strided_batched_(handle,m,n, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_cgetf2_strided_batched_rank_0(handle,m,n,A,lda,strideA,ipiv,strideP,myInfo, &
@@ -54117,11 +53209,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideA
       integer(c_int),target :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cgetf2_strided_batched_rank_0 = rocsolver_cgetf2_strided_batched_(handle,m,n, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_cgetf2_strided_batched_rank_1(handle,m,n,A,lda,strideA,ipiv,strideP,myInfo, &
@@ -54139,11 +53231,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideA
       integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cgetf2_strided_batched_rank_1 = rocsolver_cgetf2_strided_batched_(handle,m,n, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_cgetf2_strided_batched_full_rank(handle,m,n,A,lda,strideA,ipiv,strideP, &
@@ -54159,13 +53251,13 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: ipiv
+      integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cgetf2_strided_batched_full_rank = rocsolver_cgetf2_strided_batched_(handle,m,n, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_zgetf2_strided_batched_rank_0(handle,m,n,A,lda,strideA,ipiv,strideP,myInfo, &
@@ -54183,11 +53275,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideA
       integer(c_int),target :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zgetf2_strided_batched_rank_0 = rocsolver_zgetf2_strided_batched_(handle,m,n, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_zgetf2_strided_batched_rank_1(handle,m,n,A,lda,strideA,ipiv,strideP,myInfo, &
@@ -54205,11 +53297,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideA
       integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zgetf2_strided_batched_rank_1 = rocsolver_zgetf2_strided_batched_(handle,m,n, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_zgetf2_strided_batched_full_rank(handle,m,n,A,lda,strideA,ipiv,strideP, &
@@ -54225,13 +53317,13 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: ipiv
+      integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zgetf2_strided_batched_full_rank = rocsolver_zgetf2_strided_batched_(handle,m,n, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_sgetrf_rank_0(handle,m,n,A,lda,ipiv,myInfo)
@@ -54246,9 +53338,9 @@ module hipfort_rocsolver
       real(c_float),target :: A
       integer(c_int) :: lda
       integer(c_int),target :: ipiv
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_sgetrf_rank_0 = rocsolver_sgetrf_(handle,m,n,c_loc(A),lda,c_loc(ipiv),c_loc(myInfo))
+      rocsolver_sgetrf_rank_0 = rocsolver_sgetrf_(handle,m,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_sgetrf_rank_1(handle,m,n,A,lda,ipiv,myInfo)
@@ -54263,9 +53355,9 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int),target,dimension(:) :: ipiv
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_sgetrf_rank_1 = rocsolver_sgetrf_(handle,m,n,c_loc(A),lda,c_loc(ipiv),c_loc(myInfo))
+      rocsolver_sgetrf_rank_1 = rocsolver_sgetrf_(handle,m,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_sgetrf_full_rank(handle,m,n,A,lda,ipiv,myInfo)
@@ -54279,11 +53371,10 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int),target,dimension(:,:) :: myInfo
+      integer(c_int),target,dimension(:) :: ipiv
+      type(c_ptr) :: myInfo
       !
-      rocsolver_sgetrf_full_rank = rocsolver_sgetrf_(handle,m,n,c_loc(A),lda,c_loc(ipiv), &
-        c_loc(myInfo))
+      rocsolver_sgetrf_full_rank = rocsolver_sgetrf_(handle,m,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_dgetrf_rank_0(handle,m,n,A,lda,ipiv,myInfo)
@@ -54298,9 +53389,9 @@ module hipfort_rocsolver
       real(c_double),target :: A
       integer(c_int) :: lda
       integer(c_int),target :: ipiv
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_dgetrf_rank_0 = rocsolver_dgetrf_(handle,m,n,c_loc(A),lda,c_loc(ipiv),c_loc(myInfo))
+      rocsolver_dgetrf_rank_0 = rocsolver_dgetrf_(handle,m,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_dgetrf_rank_1(handle,m,n,A,lda,ipiv,myInfo)
@@ -54315,9 +53406,9 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int),target,dimension(:) :: ipiv
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_dgetrf_rank_1 = rocsolver_dgetrf_(handle,m,n,c_loc(A),lda,c_loc(ipiv),c_loc(myInfo))
+      rocsolver_dgetrf_rank_1 = rocsolver_dgetrf_(handle,m,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_dgetrf_full_rank(handle,m,n,A,lda,ipiv,myInfo)
@@ -54331,11 +53422,10 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int),target,dimension(:,:) :: myInfo
+      integer(c_int),target,dimension(:) :: ipiv
+      type(c_ptr) :: myInfo
       !
-      rocsolver_dgetrf_full_rank = rocsolver_dgetrf_(handle,m,n,c_loc(A),lda,c_loc(ipiv), &
-        c_loc(myInfo))
+      rocsolver_dgetrf_full_rank = rocsolver_dgetrf_(handle,m,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_cgetrf_rank_0(handle,m,n,A,lda,ipiv,myInfo)
@@ -54350,9 +53440,9 @@ module hipfort_rocsolver
       complex(c_float_complex),target :: A
       integer(c_int) :: lda
       integer(c_int),target :: ipiv
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_cgetrf_rank_0 = rocsolver_cgetrf_(handle,m,n,c_loc(A),lda,c_loc(ipiv),c_loc(myInfo))
+      rocsolver_cgetrf_rank_0 = rocsolver_cgetrf_(handle,m,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_cgetrf_rank_1(handle,m,n,A,lda,ipiv,myInfo)
@@ -54367,9 +53457,9 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int),target,dimension(:) :: ipiv
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_cgetrf_rank_1 = rocsolver_cgetrf_(handle,m,n,c_loc(A),lda,c_loc(ipiv),c_loc(myInfo))
+      rocsolver_cgetrf_rank_1 = rocsolver_cgetrf_(handle,m,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_cgetrf_full_rank(handle,m,n,A,lda,ipiv,myInfo)
@@ -54383,11 +53473,10 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int),target,dimension(:,:) :: myInfo
+      integer(c_int),target,dimension(:) :: ipiv
+      type(c_ptr) :: myInfo
       !
-      rocsolver_cgetrf_full_rank = rocsolver_cgetrf_(handle,m,n,c_loc(A),lda,c_loc(ipiv), &
-        c_loc(myInfo))
+      rocsolver_cgetrf_full_rank = rocsolver_cgetrf_(handle,m,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_zgetrf_rank_0(handle,m,n,A,lda,ipiv,myInfo)
@@ -54402,9 +53491,9 @@ module hipfort_rocsolver
       complex(c_double_complex),target :: A
       integer(c_int) :: lda
       integer(c_int),target :: ipiv
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_zgetrf_rank_0 = rocsolver_zgetrf_(handle,m,n,c_loc(A),lda,c_loc(ipiv),c_loc(myInfo))
+      rocsolver_zgetrf_rank_0 = rocsolver_zgetrf_(handle,m,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_zgetrf_rank_1(handle,m,n,A,lda,ipiv,myInfo)
@@ -54419,9 +53508,9 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int),target,dimension(:) :: ipiv
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_zgetrf_rank_1 = rocsolver_zgetrf_(handle,m,n,c_loc(A),lda,c_loc(ipiv),c_loc(myInfo))
+      rocsolver_zgetrf_rank_1 = rocsolver_zgetrf_(handle,m,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_zgetrf_full_rank(handle,m,n,A,lda,ipiv,myInfo)
@@ -54435,11 +53524,10 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int),target,dimension(:,:) :: myInfo
+      integer(c_int),target,dimension(:) :: ipiv
+      type(c_ptr) :: myInfo
       !
-      rocsolver_zgetrf_full_rank = rocsolver_zgetrf_(handle,m,n,c_loc(A),lda,c_loc(ipiv), &
-        c_loc(myInfo))
+      rocsolver_zgetrf_full_rank = rocsolver_zgetrf_(handle,m,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_sgetrf_batched_rank_0(handle,m,n,A,lda,ipiv,strideP,myInfo,batch_count)
@@ -54455,11 +53543,11 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       integer(c_int),target :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_sgetrf_batched_rank_0 = rocsolver_sgetrf_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,c_loc(myInfo),batch_count)
+        strideP,myInfo,batch_count)
     end function
 
     function rocsolver_sgetrf_batched_rank_1(handle,m,n,A,lda,ipiv,strideP,myInfo,batch_count)
@@ -54475,31 +53563,11 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_sgetrf_batched_rank_1 = rocsolver_sgetrf_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_sgetrf_batched_full_rank(handle,m,n,A,lda,ipiv,strideP,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_sgetrf_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_sgetrf_batched_full_rank = rocsolver_sgetrf_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,c_loc(myInfo),batch_count)
+        strideP,myInfo,batch_count)
     end function
 
     function rocsolver_dgetrf_batched_rank_0(handle,m,n,A,lda,ipiv,strideP,myInfo,batch_count)
@@ -54515,11 +53583,11 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       integer(c_int),target :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dgetrf_batched_rank_0 = rocsolver_dgetrf_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,c_loc(myInfo),batch_count)
+        strideP,myInfo,batch_count)
     end function
 
     function rocsolver_dgetrf_batched_rank_1(handle,m,n,A,lda,ipiv,strideP,myInfo,batch_count)
@@ -54535,31 +53603,11 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dgetrf_batched_rank_1 = rocsolver_dgetrf_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_dgetrf_batched_full_rank(handle,m,n,A,lda,ipiv,strideP,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_dgetrf_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_dgetrf_batched_full_rank = rocsolver_dgetrf_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,c_loc(myInfo),batch_count)
+        strideP,myInfo,batch_count)
     end function
 
     function rocsolver_cgetrf_batched_rank_0(handle,m,n,A,lda,ipiv,strideP,myInfo,batch_count)
@@ -54575,11 +53623,11 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       integer(c_int),target :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cgetrf_batched_rank_0 = rocsolver_cgetrf_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,c_loc(myInfo),batch_count)
+        strideP,myInfo,batch_count)
     end function
 
     function rocsolver_cgetrf_batched_rank_1(handle,m,n,A,lda,ipiv,strideP,myInfo,batch_count)
@@ -54595,31 +53643,11 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cgetrf_batched_rank_1 = rocsolver_cgetrf_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_cgetrf_batched_full_rank(handle,m,n,A,lda,ipiv,strideP,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_cgetrf_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_cgetrf_batched_full_rank = rocsolver_cgetrf_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,c_loc(myInfo),batch_count)
+        strideP,myInfo,batch_count)
     end function
 
     function rocsolver_zgetrf_batched_rank_0(handle,m,n,A,lda,ipiv,strideP,myInfo,batch_count)
@@ -54635,11 +53663,11 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       integer(c_int),target :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zgetrf_batched_rank_0 = rocsolver_zgetrf_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,c_loc(myInfo),batch_count)
+        strideP,myInfo,batch_count)
     end function
 
     function rocsolver_zgetrf_batched_rank_1(handle,m,n,A,lda,ipiv,strideP,myInfo,batch_count)
@@ -54655,31 +53683,11 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zgetrf_batched_rank_1 = rocsolver_zgetrf_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_zgetrf_batched_full_rank(handle,m,n,A,lda,ipiv,strideP,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_zgetrf_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_zgetrf_batched_full_rank = rocsolver_zgetrf_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,c_loc(myInfo),batch_count)
+        strideP,myInfo,batch_count)
     end function
 
     function rocsolver_sgetrf_strided_batched_rank_0(handle,m,n,A,lda,strideA,ipiv,strideP,myInfo, &
@@ -54697,11 +53705,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideA
       integer(c_int),target :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_sgetrf_strided_batched_rank_0 = rocsolver_sgetrf_strided_batched_(handle,m,n, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_sgetrf_strided_batched_rank_1(handle,m,n,A,lda,strideA,ipiv,strideP,myInfo, &
@@ -54719,11 +53727,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideA
       integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_sgetrf_strided_batched_rank_1 = rocsolver_sgetrf_strided_batched_(handle,m,n, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_sgetrf_strided_batched_full_rank(handle,m,n,A,lda,strideA,ipiv,strideP, &
@@ -54739,13 +53747,13 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: ipiv
+      integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_sgetrf_strided_batched_full_rank = rocsolver_sgetrf_strided_batched_(handle,m,n, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_dgetrf_strided_batched_rank_0(handle,m,n,A,lda,strideA,ipiv,strideP,myInfo, &
@@ -54763,11 +53771,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideA
       integer(c_int),target :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dgetrf_strided_batched_rank_0 = rocsolver_dgetrf_strided_batched_(handle,m,n, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_dgetrf_strided_batched_rank_1(handle,m,n,A,lda,strideA,ipiv,strideP,myInfo, &
@@ -54785,11 +53793,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideA
       integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dgetrf_strided_batched_rank_1 = rocsolver_dgetrf_strided_batched_(handle,m,n, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_dgetrf_strided_batched_full_rank(handle,m,n,A,lda,strideA,ipiv,strideP, &
@@ -54805,13 +53813,13 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: ipiv
+      integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dgetrf_strided_batched_full_rank = rocsolver_dgetrf_strided_batched_(handle,m,n, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_cgetrf_strided_batched_rank_0(handle,m,n,A,lda,strideA,ipiv,strideP,myInfo, &
@@ -54829,11 +53837,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideA
       integer(c_int),target :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cgetrf_strided_batched_rank_0 = rocsolver_cgetrf_strided_batched_(handle,m,n, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_cgetrf_strided_batched_rank_1(handle,m,n,A,lda,strideA,ipiv,strideP,myInfo, &
@@ -54851,11 +53859,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideA
       integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cgetrf_strided_batched_rank_1 = rocsolver_cgetrf_strided_batched_(handle,m,n, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_cgetrf_strided_batched_full_rank(handle,m,n,A,lda,strideA,ipiv,strideP, &
@@ -54871,13 +53879,13 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: ipiv
+      integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cgetrf_strided_batched_full_rank = rocsolver_cgetrf_strided_batched_(handle,m,n, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_zgetrf_strided_batched_rank_0(handle,m,n,A,lda,strideA,ipiv,strideP,myInfo, &
@@ -54895,11 +53903,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideA
       integer(c_int),target :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zgetrf_strided_batched_rank_0 = rocsolver_zgetrf_strided_batched_(handle,m,n, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_zgetrf_strided_batched_rank_1(handle,m,n,A,lda,strideA,ipiv,strideP,myInfo, &
@@ -54917,11 +53925,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideA
       integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zgetrf_strided_batched_rank_1 = rocsolver_zgetrf_strided_batched_(handle,m,n, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_zgetrf_strided_batched_full_rank(handle,m,n,A,lda,strideA,ipiv,strideP, &
@@ -54937,13 +53945,13 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: ipiv
+      integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zgetrf_strided_batched_full_rank = rocsolver_zgetrf_strided_batched_(handle,m,n, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_sgeqr2_rank_0(handle,m,n,A,lda,ipiv)
@@ -54989,7 +53997,7 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: ipiv
+      real(c_float),target,dimension(:) :: ipiv
       !
       rocsolver_sgeqr2_full_rank = rocsolver_sgeqr2_(handle,m,n,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -55037,7 +54045,7 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: ipiv
+      real(c_double),target,dimension(:) :: ipiv
       !
       rocsolver_dgeqr2_full_rank = rocsolver_dgeqr2_(handle,m,n,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -55085,7 +54093,7 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:,:) :: ipiv
+      complex(c_float_complex),target,dimension(:) :: ipiv
       !
       rocsolver_cgeqr2_full_rank = rocsolver_cgeqr2_(handle,m,n,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -55133,7 +54141,7 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:,:) :: ipiv
+      complex(c_double_complex),target,dimension(:) :: ipiv
       !
       rocsolver_zgeqr2_full_rank = rocsolver_zgeqr2_(handle,m,n,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -55176,25 +54184,6 @@ module hipfort_rocsolver
         strideP,batch_count)
     end function
 
-    function rocsolver_sgeqr2_batched_full_rank(handle,m,n,A,lda,ipiv,strideP,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_sgeqr2_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      integer(c_int) :: batch_count
-      !
-      rocsolver_sgeqr2_batched_full_rank = rocsolver_sgeqr2_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,batch_count)
-    end function
-
     function rocsolver_dgeqr2_batched_rank_0(handle,m,n,A,lda,ipiv,strideP,batch_count)
       use iso_c_binding
       use hipfort_rocsolver_enums
@@ -55230,25 +54219,6 @@ module hipfort_rocsolver
       integer(c_int) :: batch_count
       !
       rocsolver_dgeqr2_batched_rank_1 = rocsolver_dgeqr2_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,batch_count)
-    end function
-
-    function rocsolver_dgeqr2_batched_full_rank(handle,m,n,A,lda,ipiv,strideP,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_dgeqr2_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      integer(c_int) :: batch_count
-      !
-      rocsolver_dgeqr2_batched_full_rank = rocsolver_dgeqr2_batched_(handle,m,n,A,lda,c_loc(ipiv), &
         strideP,batch_count)
     end function
 
@@ -55290,25 +54260,6 @@ module hipfort_rocsolver
         strideP,batch_count)
     end function
 
-    function rocsolver_cgeqr2_batched_full_rank(handle,m,n,A,lda,ipiv,strideP,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_cgeqr2_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      integer(c_int) :: batch_count
-      !
-      rocsolver_cgeqr2_batched_full_rank = rocsolver_cgeqr2_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,batch_count)
-    end function
-
     function rocsolver_zgeqr2_batched_rank_0(handle,m,n,A,lda,ipiv,strideP,batch_count)
       use iso_c_binding
       use hipfort_rocsolver_enums
@@ -55344,25 +54295,6 @@ module hipfort_rocsolver
       integer(c_int) :: batch_count
       !
       rocsolver_zgeqr2_batched_rank_1 = rocsolver_zgeqr2_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,batch_count)
-    end function
-
-    function rocsolver_zgeqr2_batched_full_rank(handle,m,n,A,lda,ipiv,strideP,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_zgeqr2_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      integer(c_int) :: batch_count
-      !
-      rocsolver_zgeqr2_batched_full_rank = rocsolver_zgeqr2_batched_(handle,m,n,A,lda,c_loc(ipiv), &
         strideP,batch_count)
     end function
 
@@ -55421,7 +54353,7 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_float),target,dimension(:,:) :: ipiv
+      real(c_float),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
       integer(c_int) :: batch_count
       !
@@ -55484,7 +54416,7 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_double),target,dimension(:,:) :: ipiv
+      real(c_double),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
       integer(c_int) :: batch_count
       !
@@ -55547,7 +54479,7 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      complex(c_float_complex),target,dimension(:,:) :: ipiv
+      complex(c_float_complex),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
       integer(c_int) :: batch_count
       !
@@ -55610,7 +54542,7 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      complex(c_double_complex),target,dimension(:,:) :: ipiv
+      complex(c_double_complex),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
       integer(c_int) :: batch_count
       !
@@ -55661,7 +54593,7 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: ipiv
+      real(c_float),target,dimension(:) :: ipiv
       !
       rocsolver_sgerq2_full_rank = rocsolver_sgerq2_(handle,m,n,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -55709,7 +54641,7 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: ipiv
+      real(c_double),target,dimension(:) :: ipiv
       !
       rocsolver_dgerq2_full_rank = rocsolver_dgerq2_(handle,m,n,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -55757,7 +54689,7 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:,:) :: ipiv
+      complex(c_float_complex),target,dimension(:) :: ipiv
       !
       rocsolver_cgerq2_full_rank = rocsolver_cgerq2_(handle,m,n,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -55805,7 +54737,7 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:,:) :: ipiv
+      complex(c_double_complex),target,dimension(:) :: ipiv
       !
       rocsolver_zgerq2_full_rank = rocsolver_zgerq2_(handle,m,n,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -55848,25 +54780,6 @@ module hipfort_rocsolver
         strideP,batch_count)
     end function
 
-    function rocsolver_sgerq2_batched_full_rank(handle,m,n,A,lda,ipiv,strideP,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_sgerq2_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      integer(c_int) :: batch_count
-      !
-      rocsolver_sgerq2_batched_full_rank = rocsolver_sgerq2_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,batch_count)
-    end function
-
     function rocsolver_dgerq2_batched_rank_0(handle,m,n,A,lda,ipiv,strideP,batch_count)
       use iso_c_binding
       use hipfort_rocsolver_enums
@@ -55902,25 +54815,6 @@ module hipfort_rocsolver
       integer(c_int) :: batch_count
       !
       rocsolver_dgerq2_batched_rank_1 = rocsolver_dgerq2_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,batch_count)
-    end function
-
-    function rocsolver_dgerq2_batched_full_rank(handle,m,n,A,lda,ipiv,strideP,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_dgerq2_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      integer(c_int) :: batch_count
-      !
-      rocsolver_dgerq2_batched_full_rank = rocsolver_dgerq2_batched_(handle,m,n,A,lda,c_loc(ipiv), &
         strideP,batch_count)
     end function
 
@@ -55962,25 +54856,6 @@ module hipfort_rocsolver
         strideP,batch_count)
     end function
 
-    function rocsolver_cgerq2_batched_full_rank(handle,m,n,A,lda,ipiv,strideP,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_cgerq2_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      integer(c_int) :: batch_count
-      !
-      rocsolver_cgerq2_batched_full_rank = rocsolver_cgerq2_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,batch_count)
-    end function
-
     function rocsolver_zgerq2_batched_rank_0(handle,m,n,A,lda,ipiv,strideP,batch_count)
       use iso_c_binding
       use hipfort_rocsolver_enums
@@ -56016,25 +54891,6 @@ module hipfort_rocsolver
       integer(c_int) :: batch_count
       !
       rocsolver_zgerq2_batched_rank_1 = rocsolver_zgerq2_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,batch_count)
-    end function
-
-    function rocsolver_zgerq2_batched_full_rank(handle,m,n,A,lda,ipiv,strideP,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_zgerq2_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      integer(c_int) :: batch_count
-      !
-      rocsolver_zgerq2_batched_full_rank = rocsolver_zgerq2_batched_(handle,m,n,A,lda,c_loc(ipiv), &
         strideP,batch_count)
     end function
 
@@ -56093,7 +54949,7 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_float),target,dimension(:,:) :: ipiv
+      real(c_float),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
       integer(c_int) :: batch_count
       !
@@ -56156,7 +55012,7 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_double),target,dimension(:,:) :: ipiv
+      real(c_double),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
       integer(c_int) :: batch_count
       !
@@ -56219,7 +55075,7 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      complex(c_float_complex),target,dimension(:,:) :: ipiv
+      complex(c_float_complex),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
       integer(c_int) :: batch_count
       !
@@ -56282,7 +55138,7 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      complex(c_double_complex),target,dimension(:,:) :: ipiv
+      complex(c_double_complex),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
       integer(c_int) :: batch_count
       !
@@ -56333,7 +55189,7 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: ipiv
+      real(c_float),target,dimension(:) :: ipiv
       !
       rocsolver_sgeql2_full_rank = rocsolver_sgeql2_(handle,m,n,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -56381,7 +55237,7 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: ipiv
+      real(c_double),target,dimension(:) :: ipiv
       !
       rocsolver_dgeql2_full_rank = rocsolver_dgeql2_(handle,m,n,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -56429,7 +55285,7 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:,:) :: ipiv
+      complex(c_float_complex),target,dimension(:) :: ipiv
       !
       rocsolver_cgeql2_full_rank = rocsolver_cgeql2_(handle,m,n,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -56477,7 +55333,7 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:,:) :: ipiv
+      complex(c_double_complex),target,dimension(:) :: ipiv
       !
       rocsolver_zgeql2_full_rank = rocsolver_zgeql2_(handle,m,n,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -56520,25 +55376,6 @@ module hipfort_rocsolver
         strideP,batch_count)
     end function
 
-    function rocsolver_sgeql2_batched_full_rank(handle,m,n,A,lda,ipiv,strideP,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_sgeql2_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      integer(c_int) :: batch_count
-      !
-      rocsolver_sgeql2_batched_full_rank = rocsolver_sgeql2_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,batch_count)
-    end function
-
     function rocsolver_dgeql2_batched_rank_0(handle,m,n,A,lda,ipiv,strideP,batch_count)
       use iso_c_binding
       use hipfort_rocsolver_enums
@@ -56574,25 +55411,6 @@ module hipfort_rocsolver
       integer(c_int) :: batch_count
       !
       rocsolver_dgeql2_batched_rank_1 = rocsolver_dgeql2_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,batch_count)
-    end function
-
-    function rocsolver_dgeql2_batched_full_rank(handle,m,n,A,lda,ipiv,strideP,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_dgeql2_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      integer(c_int) :: batch_count
-      !
-      rocsolver_dgeql2_batched_full_rank = rocsolver_dgeql2_batched_(handle,m,n,A,lda,c_loc(ipiv), &
         strideP,batch_count)
     end function
 
@@ -56634,25 +55452,6 @@ module hipfort_rocsolver
         strideP,batch_count)
     end function
 
-    function rocsolver_cgeql2_batched_full_rank(handle,m,n,A,lda,ipiv,strideP,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_cgeql2_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      integer(c_int) :: batch_count
-      !
-      rocsolver_cgeql2_batched_full_rank = rocsolver_cgeql2_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,batch_count)
-    end function
-
     function rocsolver_zgeql2_batched_rank_0(handle,m,n,A,lda,ipiv,strideP,batch_count)
       use iso_c_binding
       use hipfort_rocsolver_enums
@@ -56688,25 +55487,6 @@ module hipfort_rocsolver
       integer(c_int) :: batch_count
       !
       rocsolver_zgeql2_batched_rank_1 = rocsolver_zgeql2_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,batch_count)
-    end function
-
-    function rocsolver_zgeql2_batched_full_rank(handle,m,n,A,lda,ipiv,strideP,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_zgeql2_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      integer(c_int) :: batch_count
-      !
-      rocsolver_zgeql2_batched_full_rank = rocsolver_zgeql2_batched_(handle,m,n,A,lda,c_loc(ipiv), &
         strideP,batch_count)
     end function
 
@@ -56765,7 +55545,7 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_float),target,dimension(:,:) :: ipiv
+      real(c_float),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
       integer(c_int) :: batch_count
       !
@@ -56828,7 +55608,7 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_double),target,dimension(:,:) :: ipiv
+      real(c_double),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
       integer(c_int) :: batch_count
       !
@@ -56891,7 +55671,7 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      complex(c_float_complex),target,dimension(:,:) :: ipiv
+      complex(c_float_complex),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
       integer(c_int) :: batch_count
       !
@@ -56954,7 +55734,7 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      complex(c_double_complex),target,dimension(:,:) :: ipiv
+      complex(c_double_complex),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
       integer(c_int) :: batch_count
       !
@@ -57005,7 +55785,7 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: ipiv
+      real(c_float),target,dimension(:) :: ipiv
       !
       rocsolver_sgelq2_full_rank = rocsolver_sgelq2_(handle,m,n,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -57053,7 +55833,7 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: ipiv
+      real(c_double),target,dimension(:) :: ipiv
       !
       rocsolver_dgelq2_full_rank = rocsolver_dgelq2_(handle,m,n,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -57101,7 +55881,7 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:,:) :: ipiv
+      complex(c_float_complex),target,dimension(:) :: ipiv
       !
       rocsolver_cgelq2_full_rank = rocsolver_cgelq2_(handle,m,n,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -57149,7 +55929,7 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:,:) :: ipiv
+      complex(c_double_complex),target,dimension(:) :: ipiv
       !
       rocsolver_zgelq2_full_rank = rocsolver_zgelq2_(handle,m,n,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -57192,25 +55972,6 @@ module hipfort_rocsolver
         strideP,batch_count)
     end function
 
-    function rocsolver_sgelq2_batched_full_rank(handle,m,n,A,lda,ipiv,strideP,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_sgelq2_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      integer(c_int) :: batch_count
-      !
-      rocsolver_sgelq2_batched_full_rank = rocsolver_sgelq2_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,batch_count)
-    end function
-
     function rocsolver_dgelq2_batched_rank_0(handle,m,n,A,lda,ipiv,strideP,batch_count)
       use iso_c_binding
       use hipfort_rocsolver_enums
@@ -57246,25 +56007,6 @@ module hipfort_rocsolver
       integer(c_int) :: batch_count
       !
       rocsolver_dgelq2_batched_rank_1 = rocsolver_dgelq2_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,batch_count)
-    end function
-
-    function rocsolver_dgelq2_batched_full_rank(handle,m,n,A,lda,ipiv,strideP,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_dgelq2_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      integer(c_int) :: batch_count
-      !
-      rocsolver_dgelq2_batched_full_rank = rocsolver_dgelq2_batched_(handle,m,n,A,lda,c_loc(ipiv), &
         strideP,batch_count)
     end function
 
@@ -57306,25 +56048,6 @@ module hipfort_rocsolver
         strideP,batch_count)
     end function
 
-    function rocsolver_cgelq2_batched_full_rank(handle,m,n,A,lda,ipiv,strideP,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_cgelq2_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      integer(c_int) :: batch_count
-      !
-      rocsolver_cgelq2_batched_full_rank = rocsolver_cgelq2_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,batch_count)
-    end function
-
     function rocsolver_zgelq2_batched_rank_0(handle,m,n,A,lda,ipiv,strideP,batch_count)
       use iso_c_binding
       use hipfort_rocsolver_enums
@@ -57360,25 +56083,6 @@ module hipfort_rocsolver
       integer(c_int) :: batch_count
       !
       rocsolver_zgelq2_batched_rank_1 = rocsolver_zgelq2_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,batch_count)
-    end function
-
-    function rocsolver_zgelq2_batched_full_rank(handle,m,n,A,lda,ipiv,strideP,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_zgelq2_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      integer(c_int) :: batch_count
-      !
-      rocsolver_zgelq2_batched_full_rank = rocsolver_zgelq2_batched_(handle,m,n,A,lda,c_loc(ipiv), &
         strideP,batch_count)
     end function
 
@@ -57437,7 +56141,7 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_float),target,dimension(:,:) :: ipiv
+      real(c_float),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
       integer(c_int) :: batch_count
       !
@@ -57500,7 +56204,7 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_double),target,dimension(:,:) :: ipiv
+      real(c_double),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
       integer(c_int) :: batch_count
       !
@@ -57563,7 +56267,7 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      complex(c_float_complex),target,dimension(:,:) :: ipiv
+      complex(c_float_complex),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
       integer(c_int) :: batch_count
       !
@@ -57626,7 +56330,7 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      complex(c_double_complex),target,dimension(:,:) :: ipiv
+      complex(c_double_complex),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
       integer(c_int) :: batch_count
       !
@@ -57677,7 +56381,7 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: ipiv
+      real(c_float),target,dimension(:) :: ipiv
       !
       rocsolver_sgeqrf_full_rank = rocsolver_sgeqrf_(handle,m,n,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -57725,7 +56429,7 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: ipiv
+      real(c_double),target,dimension(:) :: ipiv
       !
       rocsolver_dgeqrf_full_rank = rocsolver_dgeqrf_(handle,m,n,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -57773,7 +56477,7 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:,:) :: ipiv
+      complex(c_float_complex),target,dimension(:) :: ipiv
       !
       rocsolver_cgeqrf_full_rank = rocsolver_cgeqrf_(handle,m,n,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -57821,7 +56525,7 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:,:) :: ipiv
+      complex(c_double_complex),target,dimension(:) :: ipiv
       !
       rocsolver_zgeqrf_full_rank = rocsolver_zgeqrf_(handle,m,n,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -57864,25 +56568,6 @@ module hipfort_rocsolver
         strideP,batch_count)
     end function
 
-    function rocsolver_sgeqrf_batched_full_rank(handle,m,n,A,lda,ipiv,strideP,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_sgeqrf_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      integer(c_int) :: batch_count
-      !
-      rocsolver_sgeqrf_batched_full_rank = rocsolver_sgeqrf_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,batch_count)
-    end function
-
     function rocsolver_dgeqrf_batched_rank_0(handle,m,n,A,lda,ipiv,strideP,batch_count)
       use iso_c_binding
       use hipfort_rocsolver_enums
@@ -57918,25 +56603,6 @@ module hipfort_rocsolver
       integer(c_int) :: batch_count
       !
       rocsolver_dgeqrf_batched_rank_1 = rocsolver_dgeqrf_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,batch_count)
-    end function
-
-    function rocsolver_dgeqrf_batched_full_rank(handle,m,n,A,lda,ipiv,strideP,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_dgeqrf_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      integer(c_int) :: batch_count
-      !
-      rocsolver_dgeqrf_batched_full_rank = rocsolver_dgeqrf_batched_(handle,m,n,A,lda,c_loc(ipiv), &
         strideP,batch_count)
     end function
 
@@ -57978,25 +56644,6 @@ module hipfort_rocsolver
         strideP,batch_count)
     end function
 
-    function rocsolver_cgeqrf_batched_full_rank(handle,m,n,A,lda,ipiv,strideP,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_cgeqrf_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      integer(c_int) :: batch_count
-      !
-      rocsolver_cgeqrf_batched_full_rank = rocsolver_cgeqrf_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,batch_count)
-    end function
-
     function rocsolver_zgeqrf_batched_rank_0(handle,m,n,A,lda,ipiv,strideP,batch_count)
       use iso_c_binding
       use hipfort_rocsolver_enums
@@ -58032,25 +56679,6 @@ module hipfort_rocsolver
       integer(c_int) :: batch_count
       !
       rocsolver_zgeqrf_batched_rank_1 = rocsolver_zgeqrf_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,batch_count)
-    end function
-
-    function rocsolver_zgeqrf_batched_full_rank(handle,m,n,A,lda,ipiv,strideP,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_zgeqrf_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      integer(c_int) :: batch_count
-      !
-      rocsolver_zgeqrf_batched_full_rank = rocsolver_zgeqrf_batched_(handle,m,n,A,lda,c_loc(ipiv), &
         strideP,batch_count)
     end function
 
@@ -58109,7 +56737,7 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_float),target,dimension(:,:) :: ipiv
+      real(c_float),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
       integer(c_int) :: batch_count
       !
@@ -58172,7 +56800,7 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_double),target,dimension(:,:) :: ipiv
+      real(c_double),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
       integer(c_int) :: batch_count
       !
@@ -58235,7 +56863,7 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      complex(c_float_complex),target,dimension(:,:) :: ipiv
+      complex(c_float_complex),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
       integer(c_int) :: batch_count
       !
@@ -58298,7 +56926,7 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      complex(c_double_complex),target,dimension(:,:) :: ipiv
+      complex(c_double_complex),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
       integer(c_int) :: batch_count
       !
@@ -58349,7 +56977,7 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: ipiv
+      real(c_float),target,dimension(:) :: ipiv
       !
       rocsolver_sgerqf_full_rank = rocsolver_sgerqf_(handle,m,n,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -58397,7 +57025,7 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: ipiv
+      real(c_double),target,dimension(:) :: ipiv
       !
       rocsolver_dgerqf_full_rank = rocsolver_dgerqf_(handle,m,n,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -58445,7 +57073,7 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:,:) :: ipiv
+      complex(c_float_complex),target,dimension(:) :: ipiv
       !
       rocsolver_cgerqf_full_rank = rocsolver_cgerqf_(handle,m,n,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -58493,7 +57121,7 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:,:) :: ipiv
+      complex(c_double_complex),target,dimension(:) :: ipiv
       !
       rocsolver_zgerqf_full_rank = rocsolver_zgerqf_(handle,m,n,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -58536,25 +57164,6 @@ module hipfort_rocsolver
         strideP,batch_count)
     end function
 
-    function rocsolver_sgerqf_batched_full_rank(handle,m,n,A,lda,ipiv,strideP,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_sgerqf_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      integer(c_int) :: batch_count
-      !
-      rocsolver_sgerqf_batched_full_rank = rocsolver_sgerqf_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,batch_count)
-    end function
-
     function rocsolver_dgerqf_batched_rank_0(handle,m,n,A,lda,ipiv,strideP,batch_count)
       use iso_c_binding
       use hipfort_rocsolver_enums
@@ -58590,25 +57199,6 @@ module hipfort_rocsolver
       integer(c_int) :: batch_count
       !
       rocsolver_dgerqf_batched_rank_1 = rocsolver_dgerqf_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,batch_count)
-    end function
-
-    function rocsolver_dgerqf_batched_full_rank(handle,m,n,A,lda,ipiv,strideP,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_dgerqf_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      integer(c_int) :: batch_count
-      !
-      rocsolver_dgerqf_batched_full_rank = rocsolver_dgerqf_batched_(handle,m,n,A,lda,c_loc(ipiv), &
         strideP,batch_count)
     end function
 
@@ -58650,25 +57240,6 @@ module hipfort_rocsolver
         strideP,batch_count)
     end function
 
-    function rocsolver_cgerqf_batched_full_rank(handle,m,n,A,lda,ipiv,strideP,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_cgerqf_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      integer(c_int) :: batch_count
-      !
-      rocsolver_cgerqf_batched_full_rank = rocsolver_cgerqf_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,batch_count)
-    end function
-
     function rocsolver_zgerqf_batched_rank_0(handle,m,n,A,lda,ipiv,strideP,batch_count)
       use iso_c_binding
       use hipfort_rocsolver_enums
@@ -58704,25 +57275,6 @@ module hipfort_rocsolver
       integer(c_int) :: batch_count
       !
       rocsolver_zgerqf_batched_rank_1 = rocsolver_zgerqf_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,batch_count)
-    end function
-
-    function rocsolver_zgerqf_batched_full_rank(handle,m,n,A,lda,ipiv,strideP,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_zgerqf_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      integer(c_int) :: batch_count
-      !
-      rocsolver_zgerqf_batched_full_rank = rocsolver_zgerqf_batched_(handle,m,n,A,lda,c_loc(ipiv), &
         strideP,batch_count)
     end function
 
@@ -58781,7 +57333,7 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_float),target,dimension(:,:) :: ipiv
+      real(c_float),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
       integer(c_int) :: batch_count
       !
@@ -58844,7 +57396,7 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_double),target,dimension(:,:) :: ipiv
+      real(c_double),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
       integer(c_int) :: batch_count
       !
@@ -58907,7 +57459,7 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      complex(c_float_complex),target,dimension(:,:) :: ipiv
+      complex(c_float_complex),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
       integer(c_int) :: batch_count
       !
@@ -58970,7 +57522,7 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      complex(c_double_complex),target,dimension(:,:) :: ipiv
+      complex(c_double_complex),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
       integer(c_int) :: batch_count
       !
@@ -59021,7 +57573,7 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: ipiv
+      real(c_float),target,dimension(:) :: ipiv
       !
       rocsolver_sgeqlf_full_rank = rocsolver_sgeqlf_(handle,m,n,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -59069,7 +57621,7 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: ipiv
+      real(c_double),target,dimension(:) :: ipiv
       !
       rocsolver_dgeqlf_full_rank = rocsolver_dgeqlf_(handle,m,n,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -59117,7 +57669,7 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:,:) :: ipiv
+      complex(c_float_complex),target,dimension(:) :: ipiv
       !
       rocsolver_cgeqlf_full_rank = rocsolver_cgeqlf_(handle,m,n,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -59165,7 +57717,7 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:,:) :: ipiv
+      complex(c_double_complex),target,dimension(:) :: ipiv
       !
       rocsolver_zgeqlf_full_rank = rocsolver_zgeqlf_(handle,m,n,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -59208,25 +57760,6 @@ module hipfort_rocsolver
         strideP,batch_count)
     end function
 
-    function rocsolver_sgeqlf_batched_full_rank(handle,m,n,A,lda,ipiv,strideP,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_sgeqlf_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      integer(c_int) :: batch_count
-      !
-      rocsolver_sgeqlf_batched_full_rank = rocsolver_sgeqlf_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,batch_count)
-    end function
-
     function rocsolver_dgeqlf_batched_rank_0(handle,m,n,A,lda,ipiv,strideP,batch_count)
       use iso_c_binding
       use hipfort_rocsolver_enums
@@ -59262,25 +57795,6 @@ module hipfort_rocsolver
       integer(c_int) :: batch_count
       !
       rocsolver_dgeqlf_batched_rank_1 = rocsolver_dgeqlf_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,batch_count)
-    end function
-
-    function rocsolver_dgeqlf_batched_full_rank(handle,m,n,A,lda,ipiv,strideP,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_dgeqlf_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      integer(c_int) :: batch_count
-      !
-      rocsolver_dgeqlf_batched_full_rank = rocsolver_dgeqlf_batched_(handle,m,n,A,lda,c_loc(ipiv), &
         strideP,batch_count)
     end function
 
@@ -59322,25 +57836,6 @@ module hipfort_rocsolver
         strideP,batch_count)
     end function
 
-    function rocsolver_cgeqlf_batched_full_rank(handle,m,n,A,lda,ipiv,strideP,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_cgeqlf_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      integer(c_int) :: batch_count
-      !
-      rocsolver_cgeqlf_batched_full_rank = rocsolver_cgeqlf_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,batch_count)
-    end function
-
     function rocsolver_zgeqlf_batched_rank_0(handle,m,n,A,lda,ipiv,strideP,batch_count)
       use iso_c_binding
       use hipfort_rocsolver_enums
@@ -59376,25 +57871,6 @@ module hipfort_rocsolver
       integer(c_int) :: batch_count
       !
       rocsolver_zgeqlf_batched_rank_1 = rocsolver_zgeqlf_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,batch_count)
-    end function
-
-    function rocsolver_zgeqlf_batched_full_rank(handle,m,n,A,lda,ipiv,strideP,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_zgeqlf_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      integer(c_int) :: batch_count
-      !
-      rocsolver_zgeqlf_batched_full_rank = rocsolver_zgeqlf_batched_(handle,m,n,A,lda,c_loc(ipiv), &
         strideP,batch_count)
     end function
 
@@ -59453,7 +57929,7 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_float),target,dimension(:,:) :: ipiv
+      real(c_float),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
       integer(c_int) :: batch_count
       !
@@ -59516,7 +57992,7 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_double),target,dimension(:,:) :: ipiv
+      real(c_double),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
       integer(c_int) :: batch_count
       !
@@ -59579,7 +58055,7 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      complex(c_float_complex),target,dimension(:,:) :: ipiv
+      complex(c_float_complex),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
       integer(c_int) :: batch_count
       !
@@ -59642,7 +58118,7 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      complex(c_double_complex),target,dimension(:,:) :: ipiv
+      complex(c_double_complex),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
       integer(c_int) :: batch_count
       !
@@ -59693,7 +58169,7 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: ipiv
+      real(c_float),target,dimension(:) :: ipiv
       !
       rocsolver_sgelqf_full_rank = rocsolver_sgelqf_(handle,m,n,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -59741,7 +58217,7 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: ipiv
+      real(c_double),target,dimension(:) :: ipiv
       !
       rocsolver_dgelqf_full_rank = rocsolver_dgelqf_(handle,m,n,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -59789,7 +58265,7 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:,:) :: ipiv
+      complex(c_float_complex),target,dimension(:) :: ipiv
       !
       rocsolver_cgelqf_full_rank = rocsolver_cgelqf_(handle,m,n,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -59837,7 +58313,7 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:,:) :: ipiv
+      complex(c_double_complex),target,dimension(:) :: ipiv
       !
       rocsolver_zgelqf_full_rank = rocsolver_zgelqf_(handle,m,n,c_loc(A),lda,c_loc(ipiv))
     end function
@@ -59880,25 +58356,6 @@ module hipfort_rocsolver
         strideP,batch_count)
     end function
 
-    function rocsolver_sgelqf_batched_full_rank(handle,m,n,A,lda,ipiv,strideP,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_sgelqf_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      integer(c_int) :: batch_count
-      !
-      rocsolver_sgelqf_batched_full_rank = rocsolver_sgelqf_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,batch_count)
-    end function
-
     function rocsolver_dgelqf_batched_rank_0(handle,m,n,A,lda,ipiv,strideP,batch_count)
       use iso_c_binding
       use hipfort_rocsolver_enums
@@ -59934,25 +58391,6 @@ module hipfort_rocsolver
       integer(c_int) :: batch_count
       !
       rocsolver_dgelqf_batched_rank_1 = rocsolver_dgelqf_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,batch_count)
-    end function
-
-    function rocsolver_dgelqf_batched_full_rank(handle,m,n,A,lda,ipiv,strideP,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_dgelqf_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      integer(c_int) :: batch_count
-      !
-      rocsolver_dgelqf_batched_full_rank = rocsolver_dgelqf_batched_(handle,m,n,A,lda,c_loc(ipiv), &
         strideP,batch_count)
     end function
 
@@ -59994,25 +58432,6 @@ module hipfort_rocsolver
         strideP,batch_count)
     end function
 
-    function rocsolver_cgelqf_batched_full_rank(handle,m,n,A,lda,ipiv,strideP,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_cgelqf_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      complex(c_float_complex),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      integer(c_int) :: batch_count
-      !
-      rocsolver_cgelqf_batched_full_rank = rocsolver_cgelqf_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,batch_count)
-    end function
-
     function rocsolver_zgelqf_batched_rank_0(handle,m,n,A,lda,ipiv,strideP,batch_count)
       use iso_c_binding
       use hipfort_rocsolver_enums
@@ -60048,25 +58467,6 @@ module hipfort_rocsolver
       integer(c_int) :: batch_count
       !
       rocsolver_zgelqf_batched_rank_1 = rocsolver_zgelqf_batched_(handle,m,n,A,lda,c_loc(ipiv), &
-        strideP,batch_count)
-    end function
-
-    function rocsolver_zgelqf_batched_full_rank(handle,m,n,A,lda,ipiv,strideP,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_zgelqf_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      complex(c_double_complex),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      integer(c_int) :: batch_count
-      !
-      rocsolver_zgelqf_batched_full_rank = rocsolver_zgelqf_batched_(handle,m,n,A,lda,c_loc(ipiv), &
         strideP,batch_count)
     end function
 
@@ -60125,7 +58525,7 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_float),target,dimension(:,:) :: ipiv
+      real(c_float),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
       integer(c_int) :: batch_count
       !
@@ -60188,7 +58588,7 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_double),target,dimension(:,:) :: ipiv
+      real(c_double),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
       integer(c_int) :: batch_count
       !
@@ -60251,7 +58651,7 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      complex(c_float_complex),target,dimension(:,:) :: ipiv
+      complex(c_float_complex),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
       integer(c_int) :: batch_count
       !
@@ -60314,7 +58714,7 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      complex(c_double_complex),target,dimension(:,:) :: ipiv
+      complex(c_double_complex),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
       integer(c_int) :: batch_count
       !
@@ -60373,10 +58773,10 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: D
-      real(c_float),target,dimension(:,:) :: E
-      real(c_float),target,dimension(:,:) :: tauq
-      real(c_float),target,dimension(:,:) :: taup
+      real(c_float),target,dimension(:) :: D
+      real(c_float),target,dimension(:) :: E
+      real(c_float),target,dimension(:) :: tauq
+      real(c_float),target,dimension(:) :: taup
       !
       rocsolver_sgebd2_full_rank = rocsolver_sgebd2_(handle,m,n,c_loc(A),lda,c_loc(D),c_loc(E), &
         c_loc(tauq),c_loc(taup))
@@ -60433,10 +58833,10 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: D
-      real(c_double),target,dimension(:,:) :: E
-      real(c_double),target,dimension(:,:) :: tauq
-      real(c_double),target,dimension(:,:) :: taup
+      real(c_double),target,dimension(:) :: D
+      real(c_double),target,dimension(:) :: E
+      real(c_double),target,dimension(:) :: tauq
+      real(c_double),target,dimension(:) :: taup
       !
       rocsolver_dgebd2_full_rank = rocsolver_dgebd2_(handle,m,n,c_loc(A),lda,c_loc(D),c_loc(E), &
         c_loc(tauq),c_loc(taup))
@@ -60493,10 +58893,10 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: D
-      real(c_float),target,dimension(:,:) :: E
-      complex(c_float_complex),target,dimension(:,:) :: tauq
-      complex(c_float_complex),target,dimension(:,:) :: taup
+      real(c_float),target,dimension(:) :: D
+      real(c_float),target,dimension(:) :: E
+      complex(c_float_complex),target,dimension(:) :: tauq
+      complex(c_float_complex),target,dimension(:) :: taup
       !
       rocsolver_cgebd2_full_rank = rocsolver_cgebd2_(handle,m,n,c_loc(A),lda,c_loc(D),c_loc(E), &
         c_loc(tauq),c_loc(taup))
@@ -60553,10 +58953,10 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: D
-      real(c_double),target,dimension(:,:) :: E
-      complex(c_double_complex),target,dimension(:,:) :: tauq
-      complex(c_double_complex),target,dimension(:,:) :: taup
+      real(c_double),target,dimension(:) :: D
+      real(c_double),target,dimension(:) :: E
+      complex(c_double_complex),target,dimension(:) :: tauq
+      complex(c_double_complex),target,dimension(:) :: taup
       !
       rocsolver_zgebd2_full_rank = rocsolver_zgebd2_(handle,m,n,c_loc(A),lda,c_loc(D),c_loc(E), &
         c_loc(tauq),c_loc(taup))
@@ -60614,32 +59014,6 @@ module hipfort_rocsolver
         strideD,c_loc(E),strideE,c_loc(tauq),strideQ,c_loc(taup),strideP,batch_count)
     end function
 
-    function rocsolver_sgebd2_batched_full_rank(handle,m,n,A,lda,D,strideD,E,strideE,tauq,strideQ, &
-        taup,strideP,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_sgebd2_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: D
-      integer(c_int64_t) :: strideD
-      real(c_float),target,dimension(:,:) :: E
-      integer(c_int64_t) :: strideE
-      real(c_float),target,dimension(:,:) :: tauq
-      integer(c_int64_t) :: strideQ
-      real(c_float),target,dimension(:,:) :: taup
-      integer(c_int64_t) :: strideP
-      integer(c_int) :: batch_count
-      !
-      rocsolver_sgebd2_batched_full_rank = rocsolver_sgebd2_batched_(handle,m,n,A,lda,c_loc(D), &
-        strideD,c_loc(E),strideE,c_loc(tauq),strideQ,c_loc(taup),strideP,batch_count)
-    end function
-
     function rocsolver_dgebd2_batched_rank_0(handle,m,n,A,lda,D,strideD,E,strideE,tauq,strideQ, &
         taup,strideP,batch_count)
       use iso_c_binding
@@ -60689,32 +59063,6 @@ module hipfort_rocsolver
       integer(c_int) :: batch_count
       !
       rocsolver_dgebd2_batched_rank_1 = rocsolver_dgebd2_batched_(handle,m,n,A,lda,c_loc(D), &
-        strideD,c_loc(E),strideE,c_loc(tauq),strideQ,c_loc(taup),strideP,batch_count)
-    end function
-
-    function rocsolver_dgebd2_batched_full_rank(handle,m,n,A,lda,D,strideD,E,strideE,tauq,strideQ, &
-        taup,strideP,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_dgebd2_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: D
-      integer(c_int64_t) :: strideD
-      real(c_double),target,dimension(:,:) :: E
-      integer(c_int64_t) :: strideE
-      real(c_double),target,dimension(:,:) :: tauq
-      integer(c_int64_t) :: strideQ
-      real(c_double),target,dimension(:,:) :: taup
-      integer(c_int64_t) :: strideP
-      integer(c_int) :: batch_count
-      !
-      rocsolver_dgebd2_batched_full_rank = rocsolver_dgebd2_batched_(handle,m,n,A,lda,c_loc(D), &
         strideD,c_loc(E),strideE,c_loc(tauq),strideQ,c_loc(taup),strideP,batch_count)
     end function
 
@@ -60770,32 +59118,6 @@ module hipfort_rocsolver
         strideD,c_loc(E),strideE,c_loc(tauq),strideQ,c_loc(taup),strideP,batch_count)
     end function
 
-    function rocsolver_cgebd2_batched_full_rank(handle,m,n,A,lda,D,strideD,E,strideE,tauq,strideQ, &
-        taup,strideP,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_cgebd2_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: D
-      integer(c_int64_t) :: strideD
-      real(c_float),target,dimension(:,:) :: E
-      integer(c_int64_t) :: strideE
-      complex(c_float_complex),target,dimension(:,:) :: tauq
-      integer(c_int64_t) :: strideQ
-      complex(c_float_complex),target,dimension(:,:) :: taup
-      integer(c_int64_t) :: strideP
-      integer(c_int) :: batch_count
-      !
-      rocsolver_cgebd2_batched_full_rank = rocsolver_cgebd2_batched_(handle,m,n,A,lda,c_loc(D), &
-        strideD,c_loc(E),strideE,c_loc(tauq),strideQ,c_loc(taup),strideP,batch_count)
-    end function
-
     function rocsolver_zgebd2_batched_rank_0(handle,m,n,A,lda,D,strideD,E,strideE,tauq,strideQ, &
         taup,strideP,batch_count)
       use iso_c_binding
@@ -60845,32 +59167,6 @@ module hipfort_rocsolver
       integer(c_int) :: batch_count
       !
       rocsolver_zgebd2_batched_rank_1 = rocsolver_zgebd2_batched_(handle,m,n,A,lda,c_loc(D), &
-        strideD,c_loc(E),strideE,c_loc(tauq),strideQ,c_loc(taup),strideP,batch_count)
-    end function
-
-    function rocsolver_zgebd2_batched_full_rank(handle,m,n,A,lda,D,strideD,E,strideE,tauq,strideQ, &
-        taup,strideP,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_zgebd2_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: D
-      integer(c_int64_t) :: strideD
-      real(c_double),target,dimension(:,:) :: E
-      integer(c_int64_t) :: strideE
-      complex(c_double_complex),target,dimension(:,:) :: tauq
-      integer(c_int64_t) :: strideQ
-      complex(c_double_complex),target,dimension(:,:) :: taup
-      integer(c_int64_t) :: strideP
-      integer(c_int) :: batch_count
-      !
-      rocsolver_zgebd2_batched_full_rank = rocsolver_zgebd2_batched_(handle,m,n,A,lda,c_loc(D), &
         strideD,c_loc(E),strideE,c_loc(tauq),strideQ,c_loc(taup),strideP,batch_count)
     end function
 
@@ -60943,13 +59239,13 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_float),target,dimension(:,:) :: D
+      real(c_float),target,dimension(:) :: D
       integer(c_int64_t) :: strideD
-      real(c_float),target,dimension(:,:) :: E
+      real(c_float),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      real(c_float),target,dimension(:,:) :: tauq
+      real(c_float),target,dimension(:) :: tauq
       integer(c_int64_t) :: strideQ
-      real(c_float),target,dimension(:,:) :: taup
+      real(c_float),target,dimension(:) :: taup
       integer(c_int64_t) :: strideP
       integer(c_int) :: batch_count
       !
@@ -61027,13 +59323,13 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_double),target,dimension(:,:) :: D
+      real(c_double),target,dimension(:) :: D
       integer(c_int64_t) :: strideD
-      real(c_double),target,dimension(:,:) :: E
+      real(c_double),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      real(c_double),target,dimension(:,:) :: tauq
+      real(c_double),target,dimension(:) :: tauq
       integer(c_int64_t) :: strideQ
-      real(c_double),target,dimension(:,:) :: taup
+      real(c_double),target,dimension(:) :: taup
       integer(c_int64_t) :: strideP
       integer(c_int) :: batch_count
       !
@@ -61111,13 +59407,13 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_float),target,dimension(:,:) :: D
+      real(c_float),target,dimension(:) :: D
       integer(c_int64_t) :: strideD
-      real(c_float),target,dimension(:,:) :: E
+      real(c_float),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      complex(c_float_complex),target,dimension(:,:) :: tauq
+      complex(c_float_complex),target,dimension(:) :: tauq
       integer(c_int64_t) :: strideQ
-      complex(c_float_complex),target,dimension(:,:) :: taup
+      complex(c_float_complex),target,dimension(:) :: taup
       integer(c_int64_t) :: strideP
       integer(c_int) :: batch_count
       !
@@ -61195,13 +59491,13 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_double),target,dimension(:,:) :: D
+      real(c_double),target,dimension(:) :: D
       integer(c_int64_t) :: strideD
-      real(c_double),target,dimension(:,:) :: E
+      real(c_double),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      complex(c_double_complex),target,dimension(:,:) :: tauq
+      complex(c_double_complex),target,dimension(:) :: tauq
       integer(c_int64_t) :: strideQ
-      complex(c_double_complex),target,dimension(:,:) :: taup
+      complex(c_double_complex),target,dimension(:) :: taup
       integer(c_int64_t) :: strideP
       integer(c_int) :: batch_count
       !
@@ -61261,10 +59557,10 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: D
-      real(c_float),target,dimension(:,:) :: E
-      real(c_float),target,dimension(:,:) :: tauq
-      real(c_float),target,dimension(:,:) :: taup
+      real(c_float),target,dimension(:) :: D
+      real(c_float),target,dimension(:) :: E
+      real(c_float),target,dimension(:) :: tauq
+      real(c_float),target,dimension(:) :: taup
       !
       rocsolver_sgebrd_full_rank = rocsolver_sgebrd_(handle,m,n,c_loc(A),lda,c_loc(D),c_loc(E), &
         c_loc(tauq),c_loc(taup))
@@ -61321,10 +59617,10 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: D
-      real(c_double),target,dimension(:,:) :: E
-      real(c_double),target,dimension(:,:) :: tauq
-      real(c_double),target,dimension(:,:) :: taup
+      real(c_double),target,dimension(:) :: D
+      real(c_double),target,dimension(:) :: E
+      real(c_double),target,dimension(:) :: tauq
+      real(c_double),target,dimension(:) :: taup
       !
       rocsolver_dgebrd_full_rank = rocsolver_dgebrd_(handle,m,n,c_loc(A),lda,c_loc(D),c_loc(E), &
         c_loc(tauq),c_loc(taup))
@@ -61381,10 +59677,10 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: D
-      real(c_float),target,dimension(:,:) :: E
-      complex(c_float_complex),target,dimension(:,:) :: tauq
-      complex(c_float_complex),target,dimension(:,:) :: taup
+      real(c_float),target,dimension(:) :: D
+      real(c_float),target,dimension(:) :: E
+      complex(c_float_complex),target,dimension(:) :: tauq
+      complex(c_float_complex),target,dimension(:) :: taup
       !
       rocsolver_cgebrd_full_rank = rocsolver_cgebrd_(handle,m,n,c_loc(A),lda,c_loc(D),c_loc(E), &
         c_loc(tauq),c_loc(taup))
@@ -61441,10 +59737,10 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: D
-      real(c_double),target,dimension(:,:) :: E
-      complex(c_double_complex),target,dimension(:,:) :: tauq
-      complex(c_double_complex),target,dimension(:,:) :: taup
+      real(c_double),target,dimension(:) :: D
+      real(c_double),target,dimension(:) :: E
+      complex(c_double_complex),target,dimension(:) :: tauq
+      complex(c_double_complex),target,dimension(:) :: taup
       !
       rocsolver_zgebrd_full_rank = rocsolver_zgebrd_(handle,m,n,c_loc(A),lda,c_loc(D),c_loc(E), &
         c_loc(tauq),c_loc(taup))
@@ -61502,32 +59798,6 @@ module hipfort_rocsolver
         strideD,c_loc(E),strideE,c_loc(tauq),strideQ,c_loc(taup),strideP,batch_count)
     end function
 
-    function rocsolver_sgebrd_batched_full_rank(handle,m,n,A,lda,D,strideD,E,strideE,tauq,strideQ, &
-        taup,strideP,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_sgebrd_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: D
-      integer(c_int64_t) :: strideD
-      real(c_float),target,dimension(:,:) :: E
-      integer(c_int64_t) :: strideE
-      real(c_float),target,dimension(:,:) :: tauq
-      integer(c_int64_t) :: strideQ
-      real(c_float),target,dimension(:,:) :: taup
-      integer(c_int64_t) :: strideP
-      integer(c_int) :: batch_count
-      !
-      rocsolver_sgebrd_batched_full_rank = rocsolver_sgebrd_batched_(handle,m,n,A,lda,c_loc(D), &
-        strideD,c_loc(E),strideE,c_loc(tauq),strideQ,c_loc(taup),strideP,batch_count)
-    end function
-
     function rocsolver_dgebrd_batched_rank_0(handle,m,n,A,lda,D,strideD,E,strideE,tauq,strideQ, &
         taup,strideP,batch_count)
       use iso_c_binding
@@ -61577,32 +59847,6 @@ module hipfort_rocsolver
       integer(c_int) :: batch_count
       !
       rocsolver_dgebrd_batched_rank_1 = rocsolver_dgebrd_batched_(handle,m,n,A,lda,c_loc(D), &
-        strideD,c_loc(E),strideE,c_loc(tauq),strideQ,c_loc(taup),strideP,batch_count)
-    end function
-
-    function rocsolver_dgebrd_batched_full_rank(handle,m,n,A,lda,D,strideD,E,strideE,tauq,strideQ, &
-        taup,strideP,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_dgebrd_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: D
-      integer(c_int64_t) :: strideD
-      real(c_double),target,dimension(:,:) :: E
-      integer(c_int64_t) :: strideE
-      real(c_double),target,dimension(:,:) :: tauq
-      integer(c_int64_t) :: strideQ
-      real(c_double),target,dimension(:,:) :: taup
-      integer(c_int64_t) :: strideP
-      integer(c_int) :: batch_count
-      !
-      rocsolver_dgebrd_batched_full_rank = rocsolver_dgebrd_batched_(handle,m,n,A,lda,c_loc(D), &
         strideD,c_loc(E),strideE,c_loc(tauq),strideQ,c_loc(taup),strideP,batch_count)
     end function
 
@@ -61658,32 +59902,6 @@ module hipfort_rocsolver
         strideD,c_loc(E),strideE,c_loc(tauq),strideQ,c_loc(taup),strideP,batch_count)
     end function
 
-    function rocsolver_cgebrd_batched_full_rank(handle,m,n,A,lda,D,strideD,E,strideE,tauq,strideQ, &
-        taup,strideP,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_cgebrd_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: D
-      integer(c_int64_t) :: strideD
-      real(c_float),target,dimension(:,:) :: E
-      integer(c_int64_t) :: strideE
-      complex(c_float_complex),target,dimension(:,:) :: tauq
-      integer(c_int64_t) :: strideQ
-      complex(c_float_complex),target,dimension(:,:) :: taup
-      integer(c_int64_t) :: strideP
-      integer(c_int) :: batch_count
-      !
-      rocsolver_cgebrd_batched_full_rank = rocsolver_cgebrd_batched_(handle,m,n,A,lda,c_loc(D), &
-        strideD,c_loc(E),strideE,c_loc(tauq),strideQ,c_loc(taup),strideP,batch_count)
-    end function
-
     function rocsolver_zgebrd_batched_rank_0(handle,m,n,A,lda,D,strideD,E,strideE,tauq,strideQ, &
         taup,strideP,batch_count)
       use iso_c_binding
@@ -61733,32 +59951,6 @@ module hipfort_rocsolver
       integer(c_int) :: batch_count
       !
       rocsolver_zgebrd_batched_rank_1 = rocsolver_zgebrd_batched_(handle,m,n,A,lda,c_loc(D), &
-        strideD,c_loc(E),strideE,c_loc(tauq),strideQ,c_loc(taup),strideP,batch_count)
-    end function
-
-    function rocsolver_zgebrd_batched_full_rank(handle,m,n,A,lda,D,strideD,E,strideE,tauq,strideQ, &
-        taup,strideP,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_zgebrd_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: m
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: D
-      integer(c_int64_t) :: strideD
-      real(c_double),target,dimension(:,:) :: E
-      integer(c_int64_t) :: strideE
-      complex(c_double_complex),target,dimension(:,:) :: tauq
-      integer(c_int64_t) :: strideQ
-      complex(c_double_complex),target,dimension(:,:) :: taup
-      integer(c_int64_t) :: strideP
-      integer(c_int) :: batch_count
-      !
-      rocsolver_zgebrd_batched_full_rank = rocsolver_zgebrd_batched_(handle,m,n,A,lda,c_loc(D), &
         strideD,c_loc(E),strideE,c_loc(tauq),strideQ,c_loc(taup),strideP,batch_count)
     end function
 
@@ -61831,13 +60023,13 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_float),target,dimension(:,:) :: D
+      real(c_float),target,dimension(:) :: D
       integer(c_int64_t) :: strideD
-      real(c_float),target,dimension(:,:) :: E
+      real(c_float),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      real(c_float),target,dimension(:,:) :: tauq
+      real(c_float),target,dimension(:) :: tauq
       integer(c_int64_t) :: strideQ
-      real(c_float),target,dimension(:,:) :: taup
+      real(c_float),target,dimension(:) :: taup
       integer(c_int64_t) :: strideP
       integer(c_int) :: batch_count
       !
@@ -61915,13 +60107,13 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_double),target,dimension(:,:) :: D
+      real(c_double),target,dimension(:) :: D
       integer(c_int64_t) :: strideD
-      real(c_double),target,dimension(:,:) :: E
+      real(c_double),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      real(c_double),target,dimension(:,:) :: tauq
+      real(c_double),target,dimension(:) :: tauq
       integer(c_int64_t) :: strideQ
-      real(c_double),target,dimension(:,:) :: taup
+      real(c_double),target,dimension(:) :: taup
       integer(c_int64_t) :: strideP
       integer(c_int) :: batch_count
       !
@@ -61999,13 +60191,13 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_float),target,dimension(:,:) :: D
+      real(c_float),target,dimension(:) :: D
       integer(c_int64_t) :: strideD
-      real(c_float),target,dimension(:,:) :: E
+      real(c_float),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      complex(c_float_complex),target,dimension(:,:) :: tauq
+      complex(c_float_complex),target,dimension(:) :: tauq
       integer(c_int64_t) :: strideQ
-      complex(c_float_complex),target,dimension(:,:) :: taup
+      complex(c_float_complex),target,dimension(:) :: taup
       integer(c_int64_t) :: strideP
       integer(c_int) :: batch_count
       !
@@ -62083,13 +60275,13 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_double),target,dimension(:,:) :: D
+      real(c_double),target,dimension(:) :: D
       integer(c_int64_t) :: strideD
-      real(c_double),target,dimension(:,:) :: E
+      real(c_double),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      complex(c_double_complex),target,dimension(:,:) :: tauq
+      complex(c_double_complex),target,dimension(:) :: tauq
       integer(c_int64_t) :: strideQ
-      complex(c_double_complex),target,dimension(:,:) :: taup
+      complex(c_double_complex),target,dimension(:) :: taup
       integer(c_int64_t) :: strideP
       integer(c_int) :: batch_count
       !
@@ -62150,7 +60342,7 @@ module hipfort_rocsolver
       integer(c_int) :: nrhs
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
+      integer(c_int),target,dimension(:) :: ipiv
       real(c_float),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       !
@@ -62210,7 +60402,7 @@ module hipfort_rocsolver
       integer(c_int) :: nrhs
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
+      integer(c_int),target,dimension(:) :: ipiv
       real(c_double),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       !
@@ -62270,7 +60462,7 @@ module hipfort_rocsolver
       integer(c_int) :: nrhs
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
+      integer(c_int),target,dimension(:) :: ipiv
       complex(c_float_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       !
@@ -62330,7 +60522,7 @@ module hipfort_rocsolver
       integer(c_int) :: nrhs
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
+      integer(c_int),target,dimension(:) :: ipiv
       complex(c_double_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       !
@@ -62384,29 +60576,6 @@ module hipfort_rocsolver
         c_loc(ipiv),strideP,B,ldb,batch_count)
     end function
 
-    function rocsolver_sgetrs_batched_full_rank(handle,trans,n,nrhs,A,lda,ipiv,strideP,B,ldb, &
-        batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_sgetrs_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_operation_none)) :: trans
-      integer(c_int) :: n
-      integer(c_int) :: nrhs
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      type(c_ptr) :: B
-      integer(c_int) :: ldb
-      integer(c_int) :: batch_count
-      !
-      rocsolver_sgetrs_batched_full_rank = rocsolver_sgetrs_batched_(handle,trans,n,nrhs,A,lda, &
-        c_loc(ipiv),strideP,B,ldb,batch_count)
-    end function
-
     function rocsolver_dgetrs_batched_rank_0(handle,trans,n,nrhs,A,lda,ipiv,strideP,B,ldb, &
         batch_count)
       use iso_c_binding
@@ -62450,29 +60619,6 @@ module hipfort_rocsolver
       integer(c_int) :: batch_count
       !
       rocsolver_dgetrs_batched_rank_1 = rocsolver_dgetrs_batched_(handle,trans,n,nrhs,A,lda, &
-        c_loc(ipiv),strideP,B,ldb,batch_count)
-    end function
-
-    function rocsolver_dgetrs_batched_full_rank(handle,trans,n,nrhs,A,lda,ipiv,strideP,B,ldb, &
-        batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_dgetrs_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_operation_none)) :: trans
-      integer(c_int) :: n
-      integer(c_int) :: nrhs
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      type(c_ptr) :: B
-      integer(c_int) :: ldb
-      integer(c_int) :: batch_count
-      !
-      rocsolver_dgetrs_batched_full_rank = rocsolver_dgetrs_batched_(handle,trans,n,nrhs,A,lda, &
         c_loc(ipiv),strideP,B,ldb,batch_count)
     end function
 
@@ -62522,29 +60668,6 @@ module hipfort_rocsolver
         c_loc(ipiv),strideP,B,ldb,batch_count)
     end function
 
-    function rocsolver_cgetrs_batched_full_rank(handle,trans,n,nrhs,A,lda,ipiv,strideP,B,ldb, &
-        batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_cgetrs_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_operation_none)) :: trans
-      integer(c_int) :: n
-      integer(c_int) :: nrhs
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      type(c_ptr) :: B
-      integer(c_int) :: ldb
-      integer(c_int) :: batch_count
-      !
-      rocsolver_cgetrs_batched_full_rank = rocsolver_cgetrs_batched_(handle,trans,n,nrhs,A,lda, &
-        c_loc(ipiv),strideP,B,ldb,batch_count)
-    end function
-
     function rocsolver_zgetrs_batched_rank_0(handle,trans,n,nrhs,A,lda,ipiv,strideP,B,ldb, &
         batch_count)
       use iso_c_binding
@@ -62588,29 +60711,6 @@ module hipfort_rocsolver
       integer(c_int) :: batch_count
       !
       rocsolver_zgetrs_batched_rank_1 = rocsolver_zgetrs_batched_(handle,trans,n,nrhs,A,lda, &
-        c_loc(ipiv),strideP,B,ldb,batch_count)
-    end function
-
-    function rocsolver_zgetrs_batched_full_rank(handle,trans,n,nrhs,A,lda,ipiv,strideP,B,ldb, &
-        batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_zgetrs_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_operation_none)) :: trans
-      integer(c_int) :: n
-      integer(c_int) :: nrhs
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      type(c_ptr) :: B
-      integer(c_int) :: ldb
-      integer(c_int) :: batch_count
-      !
-      rocsolver_zgetrs_batched_full_rank = rocsolver_zgetrs_batched_(handle,trans,n,nrhs,A,lda, &
         c_loc(ipiv),strideP,B,ldb,batch_count)
     end function
 
@@ -62678,7 +60778,7 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: ipiv
+      integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
       real(c_float),target,dimension(:,:) :: B
       integer(c_int) :: ldb
@@ -62753,7 +60853,7 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: ipiv
+      integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
       real(c_double),target,dimension(:,:) :: B
       integer(c_int) :: ldb
@@ -62828,7 +60928,7 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: ipiv
+      integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
       complex(c_float_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
@@ -62903,7 +61003,7 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: ipiv
+      integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
       complex(c_double_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
@@ -62928,10 +61028,10 @@ module hipfort_rocsolver
       integer(c_int),target :: ipiv
       real(c_float),target :: B
       integer(c_int) :: ldb
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_sgesv_rank_0 = rocsolver_sgesv_(handle,n,nrhs,c_loc(A),lda,c_loc(ipiv),c_loc(B), &
-        ldb,c_loc(myInfo))
+        ldb,myInfo)
     end function
 
     function rocsolver_sgesv_rank_1(handle,n,nrhs,A,lda,ipiv,B,ldb,myInfo)
@@ -62948,10 +61048,10 @@ module hipfort_rocsolver
       integer(c_int),target,dimension(:) :: ipiv
       real(c_float),target,dimension(:) :: B
       integer(c_int) :: ldb
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_sgesv_rank_1 = rocsolver_sgesv_(handle,n,nrhs,c_loc(A),lda,c_loc(ipiv),c_loc(B), &
-        ldb,c_loc(myInfo))
+        ldb,myInfo)
     end function
 
     function rocsolver_sgesv_full_rank(handle,n,nrhs,A,lda,ipiv,B,ldb,myInfo)
@@ -62965,13 +61065,13 @@ module hipfort_rocsolver
       integer(c_int) :: nrhs
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
+      integer(c_int),target,dimension(:) :: ipiv
       real(c_float),target,dimension(:,:) :: B
       integer(c_int) :: ldb
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_sgesv_full_rank = rocsolver_sgesv_(handle,n,nrhs,c_loc(A),lda,c_loc(ipiv), &
-        c_loc(B),ldb,c_loc(myInfo))
+        c_loc(B),ldb,myInfo)
     end function
 
     function rocsolver_dgesv_rank_0(handle,n,nrhs,A,lda,ipiv,B,ldb,myInfo)
@@ -62988,10 +61088,10 @@ module hipfort_rocsolver
       integer(c_int),target :: ipiv
       real(c_double),target :: B
       integer(c_int) :: ldb
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_dgesv_rank_0 = rocsolver_dgesv_(handle,n,nrhs,c_loc(A),lda,c_loc(ipiv),c_loc(B), &
-        ldb,c_loc(myInfo))
+        ldb,myInfo)
     end function
 
     function rocsolver_dgesv_rank_1(handle,n,nrhs,A,lda,ipiv,B,ldb,myInfo)
@@ -63008,10 +61108,10 @@ module hipfort_rocsolver
       integer(c_int),target,dimension(:) :: ipiv
       real(c_double),target,dimension(:) :: B
       integer(c_int) :: ldb
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_dgesv_rank_1 = rocsolver_dgesv_(handle,n,nrhs,c_loc(A),lda,c_loc(ipiv),c_loc(B), &
-        ldb,c_loc(myInfo))
+        ldb,myInfo)
     end function
 
     function rocsolver_dgesv_full_rank(handle,n,nrhs,A,lda,ipiv,B,ldb,myInfo)
@@ -63025,13 +61125,13 @@ module hipfort_rocsolver
       integer(c_int) :: nrhs
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
+      integer(c_int),target,dimension(:) :: ipiv
       real(c_double),target,dimension(:,:) :: B
       integer(c_int) :: ldb
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_dgesv_full_rank = rocsolver_dgesv_(handle,n,nrhs,c_loc(A),lda,c_loc(ipiv), &
-        c_loc(B),ldb,c_loc(myInfo))
+        c_loc(B),ldb,myInfo)
     end function
 
     function rocsolver_cgesv_rank_0(handle,n,nrhs,A,lda,ipiv,B,ldb,myInfo)
@@ -63048,10 +61148,10 @@ module hipfort_rocsolver
       integer(c_int),target :: ipiv
       complex(c_float_complex),target :: B
       integer(c_int) :: ldb
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_cgesv_rank_0 = rocsolver_cgesv_(handle,n,nrhs,c_loc(A),lda,c_loc(ipiv),c_loc(B), &
-        ldb,c_loc(myInfo))
+        ldb,myInfo)
     end function
 
     function rocsolver_cgesv_rank_1(handle,n,nrhs,A,lda,ipiv,B,ldb,myInfo)
@@ -63068,10 +61168,10 @@ module hipfort_rocsolver
       integer(c_int),target,dimension(:) :: ipiv
       complex(c_float_complex),target,dimension(:) :: B
       integer(c_int) :: ldb
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_cgesv_rank_1 = rocsolver_cgesv_(handle,n,nrhs,c_loc(A),lda,c_loc(ipiv),c_loc(B), &
-        ldb,c_loc(myInfo))
+        ldb,myInfo)
     end function
 
     function rocsolver_cgesv_full_rank(handle,n,nrhs,A,lda,ipiv,B,ldb,myInfo)
@@ -63085,13 +61185,13 @@ module hipfort_rocsolver
       integer(c_int) :: nrhs
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
+      integer(c_int),target,dimension(:) :: ipiv
       complex(c_float_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_cgesv_full_rank = rocsolver_cgesv_(handle,n,nrhs,c_loc(A),lda,c_loc(ipiv), &
-        c_loc(B),ldb,c_loc(myInfo))
+        c_loc(B),ldb,myInfo)
     end function
 
     function rocsolver_zgesv_rank_0(handle,n,nrhs,A,lda,ipiv,B,ldb,myInfo)
@@ -63108,10 +61208,10 @@ module hipfort_rocsolver
       integer(c_int),target :: ipiv
       complex(c_double_complex),target :: B
       integer(c_int) :: ldb
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_zgesv_rank_0 = rocsolver_zgesv_(handle,n,nrhs,c_loc(A),lda,c_loc(ipiv),c_loc(B), &
-        ldb,c_loc(myInfo))
+        ldb,myInfo)
     end function
 
     function rocsolver_zgesv_rank_1(handle,n,nrhs,A,lda,ipiv,B,ldb,myInfo)
@@ -63128,10 +61228,10 @@ module hipfort_rocsolver
       integer(c_int),target,dimension(:) :: ipiv
       complex(c_double_complex),target,dimension(:) :: B
       integer(c_int) :: ldb
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_zgesv_rank_1 = rocsolver_zgesv_(handle,n,nrhs,c_loc(A),lda,c_loc(ipiv),c_loc(B), &
-        ldb,c_loc(myInfo))
+        ldb,myInfo)
     end function
 
     function rocsolver_zgesv_full_rank(handle,n,nrhs,A,lda,ipiv,B,ldb,myInfo)
@@ -63145,13 +61245,13 @@ module hipfort_rocsolver
       integer(c_int) :: nrhs
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
+      integer(c_int),target,dimension(:) :: ipiv
       complex(c_double_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_zgesv_full_rank = rocsolver_zgesv_(handle,n,nrhs,c_loc(A),lda,c_loc(ipiv), &
-        c_loc(B),ldb,c_loc(myInfo))
+        c_loc(B),ldb,myInfo)
     end function
 
     function rocsolver_sgesv_batched_rank_0(handle,n,nrhs,A,lda,ipiv,strideP,B,ldb,myInfo, &
@@ -63170,11 +61270,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideP
       type(c_ptr) :: B
       integer(c_int) :: ldb
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_sgesv_batched_rank_0 = rocsolver_sgesv_batched_(handle,n,nrhs,A,lda,c_loc(ipiv), &
-        strideP,B,ldb,c_loc(myInfo),batch_count)
+        strideP,B,ldb,myInfo,batch_count)
     end function
 
     function rocsolver_sgesv_batched_rank_1(handle,n,nrhs,A,lda,ipiv,strideP,B,ldb,myInfo, &
@@ -63193,34 +61293,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideP
       type(c_ptr) :: B
       integer(c_int) :: ldb
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_sgesv_batched_rank_1 = rocsolver_sgesv_batched_(handle,n,nrhs,A,lda,c_loc(ipiv), &
-        strideP,B,ldb,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_sgesv_batched_full_rank(handle,n,nrhs,A,lda,ipiv,strideP,B,ldb,myInfo, &
-        batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_sgesv_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      integer(c_int) :: nrhs
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      type(c_ptr) :: B
-      integer(c_int) :: ldb
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_sgesv_batched_full_rank = rocsolver_sgesv_batched_(handle,n,nrhs,A,lda, &
-        c_loc(ipiv),strideP,B,ldb,c_loc(myInfo),batch_count)
+        strideP,B,ldb,myInfo,batch_count)
     end function
 
     function rocsolver_dgesv_batched_rank_0(handle,n,nrhs,A,lda,ipiv,strideP,B,ldb,myInfo, &
@@ -63239,11 +61316,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideP
       type(c_ptr) :: B
       integer(c_int) :: ldb
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dgesv_batched_rank_0 = rocsolver_dgesv_batched_(handle,n,nrhs,A,lda,c_loc(ipiv), &
-        strideP,B,ldb,c_loc(myInfo),batch_count)
+        strideP,B,ldb,myInfo,batch_count)
     end function
 
     function rocsolver_dgesv_batched_rank_1(handle,n,nrhs,A,lda,ipiv,strideP,B,ldb,myInfo, &
@@ -63262,34 +61339,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideP
       type(c_ptr) :: B
       integer(c_int) :: ldb
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dgesv_batched_rank_1 = rocsolver_dgesv_batched_(handle,n,nrhs,A,lda,c_loc(ipiv), &
-        strideP,B,ldb,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_dgesv_batched_full_rank(handle,n,nrhs,A,lda,ipiv,strideP,B,ldb,myInfo, &
-        batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_dgesv_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      integer(c_int) :: nrhs
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      type(c_ptr) :: B
-      integer(c_int) :: ldb
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_dgesv_batched_full_rank = rocsolver_dgesv_batched_(handle,n,nrhs,A,lda, &
-        c_loc(ipiv),strideP,B,ldb,c_loc(myInfo),batch_count)
+        strideP,B,ldb,myInfo,batch_count)
     end function
 
     function rocsolver_cgesv_batched_rank_0(handle,n,nrhs,A,lda,ipiv,strideP,B,ldb,myInfo, &
@@ -63308,11 +61362,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideP
       type(c_ptr) :: B
       integer(c_int) :: ldb
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cgesv_batched_rank_0 = rocsolver_cgesv_batched_(handle,n,nrhs,A,lda,c_loc(ipiv), &
-        strideP,B,ldb,c_loc(myInfo),batch_count)
+        strideP,B,ldb,myInfo,batch_count)
     end function
 
     function rocsolver_cgesv_batched_rank_1(handle,n,nrhs,A,lda,ipiv,strideP,B,ldb,myInfo, &
@@ -63331,34 +61385,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideP
       type(c_ptr) :: B
       integer(c_int) :: ldb
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cgesv_batched_rank_1 = rocsolver_cgesv_batched_(handle,n,nrhs,A,lda,c_loc(ipiv), &
-        strideP,B,ldb,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_cgesv_batched_full_rank(handle,n,nrhs,A,lda,ipiv,strideP,B,ldb,myInfo, &
-        batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_cgesv_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      integer(c_int) :: nrhs
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      type(c_ptr) :: B
-      integer(c_int) :: ldb
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_cgesv_batched_full_rank = rocsolver_cgesv_batched_(handle,n,nrhs,A,lda, &
-        c_loc(ipiv),strideP,B,ldb,c_loc(myInfo),batch_count)
+        strideP,B,ldb,myInfo,batch_count)
     end function
 
     function rocsolver_zgesv_batched_rank_0(handle,n,nrhs,A,lda,ipiv,strideP,B,ldb,myInfo, &
@@ -63377,11 +61408,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideP
       type(c_ptr) :: B
       integer(c_int) :: ldb
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zgesv_batched_rank_0 = rocsolver_zgesv_batched_(handle,n,nrhs,A,lda,c_loc(ipiv), &
-        strideP,B,ldb,c_loc(myInfo),batch_count)
+        strideP,B,ldb,myInfo,batch_count)
     end function
 
     function rocsolver_zgesv_batched_rank_1(handle,n,nrhs,A,lda,ipiv,strideP,B,ldb,myInfo, &
@@ -63400,34 +61431,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideP
       type(c_ptr) :: B
       integer(c_int) :: ldb
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zgesv_batched_rank_1 = rocsolver_zgesv_batched_(handle,n,nrhs,A,lda,c_loc(ipiv), &
-        strideP,B,ldb,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_zgesv_batched_full_rank(handle,n,nrhs,A,lda,ipiv,strideP,B,ldb,myInfo, &
-        batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_zgesv_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      integer(c_int) :: nrhs
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      type(c_ptr) :: B
-      integer(c_int) :: ldb
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_zgesv_batched_full_rank = rocsolver_zgesv_batched_(handle,n,nrhs,A,lda, &
-        c_loc(ipiv),strideP,B,ldb,c_loc(myInfo),batch_count)
+        strideP,B,ldb,myInfo,batch_count)
     end function
 
     function rocsolver_sgesv_strided_batched_rank_0(handle,n,nrhs,A,lda,strideA,ipiv,strideP,B, &
@@ -63448,11 +61456,11 @@ module hipfort_rocsolver
       real(c_float),target :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_sgesv_strided_batched_rank_0 = rocsolver_sgesv_strided_batched_(handle,n,nrhs, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(B),ldb,strideB,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(B),ldb,strideB,myInfo,batch_count)
     end function
 
     function rocsolver_sgesv_strided_batched_rank_1(handle,n,nrhs,A,lda,strideA,ipiv,strideP,B, &
@@ -63473,11 +61481,11 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:) :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_sgesv_strided_batched_rank_1 = rocsolver_sgesv_strided_batched_(handle,n,nrhs, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(B),ldb,strideB,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(B),ldb,strideB,myInfo,batch_count)
     end function
 
     function rocsolver_sgesv_strided_batched_full_rank(handle,n,nrhs,A,lda,strideA,ipiv,strideP,B, &
@@ -63493,16 +61501,16 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: ipiv
+      integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
       real(c_float),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_sgesv_strided_batched_full_rank = rocsolver_sgesv_strided_batched_(handle,n,nrhs, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(B),ldb,strideB,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(B),ldb,strideB,myInfo,batch_count)
     end function
 
     function rocsolver_dgesv_strided_batched_rank_0(handle,n,nrhs,A,lda,strideA,ipiv,strideP,B, &
@@ -63523,11 +61531,11 @@ module hipfort_rocsolver
       real(c_double),target :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dgesv_strided_batched_rank_0 = rocsolver_dgesv_strided_batched_(handle,n,nrhs, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(B),ldb,strideB,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(B),ldb,strideB,myInfo,batch_count)
     end function
 
     function rocsolver_dgesv_strided_batched_rank_1(handle,n,nrhs,A,lda,strideA,ipiv,strideP,B, &
@@ -63548,11 +61556,11 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:) :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dgesv_strided_batched_rank_1 = rocsolver_dgesv_strided_batched_(handle,n,nrhs, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(B),ldb,strideB,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(B),ldb,strideB,myInfo,batch_count)
     end function
 
     function rocsolver_dgesv_strided_batched_full_rank(handle,n,nrhs,A,lda,strideA,ipiv,strideP,B, &
@@ -63568,16 +61576,16 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: ipiv
+      integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
       real(c_double),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dgesv_strided_batched_full_rank = rocsolver_dgesv_strided_batched_(handle,n,nrhs, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(B),ldb,strideB,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(B),ldb,strideB,myInfo,batch_count)
     end function
 
     function rocsolver_cgesv_strided_batched_rank_0(handle,n,nrhs,A,lda,strideA,ipiv,strideP,B, &
@@ -63598,11 +61606,11 @@ module hipfort_rocsolver
       complex(c_float_complex),target :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cgesv_strided_batched_rank_0 = rocsolver_cgesv_strided_batched_(handle,n,nrhs, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(B),ldb,strideB,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(B),ldb,strideB,myInfo,batch_count)
     end function
 
     function rocsolver_cgesv_strided_batched_rank_1(handle,n,nrhs,A,lda,strideA,ipiv,strideP,B, &
@@ -63623,11 +61631,11 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:) :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cgesv_strided_batched_rank_1 = rocsolver_cgesv_strided_batched_(handle,n,nrhs, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(B),ldb,strideB,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(B),ldb,strideB,myInfo,batch_count)
     end function
 
     function rocsolver_cgesv_strided_batched_full_rank(handle,n,nrhs,A,lda,strideA,ipiv,strideP,B, &
@@ -63643,16 +61651,16 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: ipiv
+      integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
       complex(c_float_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cgesv_strided_batched_full_rank = rocsolver_cgesv_strided_batched_(handle,n,nrhs, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(B),ldb,strideB,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(B),ldb,strideB,myInfo,batch_count)
     end function
 
     function rocsolver_zgesv_strided_batched_rank_0(handle,n,nrhs,A,lda,strideA,ipiv,strideP,B, &
@@ -63673,11 +61681,11 @@ module hipfort_rocsolver
       complex(c_double_complex),target :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zgesv_strided_batched_rank_0 = rocsolver_zgesv_strided_batched_(handle,n,nrhs, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(B),ldb,strideB,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(B),ldb,strideB,myInfo,batch_count)
     end function
 
     function rocsolver_zgesv_strided_batched_rank_1(handle,n,nrhs,A,lda,strideA,ipiv,strideP,B, &
@@ -63698,11 +61706,11 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:) :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zgesv_strided_batched_rank_1 = rocsolver_zgesv_strided_batched_(handle,n,nrhs, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(B),ldb,strideB,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(B),ldb,strideB,myInfo,batch_count)
     end function
 
     function rocsolver_zgesv_strided_batched_full_rank(handle,n,nrhs,A,lda,strideA,ipiv,strideP,B, &
@@ -63718,16 +61726,16 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: ipiv
+      integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
       complex(c_double_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zgesv_strided_batched_full_rank = rocsolver_zgesv_strided_batched_(handle,n,nrhs, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(B),ldb,strideB,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(B),ldb,strideB,myInfo,batch_count)
     end function
 
     function rocsolver_sgetri_rank_0(handle,n,A,lda,ipiv,myInfo)
@@ -63741,9 +61749,9 @@ module hipfort_rocsolver
       real(c_float),target :: A
       integer(c_int) :: lda
       integer(c_int),target :: ipiv
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_sgetri_rank_0 = rocsolver_sgetri_(handle,n,c_loc(A),lda,c_loc(ipiv),c_loc(myInfo))
+      rocsolver_sgetri_rank_0 = rocsolver_sgetri_(handle,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_sgetri_rank_1(handle,n,A,lda,ipiv,myInfo)
@@ -63757,9 +61765,9 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int),target,dimension(:) :: ipiv
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_sgetri_rank_1 = rocsolver_sgetri_(handle,n,c_loc(A),lda,c_loc(ipiv),c_loc(myInfo))
+      rocsolver_sgetri_rank_1 = rocsolver_sgetri_(handle,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_sgetri_full_rank(handle,n,A,lda,ipiv,myInfo)
@@ -63772,11 +61780,10 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int),target,dimension(:,:) :: myInfo
+      integer(c_int),target,dimension(:) :: ipiv
+      type(c_ptr) :: myInfo
       !
-      rocsolver_sgetri_full_rank = rocsolver_sgetri_(handle,n,c_loc(A),lda,c_loc(ipiv), &
-        c_loc(myInfo))
+      rocsolver_sgetri_full_rank = rocsolver_sgetri_(handle,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_dgetri_rank_0(handle,n,A,lda,ipiv,myInfo)
@@ -63790,9 +61797,9 @@ module hipfort_rocsolver
       real(c_double),target :: A
       integer(c_int) :: lda
       integer(c_int),target :: ipiv
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_dgetri_rank_0 = rocsolver_dgetri_(handle,n,c_loc(A),lda,c_loc(ipiv),c_loc(myInfo))
+      rocsolver_dgetri_rank_0 = rocsolver_dgetri_(handle,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_dgetri_rank_1(handle,n,A,lda,ipiv,myInfo)
@@ -63806,9 +61813,9 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int),target,dimension(:) :: ipiv
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_dgetri_rank_1 = rocsolver_dgetri_(handle,n,c_loc(A),lda,c_loc(ipiv),c_loc(myInfo))
+      rocsolver_dgetri_rank_1 = rocsolver_dgetri_(handle,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_dgetri_full_rank(handle,n,A,lda,ipiv,myInfo)
@@ -63821,11 +61828,10 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int),target,dimension(:,:) :: myInfo
+      integer(c_int),target,dimension(:) :: ipiv
+      type(c_ptr) :: myInfo
       !
-      rocsolver_dgetri_full_rank = rocsolver_dgetri_(handle,n,c_loc(A),lda,c_loc(ipiv), &
-        c_loc(myInfo))
+      rocsolver_dgetri_full_rank = rocsolver_dgetri_(handle,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_cgetri_rank_0(handle,n,A,lda,ipiv,myInfo)
@@ -63839,9 +61845,9 @@ module hipfort_rocsolver
       complex(c_float_complex),target :: A
       integer(c_int) :: lda
       integer(c_int),target :: ipiv
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_cgetri_rank_0 = rocsolver_cgetri_(handle,n,c_loc(A),lda,c_loc(ipiv),c_loc(myInfo))
+      rocsolver_cgetri_rank_0 = rocsolver_cgetri_(handle,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_cgetri_rank_1(handle,n,A,lda,ipiv,myInfo)
@@ -63855,9 +61861,9 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int),target,dimension(:) :: ipiv
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_cgetri_rank_1 = rocsolver_cgetri_(handle,n,c_loc(A),lda,c_loc(ipiv),c_loc(myInfo))
+      rocsolver_cgetri_rank_1 = rocsolver_cgetri_(handle,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_cgetri_full_rank(handle,n,A,lda,ipiv,myInfo)
@@ -63870,11 +61876,10 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int),target,dimension(:,:) :: myInfo
+      integer(c_int),target,dimension(:) :: ipiv
+      type(c_ptr) :: myInfo
       !
-      rocsolver_cgetri_full_rank = rocsolver_cgetri_(handle,n,c_loc(A),lda,c_loc(ipiv), &
-        c_loc(myInfo))
+      rocsolver_cgetri_full_rank = rocsolver_cgetri_(handle,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_zgetri_rank_0(handle,n,A,lda,ipiv,myInfo)
@@ -63888,9 +61893,9 @@ module hipfort_rocsolver
       complex(c_double_complex),target :: A
       integer(c_int) :: lda
       integer(c_int),target :: ipiv
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_zgetri_rank_0 = rocsolver_zgetri_(handle,n,c_loc(A),lda,c_loc(ipiv),c_loc(myInfo))
+      rocsolver_zgetri_rank_0 = rocsolver_zgetri_(handle,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_zgetri_rank_1(handle,n,A,lda,ipiv,myInfo)
@@ -63904,9 +61909,9 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int),target,dimension(:) :: ipiv
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_zgetri_rank_1 = rocsolver_zgetri_(handle,n,c_loc(A),lda,c_loc(ipiv),c_loc(myInfo))
+      rocsolver_zgetri_rank_1 = rocsolver_zgetri_(handle,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_zgetri_full_rank(handle,n,A,lda,ipiv,myInfo)
@@ -63919,11 +61924,10 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int),target,dimension(:,:) :: myInfo
+      integer(c_int),target,dimension(:) :: ipiv
+      type(c_ptr) :: myInfo
       !
-      rocsolver_zgetri_full_rank = rocsolver_zgetri_(handle,n,c_loc(A),lda,c_loc(ipiv), &
-        c_loc(myInfo))
+      rocsolver_zgetri_full_rank = rocsolver_zgetri_(handle,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_sgetri_batched_rank_0(handle,n,A,lda,ipiv,strideP,myInfo,batch_count)
@@ -63938,11 +61942,11 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       integer(c_int),target :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_sgetri_batched_rank_0 = rocsolver_sgetri_batched_(handle,n,A,lda,c_loc(ipiv), &
-        strideP,c_loc(myInfo),batch_count)
+        strideP,myInfo,batch_count)
     end function
 
     function rocsolver_sgetri_batched_rank_1(handle,n,A,lda,ipiv,strideP,myInfo,batch_count)
@@ -63957,30 +61961,11 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_sgetri_batched_rank_1 = rocsolver_sgetri_batched_(handle,n,A,lda,c_loc(ipiv), &
-        strideP,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_sgetri_batched_full_rank(handle,n,A,lda,ipiv,strideP,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_sgetri_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_sgetri_batched_full_rank = rocsolver_sgetri_batched_(handle,n,A,lda,c_loc(ipiv), &
-        strideP,c_loc(myInfo),batch_count)
+        strideP,myInfo,batch_count)
     end function
 
     function rocsolver_dgetri_batched_rank_0(handle,n,A,lda,ipiv,strideP,myInfo,batch_count)
@@ -63995,11 +61980,11 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       integer(c_int),target :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dgetri_batched_rank_0 = rocsolver_dgetri_batched_(handle,n,A,lda,c_loc(ipiv), &
-        strideP,c_loc(myInfo),batch_count)
+        strideP,myInfo,batch_count)
     end function
 
     function rocsolver_dgetri_batched_rank_1(handle,n,A,lda,ipiv,strideP,myInfo,batch_count)
@@ -64014,30 +61999,11 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dgetri_batched_rank_1 = rocsolver_dgetri_batched_(handle,n,A,lda,c_loc(ipiv), &
-        strideP,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_dgetri_batched_full_rank(handle,n,A,lda,ipiv,strideP,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_dgetri_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_dgetri_batched_full_rank = rocsolver_dgetri_batched_(handle,n,A,lda,c_loc(ipiv), &
-        strideP,c_loc(myInfo),batch_count)
+        strideP,myInfo,batch_count)
     end function
 
     function rocsolver_cgetri_batched_rank_0(handle,n,A,lda,ipiv,strideP,myInfo,batch_count)
@@ -64052,11 +62018,11 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       integer(c_int),target :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cgetri_batched_rank_0 = rocsolver_cgetri_batched_(handle,n,A,lda,c_loc(ipiv), &
-        strideP,c_loc(myInfo),batch_count)
+        strideP,myInfo,batch_count)
     end function
 
     function rocsolver_cgetri_batched_rank_1(handle,n,A,lda,ipiv,strideP,myInfo,batch_count)
@@ -64071,30 +62037,11 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cgetri_batched_rank_1 = rocsolver_cgetri_batched_(handle,n,A,lda,c_loc(ipiv), &
-        strideP,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_cgetri_batched_full_rank(handle,n,A,lda,ipiv,strideP,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_cgetri_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_cgetri_batched_full_rank = rocsolver_cgetri_batched_(handle,n,A,lda,c_loc(ipiv), &
-        strideP,c_loc(myInfo),batch_count)
+        strideP,myInfo,batch_count)
     end function
 
     function rocsolver_zgetri_batched_rank_0(handle,n,A,lda,ipiv,strideP,myInfo,batch_count)
@@ -64109,11 +62056,11 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       integer(c_int),target :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zgetri_batched_rank_0 = rocsolver_zgetri_batched_(handle,n,A,lda,c_loc(ipiv), &
-        strideP,c_loc(myInfo),batch_count)
+        strideP,myInfo,batch_count)
     end function
 
     function rocsolver_zgetri_batched_rank_1(handle,n,A,lda,ipiv,strideP,myInfo,batch_count)
@@ -64128,30 +62075,11 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zgetri_batched_rank_1 = rocsolver_zgetri_batched_(handle,n,A,lda,c_loc(ipiv), &
-        strideP,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_zgetri_batched_full_rank(handle,n,A,lda,ipiv,strideP,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_zgetri_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_zgetri_batched_full_rank = rocsolver_zgetri_batched_(handle,n,A,lda,c_loc(ipiv), &
-        strideP,c_loc(myInfo),batch_count)
+        strideP,myInfo,batch_count)
     end function
 
     function rocsolver_sgetri_strided_batched_rank_0(handle,n,A,lda,strideA,ipiv,strideP,myInfo, &
@@ -64168,11 +62096,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideA
       integer(c_int),target :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_sgetri_strided_batched_rank_0 = rocsolver_sgetri_strided_batched_(handle,n, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_sgetri_strided_batched_rank_1(handle,n,A,lda,strideA,ipiv,strideP,myInfo, &
@@ -64189,11 +62117,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideA
       integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_sgetri_strided_batched_rank_1 = rocsolver_sgetri_strided_batched_(handle,n, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_sgetri_strided_batched_full_rank(handle,n,A,lda,strideA,ipiv,strideP, &
@@ -64208,13 +62136,13 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: ipiv
+      integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_sgetri_strided_batched_full_rank = rocsolver_sgetri_strided_batched_(handle,n, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_dgetri_strided_batched_rank_0(handle,n,A,lda,strideA,ipiv,strideP,myInfo, &
@@ -64231,11 +62159,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideA
       integer(c_int),target :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dgetri_strided_batched_rank_0 = rocsolver_dgetri_strided_batched_(handle,n, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_dgetri_strided_batched_rank_1(handle,n,A,lda,strideA,ipiv,strideP,myInfo, &
@@ -64252,11 +62180,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideA
       integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dgetri_strided_batched_rank_1 = rocsolver_dgetri_strided_batched_(handle,n, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_dgetri_strided_batched_full_rank(handle,n,A,lda,strideA,ipiv,strideP, &
@@ -64271,13 +62199,13 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: ipiv
+      integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dgetri_strided_batched_full_rank = rocsolver_dgetri_strided_batched_(handle,n, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_cgetri_strided_batched_rank_0(handle,n,A,lda,strideA,ipiv,strideP,myInfo, &
@@ -64294,11 +62222,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideA
       integer(c_int),target :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cgetri_strided_batched_rank_0 = rocsolver_cgetri_strided_batched_(handle,n, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_cgetri_strided_batched_rank_1(handle,n,A,lda,strideA,ipiv,strideP,myInfo, &
@@ -64315,11 +62243,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideA
       integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cgetri_strided_batched_rank_1 = rocsolver_cgetri_strided_batched_(handle,n, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_cgetri_strided_batched_full_rank(handle,n,A,lda,strideA,ipiv,strideP, &
@@ -64334,13 +62262,13 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: ipiv
+      integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cgetri_strided_batched_full_rank = rocsolver_cgetri_strided_batched_(handle,n, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_zgetri_strided_batched_rank_0(handle,n,A,lda,strideA,ipiv,strideP,myInfo, &
@@ -64357,11 +62285,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideA
       integer(c_int),target :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zgetri_strided_batched_rank_0 = rocsolver_zgetri_strided_batched_(handle,n, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_zgetri_strided_batched_rank_1(handle,n,A,lda,strideA,ipiv,strideP,myInfo, &
@@ -64378,11 +62306,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideA
       integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zgetri_strided_batched_rank_1 = rocsolver_zgetri_strided_batched_(handle,n, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_zgetri_strided_batched_full_rank(handle,n,A,lda,strideA,ipiv,strideP, &
@@ -64397,13 +62325,13 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: ipiv
+      integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zgetri_strided_batched_full_rank = rocsolver_zgetri_strided_batched_(handle,n, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_sgetri_npvt_rank_0(handle,n,A,lda,myInfo)
@@ -64416,9 +62344,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_float),target :: A
       integer(c_int) :: lda
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_sgetri_npvt_rank_0 = rocsolver_sgetri_npvt_(handle,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_sgetri_npvt_rank_0 = rocsolver_sgetri_npvt_(handle,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_sgetri_npvt_rank_1(handle,n,A,lda,myInfo)
@@ -64431,9 +62359,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_float),target,dimension(:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_sgetri_npvt_rank_1 = rocsolver_sgetri_npvt_(handle,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_sgetri_npvt_rank_1 = rocsolver_sgetri_npvt_(handle,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_sgetri_npvt_full_rank(handle,n,A,lda,myInfo)
@@ -64446,9 +62374,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_sgetri_npvt_full_rank = rocsolver_sgetri_npvt_(handle,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_sgetri_npvt_full_rank = rocsolver_sgetri_npvt_(handle,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_dgetri_npvt_rank_0(handle,n,A,lda,myInfo)
@@ -64461,9 +62389,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_double),target :: A
       integer(c_int) :: lda
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_dgetri_npvt_rank_0 = rocsolver_dgetri_npvt_(handle,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_dgetri_npvt_rank_0 = rocsolver_dgetri_npvt_(handle,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_dgetri_npvt_rank_1(handle,n,A,lda,myInfo)
@@ -64476,9 +62404,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_double),target,dimension(:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_dgetri_npvt_rank_1 = rocsolver_dgetri_npvt_(handle,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_dgetri_npvt_rank_1 = rocsolver_dgetri_npvt_(handle,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_dgetri_npvt_full_rank(handle,n,A,lda,myInfo)
@@ -64491,9 +62419,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_dgetri_npvt_full_rank = rocsolver_dgetri_npvt_(handle,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_dgetri_npvt_full_rank = rocsolver_dgetri_npvt_(handle,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_cgetri_npvt_rank_0(handle,n,A,lda,myInfo)
@@ -64506,9 +62434,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_float_complex),target :: A
       integer(c_int) :: lda
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_cgetri_npvt_rank_0 = rocsolver_cgetri_npvt_(handle,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_cgetri_npvt_rank_0 = rocsolver_cgetri_npvt_(handle,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_cgetri_npvt_rank_1(handle,n,A,lda,myInfo)
@@ -64521,9 +62449,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_cgetri_npvt_rank_1 = rocsolver_cgetri_npvt_(handle,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_cgetri_npvt_rank_1 = rocsolver_cgetri_npvt_(handle,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_cgetri_npvt_full_rank(handle,n,A,lda,myInfo)
@@ -64536,9 +62464,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_cgetri_npvt_full_rank = rocsolver_cgetri_npvt_(handle,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_cgetri_npvt_full_rank = rocsolver_cgetri_npvt_(handle,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_zgetri_npvt_rank_0(handle,n,A,lda,myInfo)
@@ -64551,9 +62479,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_double_complex),target :: A
       integer(c_int) :: lda
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_zgetri_npvt_rank_0 = rocsolver_zgetri_npvt_(handle,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_zgetri_npvt_rank_0 = rocsolver_zgetri_npvt_(handle,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_zgetri_npvt_rank_1(handle,n,A,lda,myInfo)
@@ -64566,9 +62494,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_zgetri_npvt_rank_1 = rocsolver_zgetri_npvt_(handle,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_zgetri_npvt_rank_1 = rocsolver_zgetri_npvt_(handle,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_zgetri_npvt_full_rank(handle,n,A,lda,myInfo)
@@ -64581,213 +62509,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_zgetri_npvt_full_rank = rocsolver_zgetri_npvt_(handle,n,c_loc(A),lda,c_loc(myInfo))
-    end function
-
-    function rocsolver_sgetri_npvt_batched_rank_0(handle,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_sgetri_npvt_batched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_sgetri_npvt_batched_rank_0 = rocsolver_sgetri_npvt_batched_(handle,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_sgetri_npvt_batched_rank_1(handle,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_sgetri_npvt_batched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_sgetri_npvt_batched_rank_1 = rocsolver_sgetri_npvt_batched_(handle,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_sgetri_npvt_batched_full_rank(handle,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_sgetri_npvt_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_sgetri_npvt_batched_full_rank = rocsolver_sgetri_npvt_batched_(handle,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_dgetri_npvt_batched_rank_0(handle,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_dgetri_npvt_batched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_dgetri_npvt_batched_rank_0 = rocsolver_dgetri_npvt_batched_(handle,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_dgetri_npvt_batched_rank_1(handle,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_dgetri_npvt_batched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_dgetri_npvt_batched_rank_1 = rocsolver_dgetri_npvt_batched_(handle,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_dgetri_npvt_batched_full_rank(handle,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_dgetri_npvt_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_dgetri_npvt_batched_full_rank = rocsolver_dgetri_npvt_batched_(handle,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_cgetri_npvt_batched_rank_0(handle,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_cgetri_npvt_batched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_cgetri_npvt_batched_rank_0 = rocsolver_cgetri_npvt_batched_(handle,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_cgetri_npvt_batched_rank_1(handle,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_cgetri_npvt_batched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_cgetri_npvt_batched_rank_1 = rocsolver_cgetri_npvt_batched_(handle,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_cgetri_npvt_batched_full_rank(handle,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_cgetri_npvt_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_cgetri_npvt_batched_full_rank = rocsolver_cgetri_npvt_batched_(handle,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_zgetri_npvt_batched_rank_0(handle,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_zgetri_npvt_batched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_zgetri_npvt_batched_rank_0 = rocsolver_zgetri_npvt_batched_(handle,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_zgetri_npvt_batched_rank_1(handle,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_zgetri_npvt_batched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_zgetri_npvt_batched_rank_1 = rocsolver_zgetri_npvt_batched_(handle,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_zgetri_npvt_batched_full_rank(handle,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_zgetri_npvt_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_zgetri_npvt_batched_full_rank = rocsolver_zgetri_npvt_batched_(handle,n,A,lda, &
-        c_loc(myInfo),batch_count)
+      rocsolver_zgetri_npvt_full_rank = rocsolver_zgetri_npvt_(handle,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_sgetri_npvt_strided_batched_rank_0(handle,n,A,lda,strideA,myInfo,batch_count)
@@ -64801,11 +62525,11 @@ module hipfort_rocsolver
       real(c_float),target :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_sgetri_npvt_strided_batched_rank_0 = rocsolver_sgetri_npvt_strided_batched_( &
-        handle,n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        handle,n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_sgetri_npvt_strided_batched_rank_1(handle,n,A,lda,strideA,myInfo,batch_count)
@@ -64819,11 +62543,11 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_sgetri_npvt_strided_batched_rank_1 = rocsolver_sgetri_npvt_strided_batched_( &
-        handle,n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        handle,n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_sgetri_npvt_strided_batched_full_rank(handle,n,A,lda,strideA,myInfo, &
@@ -64838,11 +62562,11 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_sgetri_npvt_strided_batched_full_rank = rocsolver_sgetri_npvt_strided_batched_( &
-        handle,n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        handle,n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_dgetri_npvt_strided_batched_rank_0(handle,n,A,lda,strideA,myInfo,batch_count)
@@ -64856,11 +62580,11 @@ module hipfort_rocsolver
       real(c_double),target :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dgetri_npvt_strided_batched_rank_0 = rocsolver_dgetri_npvt_strided_batched_( &
-        handle,n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        handle,n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_dgetri_npvt_strided_batched_rank_1(handle,n,A,lda,strideA,myInfo,batch_count)
@@ -64874,11 +62598,11 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dgetri_npvt_strided_batched_rank_1 = rocsolver_dgetri_npvt_strided_batched_( &
-        handle,n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        handle,n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_dgetri_npvt_strided_batched_full_rank(handle,n,A,lda,strideA,myInfo, &
@@ -64893,11 +62617,11 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dgetri_npvt_strided_batched_full_rank = rocsolver_dgetri_npvt_strided_batched_( &
-        handle,n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        handle,n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_cgetri_npvt_strided_batched_rank_0(handle,n,A,lda,strideA,myInfo,batch_count)
@@ -64911,11 +62635,11 @@ module hipfort_rocsolver
       complex(c_float_complex),target :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cgetri_npvt_strided_batched_rank_0 = rocsolver_cgetri_npvt_strided_batched_( &
-        handle,n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        handle,n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_cgetri_npvt_strided_batched_rank_1(handle,n,A,lda,strideA,myInfo,batch_count)
@@ -64929,11 +62653,11 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cgetri_npvt_strided_batched_rank_1 = rocsolver_cgetri_npvt_strided_batched_( &
-        handle,n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        handle,n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_cgetri_npvt_strided_batched_full_rank(handle,n,A,lda,strideA,myInfo, &
@@ -64948,11 +62672,11 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cgetri_npvt_strided_batched_full_rank = rocsolver_cgetri_npvt_strided_batched_( &
-        handle,n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        handle,n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_zgetri_npvt_strided_batched_rank_0(handle,n,A,lda,strideA,myInfo,batch_count)
@@ -64966,11 +62690,11 @@ module hipfort_rocsolver
       complex(c_double_complex),target :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zgetri_npvt_strided_batched_rank_0 = rocsolver_zgetri_npvt_strided_batched_( &
-        handle,n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        handle,n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_zgetri_npvt_strided_batched_rank_1(handle,n,A,lda,strideA,myInfo,batch_count)
@@ -64984,11 +62708,11 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zgetri_npvt_strided_batched_rank_1 = rocsolver_zgetri_npvt_strided_batched_( &
-        handle,n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        handle,n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_zgetri_npvt_strided_batched_full_rank(handle,n,A,lda,strideA,myInfo, &
@@ -65003,11 +62727,11 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zgetri_npvt_strided_batched_full_rank = rocsolver_zgetri_npvt_strided_batched_( &
-        handle,n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        handle,n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_sgels_rank_0(handle,trans,m,n,nrhs,A,lda,B,ldb,myInfo)
@@ -65025,10 +62749,10 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       real(c_float),target :: B
       integer(c_int) :: ldb
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_sgels_rank_0 = rocsolver_sgels_(handle,trans,m,n,nrhs,c_loc(A),lda,c_loc(B),ldb, &
-        c_loc(myInfo))
+        myInfo)
     end function
 
     function rocsolver_sgels_rank_1(handle,trans,m,n,nrhs,A,lda,B,ldb,myInfo)
@@ -65046,10 +62770,10 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       real(c_float),target,dimension(:) :: B
       integer(c_int) :: ldb
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_sgels_rank_1 = rocsolver_sgels_(handle,trans,m,n,nrhs,c_loc(A),lda,c_loc(B),ldb, &
-        c_loc(myInfo))
+        myInfo)
     end function
 
     function rocsolver_sgels_full_rank(handle,trans,m,n,nrhs,A,lda,B,ldb,myInfo)
@@ -65067,10 +62791,10 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       real(c_float),target,dimension(:,:) :: B
       integer(c_int) :: ldb
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_sgels_full_rank = rocsolver_sgels_(handle,trans,m,n,nrhs,c_loc(A),lda,c_loc(B), &
-        ldb,c_loc(myInfo))
+        ldb,myInfo)
     end function
 
     function rocsolver_dgels_rank_0(handle,trans,m,n,nrhs,A,lda,B,ldb,myInfo)
@@ -65088,10 +62812,10 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       real(c_double),target :: B
       integer(c_int) :: ldb
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_dgels_rank_0 = rocsolver_dgels_(handle,trans,m,n,nrhs,c_loc(A),lda,c_loc(B),ldb, &
-        c_loc(myInfo))
+        myInfo)
     end function
 
     function rocsolver_dgels_rank_1(handle,trans,m,n,nrhs,A,lda,B,ldb,myInfo)
@@ -65109,10 +62833,10 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       real(c_double),target,dimension(:) :: B
       integer(c_int) :: ldb
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_dgels_rank_1 = rocsolver_dgels_(handle,trans,m,n,nrhs,c_loc(A),lda,c_loc(B),ldb, &
-        c_loc(myInfo))
+        myInfo)
     end function
 
     function rocsolver_dgels_full_rank(handle,trans,m,n,nrhs,A,lda,B,ldb,myInfo)
@@ -65130,10 +62854,10 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       real(c_double),target,dimension(:,:) :: B
       integer(c_int) :: ldb
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_dgels_full_rank = rocsolver_dgels_(handle,trans,m,n,nrhs,c_loc(A),lda,c_loc(B), &
-        ldb,c_loc(myInfo))
+        ldb,myInfo)
     end function
 
     function rocsolver_cgels_rank_0(handle,trans,m,n,nrhs,A,lda,B,ldb,myInfo)
@@ -65151,10 +62875,10 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       complex(c_float_complex),target :: B
       integer(c_int) :: ldb
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_cgels_rank_0 = rocsolver_cgels_(handle,trans,m,n,nrhs,c_loc(A),lda,c_loc(B),ldb, &
-        c_loc(myInfo))
+        myInfo)
     end function
 
     function rocsolver_cgels_rank_1(handle,trans,m,n,nrhs,A,lda,B,ldb,myInfo)
@@ -65172,10 +62896,10 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       complex(c_float_complex),target,dimension(:) :: B
       integer(c_int) :: ldb
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_cgels_rank_1 = rocsolver_cgels_(handle,trans,m,n,nrhs,c_loc(A),lda,c_loc(B),ldb, &
-        c_loc(myInfo))
+        myInfo)
     end function
 
     function rocsolver_cgels_full_rank(handle,trans,m,n,nrhs,A,lda,B,ldb,myInfo)
@@ -65193,10 +62917,10 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       complex(c_float_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_cgels_full_rank = rocsolver_cgels_(handle,trans,m,n,nrhs,c_loc(A),lda,c_loc(B), &
-        ldb,c_loc(myInfo))
+        ldb,myInfo)
     end function
 
     function rocsolver_zgels_rank_0(handle,trans,m,n,nrhs,A,lda,B,ldb,myInfo)
@@ -65214,10 +62938,10 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       complex(c_double_complex),target :: B
       integer(c_int) :: ldb
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_zgels_rank_0 = rocsolver_zgels_(handle,trans,m,n,nrhs,c_loc(A),lda,c_loc(B),ldb, &
-        c_loc(myInfo))
+        myInfo)
     end function
 
     function rocsolver_zgels_rank_1(handle,trans,m,n,nrhs,A,lda,B,ldb,myInfo)
@@ -65235,10 +62959,10 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       complex(c_double_complex),target,dimension(:) :: B
       integer(c_int) :: ldb
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_zgels_rank_1 = rocsolver_zgels_(handle,trans,m,n,nrhs,c_loc(A),lda,c_loc(B),ldb, &
-        c_loc(myInfo))
+        myInfo)
     end function
 
     function rocsolver_zgels_full_rank(handle,trans,m,n,nrhs,A,lda,B,ldb,myInfo)
@@ -65256,274 +62980,10 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       complex(c_double_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_zgels_full_rank = rocsolver_zgels_(handle,trans,m,n,nrhs,c_loc(A),lda,c_loc(B), &
-        ldb,c_loc(myInfo))
-    end function
-
-    function rocsolver_sgels_batched_rank_0(handle,trans,m,n,nrhs,A,lda,B,ldb,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_sgels_batched_rank_0
-      type(c_ptr) :: handle
-      integer(kind(rocblas_operation_none)) :: trans
-      integer(c_int) :: m
-      integer(c_int) :: n
-      integer(c_int) :: nrhs
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: B
-      integer(c_int) :: ldb
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_sgels_batched_rank_0 = rocsolver_sgels_batched_(handle,trans,m,n,nrhs,A,lda,B,ldb, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_sgels_batched_rank_1(handle,trans,m,n,nrhs,A,lda,B,ldb,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_sgels_batched_rank_1
-      type(c_ptr) :: handle
-      integer(kind(rocblas_operation_none)) :: trans
-      integer(c_int) :: m
-      integer(c_int) :: n
-      integer(c_int) :: nrhs
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: B
-      integer(c_int) :: ldb
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_sgels_batched_rank_1 = rocsolver_sgels_batched_(handle,trans,m,n,nrhs,A,lda,B,ldb, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_sgels_batched_full_rank(handle,trans,m,n,nrhs,A,lda,B,ldb,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_sgels_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_operation_none)) :: trans
-      integer(c_int) :: m
-      integer(c_int) :: n
-      integer(c_int) :: nrhs
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: B
-      integer(c_int) :: ldb
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_sgels_batched_full_rank = rocsolver_sgels_batched_(handle,trans,m,n,nrhs,A,lda,B, &
-        ldb,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_dgels_batched_rank_0(handle,trans,m,n,nrhs,A,lda,B,ldb,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_dgels_batched_rank_0
-      type(c_ptr) :: handle
-      integer(kind(rocblas_operation_none)) :: trans
-      integer(c_int) :: m
-      integer(c_int) :: n
-      integer(c_int) :: nrhs
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: B
-      integer(c_int) :: ldb
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_dgels_batched_rank_0 = rocsolver_dgels_batched_(handle,trans,m,n,nrhs,A,lda,B,ldb, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_dgels_batched_rank_1(handle,trans,m,n,nrhs,A,lda,B,ldb,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_dgels_batched_rank_1
-      type(c_ptr) :: handle
-      integer(kind(rocblas_operation_none)) :: trans
-      integer(c_int) :: m
-      integer(c_int) :: n
-      integer(c_int) :: nrhs
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: B
-      integer(c_int) :: ldb
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_dgels_batched_rank_1 = rocsolver_dgels_batched_(handle,trans,m,n,nrhs,A,lda,B,ldb, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_dgels_batched_full_rank(handle,trans,m,n,nrhs,A,lda,B,ldb,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_dgels_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_operation_none)) :: trans
-      integer(c_int) :: m
-      integer(c_int) :: n
-      integer(c_int) :: nrhs
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: B
-      integer(c_int) :: ldb
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_dgels_batched_full_rank = rocsolver_dgels_batched_(handle,trans,m,n,nrhs,A,lda,B, &
-        ldb,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_cgels_batched_rank_0(handle,trans,m,n,nrhs,A,lda,B,ldb,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_cgels_batched_rank_0
-      type(c_ptr) :: handle
-      integer(kind(rocblas_operation_none)) :: trans
-      integer(c_int) :: m
-      integer(c_int) :: n
-      integer(c_int) :: nrhs
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: B
-      integer(c_int) :: ldb
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_cgels_batched_rank_0 = rocsolver_cgels_batched_(handle,trans,m,n,nrhs,A,lda,B,ldb, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_cgels_batched_rank_1(handle,trans,m,n,nrhs,A,lda,B,ldb,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_cgels_batched_rank_1
-      type(c_ptr) :: handle
-      integer(kind(rocblas_operation_none)) :: trans
-      integer(c_int) :: m
-      integer(c_int) :: n
-      integer(c_int) :: nrhs
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: B
-      integer(c_int) :: ldb
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_cgels_batched_rank_1 = rocsolver_cgels_batched_(handle,trans,m,n,nrhs,A,lda,B,ldb, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_cgels_batched_full_rank(handle,trans,m,n,nrhs,A,lda,B,ldb,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_cgels_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_operation_none)) :: trans
-      integer(c_int) :: m
-      integer(c_int) :: n
-      integer(c_int) :: nrhs
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: B
-      integer(c_int) :: ldb
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_cgels_batched_full_rank = rocsolver_cgels_batched_(handle,trans,m,n,nrhs,A,lda,B, &
-        ldb,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_zgels_batched_rank_0(handle,trans,m,n,nrhs,A,lda,B,ldb,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_zgels_batched_rank_0
-      type(c_ptr) :: handle
-      integer(kind(rocblas_operation_none)) :: trans
-      integer(c_int) :: m
-      integer(c_int) :: n
-      integer(c_int) :: nrhs
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: B
-      integer(c_int) :: ldb
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_zgels_batched_rank_0 = rocsolver_zgels_batched_(handle,trans,m,n,nrhs,A,lda,B,ldb, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_zgels_batched_rank_1(handle,trans,m,n,nrhs,A,lda,B,ldb,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_zgels_batched_rank_1
-      type(c_ptr) :: handle
-      integer(kind(rocblas_operation_none)) :: trans
-      integer(c_int) :: m
-      integer(c_int) :: n
-      integer(c_int) :: nrhs
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: B
-      integer(c_int) :: ldb
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_zgels_batched_rank_1 = rocsolver_zgels_batched_(handle,trans,m,n,nrhs,A,lda,B,ldb, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_zgels_batched_full_rank(handle,trans,m,n,nrhs,A,lda,B,ldb,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_zgels_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_operation_none)) :: trans
-      integer(c_int) :: m
-      integer(c_int) :: n
-      integer(c_int) :: nrhs
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: B
-      integer(c_int) :: ldb
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_zgels_batched_full_rank = rocsolver_zgels_batched_(handle,trans,m,n,nrhs,A,lda,B, &
-        ldb,c_loc(myInfo),batch_count)
+        ldb,myInfo)
     end function
 
     function rocsolver_sgels_strided_batched_rank_0(handle,trans,m,n,nrhs,A,lda,strideA,B,ldb, &
@@ -65544,11 +63004,11 @@ module hipfort_rocsolver
       real(c_float),target :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_sgels_strided_batched_rank_0 = rocsolver_sgels_strided_batched_(handle,trans,m,n, &
-        nrhs,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(myInfo),batch_count)
+        nrhs,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,myInfo,batch_count)
     end function
 
     function rocsolver_sgels_strided_batched_rank_1(handle,trans,m,n,nrhs,A,lda,strideA,B,ldb, &
@@ -65569,11 +63029,11 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:) :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_sgels_strided_batched_rank_1 = rocsolver_sgels_strided_batched_(handle,trans,m,n, &
-        nrhs,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(myInfo),batch_count)
+        nrhs,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,myInfo,batch_count)
     end function
 
     function rocsolver_sgels_strided_batched_full_rank(handle,trans,m,n,nrhs,A,lda,strideA,B,ldb, &
@@ -65594,11 +63054,11 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_sgels_strided_batched_full_rank = rocsolver_sgels_strided_batched_(handle,trans,m, &
-        n,nrhs,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(myInfo),batch_count)
+        n,nrhs,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,myInfo,batch_count)
     end function
 
     function rocsolver_dgels_strided_batched_rank_0(handle,trans,m,n,nrhs,A,lda,strideA,B,ldb, &
@@ -65619,11 +63079,11 @@ module hipfort_rocsolver
       real(c_double),target :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dgels_strided_batched_rank_0 = rocsolver_dgels_strided_batched_(handle,trans,m,n, &
-        nrhs,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(myInfo),batch_count)
+        nrhs,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,myInfo,batch_count)
     end function
 
     function rocsolver_dgels_strided_batched_rank_1(handle,trans,m,n,nrhs,A,lda,strideA,B,ldb, &
@@ -65644,11 +63104,11 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:) :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dgels_strided_batched_rank_1 = rocsolver_dgels_strided_batched_(handle,trans,m,n, &
-        nrhs,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(myInfo),batch_count)
+        nrhs,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,myInfo,batch_count)
     end function
 
     function rocsolver_dgels_strided_batched_full_rank(handle,trans,m,n,nrhs,A,lda,strideA,B,ldb, &
@@ -65669,11 +63129,11 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dgels_strided_batched_full_rank = rocsolver_dgels_strided_batched_(handle,trans,m, &
-        n,nrhs,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(myInfo),batch_count)
+        n,nrhs,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,myInfo,batch_count)
     end function
 
     function rocsolver_cgels_strided_batched_rank_0(handle,trans,m,n,nrhs,A,lda,strideA,B,ldb, &
@@ -65694,11 +63154,11 @@ module hipfort_rocsolver
       complex(c_float_complex),target :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cgels_strided_batched_rank_0 = rocsolver_cgels_strided_batched_(handle,trans,m,n, &
-        nrhs,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(myInfo),batch_count)
+        nrhs,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,myInfo,batch_count)
     end function
 
     function rocsolver_cgels_strided_batched_rank_1(handle,trans,m,n,nrhs,A,lda,strideA,B,ldb, &
@@ -65719,11 +63179,11 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:) :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cgels_strided_batched_rank_1 = rocsolver_cgels_strided_batched_(handle,trans,m,n, &
-        nrhs,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(myInfo),batch_count)
+        nrhs,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,myInfo,batch_count)
     end function
 
     function rocsolver_cgels_strided_batched_full_rank(handle,trans,m,n,nrhs,A,lda,strideA,B,ldb, &
@@ -65744,11 +63204,11 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cgels_strided_batched_full_rank = rocsolver_cgels_strided_batched_(handle,trans,m, &
-        n,nrhs,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(myInfo),batch_count)
+        n,nrhs,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,myInfo,batch_count)
     end function
 
     function rocsolver_zgels_strided_batched_rank_0(handle,trans,m,n,nrhs,A,lda,strideA,B,ldb, &
@@ -65769,11 +63229,11 @@ module hipfort_rocsolver
       complex(c_double_complex),target :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zgels_strided_batched_rank_0 = rocsolver_zgels_strided_batched_(handle,trans,m,n, &
-        nrhs,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(myInfo),batch_count)
+        nrhs,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,myInfo,batch_count)
     end function
 
     function rocsolver_zgels_strided_batched_rank_1(handle,trans,m,n,nrhs,A,lda,strideA,B,ldb, &
@@ -65794,11 +63254,11 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:) :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zgels_strided_batched_rank_1 = rocsolver_zgels_strided_batched_(handle,trans,m,n, &
-        nrhs,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(myInfo),batch_count)
+        nrhs,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,myInfo,batch_count)
     end function
 
     function rocsolver_zgels_strided_batched_full_rank(handle,trans,m,n,nrhs,A,lda,strideA,B,ldb, &
@@ -65819,11 +63279,11 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zgels_strided_batched_full_rank = rocsolver_zgels_strided_batched_(handle,trans,m, &
-        n,nrhs,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(myInfo),batch_count)
+        n,nrhs,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,myInfo,batch_count)
     end function
 
     function rocsolver_spotf2_rank_0(handle,uplo,n,A,lda,myInfo)
@@ -65837,9 +63297,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_float),target :: A
       integer(c_int) :: lda
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_spotf2_rank_0 = rocsolver_spotf2_(handle,uplo,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_spotf2_rank_0 = rocsolver_spotf2_(handle,uplo,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_spotf2_rank_1(handle,uplo,n,A,lda,myInfo)
@@ -65853,9 +63313,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_float),target,dimension(:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_spotf2_rank_1 = rocsolver_spotf2_(handle,uplo,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_spotf2_rank_1 = rocsolver_spotf2_(handle,uplo,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_spotf2_full_rank(handle,uplo,n,A,lda,myInfo)
@@ -65869,9 +63329,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_spotf2_full_rank = rocsolver_spotf2_(handle,uplo,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_spotf2_full_rank = rocsolver_spotf2_(handle,uplo,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_dpotf2_rank_0(handle,uplo,n,A,lda,myInfo)
@@ -65885,9 +63345,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_double),target :: A
       integer(c_int) :: lda
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_dpotf2_rank_0 = rocsolver_dpotf2_(handle,uplo,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_dpotf2_rank_0 = rocsolver_dpotf2_(handle,uplo,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_dpotf2_rank_1(handle,uplo,n,A,lda,myInfo)
@@ -65901,9 +63361,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_double),target,dimension(:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_dpotf2_rank_1 = rocsolver_dpotf2_(handle,uplo,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_dpotf2_rank_1 = rocsolver_dpotf2_(handle,uplo,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_dpotf2_full_rank(handle,uplo,n,A,lda,myInfo)
@@ -65917,9 +63377,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_dpotf2_full_rank = rocsolver_dpotf2_(handle,uplo,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_dpotf2_full_rank = rocsolver_dpotf2_(handle,uplo,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_cpotf2_rank_0(handle,uplo,n,A,lda,myInfo)
@@ -65933,9 +63393,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_float_complex),target :: A
       integer(c_int) :: lda
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_cpotf2_rank_0 = rocsolver_cpotf2_(handle,uplo,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_cpotf2_rank_0 = rocsolver_cpotf2_(handle,uplo,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_cpotf2_rank_1(handle,uplo,n,A,lda,myInfo)
@@ -65949,9 +63409,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_cpotf2_rank_1 = rocsolver_cpotf2_(handle,uplo,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_cpotf2_rank_1 = rocsolver_cpotf2_(handle,uplo,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_cpotf2_full_rank(handle,uplo,n,A,lda,myInfo)
@@ -65965,9 +63425,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_cpotf2_full_rank = rocsolver_cpotf2_(handle,uplo,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_cpotf2_full_rank = rocsolver_cpotf2_(handle,uplo,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_zpotf2_rank_0(handle,uplo,n,A,lda,myInfo)
@@ -65981,9 +63441,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_double_complex),target :: A
       integer(c_int) :: lda
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_zpotf2_rank_0 = rocsolver_zpotf2_(handle,uplo,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_zpotf2_rank_0 = rocsolver_zpotf2_(handle,uplo,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_zpotf2_rank_1(handle,uplo,n,A,lda,myInfo)
@@ -65997,9 +63457,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_zpotf2_rank_1 = rocsolver_zpotf2_(handle,uplo,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_zpotf2_rank_1 = rocsolver_zpotf2_(handle,uplo,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_zpotf2_full_rank(handle,uplo,n,A,lda,myInfo)
@@ -66013,225 +63473,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_zpotf2_full_rank = rocsolver_zpotf2_(handle,uplo,n,c_loc(A),lda,c_loc(myInfo))
-    end function
-
-    function rocsolver_spotf2_batched_rank_0(handle,uplo,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_spotf2_batched_rank_0
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_spotf2_batched_rank_0 = rocsolver_spotf2_batched_(handle,uplo,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_spotf2_batched_rank_1(handle,uplo,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_spotf2_batched_rank_1
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_spotf2_batched_rank_1 = rocsolver_spotf2_batched_(handle,uplo,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_spotf2_batched_full_rank(handle,uplo,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_spotf2_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_spotf2_batched_full_rank = rocsolver_spotf2_batched_(handle,uplo,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_dpotf2_batched_rank_0(handle,uplo,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_dpotf2_batched_rank_0
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_dpotf2_batched_rank_0 = rocsolver_dpotf2_batched_(handle,uplo,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_dpotf2_batched_rank_1(handle,uplo,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_dpotf2_batched_rank_1
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_dpotf2_batched_rank_1 = rocsolver_dpotf2_batched_(handle,uplo,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_dpotf2_batched_full_rank(handle,uplo,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_dpotf2_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_dpotf2_batched_full_rank = rocsolver_dpotf2_batched_(handle,uplo,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_cpotf2_batched_rank_0(handle,uplo,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_cpotf2_batched_rank_0
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_cpotf2_batched_rank_0 = rocsolver_cpotf2_batched_(handle,uplo,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_cpotf2_batched_rank_1(handle,uplo,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_cpotf2_batched_rank_1
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_cpotf2_batched_rank_1 = rocsolver_cpotf2_batched_(handle,uplo,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_cpotf2_batched_full_rank(handle,uplo,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_cpotf2_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_cpotf2_batched_full_rank = rocsolver_cpotf2_batched_(handle,uplo,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_zpotf2_batched_rank_0(handle,uplo,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_zpotf2_batched_rank_0
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_zpotf2_batched_rank_0 = rocsolver_zpotf2_batched_(handle,uplo,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_zpotf2_batched_rank_1(handle,uplo,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_zpotf2_batched_rank_1
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_zpotf2_batched_rank_1 = rocsolver_zpotf2_batched_(handle,uplo,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_zpotf2_batched_full_rank(handle,uplo,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_zpotf2_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_zpotf2_batched_full_rank = rocsolver_zpotf2_batched_(handle,uplo,n,A,lda, &
-        c_loc(myInfo),batch_count)
+      rocsolver_zpotf2_full_rank = rocsolver_zpotf2_(handle,uplo,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_spotf2_strided_batched_rank_0(handle,uplo,n,A,lda,strideA,myInfo,batch_count)
@@ -66246,11 +63490,11 @@ module hipfort_rocsolver
       real(c_float),target :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_spotf2_strided_batched_rank_0 = rocsolver_spotf2_strided_batched_(handle,uplo,n, &
-        c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_spotf2_strided_batched_rank_1(handle,uplo,n,A,lda,strideA,myInfo,batch_count)
@@ -66265,11 +63509,11 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_spotf2_strided_batched_rank_1 = rocsolver_spotf2_strided_batched_(handle,uplo,n, &
-        c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_spotf2_strided_batched_full_rank(handle,uplo,n,A,lda,strideA,myInfo, &
@@ -66285,11 +63529,11 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_spotf2_strided_batched_full_rank = rocsolver_spotf2_strided_batched_(handle,uplo, &
-        n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_dpotf2_strided_batched_rank_0(handle,uplo,n,A,lda,strideA,myInfo,batch_count)
@@ -66304,11 +63548,11 @@ module hipfort_rocsolver
       real(c_double),target :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dpotf2_strided_batched_rank_0 = rocsolver_dpotf2_strided_batched_(handle,uplo,n, &
-        c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_dpotf2_strided_batched_rank_1(handle,uplo,n,A,lda,strideA,myInfo,batch_count)
@@ -66323,11 +63567,11 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dpotf2_strided_batched_rank_1 = rocsolver_dpotf2_strided_batched_(handle,uplo,n, &
-        c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_dpotf2_strided_batched_full_rank(handle,uplo,n,A,lda,strideA,myInfo, &
@@ -66343,11 +63587,11 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dpotf2_strided_batched_full_rank = rocsolver_dpotf2_strided_batched_(handle,uplo, &
-        n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_cpotf2_strided_batched_rank_0(handle,uplo,n,A,lda,strideA,myInfo,batch_count)
@@ -66362,11 +63606,11 @@ module hipfort_rocsolver
       complex(c_float_complex),target :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cpotf2_strided_batched_rank_0 = rocsolver_cpotf2_strided_batched_(handle,uplo,n, &
-        c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_cpotf2_strided_batched_rank_1(handle,uplo,n,A,lda,strideA,myInfo,batch_count)
@@ -66381,11 +63625,11 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cpotf2_strided_batched_rank_1 = rocsolver_cpotf2_strided_batched_(handle,uplo,n, &
-        c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_cpotf2_strided_batched_full_rank(handle,uplo,n,A,lda,strideA,myInfo, &
@@ -66401,11 +63645,11 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cpotf2_strided_batched_full_rank = rocsolver_cpotf2_strided_batched_(handle,uplo, &
-        n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_zpotf2_strided_batched_rank_0(handle,uplo,n,A,lda,strideA,myInfo,batch_count)
@@ -66420,11 +63664,11 @@ module hipfort_rocsolver
       complex(c_double_complex),target :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zpotf2_strided_batched_rank_0 = rocsolver_zpotf2_strided_batched_(handle,uplo,n, &
-        c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_zpotf2_strided_batched_rank_1(handle,uplo,n,A,lda,strideA,myInfo,batch_count)
@@ -66439,11 +63683,11 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zpotf2_strided_batched_rank_1 = rocsolver_zpotf2_strided_batched_(handle,uplo,n, &
-        c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_zpotf2_strided_batched_full_rank(handle,uplo,n,A,lda,strideA,myInfo, &
@@ -66459,11 +63703,11 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zpotf2_strided_batched_full_rank = rocsolver_zpotf2_strided_batched_(handle,uplo, &
-        n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_spotrf_rank_0(handle,uplo,n,A,lda,myInfo)
@@ -66477,9 +63721,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_float),target :: A
       integer(c_int) :: lda
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_spotrf_rank_0 = rocsolver_spotrf_(handle,uplo,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_spotrf_rank_0 = rocsolver_spotrf_(handle,uplo,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_spotrf_rank_1(handle,uplo,n,A,lda,myInfo)
@@ -66493,9 +63737,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_float),target,dimension(:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_spotrf_rank_1 = rocsolver_spotrf_(handle,uplo,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_spotrf_rank_1 = rocsolver_spotrf_(handle,uplo,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_spotrf_full_rank(handle,uplo,n,A,lda,myInfo)
@@ -66509,9 +63753,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_spotrf_full_rank = rocsolver_spotrf_(handle,uplo,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_spotrf_full_rank = rocsolver_spotrf_(handle,uplo,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_dpotrf_rank_0(handle,uplo,n,A,lda,myInfo)
@@ -66525,9 +63769,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_double),target :: A
       integer(c_int) :: lda
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_dpotrf_rank_0 = rocsolver_dpotrf_(handle,uplo,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_dpotrf_rank_0 = rocsolver_dpotrf_(handle,uplo,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_dpotrf_rank_1(handle,uplo,n,A,lda,myInfo)
@@ -66541,9 +63785,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_double),target,dimension(:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_dpotrf_rank_1 = rocsolver_dpotrf_(handle,uplo,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_dpotrf_rank_1 = rocsolver_dpotrf_(handle,uplo,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_dpotrf_full_rank(handle,uplo,n,A,lda,myInfo)
@@ -66557,9 +63801,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_dpotrf_full_rank = rocsolver_dpotrf_(handle,uplo,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_dpotrf_full_rank = rocsolver_dpotrf_(handle,uplo,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_cpotrf_rank_0(handle,uplo,n,A,lda,myInfo)
@@ -66573,9 +63817,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_float_complex),target :: A
       integer(c_int) :: lda
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_cpotrf_rank_0 = rocsolver_cpotrf_(handle,uplo,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_cpotrf_rank_0 = rocsolver_cpotrf_(handle,uplo,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_cpotrf_rank_1(handle,uplo,n,A,lda,myInfo)
@@ -66589,9 +63833,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_cpotrf_rank_1 = rocsolver_cpotrf_(handle,uplo,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_cpotrf_rank_1 = rocsolver_cpotrf_(handle,uplo,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_cpotrf_full_rank(handle,uplo,n,A,lda,myInfo)
@@ -66605,9 +63849,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_cpotrf_full_rank = rocsolver_cpotrf_(handle,uplo,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_cpotrf_full_rank = rocsolver_cpotrf_(handle,uplo,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_zpotrf_rank_0(handle,uplo,n,A,lda,myInfo)
@@ -66621,9 +63865,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_double_complex),target :: A
       integer(c_int) :: lda
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_zpotrf_rank_0 = rocsolver_zpotrf_(handle,uplo,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_zpotrf_rank_0 = rocsolver_zpotrf_(handle,uplo,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_zpotrf_rank_1(handle,uplo,n,A,lda,myInfo)
@@ -66637,9 +63881,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_zpotrf_rank_1 = rocsolver_zpotrf_(handle,uplo,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_zpotrf_rank_1 = rocsolver_zpotrf_(handle,uplo,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_zpotrf_full_rank(handle,uplo,n,A,lda,myInfo)
@@ -66653,225 +63897,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_zpotrf_full_rank = rocsolver_zpotrf_(handle,uplo,n,c_loc(A),lda,c_loc(myInfo))
-    end function
-
-    function rocsolver_spotrf_batched_rank_0(handle,uplo,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_spotrf_batched_rank_0
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_spotrf_batched_rank_0 = rocsolver_spotrf_batched_(handle,uplo,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_spotrf_batched_rank_1(handle,uplo,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_spotrf_batched_rank_1
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_spotrf_batched_rank_1 = rocsolver_spotrf_batched_(handle,uplo,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_spotrf_batched_full_rank(handle,uplo,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_spotrf_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_spotrf_batched_full_rank = rocsolver_spotrf_batched_(handle,uplo,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_dpotrf_batched_rank_0(handle,uplo,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_dpotrf_batched_rank_0
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_dpotrf_batched_rank_0 = rocsolver_dpotrf_batched_(handle,uplo,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_dpotrf_batched_rank_1(handle,uplo,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_dpotrf_batched_rank_1
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_dpotrf_batched_rank_1 = rocsolver_dpotrf_batched_(handle,uplo,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_dpotrf_batched_full_rank(handle,uplo,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_dpotrf_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_dpotrf_batched_full_rank = rocsolver_dpotrf_batched_(handle,uplo,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_cpotrf_batched_rank_0(handle,uplo,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_cpotrf_batched_rank_0
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_cpotrf_batched_rank_0 = rocsolver_cpotrf_batched_(handle,uplo,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_cpotrf_batched_rank_1(handle,uplo,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_cpotrf_batched_rank_1
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_cpotrf_batched_rank_1 = rocsolver_cpotrf_batched_(handle,uplo,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_cpotrf_batched_full_rank(handle,uplo,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_cpotrf_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_cpotrf_batched_full_rank = rocsolver_cpotrf_batched_(handle,uplo,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_zpotrf_batched_rank_0(handle,uplo,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_zpotrf_batched_rank_0
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_zpotrf_batched_rank_0 = rocsolver_zpotrf_batched_(handle,uplo,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_zpotrf_batched_rank_1(handle,uplo,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_zpotrf_batched_rank_1
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_zpotrf_batched_rank_1 = rocsolver_zpotrf_batched_(handle,uplo,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_zpotrf_batched_full_rank(handle,uplo,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_zpotrf_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_zpotrf_batched_full_rank = rocsolver_zpotrf_batched_(handle,uplo,n,A,lda, &
-        c_loc(myInfo),batch_count)
+      rocsolver_zpotrf_full_rank = rocsolver_zpotrf_(handle,uplo,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_spotrf_strided_batched_rank_0(handle,uplo,n,A,lda,strideA,myInfo,batch_count)
@@ -66886,11 +63914,11 @@ module hipfort_rocsolver
       real(c_float),target :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_spotrf_strided_batched_rank_0 = rocsolver_spotrf_strided_batched_(handle,uplo,n, &
-        c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_spotrf_strided_batched_rank_1(handle,uplo,n,A,lda,strideA,myInfo,batch_count)
@@ -66905,11 +63933,11 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_spotrf_strided_batched_rank_1 = rocsolver_spotrf_strided_batched_(handle,uplo,n, &
-        c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_spotrf_strided_batched_full_rank(handle,uplo,n,A,lda,strideA,myInfo, &
@@ -66925,11 +63953,11 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_spotrf_strided_batched_full_rank = rocsolver_spotrf_strided_batched_(handle,uplo, &
-        n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_dpotrf_strided_batched_rank_0(handle,uplo,n,A,lda,strideA,myInfo,batch_count)
@@ -66944,11 +63972,11 @@ module hipfort_rocsolver
       real(c_double),target :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dpotrf_strided_batched_rank_0 = rocsolver_dpotrf_strided_batched_(handle,uplo,n, &
-        c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_dpotrf_strided_batched_rank_1(handle,uplo,n,A,lda,strideA,myInfo,batch_count)
@@ -66963,11 +63991,11 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dpotrf_strided_batched_rank_1 = rocsolver_dpotrf_strided_batched_(handle,uplo,n, &
-        c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_dpotrf_strided_batched_full_rank(handle,uplo,n,A,lda,strideA,myInfo, &
@@ -66983,11 +64011,11 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dpotrf_strided_batched_full_rank = rocsolver_dpotrf_strided_batched_(handle,uplo, &
-        n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_cpotrf_strided_batched_rank_0(handle,uplo,n,A,lda,strideA,myInfo,batch_count)
@@ -67002,11 +64030,11 @@ module hipfort_rocsolver
       complex(c_float_complex),target :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cpotrf_strided_batched_rank_0 = rocsolver_cpotrf_strided_batched_(handle,uplo,n, &
-        c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_cpotrf_strided_batched_rank_1(handle,uplo,n,A,lda,strideA,myInfo,batch_count)
@@ -67021,11 +64049,11 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cpotrf_strided_batched_rank_1 = rocsolver_cpotrf_strided_batched_(handle,uplo,n, &
-        c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_cpotrf_strided_batched_full_rank(handle,uplo,n,A,lda,strideA,myInfo, &
@@ -67041,11 +64069,11 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cpotrf_strided_batched_full_rank = rocsolver_cpotrf_strided_batched_(handle,uplo, &
-        n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_zpotrf_strided_batched_rank_0(handle,uplo,n,A,lda,strideA,myInfo,batch_count)
@@ -67060,11 +64088,11 @@ module hipfort_rocsolver
       complex(c_double_complex),target :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zpotrf_strided_batched_rank_0 = rocsolver_zpotrf_strided_batched_(handle,uplo,n, &
-        c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_zpotrf_strided_batched_rank_1(handle,uplo,n,A,lda,strideA,myInfo,batch_count)
@@ -67079,11 +64107,11 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zpotrf_strided_batched_rank_1 = rocsolver_zpotrf_strided_batched_(handle,uplo,n, &
-        c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_zpotrf_strided_batched_full_rank(handle,uplo,n,A,lda,strideA,myInfo, &
@@ -67099,11 +64127,11 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zpotrf_strided_batched_full_rank = rocsolver_zpotrf_strided_batched_(handle,uplo, &
-        n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_spotrs_rank_0(handle,uplo,n,nrhs,A,lda,B,ldb)
@@ -67612,10 +64640,9 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       real(c_float),target :: B
       integer(c_int) :: ldb
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_sposv_rank_0 = rocsolver_sposv_(handle,uplo,n,nrhs,c_loc(A),lda,c_loc(B),ldb, &
-        c_loc(myInfo))
+      rocsolver_sposv_rank_0 = rocsolver_sposv_(handle,uplo,n,nrhs,c_loc(A),lda,c_loc(B),ldb,myInfo)
     end function
 
     function rocsolver_sposv_rank_1(handle,uplo,n,nrhs,A,lda,B,ldb,myInfo)
@@ -67632,10 +64659,9 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       real(c_float),target,dimension(:) :: B
       integer(c_int) :: ldb
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_sposv_rank_1 = rocsolver_sposv_(handle,uplo,n,nrhs,c_loc(A),lda,c_loc(B),ldb, &
-        c_loc(myInfo))
+      rocsolver_sposv_rank_1 = rocsolver_sposv_(handle,uplo,n,nrhs,c_loc(A),lda,c_loc(B),ldb,myInfo)
     end function
 
     function rocsolver_sposv_full_rank(handle,uplo,n,nrhs,A,lda,B,ldb,myInfo)
@@ -67652,10 +64678,10 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       real(c_float),target,dimension(:,:) :: B
       integer(c_int) :: ldb
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_sposv_full_rank = rocsolver_sposv_(handle,uplo,n,nrhs,c_loc(A),lda,c_loc(B),ldb, &
-        c_loc(myInfo))
+        myInfo)
     end function
 
     function rocsolver_dposv_rank_0(handle,uplo,n,nrhs,A,lda,B,ldb,myInfo)
@@ -67672,10 +64698,9 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       real(c_double),target :: B
       integer(c_int) :: ldb
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_dposv_rank_0 = rocsolver_dposv_(handle,uplo,n,nrhs,c_loc(A),lda,c_loc(B),ldb, &
-        c_loc(myInfo))
+      rocsolver_dposv_rank_0 = rocsolver_dposv_(handle,uplo,n,nrhs,c_loc(A),lda,c_loc(B),ldb,myInfo)
     end function
 
     function rocsolver_dposv_rank_1(handle,uplo,n,nrhs,A,lda,B,ldb,myInfo)
@@ -67692,10 +64717,9 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       real(c_double),target,dimension(:) :: B
       integer(c_int) :: ldb
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_dposv_rank_1 = rocsolver_dposv_(handle,uplo,n,nrhs,c_loc(A),lda,c_loc(B),ldb, &
-        c_loc(myInfo))
+      rocsolver_dposv_rank_1 = rocsolver_dposv_(handle,uplo,n,nrhs,c_loc(A),lda,c_loc(B),ldb,myInfo)
     end function
 
     function rocsolver_dposv_full_rank(handle,uplo,n,nrhs,A,lda,B,ldb,myInfo)
@@ -67712,10 +64736,10 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       real(c_double),target,dimension(:,:) :: B
       integer(c_int) :: ldb
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_dposv_full_rank = rocsolver_dposv_(handle,uplo,n,nrhs,c_loc(A),lda,c_loc(B),ldb, &
-        c_loc(myInfo))
+        myInfo)
     end function
 
     function rocsolver_cposv_rank_0(handle,uplo,n,nrhs,A,lda,B,ldb,myInfo)
@@ -67732,10 +64756,9 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       complex(c_float_complex),target :: B
       integer(c_int) :: ldb
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_cposv_rank_0 = rocsolver_cposv_(handle,uplo,n,nrhs,c_loc(A),lda,c_loc(B),ldb, &
-        c_loc(myInfo))
+      rocsolver_cposv_rank_0 = rocsolver_cposv_(handle,uplo,n,nrhs,c_loc(A),lda,c_loc(B),ldb,myInfo)
     end function
 
     function rocsolver_cposv_rank_1(handle,uplo,n,nrhs,A,lda,B,ldb,myInfo)
@@ -67752,10 +64775,9 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       complex(c_float_complex),target,dimension(:) :: B
       integer(c_int) :: ldb
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_cposv_rank_1 = rocsolver_cposv_(handle,uplo,n,nrhs,c_loc(A),lda,c_loc(B),ldb, &
-        c_loc(myInfo))
+      rocsolver_cposv_rank_1 = rocsolver_cposv_(handle,uplo,n,nrhs,c_loc(A),lda,c_loc(B),ldb,myInfo)
     end function
 
     function rocsolver_cposv_full_rank(handle,uplo,n,nrhs,A,lda,B,ldb,myInfo)
@@ -67772,10 +64794,10 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       complex(c_float_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_cposv_full_rank = rocsolver_cposv_(handle,uplo,n,nrhs,c_loc(A),lda,c_loc(B),ldb, &
-        c_loc(myInfo))
+        myInfo)
     end function
 
     function rocsolver_zposv_rank_0(handle,uplo,n,nrhs,A,lda,B,ldb,myInfo)
@@ -67792,10 +64814,9 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       complex(c_double_complex),target :: B
       integer(c_int) :: ldb
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_zposv_rank_0 = rocsolver_zposv_(handle,uplo,n,nrhs,c_loc(A),lda,c_loc(B),ldb, &
-        c_loc(myInfo))
+      rocsolver_zposv_rank_0 = rocsolver_zposv_(handle,uplo,n,nrhs,c_loc(A),lda,c_loc(B),ldb,myInfo)
     end function
 
     function rocsolver_zposv_rank_1(handle,uplo,n,nrhs,A,lda,B,ldb,myInfo)
@@ -67812,10 +64833,9 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       complex(c_double_complex),target,dimension(:) :: B
       integer(c_int) :: ldb
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_zposv_rank_1 = rocsolver_zposv_(handle,uplo,n,nrhs,c_loc(A),lda,c_loc(B),ldb, &
-        c_loc(myInfo))
+      rocsolver_zposv_rank_1 = rocsolver_zposv_(handle,uplo,n,nrhs,c_loc(A),lda,c_loc(B),ldb,myInfo)
     end function
 
     function rocsolver_zposv_full_rank(handle,uplo,n,nrhs,A,lda,B,ldb,myInfo)
@@ -67832,262 +64852,10 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       complex(c_double_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_zposv_full_rank = rocsolver_zposv_(handle,uplo,n,nrhs,c_loc(A),lda,c_loc(B),ldb, &
-        c_loc(myInfo))
-    end function
-
-    function rocsolver_sposv_batched_rank_0(handle,uplo,n,nrhs,A,lda,B,ldb,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_sposv_batched_rank_0
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      integer(c_int) :: nrhs
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: B
-      integer(c_int) :: ldb
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_sposv_batched_rank_0 = rocsolver_sposv_batched_(handle,uplo,n,nrhs,A,lda,B,ldb, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_sposv_batched_rank_1(handle,uplo,n,nrhs,A,lda,B,ldb,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_sposv_batched_rank_1
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      integer(c_int) :: nrhs
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: B
-      integer(c_int) :: ldb
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_sposv_batched_rank_1 = rocsolver_sposv_batched_(handle,uplo,n,nrhs,A,lda,B,ldb, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_sposv_batched_full_rank(handle,uplo,n,nrhs,A,lda,B,ldb,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_sposv_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      integer(c_int) :: nrhs
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: B
-      integer(c_int) :: ldb
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_sposv_batched_full_rank = rocsolver_sposv_batched_(handle,uplo,n,nrhs,A,lda,B,ldb, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_dposv_batched_rank_0(handle,uplo,n,nrhs,A,lda,B,ldb,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_dposv_batched_rank_0
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      integer(c_int) :: nrhs
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: B
-      integer(c_int) :: ldb
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_dposv_batched_rank_0 = rocsolver_dposv_batched_(handle,uplo,n,nrhs,A,lda,B,ldb, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_dposv_batched_rank_1(handle,uplo,n,nrhs,A,lda,B,ldb,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_dposv_batched_rank_1
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      integer(c_int) :: nrhs
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: B
-      integer(c_int) :: ldb
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_dposv_batched_rank_1 = rocsolver_dposv_batched_(handle,uplo,n,nrhs,A,lda,B,ldb, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_dposv_batched_full_rank(handle,uplo,n,nrhs,A,lda,B,ldb,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_dposv_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      integer(c_int) :: nrhs
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: B
-      integer(c_int) :: ldb
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_dposv_batched_full_rank = rocsolver_dposv_batched_(handle,uplo,n,nrhs,A,lda,B,ldb, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_cposv_batched_rank_0(handle,uplo,n,nrhs,A,lda,B,ldb,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_cposv_batched_rank_0
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      integer(c_int) :: nrhs
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: B
-      integer(c_int) :: ldb
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_cposv_batched_rank_0 = rocsolver_cposv_batched_(handle,uplo,n,nrhs,A,lda,B,ldb, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_cposv_batched_rank_1(handle,uplo,n,nrhs,A,lda,B,ldb,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_cposv_batched_rank_1
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      integer(c_int) :: nrhs
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: B
-      integer(c_int) :: ldb
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_cposv_batched_rank_1 = rocsolver_cposv_batched_(handle,uplo,n,nrhs,A,lda,B,ldb, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_cposv_batched_full_rank(handle,uplo,n,nrhs,A,lda,B,ldb,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_cposv_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      integer(c_int) :: nrhs
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: B
-      integer(c_int) :: ldb
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_cposv_batched_full_rank = rocsolver_cposv_batched_(handle,uplo,n,nrhs,A,lda,B,ldb, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_zposv_batched_rank_0(handle,uplo,n,nrhs,A,lda,B,ldb,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_zposv_batched_rank_0
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      integer(c_int) :: nrhs
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: B
-      integer(c_int) :: ldb
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_zposv_batched_rank_0 = rocsolver_zposv_batched_(handle,uplo,n,nrhs,A,lda,B,ldb, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_zposv_batched_rank_1(handle,uplo,n,nrhs,A,lda,B,ldb,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_zposv_batched_rank_1
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      integer(c_int) :: nrhs
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: B
-      integer(c_int) :: ldb
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_zposv_batched_rank_1 = rocsolver_zposv_batched_(handle,uplo,n,nrhs,A,lda,B,ldb, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_zposv_batched_full_rank(handle,uplo,n,nrhs,A,lda,B,ldb,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_zposv_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      integer(c_int) :: nrhs
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: B
-      integer(c_int) :: ldb
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_zposv_batched_full_rank = rocsolver_zposv_batched_(handle,uplo,n,nrhs,A,lda,B,ldb, &
-        c_loc(myInfo),batch_count)
+        myInfo)
     end function
 
     function rocsolver_sposv_strided_batched_rank_0(handle,uplo,n,nrhs,A,lda,strideA,B,ldb, &
@@ -68107,11 +64875,11 @@ module hipfort_rocsolver
       real(c_float),target :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_sposv_strided_batched_rank_0 = rocsolver_sposv_strided_batched_(handle,uplo,n, &
-        nrhs,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(myInfo),batch_count)
+        nrhs,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,myInfo,batch_count)
     end function
 
     function rocsolver_sposv_strided_batched_rank_1(handle,uplo,n,nrhs,A,lda,strideA,B,ldb, &
@@ -68131,11 +64899,11 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:) :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_sposv_strided_batched_rank_1 = rocsolver_sposv_strided_batched_(handle,uplo,n, &
-        nrhs,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(myInfo),batch_count)
+        nrhs,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,myInfo,batch_count)
     end function
 
     function rocsolver_sposv_strided_batched_full_rank(handle,uplo,n,nrhs,A,lda,strideA,B,ldb, &
@@ -68155,11 +64923,11 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_sposv_strided_batched_full_rank = rocsolver_sposv_strided_batched_(handle,uplo,n, &
-        nrhs,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(myInfo),batch_count)
+        nrhs,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,myInfo,batch_count)
     end function
 
     function rocsolver_dposv_strided_batched_rank_0(handle,uplo,n,nrhs,A,lda,strideA,B,ldb, &
@@ -68179,11 +64947,11 @@ module hipfort_rocsolver
       real(c_double),target :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dposv_strided_batched_rank_0 = rocsolver_dposv_strided_batched_(handle,uplo,n, &
-        nrhs,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(myInfo),batch_count)
+        nrhs,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,myInfo,batch_count)
     end function
 
     function rocsolver_dposv_strided_batched_rank_1(handle,uplo,n,nrhs,A,lda,strideA,B,ldb, &
@@ -68203,11 +64971,11 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:) :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dposv_strided_batched_rank_1 = rocsolver_dposv_strided_batched_(handle,uplo,n, &
-        nrhs,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(myInfo),batch_count)
+        nrhs,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,myInfo,batch_count)
     end function
 
     function rocsolver_dposv_strided_batched_full_rank(handle,uplo,n,nrhs,A,lda,strideA,B,ldb, &
@@ -68227,11 +64995,11 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dposv_strided_batched_full_rank = rocsolver_dposv_strided_batched_(handle,uplo,n, &
-        nrhs,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(myInfo),batch_count)
+        nrhs,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,myInfo,batch_count)
     end function
 
     function rocsolver_cposv_strided_batched_rank_0(handle,uplo,n,nrhs,A,lda,strideA,B,ldb, &
@@ -68251,11 +65019,11 @@ module hipfort_rocsolver
       complex(c_float_complex),target :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cposv_strided_batched_rank_0 = rocsolver_cposv_strided_batched_(handle,uplo,n, &
-        nrhs,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(myInfo),batch_count)
+        nrhs,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,myInfo,batch_count)
     end function
 
     function rocsolver_cposv_strided_batched_rank_1(handle,uplo,n,nrhs,A,lda,strideA,B,ldb, &
@@ -68275,11 +65043,11 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:) :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cposv_strided_batched_rank_1 = rocsolver_cposv_strided_batched_(handle,uplo,n, &
-        nrhs,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(myInfo),batch_count)
+        nrhs,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,myInfo,batch_count)
     end function
 
     function rocsolver_cposv_strided_batched_full_rank(handle,uplo,n,nrhs,A,lda,strideA,B,ldb, &
@@ -68299,11 +65067,11 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cposv_strided_batched_full_rank = rocsolver_cposv_strided_batched_(handle,uplo,n, &
-        nrhs,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(myInfo),batch_count)
+        nrhs,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,myInfo,batch_count)
     end function
 
     function rocsolver_zposv_strided_batched_rank_0(handle,uplo,n,nrhs,A,lda,strideA,B,ldb, &
@@ -68323,11 +65091,11 @@ module hipfort_rocsolver
       complex(c_double_complex),target :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zposv_strided_batched_rank_0 = rocsolver_zposv_strided_batched_(handle,uplo,n, &
-        nrhs,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(myInfo),batch_count)
+        nrhs,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,myInfo,batch_count)
     end function
 
     function rocsolver_zposv_strided_batched_rank_1(handle,uplo,n,nrhs,A,lda,strideA,B,ldb, &
@@ -68347,11 +65115,11 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:) :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zposv_strided_batched_rank_1 = rocsolver_zposv_strided_batched_(handle,uplo,n, &
-        nrhs,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(myInfo),batch_count)
+        nrhs,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,myInfo,batch_count)
     end function
 
     function rocsolver_zposv_strided_batched_full_rank(handle,uplo,n,nrhs,A,lda,strideA,B,ldb, &
@@ -68371,11 +65139,11 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zposv_strided_batched_full_rank = rocsolver_zposv_strided_batched_(handle,uplo,n, &
-        nrhs,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(myInfo),batch_count)
+        nrhs,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,myInfo,batch_count)
     end function
 
     function rocsolver_spotri_rank_0(handle,uplo,n,A,lda,myInfo)
@@ -68389,9 +65157,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_float),target :: A
       integer(c_int) :: lda
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_spotri_rank_0 = rocsolver_spotri_(handle,uplo,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_spotri_rank_0 = rocsolver_spotri_(handle,uplo,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_spotri_rank_1(handle,uplo,n,A,lda,myInfo)
@@ -68405,9 +65173,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_float),target,dimension(:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_spotri_rank_1 = rocsolver_spotri_(handle,uplo,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_spotri_rank_1 = rocsolver_spotri_(handle,uplo,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_spotri_full_rank(handle,uplo,n,A,lda,myInfo)
@@ -68421,9 +65189,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_spotri_full_rank = rocsolver_spotri_(handle,uplo,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_spotri_full_rank = rocsolver_spotri_(handle,uplo,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_dpotri_rank_0(handle,uplo,n,A,lda,myInfo)
@@ -68437,9 +65205,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_double),target :: A
       integer(c_int) :: lda
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_dpotri_rank_0 = rocsolver_dpotri_(handle,uplo,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_dpotri_rank_0 = rocsolver_dpotri_(handle,uplo,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_dpotri_rank_1(handle,uplo,n,A,lda,myInfo)
@@ -68453,9 +65221,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_double),target,dimension(:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_dpotri_rank_1 = rocsolver_dpotri_(handle,uplo,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_dpotri_rank_1 = rocsolver_dpotri_(handle,uplo,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_dpotri_full_rank(handle,uplo,n,A,lda,myInfo)
@@ -68469,9 +65237,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_dpotri_full_rank = rocsolver_dpotri_(handle,uplo,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_dpotri_full_rank = rocsolver_dpotri_(handle,uplo,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_cpotri_rank_0(handle,uplo,n,A,lda,myInfo)
@@ -68485,9 +65253,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_float_complex),target :: A
       integer(c_int) :: lda
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_cpotri_rank_0 = rocsolver_cpotri_(handle,uplo,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_cpotri_rank_0 = rocsolver_cpotri_(handle,uplo,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_cpotri_rank_1(handle,uplo,n,A,lda,myInfo)
@@ -68501,9 +65269,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_cpotri_rank_1 = rocsolver_cpotri_(handle,uplo,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_cpotri_rank_1 = rocsolver_cpotri_(handle,uplo,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_cpotri_full_rank(handle,uplo,n,A,lda,myInfo)
@@ -68517,9 +65285,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_cpotri_full_rank = rocsolver_cpotri_(handle,uplo,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_cpotri_full_rank = rocsolver_cpotri_(handle,uplo,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_zpotri_rank_0(handle,uplo,n,A,lda,myInfo)
@@ -68533,9 +65301,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_double_complex),target :: A
       integer(c_int) :: lda
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_zpotri_rank_0 = rocsolver_zpotri_(handle,uplo,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_zpotri_rank_0 = rocsolver_zpotri_(handle,uplo,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_zpotri_rank_1(handle,uplo,n,A,lda,myInfo)
@@ -68549,9 +65317,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_zpotri_rank_1 = rocsolver_zpotri_(handle,uplo,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_zpotri_rank_1 = rocsolver_zpotri_(handle,uplo,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_zpotri_full_rank(handle,uplo,n,A,lda,myInfo)
@@ -68565,225 +65333,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_zpotri_full_rank = rocsolver_zpotri_(handle,uplo,n,c_loc(A),lda,c_loc(myInfo))
-    end function
-
-    function rocsolver_spotri_batched_rank_0(handle,uplo,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_spotri_batched_rank_0
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_spotri_batched_rank_0 = rocsolver_spotri_batched_(handle,uplo,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_spotri_batched_rank_1(handle,uplo,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_spotri_batched_rank_1
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_spotri_batched_rank_1 = rocsolver_spotri_batched_(handle,uplo,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_spotri_batched_full_rank(handle,uplo,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_spotri_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_spotri_batched_full_rank = rocsolver_spotri_batched_(handle,uplo,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_dpotri_batched_rank_0(handle,uplo,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_dpotri_batched_rank_0
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_dpotri_batched_rank_0 = rocsolver_dpotri_batched_(handle,uplo,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_dpotri_batched_rank_1(handle,uplo,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_dpotri_batched_rank_1
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_dpotri_batched_rank_1 = rocsolver_dpotri_batched_(handle,uplo,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_dpotri_batched_full_rank(handle,uplo,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_dpotri_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_dpotri_batched_full_rank = rocsolver_dpotri_batched_(handle,uplo,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_cpotri_batched_rank_0(handle,uplo,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_cpotri_batched_rank_0
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_cpotri_batched_rank_0 = rocsolver_cpotri_batched_(handle,uplo,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_cpotri_batched_rank_1(handle,uplo,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_cpotri_batched_rank_1
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_cpotri_batched_rank_1 = rocsolver_cpotri_batched_(handle,uplo,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_cpotri_batched_full_rank(handle,uplo,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_cpotri_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_cpotri_batched_full_rank = rocsolver_cpotri_batched_(handle,uplo,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_zpotri_batched_rank_0(handle,uplo,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_zpotri_batched_rank_0
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_zpotri_batched_rank_0 = rocsolver_zpotri_batched_(handle,uplo,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_zpotri_batched_rank_1(handle,uplo,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_zpotri_batched_rank_1
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_zpotri_batched_rank_1 = rocsolver_zpotri_batched_(handle,uplo,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_zpotri_batched_full_rank(handle,uplo,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_zpotri_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_zpotri_batched_full_rank = rocsolver_zpotri_batched_(handle,uplo,n,A,lda, &
-        c_loc(myInfo),batch_count)
+      rocsolver_zpotri_full_rank = rocsolver_zpotri_(handle,uplo,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_spotri_strided_batched_rank_0(handle,uplo,n,A,lda,strideA,myInfo,batch_count)
@@ -68798,11 +65350,11 @@ module hipfort_rocsolver
       real(c_float),target :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_spotri_strided_batched_rank_0 = rocsolver_spotri_strided_batched_(handle,uplo,n, &
-        c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_spotri_strided_batched_rank_1(handle,uplo,n,A,lda,strideA,myInfo,batch_count)
@@ -68817,11 +65369,11 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_spotri_strided_batched_rank_1 = rocsolver_spotri_strided_batched_(handle,uplo,n, &
-        c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_spotri_strided_batched_full_rank(handle,uplo,n,A,lda,strideA,myInfo, &
@@ -68837,11 +65389,11 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_spotri_strided_batched_full_rank = rocsolver_spotri_strided_batched_(handle,uplo, &
-        n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_dpotri_strided_batched_rank_0(handle,uplo,n,A,lda,strideA,myInfo,batch_count)
@@ -68856,11 +65408,11 @@ module hipfort_rocsolver
       real(c_double),target :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dpotri_strided_batched_rank_0 = rocsolver_dpotri_strided_batched_(handle,uplo,n, &
-        c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_dpotri_strided_batched_rank_1(handle,uplo,n,A,lda,strideA,myInfo,batch_count)
@@ -68875,11 +65427,11 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dpotri_strided_batched_rank_1 = rocsolver_dpotri_strided_batched_(handle,uplo,n, &
-        c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_dpotri_strided_batched_full_rank(handle,uplo,n,A,lda,strideA,myInfo, &
@@ -68895,11 +65447,11 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dpotri_strided_batched_full_rank = rocsolver_dpotri_strided_batched_(handle,uplo, &
-        n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_cpotri_strided_batched_rank_0(handle,uplo,n,A,lda,strideA,myInfo,batch_count)
@@ -68914,11 +65466,11 @@ module hipfort_rocsolver
       complex(c_float_complex),target :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cpotri_strided_batched_rank_0 = rocsolver_cpotri_strided_batched_(handle,uplo,n, &
-        c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_cpotri_strided_batched_rank_1(handle,uplo,n,A,lda,strideA,myInfo,batch_count)
@@ -68933,11 +65485,11 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cpotri_strided_batched_rank_1 = rocsolver_cpotri_strided_batched_(handle,uplo,n, &
-        c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_cpotri_strided_batched_full_rank(handle,uplo,n,A,lda,strideA,myInfo, &
@@ -68953,11 +65505,11 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cpotri_strided_batched_full_rank = rocsolver_cpotri_strided_batched_(handle,uplo, &
-        n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_zpotri_strided_batched_rank_0(handle,uplo,n,A,lda,strideA,myInfo,batch_count)
@@ -68972,11 +65524,11 @@ module hipfort_rocsolver
       complex(c_double_complex),target :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zpotri_strided_batched_rank_0 = rocsolver_zpotri_strided_batched_(handle,uplo,n, &
-        c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_zpotri_strided_batched_rank_1(handle,uplo,n,A,lda,strideA,myInfo,batch_count)
@@ -68991,11 +65543,11 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zpotri_strided_batched_rank_1 = rocsolver_zpotri_strided_batched_(handle,uplo,n, &
-        c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_zpotri_strided_batched_full_rank(handle,uplo,n,A,lda,strideA,myInfo, &
@@ -69011,11 +65563,11 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zpotri_strided_batched_full_rank = rocsolver_zpotri_strided_batched_(handle,uplo, &
-        n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_sgesvd_rank_0(handle,left_svect,right_svect,m,n,A,lda,S,U,ldu,V,ldv,E, &
@@ -69039,10 +65591,10 @@ module hipfort_rocsolver
       integer(c_int) :: ldv
       real(c_float),target :: E
       integer(kind(rocblas_outofplace)) :: fast_alg
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_sgesvd_rank_0 = rocsolver_sgesvd_(handle,left_svect,right_svect,m,n,c_loc(A),lda, &
-        c_loc(S),c_loc(U),ldu,c_loc(V),ldv,c_loc(E),fast_alg,c_loc(myInfo))
+        c_loc(S),c_loc(U),ldu,c_loc(V),ldv,c_loc(E),fast_alg,myInfo)
     end function
 
     function rocsolver_sgesvd_rank_1(handle,left_svect,right_svect,m,n,A,lda,S,U,ldu,V,ldv,E, &
@@ -69066,10 +65618,10 @@ module hipfort_rocsolver
       integer(c_int) :: ldv
       real(c_float),target,dimension(:) :: E
       integer(kind(rocblas_outofplace)) :: fast_alg
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_sgesvd_rank_1 = rocsolver_sgesvd_(handle,left_svect,right_svect,m,n,c_loc(A),lda, &
-        c_loc(S),c_loc(U),ldu,c_loc(V),ldv,c_loc(E),fast_alg,c_loc(myInfo))
+        c_loc(S),c_loc(U),ldu,c_loc(V),ldv,c_loc(E),fast_alg,myInfo)
     end function
 
     function rocsolver_sgesvd_full_rank(handle,left_svect,right_svect,m,n,A,lda,S,U,ldu,V,ldv,E, &
@@ -69086,17 +65638,17 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: S
+      real(c_float),target,dimension(:) :: S
       real(c_float),target,dimension(:,:) :: U
       integer(c_int) :: ldu
       real(c_float),target,dimension(:,:) :: V
       integer(c_int) :: ldv
-      real(c_float),target,dimension(:,:) :: E
+      real(c_float),target,dimension(:) :: E
       integer(kind(rocblas_outofplace)) :: fast_alg
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_sgesvd_full_rank = rocsolver_sgesvd_(handle,left_svect,right_svect,m,n,c_loc(A), &
-        lda,c_loc(S),c_loc(U),ldu,c_loc(V),ldv,c_loc(E),fast_alg,c_loc(myInfo))
+        lda,c_loc(S),c_loc(U),ldu,c_loc(V),ldv,c_loc(E),fast_alg,myInfo)
     end function
 
     function rocsolver_dgesvd_rank_0(handle,left_svect,right_svect,m,n,A,lda,S,U,ldu,V,ldv,E, &
@@ -69120,10 +65672,10 @@ module hipfort_rocsolver
       integer(c_int) :: ldv
       real(c_double),target :: E
       integer(kind(rocblas_outofplace)) :: fast_alg
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_dgesvd_rank_0 = rocsolver_dgesvd_(handle,left_svect,right_svect,m,n,c_loc(A),lda, &
-        c_loc(S),c_loc(U),ldu,c_loc(V),ldv,c_loc(E),fast_alg,c_loc(myInfo))
+        c_loc(S),c_loc(U),ldu,c_loc(V),ldv,c_loc(E),fast_alg,myInfo)
     end function
 
     function rocsolver_dgesvd_rank_1(handle,left_svect,right_svect,m,n,A,lda,S,U,ldu,V,ldv,E, &
@@ -69147,10 +65699,10 @@ module hipfort_rocsolver
       integer(c_int) :: ldv
       real(c_double),target,dimension(:) :: E
       integer(kind(rocblas_outofplace)) :: fast_alg
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_dgesvd_rank_1 = rocsolver_dgesvd_(handle,left_svect,right_svect,m,n,c_loc(A),lda, &
-        c_loc(S),c_loc(U),ldu,c_loc(V),ldv,c_loc(E),fast_alg,c_loc(myInfo))
+        c_loc(S),c_loc(U),ldu,c_loc(V),ldv,c_loc(E),fast_alg,myInfo)
     end function
 
     function rocsolver_dgesvd_full_rank(handle,left_svect,right_svect,m,n,A,lda,S,U,ldu,V,ldv,E, &
@@ -69167,17 +65719,17 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: S
+      real(c_double),target,dimension(:) :: S
       real(c_double),target,dimension(:,:) :: U
       integer(c_int) :: ldu
       real(c_double),target,dimension(:,:) :: V
       integer(c_int) :: ldv
-      real(c_double),target,dimension(:,:) :: E
+      real(c_double),target,dimension(:) :: E
       integer(kind(rocblas_outofplace)) :: fast_alg
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_dgesvd_full_rank = rocsolver_dgesvd_(handle,left_svect,right_svect,m,n,c_loc(A), &
-        lda,c_loc(S),c_loc(U),ldu,c_loc(V),ldv,c_loc(E),fast_alg,c_loc(myInfo))
+        lda,c_loc(S),c_loc(U),ldu,c_loc(V),ldv,c_loc(E),fast_alg,myInfo)
     end function
 
     function rocsolver_cgesvd_rank_0(handle,left_svect,right_svect,m,n,A,lda,S,U,ldu,V,ldv,E, &
@@ -69201,10 +65753,10 @@ module hipfort_rocsolver
       integer(c_int) :: ldv
       real(c_float),target :: E
       integer(kind(rocblas_outofplace)) :: fast_alg
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_cgesvd_rank_0 = rocsolver_cgesvd_(handle,left_svect,right_svect,m,n,c_loc(A),lda, &
-        c_loc(S),c_loc(U),ldu,c_loc(V),ldv,c_loc(E),fast_alg,c_loc(myInfo))
+        c_loc(S),c_loc(U),ldu,c_loc(V),ldv,c_loc(E),fast_alg,myInfo)
     end function
 
     function rocsolver_cgesvd_rank_1(handle,left_svect,right_svect,m,n,A,lda,S,U,ldu,V,ldv,E, &
@@ -69228,10 +65780,10 @@ module hipfort_rocsolver
       integer(c_int) :: ldv
       real(c_float),target,dimension(:) :: E
       integer(kind(rocblas_outofplace)) :: fast_alg
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_cgesvd_rank_1 = rocsolver_cgesvd_(handle,left_svect,right_svect,m,n,c_loc(A),lda, &
-        c_loc(S),c_loc(U),ldu,c_loc(V),ldv,c_loc(E),fast_alg,c_loc(myInfo))
+        c_loc(S),c_loc(U),ldu,c_loc(V),ldv,c_loc(E),fast_alg,myInfo)
     end function
 
     function rocsolver_cgesvd_full_rank(handle,left_svect,right_svect,m,n,A,lda,S,U,ldu,V,ldv,E, &
@@ -69248,17 +65800,17 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: S
+      real(c_float),target,dimension(:) :: S
       complex(c_float_complex),target,dimension(:,:) :: U
       integer(c_int) :: ldu
       complex(c_float_complex),target,dimension(:,:) :: V
       integer(c_int) :: ldv
-      real(c_float),target,dimension(:,:) :: E
+      real(c_float),target,dimension(:) :: E
       integer(kind(rocblas_outofplace)) :: fast_alg
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_cgesvd_full_rank = rocsolver_cgesvd_(handle,left_svect,right_svect,m,n,c_loc(A), &
-        lda,c_loc(S),c_loc(U),ldu,c_loc(V),ldv,c_loc(E),fast_alg,c_loc(myInfo))
+        lda,c_loc(S),c_loc(U),ldu,c_loc(V),ldv,c_loc(E),fast_alg,myInfo)
     end function
 
     function rocsolver_zgesvd_rank_0(handle,left_svect,right_svect,m,n,A,lda,S,U,ldu,V,ldv,E, &
@@ -69282,10 +65834,10 @@ module hipfort_rocsolver
       integer(c_int) :: ldv
       real(c_double),target :: E
       integer(kind(rocblas_outofplace)) :: fast_alg
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_zgesvd_rank_0 = rocsolver_zgesvd_(handle,left_svect,right_svect,m,n,c_loc(A),lda, &
-        c_loc(S),c_loc(U),ldu,c_loc(V),ldv,c_loc(E),fast_alg,c_loc(myInfo))
+        c_loc(S),c_loc(U),ldu,c_loc(V),ldv,c_loc(E),fast_alg,myInfo)
     end function
 
     function rocsolver_zgesvd_rank_1(handle,left_svect,right_svect,m,n,A,lda,S,U,ldu,V,ldv,E, &
@@ -69309,10 +65861,10 @@ module hipfort_rocsolver
       integer(c_int) :: ldv
       real(c_double),target,dimension(:) :: E
       integer(kind(rocblas_outofplace)) :: fast_alg
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_zgesvd_rank_1 = rocsolver_zgesvd_(handle,left_svect,right_svect,m,n,c_loc(A),lda, &
-        c_loc(S),c_loc(U),ldu,c_loc(V),ldv,c_loc(E),fast_alg,c_loc(myInfo))
+        c_loc(S),c_loc(U),ldu,c_loc(V),ldv,c_loc(E),fast_alg,myInfo)
     end function
 
     function rocsolver_zgesvd_full_rank(handle,left_svect,right_svect,m,n,A,lda,S,U,ldu,V,ldv,E, &
@@ -69329,17 +65881,17 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: S
+      real(c_double),target,dimension(:) :: S
       complex(c_double_complex),target,dimension(:,:) :: U
       integer(c_int) :: ldu
       complex(c_double_complex),target,dimension(:,:) :: V
       integer(c_int) :: ldv
-      real(c_double),target,dimension(:,:) :: E
+      real(c_double),target,dimension(:) :: E
       integer(kind(rocblas_outofplace)) :: fast_alg
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_zgesvd_full_rank = rocsolver_zgesvd_(handle,left_svect,right_svect,m,n,c_loc(A), &
-        lda,c_loc(S),c_loc(U),ldu,c_loc(V),ldv,c_loc(E),fast_alg,c_loc(myInfo))
+        lda,c_loc(S),c_loc(U),ldu,c_loc(V),ldv,c_loc(E),fast_alg,myInfo)
     end function
 
     function rocsolver_sgesvd_batched_rank_0(handle,left_svect,right_svect,m,n,A,lda,S,strideS,U, &
@@ -69367,12 +65919,12 @@ module hipfort_rocsolver
       real(c_float),target :: E
       integer(c_int64_t) :: strideE
       integer(kind(rocblas_outofplace)) :: fast_alg
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_sgesvd_batched_rank_0 = rocsolver_sgesvd_batched_(handle,left_svect,right_svect,m, &
         n,A,lda,c_loc(S),strideS,c_loc(U),ldu,strideU,c_loc(V),ldv,strideV,c_loc(E),strideE, &
-        fast_alg,c_loc(myInfo),batch_count)
+        fast_alg,myInfo,batch_count)
     end function
 
     function rocsolver_sgesvd_batched_rank_1(handle,left_svect,right_svect,m,n,A,lda,S,strideS,U, &
@@ -69400,12 +65952,12 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
       integer(kind(rocblas_outofplace)) :: fast_alg
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_sgesvd_batched_rank_1 = rocsolver_sgesvd_batched_(handle,left_svect,right_svect,m, &
         n,A,lda,c_loc(S),strideS,c_loc(U),ldu,strideU,c_loc(V),ldv,strideV,c_loc(E),strideE, &
-        fast_alg,c_loc(myInfo),batch_count)
+        fast_alg,myInfo,batch_count)
     end function
 
     function rocsolver_sgesvd_batched_full_rank(handle,left_svect,right_svect,m,n,A,lda,S,strideS, &
@@ -69422,7 +65974,7 @@ module hipfort_rocsolver
       integer(c_int) :: n
       type(c_ptr) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: S
+      real(c_float),target,dimension(:) :: S
       integer(c_int64_t) :: strideS
       real(c_float),target,dimension(:,:) :: U
       integer(c_int) :: ldu
@@ -69430,15 +65982,15 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:,:) :: V
       integer(c_int) :: ldv
       integer(c_int64_t) :: strideV
-      real(c_float),target,dimension(:,:) :: E
+      real(c_float),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
       integer(kind(rocblas_outofplace)) :: fast_alg
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_sgesvd_batched_full_rank = rocsolver_sgesvd_batched_(handle,left_svect, &
         right_svect,m,n,A,lda,c_loc(S),strideS,c_loc(U),ldu,strideU,c_loc(V),ldv,strideV,c_loc(E), &
-        strideE,fast_alg,c_loc(myInfo),batch_count)
+        strideE,fast_alg,myInfo,batch_count)
     end function
 
     function rocsolver_dgesvd_batched_rank_0(handle,left_svect,right_svect,m,n,A,lda,S,strideS,U, &
@@ -69466,12 +66018,12 @@ module hipfort_rocsolver
       real(c_double),target :: E
       integer(c_int64_t) :: strideE
       integer(kind(rocblas_outofplace)) :: fast_alg
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dgesvd_batched_rank_0 = rocsolver_dgesvd_batched_(handle,left_svect,right_svect,m, &
         n,A,lda,c_loc(S),strideS,c_loc(U),ldu,strideU,c_loc(V),ldv,strideV,c_loc(E),strideE, &
-        fast_alg,c_loc(myInfo),batch_count)
+        fast_alg,myInfo,batch_count)
     end function
 
     function rocsolver_dgesvd_batched_rank_1(handle,left_svect,right_svect,m,n,A,lda,S,strideS,U, &
@@ -69499,12 +66051,12 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
       integer(kind(rocblas_outofplace)) :: fast_alg
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dgesvd_batched_rank_1 = rocsolver_dgesvd_batched_(handle,left_svect,right_svect,m, &
         n,A,lda,c_loc(S),strideS,c_loc(U),ldu,strideU,c_loc(V),ldv,strideV,c_loc(E),strideE, &
-        fast_alg,c_loc(myInfo),batch_count)
+        fast_alg,myInfo,batch_count)
     end function
 
     function rocsolver_dgesvd_batched_full_rank(handle,left_svect,right_svect,m,n,A,lda,S,strideS, &
@@ -69521,7 +66073,7 @@ module hipfort_rocsolver
       integer(c_int) :: n
       type(c_ptr) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: S
+      real(c_double),target,dimension(:) :: S
       integer(c_int64_t) :: strideS
       real(c_double),target,dimension(:,:) :: U
       integer(c_int) :: ldu
@@ -69529,15 +66081,15 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:,:) :: V
       integer(c_int) :: ldv
       integer(c_int64_t) :: strideV
-      real(c_double),target,dimension(:,:) :: E
+      real(c_double),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
       integer(kind(rocblas_outofplace)) :: fast_alg
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dgesvd_batched_full_rank = rocsolver_dgesvd_batched_(handle,left_svect, &
         right_svect,m,n,A,lda,c_loc(S),strideS,c_loc(U),ldu,strideU,c_loc(V),ldv,strideV,c_loc(E), &
-        strideE,fast_alg,c_loc(myInfo),batch_count)
+        strideE,fast_alg,myInfo,batch_count)
     end function
 
     function rocsolver_cgesvd_batched_rank_0(handle,left_svect,right_svect,m,n,A,lda,S,strideS,U, &
@@ -69565,12 +66117,12 @@ module hipfort_rocsolver
       real(c_float),target :: E
       integer(c_int64_t) :: strideE
       integer(kind(rocblas_outofplace)) :: fast_alg
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cgesvd_batched_rank_0 = rocsolver_cgesvd_batched_(handle,left_svect,right_svect,m, &
         n,A,lda,c_loc(S),strideS,c_loc(U),ldu,strideU,c_loc(V),ldv,strideV,c_loc(E),strideE, &
-        fast_alg,c_loc(myInfo),batch_count)
+        fast_alg,myInfo,batch_count)
     end function
 
     function rocsolver_cgesvd_batched_rank_1(handle,left_svect,right_svect,m,n,A,lda,S,strideS,U, &
@@ -69598,12 +66150,12 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
       integer(kind(rocblas_outofplace)) :: fast_alg
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cgesvd_batched_rank_1 = rocsolver_cgesvd_batched_(handle,left_svect,right_svect,m, &
         n,A,lda,c_loc(S),strideS,c_loc(U),ldu,strideU,c_loc(V),ldv,strideV,c_loc(E),strideE, &
-        fast_alg,c_loc(myInfo),batch_count)
+        fast_alg,myInfo,batch_count)
     end function
 
     function rocsolver_cgesvd_batched_full_rank(handle,left_svect,right_svect,m,n,A,lda,S,strideS, &
@@ -69620,7 +66172,7 @@ module hipfort_rocsolver
       integer(c_int) :: n
       type(c_ptr) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: S
+      real(c_float),target,dimension(:) :: S
       integer(c_int64_t) :: strideS
       complex(c_float_complex),target,dimension(:,:) :: U
       integer(c_int) :: ldu
@@ -69628,15 +66180,15 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:,:) :: V
       integer(c_int) :: ldv
       integer(c_int64_t) :: strideV
-      real(c_float),target,dimension(:,:) :: E
+      real(c_float),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
       integer(kind(rocblas_outofplace)) :: fast_alg
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cgesvd_batched_full_rank = rocsolver_cgesvd_batched_(handle,left_svect, &
         right_svect,m,n,A,lda,c_loc(S),strideS,c_loc(U),ldu,strideU,c_loc(V),ldv,strideV,c_loc(E), &
-        strideE,fast_alg,c_loc(myInfo),batch_count)
+        strideE,fast_alg,myInfo,batch_count)
     end function
 
     function rocsolver_zgesvd_batched_rank_0(handle,left_svect,right_svect,m,n,A,lda,S,strideS,U, &
@@ -69664,12 +66216,12 @@ module hipfort_rocsolver
       real(c_double),target :: E
       integer(c_int64_t) :: strideE
       integer(kind(rocblas_outofplace)) :: fast_alg
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zgesvd_batched_rank_0 = rocsolver_zgesvd_batched_(handle,left_svect,right_svect,m, &
         n,A,lda,c_loc(S),strideS,c_loc(U),ldu,strideU,c_loc(V),ldv,strideV,c_loc(E),strideE, &
-        fast_alg,c_loc(myInfo),batch_count)
+        fast_alg,myInfo,batch_count)
     end function
 
     function rocsolver_zgesvd_batched_rank_1(handle,left_svect,right_svect,m,n,A,lda,S,strideS,U, &
@@ -69697,12 +66249,12 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
       integer(kind(rocblas_outofplace)) :: fast_alg
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zgesvd_batched_rank_1 = rocsolver_zgesvd_batched_(handle,left_svect,right_svect,m, &
         n,A,lda,c_loc(S),strideS,c_loc(U),ldu,strideU,c_loc(V),ldv,strideV,c_loc(E),strideE, &
-        fast_alg,c_loc(myInfo),batch_count)
+        fast_alg,myInfo,batch_count)
     end function
 
     function rocsolver_zgesvd_batched_full_rank(handle,left_svect,right_svect,m,n,A,lda,S,strideS, &
@@ -69719,7 +66271,7 @@ module hipfort_rocsolver
       integer(c_int) :: n
       type(c_ptr) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: S
+      real(c_double),target,dimension(:) :: S
       integer(c_int64_t) :: strideS
       complex(c_double_complex),target,dimension(:,:) :: U
       integer(c_int) :: ldu
@@ -69727,15 +66279,15 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:,:) :: V
       integer(c_int) :: ldv
       integer(c_int64_t) :: strideV
-      real(c_double),target,dimension(:,:) :: E
+      real(c_double),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
       integer(kind(rocblas_outofplace)) :: fast_alg
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zgesvd_batched_full_rank = rocsolver_zgesvd_batched_(handle,left_svect, &
         right_svect,m,n,A,lda,c_loc(S),strideS,c_loc(U),ldu,strideU,c_loc(V),ldv,strideV,c_loc(E), &
-        strideE,fast_alg,c_loc(myInfo),batch_count)
+        strideE,fast_alg,myInfo,batch_count)
     end function
 
     function rocsolver_sgesvd_strided_batched_rank_0(handle,left_svect,right_svect,m,n,A,lda, &
@@ -69764,12 +66316,12 @@ module hipfort_rocsolver
       real(c_float),target :: E
       integer(c_int64_t) :: strideE
       integer(kind(rocblas_outofplace)) :: fast_alg
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_sgesvd_strided_batched_rank_0 = rocsolver_sgesvd_strided_batched_(handle, &
         left_svect,right_svect,m,n,c_loc(A),lda,strideA,c_loc(S),strideS,c_loc(U),ldu,strideU, &
-        c_loc(V),ldv,strideV,c_loc(E),strideE,fast_alg,c_loc(myInfo),batch_count)
+        c_loc(V),ldv,strideV,c_loc(E),strideE,fast_alg,myInfo,batch_count)
     end function
 
     function rocsolver_sgesvd_strided_batched_rank_1(handle,left_svect,right_svect,m,n,A,lda, &
@@ -69798,12 +66350,12 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
       integer(kind(rocblas_outofplace)) :: fast_alg
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_sgesvd_strided_batched_rank_1 = rocsolver_sgesvd_strided_batched_(handle, &
         left_svect,right_svect,m,n,c_loc(A),lda,strideA,c_loc(S),strideS,c_loc(U),ldu,strideU, &
-        c_loc(V),ldv,strideV,c_loc(E),strideE,fast_alg,c_loc(myInfo),batch_count)
+        c_loc(V),ldv,strideV,c_loc(E),strideE,fast_alg,myInfo,batch_count)
     end function
 
     function rocsolver_sgesvd_strided_batched_full_rank(handle,left_svect,right_svect,m,n,A,lda, &
@@ -69821,7 +66373,7 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_float),target,dimension(:,:) :: S
+      real(c_float),target,dimension(:) :: S
       integer(c_int64_t) :: strideS
       real(c_float),target,dimension(:,:) :: U
       integer(c_int) :: ldu
@@ -69829,15 +66381,15 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:,:) :: V
       integer(c_int) :: ldv
       integer(c_int64_t) :: strideV
-      real(c_float),target,dimension(:,:) :: E
+      real(c_float),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
       integer(kind(rocblas_outofplace)) :: fast_alg
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_sgesvd_strided_batched_full_rank = rocsolver_sgesvd_strided_batched_(handle, &
         left_svect,right_svect,m,n,c_loc(A),lda,strideA,c_loc(S),strideS,c_loc(U),ldu,strideU, &
-        c_loc(V),ldv,strideV,c_loc(E),strideE,fast_alg,c_loc(myInfo),batch_count)
+        c_loc(V),ldv,strideV,c_loc(E),strideE,fast_alg,myInfo,batch_count)
     end function
 
     function rocsolver_dgesvd_strided_batched_rank_0(handle,left_svect,right_svect,m,n,A,lda, &
@@ -69866,12 +66418,12 @@ module hipfort_rocsolver
       real(c_double),target :: E
       integer(c_int64_t) :: strideE
       integer(kind(rocblas_outofplace)) :: fast_alg
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dgesvd_strided_batched_rank_0 = rocsolver_dgesvd_strided_batched_(handle, &
         left_svect,right_svect,m,n,c_loc(A),lda,strideA,c_loc(S),strideS,c_loc(U),ldu,strideU, &
-        c_loc(V),ldv,strideV,c_loc(E),strideE,fast_alg,c_loc(myInfo),batch_count)
+        c_loc(V),ldv,strideV,c_loc(E),strideE,fast_alg,myInfo,batch_count)
     end function
 
     function rocsolver_dgesvd_strided_batched_rank_1(handle,left_svect,right_svect,m,n,A,lda, &
@@ -69900,12 +66452,12 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
       integer(kind(rocblas_outofplace)) :: fast_alg
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dgesvd_strided_batched_rank_1 = rocsolver_dgesvd_strided_batched_(handle, &
         left_svect,right_svect,m,n,c_loc(A),lda,strideA,c_loc(S),strideS,c_loc(U),ldu,strideU, &
-        c_loc(V),ldv,strideV,c_loc(E),strideE,fast_alg,c_loc(myInfo),batch_count)
+        c_loc(V),ldv,strideV,c_loc(E),strideE,fast_alg,myInfo,batch_count)
     end function
 
     function rocsolver_dgesvd_strided_batched_full_rank(handle,left_svect,right_svect,m,n,A,lda, &
@@ -69923,7 +66475,7 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_double),target,dimension(:,:) :: S
+      real(c_double),target,dimension(:) :: S
       integer(c_int64_t) :: strideS
       real(c_double),target,dimension(:,:) :: U
       integer(c_int) :: ldu
@@ -69931,15 +66483,15 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:,:) :: V
       integer(c_int) :: ldv
       integer(c_int64_t) :: strideV
-      real(c_double),target,dimension(:,:) :: E
+      real(c_double),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
       integer(kind(rocblas_outofplace)) :: fast_alg
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dgesvd_strided_batched_full_rank = rocsolver_dgesvd_strided_batched_(handle, &
         left_svect,right_svect,m,n,c_loc(A),lda,strideA,c_loc(S),strideS,c_loc(U),ldu,strideU, &
-        c_loc(V),ldv,strideV,c_loc(E),strideE,fast_alg,c_loc(myInfo),batch_count)
+        c_loc(V),ldv,strideV,c_loc(E),strideE,fast_alg,myInfo,batch_count)
     end function
 
     function rocsolver_cgesvd_strided_batched_rank_0(handle,left_svect,right_svect,m,n,A,lda, &
@@ -69968,12 +66520,12 @@ module hipfort_rocsolver
       real(c_float),target :: E
       integer(c_int64_t) :: strideE
       integer(kind(rocblas_outofplace)) :: fast_alg
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cgesvd_strided_batched_rank_0 = rocsolver_cgesvd_strided_batched_(handle, &
         left_svect,right_svect,m,n,c_loc(A),lda,strideA,c_loc(S),strideS,c_loc(U),ldu,strideU, &
-        c_loc(V),ldv,strideV,c_loc(E),strideE,fast_alg,c_loc(myInfo),batch_count)
+        c_loc(V),ldv,strideV,c_loc(E),strideE,fast_alg,myInfo,batch_count)
     end function
 
     function rocsolver_cgesvd_strided_batched_rank_1(handle,left_svect,right_svect,m,n,A,lda, &
@@ -70002,12 +66554,12 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
       integer(kind(rocblas_outofplace)) :: fast_alg
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cgesvd_strided_batched_rank_1 = rocsolver_cgesvd_strided_batched_(handle, &
         left_svect,right_svect,m,n,c_loc(A),lda,strideA,c_loc(S),strideS,c_loc(U),ldu,strideU, &
-        c_loc(V),ldv,strideV,c_loc(E),strideE,fast_alg,c_loc(myInfo),batch_count)
+        c_loc(V),ldv,strideV,c_loc(E),strideE,fast_alg,myInfo,batch_count)
     end function
 
     function rocsolver_cgesvd_strided_batched_full_rank(handle,left_svect,right_svect,m,n,A,lda, &
@@ -70025,7 +66577,7 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_float),target,dimension(:,:) :: S
+      real(c_float),target,dimension(:) :: S
       integer(c_int64_t) :: strideS
       complex(c_float_complex),target,dimension(:,:) :: U
       integer(c_int) :: ldu
@@ -70033,15 +66585,15 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:,:) :: V
       integer(c_int) :: ldv
       integer(c_int64_t) :: strideV
-      real(c_float),target,dimension(:,:) :: E
+      real(c_float),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
       integer(kind(rocblas_outofplace)) :: fast_alg
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cgesvd_strided_batched_full_rank = rocsolver_cgesvd_strided_batched_(handle, &
         left_svect,right_svect,m,n,c_loc(A),lda,strideA,c_loc(S),strideS,c_loc(U),ldu,strideU, &
-        c_loc(V),ldv,strideV,c_loc(E),strideE,fast_alg,c_loc(myInfo),batch_count)
+        c_loc(V),ldv,strideV,c_loc(E),strideE,fast_alg,myInfo,batch_count)
     end function
 
     function rocsolver_zgesvd_strided_batched_rank_0(handle,left_svect,right_svect,m,n,A,lda, &
@@ -70070,12 +66622,12 @@ module hipfort_rocsolver
       real(c_double),target :: E
       integer(c_int64_t) :: strideE
       integer(kind(rocblas_outofplace)) :: fast_alg
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zgesvd_strided_batched_rank_0 = rocsolver_zgesvd_strided_batched_(handle, &
         left_svect,right_svect,m,n,c_loc(A),lda,strideA,c_loc(S),strideS,c_loc(U),ldu,strideU, &
-        c_loc(V),ldv,strideV,c_loc(E),strideE,fast_alg,c_loc(myInfo),batch_count)
+        c_loc(V),ldv,strideV,c_loc(E),strideE,fast_alg,myInfo,batch_count)
     end function
 
     function rocsolver_zgesvd_strided_batched_rank_1(handle,left_svect,right_svect,m,n,A,lda, &
@@ -70104,12 +66656,12 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
       integer(kind(rocblas_outofplace)) :: fast_alg
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zgesvd_strided_batched_rank_1 = rocsolver_zgesvd_strided_batched_(handle, &
         left_svect,right_svect,m,n,c_loc(A),lda,strideA,c_loc(S),strideS,c_loc(U),ldu,strideU, &
-        c_loc(V),ldv,strideV,c_loc(E),strideE,fast_alg,c_loc(myInfo),batch_count)
+        c_loc(V),ldv,strideV,c_loc(E),strideE,fast_alg,myInfo,batch_count)
     end function
 
     function rocsolver_zgesvd_strided_batched_full_rank(handle,left_svect,right_svect,m,n,A,lda, &
@@ -70127,7 +66679,7 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_double),target,dimension(:,:) :: S
+      real(c_double),target,dimension(:) :: S
       integer(c_int64_t) :: strideS
       complex(c_double_complex),target,dimension(:,:) :: U
       integer(c_int) :: ldu
@@ -70135,15 +66687,15 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:,:) :: V
       integer(c_int) :: ldv
       integer(c_int64_t) :: strideV
-      real(c_double),target,dimension(:,:) :: E
+      real(c_double),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
       integer(kind(rocblas_outofplace)) :: fast_alg
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zgesvd_strided_batched_full_rank = rocsolver_zgesvd_strided_batched_(handle, &
         left_svect,right_svect,m,n,c_loc(A),lda,strideA,c_loc(S),strideS,c_loc(U),ldu,strideU, &
-        c_loc(V),ldv,strideV,c_loc(E),strideE,fast_alg,c_loc(myInfo),batch_count)
+        c_loc(V),ldv,strideV,c_loc(E),strideE,fast_alg,myInfo,batch_count)
     end function
 
     function rocsolver_ssytd2_rank_0(handle,uplo,n,A,lda,D,E,tau)
@@ -70193,8 +66745,8 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: D
-      real(c_float),target,dimension(:,:) :: E
+      real(c_float),target,dimension(:) :: D
+      real(c_float),target,dimension(:) :: E
       real(c_float) :: tau
       !
       rocsolver_ssytd2_full_rank = rocsolver_ssytd2_(handle,uplo,n,c_loc(A),lda,c_loc(D),c_loc(E), &
@@ -70248,8 +66800,8 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: D
-      real(c_double),target,dimension(:,:) :: E
+      real(c_double),target,dimension(:) :: D
+      real(c_double),target,dimension(:) :: E
       real(c_double) :: tau
       !
       rocsolver_dsytd2_full_rank = rocsolver_dsytd2_(handle,uplo,n,c_loc(A),lda,c_loc(D),c_loc(E), &
@@ -70303,8 +66855,8 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: D
-      real(c_float),target,dimension(:,:) :: E
+      real(c_float),target,dimension(:) :: D
+      real(c_float),target,dimension(:) :: E
       complex(c_float_complex) :: tau
       !
       rocsolver_chetd2_full_rank = rocsolver_chetd2_(handle,uplo,n,c_loc(A),lda,c_loc(D),c_loc(E), &
@@ -70358,8 +66910,8 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: D
-      real(c_double),target,dimension(:,:) :: E
+      real(c_double),target,dimension(:) :: D
+      real(c_double),target,dimension(:) :: E
       complex(c_double_complex) :: tau
       !
       rocsolver_zhetd2_full_rank = rocsolver_zhetd2_(handle,uplo,n,c_loc(A),lda,c_loc(D),c_loc(E), &
@@ -70414,30 +66966,6 @@ module hipfort_rocsolver
         strideD,c_loc(E),strideE,tau,strideP,batch_count)
     end function
 
-    function rocsolver_ssytd2_batched_full_rank(handle,uplo,n,A,lda,D,strideD,E,strideE,tau, &
-        strideP,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_ssytd2_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: D
-      integer(c_int64_t) :: strideD
-      real(c_float),target,dimension(:,:) :: E
-      integer(c_int64_t) :: strideE
-      real(c_float) :: tau
-      integer(c_int64_t) :: strideP
-      integer(c_int) :: batch_count
-      !
-      rocsolver_ssytd2_batched_full_rank = rocsolver_ssytd2_batched_(handle,uplo,n,A,lda,c_loc(D), &
-        strideD,c_loc(E),strideE,tau,strideP,batch_count)
-    end function
-
     function rocsolver_dsytd2_batched_rank_0(handle,uplo,n,A,lda,D,strideD,E,strideE,tau,strideP, &
         batch_count)
       use iso_c_binding
@@ -70483,30 +67011,6 @@ module hipfort_rocsolver
       integer(c_int) :: batch_count
       !
       rocsolver_dsytd2_batched_rank_1 = rocsolver_dsytd2_batched_(handle,uplo,n,A,lda,c_loc(D), &
-        strideD,c_loc(E),strideE,tau,strideP,batch_count)
-    end function
-
-    function rocsolver_dsytd2_batched_full_rank(handle,uplo,n,A,lda,D,strideD,E,strideE,tau, &
-        strideP,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_dsytd2_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: D
-      integer(c_int64_t) :: strideD
-      real(c_double),target,dimension(:,:) :: E
-      integer(c_int64_t) :: strideE
-      real(c_double) :: tau
-      integer(c_int64_t) :: strideP
-      integer(c_int) :: batch_count
-      !
-      rocsolver_dsytd2_batched_full_rank = rocsolver_dsytd2_batched_(handle,uplo,n,A,lda,c_loc(D), &
         strideD,c_loc(E),strideE,tau,strideP,batch_count)
     end function
 
@@ -70558,30 +67062,6 @@ module hipfort_rocsolver
         strideD,c_loc(E),strideE,tau,strideP,batch_count)
     end function
 
-    function rocsolver_chetd2_batched_full_rank(handle,uplo,n,A,lda,D,strideD,E,strideE,tau, &
-        strideP,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_chetd2_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: D
-      integer(c_int64_t) :: strideD
-      real(c_float),target,dimension(:,:) :: E
-      integer(c_int64_t) :: strideE
-      complex(c_float_complex) :: tau
-      integer(c_int64_t) :: strideP
-      integer(c_int) :: batch_count
-      !
-      rocsolver_chetd2_batched_full_rank = rocsolver_chetd2_batched_(handle,uplo,n,A,lda,c_loc(D), &
-        strideD,c_loc(E),strideE,tau,strideP,batch_count)
-    end function
-
     function rocsolver_zhetd2_batched_rank_0(handle,uplo,n,A,lda,D,strideD,E,strideE,tau,strideP, &
         batch_count)
       use iso_c_binding
@@ -70627,30 +67107,6 @@ module hipfort_rocsolver
       integer(c_int) :: batch_count
       !
       rocsolver_zhetd2_batched_rank_1 = rocsolver_zhetd2_batched_(handle,uplo,n,A,lda,c_loc(D), &
-        strideD,c_loc(E),strideE,tau,strideP,batch_count)
-    end function
-
-    function rocsolver_zhetd2_batched_full_rank(handle,uplo,n,A,lda,D,strideD,E,strideE,tau, &
-        strideP,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_zhetd2_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: D
-      integer(c_int64_t) :: strideD
-      real(c_double),target,dimension(:,:) :: E
-      integer(c_int64_t) :: strideE
-      complex(c_double_complex) :: tau
-      integer(c_int64_t) :: strideP
-      integer(c_int) :: batch_count
-      !
-      rocsolver_zhetd2_batched_full_rank = rocsolver_zhetd2_batched_(handle,uplo,n,A,lda,c_loc(D), &
         strideD,c_loc(E),strideE,tau,strideP,batch_count)
     end function
 
@@ -70717,9 +67173,9 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_float),target,dimension(:,:) :: D
+      real(c_float),target,dimension(:) :: D
       integer(c_int64_t) :: strideD
-      real(c_float),target,dimension(:,:) :: E
+      real(c_float),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
       real(c_float) :: tau
       integer(c_int64_t) :: strideP
@@ -70792,9 +67248,9 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_double),target,dimension(:,:) :: D
+      real(c_double),target,dimension(:) :: D
       integer(c_int64_t) :: strideD
-      real(c_double),target,dimension(:,:) :: E
+      real(c_double),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
       real(c_double) :: tau
       integer(c_int64_t) :: strideP
@@ -70867,9 +67323,9 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_float),target,dimension(:,:) :: D
+      real(c_float),target,dimension(:) :: D
       integer(c_int64_t) :: strideD
-      real(c_float),target,dimension(:,:) :: E
+      real(c_float),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
       complex(c_float_complex) :: tau
       integer(c_int64_t) :: strideP
@@ -70942,9 +67398,9 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_double),target,dimension(:,:) :: D
+      real(c_double),target,dimension(:) :: D
       integer(c_int64_t) :: strideD
-      real(c_double),target,dimension(:,:) :: E
+      real(c_double),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
       complex(c_double_complex) :: tau
       integer(c_int64_t) :: strideP
@@ -71001,8 +67457,8 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: D
-      real(c_float),target,dimension(:,:) :: E
+      real(c_float),target,dimension(:) :: D
+      real(c_float),target,dimension(:) :: E
       real(c_float) :: tau
       !
       rocsolver_ssytrd_full_rank = rocsolver_ssytrd_(handle,uplo,n,c_loc(A),lda,c_loc(D),c_loc(E), &
@@ -71056,8 +67512,8 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: D
-      real(c_double),target,dimension(:,:) :: E
+      real(c_double),target,dimension(:) :: D
+      real(c_double),target,dimension(:) :: E
       real(c_double) :: tau
       !
       rocsolver_dsytrd_full_rank = rocsolver_dsytrd_(handle,uplo,n,c_loc(A),lda,c_loc(D),c_loc(E), &
@@ -71111,8 +67567,8 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: D
-      real(c_float),target,dimension(:,:) :: E
+      real(c_float),target,dimension(:) :: D
+      real(c_float),target,dimension(:) :: E
       complex(c_float_complex) :: tau
       !
       rocsolver_chetrd_full_rank = rocsolver_chetrd_(handle,uplo,n,c_loc(A),lda,c_loc(D),c_loc(E), &
@@ -71166,8 +67622,8 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: D
-      real(c_double),target,dimension(:,:) :: E
+      real(c_double),target,dimension(:) :: D
+      real(c_double),target,dimension(:) :: E
       complex(c_double_complex) :: tau
       !
       rocsolver_zhetrd_full_rank = rocsolver_zhetrd_(handle,uplo,n,c_loc(A),lda,c_loc(D),c_loc(E), &
@@ -71222,30 +67678,6 @@ module hipfort_rocsolver
         strideD,c_loc(E),strideE,tau,strideP,batch_count)
     end function
 
-    function rocsolver_ssytrd_batched_full_rank(handle,uplo,n,A,lda,D,strideD,E,strideE,tau, &
-        strideP,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_ssytrd_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: D
-      integer(c_int64_t) :: strideD
-      real(c_float),target,dimension(:,:) :: E
-      integer(c_int64_t) :: strideE
-      real(c_float) :: tau
-      integer(c_int64_t) :: strideP
-      integer(c_int) :: batch_count
-      !
-      rocsolver_ssytrd_batched_full_rank = rocsolver_ssytrd_batched_(handle,uplo,n,A,lda,c_loc(D), &
-        strideD,c_loc(E),strideE,tau,strideP,batch_count)
-    end function
-
     function rocsolver_dsytrd_batched_rank_0(handle,uplo,n,A,lda,D,strideD,E,strideE,tau,strideP, &
         batch_count)
       use iso_c_binding
@@ -71291,30 +67723,6 @@ module hipfort_rocsolver
       integer(c_int) :: batch_count
       !
       rocsolver_dsytrd_batched_rank_1 = rocsolver_dsytrd_batched_(handle,uplo,n,A,lda,c_loc(D), &
-        strideD,c_loc(E),strideE,tau,strideP,batch_count)
-    end function
-
-    function rocsolver_dsytrd_batched_full_rank(handle,uplo,n,A,lda,D,strideD,E,strideE,tau, &
-        strideP,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_dsytrd_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: D
-      integer(c_int64_t) :: strideD
-      real(c_double),target,dimension(:,:) :: E
-      integer(c_int64_t) :: strideE
-      real(c_double) :: tau
-      integer(c_int64_t) :: strideP
-      integer(c_int) :: batch_count
-      !
-      rocsolver_dsytrd_batched_full_rank = rocsolver_dsytrd_batched_(handle,uplo,n,A,lda,c_loc(D), &
         strideD,c_loc(E),strideE,tau,strideP,batch_count)
     end function
 
@@ -71366,30 +67774,6 @@ module hipfort_rocsolver
         strideD,c_loc(E),strideE,tau,strideP,batch_count)
     end function
 
-    function rocsolver_chetrd_batched_full_rank(handle,uplo,n,A,lda,D,strideD,E,strideE,tau, &
-        strideP,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_chetrd_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: D
-      integer(c_int64_t) :: strideD
-      real(c_float),target,dimension(:,:) :: E
-      integer(c_int64_t) :: strideE
-      complex(c_float_complex) :: tau
-      integer(c_int64_t) :: strideP
-      integer(c_int) :: batch_count
-      !
-      rocsolver_chetrd_batched_full_rank = rocsolver_chetrd_batched_(handle,uplo,n,A,lda,c_loc(D), &
-        strideD,c_loc(E),strideE,tau,strideP,batch_count)
-    end function
-
     function rocsolver_zhetrd_batched_rank_0(handle,uplo,n,A,lda,D,strideD,E,strideE,tau,strideP, &
         batch_count)
       use iso_c_binding
@@ -71435,30 +67819,6 @@ module hipfort_rocsolver
       integer(c_int) :: batch_count
       !
       rocsolver_zhetrd_batched_rank_1 = rocsolver_zhetrd_batched_(handle,uplo,n,A,lda,c_loc(D), &
-        strideD,c_loc(E),strideE,tau,strideP,batch_count)
-    end function
-
-    function rocsolver_zhetrd_batched_full_rank(handle,uplo,n,A,lda,D,strideD,E,strideE,tau, &
-        strideP,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_zhetrd_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: D
-      integer(c_int64_t) :: strideD
-      real(c_double),target,dimension(:,:) :: E
-      integer(c_int64_t) :: strideE
-      complex(c_double_complex) :: tau
-      integer(c_int64_t) :: strideP
-      integer(c_int) :: batch_count
-      !
-      rocsolver_zhetrd_batched_full_rank = rocsolver_zhetrd_batched_(handle,uplo,n,A,lda,c_loc(D), &
         strideD,c_loc(E),strideE,tau,strideP,batch_count)
     end function
 
@@ -71525,9 +67885,9 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_float),target,dimension(:,:) :: D
+      real(c_float),target,dimension(:) :: D
       integer(c_int64_t) :: strideD
-      real(c_float),target,dimension(:,:) :: E
+      real(c_float),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
       real(c_float) :: tau
       integer(c_int64_t) :: strideP
@@ -71600,9 +67960,9 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_double),target,dimension(:,:) :: D
+      real(c_double),target,dimension(:) :: D
       integer(c_int64_t) :: strideD
-      real(c_double),target,dimension(:,:) :: E
+      real(c_double),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
       real(c_double) :: tau
       integer(c_int64_t) :: strideP
@@ -71675,9 +68035,9 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_float),target,dimension(:,:) :: D
+      real(c_float),target,dimension(:) :: D
       integer(c_int64_t) :: strideD
-      real(c_float),target,dimension(:,:) :: E
+      real(c_float),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
       complex(c_float_complex) :: tau
       integer(c_int64_t) :: strideP
@@ -71750,9 +68110,9 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_double),target,dimension(:,:) :: D
+      real(c_double),target,dimension(:) :: D
       integer(c_int64_t) :: strideD
-      real(c_double),target,dimension(:,:) :: E
+      real(c_double),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
       complex(c_double_complex) :: tau
       integer(c_int64_t) :: strideP
@@ -72760,10 +69120,10 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       real(c_float),target :: D
       real(c_float),target :: E
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_ssyev_rank_0 = rocsolver_ssyev_(handle,evect,uplo,n,c_loc(A),lda,c_loc(D), &
-        c_loc(E),c_loc(myInfo))
+        c_loc(E),myInfo)
     end function
 
     function rocsolver_ssyev_rank_1(handle,evect,uplo,n,A,lda,D,E,myInfo)
@@ -72780,10 +69140,10 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       real(c_float),target,dimension(:) :: D
       real(c_float),target,dimension(:) :: E
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_ssyev_rank_1 = rocsolver_ssyev_(handle,evect,uplo,n,c_loc(A),lda,c_loc(D), &
-        c_loc(E),c_loc(myInfo))
+        c_loc(E),myInfo)
     end function
 
     function rocsolver_ssyev_full_rank(handle,evect,uplo,n,A,lda,D,E,myInfo)
@@ -72798,12 +69158,12 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: D
-      real(c_float),target,dimension(:,:) :: E
-      integer(c_int),target,dimension(:,:) :: myInfo
+      real(c_float),target,dimension(:) :: D
+      real(c_float),target,dimension(:) :: E
+      type(c_ptr) :: myInfo
       !
       rocsolver_ssyev_full_rank = rocsolver_ssyev_(handle,evect,uplo,n,c_loc(A),lda,c_loc(D), &
-        c_loc(E),c_loc(myInfo))
+        c_loc(E),myInfo)
     end function
 
     function rocsolver_dsyev_rank_0(handle,evect,uplo,n,A,lda,D,E,myInfo)
@@ -72820,10 +69180,10 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       real(c_double),target :: D
       real(c_double),target :: E
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_dsyev_rank_0 = rocsolver_dsyev_(handle,evect,uplo,n,c_loc(A),lda,c_loc(D), &
-        c_loc(E),c_loc(myInfo))
+        c_loc(E),myInfo)
     end function
 
     function rocsolver_dsyev_rank_1(handle,evect,uplo,n,A,lda,D,E,myInfo)
@@ -72840,10 +69200,10 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       real(c_double),target,dimension(:) :: D
       real(c_double),target,dimension(:) :: E
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_dsyev_rank_1 = rocsolver_dsyev_(handle,evect,uplo,n,c_loc(A),lda,c_loc(D), &
-        c_loc(E),c_loc(myInfo))
+        c_loc(E),myInfo)
     end function
 
     function rocsolver_dsyev_full_rank(handle,evect,uplo,n,A,lda,D,E,myInfo)
@@ -72858,12 +69218,12 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: D
-      real(c_double),target,dimension(:,:) :: E
-      integer(c_int),target,dimension(:,:) :: myInfo
+      real(c_double),target,dimension(:) :: D
+      real(c_double),target,dimension(:) :: E
+      type(c_ptr) :: myInfo
       !
       rocsolver_dsyev_full_rank = rocsolver_dsyev_(handle,evect,uplo,n,c_loc(A),lda,c_loc(D), &
-        c_loc(E),c_loc(myInfo))
+        c_loc(E),myInfo)
     end function
 
     function rocsolver_cheev_rank_0(handle,evect,uplo,n,A,lda,D,E,myInfo)
@@ -72880,10 +69240,10 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       real(c_float),target :: D
       real(c_float),target :: E
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_cheev_rank_0 = rocsolver_cheev_(handle,evect,uplo,n,c_loc(A),lda,c_loc(D), &
-        c_loc(E),c_loc(myInfo))
+        c_loc(E),myInfo)
     end function
 
     function rocsolver_cheev_rank_1(handle,evect,uplo,n,A,lda,D,E,myInfo)
@@ -72900,10 +69260,10 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       real(c_float),target,dimension(:) :: D
       real(c_float),target,dimension(:) :: E
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_cheev_rank_1 = rocsolver_cheev_(handle,evect,uplo,n,c_loc(A),lda,c_loc(D), &
-        c_loc(E),c_loc(myInfo))
+        c_loc(E),myInfo)
     end function
 
     function rocsolver_cheev_full_rank(handle,evect,uplo,n,A,lda,D,E,myInfo)
@@ -72918,12 +69278,12 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: D
-      real(c_float),target,dimension(:,:) :: E
-      integer(c_int),target,dimension(:,:) :: myInfo
+      real(c_float),target,dimension(:) :: D
+      real(c_float),target,dimension(:) :: E
+      type(c_ptr) :: myInfo
       !
       rocsolver_cheev_full_rank = rocsolver_cheev_(handle,evect,uplo,n,c_loc(A),lda,c_loc(D), &
-        c_loc(E),c_loc(myInfo))
+        c_loc(E),myInfo)
     end function
 
     function rocsolver_zheev_rank_0(handle,evect,uplo,n,A,lda,D,E,myInfo)
@@ -72940,10 +69300,10 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       real(c_double),target :: D
       real(c_double),target :: E
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_zheev_rank_0 = rocsolver_zheev_(handle,evect,uplo,n,c_loc(A),lda,c_loc(D), &
-        c_loc(E),c_loc(myInfo))
+        c_loc(E),myInfo)
     end function
 
     function rocsolver_zheev_rank_1(handle,evect,uplo,n,A,lda,D,E,myInfo)
@@ -72960,10 +69320,10 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       real(c_double),target,dimension(:) :: D
       real(c_double),target,dimension(:) :: E
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_zheev_rank_1 = rocsolver_zheev_(handle,evect,uplo,n,c_loc(A),lda,c_loc(D), &
-        c_loc(E),c_loc(myInfo))
+        c_loc(E),myInfo)
     end function
 
     function rocsolver_zheev_full_rank(handle,evect,uplo,n,A,lda,D,E,myInfo)
@@ -72978,12 +69338,12 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: D
-      real(c_double),target,dimension(:,:) :: E
-      integer(c_int),target,dimension(:,:) :: myInfo
+      real(c_double),target,dimension(:) :: D
+      real(c_double),target,dimension(:) :: E
+      type(c_ptr) :: myInfo
       !
       rocsolver_zheev_full_rank = rocsolver_zheev_(handle,evect,uplo,n,c_loc(A),lda,c_loc(D), &
-        c_loc(E),c_loc(myInfo))
+        c_loc(E),myInfo)
     end function
 
     function rocsolver_ssyev_batched_rank_0(handle,evect,uplo,n,A,lda,D,strideD,E,strideE,myInfo, &
@@ -73003,11 +69363,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_float),target :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_ssyev_batched_rank_0 = rocsolver_ssyev_batched_(handle,evect,uplo,n,A,lda, &
-        c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_ssyev_batched_rank_1(handle,evect,uplo,n,A,lda,D,strideD,E,strideE,myInfo, &
@@ -73027,35 +69387,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_float),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_ssyev_batched_rank_1 = rocsolver_ssyev_batched_(handle,evect,uplo,n,A,lda, &
-        c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_ssyev_batched_full_rank(handle,evect,uplo,n,A,lda,D,strideD,E,strideE, &
-        myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_ssyev_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_evect_original)) :: evect
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: D
-      integer(c_int64_t) :: strideD
-      real(c_float),target,dimension(:,:) :: E
-      integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_ssyev_batched_full_rank = rocsolver_ssyev_batched_(handle,evect,uplo,n,A,lda, &
-        c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_dsyev_batched_rank_0(handle,evect,uplo,n,A,lda,D,strideD,E,strideE,myInfo, &
@@ -73075,11 +69411,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_double),target :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dsyev_batched_rank_0 = rocsolver_dsyev_batched_(handle,evect,uplo,n,A,lda, &
-        c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_dsyev_batched_rank_1(handle,evect,uplo,n,A,lda,D,strideD,E,strideE,myInfo, &
@@ -73099,35 +69435,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_double),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dsyev_batched_rank_1 = rocsolver_dsyev_batched_(handle,evect,uplo,n,A,lda, &
-        c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_dsyev_batched_full_rank(handle,evect,uplo,n,A,lda,D,strideD,E,strideE, &
-        myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_dsyev_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_evect_original)) :: evect
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: D
-      integer(c_int64_t) :: strideD
-      real(c_double),target,dimension(:,:) :: E
-      integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_dsyev_batched_full_rank = rocsolver_dsyev_batched_(handle,evect,uplo,n,A,lda, &
-        c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_cheev_batched_rank_0(handle,evect,uplo,n,A,lda,D,strideD,E,strideE,myInfo, &
@@ -73147,11 +69459,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_float),target :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cheev_batched_rank_0 = rocsolver_cheev_batched_(handle,evect,uplo,n,A,lda, &
-        c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_cheev_batched_rank_1(handle,evect,uplo,n,A,lda,D,strideD,E,strideE,myInfo, &
@@ -73171,35 +69483,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_float),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cheev_batched_rank_1 = rocsolver_cheev_batched_(handle,evect,uplo,n,A,lda, &
-        c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_cheev_batched_full_rank(handle,evect,uplo,n,A,lda,D,strideD,E,strideE, &
-        myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_cheev_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_evect_original)) :: evect
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: D
-      integer(c_int64_t) :: strideD
-      real(c_float),target,dimension(:,:) :: E
-      integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_cheev_batched_full_rank = rocsolver_cheev_batched_(handle,evect,uplo,n,A,lda, &
-        c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_zheev_batched_rank_0(handle,evect,uplo,n,A,lda,D,strideD,E,strideE,myInfo, &
@@ -73219,11 +69507,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_double),target :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zheev_batched_rank_0 = rocsolver_zheev_batched_(handle,evect,uplo,n,A,lda, &
-        c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_zheev_batched_rank_1(handle,evect,uplo,n,A,lda,D,strideD,E,strideE,myInfo, &
@@ -73243,35 +69531,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_double),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zheev_batched_rank_1 = rocsolver_zheev_batched_(handle,evect,uplo,n,A,lda, &
-        c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_zheev_batched_full_rank(handle,evect,uplo,n,A,lda,D,strideD,E,strideE, &
-        myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_zheev_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_evect_original)) :: evect
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: D
-      integer(c_int64_t) :: strideD
-      real(c_double),target,dimension(:,:) :: E
-      integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_zheev_batched_full_rank = rocsolver_zheev_batched_(handle,evect,uplo,n,A,lda, &
-        c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_ssyev_strided_batched_rank_0(handle,evect,uplo,n,A,lda,strideA,D,strideD,E, &
@@ -73292,11 +69556,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_float),target :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_ssyev_strided_batched_rank_0 = rocsolver_ssyev_strided_batched_(handle,evect,uplo, &
-        n,c_loc(A),lda,strideA,c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        n,c_loc(A),lda,strideA,c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_ssyev_strided_batched_rank_1(handle,evect,uplo,n,A,lda,strideA,D,strideD,E, &
@@ -73317,11 +69581,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_float),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_ssyev_strided_batched_rank_1 = rocsolver_ssyev_strided_batched_(handle,evect,uplo, &
-        n,c_loc(A),lda,strideA,c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        n,c_loc(A),lda,strideA,c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_ssyev_strided_batched_full_rank(handle,evect,uplo,n,A,lda,strideA,D, &
@@ -73338,15 +69602,15 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_float),target,dimension(:,:) :: D
+      real(c_float),target,dimension(:) :: D
       integer(c_int64_t) :: strideD
-      real(c_float),target,dimension(:,:) :: E
+      real(c_float),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_ssyev_strided_batched_full_rank = rocsolver_ssyev_strided_batched_(handle,evect, &
-        uplo,n,c_loc(A),lda,strideA,c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        uplo,n,c_loc(A),lda,strideA,c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_dsyev_strided_batched_rank_0(handle,evect,uplo,n,A,lda,strideA,D,strideD,E, &
@@ -73367,11 +69631,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_double),target :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dsyev_strided_batched_rank_0 = rocsolver_dsyev_strided_batched_(handle,evect,uplo, &
-        n,c_loc(A),lda,strideA,c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        n,c_loc(A),lda,strideA,c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_dsyev_strided_batched_rank_1(handle,evect,uplo,n,A,lda,strideA,D,strideD,E, &
@@ -73392,11 +69656,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_double),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dsyev_strided_batched_rank_1 = rocsolver_dsyev_strided_batched_(handle,evect,uplo, &
-        n,c_loc(A),lda,strideA,c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        n,c_loc(A),lda,strideA,c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_dsyev_strided_batched_full_rank(handle,evect,uplo,n,A,lda,strideA,D, &
@@ -73413,15 +69677,15 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_double),target,dimension(:,:) :: D
+      real(c_double),target,dimension(:) :: D
       integer(c_int64_t) :: strideD
-      real(c_double),target,dimension(:,:) :: E
+      real(c_double),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dsyev_strided_batched_full_rank = rocsolver_dsyev_strided_batched_(handle,evect, &
-        uplo,n,c_loc(A),lda,strideA,c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        uplo,n,c_loc(A),lda,strideA,c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_cheev_strided_batched_rank_0(handle,evect,uplo,n,A,lda,strideA,D,strideD,E, &
@@ -73442,11 +69706,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_float),target :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cheev_strided_batched_rank_0 = rocsolver_cheev_strided_batched_(handle,evect,uplo, &
-        n,c_loc(A),lda,strideA,c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        n,c_loc(A),lda,strideA,c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_cheev_strided_batched_rank_1(handle,evect,uplo,n,A,lda,strideA,D,strideD,E, &
@@ -73467,11 +69731,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_float),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cheev_strided_batched_rank_1 = rocsolver_cheev_strided_batched_(handle,evect,uplo, &
-        n,c_loc(A),lda,strideA,c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        n,c_loc(A),lda,strideA,c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_cheev_strided_batched_full_rank(handle,evect,uplo,n,A,lda,strideA,D, &
@@ -73488,15 +69752,15 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_float),target,dimension(:,:) :: D
+      real(c_float),target,dimension(:) :: D
       integer(c_int64_t) :: strideD
-      real(c_float),target,dimension(:,:) :: E
+      real(c_float),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cheev_strided_batched_full_rank = rocsolver_cheev_strided_batched_(handle,evect, &
-        uplo,n,c_loc(A),lda,strideA,c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        uplo,n,c_loc(A),lda,strideA,c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_zheev_strided_batched_rank_0(handle,evect,uplo,n,A,lda,strideA,D,strideD,E, &
@@ -73517,11 +69781,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_double),target :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zheev_strided_batched_rank_0 = rocsolver_zheev_strided_batched_(handle,evect,uplo, &
-        n,c_loc(A),lda,strideA,c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        n,c_loc(A),lda,strideA,c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_zheev_strided_batched_rank_1(handle,evect,uplo,n,A,lda,strideA,D,strideD,E, &
@@ -73542,11 +69806,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_double),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zheev_strided_batched_rank_1 = rocsolver_zheev_strided_batched_(handle,evect,uplo, &
-        n,c_loc(A),lda,strideA,c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        n,c_loc(A),lda,strideA,c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_zheev_strided_batched_full_rank(handle,evect,uplo,n,A,lda,strideA,D, &
@@ -73563,15 +69827,15 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_double),target,dimension(:,:) :: D
+      real(c_double),target,dimension(:) :: D
       integer(c_int64_t) :: strideD
-      real(c_double),target,dimension(:,:) :: E
+      real(c_double),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zheev_strided_batched_full_rank = rocsolver_zheev_strided_batched_(handle,evect, &
-        uplo,n,c_loc(A),lda,strideA,c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        uplo,n,c_loc(A),lda,strideA,c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_ssyevd_rank_0(handle,evect,uplo,n,A,lda,D,E,myInfo)
@@ -73588,10 +69852,10 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       real(c_float),target :: D
       real(c_float),target :: E
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_ssyevd_rank_0 = rocsolver_ssyevd_(handle,evect,uplo,n,c_loc(A),lda,c_loc(D), &
-        c_loc(E),c_loc(myInfo))
+        c_loc(E),myInfo)
     end function
 
     function rocsolver_ssyevd_rank_1(handle,evect,uplo,n,A,lda,D,E,myInfo)
@@ -73608,10 +69872,10 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       real(c_float),target,dimension(:) :: D
       real(c_float),target,dimension(:) :: E
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_ssyevd_rank_1 = rocsolver_ssyevd_(handle,evect,uplo,n,c_loc(A),lda,c_loc(D), &
-        c_loc(E),c_loc(myInfo))
+        c_loc(E),myInfo)
     end function
 
     function rocsolver_ssyevd_full_rank(handle,evect,uplo,n,A,lda,D,E,myInfo)
@@ -73626,12 +69890,12 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: D
-      real(c_float),target,dimension(:,:) :: E
-      integer(c_int),target,dimension(:,:) :: myInfo
+      real(c_float),target,dimension(:) :: D
+      real(c_float),target,dimension(:) :: E
+      type(c_ptr) :: myInfo
       !
       rocsolver_ssyevd_full_rank = rocsolver_ssyevd_(handle,evect,uplo,n,c_loc(A),lda,c_loc(D), &
-        c_loc(E),c_loc(myInfo))
+        c_loc(E),myInfo)
     end function
 
     function rocsolver_dsyevd_rank_0(handle,evect,uplo,n,A,lda,D,E,myInfo)
@@ -73648,10 +69912,10 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       real(c_double),target :: D
       real(c_double),target :: E
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_dsyevd_rank_0 = rocsolver_dsyevd_(handle,evect,uplo,n,c_loc(A),lda,c_loc(D), &
-        c_loc(E),c_loc(myInfo))
+        c_loc(E),myInfo)
     end function
 
     function rocsolver_dsyevd_rank_1(handle,evect,uplo,n,A,lda,D,E,myInfo)
@@ -73668,10 +69932,10 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       real(c_double),target,dimension(:) :: D
       real(c_double),target,dimension(:) :: E
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_dsyevd_rank_1 = rocsolver_dsyevd_(handle,evect,uplo,n,c_loc(A),lda,c_loc(D), &
-        c_loc(E),c_loc(myInfo))
+        c_loc(E),myInfo)
     end function
 
     function rocsolver_dsyevd_full_rank(handle,evect,uplo,n,A,lda,D,E,myInfo)
@@ -73686,12 +69950,12 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: D
-      real(c_double),target,dimension(:,:) :: E
-      integer(c_int),target,dimension(:,:) :: myInfo
+      real(c_double),target,dimension(:) :: D
+      real(c_double),target,dimension(:) :: E
+      type(c_ptr) :: myInfo
       !
       rocsolver_dsyevd_full_rank = rocsolver_dsyevd_(handle,evect,uplo,n,c_loc(A),lda,c_loc(D), &
-        c_loc(E),c_loc(myInfo))
+        c_loc(E),myInfo)
     end function
 
     function rocsolver_cheevd_rank_0(handle,evect,uplo,n,A,lda,D,E,myInfo)
@@ -73708,10 +69972,10 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       real(c_float),target :: D
       real(c_float),target :: E
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_cheevd_rank_0 = rocsolver_cheevd_(handle,evect,uplo,n,c_loc(A),lda,c_loc(D), &
-        c_loc(E),c_loc(myInfo))
+        c_loc(E),myInfo)
     end function
 
     function rocsolver_cheevd_rank_1(handle,evect,uplo,n,A,lda,D,E,myInfo)
@@ -73728,10 +69992,10 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       real(c_float),target,dimension(:) :: D
       real(c_float),target,dimension(:) :: E
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_cheevd_rank_1 = rocsolver_cheevd_(handle,evect,uplo,n,c_loc(A),lda,c_loc(D), &
-        c_loc(E),c_loc(myInfo))
+        c_loc(E),myInfo)
     end function
 
     function rocsolver_cheevd_full_rank(handle,evect,uplo,n,A,lda,D,E,myInfo)
@@ -73746,12 +70010,12 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: D
-      real(c_float),target,dimension(:,:) :: E
-      integer(c_int),target,dimension(:,:) :: myInfo
+      real(c_float),target,dimension(:) :: D
+      real(c_float),target,dimension(:) :: E
+      type(c_ptr) :: myInfo
       !
       rocsolver_cheevd_full_rank = rocsolver_cheevd_(handle,evect,uplo,n,c_loc(A),lda,c_loc(D), &
-        c_loc(E),c_loc(myInfo))
+        c_loc(E),myInfo)
     end function
 
     function rocsolver_zheevd_rank_0(handle,evect,uplo,n,A,lda,D,E,myInfo)
@@ -73768,10 +70032,10 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       real(c_double),target :: D
       real(c_double),target :: E
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_zheevd_rank_0 = rocsolver_zheevd_(handle,evect,uplo,n,c_loc(A),lda,c_loc(D), &
-        c_loc(E),c_loc(myInfo))
+        c_loc(E),myInfo)
     end function
 
     function rocsolver_zheevd_rank_1(handle,evect,uplo,n,A,lda,D,E,myInfo)
@@ -73788,10 +70052,10 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       real(c_double),target,dimension(:) :: D
       real(c_double),target,dimension(:) :: E
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_zheevd_rank_1 = rocsolver_zheevd_(handle,evect,uplo,n,c_loc(A),lda,c_loc(D), &
-        c_loc(E),c_loc(myInfo))
+        c_loc(E),myInfo)
     end function
 
     function rocsolver_zheevd_full_rank(handle,evect,uplo,n,A,lda,D,E,myInfo)
@@ -73806,12 +70070,12 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: D
-      real(c_double),target,dimension(:,:) :: E
-      integer(c_int),target,dimension(:,:) :: myInfo
+      real(c_double),target,dimension(:) :: D
+      real(c_double),target,dimension(:) :: E
+      type(c_ptr) :: myInfo
       !
       rocsolver_zheevd_full_rank = rocsolver_zheevd_(handle,evect,uplo,n,c_loc(A),lda,c_loc(D), &
-        c_loc(E),c_loc(myInfo))
+        c_loc(E),myInfo)
     end function
 
     function rocsolver_ssyevd_batched_rank_0(handle,evect,uplo,n,A,lda,D,strideD,E,strideE,myInfo, &
@@ -73831,11 +70095,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_float),target :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_ssyevd_batched_rank_0 = rocsolver_ssyevd_batched_(handle,evect,uplo,n,A,lda, &
-        c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_ssyevd_batched_rank_1(handle,evect,uplo,n,A,lda,D,strideD,E,strideE,myInfo, &
@@ -73855,35 +70119,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_float),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_ssyevd_batched_rank_1 = rocsolver_ssyevd_batched_(handle,evect,uplo,n,A,lda, &
-        c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_ssyevd_batched_full_rank(handle,evect,uplo,n,A,lda,D,strideD,E,strideE, &
-        myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_ssyevd_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_evect_original)) :: evect
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: D
-      integer(c_int64_t) :: strideD
-      real(c_float),target,dimension(:,:) :: E
-      integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_ssyevd_batched_full_rank = rocsolver_ssyevd_batched_(handle,evect,uplo,n,A,lda, &
-        c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_dsyevd_batched_rank_0(handle,evect,uplo,n,A,lda,D,strideD,E,strideE,myInfo, &
@@ -73903,11 +70143,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_double),target :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dsyevd_batched_rank_0 = rocsolver_dsyevd_batched_(handle,evect,uplo,n,A,lda, &
-        c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_dsyevd_batched_rank_1(handle,evect,uplo,n,A,lda,D,strideD,E,strideE,myInfo, &
@@ -73927,35 +70167,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_double),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dsyevd_batched_rank_1 = rocsolver_dsyevd_batched_(handle,evect,uplo,n,A,lda, &
-        c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_dsyevd_batched_full_rank(handle,evect,uplo,n,A,lda,D,strideD,E,strideE, &
-        myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_dsyevd_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_evect_original)) :: evect
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: D
-      integer(c_int64_t) :: strideD
-      real(c_double),target,dimension(:,:) :: E
-      integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_dsyevd_batched_full_rank = rocsolver_dsyevd_batched_(handle,evect,uplo,n,A,lda, &
-        c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_cheevd_batched_rank_0(handle,evect,uplo,n,A,lda,D,strideD,E,strideE,myInfo, &
@@ -73975,11 +70191,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_float),target :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cheevd_batched_rank_0 = rocsolver_cheevd_batched_(handle,evect,uplo,n,A,lda, &
-        c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_cheevd_batched_rank_1(handle,evect,uplo,n,A,lda,D,strideD,E,strideE,myInfo, &
@@ -73999,35 +70215,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_float),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cheevd_batched_rank_1 = rocsolver_cheevd_batched_(handle,evect,uplo,n,A,lda, &
-        c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_cheevd_batched_full_rank(handle,evect,uplo,n,A,lda,D,strideD,E,strideE, &
-        myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_cheevd_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_evect_original)) :: evect
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      real(c_float),target,dimension(:,:) :: D
-      integer(c_int64_t) :: strideD
-      real(c_float),target,dimension(:,:) :: E
-      integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_cheevd_batched_full_rank = rocsolver_cheevd_batched_(handle,evect,uplo,n,A,lda, &
-        c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_zheevd_batched_rank_0(handle,evect,uplo,n,A,lda,D,strideD,E,strideE,myInfo, &
@@ -74047,11 +70239,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_double),target :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zheevd_batched_rank_0 = rocsolver_zheevd_batched_(handle,evect,uplo,n,A,lda, &
-        c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_zheevd_batched_rank_1(handle,evect,uplo,n,A,lda,D,strideD,E,strideE,myInfo, &
@@ -74071,35 +70263,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_double),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zheevd_batched_rank_1 = rocsolver_zheevd_batched_(handle,evect,uplo,n,A,lda, &
-        c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_zheevd_batched_full_rank(handle,evect,uplo,n,A,lda,D,strideD,E,strideE, &
-        myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_zheevd_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_evect_original)) :: evect
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      real(c_double),target,dimension(:,:) :: D
-      integer(c_int64_t) :: strideD
-      real(c_double),target,dimension(:,:) :: E
-      integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_zheevd_batched_full_rank = rocsolver_zheevd_batched_(handle,evect,uplo,n,A,lda, &
-        c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_ssyevd_strided_batched_rank_0(handle,evect,uplo,n,A,lda,strideA,D,strideD, &
@@ -74120,11 +70288,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_float),target :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_ssyevd_strided_batched_rank_0 = rocsolver_ssyevd_strided_batched_(handle,evect, &
-        uplo,n,c_loc(A),lda,strideA,c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        uplo,n,c_loc(A),lda,strideA,c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_ssyevd_strided_batched_rank_1(handle,evect,uplo,n,A,lda,strideA,D,strideD, &
@@ -74145,11 +70313,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_float),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_ssyevd_strided_batched_rank_1 = rocsolver_ssyevd_strided_batched_(handle,evect, &
-        uplo,n,c_loc(A),lda,strideA,c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        uplo,n,c_loc(A),lda,strideA,c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_ssyevd_strided_batched_full_rank(handle,evect,uplo,n,A,lda,strideA,D, &
@@ -74166,15 +70334,15 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_float),target,dimension(:,:) :: D
+      real(c_float),target,dimension(:) :: D
       integer(c_int64_t) :: strideD
-      real(c_float),target,dimension(:,:) :: E
+      real(c_float),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_ssyevd_strided_batched_full_rank = rocsolver_ssyevd_strided_batched_(handle,evect, &
-        uplo,n,c_loc(A),lda,strideA,c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        uplo,n,c_loc(A),lda,strideA,c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_dsyevd_strided_batched_rank_0(handle,evect,uplo,n,A,lda,strideA,D,strideD, &
@@ -74195,11 +70363,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_double),target :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dsyevd_strided_batched_rank_0 = rocsolver_dsyevd_strided_batched_(handle,evect, &
-        uplo,n,c_loc(A),lda,strideA,c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        uplo,n,c_loc(A),lda,strideA,c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_dsyevd_strided_batched_rank_1(handle,evect,uplo,n,A,lda,strideA,D,strideD, &
@@ -74220,11 +70388,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_double),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dsyevd_strided_batched_rank_1 = rocsolver_dsyevd_strided_batched_(handle,evect, &
-        uplo,n,c_loc(A),lda,strideA,c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        uplo,n,c_loc(A),lda,strideA,c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_dsyevd_strided_batched_full_rank(handle,evect,uplo,n,A,lda,strideA,D, &
@@ -74241,15 +70409,15 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_double),target,dimension(:,:) :: D
+      real(c_double),target,dimension(:) :: D
       integer(c_int64_t) :: strideD
-      real(c_double),target,dimension(:,:) :: E
+      real(c_double),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dsyevd_strided_batched_full_rank = rocsolver_dsyevd_strided_batched_(handle,evect, &
-        uplo,n,c_loc(A),lda,strideA,c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        uplo,n,c_loc(A),lda,strideA,c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_cheevd_strided_batched_rank_0(handle,evect,uplo,n,A,lda,strideA,D,strideD, &
@@ -74270,11 +70438,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_float),target :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cheevd_strided_batched_rank_0 = rocsolver_cheevd_strided_batched_(handle,evect, &
-        uplo,n,c_loc(A),lda,strideA,c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        uplo,n,c_loc(A),lda,strideA,c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_cheevd_strided_batched_rank_1(handle,evect,uplo,n,A,lda,strideA,D,strideD, &
@@ -74295,11 +70463,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_float),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cheevd_strided_batched_rank_1 = rocsolver_cheevd_strided_batched_(handle,evect, &
-        uplo,n,c_loc(A),lda,strideA,c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        uplo,n,c_loc(A),lda,strideA,c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_cheevd_strided_batched_full_rank(handle,evect,uplo,n,A,lda,strideA,D, &
@@ -74316,15 +70484,15 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_float),target,dimension(:,:) :: D
+      real(c_float),target,dimension(:) :: D
       integer(c_int64_t) :: strideD
-      real(c_float),target,dimension(:,:) :: E
+      real(c_float),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cheevd_strided_batched_full_rank = rocsolver_cheevd_strided_batched_(handle,evect, &
-        uplo,n,c_loc(A),lda,strideA,c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        uplo,n,c_loc(A),lda,strideA,c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_zheevd_strided_batched_rank_0(handle,evect,uplo,n,A,lda,strideA,D,strideD, &
@@ -74345,11 +70513,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_double),target :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zheevd_strided_batched_rank_0 = rocsolver_zheevd_strided_batched_(handle,evect, &
-        uplo,n,c_loc(A),lda,strideA,c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        uplo,n,c_loc(A),lda,strideA,c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_zheevd_strided_batched_rank_1(handle,evect,uplo,n,A,lda,strideA,D,strideD, &
@@ -74370,11 +70538,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_double),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zheevd_strided_batched_rank_1 = rocsolver_zheevd_strided_batched_(handle,evect, &
-        uplo,n,c_loc(A),lda,strideA,c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        uplo,n,c_loc(A),lda,strideA,c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_zheevd_strided_batched_full_rank(handle,evect,uplo,n,A,lda,strideA,D, &
@@ -74391,15 +70559,15 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      real(c_double),target,dimension(:,:) :: D
+      real(c_double),target,dimension(:) :: D
       integer(c_int64_t) :: strideD
-      real(c_double),target,dimension(:,:) :: E
+      real(c_double),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zheevd_strided_batched_full_rank = rocsolver_zheevd_strided_batched_(handle,evect, &
-        uplo,n,c_loc(A),lda,strideA,c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        uplo,n,c_loc(A),lda,strideA,c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_ssygv_rank_0(handle,itype,evect,uplo,n,A,lda,B,ldb,D,E,myInfo)
@@ -74419,10 +70587,10 @@ module hipfort_rocsolver
       integer(c_int) :: ldb
       real(c_float),target :: D
       real(c_float),target :: E
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_ssygv_rank_0 = rocsolver_ssygv_(handle,itype,evect,uplo,n,c_loc(A),lda,c_loc(B), &
-        ldb,c_loc(D),c_loc(E),c_loc(myInfo))
+        ldb,c_loc(D),c_loc(E),myInfo)
     end function
 
     function rocsolver_ssygv_rank_1(handle,itype,evect,uplo,n,A,lda,B,ldb,D,E,myInfo)
@@ -74442,10 +70610,10 @@ module hipfort_rocsolver
       integer(c_int) :: ldb
       real(c_float),target,dimension(:) :: D
       real(c_float),target,dimension(:) :: E
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_ssygv_rank_1 = rocsolver_ssygv_(handle,itype,evect,uplo,n,c_loc(A),lda,c_loc(B), &
-        ldb,c_loc(D),c_loc(E),c_loc(myInfo))
+        ldb,c_loc(D),c_loc(E),myInfo)
     end function
 
     function rocsolver_ssygv_full_rank(handle,itype,evect,uplo,n,A,lda,B,ldb,D,E,myInfo)
@@ -74463,12 +70631,12 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       real(c_float),target,dimension(:,:) :: B
       integer(c_int) :: ldb
-      real(c_float),target,dimension(:,:) :: D
-      real(c_float),target,dimension(:,:) :: E
-      integer(c_int),target,dimension(:,:) :: myInfo
+      real(c_float),target,dimension(:) :: D
+      real(c_float),target,dimension(:) :: E
+      type(c_ptr) :: myInfo
       !
       rocsolver_ssygv_full_rank = rocsolver_ssygv_(handle,itype,evect,uplo,n,c_loc(A),lda, &
-        c_loc(B),ldb,c_loc(D),c_loc(E),c_loc(myInfo))
+        c_loc(B),ldb,c_loc(D),c_loc(E),myInfo)
     end function
 
     function rocsolver_dsygv_rank_0(handle,itype,evect,uplo,n,A,lda,B,ldb,D,E,myInfo)
@@ -74488,10 +70656,10 @@ module hipfort_rocsolver
       integer(c_int) :: ldb
       real(c_double),target :: D
       real(c_double),target :: E
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_dsygv_rank_0 = rocsolver_dsygv_(handle,itype,evect,uplo,n,c_loc(A),lda,c_loc(B), &
-        ldb,c_loc(D),c_loc(E),c_loc(myInfo))
+        ldb,c_loc(D),c_loc(E),myInfo)
     end function
 
     function rocsolver_dsygv_rank_1(handle,itype,evect,uplo,n,A,lda,B,ldb,D,E,myInfo)
@@ -74511,10 +70679,10 @@ module hipfort_rocsolver
       integer(c_int) :: ldb
       real(c_double),target,dimension(:) :: D
       real(c_double),target,dimension(:) :: E
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_dsygv_rank_1 = rocsolver_dsygv_(handle,itype,evect,uplo,n,c_loc(A),lda,c_loc(B), &
-        ldb,c_loc(D),c_loc(E),c_loc(myInfo))
+        ldb,c_loc(D),c_loc(E),myInfo)
     end function
 
     function rocsolver_dsygv_full_rank(handle,itype,evect,uplo,n,A,lda,B,ldb,D,E,myInfo)
@@ -74532,12 +70700,12 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       real(c_double),target,dimension(:,:) :: B
       integer(c_int) :: ldb
-      real(c_double),target,dimension(:,:) :: D
-      real(c_double),target,dimension(:,:) :: E
-      integer(c_int),target,dimension(:,:) :: myInfo
+      real(c_double),target,dimension(:) :: D
+      real(c_double),target,dimension(:) :: E
+      type(c_ptr) :: myInfo
       !
       rocsolver_dsygv_full_rank = rocsolver_dsygv_(handle,itype,evect,uplo,n,c_loc(A),lda, &
-        c_loc(B),ldb,c_loc(D),c_loc(E),c_loc(myInfo))
+        c_loc(B),ldb,c_loc(D),c_loc(E),myInfo)
     end function
 
     function rocsolver_chegv_rank_0(handle,itype,evect,uplo,n,A,lda,B,ldb,D,E,myInfo)
@@ -74557,10 +70725,10 @@ module hipfort_rocsolver
       integer(c_int) :: ldb
       real(c_float),target :: D
       real(c_float),target :: E
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_chegv_rank_0 = rocsolver_chegv_(handle,itype,evect,uplo,n,c_loc(A),lda,c_loc(B), &
-        ldb,c_loc(D),c_loc(E),c_loc(myInfo))
+        ldb,c_loc(D),c_loc(E),myInfo)
     end function
 
     function rocsolver_chegv_rank_1(handle,itype,evect,uplo,n,A,lda,B,ldb,D,E,myInfo)
@@ -74580,10 +70748,10 @@ module hipfort_rocsolver
       integer(c_int) :: ldb
       real(c_float),target,dimension(:) :: D
       real(c_float),target,dimension(:) :: E
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_chegv_rank_1 = rocsolver_chegv_(handle,itype,evect,uplo,n,c_loc(A),lda,c_loc(B), &
-        ldb,c_loc(D),c_loc(E),c_loc(myInfo))
+        ldb,c_loc(D),c_loc(E),myInfo)
     end function
 
     function rocsolver_chegv_full_rank(handle,itype,evect,uplo,n,A,lda,B,ldb,D,E,myInfo)
@@ -74601,12 +70769,12 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       complex(c_float_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
-      real(c_float),target,dimension(:,:) :: D
-      real(c_float),target,dimension(:,:) :: E
-      integer(c_int),target,dimension(:,:) :: myInfo
+      real(c_float),target,dimension(:) :: D
+      real(c_float),target,dimension(:) :: E
+      type(c_ptr) :: myInfo
       !
       rocsolver_chegv_full_rank = rocsolver_chegv_(handle,itype,evect,uplo,n,c_loc(A),lda, &
-        c_loc(B),ldb,c_loc(D),c_loc(E),c_loc(myInfo))
+        c_loc(B),ldb,c_loc(D),c_loc(E),myInfo)
     end function
 
     function rocsolver_zhegv_rank_0(handle,itype,evect,uplo,n,A,lda,B,ldb,D,E,myInfo)
@@ -74626,10 +70794,10 @@ module hipfort_rocsolver
       integer(c_int) :: ldb
       real(c_double),target :: D
       real(c_double),target :: E
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_zhegv_rank_0 = rocsolver_zhegv_(handle,itype,evect,uplo,n,c_loc(A),lda,c_loc(B), &
-        ldb,c_loc(D),c_loc(E),c_loc(myInfo))
+        ldb,c_loc(D),c_loc(E),myInfo)
     end function
 
     function rocsolver_zhegv_rank_1(handle,itype,evect,uplo,n,A,lda,B,ldb,D,E,myInfo)
@@ -74649,10 +70817,10 @@ module hipfort_rocsolver
       integer(c_int) :: ldb
       real(c_double),target,dimension(:) :: D
       real(c_double),target,dimension(:) :: E
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_zhegv_rank_1 = rocsolver_zhegv_(handle,itype,evect,uplo,n,c_loc(A),lda,c_loc(B), &
-        ldb,c_loc(D),c_loc(E),c_loc(myInfo))
+        ldb,c_loc(D),c_loc(E),myInfo)
     end function
 
     function rocsolver_zhegv_full_rank(handle,itype,evect,uplo,n,A,lda,B,ldb,D,E,myInfo)
@@ -74670,12 +70838,12 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       complex(c_double_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
-      real(c_double),target,dimension(:,:) :: D
-      real(c_double),target,dimension(:,:) :: E
-      integer(c_int),target,dimension(:,:) :: myInfo
+      real(c_double),target,dimension(:) :: D
+      real(c_double),target,dimension(:) :: E
+      type(c_ptr) :: myInfo
       !
       rocsolver_zhegv_full_rank = rocsolver_zhegv_(handle,itype,evect,uplo,n,c_loc(A),lda, &
-        c_loc(B),ldb,c_loc(D),c_loc(E),c_loc(myInfo))
+        c_loc(B),ldb,c_loc(D),c_loc(E),myInfo)
     end function
 
     function rocsolver_ssygv_batched_rank_0(handle,itype,evect,uplo,n,A,lda,B,ldb,D,strideD,E, &
@@ -74698,11 +70866,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_float),target :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_ssygv_batched_rank_0 = rocsolver_ssygv_batched_(handle,itype,evect,uplo,n,A,lda,B, &
-        ldb,c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        ldb,c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_ssygv_batched_rank_1(handle,itype,evect,uplo,n,A,lda,B,ldb,D,strideD,E, &
@@ -74725,38 +70893,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_float),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_ssygv_batched_rank_1 = rocsolver_ssygv_batched_(handle,itype,evect,uplo,n,A,lda,B, &
-        ldb,c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_ssygv_batched_full_rank(handle,itype,evect,uplo,n,A,lda,B,ldb,D,strideD,E, &
-        strideE,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_ssygv_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_eform_ax)) :: itype
-      integer(kind(rocblas_evect_original)) :: evect
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: B
-      integer(c_int) :: ldb
-      real(c_float),target,dimension(:,:) :: D
-      integer(c_int64_t) :: strideD
-      real(c_float),target,dimension(:,:) :: E
-      integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_ssygv_batched_full_rank = rocsolver_ssygv_batched_(handle,itype,evect,uplo,n,A, &
-        lda,B,ldb,c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        ldb,c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_dsygv_batched_rank_0(handle,itype,evect,uplo,n,A,lda,B,ldb,D,strideD,E, &
@@ -74779,11 +70920,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_double),target :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dsygv_batched_rank_0 = rocsolver_dsygv_batched_(handle,itype,evect,uplo,n,A,lda,B, &
-        ldb,c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        ldb,c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_dsygv_batched_rank_1(handle,itype,evect,uplo,n,A,lda,B,ldb,D,strideD,E, &
@@ -74806,38 +70947,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_double),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dsygv_batched_rank_1 = rocsolver_dsygv_batched_(handle,itype,evect,uplo,n,A,lda,B, &
-        ldb,c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_dsygv_batched_full_rank(handle,itype,evect,uplo,n,A,lda,B,ldb,D,strideD,E, &
-        strideE,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_dsygv_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_eform_ax)) :: itype
-      integer(kind(rocblas_evect_original)) :: evect
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: B
-      integer(c_int) :: ldb
-      real(c_double),target,dimension(:,:) :: D
-      integer(c_int64_t) :: strideD
-      real(c_double),target,dimension(:,:) :: E
-      integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_dsygv_batched_full_rank = rocsolver_dsygv_batched_(handle,itype,evect,uplo,n,A, &
-        lda,B,ldb,c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        ldb,c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_chegv_batched_rank_0(handle,itype,evect,uplo,n,A,lda,B,ldb,D,strideD,E, &
@@ -74860,11 +70974,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_float),target :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_chegv_batched_rank_0 = rocsolver_chegv_batched_(handle,itype,evect,uplo,n,A,lda,B, &
-        ldb,c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        ldb,c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_chegv_batched_rank_1(handle,itype,evect,uplo,n,A,lda,B,ldb,D,strideD,E, &
@@ -74887,38 +71001,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_float),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_chegv_batched_rank_1 = rocsolver_chegv_batched_(handle,itype,evect,uplo,n,A,lda,B, &
-        ldb,c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_chegv_batched_full_rank(handle,itype,evect,uplo,n,A,lda,B,ldb,D,strideD,E, &
-        strideE,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_chegv_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_eform_ax)) :: itype
-      integer(kind(rocblas_evect_original)) :: evect
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: B
-      integer(c_int) :: ldb
-      real(c_float),target,dimension(:,:) :: D
-      integer(c_int64_t) :: strideD
-      real(c_float),target,dimension(:,:) :: E
-      integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_chegv_batched_full_rank = rocsolver_chegv_batched_(handle,itype,evect,uplo,n,A, &
-        lda,B,ldb,c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        ldb,c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_zhegv_batched_rank_0(handle,itype,evect,uplo,n,A,lda,B,ldb,D,strideD,E, &
@@ -74941,11 +71028,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_double),target :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zhegv_batched_rank_0 = rocsolver_zhegv_batched_(handle,itype,evect,uplo,n,A,lda,B, &
-        ldb,c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        ldb,c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_zhegv_batched_rank_1(handle,itype,evect,uplo,n,A,lda,B,ldb,D,strideD,E, &
@@ -74968,38 +71055,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_double),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zhegv_batched_rank_1 = rocsolver_zhegv_batched_(handle,itype,evect,uplo,n,A,lda,B, &
-        ldb,c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_zhegv_batched_full_rank(handle,itype,evect,uplo,n,A,lda,B,ldb,D,strideD,E, &
-        strideE,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_zhegv_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_eform_ax)) :: itype
-      integer(kind(rocblas_evect_original)) :: evect
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: B
-      integer(c_int) :: ldb
-      real(c_double),target,dimension(:,:) :: D
-      integer(c_int64_t) :: strideD
-      real(c_double),target,dimension(:,:) :: E
-      integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_zhegv_batched_full_rank = rocsolver_zhegv_batched_(handle,itype,evect,uplo,n,A, &
-        lda,B,ldb,c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        ldb,c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_ssygv_strided_batched_rank_0(handle,itype,evect,uplo,n,A,lda,strideA,B,ldb, &
@@ -75024,12 +71084,12 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_float),target :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_ssygv_strided_batched_rank_0 = rocsolver_ssygv_strided_batched_(handle,itype, &
         evect,uplo,n,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(D),strideD,c_loc(E),strideE, &
-        c_loc(myInfo),batch_count)
+        myInfo,batch_count)
     end function
 
     function rocsolver_ssygv_strided_batched_rank_1(handle,itype,evect,uplo,n,A,lda,strideA,B,ldb, &
@@ -75054,12 +71114,12 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_float),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_ssygv_strided_batched_rank_1 = rocsolver_ssygv_strided_batched_(handle,itype, &
         evect,uplo,n,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(D),strideD,c_loc(E),strideE, &
-        c_loc(myInfo),batch_count)
+        myInfo,batch_count)
     end function
 
     function rocsolver_ssygv_strided_batched_full_rank(handle,itype,evect,uplo,n,A,lda,strideA,B, &
@@ -75080,16 +71140,16 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      real(c_float),target,dimension(:,:) :: D
+      real(c_float),target,dimension(:) :: D
       integer(c_int64_t) :: strideD
-      real(c_float),target,dimension(:,:) :: E
+      real(c_float),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_ssygv_strided_batched_full_rank = rocsolver_ssygv_strided_batched_(handle,itype, &
         evect,uplo,n,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(D),strideD,c_loc(E),strideE, &
-        c_loc(myInfo),batch_count)
+        myInfo,batch_count)
     end function
 
     function rocsolver_dsygv_strided_batched_rank_0(handle,itype,evect,uplo,n,A,lda,strideA,B,ldb, &
@@ -75114,12 +71174,12 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_double),target :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dsygv_strided_batched_rank_0 = rocsolver_dsygv_strided_batched_(handle,itype, &
         evect,uplo,n,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(D),strideD,c_loc(E),strideE, &
-        c_loc(myInfo),batch_count)
+        myInfo,batch_count)
     end function
 
     function rocsolver_dsygv_strided_batched_rank_1(handle,itype,evect,uplo,n,A,lda,strideA,B,ldb, &
@@ -75144,12 +71204,12 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_double),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dsygv_strided_batched_rank_1 = rocsolver_dsygv_strided_batched_(handle,itype, &
         evect,uplo,n,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(D),strideD,c_loc(E),strideE, &
-        c_loc(myInfo),batch_count)
+        myInfo,batch_count)
     end function
 
     function rocsolver_dsygv_strided_batched_full_rank(handle,itype,evect,uplo,n,A,lda,strideA,B, &
@@ -75170,16 +71230,16 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      real(c_double),target,dimension(:,:) :: D
+      real(c_double),target,dimension(:) :: D
       integer(c_int64_t) :: strideD
-      real(c_double),target,dimension(:,:) :: E
+      real(c_double),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dsygv_strided_batched_full_rank = rocsolver_dsygv_strided_batched_(handle,itype, &
         evect,uplo,n,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(D),strideD,c_loc(E),strideE, &
-        c_loc(myInfo),batch_count)
+        myInfo,batch_count)
     end function
 
     function rocsolver_chegv_strided_batched_rank_0(handle,itype,evect,uplo,n,A,lda,strideA,B,ldb, &
@@ -75204,12 +71264,12 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_float),target :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_chegv_strided_batched_rank_0 = rocsolver_chegv_strided_batched_(handle,itype, &
         evect,uplo,n,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(D),strideD,c_loc(E),strideE, &
-        c_loc(myInfo),batch_count)
+        myInfo,batch_count)
     end function
 
     function rocsolver_chegv_strided_batched_rank_1(handle,itype,evect,uplo,n,A,lda,strideA,B,ldb, &
@@ -75234,12 +71294,12 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_float),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_chegv_strided_batched_rank_1 = rocsolver_chegv_strided_batched_(handle,itype, &
         evect,uplo,n,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(D),strideD,c_loc(E),strideE, &
-        c_loc(myInfo),batch_count)
+        myInfo,batch_count)
     end function
 
     function rocsolver_chegv_strided_batched_full_rank(handle,itype,evect,uplo,n,A,lda,strideA,B, &
@@ -75260,16 +71320,16 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      real(c_float),target,dimension(:,:) :: D
+      real(c_float),target,dimension(:) :: D
       integer(c_int64_t) :: strideD
-      real(c_float),target,dimension(:,:) :: E
+      real(c_float),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_chegv_strided_batched_full_rank = rocsolver_chegv_strided_batched_(handle,itype, &
         evect,uplo,n,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(D),strideD,c_loc(E),strideE, &
-        c_loc(myInfo),batch_count)
+        myInfo,batch_count)
     end function
 
     function rocsolver_zhegv_strided_batched_rank_0(handle,itype,evect,uplo,n,A,lda,strideA,B,ldb, &
@@ -75294,12 +71354,12 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_double),target :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zhegv_strided_batched_rank_0 = rocsolver_zhegv_strided_batched_(handle,itype, &
         evect,uplo,n,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(D),strideD,c_loc(E),strideE, &
-        c_loc(myInfo),batch_count)
+        myInfo,batch_count)
     end function
 
     function rocsolver_zhegv_strided_batched_rank_1(handle,itype,evect,uplo,n,A,lda,strideA,B,ldb, &
@@ -75324,12 +71384,12 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_double),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zhegv_strided_batched_rank_1 = rocsolver_zhegv_strided_batched_(handle,itype, &
         evect,uplo,n,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(D),strideD,c_loc(E),strideE, &
-        c_loc(myInfo),batch_count)
+        myInfo,batch_count)
     end function
 
     function rocsolver_zhegv_strided_batched_full_rank(handle,itype,evect,uplo,n,A,lda,strideA,B, &
@@ -75350,16 +71410,16 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      real(c_double),target,dimension(:,:) :: D
+      real(c_double),target,dimension(:) :: D
       integer(c_int64_t) :: strideD
-      real(c_double),target,dimension(:,:) :: E
+      real(c_double),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zhegv_strided_batched_full_rank = rocsolver_zhegv_strided_batched_(handle,itype, &
         evect,uplo,n,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(D),strideD,c_loc(E),strideE, &
-        c_loc(myInfo),batch_count)
+        myInfo,batch_count)
     end function
 
     function rocsolver_ssygvd_rank_0(handle,itype,evect,uplo,n,A,lda,B,ldb,D,E,myInfo)
@@ -75379,10 +71439,10 @@ module hipfort_rocsolver
       integer(c_int) :: ldb
       real(c_float),target :: D
       real(c_float),target :: E
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_ssygvd_rank_0 = rocsolver_ssygvd_(handle,itype,evect,uplo,n,c_loc(A),lda,c_loc(B), &
-        ldb,c_loc(D),c_loc(E),c_loc(myInfo))
+        ldb,c_loc(D),c_loc(E),myInfo)
     end function
 
     function rocsolver_ssygvd_rank_1(handle,itype,evect,uplo,n,A,lda,B,ldb,D,E,myInfo)
@@ -75402,10 +71462,10 @@ module hipfort_rocsolver
       integer(c_int) :: ldb
       real(c_float),target,dimension(:) :: D
       real(c_float),target,dimension(:) :: E
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_ssygvd_rank_1 = rocsolver_ssygvd_(handle,itype,evect,uplo,n,c_loc(A),lda,c_loc(B), &
-        ldb,c_loc(D),c_loc(E),c_loc(myInfo))
+        ldb,c_loc(D),c_loc(E),myInfo)
     end function
 
     function rocsolver_ssygvd_full_rank(handle,itype,evect,uplo,n,A,lda,B,ldb,D,E,myInfo)
@@ -75423,12 +71483,12 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       real(c_float),target,dimension(:,:) :: B
       integer(c_int) :: ldb
-      real(c_float),target,dimension(:,:) :: D
-      real(c_float),target,dimension(:,:) :: E
-      integer(c_int),target,dimension(:,:) :: myInfo
+      real(c_float),target,dimension(:) :: D
+      real(c_float),target,dimension(:) :: E
+      type(c_ptr) :: myInfo
       !
       rocsolver_ssygvd_full_rank = rocsolver_ssygvd_(handle,itype,evect,uplo,n,c_loc(A),lda, &
-        c_loc(B),ldb,c_loc(D),c_loc(E),c_loc(myInfo))
+        c_loc(B),ldb,c_loc(D),c_loc(E),myInfo)
     end function
 
     function rocsolver_dsygvd_rank_0(handle,itype,evect,uplo,n,A,lda,B,ldb,D,E,myInfo)
@@ -75448,10 +71508,10 @@ module hipfort_rocsolver
       integer(c_int) :: ldb
       real(c_double),target :: D
       real(c_double),target :: E
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_dsygvd_rank_0 = rocsolver_dsygvd_(handle,itype,evect,uplo,n,c_loc(A),lda,c_loc(B), &
-        ldb,c_loc(D),c_loc(E),c_loc(myInfo))
+        ldb,c_loc(D),c_loc(E),myInfo)
     end function
 
     function rocsolver_dsygvd_rank_1(handle,itype,evect,uplo,n,A,lda,B,ldb,D,E,myInfo)
@@ -75471,10 +71531,10 @@ module hipfort_rocsolver
       integer(c_int) :: ldb
       real(c_double),target,dimension(:) :: D
       real(c_double),target,dimension(:) :: E
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_dsygvd_rank_1 = rocsolver_dsygvd_(handle,itype,evect,uplo,n,c_loc(A),lda,c_loc(B), &
-        ldb,c_loc(D),c_loc(E),c_loc(myInfo))
+        ldb,c_loc(D),c_loc(E),myInfo)
     end function
 
     function rocsolver_dsygvd_full_rank(handle,itype,evect,uplo,n,A,lda,B,ldb,D,E,myInfo)
@@ -75492,12 +71552,12 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       real(c_double),target,dimension(:,:) :: B
       integer(c_int) :: ldb
-      real(c_double),target,dimension(:,:) :: D
-      real(c_double),target,dimension(:,:) :: E
-      integer(c_int),target,dimension(:,:) :: myInfo
+      real(c_double),target,dimension(:) :: D
+      real(c_double),target,dimension(:) :: E
+      type(c_ptr) :: myInfo
       !
       rocsolver_dsygvd_full_rank = rocsolver_dsygvd_(handle,itype,evect,uplo,n,c_loc(A),lda, &
-        c_loc(B),ldb,c_loc(D),c_loc(E),c_loc(myInfo))
+        c_loc(B),ldb,c_loc(D),c_loc(E),myInfo)
     end function
 
     function rocsolver_chegvd_rank_0(handle,itype,evect,uplo,n,A,lda,B,ldb,D,E,myInfo)
@@ -75517,10 +71577,10 @@ module hipfort_rocsolver
       integer(c_int) :: ldb
       real(c_float),target :: D
       real(c_float),target :: E
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_chegvd_rank_0 = rocsolver_chegvd_(handle,itype,evect,uplo,n,c_loc(A),lda,c_loc(B), &
-        ldb,c_loc(D),c_loc(E),c_loc(myInfo))
+        ldb,c_loc(D),c_loc(E),myInfo)
     end function
 
     function rocsolver_chegvd_rank_1(handle,itype,evect,uplo,n,A,lda,B,ldb,D,E,myInfo)
@@ -75540,10 +71600,10 @@ module hipfort_rocsolver
       integer(c_int) :: ldb
       real(c_float),target,dimension(:) :: D
       real(c_float),target,dimension(:) :: E
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_chegvd_rank_1 = rocsolver_chegvd_(handle,itype,evect,uplo,n,c_loc(A),lda,c_loc(B), &
-        ldb,c_loc(D),c_loc(E),c_loc(myInfo))
+        ldb,c_loc(D),c_loc(E),myInfo)
     end function
 
     function rocsolver_chegvd_full_rank(handle,itype,evect,uplo,n,A,lda,B,ldb,D,E,myInfo)
@@ -75561,12 +71621,12 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       complex(c_float_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
-      real(c_float),target,dimension(:,:) :: D
-      real(c_float),target,dimension(:,:) :: E
-      integer(c_int),target,dimension(:,:) :: myInfo
+      real(c_float),target,dimension(:) :: D
+      real(c_float),target,dimension(:) :: E
+      type(c_ptr) :: myInfo
       !
       rocsolver_chegvd_full_rank = rocsolver_chegvd_(handle,itype,evect,uplo,n,c_loc(A),lda, &
-        c_loc(B),ldb,c_loc(D),c_loc(E),c_loc(myInfo))
+        c_loc(B),ldb,c_loc(D),c_loc(E),myInfo)
     end function
 
     function rocsolver_zhegvd_rank_0(handle,itype,evect,uplo,n,A,lda,B,ldb,D,E,myInfo)
@@ -75586,10 +71646,10 @@ module hipfort_rocsolver
       integer(c_int) :: ldb
       real(c_double),target :: D
       real(c_double),target :: E
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_zhegvd_rank_0 = rocsolver_zhegvd_(handle,itype,evect,uplo,n,c_loc(A),lda,c_loc(B), &
-        ldb,c_loc(D),c_loc(E),c_loc(myInfo))
+        ldb,c_loc(D),c_loc(E),myInfo)
     end function
 
     function rocsolver_zhegvd_rank_1(handle,itype,evect,uplo,n,A,lda,B,ldb,D,E,myInfo)
@@ -75609,10 +71669,10 @@ module hipfort_rocsolver
       integer(c_int) :: ldb
       real(c_double),target,dimension(:) :: D
       real(c_double),target,dimension(:) :: E
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_zhegvd_rank_1 = rocsolver_zhegvd_(handle,itype,evect,uplo,n,c_loc(A),lda,c_loc(B), &
-        ldb,c_loc(D),c_loc(E),c_loc(myInfo))
+        ldb,c_loc(D),c_loc(E),myInfo)
     end function
 
     function rocsolver_zhegvd_full_rank(handle,itype,evect,uplo,n,A,lda,B,ldb,D,E,myInfo)
@@ -75630,12 +71690,12 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       complex(c_double_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
-      real(c_double),target,dimension(:,:) :: D
-      real(c_double),target,dimension(:,:) :: E
-      integer(c_int),target,dimension(:,:) :: myInfo
+      real(c_double),target,dimension(:) :: D
+      real(c_double),target,dimension(:) :: E
+      type(c_ptr) :: myInfo
       !
       rocsolver_zhegvd_full_rank = rocsolver_zhegvd_(handle,itype,evect,uplo,n,c_loc(A),lda, &
-        c_loc(B),ldb,c_loc(D),c_loc(E),c_loc(myInfo))
+        c_loc(B),ldb,c_loc(D),c_loc(E),myInfo)
     end function
 
     function rocsolver_ssygvd_batched_rank_0(handle,itype,evect,uplo,n,A,lda,B,ldb,D,strideD,E, &
@@ -75658,11 +71718,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_float),target :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_ssygvd_batched_rank_0 = rocsolver_ssygvd_batched_(handle,itype,evect,uplo,n,A,lda, &
-        B,ldb,c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        B,ldb,c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_ssygvd_batched_rank_1(handle,itype,evect,uplo,n,A,lda,B,ldb,D,strideD,E, &
@@ -75685,38 +71745,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_float),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_ssygvd_batched_rank_1 = rocsolver_ssygvd_batched_(handle,itype,evect,uplo,n,A,lda, &
-        B,ldb,c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_ssygvd_batched_full_rank(handle,itype,evect,uplo,n,A,lda,B,ldb,D,strideD,E, &
-        strideE,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_ssygvd_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_eform_ax)) :: itype
-      integer(kind(rocblas_evect_original)) :: evect
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: B
-      integer(c_int) :: ldb
-      real(c_float),target,dimension(:,:) :: D
-      integer(c_int64_t) :: strideD
-      real(c_float),target,dimension(:,:) :: E
-      integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_ssygvd_batched_full_rank = rocsolver_ssygvd_batched_(handle,itype,evect,uplo,n,A, &
-        lda,B,ldb,c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        B,ldb,c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_dsygvd_batched_rank_0(handle,itype,evect,uplo,n,A,lda,B,ldb,D,strideD,E, &
@@ -75739,11 +71772,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_double),target :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dsygvd_batched_rank_0 = rocsolver_dsygvd_batched_(handle,itype,evect,uplo,n,A,lda, &
-        B,ldb,c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        B,ldb,c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_dsygvd_batched_rank_1(handle,itype,evect,uplo,n,A,lda,B,ldb,D,strideD,E, &
@@ -75766,38 +71799,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_double),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dsygvd_batched_rank_1 = rocsolver_dsygvd_batched_(handle,itype,evect,uplo,n,A,lda, &
-        B,ldb,c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_dsygvd_batched_full_rank(handle,itype,evect,uplo,n,A,lda,B,ldb,D,strideD,E, &
-        strideE,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_dsygvd_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_eform_ax)) :: itype
-      integer(kind(rocblas_evect_original)) :: evect
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: B
-      integer(c_int) :: ldb
-      real(c_double),target,dimension(:,:) :: D
-      integer(c_int64_t) :: strideD
-      real(c_double),target,dimension(:,:) :: E
-      integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_dsygvd_batched_full_rank = rocsolver_dsygvd_batched_(handle,itype,evect,uplo,n,A, &
-        lda,B,ldb,c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        B,ldb,c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_chegvd_batched_rank_0(handle,itype,evect,uplo,n,A,lda,B,ldb,D,strideD,E, &
@@ -75820,11 +71826,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_float),target :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_chegvd_batched_rank_0 = rocsolver_chegvd_batched_(handle,itype,evect,uplo,n,A,lda, &
-        B,ldb,c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        B,ldb,c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_chegvd_batched_rank_1(handle,itype,evect,uplo,n,A,lda,B,ldb,D,strideD,E, &
@@ -75847,38 +71853,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_float),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_chegvd_batched_rank_1 = rocsolver_chegvd_batched_(handle,itype,evect,uplo,n,A,lda, &
-        B,ldb,c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_chegvd_batched_full_rank(handle,itype,evect,uplo,n,A,lda,B,ldb,D,strideD,E, &
-        strideE,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_chegvd_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_eform_ax)) :: itype
-      integer(kind(rocblas_evect_original)) :: evect
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: B
-      integer(c_int) :: ldb
-      real(c_float),target,dimension(:,:) :: D
-      integer(c_int64_t) :: strideD
-      real(c_float),target,dimension(:,:) :: E
-      integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_chegvd_batched_full_rank = rocsolver_chegvd_batched_(handle,itype,evect,uplo,n,A, &
-        lda,B,ldb,c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        B,ldb,c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_zhegvd_batched_rank_0(handle,itype,evect,uplo,n,A,lda,B,ldb,D,strideD,E, &
@@ -75901,11 +71880,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_double),target :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zhegvd_batched_rank_0 = rocsolver_zhegvd_batched_(handle,itype,evect,uplo,n,A,lda, &
-        B,ldb,c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        B,ldb,c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_zhegvd_batched_rank_1(handle,itype,evect,uplo,n,A,lda,B,ldb,D,strideD,E, &
@@ -75928,38 +71907,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_double),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zhegvd_batched_rank_1 = rocsolver_zhegvd_batched_(handle,itype,evect,uplo,n,A,lda, &
-        B,ldb,c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_zhegvd_batched_full_rank(handle,itype,evect,uplo,n,A,lda,B,ldb,D,strideD,E, &
-        strideE,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_zhegvd_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_eform_ax)) :: itype
-      integer(kind(rocblas_evect_original)) :: evect
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: B
-      integer(c_int) :: ldb
-      real(c_double),target,dimension(:,:) :: D
-      integer(c_int64_t) :: strideD
-      real(c_double),target,dimension(:,:) :: E
-      integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_zhegvd_batched_full_rank = rocsolver_zhegvd_batched_(handle,itype,evect,uplo,n,A, &
-        lda,B,ldb,c_loc(D),strideD,c_loc(E),strideE,c_loc(myInfo),batch_count)
+        B,ldb,c_loc(D),strideD,c_loc(E),strideE,myInfo,batch_count)
     end function
 
     function rocsolver_ssygvd_strided_batched_rank_0(handle,itype,evect,uplo,n,A,lda,strideA,B, &
@@ -75984,12 +71936,12 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_float),target :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_ssygvd_strided_batched_rank_0 = rocsolver_ssygvd_strided_batched_(handle,itype, &
         evect,uplo,n,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(D),strideD,c_loc(E),strideE, &
-        c_loc(myInfo),batch_count)
+        myInfo,batch_count)
     end function
 
     function rocsolver_ssygvd_strided_batched_rank_1(handle,itype,evect,uplo,n,A,lda,strideA,B, &
@@ -76014,12 +71966,12 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_float),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_ssygvd_strided_batched_rank_1 = rocsolver_ssygvd_strided_batched_(handle,itype, &
         evect,uplo,n,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(D),strideD,c_loc(E),strideE, &
-        c_loc(myInfo),batch_count)
+        myInfo,batch_count)
     end function
 
     function rocsolver_ssygvd_strided_batched_full_rank(handle,itype,evect,uplo,n,A,lda,strideA,B, &
@@ -76040,16 +71992,16 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      real(c_float),target,dimension(:,:) :: D
+      real(c_float),target,dimension(:) :: D
       integer(c_int64_t) :: strideD
-      real(c_float),target,dimension(:,:) :: E
+      real(c_float),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_ssygvd_strided_batched_full_rank = rocsolver_ssygvd_strided_batched_(handle,itype, &
         evect,uplo,n,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(D),strideD,c_loc(E),strideE, &
-        c_loc(myInfo),batch_count)
+        myInfo,batch_count)
     end function
 
     function rocsolver_dsygvd_strided_batched_rank_0(handle,itype,evect,uplo,n,A,lda,strideA,B, &
@@ -76074,12 +72026,12 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_double),target :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dsygvd_strided_batched_rank_0 = rocsolver_dsygvd_strided_batched_(handle,itype, &
         evect,uplo,n,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(D),strideD,c_loc(E),strideE, &
-        c_loc(myInfo),batch_count)
+        myInfo,batch_count)
     end function
 
     function rocsolver_dsygvd_strided_batched_rank_1(handle,itype,evect,uplo,n,A,lda,strideA,B, &
@@ -76104,12 +72056,12 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_double),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dsygvd_strided_batched_rank_1 = rocsolver_dsygvd_strided_batched_(handle,itype, &
         evect,uplo,n,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(D),strideD,c_loc(E),strideE, &
-        c_loc(myInfo),batch_count)
+        myInfo,batch_count)
     end function
 
     function rocsolver_dsygvd_strided_batched_full_rank(handle,itype,evect,uplo,n,A,lda,strideA,B, &
@@ -76130,16 +72082,16 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      real(c_double),target,dimension(:,:) :: D
+      real(c_double),target,dimension(:) :: D
       integer(c_int64_t) :: strideD
-      real(c_double),target,dimension(:,:) :: E
+      real(c_double),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dsygvd_strided_batched_full_rank = rocsolver_dsygvd_strided_batched_(handle,itype, &
         evect,uplo,n,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(D),strideD,c_loc(E),strideE, &
-        c_loc(myInfo),batch_count)
+        myInfo,batch_count)
     end function
 
     function rocsolver_chegvd_strided_batched_rank_0(handle,itype,evect,uplo,n,A,lda,strideA,B, &
@@ -76164,12 +72116,12 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_float),target :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_chegvd_strided_batched_rank_0 = rocsolver_chegvd_strided_batched_(handle,itype, &
         evect,uplo,n,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(D),strideD,c_loc(E),strideE, &
-        c_loc(myInfo),batch_count)
+        myInfo,batch_count)
     end function
 
     function rocsolver_chegvd_strided_batched_rank_1(handle,itype,evect,uplo,n,A,lda,strideA,B, &
@@ -76194,12 +72146,12 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_float),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_chegvd_strided_batched_rank_1 = rocsolver_chegvd_strided_batched_(handle,itype, &
         evect,uplo,n,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(D),strideD,c_loc(E),strideE, &
-        c_loc(myInfo),batch_count)
+        myInfo,batch_count)
     end function
 
     function rocsolver_chegvd_strided_batched_full_rank(handle,itype,evect,uplo,n,A,lda,strideA,B, &
@@ -76220,16 +72172,16 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      real(c_float),target,dimension(:,:) :: D
+      real(c_float),target,dimension(:) :: D
       integer(c_int64_t) :: strideD
-      real(c_float),target,dimension(:,:) :: E
+      real(c_float),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_chegvd_strided_batched_full_rank = rocsolver_chegvd_strided_batched_(handle,itype, &
         evect,uplo,n,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(D),strideD,c_loc(E),strideE, &
-        c_loc(myInfo),batch_count)
+        myInfo,batch_count)
     end function
 
     function rocsolver_zhegvd_strided_batched_rank_0(handle,itype,evect,uplo,n,A,lda,strideA,B, &
@@ -76254,12 +72206,12 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_double),target :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zhegvd_strided_batched_rank_0 = rocsolver_zhegvd_strided_batched_(handle,itype, &
         evect,uplo,n,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(D),strideD,c_loc(E),strideE, &
-        c_loc(myInfo),batch_count)
+        myInfo,batch_count)
     end function
 
     function rocsolver_zhegvd_strided_batched_rank_1(handle,itype,evect,uplo,n,A,lda,strideA,B, &
@@ -76284,12 +72236,12 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideD
       real(c_double),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zhegvd_strided_batched_rank_1 = rocsolver_zhegvd_strided_batched_(handle,itype, &
         evect,uplo,n,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(D),strideD,c_loc(E),strideE, &
-        c_loc(myInfo),batch_count)
+        myInfo,batch_count)
     end function
 
     function rocsolver_zhegvd_strided_batched_full_rank(handle,itype,evect,uplo,n,A,lda,strideA,B, &
@@ -76310,16 +72262,16 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       integer(c_int64_t) :: strideB
-      real(c_double),target,dimension(:,:) :: D
+      real(c_double),target,dimension(:) :: D
       integer(c_int64_t) :: strideD
-      real(c_double),target,dimension(:,:) :: E
+      real(c_double),target,dimension(:) :: E
       integer(c_int64_t) :: strideE
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zhegvd_strided_batched_full_rank = rocsolver_zhegvd_strided_batched_(handle,itype, &
         evect,uplo,n,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(D),strideD,c_loc(E),strideE, &
-        c_loc(myInfo),batch_count)
+        myInfo,batch_count)
     end function
 
     function rocsolver_chegvdx_rank_0(handle,itype,evect,erange,uplo,n,A,lda,B,ldb,vl,vu,il,iu, &
@@ -76406,10 +72358,10 @@ module hipfort_rocsolver
       integer(c_int) :: il
       integer(c_int) :: iu
       integer(c_int) :: nev
-      real(c_float),target,dimension(:,:) :: W
+      real(c_float),target,dimension(:) :: W
       complex(c_float_complex),target,dimension(:,:) :: Z
       integer(c_int) :: ldz
-      integer(c_int),target,dimension(:,:) :: myInfo
+      integer(c_int),target,dimension(:) :: myInfo
       !
       rocsolver_chegvdx_full_rank = rocsolver_chegvdx_(handle,itype,evect,erange,uplo,n,c_loc(A), &
         lda,c_loc(B),ldb,vl,vu,il,iu,nev,c_loc(W),c_loc(Z),ldz,c_loc(myInfo))
@@ -76499,10 +72451,10 @@ module hipfort_rocsolver
       integer(c_int) :: il
       integer(c_int) :: iu
       integer(c_int) :: nev
-      real(c_double),target,dimension(:,:) :: W
+      real(c_double),target,dimension(:) :: W
       complex(c_double_complex),target,dimension(:,:) :: Z
       integer(c_int) :: ldz
-      integer(c_int),target,dimension(:,:) :: myInfo
+      integer(c_int),target,dimension(:) :: myInfo
       !
       rocsolver_zhegvdx_full_rank = rocsolver_zhegvdx_(handle,itype,evect,erange,uplo,n,c_loc(A), &
         lda,c_loc(B),ldb,vl,vu,il,iu,nev,c_loc(W),c_loc(Z),ldz,c_loc(myInfo))
@@ -76521,10 +72473,10 @@ module hipfort_rocsolver
       integer(c_int),target :: ipiv
       real(c_float),target :: C
       integer(c_int) :: ldc
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_sgetri_outofplace_rank_0 = rocsolver_sgetri_outofplace_(handle,n,c_loc(A),lda, &
-        c_loc(ipiv),c_loc(C),ldc,c_loc(myInfo))
+        c_loc(ipiv),c_loc(C),ldc,myInfo)
     end function
 
     function rocsolver_sgetri_outofplace_rank_1(handle,n,A,lda,ipiv,C,ldc,myInfo)
@@ -76540,10 +72492,10 @@ module hipfort_rocsolver
       integer(c_int),target,dimension(:) :: ipiv
       real(c_float),target,dimension(:) :: C
       integer(c_int) :: ldc
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_sgetri_outofplace_rank_1 = rocsolver_sgetri_outofplace_(handle,n,c_loc(A),lda, &
-        c_loc(ipiv),c_loc(C),ldc,c_loc(myInfo))
+        c_loc(ipiv),c_loc(C),ldc,myInfo)
     end function
 
     function rocsolver_sgetri_outofplace_full_rank(handle,n,A,lda,ipiv,C,ldc,myInfo)
@@ -76556,13 +72508,13 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
+      integer(c_int),target,dimension(:) :: ipiv
       real(c_float),target,dimension(:,:) :: C
       integer(c_int) :: ldc
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_sgetri_outofplace_full_rank = rocsolver_sgetri_outofplace_(handle,n,c_loc(A),lda, &
-        c_loc(ipiv),c_loc(C),ldc,c_loc(myInfo))
+        c_loc(ipiv),c_loc(C),ldc,myInfo)
     end function
 
     function rocsolver_dgetri_outofplace_rank_0(handle,n,A,lda,ipiv,C,ldc,myInfo)
@@ -76578,10 +72530,10 @@ module hipfort_rocsolver
       integer(c_int),target :: ipiv
       real(c_double),target :: C
       integer(c_int) :: ldc
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_dgetri_outofplace_rank_0 = rocsolver_dgetri_outofplace_(handle,n,c_loc(A),lda, &
-        c_loc(ipiv),c_loc(C),ldc,c_loc(myInfo))
+        c_loc(ipiv),c_loc(C),ldc,myInfo)
     end function
 
     function rocsolver_dgetri_outofplace_rank_1(handle,n,A,lda,ipiv,C,ldc,myInfo)
@@ -76597,10 +72549,10 @@ module hipfort_rocsolver
       integer(c_int),target,dimension(:) :: ipiv
       real(c_double),target,dimension(:) :: C
       integer(c_int) :: ldc
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_dgetri_outofplace_rank_1 = rocsolver_dgetri_outofplace_(handle,n,c_loc(A),lda, &
-        c_loc(ipiv),c_loc(C),ldc,c_loc(myInfo))
+        c_loc(ipiv),c_loc(C),ldc,myInfo)
     end function
 
     function rocsolver_dgetri_outofplace_full_rank(handle,n,A,lda,ipiv,C,ldc,myInfo)
@@ -76613,13 +72565,13 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
+      integer(c_int),target,dimension(:) :: ipiv
       real(c_double),target,dimension(:,:) :: C
       integer(c_int) :: ldc
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_dgetri_outofplace_full_rank = rocsolver_dgetri_outofplace_(handle,n,c_loc(A),lda, &
-        c_loc(ipiv),c_loc(C),ldc,c_loc(myInfo))
+        c_loc(ipiv),c_loc(C),ldc,myInfo)
     end function
 
     function rocsolver_cgetri_outofplace_rank_0(handle,n,A,lda,ipiv,C,ldc,myInfo)
@@ -76635,10 +72587,10 @@ module hipfort_rocsolver
       integer(c_int),target :: ipiv
       complex(c_float_complex),target :: C
       integer(c_int) :: ldc
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_cgetri_outofplace_rank_0 = rocsolver_cgetri_outofplace_(handle,n,c_loc(A),lda, &
-        c_loc(ipiv),c_loc(C),ldc,c_loc(myInfo))
+        c_loc(ipiv),c_loc(C),ldc,myInfo)
     end function
 
     function rocsolver_cgetri_outofplace_rank_1(handle,n,A,lda,ipiv,C,ldc,myInfo)
@@ -76654,10 +72606,10 @@ module hipfort_rocsolver
       integer(c_int),target,dimension(:) :: ipiv
       complex(c_float_complex),target,dimension(:) :: C
       integer(c_int) :: ldc
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_cgetri_outofplace_rank_1 = rocsolver_cgetri_outofplace_(handle,n,c_loc(A),lda, &
-        c_loc(ipiv),c_loc(C),ldc,c_loc(myInfo))
+        c_loc(ipiv),c_loc(C),ldc,myInfo)
     end function
 
     function rocsolver_cgetri_outofplace_full_rank(handle,n,A,lda,ipiv,C,ldc,myInfo)
@@ -76670,13 +72622,13 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
+      integer(c_int),target,dimension(:) :: ipiv
       complex(c_float_complex),target,dimension(:,:) :: C
       integer(c_int) :: ldc
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_cgetri_outofplace_full_rank = rocsolver_cgetri_outofplace_(handle,n,c_loc(A),lda, &
-        c_loc(ipiv),c_loc(C),ldc,c_loc(myInfo))
+        c_loc(ipiv),c_loc(C),ldc,myInfo)
     end function
 
     function rocsolver_zgetri_outofplace_rank_0(handle,n,A,lda,ipiv,C,ldc,myInfo)
@@ -76692,10 +72644,10 @@ module hipfort_rocsolver
       integer(c_int),target :: ipiv
       complex(c_double_complex),target :: C
       integer(c_int) :: ldc
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_zgetri_outofplace_rank_0 = rocsolver_zgetri_outofplace_(handle,n,c_loc(A),lda, &
-        c_loc(ipiv),c_loc(C),ldc,c_loc(myInfo))
+        c_loc(ipiv),c_loc(C),ldc,myInfo)
     end function
 
     function rocsolver_zgetri_outofplace_rank_1(handle,n,A,lda,ipiv,C,ldc,myInfo)
@@ -76711,10 +72663,10 @@ module hipfort_rocsolver
       integer(c_int),target,dimension(:) :: ipiv
       complex(c_double_complex),target,dimension(:) :: C
       integer(c_int) :: ldc
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_zgetri_outofplace_rank_1 = rocsolver_zgetri_outofplace_(handle,n,c_loc(A),lda, &
-        c_loc(ipiv),c_loc(C),ldc,c_loc(myInfo))
+        c_loc(ipiv),c_loc(C),ldc,myInfo)
     end function
 
     function rocsolver_zgetri_outofplace_full_rank(handle,n,A,lda,ipiv,C,ldc,myInfo)
@@ -76727,13 +72679,13 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
+      integer(c_int),target,dimension(:) :: ipiv
       complex(c_double_complex),target,dimension(:,:) :: C
       integer(c_int) :: ldc
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_zgetri_outofplace_full_rank = rocsolver_zgetri_outofplace_(handle,n,c_loc(A),lda, &
-        c_loc(ipiv),c_loc(C),ldc,c_loc(myInfo))
+        c_loc(ipiv),c_loc(C),ldc,myInfo)
     end function
 
     function rocsolver_sgetri_outofplace_batched_rank_0(handle,n,A,lda,ipiv,strideP,C,ldc,myInfo, &
@@ -76751,11 +72703,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideP
       type(c_ptr) :: C
       integer(c_int) :: ldc
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_sgetri_outofplace_batched_rank_0 = rocsolver_sgetri_outofplace_batched_(handle,n, &
-        A,lda,c_loc(ipiv),strideP,C,ldc,c_loc(myInfo),batch_count)
+        A,lda,c_loc(ipiv),strideP,C,ldc,myInfo,batch_count)
     end function
 
     function rocsolver_sgetri_outofplace_batched_rank_1(handle,n,A,lda,ipiv,strideP,C,ldc,myInfo, &
@@ -76773,33 +72725,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideP
       type(c_ptr) :: C
       integer(c_int) :: ldc
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_sgetri_outofplace_batched_rank_1 = rocsolver_sgetri_outofplace_batched_(handle,n, &
-        A,lda,c_loc(ipiv),strideP,C,ldc,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_sgetri_outofplace_batched_full_rank(handle,n,A,lda,ipiv,strideP,C,ldc, &
-        myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_sgetri_outofplace_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      type(c_ptr) :: C
-      integer(c_int) :: ldc
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_sgetri_outofplace_batched_full_rank = rocsolver_sgetri_outofplace_batched_(handle, &
-        n,A,lda,c_loc(ipiv),strideP,C,ldc,c_loc(myInfo),batch_count)
+        A,lda,c_loc(ipiv),strideP,C,ldc,myInfo,batch_count)
     end function
 
     function rocsolver_dgetri_outofplace_batched_rank_0(handle,n,A,lda,ipiv,strideP,C,ldc,myInfo, &
@@ -76817,11 +72747,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideP
       type(c_ptr) :: C
       integer(c_int) :: ldc
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dgetri_outofplace_batched_rank_0 = rocsolver_dgetri_outofplace_batched_(handle,n, &
-        A,lda,c_loc(ipiv),strideP,C,ldc,c_loc(myInfo),batch_count)
+        A,lda,c_loc(ipiv),strideP,C,ldc,myInfo,batch_count)
     end function
 
     function rocsolver_dgetri_outofplace_batched_rank_1(handle,n,A,lda,ipiv,strideP,C,ldc,myInfo, &
@@ -76839,33 +72769,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideP
       type(c_ptr) :: C
       integer(c_int) :: ldc
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dgetri_outofplace_batched_rank_1 = rocsolver_dgetri_outofplace_batched_(handle,n, &
-        A,lda,c_loc(ipiv),strideP,C,ldc,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_dgetri_outofplace_batched_full_rank(handle,n,A,lda,ipiv,strideP,C,ldc, &
-        myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_dgetri_outofplace_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      type(c_ptr) :: C
-      integer(c_int) :: ldc
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_dgetri_outofplace_batched_full_rank = rocsolver_dgetri_outofplace_batched_(handle, &
-        n,A,lda,c_loc(ipiv),strideP,C,ldc,c_loc(myInfo),batch_count)
+        A,lda,c_loc(ipiv),strideP,C,ldc,myInfo,batch_count)
     end function
 
     function rocsolver_cgetri_outofplace_batched_rank_0(handle,n,A,lda,ipiv,strideP,C,ldc,myInfo, &
@@ -76883,11 +72791,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideP
       type(c_ptr) :: C
       integer(c_int) :: ldc
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cgetri_outofplace_batched_rank_0 = rocsolver_cgetri_outofplace_batched_(handle,n, &
-        A,lda,c_loc(ipiv),strideP,C,ldc,c_loc(myInfo),batch_count)
+        A,lda,c_loc(ipiv),strideP,C,ldc,myInfo,batch_count)
     end function
 
     function rocsolver_cgetri_outofplace_batched_rank_1(handle,n,A,lda,ipiv,strideP,C,ldc,myInfo, &
@@ -76905,33 +72813,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideP
       type(c_ptr) :: C
       integer(c_int) :: ldc
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cgetri_outofplace_batched_rank_1 = rocsolver_cgetri_outofplace_batched_(handle,n, &
-        A,lda,c_loc(ipiv),strideP,C,ldc,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_cgetri_outofplace_batched_full_rank(handle,n,A,lda,ipiv,strideP,C,ldc, &
-        myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_cgetri_outofplace_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      type(c_ptr) :: C
-      integer(c_int) :: ldc
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_cgetri_outofplace_batched_full_rank = rocsolver_cgetri_outofplace_batched_(handle, &
-        n,A,lda,c_loc(ipiv),strideP,C,ldc,c_loc(myInfo),batch_count)
+        A,lda,c_loc(ipiv),strideP,C,ldc,myInfo,batch_count)
     end function
 
     function rocsolver_zgetri_outofplace_batched_rank_0(handle,n,A,lda,ipiv,strideP,C,ldc,myInfo, &
@@ -76949,11 +72835,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideP
       type(c_ptr) :: C
       integer(c_int) :: ldc
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zgetri_outofplace_batched_rank_0 = rocsolver_zgetri_outofplace_batched_(handle,n, &
-        A,lda,c_loc(ipiv),strideP,C,ldc,c_loc(myInfo),batch_count)
+        A,lda,c_loc(ipiv),strideP,C,ldc,myInfo,batch_count)
     end function
 
     function rocsolver_zgetri_outofplace_batched_rank_1(handle,n,A,lda,ipiv,strideP,C,ldc,myInfo, &
@@ -76971,33 +72857,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideP
       type(c_ptr) :: C
       integer(c_int) :: ldc
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zgetri_outofplace_batched_rank_1 = rocsolver_zgetri_outofplace_batched_(handle,n, &
-        A,lda,c_loc(ipiv),strideP,C,ldc,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_zgetri_outofplace_batched_full_rank(handle,n,A,lda,ipiv,strideP,C,ldc, &
-        myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_zgetri_outofplace_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      type(c_ptr) :: C
-      integer(c_int) :: ldc
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_zgetri_outofplace_batched_full_rank = rocsolver_zgetri_outofplace_batched_(handle, &
-        n,A,lda,c_loc(ipiv),strideP,C,ldc,c_loc(myInfo),batch_count)
+        A,lda,c_loc(ipiv),strideP,C,ldc,myInfo,batch_count)
     end function
 
     function rocsolver_sgetri_outofplace_strided_batched_rank_0(handle,n,A,lda,strideA,ipiv, &
@@ -77017,12 +72881,12 @@ module hipfort_rocsolver
       real(c_float),target :: C
       integer(c_int) :: ldc
       integer(c_int64_t) :: strideC
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_sgetri_outofplace_strided_batched_rank_0 = &
         rocsolver_sgetri_outofplace_strided_batched_(handle,n,c_loc(A),lda,strideA,c_loc(ipiv), &
-        strideP,c_loc(C),ldc,strideC,c_loc(myInfo),batch_count)
+        strideP,c_loc(C),ldc,strideC,myInfo,batch_count)
     end function
 
     function rocsolver_sgetri_outofplace_strided_batched_rank_1(handle,n,A,lda,strideA,ipiv, &
@@ -77042,12 +72906,12 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:) :: C
       integer(c_int) :: ldc
       integer(c_int64_t) :: strideC
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_sgetri_outofplace_strided_batched_rank_1 = &
         rocsolver_sgetri_outofplace_strided_batched_(handle,n,c_loc(A),lda,strideA,c_loc(ipiv), &
-        strideP,c_loc(C),ldc,strideC,c_loc(myInfo),batch_count)
+        strideP,c_loc(C),ldc,strideC,myInfo,batch_count)
     end function
 
     function rocsolver_sgetri_outofplace_strided_batched_full_rank(handle,n,A,lda,strideA,ipiv, &
@@ -77062,17 +72926,17 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: ipiv
+      integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
       real(c_float),target,dimension(:,:) :: C
       integer(c_int) :: ldc
       integer(c_int64_t) :: strideC
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_sgetri_outofplace_strided_batched_full_rank = &
         rocsolver_sgetri_outofplace_strided_batched_(handle,n,c_loc(A),lda,strideA,c_loc(ipiv), &
-        strideP,c_loc(C),ldc,strideC,c_loc(myInfo),batch_count)
+        strideP,c_loc(C),ldc,strideC,myInfo,batch_count)
     end function
 
     function rocsolver_dgetri_outofplace_strided_batched_rank_0(handle,n,A,lda,strideA,ipiv, &
@@ -77092,12 +72956,12 @@ module hipfort_rocsolver
       real(c_double),target :: C
       integer(c_int) :: ldc
       integer(c_int64_t) :: strideC
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dgetri_outofplace_strided_batched_rank_0 = &
         rocsolver_dgetri_outofplace_strided_batched_(handle,n,c_loc(A),lda,strideA,c_loc(ipiv), &
-        strideP,c_loc(C),ldc,strideC,c_loc(myInfo),batch_count)
+        strideP,c_loc(C),ldc,strideC,myInfo,batch_count)
     end function
 
     function rocsolver_dgetri_outofplace_strided_batched_rank_1(handle,n,A,lda,strideA,ipiv, &
@@ -77117,12 +72981,12 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:) :: C
       integer(c_int) :: ldc
       integer(c_int64_t) :: strideC
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dgetri_outofplace_strided_batched_rank_1 = &
         rocsolver_dgetri_outofplace_strided_batched_(handle,n,c_loc(A),lda,strideA,c_loc(ipiv), &
-        strideP,c_loc(C),ldc,strideC,c_loc(myInfo),batch_count)
+        strideP,c_loc(C),ldc,strideC,myInfo,batch_count)
     end function
 
     function rocsolver_dgetri_outofplace_strided_batched_full_rank(handle,n,A,lda,strideA,ipiv, &
@@ -77137,17 +73001,17 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: ipiv
+      integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
       real(c_double),target,dimension(:,:) :: C
       integer(c_int) :: ldc
       integer(c_int64_t) :: strideC
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dgetri_outofplace_strided_batched_full_rank = &
         rocsolver_dgetri_outofplace_strided_batched_(handle,n,c_loc(A),lda,strideA,c_loc(ipiv), &
-        strideP,c_loc(C),ldc,strideC,c_loc(myInfo),batch_count)
+        strideP,c_loc(C),ldc,strideC,myInfo,batch_count)
     end function
 
     function rocsolver_cgetri_outofplace_strided_batched_rank_0(handle,n,A,lda,strideA,ipiv, &
@@ -77167,12 +73031,12 @@ module hipfort_rocsolver
       complex(c_float_complex),target :: C
       integer(c_int) :: ldc
       integer(c_int64_t) :: strideC
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cgetri_outofplace_strided_batched_rank_0 = &
         rocsolver_cgetri_outofplace_strided_batched_(handle,n,c_loc(A),lda,strideA,c_loc(ipiv), &
-        strideP,c_loc(C),ldc,strideC,c_loc(myInfo),batch_count)
+        strideP,c_loc(C),ldc,strideC,myInfo,batch_count)
     end function
 
     function rocsolver_cgetri_outofplace_strided_batched_rank_1(handle,n,A,lda,strideA,ipiv, &
@@ -77192,12 +73056,12 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:) :: C
       integer(c_int) :: ldc
       integer(c_int64_t) :: strideC
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cgetri_outofplace_strided_batched_rank_1 = &
         rocsolver_cgetri_outofplace_strided_batched_(handle,n,c_loc(A),lda,strideA,c_loc(ipiv), &
-        strideP,c_loc(C),ldc,strideC,c_loc(myInfo),batch_count)
+        strideP,c_loc(C),ldc,strideC,myInfo,batch_count)
     end function
 
     function rocsolver_cgetri_outofplace_strided_batched_full_rank(handle,n,A,lda,strideA,ipiv, &
@@ -77212,17 +73076,17 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: ipiv
+      integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
       complex(c_float_complex),target,dimension(:,:) :: C
       integer(c_int) :: ldc
       integer(c_int64_t) :: strideC
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cgetri_outofplace_strided_batched_full_rank = &
         rocsolver_cgetri_outofplace_strided_batched_(handle,n,c_loc(A),lda,strideA,c_loc(ipiv), &
-        strideP,c_loc(C),ldc,strideC,c_loc(myInfo),batch_count)
+        strideP,c_loc(C),ldc,strideC,myInfo,batch_count)
     end function
 
     function rocsolver_zgetri_outofplace_strided_batched_rank_0(handle,n,A,lda,strideA,ipiv, &
@@ -77242,12 +73106,12 @@ module hipfort_rocsolver
       complex(c_double_complex),target :: C
       integer(c_int) :: ldc
       integer(c_int64_t) :: strideC
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zgetri_outofplace_strided_batched_rank_0 = &
         rocsolver_zgetri_outofplace_strided_batched_(handle,n,c_loc(A),lda,strideA,c_loc(ipiv), &
-        strideP,c_loc(C),ldc,strideC,c_loc(myInfo),batch_count)
+        strideP,c_loc(C),ldc,strideC,myInfo,batch_count)
     end function
 
     function rocsolver_zgetri_outofplace_strided_batched_rank_1(handle,n,A,lda,strideA,ipiv, &
@@ -77267,12 +73131,12 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:) :: C
       integer(c_int) :: ldc
       integer(c_int64_t) :: strideC
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zgetri_outofplace_strided_batched_rank_1 = &
         rocsolver_zgetri_outofplace_strided_batched_(handle,n,c_loc(A),lda,strideA,c_loc(ipiv), &
-        strideP,c_loc(C),ldc,strideC,c_loc(myInfo),batch_count)
+        strideP,c_loc(C),ldc,strideC,myInfo,batch_count)
     end function
 
     function rocsolver_zgetri_outofplace_strided_batched_full_rank(handle,n,A,lda,strideA,ipiv, &
@@ -77287,17 +73151,17 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: ipiv
+      integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
       complex(c_double_complex),target,dimension(:,:) :: C
       integer(c_int) :: ldc
       integer(c_int64_t) :: strideC
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zgetri_outofplace_strided_batched_full_rank = &
         rocsolver_zgetri_outofplace_strided_batched_(handle,n,c_loc(A),lda,strideA,c_loc(ipiv), &
-        strideP,c_loc(C),ldc,strideC,c_loc(myInfo),batch_count)
+        strideP,c_loc(C),ldc,strideC,myInfo,batch_count)
     end function
 
     function rocsolver_sgetri_npvt_outofplace_rank_0(handle,n,A,lda,C,ldc,myInfo)
@@ -77312,10 +73176,10 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       real(c_float),target :: C
       integer(c_int) :: ldc
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_sgetri_npvt_outofplace_rank_0 = rocsolver_sgetri_npvt_outofplace_(handle,n, &
-        c_loc(A),lda,c_loc(C),ldc,c_loc(myInfo))
+        c_loc(A),lda,c_loc(C),ldc,myInfo)
     end function
 
     function rocsolver_sgetri_npvt_outofplace_rank_1(handle,n,A,lda,C,ldc,myInfo)
@@ -77330,10 +73194,10 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       real(c_float),target,dimension(:) :: C
       integer(c_int) :: ldc
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_sgetri_npvt_outofplace_rank_1 = rocsolver_sgetri_npvt_outofplace_(handle,n, &
-        c_loc(A),lda,c_loc(C),ldc,c_loc(myInfo))
+        c_loc(A),lda,c_loc(C),ldc,myInfo)
     end function
 
     function rocsolver_sgetri_npvt_outofplace_full_rank(handle,n,A,lda,C,ldc,myInfo)
@@ -77348,10 +73212,10 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       real(c_float),target,dimension(:,:) :: C
       integer(c_int) :: ldc
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_sgetri_npvt_outofplace_full_rank = rocsolver_sgetri_npvt_outofplace_(handle,n, &
-        c_loc(A),lda,c_loc(C),ldc,c_loc(myInfo))
+        c_loc(A),lda,c_loc(C),ldc,myInfo)
     end function
 
     function rocsolver_dgetri_npvt_outofplace_rank_0(handle,n,A,lda,C,ldc,myInfo)
@@ -77366,10 +73230,10 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       real(c_double),target :: C
       integer(c_int) :: ldc
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_dgetri_npvt_outofplace_rank_0 = rocsolver_dgetri_npvt_outofplace_(handle,n, &
-        c_loc(A),lda,c_loc(C),ldc,c_loc(myInfo))
+        c_loc(A),lda,c_loc(C),ldc,myInfo)
     end function
 
     function rocsolver_dgetri_npvt_outofplace_rank_1(handle,n,A,lda,C,ldc,myInfo)
@@ -77384,10 +73248,10 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       real(c_double),target,dimension(:) :: C
       integer(c_int) :: ldc
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_dgetri_npvt_outofplace_rank_1 = rocsolver_dgetri_npvt_outofplace_(handle,n, &
-        c_loc(A),lda,c_loc(C),ldc,c_loc(myInfo))
+        c_loc(A),lda,c_loc(C),ldc,myInfo)
     end function
 
     function rocsolver_dgetri_npvt_outofplace_full_rank(handle,n,A,lda,C,ldc,myInfo)
@@ -77402,10 +73266,10 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       real(c_double),target,dimension(:,:) :: C
       integer(c_int) :: ldc
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_dgetri_npvt_outofplace_full_rank = rocsolver_dgetri_npvt_outofplace_(handle,n, &
-        c_loc(A),lda,c_loc(C),ldc,c_loc(myInfo))
+        c_loc(A),lda,c_loc(C),ldc,myInfo)
     end function
 
     function rocsolver_cgetri_npvt_outofplace_rank_0(handle,n,A,lda,C,ldc,myInfo)
@@ -77420,10 +73284,10 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       complex(c_float_complex),target :: C
       integer(c_int) :: ldc
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_cgetri_npvt_outofplace_rank_0 = rocsolver_cgetri_npvt_outofplace_(handle,n, &
-        c_loc(A),lda,c_loc(C),ldc,c_loc(myInfo))
+        c_loc(A),lda,c_loc(C),ldc,myInfo)
     end function
 
     function rocsolver_cgetri_npvt_outofplace_rank_1(handle,n,A,lda,C,ldc,myInfo)
@@ -77438,10 +73302,10 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       complex(c_float_complex),target,dimension(:) :: C
       integer(c_int) :: ldc
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_cgetri_npvt_outofplace_rank_1 = rocsolver_cgetri_npvt_outofplace_(handle,n, &
-        c_loc(A),lda,c_loc(C),ldc,c_loc(myInfo))
+        c_loc(A),lda,c_loc(C),ldc,myInfo)
     end function
 
     function rocsolver_cgetri_npvt_outofplace_full_rank(handle,n,A,lda,C,ldc,myInfo)
@@ -77456,10 +73320,10 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       complex(c_float_complex),target,dimension(:,:) :: C
       integer(c_int) :: ldc
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_cgetri_npvt_outofplace_full_rank = rocsolver_cgetri_npvt_outofplace_(handle,n, &
-        c_loc(A),lda,c_loc(C),ldc,c_loc(myInfo))
+        c_loc(A),lda,c_loc(C),ldc,myInfo)
     end function
 
     function rocsolver_zgetri_npvt_outofplace_rank_0(handle,n,A,lda,C,ldc,myInfo)
@@ -77474,10 +73338,10 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       complex(c_double_complex),target :: C
       integer(c_int) :: ldc
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_zgetri_npvt_outofplace_rank_0 = rocsolver_zgetri_npvt_outofplace_(handle,n, &
-        c_loc(A),lda,c_loc(C),ldc,c_loc(myInfo))
+        c_loc(A),lda,c_loc(C),ldc,myInfo)
     end function
 
     function rocsolver_zgetri_npvt_outofplace_rank_1(handle,n,A,lda,C,ldc,myInfo)
@@ -77492,10 +73356,10 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       complex(c_double_complex),target,dimension(:) :: C
       integer(c_int) :: ldc
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_zgetri_npvt_outofplace_rank_1 = rocsolver_zgetri_npvt_outofplace_(handle,n, &
-        c_loc(A),lda,c_loc(C),ldc,c_loc(myInfo))
+        c_loc(A),lda,c_loc(C),ldc,myInfo)
     end function
 
     function rocsolver_zgetri_npvt_outofplace_full_rank(handle,n,A,lda,C,ldc,myInfo)
@@ -77510,250 +73374,10 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       complex(c_double_complex),target,dimension(:,:) :: C
       integer(c_int) :: ldc
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
       rocsolver_zgetri_npvt_outofplace_full_rank = rocsolver_zgetri_npvt_outofplace_(handle,n, &
-        c_loc(A),lda,c_loc(C),ldc,c_loc(myInfo))
-    end function
-
-    function rocsolver_sgetri_npvt_outofplace_batched_rank_0(handle,n,A,lda,C,ldc,myInfo, &
-        batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_sgetri_npvt_outofplace_batched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: C
-      integer(c_int) :: ldc
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_sgetri_npvt_outofplace_batched_rank_0 = rocsolver_sgetri_npvt_outofplace_batched_( &
-        handle,n,A,lda,C,ldc,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_sgetri_npvt_outofplace_batched_rank_1(handle,n,A,lda,C,ldc,myInfo, &
-        batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_sgetri_npvt_outofplace_batched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: C
-      integer(c_int) :: ldc
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_sgetri_npvt_outofplace_batched_rank_1 = rocsolver_sgetri_npvt_outofplace_batched_( &
-        handle,n,A,lda,C,ldc,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_sgetri_npvt_outofplace_batched_full_rank(handle,n,A,lda,C,ldc,myInfo, &
-        batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_sgetri_npvt_outofplace_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: C
-      integer(c_int) :: ldc
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_sgetri_npvt_outofplace_batched_full_rank = &
-        rocsolver_sgetri_npvt_outofplace_batched_(handle,n,A,lda,C,ldc,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_dgetri_npvt_outofplace_batched_rank_0(handle,n,A,lda,C,ldc,myInfo, &
-        batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_dgetri_npvt_outofplace_batched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: C
-      integer(c_int) :: ldc
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_dgetri_npvt_outofplace_batched_rank_0 = rocsolver_dgetri_npvt_outofplace_batched_( &
-        handle,n,A,lda,C,ldc,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_dgetri_npvt_outofplace_batched_rank_1(handle,n,A,lda,C,ldc,myInfo, &
-        batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_dgetri_npvt_outofplace_batched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: C
-      integer(c_int) :: ldc
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_dgetri_npvt_outofplace_batched_rank_1 = rocsolver_dgetri_npvt_outofplace_batched_( &
-        handle,n,A,lda,C,ldc,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_dgetri_npvt_outofplace_batched_full_rank(handle,n,A,lda,C,ldc,myInfo, &
-        batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_dgetri_npvt_outofplace_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: C
-      integer(c_int) :: ldc
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_dgetri_npvt_outofplace_batched_full_rank = &
-        rocsolver_dgetri_npvt_outofplace_batched_(handle,n,A,lda,C,ldc,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_cgetri_npvt_outofplace_batched_rank_0(handle,n,A,lda,C,ldc,myInfo, &
-        batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_cgetri_npvt_outofplace_batched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: C
-      integer(c_int) :: ldc
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_cgetri_npvt_outofplace_batched_rank_0 = rocsolver_cgetri_npvt_outofplace_batched_( &
-        handle,n,A,lda,C,ldc,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_cgetri_npvt_outofplace_batched_rank_1(handle,n,A,lda,C,ldc,myInfo, &
-        batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_cgetri_npvt_outofplace_batched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: C
-      integer(c_int) :: ldc
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_cgetri_npvt_outofplace_batched_rank_1 = rocsolver_cgetri_npvt_outofplace_batched_( &
-        handle,n,A,lda,C,ldc,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_cgetri_npvt_outofplace_batched_full_rank(handle,n,A,lda,C,ldc,myInfo, &
-        batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_cgetri_npvt_outofplace_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: C
-      integer(c_int) :: ldc
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_cgetri_npvt_outofplace_batched_full_rank = &
-        rocsolver_cgetri_npvt_outofplace_batched_(handle,n,A,lda,C,ldc,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_zgetri_npvt_outofplace_batched_rank_0(handle,n,A,lda,C,ldc,myInfo, &
-        batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_zgetri_npvt_outofplace_batched_rank_0
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: C
-      integer(c_int) :: ldc
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_zgetri_npvt_outofplace_batched_rank_0 = rocsolver_zgetri_npvt_outofplace_batched_( &
-        handle,n,A,lda,C,ldc,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_zgetri_npvt_outofplace_batched_rank_1(handle,n,A,lda,C,ldc,myInfo, &
-        batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_zgetri_npvt_outofplace_batched_rank_1
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: C
-      integer(c_int) :: ldc
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_zgetri_npvt_outofplace_batched_rank_1 = rocsolver_zgetri_npvt_outofplace_batched_( &
-        handle,n,A,lda,C,ldc,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_zgetri_npvt_outofplace_batched_full_rank(handle,n,A,lda,C,ldc,myInfo, &
-        batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_zgetri_npvt_outofplace_batched_full_rank
-      type(c_ptr) :: handle
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      type(c_ptr) :: C
-      integer(c_int) :: ldc
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_zgetri_npvt_outofplace_batched_full_rank = &
-        rocsolver_zgetri_npvt_outofplace_batched_(handle,n,A,lda,C,ldc,c_loc(myInfo),batch_count)
+        c_loc(A),lda,c_loc(C),ldc,myInfo)
     end function
 
     function rocsolver_sgetri_npvt_outofplace_strided_batched_rank_0(handle,n,A,lda,strideA,C,ldc, &
@@ -77771,12 +73395,12 @@ module hipfort_rocsolver
       real(c_float),target :: C
       integer(c_int) :: ldc
       integer(c_int64_t) :: strideC
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_sgetri_npvt_outofplace_strided_batched_rank_0 = &
         rocsolver_sgetri_npvt_outofplace_strided_batched_(handle,n,c_loc(A),lda,strideA,c_loc(C), &
-        ldc,strideC,c_loc(myInfo),batch_count)
+        ldc,strideC,myInfo,batch_count)
     end function
 
     function rocsolver_sgetri_npvt_outofplace_strided_batched_rank_1(handle,n,A,lda,strideA,C,ldc, &
@@ -77794,12 +73418,12 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:) :: C
       integer(c_int) :: ldc
       integer(c_int64_t) :: strideC
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_sgetri_npvt_outofplace_strided_batched_rank_1 = &
         rocsolver_sgetri_npvt_outofplace_strided_batched_(handle,n,c_loc(A),lda,strideA,c_loc(C), &
-        ldc,strideC,c_loc(myInfo),batch_count)
+        ldc,strideC,myInfo,batch_count)
     end function
 
     function rocsolver_sgetri_npvt_outofplace_strided_batched_full_rank(handle,n,A,lda,strideA,C, &
@@ -77817,12 +73441,12 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:,:) :: C
       integer(c_int) :: ldc
       integer(c_int64_t) :: strideC
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_sgetri_npvt_outofplace_strided_batched_full_rank = &
         rocsolver_sgetri_npvt_outofplace_strided_batched_(handle,n,c_loc(A),lda,strideA,c_loc(C), &
-        ldc,strideC,c_loc(myInfo),batch_count)
+        ldc,strideC,myInfo,batch_count)
     end function
 
     function rocsolver_dgetri_npvt_outofplace_strided_batched_rank_0(handle,n,A,lda,strideA,C,ldc, &
@@ -77840,12 +73464,12 @@ module hipfort_rocsolver
       real(c_double),target :: C
       integer(c_int) :: ldc
       integer(c_int64_t) :: strideC
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dgetri_npvt_outofplace_strided_batched_rank_0 = &
         rocsolver_dgetri_npvt_outofplace_strided_batched_(handle,n,c_loc(A),lda,strideA,c_loc(C), &
-        ldc,strideC,c_loc(myInfo),batch_count)
+        ldc,strideC,myInfo,batch_count)
     end function
 
     function rocsolver_dgetri_npvt_outofplace_strided_batched_rank_1(handle,n,A,lda,strideA,C,ldc, &
@@ -77863,12 +73487,12 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:) :: C
       integer(c_int) :: ldc
       integer(c_int64_t) :: strideC
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dgetri_npvt_outofplace_strided_batched_rank_1 = &
         rocsolver_dgetri_npvt_outofplace_strided_batched_(handle,n,c_loc(A),lda,strideA,c_loc(C), &
-        ldc,strideC,c_loc(myInfo),batch_count)
+        ldc,strideC,myInfo,batch_count)
     end function
 
     function rocsolver_dgetri_npvt_outofplace_strided_batched_full_rank(handle,n,A,lda,strideA,C, &
@@ -77886,12 +73510,12 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:,:) :: C
       integer(c_int) :: ldc
       integer(c_int64_t) :: strideC
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dgetri_npvt_outofplace_strided_batched_full_rank = &
         rocsolver_dgetri_npvt_outofplace_strided_batched_(handle,n,c_loc(A),lda,strideA,c_loc(C), &
-        ldc,strideC,c_loc(myInfo),batch_count)
+        ldc,strideC,myInfo,batch_count)
     end function
 
     function rocsolver_cgetri_npvt_outofplace_strided_batched_rank_0(handle,n,A,lda,strideA,C,ldc, &
@@ -77909,12 +73533,12 @@ module hipfort_rocsolver
       complex(c_float_complex),target :: C
       integer(c_int) :: ldc
       integer(c_int64_t) :: strideC
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cgetri_npvt_outofplace_strided_batched_rank_0 = &
         rocsolver_cgetri_npvt_outofplace_strided_batched_(handle,n,c_loc(A),lda,strideA,c_loc(C), &
-        ldc,strideC,c_loc(myInfo),batch_count)
+        ldc,strideC,myInfo,batch_count)
     end function
 
     function rocsolver_cgetri_npvt_outofplace_strided_batched_rank_1(handle,n,A,lda,strideA,C,ldc, &
@@ -77932,12 +73556,12 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:) :: C
       integer(c_int) :: ldc
       integer(c_int64_t) :: strideC
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cgetri_npvt_outofplace_strided_batched_rank_1 = &
         rocsolver_cgetri_npvt_outofplace_strided_batched_(handle,n,c_loc(A),lda,strideA,c_loc(C), &
-        ldc,strideC,c_loc(myInfo),batch_count)
+        ldc,strideC,myInfo,batch_count)
     end function
 
     function rocsolver_cgetri_npvt_outofplace_strided_batched_full_rank(handle,n,A,lda,strideA,C, &
@@ -77955,12 +73579,12 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:,:) :: C
       integer(c_int) :: ldc
       integer(c_int64_t) :: strideC
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_cgetri_npvt_outofplace_strided_batched_full_rank = &
         rocsolver_cgetri_npvt_outofplace_strided_batched_(handle,n,c_loc(A),lda,strideA,c_loc(C), &
-        ldc,strideC,c_loc(myInfo),batch_count)
+        ldc,strideC,myInfo,batch_count)
     end function
 
     function rocsolver_zgetri_npvt_outofplace_strided_batched_rank_0(handle,n,A,lda,strideA,C,ldc, &
@@ -77978,12 +73602,12 @@ module hipfort_rocsolver
       complex(c_double_complex),target :: C
       integer(c_int) :: ldc
       integer(c_int64_t) :: strideC
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zgetri_npvt_outofplace_strided_batched_rank_0 = &
         rocsolver_zgetri_npvt_outofplace_strided_batched_(handle,n,c_loc(A),lda,strideA,c_loc(C), &
-        ldc,strideC,c_loc(myInfo),batch_count)
+        ldc,strideC,myInfo,batch_count)
     end function
 
     function rocsolver_zgetri_npvt_outofplace_strided_batched_rank_1(handle,n,A,lda,strideA,C,ldc, &
@@ -78001,12 +73625,12 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:) :: C
       integer(c_int) :: ldc
       integer(c_int64_t) :: strideC
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zgetri_npvt_outofplace_strided_batched_rank_1 = &
         rocsolver_zgetri_npvt_outofplace_strided_batched_(handle,n,c_loc(A),lda,strideA,c_loc(C), &
-        ldc,strideC,c_loc(myInfo),batch_count)
+        ldc,strideC,myInfo,batch_count)
     end function
 
     function rocsolver_zgetri_npvt_outofplace_strided_batched_full_rank(handle,n,A,lda,strideA,C, &
@@ -78024,12 +73648,12 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:,:) :: C
       integer(c_int) :: ldc
       integer(c_int64_t) :: strideC
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zgetri_npvt_outofplace_strided_batched_full_rank = &
         rocsolver_zgetri_npvt_outofplace_strided_batched_(handle,n,c_loc(A),lda,strideA,c_loc(C), &
-        ldc,strideC,c_loc(myInfo),batch_count)
+        ldc,strideC,myInfo,batch_count)
     end function
 
     function rocsolver_strtri_rank_0(handle,uplo,diag,n,A,lda,myInfo)
@@ -78044,9 +73668,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_float),target :: A
       integer(c_int) :: lda
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_strtri_rank_0 = rocsolver_strtri_(handle,uplo,diag,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_strtri_rank_0 = rocsolver_strtri_(handle,uplo,diag,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_strtri_rank_1(handle,uplo,diag,n,A,lda,myInfo)
@@ -78061,9 +73685,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_float),target,dimension(:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_strtri_rank_1 = rocsolver_strtri_(handle,uplo,diag,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_strtri_rank_1 = rocsolver_strtri_(handle,uplo,diag,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_strtri_full_rank(handle,uplo,diag,n,A,lda,myInfo)
@@ -78078,9 +73702,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_strtri_full_rank = rocsolver_strtri_(handle,uplo,diag,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_strtri_full_rank = rocsolver_strtri_(handle,uplo,diag,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_dtrtri_rank_0(handle,uplo,diag,n,A,lda,myInfo)
@@ -78095,9 +73719,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_double),target :: A
       integer(c_int) :: lda
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_dtrtri_rank_0 = rocsolver_dtrtri_(handle,uplo,diag,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_dtrtri_rank_0 = rocsolver_dtrtri_(handle,uplo,diag,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_dtrtri_rank_1(handle,uplo,diag,n,A,lda,myInfo)
@@ -78112,9 +73736,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_double),target,dimension(:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_dtrtri_rank_1 = rocsolver_dtrtri_(handle,uplo,diag,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_dtrtri_rank_1 = rocsolver_dtrtri_(handle,uplo,diag,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_dtrtri_full_rank(handle,uplo,diag,n,A,lda,myInfo)
@@ -78129,9 +73753,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_dtrtri_full_rank = rocsolver_dtrtri_(handle,uplo,diag,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_dtrtri_full_rank = rocsolver_dtrtri_(handle,uplo,diag,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_ctrtri_rank_0(handle,uplo,diag,n,A,lda,myInfo)
@@ -78146,9 +73770,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_float_complex),target :: A
       integer(c_int) :: lda
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_ctrtri_rank_0 = rocsolver_ctrtri_(handle,uplo,diag,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_ctrtri_rank_0 = rocsolver_ctrtri_(handle,uplo,diag,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_ctrtri_rank_1(handle,uplo,diag,n,A,lda,myInfo)
@@ -78163,9 +73787,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_ctrtri_rank_1 = rocsolver_ctrtri_(handle,uplo,diag,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_ctrtri_rank_1 = rocsolver_ctrtri_(handle,uplo,diag,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_ctrtri_full_rank(handle,uplo,diag,n,A,lda,myInfo)
@@ -78180,9 +73804,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_ctrtri_full_rank = rocsolver_ctrtri_(handle,uplo,diag,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_ctrtri_full_rank = rocsolver_ctrtri_(handle,uplo,diag,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_ztrtri_rank_0(handle,uplo,diag,n,A,lda,myInfo)
@@ -78197,9 +73821,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_double_complex),target :: A
       integer(c_int) :: lda
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_ztrtri_rank_0 = rocsolver_ztrtri_(handle,uplo,diag,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_ztrtri_rank_0 = rocsolver_ztrtri_(handle,uplo,diag,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_ztrtri_rank_1(handle,uplo,diag,n,A,lda,myInfo)
@@ -78214,9 +73838,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_ztrtri_rank_1 = rocsolver_ztrtri_(handle,uplo,diag,n,c_loc(A),lda,c_loc(myInfo))
+      rocsolver_ztrtri_rank_1 = rocsolver_ztrtri_(handle,uplo,diag,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_ztrtri_full_rank(handle,uplo,diag,n,A,lda,myInfo)
@@ -78231,237 +73855,9 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_ztrtri_full_rank = rocsolver_ztrtri_(handle,uplo,diag,n,c_loc(A),lda,c_loc(myInfo))
-    end function
-
-    function rocsolver_strtri_batched_rank_0(handle,uplo,diag,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_strtri_batched_rank_0
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(kind(rocblas_diagonal_non_unit)) :: diag
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_strtri_batched_rank_0 = rocsolver_strtri_batched_(handle,uplo,diag,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_strtri_batched_rank_1(handle,uplo,diag,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_strtri_batched_rank_1
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(kind(rocblas_diagonal_non_unit)) :: diag
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_strtri_batched_rank_1 = rocsolver_strtri_batched_(handle,uplo,diag,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_strtri_batched_full_rank(handle,uplo,diag,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_strtri_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(kind(rocblas_diagonal_non_unit)) :: diag
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_strtri_batched_full_rank = rocsolver_strtri_batched_(handle,uplo,diag,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_dtrtri_batched_rank_0(handle,uplo,diag,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_dtrtri_batched_rank_0
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(kind(rocblas_diagonal_non_unit)) :: diag
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_dtrtri_batched_rank_0 = rocsolver_dtrtri_batched_(handle,uplo,diag,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_dtrtri_batched_rank_1(handle,uplo,diag,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_dtrtri_batched_rank_1
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(kind(rocblas_diagonal_non_unit)) :: diag
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_dtrtri_batched_rank_1 = rocsolver_dtrtri_batched_(handle,uplo,diag,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_dtrtri_batched_full_rank(handle,uplo,diag,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_dtrtri_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(kind(rocblas_diagonal_non_unit)) :: diag
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_dtrtri_batched_full_rank = rocsolver_dtrtri_batched_(handle,uplo,diag,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_ctrtri_batched_rank_0(handle,uplo,diag,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_ctrtri_batched_rank_0
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(kind(rocblas_diagonal_non_unit)) :: diag
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_ctrtri_batched_rank_0 = rocsolver_ctrtri_batched_(handle,uplo,diag,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_ctrtri_batched_rank_1(handle,uplo,diag,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_ctrtri_batched_rank_1
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(kind(rocblas_diagonal_non_unit)) :: diag
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_ctrtri_batched_rank_1 = rocsolver_ctrtri_batched_(handle,uplo,diag,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_ctrtri_batched_full_rank(handle,uplo,diag,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_ctrtri_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(kind(rocblas_diagonal_non_unit)) :: diag
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_ctrtri_batched_full_rank = rocsolver_ctrtri_batched_(handle,uplo,diag,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_ztrtri_batched_rank_0(handle,uplo,diag,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_ztrtri_batched_rank_0
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(kind(rocblas_diagonal_non_unit)) :: diag
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_ztrtri_batched_rank_0 = rocsolver_ztrtri_batched_(handle,uplo,diag,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_ztrtri_batched_rank_1(handle,uplo,diag,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_ztrtri_batched_rank_1
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(kind(rocblas_diagonal_non_unit)) :: diag
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_ztrtri_batched_rank_1 = rocsolver_ztrtri_batched_(handle,uplo,diag,n,A,lda, &
-        c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_ztrtri_batched_full_rank(handle,uplo,diag,n,A,lda,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_ztrtri_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(kind(rocblas_diagonal_non_unit)) :: diag
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_ztrtri_batched_full_rank = rocsolver_ztrtri_batched_(handle,uplo,diag,n,A,lda, &
-        c_loc(myInfo),batch_count)
+      rocsolver_ztrtri_full_rank = rocsolver_ztrtri_(handle,uplo,diag,n,c_loc(A),lda,myInfo)
     end function
 
     function rocsolver_strtri_strided_batched_rank_0(handle,uplo,diag,n,A,lda,strideA,myInfo, &
@@ -78478,11 +73874,11 @@ module hipfort_rocsolver
       real(c_float),target :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_strtri_strided_batched_rank_0 = rocsolver_strtri_strided_batched_(handle,uplo, &
-        diag,n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        diag,n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_strtri_strided_batched_rank_1(handle,uplo,diag,n,A,lda,strideA,myInfo, &
@@ -78499,11 +73895,11 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_strtri_strided_batched_rank_1 = rocsolver_strtri_strided_batched_(handle,uplo, &
-        diag,n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        diag,n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_strtri_strided_batched_full_rank(handle,uplo,diag,n,A,lda,strideA,myInfo, &
@@ -78520,11 +73916,11 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_strtri_strided_batched_full_rank = rocsolver_strtri_strided_batched_(handle,uplo, &
-        diag,n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        diag,n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_dtrtri_strided_batched_rank_0(handle,uplo,diag,n,A,lda,strideA,myInfo, &
@@ -78541,11 +73937,11 @@ module hipfort_rocsolver
       real(c_double),target :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dtrtri_strided_batched_rank_0 = rocsolver_dtrtri_strided_batched_(handle,uplo, &
-        diag,n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        diag,n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_dtrtri_strided_batched_rank_1(handle,uplo,diag,n,A,lda,strideA,myInfo, &
@@ -78562,11 +73958,11 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dtrtri_strided_batched_rank_1 = rocsolver_dtrtri_strided_batched_(handle,uplo, &
-        diag,n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        diag,n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_dtrtri_strided_batched_full_rank(handle,uplo,diag,n,A,lda,strideA,myInfo, &
@@ -78583,11 +73979,11 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dtrtri_strided_batched_full_rank = rocsolver_dtrtri_strided_batched_(handle,uplo, &
-        diag,n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        diag,n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_ctrtri_strided_batched_rank_0(handle,uplo,diag,n,A,lda,strideA,myInfo, &
@@ -78604,11 +74000,11 @@ module hipfort_rocsolver
       complex(c_float_complex),target :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_ctrtri_strided_batched_rank_0 = rocsolver_ctrtri_strided_batched_(handle,uplo, &
-        diag,n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        diag,n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_ctrtri_strided_batched_rank_1(handle,uplo,diag,n,A,lda,strideA,myInfo, &
@@ -78625,11 +74021,11 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_ctrtri_strided_batched_rank_1 = rocsolver_ctrtri_strided_batched_(handle,uplo, &
-        diag,n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        diag,n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_ctrtri_strided_batched_full_rank(handle,uplo,diag,n,A,lda,strideA,myInfo, &
@@ -78646,11 +74042,11 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_ctrtri_strided_batched_full_rank = rocsolver_ctrtri_strided_batched_(handle,uplo, &
-        diag,n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        diag,n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_ztrtri_strided_batched_rank_0(handle,uplo,diag,n,A,lda,strideA,myInfo, &
@@ -78667,11 +74063,11 @@ module hipfort_rocsolver
       complex(c_double_complex),target :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_ztrtri_strided_batched_rank_0 = rocsolver_ztrtri_strided_batched_(handle,uplo, &
-        diag,n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        diag,n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_ztrtri_strided_batched_rank_1(handle,uplo,diag,n,A,lda,strideA,myInfo, &
@@ -78688,11 +74084,11 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_ztrtri_strided_batched_rank_1 = rocsolver_ztrtri_strided_batched_(handle,uplo, &
-        diag,n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        diag,n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_ztrtri_strided_batched_full_rank(handle,uplo,diag,n,A,lda,strideA,myInfo, &
@@ -78709,11 +74105,11 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_ztrtri_strided_batched_full_rank = rocsolver_ztrtri_strided_batched_(handle,uplo, &
-        diag,n,c_loc(A),lda,strideA,c_loc(myInfo),batch_count)
+        diag,n,c_loc(A),lda,strideA,myInfo,batch_count)
     end function
 
     function rocsolver_ssytf2_rank_0(handle,uplo,n,A,lda,ipiv,myInfo)
@@ -78728,10 +74124,9 @@ module hipfort_rocsolver
       real(c_float),target :: A
       integer(c_int) :: lda
       integer(c_int),target :: ipiv
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_ssytf2_rank_0 = rocsolver_ssytf2_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv), &
-        c_loc(myInfo))
+      rocsolver_ssytf2_rank_0 = rocsolver_ssytf2_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_ssytf2_rank_1(handle,uplo,n,A,lda,ipiv,myInfo)
@@ -78746,10 +74141,9 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int),target,dimension(:) :: ipiv
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_ssytf2_rank_1 = rocsolver_ssytf2_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv), &
-        c_loc(myInfo))
+      rocsolver_ssytf2_rank_1 = rocsolver_ssytf2_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_ssytf2_full_rank(handle,uplo,n,A,lda,ipiv,myInfo)
@@ -78763,11 +74157,10 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int),target,dimension(:,:) :: myInfo
+      integer(c_int),target,dimension(:) :: ipiv
+      type(c_ptr) :: myInfo
       !
-      rocsolver_ssytf2_full_rank = rocsolver_ssytf2_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv), &
-        c_loc(myInfo))
+      rocsolver_ssytf2_full_rank = rocsolver_ssytf2_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_dsytf2_rank_0(handle,uplo,n,A,lda,ipiv,myInfo)
@@ -78782,10 +74175,9 @@ module hipfort_rocsolver
       real(c_double),target :: A
       integer(c_int) :: lda
       integer(c_int),target :: ipiv
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_dsytf2_rank_0 = rocsolver_dsytf2_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv), &
-        c_loc(myInfo))
+      rocsolver_dsytf2_rank_0 = rocsolver_dsytf2_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_dsytf2_rank_1(handle,uplo,n,A,lda,ipiv,myInfo)
@@ -78800,10 +74192,9 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int),target,dimension(:) :: ipiv
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_dsytf2_rank_1 = rocsolver_dsytf2_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv), &
-        c_loc(myInfo))
+      rocsolver_dsytf2_rank_1 = rocsolver_dsytf2_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_dsytf2_full_rank(handle,uplo,n,A,lda,ipiv,myInfo)
@@ -78817,11 +74208,10 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int),target,dimension(:,:) :: myInfo
+      integer(c_int),target,dimension(:) :: ipiv
+      type(c_ptr) :: myInfo
       !
-      rocsolver_dsytf2_full_rank = rocsolver_dsytf2_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv), &
-        c_loc(myInfo))
+      rocsolver_dsytf2_full_rank = rocsolver_dsytf2_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_csytf2_rank_0(handle,uplo,n,A,lda,ipiv,myInfo)
@@ -78836,10 +74226,9 @@ module hipfort_rocsolver
       complex(c_float_complex),target :: A
       integer(c_int) :: lda
       integer(c_int),target :: ipiv
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_csytf2_rank_0 = rocsolver_csytf2_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv), &
-        c_loc(myInfo))
+      rocsolver_csytf2_rank_0 = rocsolver_csytf2_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_csytf2_rank_1(handle,uplo,n,A,lda,ipiv,myInfo)
@@ -78854,10 +74243,9 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int),target,dimension(:) :: ipiv
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_csytf2_rank_1 = rocsolver_csytf2_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv), &
-        c_loc(myInfo))
+      rocsolver_csytf2_rank_1 = rocsolver_csytf2_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_csytf2_full_rank(handle,uplo,n,A,lda,ipiv,myInfo)
@@ -78871,11 +74259,10 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int),target,dimension(:,:) :: myInfo
+      integer(c_int),target,dimension(:) :: ipiv
+      type(c_ptr) :: myInfo
       !
-      rocsolver_csytf2_full_rank = rocsolver_csytf2_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv), &
-        c_loc(myInfo))
+      rocsolver_csytf2_full_rank = rocsolver_csytf2_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_zsytf2_rank_0(handle,uplo,n,A,lda,ipiv,myInfo)
@@ -78890,10 +74277,9 @@ module hipfort_rocsolver
       complex(c_double_complex),target :: A
       integer(c_int) :: lda
       integer(c_int),target :: ipiv
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_zsytf2_rank_0 = rocsolver_zsytf2_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv), &
-        c_loc(myInfo))
+      rocsolver_zsytf2_rank_0 = rocsolver_zsytf2_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_zsytf2_rank_1(handle,uplo,n,A,lda,ipiv,myInfo)
@@ -78908,10 +74294,9 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int),target,dimension(:) :: ipiv
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_zsytf2_rank_1 = rocsolver_zsytf2_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv), &
-        c_loc(myInfo))
+      rocsolver_zsytf2_rank_1 = rocsolver_zsytf2_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_zsytf2_full_rank(handle,uplo,n,A,lda,ipiv,myInfo)
@@ -78925,11 +74310,10 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int),target,dimension(:,:) :: myInfo
+      integer(c_int),target,dimension(:) :: ipiv
+      type(c_ptr) :: myInfo
       !
-      rocsolver_zsytf2_full_rank = rocsolver_zsytf2_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv), &
-        c_loc(myInfo))
+      rocsolver_zsytf2_full_rank = rocsolver_zsytf2_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_ssytf2_batched_rank_0(handle,uplo,n,A,lda,ipiv,strideP,myInfo,batch_count)
@@ -78945,11 +74329,11 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       integer(c_int),target :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_ssytf2_batched_rank_0 = rocsolver_ssytf2_batched_(handle,uplo,n,A,lda,c_loc(ipiv), &
-        strideP,c_loc(myInfo),batch_count)
+        strideP,myInfo,batch_count)
     end function
 
     function rocsolver_ssytf2_batched_rank_1(handle,uplo,n,A,lda,ipiv,strideP,myInfo,batch_count)
@@ -78965,31 +74349,11 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_ssytf2_batched_rank_1 = rocsolver_ssytf2_batched_(handle,uplo,n,A,lda,c_loc(ipiv), &
-        strideP,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_ssytf2_batched_full_rank(handle,uplo,n,A,lda,ipiv,strideP,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_ssytf2_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_ssytf2_batched_full_rank = rocsolver_ssytf2_batched_(handle,uplo,n,A,lda, &
-        c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        strideP,myInfo,batch_count)
     end function
 
     function rocsolver_dsytf2_batched_rank_0(handle,uplo,n,A,lda,ipiv,strideP,myInfo,batch_count)
@@ -79005,11 +74369,11 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       integer(c_int),target :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dsytf2_batched_rank_0 = rocsolver_dsytf2_batched_(handle,uplo,n,A,lda,c_loc(ipiv), &
-        strideP,c_loc(myInfo),batch_count)
+        strideP,myInfo,batch_count)
     end function
 
     function rocsolver_dsytf2_batched_rank_1(handle,uplo,n,A,lda,ipiv,strideP,myInfo,batch_count)
@@ -79025,31 +74389,11 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dsytf2_batched_rank_1 = rocsolver_dsytf2_batched_(handle,uplo,n,A,lda,c_loc(ipiv), &
-        strideP,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_dsytf2_batched_full_rank(handle,uplo,n,A,lda,ipiv,strideP,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_dsytf2_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_dsytf2_batched_full_rank = rocsolver_dsytf2_batched_(handle,uplo,n,A,lda, &
-        c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        strideP,myInfo,batch_count)
     end function
 
     function rocsolver_csytf2_batched_rank_0(handle,uplo,n,A,lda,ipiv,strideP,myInfo,batch_count)
@@ -79065,11 +74409,11 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       integer(c_int),target :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_csytf2_batched_rank_0 = rocsolver_csytf2_batched_(handle,uplo,n,A,lda,c_loc(ipiv), &
-        strideP,c_loc(myInfo),batch_count)
+        strideP,myInfo,batch_count)
     end function
 
     function rocsolver_csytf2_batched_rank_1(handle,uplo,n,A,lda,ipiv,strideP,myInfo,batch_count)
@@ -79085,31 +74429,11 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_csytf2_batched_rank_1 = rocsolver_csytf2_batched_(handle,uplo,n,A,lda,c_loc(ipiv), &
-        strideP,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_csytf2_batched_full_rank(handle,uplo,n,A,lda,ipiv,strideP,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_csytf2_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_csytf2_batched_full_rank = rocsolver_csytf2_batched_(handle,uplo,n,A,lda, &
-        c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        strideP,myInfo,batch_count)
     end function
 
     function rocsolver_zsytf2_batched_rank_0(handle,uplo,n,A,lda,ipiv,strideP,myInfo,batch_count)
@@ -79125,11 +74449,11 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       integer(c_int),target :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zsytf2_batched_rank_0 = rocsolver_zsytf2_batched_(handle,uplo,n,A,lda,c_loc(ipiv), &
-        strideP,c_loc(myInfo),batch_count)
+        strideP,myInfo,batch_count)
     end function
 
     function rocsolver_zsytf2_batched_rank_1(handle,uplo,n,A,lda,ipiv,strideP,myInfo,batch_count)
@@ -79145,31 +74469,11 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zsytf2_batched_rank_1 = rocsolver_zsytf2_batched_(handle,uplo,n,A,lda,c_loc(ipiv), &
-        strideP,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_zsytf2_batched_full_rank(handle,uplo,n,A,lda,ipiv,strideP,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_zsytf2_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_zsytf2_batched_full_rank = rocsolver_zsytf2_batched_(handle,uplo,n,A,lda, &
-        c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        strideP,myInfo,batch_count)
     end function
 
     function rocsolver_ssytf2_strided_batched_rank_0(handle,uplo,n,A,lda,strideA,ipiv,strideP, &
@@ -79187,11 +74491,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideA
       integer(c_int),target :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_ssytf2_strided_batched_rank_0 = rocsolver_ssytf2_strided_batched_(handle,uplo,n, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_ssytf2_strided_batched_rank_1(handle,uplo,n,A,lda,strideA,ipiv,strideP, &
@@ -79209,11 +74513,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideA
       integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_ssytf2_strided_batched_rank_1 = rocsolver_ssytf2_strided_batched_(handle,uplo,n, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_ssytf2_strided_batched_full_rank(handle,uplo,n,A,lda,strideA,ipiv,strideP, &
@@ -79229,13 +74533,13 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: ipiv
+      integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_ssytf2_strided_batched_full_rank = rocsolver_ssytf2_strided_batched_(handle,uplo, &
-        n,c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        n,c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_dsytf2_strided_batched_rank_0(handle,uplo,n,A,lda,strideA,ipiv,strideP, &
@@ -79253,11 +74557,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideA
       integer(c_int),target :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dsytf2_strided_batched_rank_0 = rocsolver_dsytf2_strided_batched_(handle,uplo,n, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_dsytf2_strided_batched_rank_1(handle,uplo,n,A,lda,strideA,ipiv,strideP, &
@@ -79275,11 +74579,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideA
       integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dsytf2_strided_batched_rank_1 = rocsolver_dsytf2_strided_batched_(handle,uplo,n, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_dsytf2_strided_batched_full_rank(handle,uplo,n,A,lda,strideA,ipiv,strideP, &
@@ -79295,13 +74599,13 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: ipiv
+      integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dsytf2_strided_batched_full_rank = rocsolver_dsytf2_strided_batched_(handle,uplo, &
-        n,c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        n,c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_csytf2_strided_batched_rank_0(handle,uplo,n,A,lda,strideA,ipiv,strideP, &
@@ -79319,11 +74623,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideA
       integer(c_int),target :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_csytf2_strided_batched_rank_0 = rocsolver_csytf2_strided_batched_(handle,uplo,n, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_csytf2_strided_batched_rank_1(handle,uplo,n,A,lda,strideA,ipiv,strideP, &
@@ -79341,11 +74645,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideA
       integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_csytf2_strided_batched_rank_1 = rocsolver_csytf2_strided_batched_(handle,uplo,n, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_csytf2_strided_batched_full_rank(handle,uplo,n,A,lda,strideA,ipiv,strideP, &
@@ -79361,13 +74665,13 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: ipiv
+      integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_csytf2_strided_batched_full_rank = rocsolver_csytf2_strided_batched_(handle,uplo, &
-        n,c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        n,c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_zsytf2_strided_batched_rank_0(handle,uplo,n,A,lda,strideA,ipiv,strideP, &
@@ -79385,11 +74689,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideA
       integer(c_int),target :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zsytf2_strided_batched_rank_0 = rocsolver_zsytf2_strided_batched_(handle,uplo,n, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_zsytf2_strided_batched_rank_1(handle,uplo,n,A,lda,strideA,ipiv,strideP, &
@@ -79407,11 +74711,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideA
       integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zsytf2_strided_batched_rank_1 = rocsolver_zsytf2_strided_batched_(handle,uplo,n, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_zsytf2_strided_batched_full_rank(handle,uplo,n,A,lda,strideA,ipiv,strideP, &
@@ -79427,13 +74731,13 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: ipiv
+      integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zsytf2_strided_batched_full_rank = rocsolver_zsytf2_strided_batched_(handle,uplo, &
-        n,c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        n,c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_ssytrf_rank_0(handle,uplo,n,A,lda,ipiv,myInfo)
@@ -79448,10 +74752,9 @@ module hipfort_rocsolver
       real(c_float),target :: A
       integer(c_int) :: lda
       integer(c_int),target :: ipiv
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_ssytrf_rank_0 = rocsolver_ssytrf_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv), &
-        c_loc(myInfo))
+      rocsolver_ssytrf_rank_0 = rocsolver_ssytrf_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_ssytrf_rank_1(handle,uplo,n,A,lda,ipiv,myInfo)
@@ -79466,10 +74769,9 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int),target,dimension(:) :: ipiv
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_ssytrf_rank_1 = rocsolver_ssytrf_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv), &
-        c_loc(myInfo))
+      rocsolver_ssytrf_rank_1 = rocsolver_ssytrf_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_ssytrf_full_rank(handle,uplo,n,A,lda,ipiv,myInfo)
@@ -79483,11 +74785,10 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int),target,dimension(:,:) :: myInfo
+      integer(c_int),target,dimension(:) :: ipiv
+      type(c_ptr) :: myInfo
       !
-      rocsolver_ssytrf_full_rank = rocsolver_ssytrf_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv), &
-        c_loc(myInfo))
+      rocsolver_ssytrf_full_rank = rocsolver_ssytrf_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_dsytrf_rank_0(handle,uplo,n,A,lda,ipiv,myInfo)
@@ -79502,10 +74803,9 @@ module hipfort_rocsolver
       real(c_double),target :: A
       integer(c_int) :: lda
       integer(c_int),target :: ipiv
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_dsytrf_rank_0 = rocsolver_dsytrf_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv), &
-        c_loc(myInfo))
+      rocsolver_dsytrf_rank_0 = rocsolver_dsytrf_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_dsytrf_rank_1(handle,uplo,n,A,lda,ipiv,myInfo)
@@ -79520,10 +74820,9 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int),target,dimension(:) :: ipiv
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_dsytrf_rank_1 = rocsolver_dsytrf_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv), &
-        c_loc(myInfo))
+      rocsolver_dsytrf_rank_1 = rocsolver_dsytrf_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_dsytrf_full_rank(handle,uplo,n,A,lda,ipiv,myInfo)
@@ -79537,11 +74836,10 @@ module hipfort_rocsolver
       integer(c_int) :: n
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int),target,dimension(:,:) :: myInfo
+      integer(c_int),target,dimension(:) :: ipiv
+      type(c_ptr) :: myInfo
       !
-      rocsolver_dsytrf_full_rank = rocsolver_dsytrf_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv), &
-        c_loc(myInfo))
+      rocsolver_dsytrf_full_rank = rocsolver_dsytrf_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_csytrf_rank_0(handle,uplo,n,A,lda,ipiv,myInfo)
@@ -79556,10 +74854,9 @@ module hipfort_rocsolver
       complex(c_float_complex),target :: A
       integer(c_int) :: lda
       integer(c_int),target :: ipiv
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_csytrf_rank_0 = rocsolver_csytrf_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv), &
-        c_loc(myInfo))
+      rocsolver_csytrf_rank_0 = rocsolver_csytrf_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_csytrf_rank_1(handle,uplo,n,A,lda,ipiv,myInfo)
@@ -79574,10 +74871,9 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int),target,dimension(:) :: ipiv
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_csytrf_rank_1 = rocsolver_csytrf_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv), &
-        c_loc(myInfo))
+      rocsolver_csytrf_rank_1 = rocsolver_csytrf_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_csytrf_full_rank(handle,uplo,n,A,lda,ipiv,myInfo)
@@ -79591,11 +74887,10 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int),target,dimension(:,:) :: myInfo
+      integer(c_int),target,dimension(:) :: ipiv
+      type(c_ptr) :: myInfo
       !
-      rocsolver_csytrf_full_rank = rocsolver_csytrf_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv), &
-        c_loc(myInfo))
+      rocsolver_csytrf_full_rank = rocsolver_csytrf_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_zsytrf_rank_0(handle,uplo,n,A,lda,ipiv,myInfo)
@@ -79610,10 +74905,9 @@ module hipfort_rocsolver
       complex(c_double_complex),target :: A
       integer(c_int) :: lda
       integer(c_int),target :: ipiv
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_zsytrf_rank_0 = rocsolver_zsytrf_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv), &
-        c_loc(myInfo))
+      rocsolver_zsytrf_rank_0 = rocsolver_zsytrf_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_zsytrf_rank_1(handle,uplo,n,A,lda,ipiv,myInfo)
@@ -79628,10 +74922,9 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:) :: A
       integer(c_int) :: lda
       integer(c_int),target,dimension(:) :: ipiv
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       !
-      rocsolver_zsytrf_rank_1 = rocsolver_zsytrf_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv), &
-        c_loc(myInfo))
+      rocsolver_zsytrf_rank_1 = rocsolver_zsytrf_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_zsytrf_full_rank(handle,uplo,n,A,lda,ipiv,myInfo)
@@ -79645,11 +74938,10 @@ module hipfort_rocsolver
       integer(c_int) :: n
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int),target,dimension(:,:) :: myInfo
+      integer(c_int),target,dimension(:) :: ipiv
+      type(c_ptr) :: myInfo
       !
-      rocsolver_zsytrf_full_rank = rocsolver_zsytrf_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv), &
-        c_loc(myInfo))
+      rocsolver_zsytrf_full_rank = rocsolver_zsytrf_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
 
     function rocsolver_ssytrf_batched_rank_0(handle,uplo,n,A,lda,ipiv,strideP,myInfo,batch_count)
@@ -79665,11 +74957,11 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       integer(c_int),target :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_ssytrf_batched_rank_0 = rocsolver_ssytrf_batched_(handle,uplo,n,A,lda,c_loc(ipiv), &
-        strideP,c_loc(myInfo),batch_count)
+        strideP,myInfo,batch_count)
     end function
 
     function rocsolver_ssytrf_batched_rank_1(handle,uplo,n,A,lda,ipiv,strideP,myInfo,batch_count)
@@ -79685,31 +74977,11 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_ssytrf_batched_rank_1 = rocsolver_ssytrf_batched_(handle,uplo,n,A,lda,c_loc(ipiv), &
-        strideP,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_ssytrf_batched_full_rank(handle,uplo,n,A,lda,ipiv,strideP,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_ssytrf_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_ssytrf_batched_full_rank = rocsolver_ssytrf_batched_(handle,uplo,n,A,lda, &
-        c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        strideP,myInfo,batch_count)
     end function
 
     function rocsolver_dsytrf_batched_rank_0(handle,uplo,n,A,lda,ipiv,strideP,myInfo,batch_count)
@@ -79725,11 +74997,11 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       integer(c_int),target :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dsytrf_batched_rank_0 = rocsolver_dsytrf_batched_(handle,uplo,n,A,lda,c_loc(ipiv), &
-        strideP,c_loc(myInfo),batch_count)
+        strideP,myInfo,batch_count)
     end function
 
     function rocsolver_dsytrf_batched_rank_1(handle,uplo,n,A,lda,ipiv,strideP,myInfo,batch_count)
@@ -79745,31 +75017,11 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dsytrf_batched_rank_1 = rocsolver_dsytrf_batched_(handle,uplo,n,A,lda,c_loc(ipiv), &
-        strideP,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_dsytrf_batched_full_rank(handle,uplo,n,A,lda,ipiv,strideP,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_dsytrf_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_dsytrf_batched_full_rank = rocsolver_dsytrf_batched_(handle,uplo,n,A,lda, &
-        c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        strideP,myInfo,batch_count)
     end function
 
     function rocsolver_csytrf_batched_rank_0(handle,uplo,n,A,lda,ipiv,strideP,myInfo,batch_count)
@@ -79785,11 +75037,11 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       integer(c_int),target :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_csytrf_batched_rank_0 = rocsolver_csytrf_batched_(handle,uplo,n,A,lda,c_loc(ipiv), &
-        strideP,c_loc(myInfo),batch_count)
+        strideP,myInfo,batch_count)
     end function
 
     function rocsolver_csytrf_batched_rank_1(handle,uplo,n,A,lda,ipiv,strideP,myInfo,batch_count)
@@ -79805,31 +75057,11 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_csytrf_batched_rank_1 = rocsolver_csytrf_batched_(handle,uplo,n,A,lda,c_loc(ipiv), &
-        strideP,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_csytrf_batched_full_rank(handle,uplo,n,A,lda,ipiv,strideP,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_csytrf_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_csytrf_batched_full_rank = rocsolver_csytrf_batched_(handle,uplo,n,A,lda, &
-        c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        strideP,myInfo,batch_count)
     end function
 
     function rocsolver_zsytrf_batched_rank_0(handle,uplo,n,A,lda,ipiv,strideP,myInfo,batch_count)
@@ -79845,11 +75077,11 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       integer(c_int),target :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zsytrf_batched_rank_0 = rocsolver_zsytrf_batched_(handle,uplo,n,A,lda,c_loc(ipiv), &
-        strideP,c_loc(myInfo),batch_count)
+        strideP,myInfo,batch_count)
     end function
 
     function rocsolver_zsytrf_batched_rank_1(handle,uplo,n,A,lda,ipiv,strideP,myInfo,batch_count)
@@ -79865,31 +75097,11 @@ module hipfort_rocsolver
       integer(c_int) :: lda
       integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zsytrf_batched_rank_1 = rocsolver_zsytrf_batched_(handle,uplo,n,A,lda,c_loc(ipiv), &
-        strideP,c_loc(myInfo),batch_count)
-    end function
-
-    function rocsolver_zsytrf_batched_full_rank(handle,uplo,n,A,lda,ipiv,strideP,myInfo,batch_count)
-      use iso_c_binding
-      use hipfort_rocsolver_enums
-      use hipfort_rocblas_enums
-      implicit none
-      integer(kind(rocblas_status_success)) :: rocsolver_zsytrf_batched_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocblas_fill_upper)) :: uplo
-      integer(c_int) :: n
-      type(c_ptr) :: A
-      integer(c_int) :: lda
-      integer(c_int),target,dimension(:,:) :: ipiv
-      integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:,:) :: myInfo
-      integer(c_int) :: batch_count
-      !
-      rocsolver_zsytrf_batched_full_rank = rocsolver_zsytrf_batched_(handle,uplo,n,A,lda, &
-        c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        strideP,myInfo,batch_count)
     end function
 
     function rocsolver_ssytrf_strided_batched_rank_0(handle,uplo,n,A,lda,strideA,ipiv,strideP, &
@@ -79907,11 +75119,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideA
       integer(c_int),target :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_ssytrf_strided_batched_rank_0 = rocsolver_ssytrf_strided_batched_(handle,uplo,n, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_ssytrf_strided_batched_rank_1(handle,uplo,n,A,lda,strideA,ipiv,strideP, &
@@ -79929,11 +75141,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideA
       integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_ssytrf_strided_batched_rank_1 = rocsolver_ssytrf_strided_batched_(handle,uplo,n, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_ssytrf_strided_batched_full_rank(handle,uplo,n,A,lda,strideA,ipiv,strideP, &
@@ -79949,13 +75161,13 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: ipiv
+      integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_ssytrf_strided_batched_full_rank = rocsolver_ssytrf_strided_batched_(handle,uplo, &
-        n,c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        n,c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_dsytrf_strided_batched_rank_0(handle,uplo,n,A,lda,strideA,ipiv,strideP, &
@@ -79973,11 +75185,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideA
       integer(c_int),target :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dsytrf_strided_batched_rank_0 = rocsolver_dsytrf_strided_batched_(handle,uplo,n, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_dsytrf_strided_batched_rank_1(handle,uplo,n,A,lda,strideA,ipiv,strideP, &
@@ -79995,11 +75207,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideA
       integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dsytrf_strided_batched_rank_1 = rocsolver_dsytrf_strided_batched_(handle,uplo,n, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_dsytrf_strided_batched_full_rank(handle,uplo,n,A,lda,strideA,ipiv,strideP, &
@@ -80015,13 +75227,13 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: ipiv
+      integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_dsytrf_strided_batched_full_rank = rocsolver_dsytrf_strided_batched_(handle,uplo, &
-        n,c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        n,c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_csytrf_strided_batched_rank_0(handle,uplo,n,A,lda,strideA,ipiv,strideP, &
@@ -80039,11 +75251,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideA
       integer(c_int),target :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_csytrf_strided_batched_rank_0 = rocsolver_csytrf_strided_batched_(handle,uplo,n, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_csytrf_strided_batched_rank_1(handle,uplo,n,A,lda,strideA,ipiv,strideP, &
@@ -80061,11 +75273,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideA
       integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_csytrf_strided_batched_rank_1 = rocsolver_csytrf_strided_batched_(handle,uplo,n, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_csytrf_strided_batched_full_rank(handle,uplo,n,A,lda,strideA,ipiv,strideP, &
@@ -80081,13 +75293,13 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: ipiv
+      integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_csytrf_strided_batched_full_rank = rocsolver_csytrf_strided_batched_(handle,uplo, &
-        n,c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        n,c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_zsytrf_strided_batched_rank_0(handle,uplo,n,A,lda,strideA,ipiv,strideP, &
@@ -80105,11 +75317,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideA
       integer(c_int),target :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zsytrf_strided_batched_rank_0 = rocsolver_zsytrf_strided_batched_(handle,uplo,n, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_zsytrf_strided_batched_rank_1(handle,uplo,n,A,lda,strideA,ipiv,strideP, &
@@ -80127,11 +75339,11 @@ module hipfort_rocsolver
       integer(c_int64_t) :: strideA
       integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zsytrf_strided_batched_rank_1 = rocsolver_zsytrf_strided_batched_(handle,uplo,n, &
-        c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
     function rocsolver_zsytrf_strided_batched_full_rank(handle,uplo,n,A,lda,strideA,ipiv,strideP, &
@@ -80147,13 +75359,13 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int64_t) :: strideA
-      integer(c_int),target,dimension(:,:) :: ipiv
+      integer(c_int),target,dimension(:) :: ipiv
       integer(c_int64_t) :: strideP
-      integer(c_int),target,dimension(:,:) :: myInfo
+      type(c_ptr) :: myInfo
       integer(c_int) :: batch_count
       !
       rocsolver_zsytrf_strided_batched_full_rank = rocsolver_zsytrf_strided_batched_(handle,uplo, &
-        n,c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(myInfo),batch_count)
+        n,c_loc(A),lda,strideA,c_loc(ipiv),strideP,myInfo,batch_count)
     end function
 
 #endif

--- a/lib/hipfort/hipfort_rocsparse.F90
+++ b/lib/hipfort/hipfort_rocsparse.F90
@@ -14181,8 +14181,7 @@ module hipfort_rocsparse
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsparse_sgpsv_interleaved_batch_buffer_size_rank_0,&
-      rocsparse_sgpsv_interleaved_batch_buffer_size_rank_1,&
-      rocsparse_sgpsv_interleaved_batch_buffer_size_full_rank
+      rocsparse_sgpsv_interleaved_batch_buffer_size_rank_1
 #endif
   end interface
 
@@ -14211,8 +14210,7 @@ module hipfort_rocsparse
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsparse_dgpsv_interleaved_batch_buffer_size_rank_0,&
-      rocsparse_dgpsv_interleaved_batch_buffer_size_rank_1,&
-      rocsparse_dgpsv_interleaved_batch_buffer_size_full_rank
+      rocsparse_dgpsv_interleaved_batch_buffer_size_rank_1
 #endif
   end interface
 
@@ -14241,8 +14239,7 @@ module hipfort_rocsparse
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsparse_cgpsv_interleaved_batch_buffer_size_rank_0,&
-      rocsparse_cgpsv_interleaved_batch_buffer_size_rank_1,&
-      rocsparse_cgpsv_interleaved_batch_buffer_size_full_rank
+      rocsparse_cgpsv_interleaved_batch_buffer_size_rank_1
 #endif
   end interface
 
@@ -14271,8 +14268,7 @@ module hipfort_rocsparse
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsparse_zgpsv_interleaved_batch_buffer_size_rank_0,&
-      rocsparse_zgpsv_interleaved_batch_buffer_size_rank_1,&
-      rocsparse_zgpsv_interleaved_batch_buffer_size_full_rank
+      rocsparse_zgpsv_interleaved_batch_buffer_size_rank_1
 #endif
   end interface
 
@@ -14426,8 +14422,7 @@ module hipfort_rocsparse
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsparse_sgpsv_interleaved_batch_rank_0,&
-      rocsparse_sgpsv_interleaved_batch_rank_1,&
-      rocsparse_sgpsv_interleaved_batch_full_rank
+      rocsparse_sgpsv_interleaved_batch_rank_1
 #endif
   end interface
 
@@ -14456,8 +14451,7 @@ module hipfort_rocsparse
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsparse_dgpsv_interleaved_batch_rank_0,&
-      rocsparse_dgpsv_interleaved_batch_rank_1,&
-      rocsparse_dgpsv_interleaved_batch_full_rank
+      rocsparse_dgpsv_interleaved_batch_rank_1
 #endif
   end interface
 
@@ -14486,8 +14480,7 @@ module hipfort_rocsparse
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsparse_cgpsv_interleaved_batch_rank_0,&
-      rocsparse_cgpsv_interleaved_batch_rank_1,&
-      rocsparse_cgpsv_interleaved_batch_full_rank
+      rocsparse_cgpsv_interleaved_batch_rank_1
 #endif
   end interface
 
@@ -14516,8 +14509,7 @@ module hipfort_rocsparse
 #ifdef USE_FPOINTER_INTERFACES
     module procedure &
       rocsparse_zgpsv_interleaved_batch_rank_0,&
-      rocsparse_zgpsv_interleaved_batch_rank_1,&
-      rocsparse_zgpsv_interleaved_batch_full_rank
+      rocsparse_zgpsv_interleaved_batch_rank_1
 #endif
   end interface
 
@@ -35817,9 +35809,9 @@ module hipfort_rocsparse
       real(c_float) :: alpha
       type(c_ptr) :: descr
       real(c_float),target :: bsr_val
-      integer(c_int),target :: bsr_mask_ptr
+      type(c_ptr) :: bsr_mask_ptr
       integer(c_int),target :: bsr_row_ptr
-      integer(c_int),target :: bsr_end_ptr
+      type(c_ptr) :: bsr_end_ptr
       integer(c_int),target :: bsr_col_ind
       integer(c_int) :: block_dim
       real(c_float),target :: x
@@ -35827,8 +35819,8 @@ module hipfort_rocsparse
       real(c_float),target :: y
       !
       rocsparse_sbsrxmv_rank_0 = rocsparse_sbsrxmv_(handle,dir,trans,size_of_mask,mb,nb,nnzb, &
-        alpha,descr,c_loc(bsr_val),c_loc(bsr_mask_ptr),c_loc(bsr_row_ptr),c_loc(bsr_end_ptr), &
-        c_loc(bsr_col_ind),block_dim,c_loc(x),beta,c_loc(y))
+        alpha,descr,c_loc(bsr_val),bsr_mask_ptr,c_loc(bsr_row_ptr),bsr_end_ptr,c_loc(bsr_col_ind), &
+        block_dim,c_loc(x),beta,c_loc(y))
     end function
 
     function rocsparse_sbsrxmv_rank_1(handle,dir,trans,size_of_mask,mb,nb,nnzb,alpha,descr, &
@@ -35847,9 +35839,9 @@ module hipfort_rocsparse
       real(c_float) :: alpha
       type(c_ptr) :: descr
       real(c_float),target,dimension(:) :: bsr_val
-      integer(c_int),target,dimension(:) :: bsr_mask_ptr
+      type(c_ptr) :: bsr_mask_ptr
       integer(c_int),target,dimension(:) :: bsr_row_ptr
-      integer(c_int),target,dimension(:) :: bsr_end_ptr
+      type(c_ptr) :: bsr_end_ptr
       integer(c_int),target,dimension(:) :: bsr_col_ind
       integer(c_int) :: block_dim
       real(c_float),target,dimension(:) :: x
@@ -35857,8 +35849,8 @@ module hipfort_rocsparse
       real(c_float),target,dimension(:) :: y
       !
       rocsparse_sbsrxmv_rank_1 = rocsparse_sbsrxmv_(handle,dir,trans,size_of_mask,mb,nb,nnzb, &
-        alpha,descr,c_loc(bsr_val),c_loc(bsr_mask_ptr),c_loc(bsr_row_ptr),c_loc(bsr_end_ptr), &
-        c_loc(bsr_col_ind),block_dim,c_loc(x),beta,c_loc(y))
+        alpha,descr,c_loc(bsr_val),bsr_mask_ptr,c_loc(bsr_row_ptr),bsr_end_ptr,c_loc(bsr_col_ind), &
+        block_dim,c_loc(x),beta,c_loc(y))
     end function
 
     function rocsparse_dbsrxmv_rank_0(handle,dir,trans,size_of_mask,mb,nb,nnzb,alpha,descr, &
@@ -35877,9 +35869,9 @@ module hipfort_rocsparse
       real(c_double) :: alpha
       type(c_ptr) :: descr
       real(c_double),target :: bsr_val
-      integer(c_int),target :: bsr_mask_ptr
+      type(c_ptr) :: bsr_mask_ptr
       integer(c_int),target :: bsr_row_ptr
-      integer(c_int),target :: bsr_end_ptr
+      type(c_ptr) :: bsr_end_ptr
       integer(c_int),target :: bsr_col_ind
       integer(c_int) :: block_dim
       real(c_double),target :: x
@@ -35887,8 +35879,8 @@ module hipfort_rocsparse
       real(c_double),target :: y
       !
       rocsparse_dbsrxmv_rank_0 = rocsparse_dbsrxmv_(handle,dir,trans,size_of_mask,mb,nb,nnzb, &
-        alpha,descr,c_loc(bsr_val),c_loc(bsr_mask_ptr),c_loc(bsr_row_ptr),c_loc(bsr_end_ptr), &
-        c_loc(bsr_col_ind),block_dim,c_loc(x),beta,c_loc(y))
+        alpha,descr,c_loc(bsr_val),bsr_mask_ptr,c_loc(bsr_row_ptr),bsr_end_ptr,c_loc(bsr_col_ind), &
+        block_dim,c_loc(x),beta,c_loc(y))
     end function
 
     function rocsparse_dbsrxmv_rank_1(handle,dir,trans,size_of_mask,mb,nb,nnzb,alpha,descr, &
@@ -35907,9 +35899,9 @@ module hipfort_rocsparse
       real(c_double) :: alpha
       type(c_ptr) :: descr
       real(c_double),target,dimension(:) :: bsr_val
-      integer(c_int),target,dimension(:) :: bsr_mask_ptr
+      type(c_ptr) :: bsr_mask_ptr
       integer(c_int),target,dimension(:) :: bsr_row_ptr
-      integer(c_int),target,dimension(:) :: bsr_end_ptr
+      type(c_ptr) :: bsr_end_ptr
       integer(c_int),target,dimension(:) :: bsr_col_ind
       integer(c_int) :: block_dim
       real(c_double),target,dimension(:) :: x
@@ -35917,8 +35909,8 @@ module hipfort_rocsparse
       real(c_double),target,dimension(:) :: y
       !
       rocsparse_dbsrxmv_rank_1 = rocsparse_dbsrxmv_(handle,dir,trans,size_of_mask,mb,nb,nnzb, &
-        alpha,descr,c_loc(bsr_val),c_loc(bsr_mask_ptr),c_loc(bsr_row_ptr),c_loc(bsr_end_ptr), &
-        c_loc(bsr_col_ind),block_dim,c_loc(x),beta,c_loc(y))
+        alpha,descr,c_loc(bsr_val),bsr_mask_ptr,c_loc(bsr_row_ptr),bsr_end_ptr,c_loc(bsr_col_ind), &
+        block_dim,c_loc(x),beta,c_loc(y))
     end function
 
     function rocsparse_cbsrxmv_rank_0(handle,dir,trans,size_of_mask,mb,nb,nnzb,alpha,descr, &
@@ -35937,9 +35929,9 @@ module hipfort_rocsparse
       complex(c_float_complex) :: alpha
       type(c_ptr) :: descr
       complex(c_float_complex),target :: bsr_val
-      integer(c_int),target :: bsr_mask_ptr
+      type(c_ptr) :: bsr_mask_ptr
       integer(c_int),target :: bsr_row_ptr
-      integer(c_int),target :: bsr_end_ptr
+      type(c_ptr) :: bsr_end_ptr
       integer(c_int),target :: bsr_col_ind
       integer(c_int) :: block_dim
       complex(c_float_complex),target :: x
@@ -35947,8 +35939,8 @@ module hipfort_rocsparse
       complex(c_float_complex),target :: y
       !
       rocsparse_cbsrxmv_rank_0 = rocsparse_cbsrxmv_(handle,dir,trans,size_of_mask,mb,nb,nnzb, &
-        alpha,descr,c_loc(bsr_val),c_loc(bsr_mask_ptr),c_loc(bsr_row_ptr),c_loc(bsr_end_ptr), &
-        c_loc(bsr_col_ind),block_dim,c_loc(x),beta,c_loc(y))
+        alpha,descr,c_loc(bsr_val),bsr_mask_ptr,c_loc(bsr_row_ptr),bsr_end_ptr,c_loc(bsr_col_ind), &
+        block_dim,c_loc(x),beta,c_loc(y))
     end function
 
     function rocsparse_cbsrxmv_rank_1(handle,dir,trans,size_of_mask,mb,nb,nnzb,alpha,descr, &
@@ -35967,9 +35959,9 @@ module hipfort_rocsparse
       complex(c_float_complex) :: alpha
       type(c_ptr) :: descr
       complex(c_float_complex),target,dimension(:) :: bsr_val
-      integer(c_int),target,dimension(:) :: bsr_mask_ptr
+      type(c_ptr) :: bsr_mask_ptr
       integer(c_int),target,dimension(:) :: bsr_row_ptr
-      integer(c_int),target,dimension(:) :: bsr_end_ptr
+      type(c_ptr) :: bsr_end_ptr
       integer(c_int),target,dimension(:) :: bsr_col_ind
       integer(c_int) :: block_dim
       complex(c_float_complex),target,dimension(:) :: x
@@ -35977,8 +35969,8 @@ module hipfort_rocsparse
       complex(c_float_complex),target,dimension(:) :: y
       !
       rocsparse_cbsrxmv_rank_1 = rocsparse_cbsrxmv_(handle,dir,trans,size_of_mask,mb,nb,nnzb, &
-        alpha,descr,c_loc(bsr_val),c_loc(bsr_mask_ptr),c_loc(bsr_row_ptr),c_loc(bsr_end_ptr), &
-        c_loc(bsr_col_ind),block_dim,c_loc(x),beta,c_loc(y))
+        alpha,descr,c_loc(bsr_val),bsr_mask_ptr,c_loc(bsr_row_ptr),bsr_end_ptr,c_loc(bsr_col_ind), &
+        block_dim,c_loc(x),beta,c_loc(y))
     end function
 
     function rocsparse_zbsrxmv_rank_0(handle,dir,trans,size_of_mask,mb,nb,nnzb,alpha,descr, &
@@ -35997,9 +35989,9 @@ module hipfort_rocsparse
       complex(c_double_complex) :: alpha
       type(c_ptr) :: descr
       complex(c_double_complex),target :: bsr_val
-      integer(c_int),target :: bsr_mask_ptr
+      type(c_ptr) :: bsr_mask_ptr
       integer(c_int),target :: bsr_row_ptr
-      integer(c_int),target :: bsr_end_ptr
+      type(c_ptr) :: bsr_end_ptr
       integer(c_int),target :: bsr_col_ind
       integer(c_int) :: block_dim
       complex(c_double_complex),target :: x
@@ -36007,8 +35999,8 @@ module hipfort_rocsparse
       complex(c_double_complex),target :: y
       !
       rocsparse_zbsrxmv_rank_0 = rocsparse_zbsrxmv_(handle,dir,trans,size_of_mask,mb,nb,nnzb, &
-        alpha,descr,c_loc(bsr_val),c_loc(bsr_mask_ptr),c_loc(bsr_row_ptr),c_loc(bsr_end_ptr), &
-        c_loc(bsr_col_ind),block_dim,c_loc(x),beta,c_loc(y))
+        alpha,descr,c_loc(bsr_val),bsr_mask_ptr,c_loc(bsr_row_ptr),bsr_end_ptr,c_loc(bsr_col_ind), &
+        block_dim,c_loc(x),beta,c_loc(y))
     end function
 
     function rocsparse_zbsrxmv_rank_1(handle,dir,trans,size_of_mask,mb,nb,nnzb,alpha,descr, &
@@ -36027,9 +36019,9 @@ module hipfort_rocsparse
       complex(c_double_complex) :: alpha
       type(c_ptr) :: descr
       complex(c_double_complex),target,dimension(:) :: bsr_val
-      integer(c_int),target,dimension(:) :: bsr_mask_ptr
+      type(c_ptr) :: bsr_mask_ptr
       integer(c_int),target,dimension(:) :: bsr_row_ptr
-      integer(c_int),target,dimension(:) :: bsr_end_ptr
+      type(c_ptr) :: bsr_end_ptr
       integer(c_int),target,dimension(:) :: bsr_col_ind
       integer(c_int) :: block_dim
       complex(c_double_complex),target,dimension(:) :: x
@@ -36037,8 +36029,8 @@ module hipfort_rocsparse
       complex(c_double_complex),target,dimension(:) :: y
       !
       rocsparse_zbsrxmv_rank_1 = rocsparse_zbsrxmv_(handle,dir,trans,size_of_mask,mb,nb,nnzb, &
-        alpha,descr,c_loc(bsr_val),c_loc(bsr_mask_ptr),c_loc(bsr_row_ptr),c_loc(bsr_end_ptr), &
-        c_loc(bsr_col_ind),block_dim,c_loc(x),beta,c_loc(y))
+        alpha,descr,c_loc(bsr_val),bsr_mask_ptr,c_loc(bsr_row_ptr),bsr_end_ptr,c_loc(bsr_col_ind), &
+        block_dim,c_loc(x),beta,c_loc(y))
     end function
 
     function rocsparse_sbsrsv_buffer_size_rank_0(handle,dir,trans,mb,nnzb,descr,bsr_val, &
@@ -38401,10 +38393,10 @@ module hipfort_rocsparse
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int) :: nnz
-      real(c_float),target,dimension(:,:) :: x_val
-      integer(c_int),target,dimension(:,:) :: x_ind
+      real(c_float),target,dimension(:) :: x_val
+      integer(c_int),target,dimension(:) :: x_ind
       real(c_float) :: beta
-      real(c_float),target,dimension(:,:) :: y
+      real(c_float),target,dimension(:) :: y
       integer(kind(rocsparse_index_base_zero)) :: idx_base
       type(c_ptr) :: temp_buffer
       !
@@ -38476,10 +38468,10 @@ module hipfort_rocsparse
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int) :: nnz
-      real(c_double),target,dimension(:,:) :: x_val
-      integer(c_int),target,dimension(:,:) :: x_ind
+      real(c_double),target,dimension(:) :: x_val
+      integer(c_int),target,dimension(:) :: x_ind
       real(c_double) :: beta
-      real(c_double),target,dimension(:,:) :: y
+      real(c_double),target,dimension(:) :: y
       integer(kind(rocsparse_index_base_zero)) :: idx_base
       type(c_ptr) :: temp_buffer
       !
@@ -38551,10 +38543,10 @@ module hipfort_rocsparse
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int) :: nnz
-      complex(c_float_complex),target,dimension(:,:) :: x_val
-      integer(c_int),target,dimension(:,:) :: x_ind
+      complex(c_float_complex),target,dimension(:) :: x_val
+      integer(c_int),target,dimension(:) :: x_ind
       complex(c_float_complex) :: beta
-      complex(c_float_complex),target,dimension(:,:) :: y
+      complex(c_float_complex),target,dimension(:) :: y
       integer(kind(rocsparse_index_base_zero)) :: idx_base
       type(c_ptr) :: temp_buffer
       !
@@ -38626,10 +38618,10 @@ module hipfort_rocsparse
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       integer(c_int) :: nnz
-      complex(c_double_complex),target,dimension(:,:) :: x_val
-      integer(c_int),target,dimension(:,:) :: x_ind
+      complex(c_double_complex),target,dimension(:) :: x_val
+      integer(c_int),target,dimension(:) :: x_ind
       complex(c_double_complex) :: beta
-      complex(c_double_complex),target,dimension(:,:) :: y
+      complex(c_double_complex),target,dimension(:) :: y
       integer(kind(rocsparse_index_base_zero)) :: idx_base
       type(c_ptr) :: temp_buffer
       !
@@ -38715,9 +38707,9 @@ module hipfort_rocsparse
       integer(c_int) :: nnzb
       real(c_float) :: alpha
       type(c_ptr) :: descr
-      real(c_float),target,dimension(:,:) :: bsr_val
-      integer(c_int),target,dimension(:,:) :: bsr_row_ptr
-      integer(c_int),target,dimension(:,:) :: bsr_col_ind
+      real(c_float),target,dimension(:) :: bsr_val
+      integer(c_int),target,dimension(:) :: bsr_row_ptr
+      integer(c_int),target,dimension(:) :: bsr_col_ind
       integer(c_int) :: block_dim
       real(c_float),target,dimension(:,:) :: B
       integer(c_int) :: ldb
@@ -38808,9 +38800,9 @@ module hipfort_rocsparse
       integer(c_int) :: nnzb
       real(c_double) :: alpha
       type(c_ptr) :: descr
-      real(c_double),target,dimension(:,:) :: bsr_val
-      integer(c_int),target,dimension(:,:) :: bsr_row_ptr
-      integer(c_int),target,dimension(:,:) :: bsr_col_ind
+      real(c_double),target,dimension(:) :: bsr_val
+      integer(c_int),target,dimension(:) :: bsr_row_ptr
+      integer(c_int),target,dimension(:) :: bsr_col_ind
       integer(c_int) :: block_dim
       real(c_double),target,dimension(:,:) :: B
       integer(c_int) :: ldb
@@ -38901,9 +38893,9 @@ module hipfort_rocsparse
       integer(c_int) :: nnzb
       complex(c_float_complex) :: alpha
       type(c_ptr) :: descr
-      complex(c_float_complex),target,dimension(:,:) :: bsr_val
-      integer(c_int),target,dimension(:,:) :: bsr_row_ptr
-      integer(c_int),target,dimension(:,:) :: bsr_col_ind
+      complex(c_float_complex),target,dimension(:) :: bsr_val
+      integer(c_int),target,dimension(:) :: bsr_row_ptr
+      integer(c_int),target,dimension(:) :: bsr_col_ind
       integer(c_int) :: block_dim
       complex(c_float_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
@@ -38994,9 +38986,9 @@ module hipfort_rocsparse
       integer(c_int) :: nnzb
       complex(c_double_complex) :: alpha
       type(c_ptr) :: descr
-      complex(c_double_complex),target,dimension(:,:) :: bsr_val
-      integer(c_int),target,dimension(:,:) :: bsr_row_ptr
-      integer(c_int),target,dimension(:,:) :: bsr_col_ind
+      complex(c_double_complex),target,dimension(:) :: bsr_val
+      integer(c_int),target,dimension(:) :: bsr_row_ptr
+      integer(c_int),target,dimension(:) :: bsr_col_ind
       integer(c_int) :: block_dim
       complex(c_double_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
@@ -39089,9 +39081,9 @@ module hipfort_rocsparse
       integer(c_int) :: nnzb
       real(c_float) :: alpha
       type(c_ptr) :: descr
-      real(c_float),target,dimension(:,:) :: bsr_val
-      integer(c_int),target,dimension(:,:) :: bsr_row_ptr
-      integer(c_int),target,dimension(:,:) :: bsr_col_ind
+      real(c_float),target,dimension(:) :: bsr_val
+      integer(c_int),target,dimension(:) :: bsr_row_ptr
+      integer(c_int),target,dimension(:) :: bsr_col_ind
       integer(c_int) :: row_block_dim
       integer(c_int) :: col_block_dim
       real(c_float),target,dimension(:,:) :: B
@@ -39185,9 +39177,9 @@ module hipfort_rocsparse
       integer(c_int) :: nnzb
       real(c_double) :: alpha
       type(c_ptr) :: descr
-      real(c_double),target,dimension(:,:) :: bsr_val
-      integer(c_int),target,dimension(:,:) :: bsr_row_ptr
-      integer(c_int),target,dimension(:,:) :: bsr_col_ind
+      real(c_double),target,dimension(:) :: bsr_val
+      integer(c_int),target,dimension(:) :: bsr_row_ptr
+      integer(c_int),target,dimension(:) :: bsr_col_ind
       integer(c_int) :: row_block_dim
       integer(c_int) :: col_block_dim
       real(c_double),target,dimension(:,:) :: B
@@ -39281,9 +39273,9 @@ module hipfort_rocsparse
       integer(c_int) :: nnzb
       complex(c_float_complex) :: alpha
       type(c_ptr) :: descr
-      complex(c_float_complex),target,dimension(:,:) :: bsr_val
-      integer(c_int),target,dimension(:,:) :: bsr_row_ptr
-      integer(c_int),target,dimension(:,:) :: bsr_col_ind
+      complex(c_float_complex),target,dimension(:) :: bsr_val
+      integer(c_int),target,dimension(:) :: bsr_row_ptr
+      integer(c_int),target,dimension(:) :: bsr_col_ind
       integer(c_int) :: row_block_dim
       integer(c_int) :: col_block_dim
       complex(c_float_complex),target,dimension(:,:) :: B
@@ -39377,9 +39369,9 @@ module hipfort_rocsparse
       integer(c_int) :: nnzb
       complex(c_double_complex) :: alpha
       type(c_ptr) :: descr
-      complex(c_double_complex),target,dimension(:,:) :: bsr_val
-      integer(c_int),target,dimension(:,:) :: bsr_row_ptr
-      integer(c_int),target,dimension(:,:) :: bsr_col_ind
+      complex(c_double_complex),target,dimension(:) :: bsr_val
+      integer(c_int),target,dimension(:) :: bsr_row_ptr
+      integer(c_int),target,dimension(:) :: bsr_col_ind
       integer(c_int) :: row_block_dim
       integer(c_int) :: col_block_dim
       complex(c_double_complex),target,dimension(:,:) :: B
@@ -39464,9 +39456,9 @@ module hipfort_rocsparse
       integer(c_int) :: nnz
       real(c_float) :: alpha
       type(c_ptr) :: descr
-      real(c_float),target,dimension(:,:) :: csr_val
-      integer(c_int),target,dimension(:,:) :: csr_row_ptr
-      integer(c_int),target,dimension(:,:) :: csr_col_ind
+      real(c_float),target,dimension(:) :: csr_val
+      integer(c_int),target,dimension(:) :: csr_row_ptr
+      integer(c_int),target,dimension(:) :: csr_col_ind
       real(c_float),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       real(c_float) :: beta
@@ -39548,9 +39540,9 @@ module hipfort_rocsparse
       integer(c_int) :: nnz
       real(c_double) :: alpha
       type(c_ptr) :: descr
-      real(c_double),target,dimension(:,:) :: csr_val
-      integer(c_int),target,dimension(:,:) :: csr_row_ptr
-      integer(c_int),target,dimension(:,:) :: csr_col_ind
+      real(c_double),target,dimension(:) :: csr_val
+      integer(c_int),target,dimension(:) :: csr_row_ptr
+      integer(c_int),target,dimension(:) :: csr_col_ind
       real(c_double),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       real(c_double) :: beta
@@ -39632,9 +39624,9 @@ module hipfort_rocsparse
       integer(c_int) :: nnz
       complex(c_float_complex) :: alpha
       type(c_ptr) :: descr
-      complex(c_float_complex),target,dimension(:,:) :: csr_val
-      integer(c_int),target,dimension(:,:) :: csr_row_ptr
-      integer(c_int),target,dimension(:,:) :: csr_col_ind
+      complex(c_float_complex),target,dimension(:) :: csr_val
+      integer(c_int),target,dimension(:) :: csr_row_ptr
+      integer(c_int),target,dimension(:) :: csr_col_ind
       complex(c_float_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       complex(c_float_complex) :: beta
@@ -39716,9 +39708,9 @@ module hipfort_rocsparse
       integer(c_int) :: nnz
       complex(c_double_complex) :: alpha
       type(c_ptr) :: descr
-      complex(c_double_complex),target,dimension(:,:) :: csr_val
-      integer(c_int),target,dimension(:,:) :: csr_row_ptr
-      integer(c_int),target,dimension(:,:) :: csr_col_ind
+      complex(c_double_complex),target,dimension(:) :: csr_val
+      integer(c_int),target,dimension(:) :: csr_row_ptr
+      integer(c_int),target,dimension(:) :: csr_col_ind
       complex(c_double_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       complex(c_double_complex) :: beta
@@ -39799,9 +39791,9 @@ module hipfort_rocsparse
       integer(c_int) :: nnz
       real(c_float) :: alpha
       type(c_ptr) :: descr
-      real(c_float),target,dimension(:,:) :: csr_val
-      integer(c_int),target,dimension(:,:) :: csr_row_ptr
-      integer(c_int),target,dimension(:,:) :: csr_col_ind
+      real(c_float),target,dimension(:) :: csr_val
+      integer(c_int),target,dimension(:) :: csr_row_ptr
+      integer(c_int),target,dimension(:) :: csr_col_ind
       real(c_float),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: myInfo
@@ -39883,9 +39875,9 @@ module hipfort_rocsparse
       integer(c_int) :: nnz
       real(c_double) :: alpha
       type(c_ptr) :: descr
-      real(c_double),target,dimension(:,:) :: csr_val
-      integer(c_int),target,dimension(:,:) :: csr_row_ptr
-      integer(c_int),target,dimension(:,:) :: csr_col_ind
+      real(c_double),target,dimension(:) :: csr_val
+      integer(c_int),target,dimension(:) :: csr_row_ptr
+      integer(c_int),target,dimension(:) :: csr_col_ind
       real(c_double),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: myInfo
@@ -39967,9 +39959,9 @@ module hipfort_rocsparse
       integer(c_int) :: nnz
       complex(c_float_complex) :: alpha
       type(c_ptr) :: descr
-      complex(c_float_complex),target,dimension(:,:) :: csr_val
-      integer(c_int),target,dimension(:,:) :: csr_row_ptr
-      integer(c_int),target,dimension(:,:) :: csr_col_ind
+      complex(c_float_complex),target,dimension(:) :: csr_val
+      integer(c_int),target,dimension(:) :: csr_row_ptr
+      integer(c_int),target,dimension(:) :: csr_col_ind
       complex(c_float_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: myInfo
@@ -40051,9 +40043,9 @@ module hipfort_rocsparse
       integer(c_int) :: nnz
       complex(c_double_complex) :: alpha
       type(c_ptr) :: descr
-      complex(c_double_complex),target,dimension(:,:) :: csr_val
-      integer(c_int),target,dimension(:,:) :: csr_row_ptr
-      integer(c_int),target,dimension(:,:) :: csr_col_ind
+      complex(c_double_complex),target,dimension(:) :: csr_val
+      integer(c_int),target,dimension(:) :: csr_row_ptr
+      integer(c_int),target,dimension(:) :: csr_col_ind
       complex(c_double_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: myInfo
@@ -40137,9 +40129,9 @@ module hipfort_rocsparse
       integer(c_int) :: nnz
       real(c_float) :: alpha
       type(c_ptr) :: descr
-      real(c_float),target,dimension(:,:) :: csr_val
-      integer(c_int),target,dimension(:,:) :: csr_row_ptr
-      integer(c_int),target,dimension(:,:) :: csr_col_ind
+      real(c_float),target,dimension(:) :: csr_val
+      integer(c_int),target,dimension(:) :: csr_row_ptr
+      integer(c_int),target,dimension(:) :: csr_col_ind
       real(c_float),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: myInfo
@@ -40224,9 +40216,9 @@ module hipfort_rocsparse
       integer(c_int) :: nnz
       real(c_double) :: alpha
       type(c_ptr) :: descr
-      real(c_double),target,dimension(:,:) :: csr_val
-      integer(c_int),target,dimension(:,:) :: csr_row_ptr
-      integer(c_int),target,dimension(:,:) :: csr_col_ind
+      real(c_double),target,dimension(:) :: csr_val
+      integer(c_int),target,dimension(:) :: csr_row_ptr
+      integer(c_int),target,dimension(:) :: csr_col_ind
       real(c_double),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: myInfo
@@ -40311,9 +40303,9 @@ module hipfort_rocsparse
       integer(c_int) :: nnz
       complex(c_float_complex) :: alpha
       type(c_ptr) :: descr
-      complex(c_float_complex),target,dimension(:,:) :: csr_val
-      integer(c_int),target,dimension(:,:) :: csr_row_ptr
-      integer(c_int),target,dimension(:,:) :: csr_col_ind
+      complex(c_float_complex),target,dimension(:) :: csr_val
+      integer(c_int),target,dimension(:) :: csr_row_ptr
+      integer(c_int),target,dimension(:) :: csr_col_ind
       complex(c_float_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: myInfo
@@ -40398,9 +40390,9 @@ module hipfort_rocsparse
       integer(c_int) :: nnz
       complex(c_double_complex) :: alpha
       type(c_ptr) :: descr
-      complex(c_double_complex),target,dimension(:,:) :: csr_val
-      integer(c_int),target,dimension(:,:) :: csr_row_ptr
-      integer(c_int),target,dimension(:,:) :: csr_col_ind
+      complex(c_double_complex),target,dimension(:) :: csr_val
+      integer(c_int),target,dimension(:) :: csr_row_ptr
+      integer(c_int),target,dimension(:) :: csr_col_ind
       complex(c_double_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: myInfo
@@ -40483,9 +40475,9 @@ module hipfort_rocsparse
       integer(c_int) :: nnz
       real(c_float) :: alpha
       type(c_ptr) :: descr
-      real(c_float),target,dimension(:,:) :: csr_val
-      integer(c_int),target,dimension(:,:) :: csr_row_ptr
-      integer(c_int),target,dimension(:,:) :: csr_col_ind
+      real(c_float),target,dimension(:) :: csr_val
+      integer(c_int),target,dimension(:) :: csr_row_ptr
+      integer(c_int),target,dimension(:) :: csr_col_ind
       real(c_float),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: myInfo
@@ -40567,9 +40559,9 @@ module hipfort_rocsparse
       integer(c_int) :: nnz
       real(c_double) :: alpha
       type(c_ptr) :: descr
-      real(c_double),target,dimension(:,:) :: csr_val
-      integer(c_int),target,dimension(:,:) :: csr_row_ptr
-      integer(c_int),target,dimension(:,:) :: csr_col_ind
+      real(c_double),target,dimension(:) :: csr_val
+      integer(c_int),target,dimension(:) :: csr_row_ptr
+      integer(c_int),target,dimension(:) :: csr_col_ind
       real(c_double),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: myInfo
@@ -40651,9 +40643,9 @@ module hipfort_rocsparse
       integer(c_int) :: nnz
       complex(c_float_complex) :: alpha
       type(c_ptr) :: descr
-      complex(c_float_complex),target,dimension(:,:) :: csr_val
-      integer(c_int),target,dimension(:,:) :: csr_row_ptr
-      integer(c_int),target,dimension(:,:) :: csr_col_ind
+      complex(c_float_complex),target,dimension(:) :: csr_val
+      integer(c_int),target,dimension(:) :: csr_row_ptr
+      integer(c_int),target,dimension(:) :: csr_col_ind
       complex(c_float_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: myInfo
@@ -40735,9 +40727,9 @@ module hipfort_rocsparse
       integer(c_int) :: nnz
       complex(c_double_complex) :: alpha
       type(c_ptr) :: descr
-      complex(c_double_complex),target,dimension(:,:) :: csr_val
-      integer(c_int),target,dimension(:,:) :: csr_row_ptr
-      integer(c_int),target,dimension(:,:) :: csr_col_ind
+      complex(c_double_complex),target,dimension(:) :: csr_val
+      integer(c_int),target,dimension(:) :: csr_row_ptr
+      integer(c_int),target,dimension(:) :: csr_col_ind
       complex(c_double_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: myInfo
@@ -41203,14 +41195,14 @@ module hipfort_rocsparse
       type(c_ptr) :: myInfo
       real(c_float),target :: B
       integer(c_int) :: ldb
-      real(c_float),target :: X
+      type(c_ptr) :: X
       integer(c_int) :: ldx
       integer(kind(rocsparse_solve_policy_auto)) :: policy
       type(c_ptr) :: temp_buffer
       !
       rocsparse_sbsrsm_solve_rank_0 = rocsparse_sbsrsm_solve_(handle,dir,trans_A,trans_X,mb,nrhs, &
         nnzb,alpha,descr,c_loc(bsr_val),c_loc(bsr_row_ptr),c_loc(bsr_col_ind),block_dim,myInfo, &
-        c_loc(B),ldb,c_loc(X),ldx,policy,temp_buffer)
+        c_loc(B),ldb,X,ldx,policy,temp_buffer)
     end function
 
     function rocsparse_sbsrsm_solve_rank_1(handle,dir,trans_A,trans_X,mb,nrhs,nnzb,alpha,descr, &
@@ -41235,14 +41227,14 @@ module hipfort_rocsparse
       type(c_ptr) :: myInfo
       real(c_float),target,dimension(:) :: B
       integer(c_int) :: ldb
-      real(c_float),target,dimension(:) :: X
+      type(c_ptr) :: X
       integer(c_int) :: ldx
       integer(kind(rocsparse_solve_policy_auto)) :: policy
       type(c_ptr) :: temp_buffer
       !
       rocsparse_sbsrsm_solve_rank_1 = rocsparse_sbsrsm_solve_(handle,dir,trans_A,trans_X,mb,nrhs, &
         nnzb,alpha,descr,c_loc(bsr_val),c_loc(bsr_row_ptr),c_loc(bsr_col_ind),block_dim,myInfo, &
-        c_loc(B),ldb,c_loc(X),ldx,policy,temp_buffer)
+        c_loc(B),ldb,X,ldx,policy,temp_buffer)
     end function
 
     function rocsparse_sbsrsm_solve_full_rank(handle,dir,trans_A,trans_X,mb,nrhs,nnzb,alpha,descr, &
@@ -41260,21 +41252,21 @@ module hipfort_rocsparse
       integer(c_int) :: nnzb
       real(c_float) :: alpha
       type(c_ptr) :: descr
-      real(c_float),target,dimension(:,:) :: bsr_val
-      integer(c_int),target,dimension(:,:) :: bsr_row_ptr
-      integer(c_int),target,dimension(:,:) :: bsr_col_ind
+      real(c_float),target,dimension(:) :: bsr_val
+      integer(c_int),target,dimension(:) :: bsr_row_ptr
+      integer(c_int),target,dimension(:) :: bsr_col_ind
       integer(c_int) :: block_dim
       type(c_ptr) :: myInfo
       real(c_float),target,dimension(:,:) :: B
       integer(c_int) :: ldb
-      real(c_float),target,dimension(:,:) :: X
+      type(c_ptr) :: X
       integer(c_int) :: ldx
       integer(kind(rocsparse_solve_policy_auto)) :: policy
       type(c_ptr) :: temp_buffer
       !
       rocsparse_sbsrsm_solve_full_rank = rocsparse_sbsrsm_solve_(handle,dir,trans_A,trans_X,mb, &
         nrhs,nnzb,alpha,descr,c_loc(bsr_val),c_loc(bsr_row_ptr),c_loc(bsr_col_ind),block_dim, &
-        myInfo,c_loc(B),ldb,c_loc(X),ldx,policy,temp_buffer)
+        myInfo,c_loc(B),ldb,X,ldx,policy,temp_buffer)
     end function
 
     function rocsparse_dbsrsm_solve_rank_0(handle,dir,trans_A,trans_X,mb,nrhs,nnzb,alpha,descr, &
@@ -41299,14 +41291,14 @@ module hipfort_rocsparse
       type(c_ptr) :: myInfo
       real(c_double),target :: B
       integer(c_int) :: ldb
-      real(c_double),target :: X
+      type(c_ptr) :: X
       integer(c_int) :: ldx
       integer(kind(rocsparse_solve_policy_auto)) :: policy
       type(c_ptr) :: temp_buffer
       !
       rocsparse_dbsrsm_solve_rank_0 = rocsparse_dbsrsm_solve_(handle,dir,trans_A,trans_X,mb,nrhs, &
         nnzb,alpha,descr,c_loc(bsr_val),c_loc(bsr_row_ptr),c_loc(bsr_col_ind),block_dim,myInfo, &
-        c_loc(B),ldb,c_loc(X),ldx,policy,temp_buffer)
+        c_loc(B),ldb,X,ldx,policy,temp_buffer)
     end function
 
     function rocsparse_dbsrsm_solve_rank_1(handle,dir,trans_A,trans_X,mb,nrhs,nnzb,alpha,descr, &
@@ -41331,14 +41323,14 @@ module hipfort_rocsparse
       type(c_ptr) :: myInfo
       real(c_double),target,dimension(:) :: B
       integer(c_int) :: ldb
-      real(c_double),target,dimension(:) :: X
+      type(c_ptr) :: X
       integer(c_int) :: ldx
       integer(kind(rocsparse_solve_policy_auto)) :: policy
       type(c_ptr) :: temp_buffer
       !
       rocsparse_dbsrsm_solve_rank_1 = rocsparse_dbsrsm_solve_(handle,dir,trans_A,trans_X,mb,nrhs, &
         nnzb,alpha,descr,c_loc(bsr_val),c_loc(bsr_row_ptr),c_loc(bsr_col_ind),block_dim,myInfo, &
-        c_loc(B),ldb,c_loc(X),ldx,policy,temp_buffer)
+        c_loc(B),ldb,X,ldx,policy,temp_buffer)
     end function
 
     function rocsparse_dbsrsm_solve_full_rank(handle,dir,trans_A,trans_X,mb,nrhs,nnzb,alpha,descr, &
@@ -41356,21 +41348,21 @@ module hipfort_rocsparse
       integer(c_int) :: nnzb
       real(c_double) :: alpha
       type(c_ptr) :: descr
-      real(c_double),target,dimension(:,:) :: bsr_val
-      integer(c_int),target,dimension(:,:) :: bsr_row_ptr
-      integer(c_int),target,dimension(:,:) :: bsr_col_ind
+      real(c_double),target,dimension(:) :: bsr_val
+      integer(c_int),target,dimension(:) :: bsr_row_ptr
+      integer(c_int),target,dimension(:) :: bsr_col_ind
       integer(c_int) :: block_dim
       type(c_ptr) :: myInfo
       real(c_double),target,dimension(:,:) :: B
       integer(c_int) :: ldb
-      real(c_double),target,dimension(:,:) :: X
+      type(c_ptr) :: X
       integer(c_int) :: ldx
       integer(kind(rocsparse_solve_policy_auto)) :: policy
       type(c_ptr) :: temp_buffer
       !
       rocsparse_dbsrsm_solve_full_rank = rocsparse_dbsrsm_solve_(handle,dir,trans_A,trans_X,mb, &
         nrhs,nnzb,alpha,descr,c_loc(bsr_val),c_loc(bsr_row_ptr),c_loc(bsr_col_ind),block_dim, &
-        myInfo,c_loc(B),ldb,c_loc(X),ldx,policy,temp_buffer)
+        myInfo,c_loc(B),ldb,X,ldx,policy,temp_buffer)
     end function
 
     function rocsparse_cbsrsm_solve_rank_0(handle,dir,trans_A,trans_X,mb,nrhs,nnzb,alpha,descr, &
@@ -41395,14 +41387,14 @@ module hipfort_rocsparse
       type(c_ptr) :: myInfo
       complex(c_float_complex),target :: B
       integer(c_int) :: ldb
-      complex(c_float_complex),target :: X
+      type(c_ptr) :: X
       integer(c_int) :: ldx
       integer(kind(rocsparse_solve_policy_auto)) :: policy
       type(c_ptr) :: temp_buffer
       !
       rocsparse_cbsrsm_solve_rank_0 = rocsparse_cbsrsm_solve_(handle,dir,trans_A,trans_X,mb,nrhs, &
         nnzb,alpha,descr,c_loc(bsr_val),c_loc(bsr_row_ptr),c_loc(bsr_col_ind),block_dim,myInfo, &
-        c_loc(B),ldb,c_loc(X),ldx,policy,temp_buffer)
+        c_loc(B),ldb,X,ldx,policy,temp_buffer)
     end function
 
     function rocsparse_cbsrsm_solve_rank_1(handle,dir,trans_A,trans_X,mb,nrhs,nnzb,alpha,descr, &
@@ -41427,14 +41419,14 @@ module hipfort_rocsparse
       type(c_ptr) :: myInfo
       complex(c_float_complex),target,dimension(:) :: B
       integer(c_int) :: ldb
-      complex(c_float_complex),target,dimension(:) :: X
+      type(c_ptr) :: X
       integer(c_int) :: ldx
       integer(kind(rocsparse_solve_policy_auto)) :: policy
       type(c_ptr) :: temp_buffer
       !
       rocsparse_cbsrsm_solve_rank_1 = rocsparse_cbsrsm_solve_(handle,dir,trans_A,trans_X,mb,nrhs, &
         nnzb,alpha,descr,c_loc(bsr_val),c_loc(bsr_row_ptr),c_loc(bsr_col_ind),block_dim,myInfo, &
-        c_loc(B),ldb,c_loc(X),ldx,policy,temp_buffer)
+        c_loc(B),ldb,X,ldx,policy,temp_buffer)
     end function
 
     function rocsparse_cbsrsm_solve_full_rank(handle,dir,trans_A,trans_X,mb,nrhs,nnzb,alpha,descr, &
@@ -41452,21 +41444,21 @@ module hipfort_rocsparse
       integer(c_int) :: nnzb
       complex(c_float_complex) :: alpha
       type(c_ptr) :: descr
-      complex(c_float_complex),target,dimension(:,:) :: bsr_val
-      integer(c_int),target,dimension(:,:) :: bsr_row_ptr
-      integer(c_int),target,dimension(:,:) :: bsr_col_ind
+      complex(c_float_complex),target,dimension(:) :: bsr_val
+      integer(c_int),target,dimension(:) :: bsr_row_ptr
+      integer(c_int),target,dimension(:) :: bsr_col_ind
       integer(c_int) :: block_dim
       type(c_ptr) :: myInfo
       complex(c_float_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
-      complex(c_float_complex),target,dimension(:,:) :: X
+      type(c_ptr) :: X
       integer(c_int) :: ldx
       integer(kind(rocsparse_solve_policy_auto)) :: policy
       type(c_ptr) :: temp_buffer
       !
       rocsparse_cbsrsm_solve_full_rank = rocsparse_cbsrsm_solve_(handle,dir,trans_A,trans_X,mb, &
         nrhs,nnzb,alpha,descr,c_loc(bsr_val),c_loc(bsr_row_ptr),c_loc(bsr_col_ind),block_dim, &
-        myInfo,c_loc(B),ldb,c_loc(X),ldx,policy,temp_buffer)
+        myInfo,c_loc(B),ldb,X,ldx,policy,temp_buffer)
     end function
 
     function rocsparse_zbsrsm_solve_rank_0(handle,dir,trans_A,trans_X,mb,nrhs,nnzb,alpha,descr, &
@@ -41491,14 +41483,14 @@ module hipfort_rocsparse
       type(c_ptr) :: myInfo
       complex(c_double_complex),target :: B
       integer(c_int) :: ldb
-      complex(c_double_complex),target :: X
+      type(c_ptr) :: X
       integer(c_int) :: ldx
       integer(kind(rocsparse_solve_policy_auto)) :: policy
       type(c_ptr) :: temp_buffer
       !
       rocsparse_zbsrsm_solve_rank_0 = rocsparse_zbsrsm_solve_(handle,dir,trans_A,trans_X,mb,nrhs, &
         nnzb,alpha,descr,c_loc(bsr_val),c_loc(bsr_row_ptr),c_loc(bsr_col_ind),block_dim,myInfo, &
-        c_loc(B),ldb,c_loc(X),ldx,policy,temp_buffer)
+        c_loc(B),ldb,X,ldx,policy,temp_buffer)
     end function
 
     function rocsparse_zbsrsm_solve_rank_1(handle,dir,trans_A,trans_X,mb,nrhs,nnzb,alpha,descr, &
@@ -41523,14 +41515,14 @@ module hipfort_rocsparse
       type(c_ptr) :: myInfo
       complex(c_double_complex),target,dimension(:) :: B
       integer(c_int) :: ldb
-      complex(c_double_complex),target,dimension(:) :: X
+      type(c_ptr) :: X
       integer(c_int) :: ldx
       integer(kind(rocsparse_solve_policy_auto)) :: policy
       type(c_ptr) :: temp_buffer
       !
       rocsparse_zbsrsm_solve_rank_1 = rocsparse_zbsrsm_solve_(handle,dir,trans_A,trans_X,mb,nrhs, &
         nnzb,alpha,descr,c_loc(bsr_val),c_loc(bsr_row_ptr),c_loc(bsr_col_ind),block_dim,myInfo, &
-        c_loc(B),ldb,c_loc(X),ldx,policy,temp_buffer)
+        c_loc(B),ldb,X,ldx,policy,temp_buffer)
     end function
 
     function rocsparse_zbsrsm_solve_full_rank(handle,dir,trans_A,trans_X,mb,nrhs,nnzb,alpha,descr, &
@@ -41548,21 +41540,21 @@ module hipfort_rocsparse
       integer(c_int) :: nnzb
       complex(c_double_complex) :: alpha
       type(c_ptr) :: descr
-      complex(c_double_complex),target,dimension(:,:) :: bsr_val
-      integer(c_int),target,dimension(:,:) :: bsr_row_ptr
-      integer(c_int),target,dimension(:,:) :: bsr_col_ind
+      complex(c_double_complex),target,dimension(:) :: bsr_val
+      integer(c_int),target,dimension(:) :: bsr_row_ptr
+      integer(c_int),target,dimension(:) :: bsr_col_ind
       integer(c_int) :: block_dim
       type(c_ptr) :: myInfo
       complex(c_double_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
-      complex(c_double_complex),target,dimension(:,:) :: X
+      type(c_ptr) :: X
       integer(c_int) :: ldx
       integer(kind(rocsparse_solve_policy_auto)) :: policy
       type(c_ptr) :: temp_buffer
       !
       rocsparse_zbsrsm_solve_full_rank = rocsparse_zbsrsm_solve_(handle,dir,trans_A,trans_X,mb, &
         nrhs,nnzb,alpha,descr,c_loc(bsr_val),c_loc(bsr_row_ptr),c_loc(bsr_col_ind),block_dim, &
-        myInfo,c_loc(B),ldb,c_loc(X),ldx,policy,temp_buffer)
+        myInfo,c_loc(B),ldb,X,ldx,policy,temp_buffer)
     end function
 
     function rocsparse_sgemmi_rank_0(handle,trans_A,trans_B,m,n,k,nnz,alpha,A,lda,descr,csr_val, &
@@ -41638,9 +41630,9 @@ module hipfort_rocsparse
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
       type(c_ptr) :: descr
-      real(c_float),target,dimension(:,:) :: csr_val
-      integer(c_int),target,dimension(:,:) :: csr_row_ptr
-      integer(c_int),target,dimension(:,:) :: csr_col_ind
+      real(c_float),target,dimension(:) :: csr_val
+      integer(c_int),target,dimension(:) :: csr_row_ptr
+      integer(c_int),target,dimension(:) :: csr_col_ind
       real(c_float) :: beta
       real(c_float),target,dimension(:,:) :: C
       integer(c_int) :: ldc
@@ -41722,9 +41714,9 @@ module hipfort_rocsparse
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
       type(c_ptr) :: descr
-      real(c_double),target,dimension(:,:) :: csr_val
-      integer(c_int),target,dimension(:,:) :: csr_row_ptr
-      integer(c_int),target,dimension(:,:) :: csr_col_ind
+      real(c_double),target,dimension(:) :: csr_val
+      integer(c_int),target,dimension(:) :: csr_row_ptr
+      integer(c_int),target,dimension(:) :: csr_col_ind
       real(c_double) :: beta
       real(c_double),target,dimension(:,:) :: C
       integer(c_int) :: ldc
@@ -41806,9 +41798,9 @@ module hipfort_rocsparse
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       type(c_ptr) :: descr
-      complex(c_float_complex),target,dimension(:,:) :: csr_val
-      integer(c_int),target,dimension(:,:) :: csr_row_ptr
-      integer(c_int),target,dimension(:,:) :: csr_col_ind
+      complex(c_float_complex),target,dimension(:) :: csr_val
+      integer(c_int),target,dimension(:) :: csr_row_ptr
+      integer(c_int),target,dimension(:) :: csr_col_ind
       complex(c_float_complex) :: beta
       complex(c_float_complex),target,dimension(:,:) :: C
       integer(c_int) :: ldc
@@ -41890,9 +41882,9 @@ module hipfort_rocsparse
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       type(c_ptr) :: descr
-      complex(c_double_complex),target,dimension(:,:) :: csr_val
-      integer(c_int),target,dimension(:,:) :: csr_row_ptr
-      integer(c_int),target,dimension(:,:) :: csr_col_ind
+      complex(c_double_complex),target,dimension(:) :: csr_val
+      integer(c_int),target,dimension(:) :: csr_row_ptr
+      integer(c_int),target,dimension(:) :: csr_col_ind
       complex(c_double_complex) :: beta
       complex(c_double_complex),target,dimension(:,:) :: C
       integer(c_int) :: ldc
@@ -45075,15 +45067,15 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      real(c_float),target :: dl
-      real(c_float),target :: d
-      real(c_float),target :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_float),target :: B
       integer(c_int) :: ldb
       integer(c_size_t) :: buffer_size
       !
-      rocsparse_sgtsv_buffer_size_rank_0 = rocsparse_sgtsv_buffer_size_(handle,m,n,c_loc(dl), &
-        c_loc(d),c_loc(du),c_loc(B),ldb,buffer_size)
+      rocsparse_sgtsv_buffer_size_rank_0 = rocsparse_sgtsv_buffer_size_(handle,m,n,dl,d,du, &
+        c_loc(B),ldb,buffer_size)
     end function
 
     function rocsparse_sgtsv_buffer_size_rank_1(handle,m,n,dl,d,du,B,ldb,buffer_size)
@@ -45094,15 +45086,15 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      real(c_float),target,dimension(:) :: dl
-      real(c_float),target,dimension(:) :: d
-      real(c_float),target,dimension(:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_float),target,dimension(:) :: B
       integer(c_int) :: ldb
       integer(c_size_t) :: buffer_size
       !
-      rocsparse_sgtsv_buffer_size_rank_1 = rocsparse_sgtsv_buffer_size_(handle,m,n,c_loc(dl), &
-        c_loc(d),c_loc(du),c_loc(B),ldb,buffer_size)
+      rocsparse_sgtsv_buffer_size_rank_1 = rocsparse_sgtsv_buffer_size_(handle,m,n,dl,d,du, &
+        c_loc(B),ldb,buffer_size)
     end function
 
     function rocsparse_sgtsv_buffer_size_full_rank(handle,m,n,dl,d,du,B,ldb,buffer_size)
@@ -45113,15 +45105,15 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      real(c_float),target,dimension(:,:) :: dl
-      real(c_float),target,dimension(:,:) :: d
-      real(c_float),target,dimension(:,:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_float),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       integer(c_size_t) :: buffer_size
       !
-      rocsparse_sgtsv_buffer_size_full_rank = rocsparse_sgtsv_buffer_size_(handle,m,n,c_loc(dl), &
-        c_loc(d),c_loc(du),c_loc(B),ldb,buffer_size)
+      rocsparse_sgtsv_buffer_size_full_rank = rocsparse_sgtsv_buffer_size_(handle,m,n,dl,d,du, &
+        c_loc(B),ldb,buffer_size)
     end function
 
     function rocsparse_dgtsv_buffer_size_rank_0(handle,m,n,dl,d,du,B,ldb,buffer_size)
@@ -45132,15 +45124,15 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      real(c_double),target :: dl
-      real(c_double),target :: d
-      real(c_double),target :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_double),target :: B
       integer(c_int) :: ldb
       integer(c_size_t) :: buffer_size
       !
-      rocsparse_dgtsv_buffer_size_rank_0 = rocsparse_dgtsv_buffer_size_(handle,m,n,c_loc(dl), &
-        c_loc(d),c_loc(du),c_loc(B),ldb,buffer_size)
+      rocsparse_dgtsv_buffer_size_rank_0 = rocsparse_dgtsv_buffer_size_(handle,m,n,dl,d,du, &
+        c_loc(B),ldb,buffer_size)
     end function
 
     function rocsparse_dgtsv_buffer_size_rank_1(handle,m,n,dl,d,du,B,ldb,buffer_size)
@@ -45151,15 +45143,15 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      real(c_double),target,dimension(:) :: dl
-      real(c_double),target,dimension(:) :: d
-      real(c_double),target,dimension(:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_double),target,dimension(:) :: B
       integer(c_int) :: ldb
       integer(c_size_t) :: buffer_size
       !
-      rocsparse_dgtsv_buffer_size_rank_1 = rocsparse_dgtsv_buffer_size_(handle,m,n,c_loc(dl), &
-        c_loc(d),c_loc(du),c_loc(B),ldb,buffer_size)
+      rocsparse_dgtsv_buffer_size_rank_1 = rocsparse_dgtsv_buffer_size_(handle,m,n,dl,d,du, &
+        c_loc(B),ldb,buffer_size)
     end function
 
     function rocsparse_dgtsv_buffer_size_full_rank(handle,m,n,dl,d,du,B,ldb,buffer_size)
@@ -45170,15 +45162,15 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      real(c_double),target,dimension(:,:) :: dl
-      real(c_double),target,dimension(:,:) :: d
-      real(c_double),target,dimension(:,:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_double),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       integer(c_size_t) :: buffer_size
       !
-      rocsparse_dgtsv_buffer_size_full_rank = rocsparse_dgtsv_buffer_size_(handle,m,n,c_loc(dl), &
-        c_loc(d),c_loc(du),c_loc(B),ldb,buffer_size)
+      rocsparse_dgtsv_buffer_size_full_rank = rocsparse_dgtsv_buffer_size_(handle,m,n,dl,d,du, &
+        c_loc(B),ldb,buffer_size)
     end function
 
     function rocsparse_cgtsv_buffer_size_rank_0(handle,m,n,dl,d,du,B,ldb,buffer_size)
@@ -45189,15 +45181,15 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      complex(c_float_complex),target :: dl
-      complex(c_float_complex),target :: d
-      complex(c_float_complex),target :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_float_complex),target :: B
       integer(c_int) :: ldb
       integer(c_size_t) :: buffer_size
       !
-      rocsparse_cgtsv_buffer_size_rank_0 = rocsparse_cgtsv_buffer_size_(handle,m,n,c_loc(dl), &
-        c_loc(d),c_loc(du),c_loc(B),ldb,buffer_size)
+      rocsparse_cgtsv_buffer_size_rank_0 = rocsparse_cgtsv_buffer_size_(handle,m,n,dl,d,du, &
+        c_loc(B),ldb,buffer_size)
     end function
 
     function rocsparse_cgtsv_buffer_size_rank_1(handle,m,n,dl,d,du,B,ldb,buffer_size)
@@ -45208,15 +45200,15 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      complex(c_float_complex),target,dimension(:) :: dl
-      complex(c_float_complex),target,dimension(:) :: d
-      complex(c_float_complex),target,dimension(:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_float_complex),target,dimension(:) :: B
       integer(c_int) :: ldb
       integer(c_size_t) :: buffer_size
       !
-      rocsparse_cgtsv_buffer_size_rank_1 = rocsparse_cgtsv_buffer_size_(handle,m,n,c_loc(dl), &
-        c_loc(d),c_loc(du),c_loc(B),ldb,buffer_size)
+      rocsparse_cgtsv_buffer_size_rank_1 = rocsparse_cgtsv_buffer_size_(handle,m,n,dl,d,du, &
+        c_loc(B),ldb,buffer_size)
     end function
 
     function rocsparse_cgtsv_buffer_size_full_rank(handle,m,n,dl,d,du,B,ldb,buffer_size)
@@ -45227,15 +45219,15 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      complex(c_float_complex),target,dimension(:,:) :: dl
-      complex(c_float_complex),target,dimension(:,:) :: d
-      complex(c_float_complex),target,dimension(:,:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_float_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       integer(c_size_t) :: buffer_size
       !
-      rocsparse_cgtsv_buffer_size_full_rank = rocsparse_cgtsv_buffer_size_(handle,m,n,c_loc(dl), &
-        c_loc(d),c_loc(du),c_loc(B),ldb,buffer_size)
+      rocsparse_cgtsv_buffer_size_full_rank = rocsparse_cgtsv_buffer_size_(handle,m,n,dl,d,du, &
+        c_loc(B),ldb,buffer_size)
     end function
 
     function rocsparse_zgtsv_buffer_size_rank_0(handle,m,n,dl,d,du,B,ldb,buffer_size)
@@ -45246,15 +45238,15 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      complex(c_double_complex),target :: dl
-      complex(c_double_complex),target :: d
-      complex(c_double_complex),target :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_double_complex),target :: B
       integer(c_int) :: ldb
       integer(c_size_t) :: buffer_size
       !
-      rocsparse_zgtsv_buffer_size_rank_0 = rocsparse_zgtsv_buffer_size_(handle,m,n,c_loc(dl), &
-        c_loc(d),c_loc(du),c_loc(B),ldb,buffer_size)
+      rocsparse_zgtsv_buffer_size_rank_0 = rocsparse_zgtsv_buffer_size_(handle,m,n,dl,d,du, &
+        c_loc(B),ldb,buffer_size)
     end function
 
     function rocsparse_zgtsv_buffer_size_rank_1(handle,m,n,dl,d,du,B,ldb,buffer_size)
@@ -45265,15 +45257,15 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      complex(c_double_complex),target,dimension(:) :: dl
-      complex(c_double_complex),target,dimension(:) :: d
-      complex(c_double_complex),target,dimension(:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_double_complex),target,dimension(:) :: B
       integer(c_int) :: ldb
       integer(c_size_t) :: buffer_size
       !
-      rocsparse_zgtsv_buffer_size_rank_1 = rocsparse_zgtsv_buffer_size_(handle,m,n,c_loc(dl), &
-        c_loc(d),c_loc(du),c_loc(B),ldb,buffer_size)
+      rocsparse_zgtsv_buffer_size_rank_1 = rocsparse_zgtsv_buffer_size_(handle,m,n,dl,d,du, &
+        c_loc(B),ldb,buffer_size)
     end function
 
     function rocsparse_zgtsv_buffer_size_full_rank(handle,m,n,dl,d,du,B,ldb,buffer_size)
@@ -45284,15 +45276,15 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      complex(c_double_complex),target,dimension(:,:) :: dl
-      complex(c_double_complex),target,dimension(:,:) :: d
-      complex(c_double_complex),target,dimension(:,:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_double_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       integer(c_size_t) :: buffer_size
       !
-      rocsparse_zgtsv_buffer_size_full_rank = rocsparse_zgtsv_buffer_size_(handle,m,n,c_loc(dl), &
-        c_loc(d),c_loc(du),c_loc(B),ldb,buffer_size)
+      rocsparse_zgtsv_buffer_size_full_rank = rocsparse_zgtsv_buffer_size_(handle,m,n,dl,d,du, &
+        c_loc(B),ldb,buffer_size)
     end function
 
     function rocsparse_sgtsv_rank_0(handle,m,n,dl,d,du,B,ldb,temp_buffer)
@@ -45303,15 +45295,14 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      real(c_float),target :: dl
-      real(c_float),target :: d
-      real(c_float),target :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_float),target :: B
       integer(c_int) :: ldb
       type(c_ptr) :: temp_buffer
       !
-      rocsparse_sgtsv_rank_0 = rocsparse_sgtsv_(handle,m,n,c_loc(dl),c_loc(d),c_loc(du),c_loc(B), &
-        ldb,temp_buffer)
+      rocsparse_sgtsv_rank_0 = rocsparse_sgtsv_(handle,m,n,dl,d,du,c_loc(B),ldb,temp_buffer)
     end function
 
     function rocsparse_sgtsv_rank_1(handle,m,n,dl,d,du,B,ldb,temp_buffer)
@@ -45322,15 +45313,14 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      real(c_float),target,dimension(:) :: dl
-      real(c_float),target,dimension(:) :: d
-      real(c_float),target,dimension(:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_float),target,dimension(:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: temp_buffer
       !
-      rocsparse_sgtsv_rank_1 = rocsparse_sgtsv_(handle,m,n,c_loc(dl),c_loc(d),c_loc(du),c_loc(B), &
-        ldb,temp_buffer)
+      rocsparse_sgtsv_rank_1 = rocsparse_sgtsv_(handle,m,n,dl,d,du,c_loc(B),ldb,temp_buffer)
     end function
 
     function rocsparse_sgtsv_full_rank(handle,m,n,dl,d,du,B,ldb,temp_buffer)
@@ -45341,15 +45331,14 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      real(c_float),target,dimension(:,:) :: dl
-      real(c_float),target,dimension(:,:) :: d
-      real(c_float),target,dimension(:,:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_float),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: temp_buffer
       !
-      rocsparse_sgtsv_full_rank = rocsparse_sgtsv_(handle,m,n,c_loc(dl),c_loc(d),c_loc(du), &
-        c_loc(B),ldb,temp_buffer)
+      rocsparse_sgtsv_full_rank = rocsparse_sgtsv_(handle,m,n,dl,d,du,c_loc(B),ldb,temp_buffer)
     end function
 
     function rocsparse_dgtsv_rank_0(handle,m,n,dl,d,du,B,ldb,temp_buffer)
@@ -45360,15 +45349,14 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      real(c_double),target :: dl
-      real(c_double),target :: d
-      real(c_double),target :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_double),target :: B
       integer(c_int) :: ldb
       type(c_ptr) :: temp_buffer
       !
-      rocsparse_dgtsv_rank_0 = rocsparse_dgtsv_(handle,m,n,c_loc(dl),c_loc(d),c_loc(du),c_loc(B), &
-        ldb,temp_buffer)
+      rocsparse_dgtsv_rank_0 = rocsparse_dgtsv_(handle,m,n,dl,d,du,c_loc(B),ldb,temp_buffer)
     end function
 
     function rocsparse_dgtsv_rank_1(handle,m,n,dl,d,du,B,ldb,temp_buffer)
@@ -45379,15 +45367,14 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      real(c_double),target,dimension(:) :: dl
-      real(c_double),target,dimension(:) :: d
-      real(c_double),target,dimension(:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_double),target,dimension(:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: temp_buffer
       !
-      rocsparse_dgtsv_rank_1 = rocsparse_dgtsv_(handle,m,n,c_loc(dl),c_loc(d),c_loc(du),c_loc(B), &
-        ldb,temp_buffer)
+      rocsparse_dgtsv_rank_1 = rocsparse_dgtsv_(handle,m,n,dl,d,du,c_loc(B),ldb,temp_buffer)
     end function
 
     function rocsparse_dgtsv_full_rank(handle,m,n,dl,d,du,B,ldb,temp_buffer)
@@ -45398,15 +45385,14 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      real(c_double),target,dimension(:,:) :: dl
-      real(c_double),target,dimension(:,:) :: d
-      real(c_double),target,dimension(:,:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_double),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: temp_buffer
       !
-      rocsparse_dgtsv_full_rank = rocsparse_dgtsv_(handle,m,n,c_loc(dl),c_loc(d),c_loc(du), &
-        c_loc(B),ldb,temp_buffer)
+      rocsparse_dgtsv_full_rank = rocsparse_dgtsv_(handle,m,n,dl,d,du,c_loc(B),ldb,temp_buffer)
     end function
 
     function rocsparse_cgtsv_rank_0(handle,m,n,dl,d,du,B,ldb,temp_buffer)
@@ -45417,15 +45403,14 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      complex(c_float_complex),target :: dl
-      complex(c_float_complex),target :: d
-      complex(c_float_complex),target :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_float_complex),target :: B
       integer(c_int) :: ldb
       type(c_ptr) :: temp_buffer
       !
-      rocsparse_cgtsv_rank_0 = rocsparse_cgtsv_(handle,m,n,c_loc(dl),c_loc(d),c_loc(du),c_loc(B), &
-        ldb,temp_buffer)
+      rocsparse_cgtsv_rank_0 = rocsparse_cgtsv_(handle,m,n,dl,d,du,c_loc(B),ldb,temp_buffer)
     end function
 
     function rocsparse_cgtsv_rank_1(handle,m,n,dl,d,du,B,ldb,temp_buffer)
@@ -45436,15 +45421,14 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      complex(c_float_complex),target,dimension(:) :: dl
-      complex(c_float_complex),target,dimension(:) :: d
-      complex(c_float_complex),target,dimension(:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_float_complex),target,dimension(:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: temp_buffer
       !
-      rocsparse_cgtsv_rank_1 = rocsparse_cgtsv_(handle,m,n,c_loc(dl),c_loc(d),c_loc(du),c_loc(B), &
-        ldb,temp_buffer)
+      rocsparse_cgtsv_rank_1 = rocsparse_cgtsv_(handle,m,n,dl,d,du,c_loc(B),ldb,temp_buffer)
     end function
 
     function rocsparse_cgtsv_full_rank(handle,m,n,dl,d,du,B,ldb,temp_buffer)
@@ -45455,15 +45439,14 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      complex(c_float_complex),target,dimension(:,:) :: dl
-      complex(c_float_complex),target,dimension(:,:) :: d
-      complex(c_float_complex),target,dimension(:,:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_float_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: temp_buffer
       !
-      rocsparse_cgtsv_full_rank = rocsparse_cgtsv_(handle,m,n,c_loc(dl),c_loc(d),c_loc(du), &
-        c_loc(B),ldb,temp_buffer)
+      rocsparse_cgtsv_full_rank = rocsparse_cgtsv_(handle,m,n,dl,d,du,c_loc(B),ldb,temp_buffer)
     end function
 
     function rocsparse_zgtsv_rank_0(handle,m,n,dl,d,du,B,ldb,temp_buffer)
@@ -45474,15 +45457,14 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      complex(c_double_complex),target :: dl
-      complex(c_double_complex),target :: d
-      complex(c_double_complex),target :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_double_complex),target :: B
       integer(c_int) :: ldb
       type(c_ptr) :: temp_buffer
       !
-      rocsparse_zgtsv_rank_0 = rocsparse_zgtsv_(handle,m,n,c_loc(dl),c_loc(d),c_loc(du),c_loc(B), &
-        ldb,temp_buffer)
+      rocsparse_zgtsv_rank_0 = rocsparse_zgtsv_(handle,m,n,dl,d,du,c_loc(B),ldb,temp_buffer)
     end function
 
     function rocsparse_zgtsv_rank_1(handle,m,n,dl,d,du,B,ldb,temp_buffer)
@@ -45493,15 +45475,14 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      complex(c_double_complex),target,dimension(:) :: dl
-      complex(c_double_complex),target,dimension(:) :: d
-      complex(c_double_complex),target,dimension(:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_double_complex),target,dimension(:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: temp_buffer
       !
-      rocsparse_zgtsv_rank_1 = rocsparse_zgtsv_(handle,m,n,c_loc(dl),c_loc(d),c_loc(du),c_loc(B), &
-        ldb,temp_buffer)
+      rocsparse_zgtsv_rank_1 = rocsparse_zgtsv_(handle,m,n,dl,d,du,c_loc(B),ldb,temp_buffer)
     end function
 
     function rocsparse_zgtsv_full_rank(handle,m,n,dl,d,du,B,ldb,temp_buffer)
@@ -45512,15 +45493,14 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      complex(c_double_complex),target,dimension(:,:) :: dl
-      complex(c_double_complex),target,dimension(:,:) :: d
-      complex(c_double_complex),target,dimension(:,:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_double_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: temp_buffer
       !
-      rocsparse_zgtsv_full_rank = rocsparse_zgtsv_(handle,m,n,c_loc(dl),c_loc(d),c_loc(du), &
-        c_loc(B),ldb,temp_buffer)
+      rocsparse_zgtsv_full_rank = rocsparse_zgtsv_(handle,m,n,dl,d,du,c_loc(B),ldb,temp_buffer)
     end function
 
     function rocsparse_sgtsv_no_pivot_buffer_size_rank_0(handle,m,n,dl,d,du,B,ldb,buffer_size)
@@ -45531,15 +45511,15 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      real(c_float),target :: dl
-      real(c_float),target :: d
-      real(c_float),target :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_float),target :: B
       integer(c_int) :: ldb
       integer(c_size_t) :: buffer_size
       !
       rocsparse_sgtsv_no_pivot_buffer_size_rank_0 = rocsparse_sgtsv_no_pivot_buffer_size_(handle, &
-        m,n,c_loc(dl),c_loc(d),c_loc(du),c_loc(B),ldb,buffer_size)
+        m,n,dl,d,du,c_loc(B),ldb,buffer_size)
     end function
 
     function rocsparse_sgtsv_no_pivot_buffer_size_rank_1(handle,m,n,dl,d,du,B,ldb,buffer_size)
@@ -45550,15 +45530,15 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      real(c_float),target,dimension(:) :: dl
-      real(c_float),target,dimension(:) :: d
-      real(c_float),target,dimension(:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_float),target,dimension(:) :: B
       integer(c_int) :: ldb
       integer(c_size_t) :: buffer_size
       !
       rocsparse_sgtsv_no_pivot_buffer_size_rank_1 = rocsparse_sgtsv_no_pivot_buffer_size_(handle, &
-        m,n,c_loc(dl),c_loc(d),c_loc(du),c_loc(B),ldb,buffer_size)
+        m,n,dl,d,du,c_loc(B),ldb,buffer_size)
     end function
 
     function rocsparse_sgtsv_no_pivot_buffer_size_full_rank(handle,m,n,dl,d,du,B,ldb,buffer_size)
@@ -45569,15 +45549,15 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      real(c_float),target,dimension(:,:) :: dl
-      real(c_float),target,dimension(:,:) :: d
-      real(c_float),target,dimension(:,:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_float),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       integer(c_size_t) :: buffer_size
       !
       rocsparse_sgtsv_no_pivot_buffer_size_full_rank = rocsparse_sgtsv_no_pivot_buffer_size_( &
-        handle,m,n,c_loc(dl),c_loc(d),c_loc(du),c_loc(B),ldb,buffer_size)
+        handle,m,n,dl,d,du,c_loc(B),ldb,buffer_size)
     end function
 
     function rocsparse_dgtsv_no_pivot_buffer_size_rank_0(handle,m,n,dl,d,du,B,ldb,buffer_size)
@@ -45588,15 +45568,15 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      real(c_double),target :: dl
-      real(c_double),target :: d
-      real(c_double),target :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_double),target :: B
       integer(c_int) :: ldb
       integer(c_size_t) :: buffer_size
       !
       rocsparse_dgtsv_no_pivot_buffer_size_rank_0 = rocsparse_dgtsv_no_pivot_buffer_size_(handle, &
-        m,n,c_loc(dl),c_loc(d),c_loc(du),c_loc(B),ldb,buffer_size)
+        m,n,dl,d,du,c_loc(B),ldb,buffer_size)
     end function
 
     function rocsparse_dgtsv_no_pivot_buffer_size_rank_1(handle,m,n,dl,d,du,B,ldb,buffer_size)
@@ -45607,15 +45587,15 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      real(c_double),target,dimension(:) :: dl
-      real(c_double),target,dimension(:) :: d
-      real(c_double),target,dimension(:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_double),target,dimension(:) :: B
       integer(c_int) :: ldb
       integer(c_size_t) :: buffer_size
       !
       rocsparse_dgtsv_no_pivot_buffer_size_rank_1 = rocsparse_dgtsv_no_pivot_buffer_size_(handle, &
-        m,n,c_loc(dl),c_loc(d),c_loc(du),c_loc(B),ldb,buffer_size)
+        m,n,dl,d,du,c_loc(B),ldb,buffer_size)
     end function
 
     function rocsparse_dgtsv_no_pivot_buffer_size_full_rank(handle,m,n,dl,d,du,B,ldb,buffer_size)
@@ -45626,15 +45606,15 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      real(c_double),target,dimension(:,:) :: dl
-      real(c_double),target,dimension(:,:) :: d
-      real(c_double),target,dimension(:,:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_double),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       integer(c_size_t) :: buffer_size
       !
       rocsparse_dgtsv_no_pivot_buffer_size_full_rank = rocsparse_dgtsv_no_pivot_buffer_size_( &
-        handle,m,n,c_loc(dl),c_loc(d),c_loc(du),c_loc(B),ldb,buffer_size)
+        handle,m,n,dl,d,du,c_loc(B),ldb,buffer_size)
     end function
 
     function rocsparse_cgtsv_no_pivot_buffer_size_rank_0(handle,m,n,dl,d,du,B,ldb,buffer_size)
@@ -45645,15 +45625,15 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      complex(c_float_complex),target :: dl
-      complex(c_float_complex),target :: d
-      complex(c_float_complex),target :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_float_complex),target :: B
       integer(c_int) :: ldb
       integer(c_size_t) :: buffer_size
       !
       rocsparse_cgtsv_no_pivot_buffer_size_rank_0 = rocsparse_cgtsv_no_pivot_buffer_size_(handle, &
-        m,n,c_loc(dl),c_loc(d),c_loc(du),c_loc(B),ldb,buffer_size)
+        m,n,dl,d,du,c_loc(B),ldb,buffer_size)
     end function
 
     function rocsparse_cgtsv_no_pivot_buffer_size_rank_1(handle,m,n,dl,d,du,B,ldb,buffer_size)
@@ -45664,15 +45644,15 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      complex(c_float_complex),target,dimension(:) :: dl
-      complex(c_float_complex),target,dimension(:) :: d
-      complex(c_float_complex),target,dimension(:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_float_complex),target,dimension(:) :: B
       integer(c_int) :: ldb
       integer(c_size_t) :: buffer_size
       !
       rocsparse_cgtsv_no_pivot_buffer_size_rank_1 = rocsparse_cgtsv_no_pivot_buffer_size_(handle, &
-        m,n,c_loc(dl),c_loc(d),c_loc(du),c_loc(B),ldb,buffer_size)
+        m,n,dl,d,du,c_loc(B),ldb,buffer_size)
     end function
 
     function rocsparse_cgtsv_no_pivot_buffer_size_full_rank(handle,m,n,dl,d,du,B,ldb,buffer_size)
@@ -45683,15 +45663,15 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      complex(c_float_complex),target,dimension(:,:) :: dl
-      complex(c_float_complex),target,dimension(:,:) :: d
-      complex(c_float_complex),target,dimension(:,:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_float_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       integer(c_size_t) :: buffer_size
       !
       rocsparse_cgtsv_no_pivot_buffer_size_full_rank = rocsparse_cgtsv_no_pivot_buffer_size_( &
-        handle,m,n,c_loc(dl),c_loc(d),c_loc(du),c_loc(B),ldb,buffer_size)
+        handle,m,n,dl,d,du,c_loc(B),ldb,buffer_size)
     end function
 
     function rocsparse_zgtsv_no_pivot_buffer_size_rank_0(handle,m,n,dl,d,du,B,ldb,buffer_size)
@@ -45702,15 +45682,15 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      complex(c_double_complex),target :: dl
-      complex(c_double_complex),target :: d
-      complex(c_double_complex),target :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_double_complex),target :: B
       integer(c_int) :: ldb
       integer(c_size_t) :: buffer_size
       !
       rocsparse_zgtsv_no_pivot_buffer_size_rank_0 = rocsparse_zgtsv_no_pivot_buffer_size_(handle, &
-        m,n,c_loc(dl),c_loc(d),c_loc(du),c_loc(B),ldb,buffer_size)
+        m,n,dl,d,du,c_loc(B),ldb,buffer_size)
     end function
 
     function rocsparse_zgtsv_no_pivot_buffer_size_rank_1(handle,m,n,dl,d,du,B,ldb,buffer_size)
@@ -45721,15 +45701,15 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      complex(c_double_complex),target,dimension(:) :: dl
-      complex(c_double_complex),target,dimension(:) :: d
-      complex(c_double_complex),target,dimension(:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_double_complex),target,dimension(:) :: B
       integer(c_int) :: ldb
       integer(c_size_t) :: buffer_size
       !
       rocsparse_zgtsv_no_pivot_buffer_size_rank_1 = rocsparse_zgtsv_no_pivot_buffer_size_(handle, &
-        m,n,c_loc(dl),c_loc(d),c_loc(du),c_loc(B),ldb,buffer_size)
+        m,n,dl,d,du,c_loc(B),ldb,buffer_size)
     end function
 
     function rocsparse_zgtsv_no_pivot_buffer_size_full_rank(handle,m,n,dl,d,du,B,ldb,buffer_size)
@@ -45740,15 +45720,15 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      complex(c_double_complex),target,dimension(:,:) :: dl
-      complex(c_double_complex),target,dimension(:,:) :: d
-      complex(c_double_complex),target,dimension(:,:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_double_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       integer(c_size_t) :: buffer_size
       !
       rocsparse_zgtsv_no_pivot_buffer_size_full_rank = rocsparse_zgtsv_no_pivot_buffer_size_( &
-        handle,m,n,c_loc(dl),c_loc(d),c_loc(du),c_loc(B),ldb,buffer_size)
+        handle,m,n,dl,d,du,c_loc(B),ldb,buffer_size)
     end function
 
     function rocsparse_sgtsv_no_pivot_rank_0(handle,m,n,dl,d,du,B,ldb,temp_buffer)
@@ -45759,15 +45739,15 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      real(c_float),target :: dl
-      real(c_float),target :: d
-      real(c_float),target :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_float),target :: B
       integer(c_int) :: ldb
       type(c_ptr) :: temp_buffer
       !
-      rocsparse_sgtsv_no_pivot_rank_0 = rocsparse_sgtsv_no_pivot_(handle,m,n,c_loc(dl),c_loc(d), &
-        c_loc(du),c_loc(B),ldb,temp_buffer)
+      rocsparse_sgtsv_no_pivot_rank_0 = rocsparse_sgtsv_no_pivot_(handle,m,n,dl,d,du,c_loc(B),ldb, &
+        temp_buffer)
     end function
 
     function rocsparse_sgtsv_no_pivot_rank_1(handle,m,n,dl,d,du,B,ldb,temp_buffer)
@@ -45778,15 +45758,15 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      real(c_float),target,dimension(:) :: dl
-      real(c_float),target,dimension(:) :: d
-      real(c_float),target,dimension(:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_float),target,dimension(:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: temp_buffer
       !
-      rocsparse_sgtsv_no_pivot_rank_1 = rocsparse_sgtsv_no_pivot_(handle,m,n,c_loc(dl),c_loc(d), &
-        c_loc(du),c_loc(B),ldb,temp_buffer)
+      rocsparse_sgtsv_no_pivot_rank_1 = rocsparse_sgtsv_no_pivot_(handle,m,n,dl,d,du,c_loc(B),ldb, &
+        temp_buffer)
     end function
 
     function rocsparse_sgtsv_no_pivot_full_rank(handle,m,n,dl,d,du,B,ldb,temp_buffer)
@@ -45797,15 +45777,15 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      real(c_float),target,dimension(:,:) :: dl
-      real(c_float),target,dimension(:,:) :: d
-      real(c_float),target,dimension(:,:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_float),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: temp_buffer
       !
-      rocsparse_sgtsv_no_pivot_full_rank = rocsparse_sgtsv_no_pivot_(handle,m,n,c_loc(dl), &
-        c_loc(d),c_loc(du),c_loc(B),ldb,temp_buffer)
+      rocsparse_sgtsv_no_pivot_full_rank = rocsparse_sgtsv_no_pivot_(handle,m,n,dl,d,du,c_loc(B), &
+        ldb,temp_buffer)
     end function
 
     function rocsparse_dgtsv_no_pivot_rank_0(handle,m,n,dl,d,du,B,ldb,temp_buffer)
@@ -45816,15 +45796,15 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      real(c_double),target :: dl
-      real(c_double),target :: d
-      real(c_double),target :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_double),target :: B
       integer(c_int) :: ldb
       type(c_ptr) :: temp_buffer
       !
-      rocsparse_dgtsv_no_pivot_rank_0 = rocsparse_dgtsv_no_pivot_(handle,m,n,c_loc(dl),c_loc(d), &
-        c_loc(du),c_loc(B),ldb,temp_buffer)
+      rocsparse_dgtsv_no_pivot_rank_0 = rocsparse_dgtsv_no_pivot_(handle,m,n,dl,d,du,c_loc(B),ldb, &
+        temp_buffer)
     end function
 
     function rocsparse_dgtsv_no_pivot_rank_1(handle,m,n,dl,d,du,B,ldb,temp_buffer)
@@ -45835,15 +45815,15 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      real(c_double),target,dimension(:) :: dl
-      real(c_double),target,dimension(:) :: d
-      real(c_double),target,dimension(:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_double),target,dimension(:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: temp_buffer
       !
-      rocsparse_dgtsv_no_pivot_rank_1 = rocsparse_dgtsv_no_pivot_(handle,m,n,c_loc(dl),c_loc(d), &
-        c_loc(du),c_loc(B),ldb,temp_buffer)
+      rocsparse_dgtsv_no_pivot_rank_1 = rocsparse_dgtsv_no_pivot_(handle,m,n,dl,d,du,c_loc(B),ldb, &
+        temp_buffer)
     end function
 
     function rocsparse_dgtsv_no_pivot_full_rank(handle,m,n,dl,d,du,B,ldb,temp_buffer)
@@ -45854,15 +45834,15 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      real(c_double),target,dimension(:,:) :: dl
-      real(c_double),target,dimension(:,:) :: d
-      real(c_double),target,dimension(:,:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_double),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: temp_buffer
       !
-      rocsparse_dgtsv_no_pivot_full_rank = rocsparse_dgtsv_no_pivot_(handle,m,n,c_loc(dl), &
-        c_loc(d),c_loc(du),c_loc(B),ldb,temp_buffer)
+      rocsparse_dgtsv_no_pivot_full_rank = rocsparse_dgtsv_no_pivot_(handle,m,n,dl,d,du,c_loc(B), &
+        ldb,temp_buffer)
     end function
 
     function rocsparse_cgtsv_no_pivot_rank_0(handle,m,n,dl,d,du,B,ldb,temp_buffer)
@@ -45873,15 +45853,15 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      complex(c_float_complex),target :: dl
-      complex(c_float_complex),target :: d
-      complex(c_float_complex),target :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_float_complex),target :: B
       integer(c_int) :: ldb
       type(c_ptr) :: temp_buffer
       !
-      rocsparse_cgtsv_no_pivot_rank_0 = rocsparse_cgtsv_no_pivot_(handle,m,n,c_loc(dl),c_loc(d), &
-        c_loc(du),c_loc(B),ldb,temp_buffer)
+      rocsparse_cgtsv_no_pivot_rank_0 = rocsparse_cgtsv_no_pivot_(handle,m,n,dl,d,du,c_loc(B),ldb, &
+        temp_buffer)
     end function
 
     function rocsparse_cgtsv_no_pivot_rank_1(handle,m,n,dl,d,du,B,ldb,temp_buffer)
@@ -45892,15 +45872,15 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      complex(c_float_complex),target,dimension(:) :: dl
-      complex(c_float_complex),target,dimension(:) :: d
-      complex(c_float_complex),target,dimension(:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_float_complex),target,dimension(:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: temp_buffer
       !
-      rocsparse_cgtsv_no_pivot_rank_1 = rocsparse_cgtsv_no_pivot_(handle,m,n,c_loc(dl),c_loc(d), &
-        c_loc(du),c_loc(B),ldb,temp_buffer)
+      rocsparse_cgtsv_no_pivot_rank_1 = rocsparse_cgtsv_no_pivot_(handle,m,n,dl,d,du,c_loc(B),ldb, &
+        temp_buffer)
     end function
 
     function rocsparse_cgtsv_no_pivot_full_rank(handle,m,n,dl,d,du,B,ldb,temp_buffer)
@@ -45911,15 +45891,15 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      complex(c_float_complex),target,dimension(:,:) :: dl
-      complex(c_float_complex),target,dimension(:,:) :: d
-      complex(c_float_complex),target,dimension(:,:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_float_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: temp_buffer
       !
-      rocsparse_cgtsv_no_pivot_full_rank = rocsparse_cgtsv_no_pivot_(handle,m,n,c_loc(dl), &
-        c_loc(d),c_loc(du),c_loc(B),ldb,temp_buffer)
+      rocsparse_cgtsv_no_pivot_full_rank = rocsparse_cgtsv_no_pivot_(handle,m,n,dl,d,du,c_loc(B), &
+        ldb,temp_buffer)
     end function
 
     function rocsparse_zgtsv_no_pivot_rank_0(handle,m,n,dl,d,du,B,ldb,temp_buffer)
@@ -45930,15 +45910,15 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      complex(c_double_complex),target :: dl
-      complex(c_double_complex),target :: d
-      complex(c_double_complex),target :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_double_complex),target :: B
       integer(c_int) :: ldb
       type(c_ptr) :: temp_buffer
       !
-      rocsparse_zgtsv_no_pivot_rank_0 = rocsparse_zgtsv_no_pivot_(handle,m,n,c_loc(dl),c_loc(d), &
-        c_loc(du),c_loc(B),ldb,temp_buffer)
+      rocsparse_zgtsv_no_pivot_rank_0 = rocsparse_zgtsv_no_pivot_(handle,m,n,dl,d,du,c_loc(B),ldb, &
+        temp_buffer)
     end function
 
     function rocsparse_zgtsv_no_pivot_rank_1(handle,m,n,dl,d,du,B,ldb,temp_buffer)
@@ -45949,15 +45929,15 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      complex(c_double_complex),target,dimension(:) :: dl
-      complex(c_double_complex),target,dimension(:) :: d
-      complex(c_double_complex),target,dimension(:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_double_complex),target,dimension(:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: temp_buffer
       !
-      rocsparse_zgtsv_no_pivot_rank_1 = rocsparse_zgtsv_no_pivot_(handle,m,n,c_loc(dl),c_loc(d), &
-        c_loc(du),c_loc(B),ldb,temp_buffer)
+      rocsparse_zgtsv_no_pivot_rank_1 = rocsparse_zgtsv_no_pivot_(handle,m,n,dl,d,du,c_loc(B),ldb, &
+        temp_buffer)
     end function
 
     function rocsparse_zgtsv_no_pivot_full_rank(handle,m,n,dl,d,du,B,ldb,temp_buffer)
@@ -45968,15 +45948,15 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(c_int) :: m
       integer(c_int) :: n
-      complex(c_double_complex),target,dimension(:,:) :: dl
-      complex(c_double_complex),target,dimension(:,:) :: d
-      complex(c_double_complex),target,dimension(:,:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_double_complex),target,dimension(:,:) :: B
       integer(c_int) :: ldb
       type(c_ptr) :: temp_buffer
       !
-      rocsparse_zgtsv_no_pivot_full_rank = rocsparse_zgtsv_no_pivot_(handle,m,n,c_loc(dl), &
-        c_loc(d),c_loc(du),c_loc(B),ldb,temp_buffer)
+      rocsparse_zgtsv_no_pivot_full_rank = rocsparse_zgtsv_no_pivot_(handle,m,n,dl,d,du,c_loc(B), &
+        ldb,temp_buffer)
     end function
 
     function rocsparse_sgtsv_no_pivot_strided_batch_buffer_size_rank_0(handle,m,dl,d,du,x, &
@@ -45987,17 +45967,17 @@ module hipfort_rocsparse
       integer(kind(rocsparse_status_success)) :: rocsparse_sgtsv_no_pivot_strided_batch_buffer_size_rank_0
       type(c_ptr) :: handle
       integer(c_int) :: m
-      real(c_float),target :: dl
-      real(c_float),target :: d
-      real(c_float),target :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_float),target :: x
       integer(c_int) :: batch_count
       integer(c_int) :: batch_stride
       integer(c_size_t) :: buffer_size
       !
       rocsparse_sgtsv_no_pivot_strided_batch_buffer_size_rank_0 = &
-        rocsparse_sgtsv_no_pivot_strided_batch_buffer_size_(handle,m,c_loc(dl),c_loc(d),c_loc(du), &
-        c_loc(x),batch_count,batch_stride,buffer_size)
+        rocsparse_sgtsv_no_pivot_strided_batch_buffer_size_(handle,m,dl,d,du,c_loc(x),batch_count, &
+        batch_stride,buffer_size)
     end function
 
     function rocsparse_sgtsv_no_pivot_strided_batch_buffer_size_rank_1(handle,m,dl,d,du,x, &
@@ -46008,17 +45988,17 @@ module hipfort_rocsparse
       integer(kind(rocsparse_status_success)) :: rocsparse_sgtsv_no_pivot_strided_batch_buffer_size_rank_1
       type(c_ptr) :: handle
       integer(c_int) :: m
-      real(c_float),target,dimension(:) :: dl
-      real(c_float),target,dimension(:) :: d
-      real(c_float),target,dimension(:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_float),target,dimension(:) :: x
       integer(c_int) :: batch_count
       integer(c_int) :: batch_stride
       integer(c_size_t) :: buffer_size
       !
       rocsparse_sgtsv_no_pivot_strided_batch_buffer_size_rank_1 = &
-        rocsparse_sgtsv_no_pivot_strided_batch_buffer_size_(handle,m,c_loc(dl),c_loc(d),c_loc(du), &
-        c_loc(x),batch_count,batch_stride,buffer_size)
+        rocsparse_sgtsv_no_pivot_strided_batch_buffer_size_(handle,m,dl,d,du,c_loc(x),batch_count, &
+        batch_stride,buffer_size)
     end function
 
     function rocsparse_dgtsv_no_pivot_strided_batch_buffer_size_rank_0(handle,m,dl,d,du,x, &
@@ -46029,17 +46009,17 @@ module hipfort_rocsparse
       integer(kind(rocsparse_status_success)) :: rocsparse_dgtsv_no_pivot_strided_batch_buffer_size_rank_0
       type(c_ptr) :: handle
       integer(c_int) :: m
-      real(c_double),target :: dl
-      real(c_double),target :: d
-      real(c_double),target :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_double),target :: x
       integer(c_int) :: batch_count
       integer(c_int) :: batch_stride
       integer(c_size_t) :: buffer_size
       !
       rocsparse_dgtsv_no_pivot_strided_batch_buffer_size_rank_0 = &
-        rocsparse_dgtsv_no_pivot_strided_batch_buffer_size_(handle,m,c_loc(dl),c_loc(d),c_loc(du), &
-        c_loc(x),batch_count,batch_stride,buffer_size)
+        rocsparse_dgtsv_no_pivot_strided_batch_buffer_size_(handle,m,dl,d,du,c_loc(x),batch_count, &
+        batch_stride,buffer_size)
     end function
 
     function rocsparse_dgtsv_no_pivot_strided_batch_buffer_size_rank_1(handle,m,dl,d,du,x, &
@@ -46050,17 +46030,17 @@ module hipfort_rocsparse
       integer(kind(rocsparse_status_success)) :: rocsparse_dgtsv_no_pivot_strided_batch_buffer_size_rank_1
       type(c_ptr) :: handle
       integer(c_int) :: m
-      real(c_double),target,dimension(:) :: dl
-      real(c_double),target,dimension(:) :: d
-      real(c_double),target,dimension(:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_double),target,dimension(:) :: x
       integer(c_int) :: batch_count
       integer(c_int) :: batch_stride
       integer(c_size_t) :: buffer_size
       !
       rocsparse_dgtsv_no_pivot_strided_batch_buffer_size_rank_1 = &
-        rocsparse_dgtsv_no_pivot_strided_batch_buffer_size_(handle,m,c_loc(dl),c_loc(d),c_loc(du), &
-        c_loc(x),batch_count,batch_stride,buffer_size)
+        rocsparse_dgtsv_no_pivot_strided_batch_buffer_size_(handle,m,dl,d,du,c_loc(x),batch_count, &
+        batch_stride,buffer_size)
     end function
 
     function rocsparse_cgtsv_no_pivot_strided_batch_buffer_size_rank_0(handle,m,dl,d,du,x, &
@@ -46071,17 +46051,17 @@ module hipfort_rocsparse
       integer(kind(rocsparse_status_success)) :: rocsparse_cgtsv_no_pivot_strided_batch_buffer_size_rank_0
       type(c_ptr) :: handle
       integer(c_int) :: m
-      complex(c_float_complex),target :: dl
-      complex(c_float_complex),target :: d
-      complex(c_float_complex),target :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_float_complex),target :: x
       integer(c_int) :: batch_count
       integer(c_int) :: batch_stride
       integer(c_size_t) :: buffer_size
       !
       rocsparse_cgtsv_no_pivot_strided_batch_buffer_size_rank_0 = &
-        rocsparse_cgtsv_no_pivot_strided_batch_buffer_size_(handle,m,c_loc(dl),c_loc(d),c_loc(du), &
-        c_loc(x),batch_count,batch_stride,buffer_size)
+        rocsparse_cgtsv_no_pivot_strided_batch_buffer_size_(handle,m,dl,d,du,c_loc(x),batch_count, &
+        batch_stride,buffer_size)
     end function
 
     function rocsparse_cgtsv_no_pivot_strided_batch_buffer_size_rank_1(handle,m,dl,d,du,x, &
@@ -46092,17 +46072,17 @@ module hipfort_rocsparse
       integer(kind(rocsparse_status_success)) :: rocsparse_cgtsv_no_pivot_strided_batch_buffer_size_rank_1
       type(c_ptr) :: handle
       integer(c_int) :: m
-      complex(c_float_complex),target,dimension(:) :: dl
-      complex(c_float_complex),target,dimension(:) :: d
-      complex(c_float_complex),target,dimension(:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: batch_count
       integer(c_int) :: batch_stride
       integer(c_size_t) :: buffer_size
       !
       rocsparse_cgtsv_no_pivot_strided_batch_buffer_size_rank_1 = &
-        rocsparse_cgtsv_no_pivot_strided_batch_buffer_size_(handle,m,c_loc(dl),c_loc(d),c_loc(du), &
-        c_loc(x),batch_count,batch_stride,buffer_size)
+        rocsparse_cgtsv_no_pivot_strided_batch_buffer_size_(handle,m,dl,d,du,c_loc(x),batch_count, &
+        batch_stride,buffer_size)
     end function
 
     function rocsparse_zgtsv_no_pivot_strided_batch_buffer_size_rank_0(handle,m,dl,d,du,x, &
@@ -46113,17 +46093,17 @@ module hipfort_rocsparse
       integer(kind(rocsparse_status_success)) :: rocsparse_zgtsv_no_pivot_strided_batch_buffer_size_rank_0
       type(c_ptr) :: handle
       integer(c_int) :: m
-      complex(c_double_complex),target :: dl
-      complex(c_double_complex),target :: d
-      complex(c_double_complex),target :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_double_complex),target :: x
       integer(c_int) :: batch_count
       integer(c_int) :: batch_stride
       integer(c_size_t) :: buffer_size
       !
       rocsparse_zgtsv_no_pivot_strided_batch_buffer_size_rank_0 = &
-        rocsparse_zgtsv_no_pivot_strided_batch_buffer_size_(handle,m,c_loc(dl),c_loc(d),c_loc(du), &
-        c_loc(x),batch_count,batch_stride,buffer_size)
+        rocsparse_zgtsv_no_pivot_strided_batch_buffer_size_(handle,m,dl,d,du,c_loc(x),batch_count, &
+        batch_stride,buffer_size)
     end function
 
     function rocsparse_zgtsv_no_pivot_strided_batch_buffer_size_rank_1(handle,m,dl,d,du,x, &
@@ -46134,17 +46114,17 @@ module hipfort_rocsparse
       integer(kind(rocsparse_status_success)) :: rocsparse_zgtsv_no_pivot_strided_batch_buffer_size_rank_1
       type(c_ptr) :: handle
       integer(c_int) :: m
-      complex(c_double_complex),target,dimension(:) :: dl
-      complex(c_double_complex),target,dimension(:) :: d
-      complex(c_double_complex),target,dimension(:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: batch_count
       integer(c_int) :: batch_stride
       integer(c_size_t) :: buffer_size
       !
       rocsparse_zgtsv_no_pivot_strided_batch_buffer_size_rank_1 = &
-        rocsparse_zgtsv_no_pivot_strided_batch_buffer_size_(handle,m,c_loc(dl),c_loc(d),c_loc(du), &
-        c_loc(x),batch_count,batch_stride,buffer_size)
+        rocsparse_zgtsv_no_pivot_strided_batch_buffer_size_(handle,m,dl,d,du,c_loc(x),batch_count, &
+        batch_stride,buffer_size)
     end function
 
     function rocsparse_sgtsv_no_pivot_strided_batch_rank_0(handle,m,dl,d,du,x,batch_count, &
@@ -46155,16 +46135,16 @@ module hipfort_rocsparse
       integer(kind(rocsparse_status_success)) :: rocsparse_sgtsv_no_pivot_strided_batch_rank_0
       type(c_ptr) :: handle
       integer(c_int) :: m
-      real(c_float),target :: dl
-      real(c_float),target :: d
-      real(c_float),target :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_float),target :: x
       integer(c_int) :: batch_count
       integer(c_int) :: batch_stride
       type(c_ptr) :: temp_buffer
       !
       rocsparse_sgtsv_no_pivot_strided_batch_rank_0 = rocsparse_sgtsv_no_pivot_strided_batch_( &
-        handle,m,c_loc(dl),c_loc(d),c_loc(du),c_loc(x),batch_count,batch_stride,temp_buffer)
+        handle,m,dl,d,du,c_loc(x),batch_count,batch_stride,temp_buffer)
     end function
 
     function rocsparse_sgtsv_no_pivot_strided_batch_rank_1(handle,m,dl,d,du,x,batch_count, &
@@ -46175,16 +46155,16 @@ module hipfort_rocsparse
       integer(kind(rocsparse_status_success)) :: rocsparse_sgtsv_no_pivot_strided_batch_rank_1
       type(c_ptr) :: handle
       integer(c_int) :: m
-      real(c_float),target,dimension(:) :: dl
-      real(c_float),target,dimension(:) :: d
-      real(c_float),target,dimension(:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_float),target,dimension(:) :: x
       integer(c_int) :: batch_count
       integer(c_int) :: batch_stride
       type(c_ptr) :: temp_buffer
       !
       rocsparse_sgtsv_no_pivot_strided_batch_rank_1 = rocsparse_sgtsv_no_pivot_strided_batch_( &
-        handle,m,c_loc(dl),c_loc(d),c_loc(du),c_loc(x),batch_count,batch_stride,temp_buffer)
+        handle,m,dl,d,du,c_loc(x),batch_count,batch_stride,temp_buffer)
     end function
 
     function rocsparse_dgtsv_no_pivot_strided_batch_rank_0(handle,m,dl,d,du,x,batch_count, &
@@ -46195,16 +46175,16 @@ module hipfort_rocsparse
       integer(kind(rocsparse_status_success)) :: rocsparse_dgtsv_no_pivot_strided_batch_rank_0
       type(c_ptr) :: handle
       integer(c_int) :: m
-      real(c_double),target :: dl
-      real(c_double),target :: d
-      real(c_double),target :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_double),target :: x
       integer(c_int) :: batch_count
       integer(c_int) :: batch_stride
       type(c_ptr) :: temp_buffer
       !
       rocsparse_dgtsv_no_pivot_strided_batch_rank_0 = rocsparse_dgtsv_no_pivot_strided_batch_( &
-        handle,m,c_loc(dl),c_loc(d),c_loc(du),c_loc(x),batch_count,batch_stride,temp_buffer)
+        handle,m,dl,d,du,c_loc(x),batch_count,batch_stride,temp_buffer)
     end function
 
     function rocsparse_dgtsv_no_pivot_strided_batch_rank_1(handle,m,dl,d,du,x,batch_count, &
@@ -46215,16 +46195,16 @@ module hipfort_rocsparse
       integer(kind(rocsparse_status_success)) :: rocsparse_dgtsv_no_pivot_strided_batch_rank_1
       type(c_ptr) :: handle
       integer(c_int) :: m
-      real(c_double),target,dimension(:) :: dl
-      real(c_double),target,dimension(:) :: d
-      real(c_double),target,dimension(:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       real(c_double),target,dimension(:) :: x
       integer(c_int) :: batch_count
       integer(c_int) :: batch_stride
       type(c_ptr) :: temp_buffer
       !
       rocsparse_dgtsv_no_pivot_strided_batch_rank_1 = rocsparse_dgtsv_no_pivot_strided_batch_( &
-        handle,m,c_loc(dl),c_loc(d),c_loc(du),c_loc(x),batch_count,batch_stride,temp_buffer)
+        handle,m,dl,d,du,c_loc(x),batch_count,batch_stride,temp_buffer)
     end function
 
     function rocsparse_cgtsv_no_pivot_strided_batch_rank_0(handle,m,dl,d,du,x,batch_count, &
@@ -46235,16 +46215,16 @@ module hipfort_rocsparse
       integer(kind(rocsparse_status_success)) :: rocsparse_cgtsv_no_pivot_strided_batch_rank_0
       type(c_ptr) :: handle
       integer(c_int) :: m
-      complex(c_float_complex),target :: dl
-      complex(c_float_complex),target :: d
-      complex(c_float_complex),target :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_float_complex),target :: x
       integer(c_int) :: batch_count
       integer(c_int) :: batch_stride
       type(c_ptr) :: temp_buffer
       !
       rocsparse_cgtsv_no_pivot_strided_batch_rank_0 = rocsparse_cgtsv_no_pivot_strided_batch_( &
-        handle,m,c_loc(dl),c_loc(d),c_loc(du),c_loc(x),batch_count,batch_stride,temp_buffer)
+        handle,m,dl,d,du,c_loc(x),batch_count,batch_stride,temp_buffer)
     end function
 
     function rocsparse_cgtsv_no_pivot_strided_batch_rank_1(handle,m,dl,d,du,x,batch_count, &
@@ -46255,16 +46235,16 @@ module hipfort_rocsparse
       integer(kind(rocsparse_status_success)) :: rocsparse_cgtsv_no_pivot_strided_batch_rank_1
       type(c_ptr) :: handle
       integer(c_int) :: m
-      complex(c_float_complex),target,dimension(:) :: dl
-      complex(c_float_complex),target,dimension(:) :: d
-      complex(c_float_complex),target,dimension(:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: batch_count
       integer(c_int) :: batch_stride
       type(c_ptr) :: temp_buffer
       !
       rocsparse_cgtsv_no_pivot_strided_batch_rank_1 = rocsparse_cgtsv_no_pivot_strided_batch_( &
-        handle,m,c_loc(dl),c_loc(d),c_loc(du),c_loc(x),batch_count,batch_stride,temp_buffer)
+        handle,m,dl,d,du,c_loc(x),batch_count,batch_stride,temp_buffer)
     end function
 
     function rocsparse_zgtsv_no_pivot_strided_batch_rank_0(handle,m,dl,d,du,x,batch_count, &
@@ -46275,16 +46255,16 @@ module hipfort_rocsparse
       integer(kind(rocsparse_status_success)) :: rocsparse_zgtsv_no_pivot_strided_batch_rank_0
       type(c_ptr) :: handle
       integer(c_int) :: m
-      complex(c_double_complex),target :: dl
-      complex(c_double_complex),target :: d
-      complex(c_double_complex),target :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_double_complex),target :: x
       integer(c_int) :: batch_count
       integer(c_int) :: batch_stride
       type(c_ptr) :: temp_buffer
       !
       rocsparse_zgtsv_no_pivot_strided_batch_rank_0 = rocsparse_zgtsv_no_pivot_strided_batch_( &
-        handle,m,c_loc(dl),c_loc(d),c_loc(du),c_loc(x),batch_count,batch_stride,temp_buffer)
+        handle,m,dl,d,du,c_loc(x),batch_count,batch_stride,temp_buffer)
     end function
 
     function rocsparse_zgtsv_no_pivot_strided_batch_rank_1(handle,m,dl,d,du,x,batch_count, &
@@ -46295,16 +46275,16 @@ module hipfort_rocsparse
       integer(kind(rocsparse_status_success)) :: rocsparse_zgtsv_no_pivot_strided_batch_rank_1
       type(c_ptr) :: handle
       integer(c_int) :: m
-      complex(c_double_complex),target,dimension(:) :: dl
-      complex(c_double_complex),target,dimension(:) :: d
-      complex(c_double_complex),target,dimension(:) :: du
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
       complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: batch_count
       integer(c_int) :: batch_stride
       type(c_ptr) :: temp_buffer
       !
       rocsparse_zgtsv_no_pivot_strided_batch_rank_1 = rocsparse_zgtsv_no_pivot_strided_batch_( &
-        handle,m,c_loc(dl),c_loc(d),c_loc(du),c_loc(x),batch_count,batch_stride,temp_buffer)
+        handle,m,dl,d,du,c_loc(x),batch_count,batch_stride,temp_buffer)
     end function
 
     function rocsparse_sgpsv_interleaved_batch_buffer_size_rank_0(handle,alg,m,ds,dl,d,du,dw,x, &
@@ -46316,19 +46296,19 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(kind(rocsparse_gpsv_interleaved_alg_default)) :: alg
       integer(c_int) :: m
-      real(c_float),target :: ds
-      real(c_float),target :: dl
-      real(c_float),target :: d
-      real(c_float),target :: du
-      real(c_float),target :: dw
+      type(c_ptr) :: ds
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
+      type(c_ptr) :: dw
       real(c_float),target :: x
       integer(c_int) :: batch_count
       integer(c_int) :: batch_stride
       integer(c_size_t) :: buffer_size
       !
       rocsparse_sgpsv_interleaved_batch_buffer_size_rank_0 = &
-        rocsparse_sgpsv_interleaved_batch_buffer_size_(handle,alg,m,c_loc(ds),c_loc(dl),c_loc(d), &
-        c_loc(du),c_loc(dw),c_loc(x),batch_count,batch_stride,buffer_size)
+        rocsparse_sgpsv_interleaved_batch_buffer_size_(handle,alg,m,ds,dl,d,du,dw,c_loc(x), &
+        batch_count,batch_stride,buffer_size)
     end function
 
     function rocsparse_sgpsv_interleaved_batch_buffer_size_rank_1(handle,alg,m,ds,dl,d,du,dw,x, &
@@ -46340,43 +46320,19 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(kind(rocsparse_gpsv_interleaved_alg_default)) :: alg
       integer(c_int) :: m
-      real(c_float),target,dimension(:) :: ds
-      real(c_float),target,dimension(:) :: dl
-      real(c_float),target,dimension(:) :: d
-      real(c_float),target,dimension(:) :: du
-      real(c_float),target,dimension(:) :: dw
+      type(c_ptr) :: ds
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
+      type(c_ptr) :: dw
       real(c_float),target,dimension(:) :: x
       integer(c_int) :: batch_count
       integer(c_int) :: batch_stride
       integer(c_size_t) :: buffer_size
       !
       rocsparse_sgpsv_interleaved_batch_buffer_size_rank_1 = &
-        rocsparse_sgpsv_interleaved_batch_buffer_size_(handle,alg,m,c_loc(ds),c_loc(dl),c_loc(d), &
-        c_loc(du),c_loc(dw),c_loc(x),batch_count,batch_stride,buffer_size)
-    end function
-
-    function rocsparse_sgpsv_interleaved_batch_buffer_size_full_rank(handle,alg,m,ds,dl,d,du,dw,x, &
+        rocsparse_sgpsv_interleaved_batch_buffer_size_(handle,alg,m,ds,dl,d,du,dw,c_loc(x), &
         batch_count,batch_stride,buffer_size)
-      use iso_c_binding
-      use hipfort_rocsparse_enums
-      implicit none
-      integer(kind(rocsparse_status_success)) :: rocsparse_sgpsv_interleaved_batch_buffer_size_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocsparse_gpsv_interleaved_alg_default)) :: alg
-      integer(c_int) :: m
-      real(c_float),target,dimension(:,:) :: ds
-      real(c_float),target,dimension(:,:) :: dl
-      real(c_float),target,dimension(:,:) :: d
-      real(c_float),target,dimension(:,:) :: du
-      real(c_float),target,dimension(:,:) :: dw
-      real(c_float),target,dimension(:,:) :: x
-      integer(c_int) :: batch_count
-      integer(c_int) :: batch_stride
-      integer(c_size_t) :: buffer_size
-      !
-      rocsparse_sgpsv_interleaved_batch_buffer_size_full_rank = &
-        rocsparse_sgpsv_interleaved_batch_buffer_size_(handle,alg,m,c_loc(ds),c_loc(dl),c_loc(d), &
-        c_loc(du),c_loc(dw),c_loc(x),batch_count,batch_stride,buffer_size)
     end function
 
     function rocsparse_dgpsv_interleaved_batch_buffer_size_rank_0(handle,alg,m,ds,dl,d,du,dw,x, &
@@ -46388,19 +46344,19 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(kind(rocsparse_gpsv_interleaved_alg_default)) :: alg
       integer(c_int) :: m
-      real(c_double),target :: ds
-      real(c_double),target :: dl
-      real(c_double),target :: d
-      real(c_double),target :: du
-      real(c_double),target :: dw
+      type(c_ptr) :: ds
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
+      type(c_ptr) :: dw
       real(c_double),target :: x
       integer(c_int) :: batch_count
       integer(c_int) :: batch_stride
       integer(c_size_t) :: buffer_size
       !
       rocsparse_dgpsv_interleaved_batch_buffer_size_rank_0 = &
-        rocsparse_dgpsv_interleaved_batch_buffer_size_(handle,alg,m,c_loc(ds),c_loc(dl),c_loc(d), &
-        c_loc(du),c_loc(dw),c_loc(x),batch_count,batch_stride,buffer_size)
+        rocsparse_dgpsv_interleaved_batch_buffer_size_(handle,alg,m,ds,dl,d,du,dw,c_loc(x), &
+        batch_count,batch_stride,buffer_size)
     end function
 
     function rocsparse_dgpsv_interleaved_batch_buffer_size_rank_1(handle,alg,m,ds,dl,d,du,dw,x, &
@@ -46412,43 +46368,19 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(kind(rocsparse_gpsv_interleaved_alg_default)) :: alg
       integer(c_int) :: m
-      real(c_double),target,dimension(:) :: ds
-      real(c_double),target,dimension(:) :: dl
-      real(c_double),target,dimension(:) :: d
-      real(c_double),target,dimension(:) :: du
-      real(c_double),target,dimension(:) :: dw
+      type(c_ptr) :: ds
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
+      type(c_ptr) :: dw
       real(c_double),target,dimension(:) :: x
       integer(c_int) :: batch_count
       integer(c_int) :: batch_stride
       integer(c_size_t) :: buffer_size
       !
       rocsparse_dgpsv_interleaved_batch_buffer_size_rank_1 = &
-        rocsparse_dgpsv_interleaved_batch_buffer_size_(handle,alg,m,c_loc(ds),c_loc(dl),c_loc(d), &
-        c_loc(du),c_loc(dw),c_loc(x),batch_count,batch_stride,buffer_size)
-    end function
-
-    function rocsparse_dgpsv_interleaved_batch_buffer_size_full_rank(handle,alg,m,ds,dl,d,du,dw,x, &
+        rocsparse_dgpsv_interleaved_batch_buffer_size_(handle,alg,m,ds,dl,d,du,dw,c_loc(x), &
         batch_count,batch_stride,buffer_size)
-      use iso_c_binding
-      use hipfort_rocsparse_enums
-      implicit none
-      integer(kind(rocsparse_status_success)) :: rocsparse_dgpsv_interleaved_batch_buffer_size_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocsparse_gpsv_interleaved_alg_default)) :: alg
-      integer(c_int) :: m
-      real(c_double),target,dimension(:,:) :: ds
-      real(c_double),target,dimension(:,:) :: dl
-      real(c_double),target,dimension(:,:) :: d
-      real(c_double),target,dimension(:,:) :: du
-      real(c_double),target,dimension(:,:) :: dw
-      real(c_double),target,dimension(:,:) :: x
-      integer(c_int) :: batch_count
-      integer(c_int) :: batch_stride
-      integer(c_size_t) :: buffer_size
-      !
-      rocsparse_dgpsv_interleaved_batch_buffer_size_full_rank = &
-        rocsparse_dgpsv_interleaved_batch_buffer_size_(handle,alg,m,c_loc(ds),c_loc(dl),c_loc(d), &
-        c_loc(du),c_loc(dw),c_loc(x),batch_count,batch_stride,buffer_size)
     end function
 
     function rocsparse_cgpsv_interleaved_batch_buffer_size_rank_0(handle,alg,m,ds,dl,d,du,dw,x, &
@@ -46460,19 +46392,19 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(kind(rocsparse_gpsv_interleaved_alg_default)) :: alg
       integer(c_int) :: m
-      complex(c_float_complex),target :: ds
-      complex(c_float_complex),target :: dl
-      complex(c_float_complex),target :: d
-      complex(c_float_complex),target :: du
-      complex(c_float_complex),target :: dw
+      type(c_ptr) :: ds
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
+      type(c_ptr) :: dw
       complex(c_float_complex),target :: x
       integer(c_int) :: batch_count
       integer(c_int) :: batch_stride
       integer(c_size_t) :: buffer_size
       !
       rocsparse_cgpsv_interleaved_batch_buffer_size_rank_0 = &
-        rocsparse_cgpsv_interleaved_batch_buffer_size_(handle,alg,m,c_loc(ds),c_loc(dl),c_loc(d), &
-        c_loc(du),c_loc(dw),c_loc(x),batch_count,batch_stride,buffer_size)
+        rocsparse_cgpsv_interleaved_batch_buffer_size_(handle,alg,m,ds,dl,d,du,dw,c_loc(x), &
+        batch_count,batch_stride,buffer_size)
     end function
 
     function rocsparse_cgpsv_interleaved_batch_buffer_size_rank_1(handle,alg,m,ds,dl,d,du,dw,x, &
@@ -46484,43 +46416,19 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(kind(rocsparse_gpsv_interleaved_alg_default)) :: alg
       integer(c_int) :: m
-      complex(c_float_complex),target,dimension(:) :: ds
-      complex(c_float_complex),target,dimension(:) :: dl
-      complex(c_float_complex),target,dimension(:) :: d
-      complex(c_float_complex),target,dimension(:) :: du
-      complex(c_float_complex),target,dimension(:) :: dw
+      type(c_ptr) :: ds
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
+      type(c_ptr) :: dw
       complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: batch_count
       integer(c_int) :: batch_stride
       integer(c_size_t) :: buffer_size
       !
       rocsparse_cgpsv_interleaved_batch_buffer_size_rank_1 = &
-        rocsparse_cgpsv_interleaved_batch_buffer_size_(handle,alg,m,c_loc(ds),c_loc(dl),c_loc(d), &
-        c_loc(du),c_loc(dw),c_loc(x),batch_count,batch_stride,buffer_size)
-    end function
-
-    function rocsparse_cgpsv_interleaved_batch_buffer_size_full_rank(handle,alg,m,ds,dl,d,du,dw,x, &
+        rocsparse_cgpsv_interleaved_batch_buffer_size_(handle,alg,m,ds,dl,d,du,dw,c_loc(x), &
         batch_count,batch_stride,buffer_size)
-      use iso_c_binding
-      use hipfort_rocsparse_enums
-      implicit none
-      integer(kind(rocsparse_status_success)) :: rocsparse_cgpsv_interleaved_batch_buffer_size_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocsparse_gpsv_interleaved_alg_default)) :: alg
-      integer(c_int) :: m
-      complex(c_float_complex),target,dimension(:,:) :: ds
-      complex(c_float_complex),target,dimension(:,:) :: dl
-      complex(c_float_complex),target,dimension(:,:) :: d
-      complex(c_float_complex),target,dimension(:,:) :: du
-      complex(c_float_complex),target,dimension(:,:) :: dw
-      complex(c_float_complex),target,dimension(:,:) :: x
-      integer(c_int) :: batch_count
-      integer(c_int) :: batch_stride
-      integer(c_size_t) :: buffer_size
-      !
-      rocsparse_cgpsv_interleaved_batch_buffer_size_full_rank = &
-        rocsparse_cgpsv_interleaved_batch_buffer_size_(handle,alg,m,c_loc(ds),c_loc(dl),c_loc(d), &
-        c_loc(du),c_loc(dw),c_loc(x),batch_count,batch_stride,buffer_size)
     end function
 
     function rocsparse_zgpsv_interleaved_batch_buffer_size_rank_0(handle,alg,m,ds,dl,d,du,dw,x, &
@@ -46532,19 +46440,19 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(kind(rocsparse_gpsv_interleaved_alg_default)) :: alg
       integer(c_int) :: m
-      complex(c_double_complex),target :: ds
-      complex(c_double_complex),target :: dl
-      complex(c_double_complex),target :: d
-      complex(c_double_complex),target :: du
-      complex(c_double_complex),target :: dw
+      type(c_ptr) :: ds
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
+      type(c_ptr) :: dw
       complex(c_double_complex),target :: x
       integer(c_int) :: batch_count
       integer(c_int) :: batch_stride
       integer(c_size_t) :: buffer_size
       !
       rocsparse_zgpsv_interleaved_batch_buffer_size_rank_0 = &
-        rocsparse_zgpsv_interleaved_batch_buffer_size_(handle,alg,m,c_loc(ds),c_loc(dl),c_loc(d), &
-        c_loc(du),c_loc(dw),c_loc(x),batch_count,batch_stride,buffer_size)
+        rocsparse_zgpsv_interleaved_batch_buffer_size_(handle,alg,m,ds,dl,d,du,dw,c_loc(x), &
+        batch_count,batch_stride,buffer_size)
     end function
 
     function rocsparse_zgpsv_interleaved_batch_buffer_size_rank_1(handle,alg,m,ds,dl,d,du,dw,x, &
@@ -46556,43 +46464,19 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(kind(rocsparse_gpsv_interleaved_alg_default)) :: alg
       integer(c_int) :: m
-      complex(c_double_complex),target,dimension(:) :: ds
-      complex(c_double_complex),target,dimension(:) :: dl
-      complex(c_double_complex),target,dimension(:) :: d
-      complex(c_double_complex),target,dimension(:) :: du
-      complex(c_double_complex),target,dimension(:) :: dw
+      type(c_ptr) :: ds
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
+      type(c_ptr) :: dw
       complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: batch_count
       integer(c_int) :: batch_stride
       integer(c_size_t) :: buffer_size
       !
       rocsparse_zgpsv_interleaved_batch_buffer_size_rank_1 = &
-        rocsparse_zgpsv_interleaved_batch_buffer_size_(handle,alg,m,c_loc(ds),c_loc(dl),c_loc(d), &
-        c_loc(du),c_loc(dw),c_loc(x),batch_count,batch_stride,buffer_size)
-    end function
-
-    function rocsparse_zgpsv_interleaved_batch_buffer_size_full_rank(handle,alg,m,ds,dl,d,du,dw,x, &
+        rocsparse_zgpsv_interleaved_batch_buffer_size_(handle,alg,m,ds,dl,d,du,dw,c_loc(x), &
         batch_count,batch_stride,buffer_size)
-      use iso_c_binding
-      use hipfort_rocsparse_enums
-      implicit none
-      integer(kind(rocsparse_status_success)) :: rocsparse_zgpsv_interleaved_batch_buffer_size_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocsparse_gpsv_interleaved_alg_default)) :: alg
-      integer(c_int) :: m
-      complex(c_double_complex),target,dimension(:,:) :: ds
-      complex(c_double_complex),target,dimension(:,:) :: dl
-      complex(c_double_complex),target,dimension(:,:) :: d
-      complex(c_double_complex),target,dimension(:,:) :: du
-      complex(c_double_complex),target,dimension(:,:) :: dw
-      complex(c_double_complex),target,dimension(:,:) :: x
-      integer(c_int) :: batch_count
-      integer(c_int) :: batch_stride
-      integer(c_size_t) :: buffer_size
-      !
-      rocsparse_zgpsv_interleaved_batch_buffer_size_full_rank = &
-        rocsparse_zgpsv_interleaved_batch_buffer_size_(handle,alg,m,c_loc(ds),c_loc(dl),c_loc(d), &
-        c_loc(du),c_loc(dw),c_loc(x),batch_count,batch_stride,buffer_size)
     end function
 
     function rocsparse_sgpsv_interleaved_batch_rank_0(handle,alg,m,ds,dl,d,du,dw,x,batch_count, &
@@ -46604,19 +46488,18 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(kind(rocsparse_gpsv_interleaved_alg_default)) :: alg
       integer(c_int) :: m
-      real(c_float),target :: ds
-      real(c_float),target :: dl
-      real(c_float),target :: d
-      real(c_float),target :: du
-      real(c_float),target :: dw
+      type(c_ptr) :: ds
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
+      type(c_ptr) :: dw
       real(c_float),target :: x
       integer(c_int) :: batch_count
       integer(c_int) :: batch_stride
       type(c_ptr) :: temp_buffer
       !
       rocsparse_sgpsv_interleaved_batch_rank_0 = rocsparse_sgpsv_interleaved_batch_(handle,alg,m, &
-        c_loc(ds),c_loc(dl),c_loc(d),c_loc(du),c_loc(dw),c_loc(x),batch_count,batch_stride, &
-        temp_buffer)
+        ds,dl,d,du,dw,c_loc(x),batch_count,batch_stride,temp_buffer)
     end function
 
     function rocsparse_sgpsv_interleaved_batch_rank_1(handle,alg,m,ds,dl,d,du,dw,x,batch_count, &
@@ -46628,43 +46511,18 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(kind(rocsparse_gpsv_interleaved_alg_default)) :: alg
       integer(c_int) :: m
-      real(c_float),target,dimension(:) :: ds
-      real(c_float),target,dimension(:) :: dl
-      real(c_float),target,dimension(:) :: d
-      real(c_float),target,dimension(:) :: du
-      real(c_float),target,dimension(:) :: dw
+      type(c_ptr) :: ds
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
+      type(c_ptr) :: dw
       real(c_float),target,dimension(:) :: x
       integer(c_int) :: batch_count
       integer(c_int) :: batch_stride
       type(c_ptr) :: temp_buffer
       !
       rocsparse_sgpsv_interleaved_batch_rank_1 = rocsparse_sgpsv_interleaved_batch_(handle,alg,m, &
-        c_loc(ds),c_loc(dl),c_loc(d),c_loc(du),c_loc(dw),c_loc(x),batch_count,batch_stride, &
-        temp_buffer)
-    end function
-
-    function rocsparse_sgpsv_interleaved_batch_full_rank(handle,alg,m,ds,dl,d,du,dw,x,batch_count, &
-        batch_stride,temp_buffer)
-      use iso_c_binding
-      use hipfort_rocsparse_enums
-      implicit none
-      integer(kind(rocsparse_status_success)) :: rocsparse_sgpsv_interleaved_batch_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocsparse_gpsv_interleaved_alg_default)) :: alg
-      integer(c_int) :: m
-      real(c_float),target,dimension(:,:) :: ds
-      real(c_float),target,dimension(:,:) :: dl
-      real(c_float),target,dimension(:,:) :: d
-      real(c_float),target,dimension(:,:) :: du
-      real(c_float),target,dimension(:,:) :: dw
-      real(c_float),target,dimension(:,:) :: x
-      integer(c_int) :: batch_count
-      integer(c_int) :: batch_stride
-      type(c_ptr) :: temp_buffer
-      !
-      rocsparse_sgpsv_interleaved_batch_full_rank = rocsparse_sgpsv_interleaved_batch_(handle,alg, &
-        m,c_loc(ds),c_loc(dl),c_loc(d),c_loc(du),c_loc(dw),c_loc(x),batch_count,batch_stride, &
-        temp_buffer)
+        ds,dl,d,du,dw,c_loc(x),batch_count,batch_stride,temp_buffer)
     end function
 
     function rocsparse_dgpsv_interleaved_batch_rank_0(handle,alg,m,ds,dl,d,du,dw,x,batch_count, &
@@ -46676,19 +46534,18 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(kind(rocsparse_gpsv_interleaved_alg_default)) :: alg
       integer(c_int) :: m
-      real(c_double),target :: ds
-      real(c_double),target :: dl
-      real(c_double),target :: d
-      real(c_double),target :: du
-      real(c_double),target :: dw
+      type(c_ptr) :: ds
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
+      type(c_ptr) :: dw
       real(c_double),target :: x
       integer(c_int) :: batch_count
       integer(c_int) :: batch_stride
       type(c_ptr) :: temp_buffer
       !
       rocsparse_dgpsv_interleaved_batch_rank_0 = rocsparse_dgpsv_interleaved_batch_(handle,alg,m, &
-        c_loc(ds),c_loc(dl),c_loc(d),c_loc(du),c_loc(dw),c_loc(x),batch_count,batch_stride, &
-        temp_buffer)
+        ds,dl,d,du,dw,c_loc(x),batch_count,batch_stride,temp_buffer)
     end function
 
     function rocsparse_dgpsv_interleaved_batch_rank_1(handle,alg,m,ds,dl,d,du,dw,x,batch_count, &
@@ -46700,43 +46557,18 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(kind(rocsparse_gpsv_interleaved_alg_default)) :: alg
       integer(c_int) :: m
-      real(c_double),target,dimension(:) :: ds
-      real(c_double),target,dimension(:) :: dl
-      real(c_double),target,dimension(:) :: d
-      real(c_double),target,dimension(:) :: du
-      real(c_double),target,dimension(:) :: dw
+      type(c_ptr) :: ds
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
+      type(c_ptr) :: dw
       real(c_double),target,dimension(:) :: x
       integer(c_int) :: batch_count
       integer(c_int) :: batch_stride
       type(c_ptr) :: temp_buffer
       !
       rocsparse_dgpsv_interleaved_batch_rank_1 = rocsparse_dgpsv_interleaved_batch_(handle,alg,m, &
-        c_loc(ds),c_loc(dl),c_loc(d),c_loc(du),c_loc(dw),c_loc(x),batch_count,batch_stride, &
-        temp_buffer)
-    end function
-
-    function rocsparse_dgpsv_interleaved_batch_full_rank(handle,alg,m,ds,dl,d,du,dw,x,batch_count, &
-        batch_stride,temp_buffer)
-      use iso_c_binding
-      use hipfort_rocsparse_enums
-      implicit none
-      integer(kind(rocsparse_status_success)) :: rocsparse_dgpsv_interleaved_batch_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocsparse_gpsv_interleaved_alg_default)) :: alg
-      integer(c_int) :: m
-      real(c_double),target,dimension(:,:) :: ds
-      real(c_double),target,dimension(:,:) :: dl
-      real(c_double),target,dimension(:,:) :: d
-      real(c_double),target,dimension(:,:) :: du
-      real(c_double),target,dimension(:,:) :: dw
-      real(c_double),target,dimension(:,:) :: x
-      integer(c_int) :: batch_count
-      integer(c_int) :: batch_stride
-      type(c_ptr) :: temp_buffer
-      !
-      rocsparse_dgpsv_interleaved_batch_full_rank = rocsparse_dgpsv_interleaved_batch_(handle,alg, &
-        m,c_loc(ds),c_loc(dl),c_loc(d),c_loc(du),c_loc(dw),c_loc(x),batch_count,batch_stride, &
-        temp_buffer)
+        ds,dl,d,du,dw,c_loc(x),batch_count,batch_stride,temp_buffer)
     end function
 
     function rocsparse_cgpsv_interleaved_batch_rank_0(handle,alg,m,ds,dl,d,du,dw,x,batch_count, &
@@ -46748,19 +46580,18 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(kind(rocsparse_gpsv_interleaved_alg_default)) :: alg
       integer(c_int) :: m
-      complex(c_float_complex),target :: ds
-      complex(c_float_complex),target :: dl
-      complex(c_float_complex),target :: d
-      complex(c_float_complex),target :: du
-      complex(c_float_complex),target :: dw
+      type(c_ptr) :: ds
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
+      type(c_ptr) :: dw
       complex(c_float_complex),target :: x
       integer(c_int) :: batch_count
       integer(c_int) :: batch_stride
       type(c_ptr) :: temp_buffer
       !
       rocsparse_cgpsv_interleaved_batch_rank_0 = rocsparse_cgpsv_interleaved_batch_(handle,alg,m, &
-        c_loc(ds),c_loc(dl),c_loc(d),c_loc(du),c_loc(dw),c_loc(x),batch_count,batch_stride, &
-        temp_buffer)
+        ds,dl,d,du,dw,c_loc(x),batch_count,batch_stride,temp_buffer)
     end function
 
     function rocsparse_cgpsv_interleaved_batch_rank_1(handle,alg,m,ds,dl,d,du,dw,x,batch_count, &
@@ -46772,43 +46603,18 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(kind(rocsparse_gpsv_interleaved_alg_default)) :: alg
       integer(c_int) :: m
-      complex(c_float_complex),target,dimension(:) :: ds
-      complex(c_float_complex),target,dimension(:) :: dl
-      complex(c_float_complex),target,dimension(:) :: d
-      complex(c_float_complex),target,dimension(:) :: du
-      complex(c_float_complex),target,dimension(:) :: dw
+      type(c_ptr) :: ds
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
+      type(c_ptr) :: dw
       complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: batch_count
       integer(c_int) :: batch_stride
       type(c_ptr) :: temp_buffer
       !
       rocsparse_cgpsv_interleaved_batch_rank_1 = rocsparse_cgpsv_interleaved_batch_(handle,alg,m, &
-        c_loc(ds),c_loc(dl),c_loc(d),c_loc(du),c_loc(dw),c_loc(x),batch_count,batch_stride, &
-        temp_buffer)
-    end function
-
-    function rocsparse_cgpsv_interleaved_batch_full_rank(handle,alg,m,ds,dl,d,du,dw,x,batch_count, &
-        batch_stride,temp_buffer)
-      use iso_c_binding
-      use hipfort_rocsparse_enums
-      implicit none
-      integer(kind(rocsparse_status_success)) :: rocsparse_cgpsv_interleaved_batch_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocsparse_gpsv_interleaved_alg_default)) :: alg
-      integer(c_int) :: m
-      complex(c_float_complex),target,dimension(:,:) :: ds
-      complex(c_float_complex),target,dimension(:,:) :: dl
-      complex(c_float_complex),target,dimension(:,:) :: d
-      complex(c_float_complex),target,dimension(:,:) :: du
-      complex(c_float_complex),target,dimension(:,:) :: dw
-      complex(c_float_complex),target,dimension(:,:) :: x
-      integer(c_int) :: batch_count
-      integer(c_int) :: batch_stride
-      type(c_ptr) :: temp_buffer
-      !
-      rocsparse_cgpsv_interleaved_batch_full_rank = rocsparse_cgpsv_interleaved_batch_(handle,alg, &
-        m,c_loc(ds),c_loc(dl),c_loc(d),c_loc(du),c_loc(dw),c_loc(x),batch_count,batch_stride, &
-        temp_buffer)
+        ds,dl,d,du,dw,c_loc(x),batch_count,batch_stride,temp_buffer)
     end function
 
     function rocsparse_zgpsv_interleaved_batch_rank_0(handle,alg,m,ds,dl,d,du,dw,x,batch_count, &
@@ -46820,19 +46626,18 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(kind(rocsparse_gpsv_interleaved_alg_default)) :: alg
       integer(c_int) :: m
-      complex(c_double_complex),target :: ds
-      complex(c_double_complex),target :: dl
-      complex(c_double_complex),target :: d
-      complex(c_double_complex),target :: du
-      complex(c_double_complex),target :: dw
+      type(c_ptr) :: ds
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
+      type(c_ptr) :: dw
       complex(c_double_complex),target :: x
       integer(c_int) :: batch_count
       integer(c_int) :: batch_stride
       type(c_ptr) :: temp_buffer
       !
       rocsparse_zgpsv_interleaved_batch_rank_0 = rocsparse_zgpsv_interleaved_batch_(handle,alg,m, &
-        c_loc(ds),c_loc(dl),c_loc(d),c_loc(du),c_loc(dw),c_loc(x),batch_count,batch_stride, &
-        temp_buffer)
+        ds,dl,d,du,dw,c_loc(x),batch_count,batch_stride,temp_buffer)
     end function
 
     function rocsparse_zgpsv_interleaved_batch_rank_1(handle,alg,m,ds,dl,d,du,dw,x,batch_count, &
@@ -46844,43 +46649,18 @@ module hipfort_rocsparse
       type(c_ptr) :: handle
       integer(kind(rocsparse_gpsv_interleaved_alg_default)) :: alg
       integer(c_int) :: m
-      complex(c_double_complex),target,dimension(:) :: ds
-      complex(c_double_complex),target,dimension(:) :: dl
-      complex(c_double_complex),target,dimension(:) :: d
-      complex(c_double_complex),target,dimension(:) :: du
-      complex(c_double_complex),target,dimension(:) :: dw
+      type(c_ptr) :: ds
+      type(c_ptr) :: dl
+      type(c_ptr) :: d
+      type(c_ptr) :: du
+      type(c_ptr) :: dw
       complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: batch_count
       integer(c_int) :: batch_stride
       type(c_ptr) :: temp_buffer
       !
       rocsparse_zgpsv_interleaved_batch_rank_1 = rocsparse_zgpsv_interleaved_batch_(handle,alg,m, &
-        c_loc(ds),c_loc(dl),c_loc(d),c_loc(du),c_loc(dw),c_loc(x),batch_count,batch_stride, &
-        temp_buffer)
-    end function
-
-    function rocsparse_zgpsv_interleaved_batch_full_rank(handle,alg,m,ds,dl,d,du,dw,x,batch_count, &
-        batch_stride,temp_buffer)
-      use iso_c_binding
-      use hipfort_rocsparse_enums
-      implicit none
-      integer(kind(rocsparse_status_success)) :: rocsparse_zgpsv_interleaved_batch_full_rank
-      type(c_ptr) :: handle
-      integer(kind(rocsparse_gpsv_interleaved_alg_default)) :: alg
-      integer(c_int) :: m
-      complex(c_double_complex),target,dimension(:,:) :: ds
-      complex(c_double_complex),target,dimension(:,:) :: dl
-      complex(c_double_complex),target,dimension(:,:) :: d
-      complex(c_double_complex),target,dimension(:,:) :: du
-      complex(c_double_complex),target,dimension(:,:) :: dw
-      complex(c_double_complex),target,dimension(:,:) :: x
-      integer(c_int) :: batch_count
-      integer(c_int) :: batch_stride
-      type(c_ptr) :: temp_buffer
-      !
-      rocsparse_zgpsv_interleaved_batch_full_rank = rocsparse_zgpsv_interleaved_batch_(handle,alg, &
-        m,c_loc(ds),c_loc(dl),c_loc(d),c_loc(du),c_loc(dw),c_loc(x),batch_count,batch_stride, &
-        temp_buffer)
+        ds,dl,d,du,dw,c_loc(x),batch_count,batch_stride,temp_buffer)
     end function
 
     function rocsparse_snnz_rank_0(handle,dir,m,n,descr,A,ld,nnz_per_row_columns, &
@@ -46936,7 +46716,7 @@ module hipfort_rocsparse
       type(c_ptr) :: descr
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: ld
-      integer(c_int),target,dimension(:,:) :: nnz_per_row_columns
+      integer(c_int),target,dimension(:) :: nnz_per_row_columns
       integer(c_int) :: nnz_total_dev_host_ptr
       !
       rocsparse_snnz_full_rank = rocsparse_snnz_(handle,dir,m,n,descr,c_loc(A),ld, &
@@ -46996,7 +46776,7 @@ module hipfort_rocsparse
       type(c_ptr) :: descr
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: ld
-      integer(c_int),target,dimension(:,:) :: nnz_per_row_columns
+      integer(c_int),target,dimension(:) :: nnz_per_row_columns
       integer(c_int) :: nnz_total_dev_host_ptr
       !
       rocsparse_dnnz_full_rank = rocsparse_dnnz_(handle,dir,m,n,descr,c_loc(A),ld, &
@@ -47056,7 +46836,7 @@ module hipfort_rocsparse
       type(c_ptr) :: descr
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: ld
-      integer(c_int),target,dimension(:,:) :: nnz_per_row_columns
+      integer(c_int),target,dimension(:) :: nnz_per_row_columns
       integer(c_int) :: nnz_total_dev_host_ptr
       !
       rocsparse_cnnz_full_rank = rocsparse_cnnz_(handle,dir,m,n,descr,c_loc(A),ld, &
@@ -47116,7 +46896,7 @@ module hipfort_rocsparse
       type(c_ptr) :: descr
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: ld
-      integer(c_int),target,dimension(:,:) :: nnz_per_row_columns
+      integer(c_int),target,dimension(:) :: nnz_per_row_columns
       integer(c_int) :: nnz_total_dev_host_ptr
       !
       rocsparse_znnz_full_rank = rocsparse_znnz_(handle,dir,m,n,descr,c_loc(A),ld, &
@@ -47177,10 +46957,10 @@ module hipfort_rocsparse
       type(c_ptr) :: descr
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: ld
-      integer(c_int),target,dimension(:,:) :: nnz_per_rows
-      real(c_float),target,dimension(:,:) :: csr_val
-      integer(c_int),target,dimension(:,:) :: csr_row_ptr
-      integer(c_int),target,dimension(:,:) :: csr_col_ind
+      integer(c_int),target,dimension(:) :: nnz_per_rows
+      real(c_float),target,dimension(:) :: csr_val
+      integer(c_int),target,dimension(:) :: csr_row_ptr
+      integer(c_int),target,dimension(:) :: csr_col_ind
       !
       rocsparse_sdense2csr_full_rank = rocsparse_sdense2csr_(handle,m,n,descr,c_loc(A),ld, &
         c_loc(nnz_per_rows),c_loc(csr_val),c_loc(csr_row_ptr),c_loc(csr_col_ind))
@@ -47240,10 +47020,10 @@ module hipfort_rocsparse
       type(c_ptr) :: descr
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: ld
-      integer(c_int),target,dimension(:,:) :: nnz_per_rows
-      real(c_double),target,dimension(:,:) :: csr_val
-      integer(c_int),target,dimension(:,:) :: csr_row_ptr
-      integer(c_int),target,dimension(:,:) :: csr_col_ind
+      integer(c_int),target,dimension(:) :: nnz_per_rows
+      real(c_double),target,dimension(:) :: csr_val
+      integer(c_int),target,dimension(:) :: csr_row_ptr
+      integer(c_int),target,dimension(:) :: csr_col_ind
       !
       rocsparse_ddense2csr_full_rank = rocsparse_ddense2csr_(handle,m,n,descr,c_loc(A),ld, &
         c_loc(nnz_per_rows),c_loc(csr_val),c_loc(csr_row_ptr),c_loc(csr_col_ind))
@@ -47303,10 +47083,10 @@ module hipfort_rocsparse
       type(c_ptr) :: descr
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: ld
-      integer(c_int),target,dimension(:,:) :: nnz_per_rows
-      complex(c_float_complex),target,dimension(:,:) :: csr_val
-      integer(c_int),target,dimension(:,:) :: csr_row_ptr
-      integer(c_int),target,dimension(:,:) :: csr_col_ind
+      integer(c_int),target,dimension(:) :: nnz_per_rows
+      complex(c_float_complex),target,dimension(:) :: csr_val
+      integer(c_int),target,dimension(:) :: csr_row_ptr
+      integer(c_int),target,dimension(:) :: csr_col_ind
       !
       rocsparse_cdense2csr_full_rank = rocsparse_cdense2csr_(handle,m,n,descr,c_loc(A),ld, &
         c_loc(nnz_per_rows),c_loc(csr_val),c_loc(csr_row_ptr),c_loc(csr_col_ind))
@@ -47366,10 +47146,10 @@ module hipfort_rocsparse
       type(c_ptr) :: descr
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: ld
-      integer(c_int),target,dimension(:,:) :: nnz_per_rows
-      complex(c_double_complex),target,dimension(:,:) :: csr_val
-      integer(c_int),target,dimension(:,:) :: csr_row_ptr
-      integer(c_int),target,dimension(:,:) :: csr_col_ind
+      integer(c_int),target,dimension(:) :: nnz_per_rows
+      complex(c_double_complex),target,dimension(:) :: csr_val
+      integer(c_int),target,dimension(:) :: csr_row_ptr
+      integer(c_int),target,dimension(:) :: csr_col_ind
       !
       rocsparse_zdense2csr_full_rank = rocsparse_zdense2csr_(handle,m,n,descr,c_loc(A),ld, &
         c_loc(nnz_per_rows),c_loc(csr_val),c_loc(csr_row_ptr),c_loc(csr_col_ind))
@@ -47434,9 +47214,9 @@ module hipfort_rocsparse
       integer(c_int) :: lda
       real(c_float) :: threshold
       type(c_ptr) :: descr
-      real(c_float),target,dimension(:,:) :: csr_val
-      integer(c_int),target,dimension(:,:) :: csr_row_ptr
-      integer(c_int),target,dimension(:,:) :: csr_col_ind
+      real(c_float),target,dimension(:) :: csr_val
+      integer(c_int),target,dimension(:) :: csr_row_ptr
+      integer(c_int),target,dimension(:) :: csr_col_ind
       integer(c_size_t) :: buffer_size
       !
       rocsparse_sprune_dense2csr_buffer_size_full_rank = rocsparse_sprune_dense2csr_buffer_size_( &
@@ -47503,9 +47283,9 @@ module hipfort_rocsparse
       integer(c_int) :: lda
       real(c_double) :: threshold
       type(c_ptr) :: descr
-      real(c_double),target,dimension(:,:) :: csr_val
-      integer(c_int),target,dimension(:,:) :: csr_row_ptr
-      integer(c_int),target,dimension(:,:) :: csr_col_ind
+      real(c_double),target,dimension(:) :: csr_val
+      integer(c_int),target,dimension(:) :: csr_row_ptr
+      integer(c_int),target,dimension(:) :: csr_col_ind
       integer(c_size_t) :: buffer_size
       !
       rocsparse_dprune_dense2csr_buffer_size_full_rank = rocsparse_dprune_dense2csr_buffer_size_( &
@@ -47568,7 +47348,7 @@ module hipfort_rocsparse
       integer(c_int) :: lda
       real(c_float) :: threshold
       type(c_ptr) :: descr
-      integer(c_int),target,dimension(:,:) :: csr_row_ptr
+      integer(c_int),target,dimension(:) :: csr_row_ptr
       integer(c_int) :: nnz_total_dev_host_ptr
       type(c_ptr) :: temp_buffer
       !
@@ -47631,7 +47411,7 @@ module hipfort_rocsparse
       integer(c_int) :: lda
       real(c_double) :: threshold
       type(c_ptr) :: descr
-      integer(c_int),target,dimension(:,:) :: csr_row_ptr
+      integer(c_int),target,dimension(:) :: csr_row_ptr
       integer(c_int) :: nnz_total_dev_host_ptr
       type(c_ptr) :: temp_buffer
       !
@@ -47696,9 +47476,9 @@ module hipfort_rocsparse
       integer(c_int) :: lda
       real(c_float) :: threshold
       type(c_ptr) :: descr
-      real(c_float),target,dimension(:,:) :: csr_val
-      integer(c_int),target,dimension(:,:) :: csr_row_ptr
-      integer(c_int),target,dimension(:,:) :: csr_col_ind
+      real(c_float),target,dimension(:) :: csr_val
+      integer(c_int),target,dimension(:) :: csr_row_ptr
+      integer(c_int),target,dimension(:) :: csr_col_ind
       type(c_ptr) :: temp_buffer
       !
       rocsparse_sprune_dense2csr_full_rank = rocsparse_sprune_dense2csr_(handle,m,n,c_loc(A),lda, &
@@ -47762,9 +47542,9 @@ module hipfort_rocsparse
       integer(c_int) :: lda
       real(c_double) :: threshold
       type(c_ptr) :: descr
-      real(c_double),target,dimension(:,:) :: csr_val
-      integer(c_int),target,dimension(:,:) :: csr_row_ptr
-      integer(c_int),target,dimension(:,:) :: csr_col_ind
+      real(c_double),target,dimension(:) :: csr_val
+      integer(c_int),target,dimension(:) :: csr_row_ptr
+      integer(c_int),target,dimension(:) :: csr_col_ind
       type(c_ptr) :: temp_buffer
       !
       rocsparse_dprune_dense2csr_full_rank = rocsparse_dprune_dense2csr_(handle,m,n,c_loc(A),lda, &
@@ -47832,9 +47612,9 @@ module hipfort_rocsparse
       integer(c_int) :: lda
       real(c_float) :: percentage
       type(c_ptr) :: descr
-      real(c_float),target,dimension(:,:) :: csr_val
-      integer(c_int),target,dimension(:,:) :: csr_row_ptr
-      integer(c_int),target,dimension(:,:) :: csr_col_ind
+      real(c_float),target,dimension(:) :: csr_val
+      integer(c_int),target,dimension(:) :: csr_row_ptr
+      integer(c_int),target,dimension(:) :: csr_col_ind
       type(c_ptr) :: myInfo
       integer(c_size_t) :: buffer_size
       !
@@ -47904,9 +47684,9 @@ module hipfort_rocsparse
       integer(c_int) :: lda
       real(c_double) :: percentage
       type(c_ptr) :: descr
-      real(c_double),target,dimension(:,:) :: csr_val
-      integer(c_int),target,dimension(:,:) :: csr_row_ptr
-      integer(c_int),target,dimension(:,:) :: csr_col_ind
+      real(c_double),target,dimension(:) :: csr_val
+      integer(c_int),target,dimension(:) :: csr_row_ptr
+      integer(c_int),target,dimension(:) :: csr_col_ind
       type(c_ptr) :: myInfo
       integer(c_size_t) :: buffer_size
       !
@@ -47974,7 +47754,7 @@ module hipfort_rocsparse
       integer(c_int) :: lda
       real(c_float) :: percentage
       type(c_ptr) :: descr
-      integer(c_int),target,dimension(:,:) :: csr_row_ptr
+      integer(c_int),target,dimension(:) :: csr_row_ptr
       integer(c_int) :: nnz_total_dev_host_ptr
       type(c_ptr) :: myInfo
       type(c_ptr) :: temp_buffer
@@ -48043,7 +47823,7 @@ module hipfort_rocsparse
       integer(c_int) :: lda
       real(c_double) :: percentage
       type(c_ptr) :: descr
-      integer(c_int),target,dimension(:,:) :: csr_row_ptr
+      integer(c_int),target,dimension(:) :: csr_row_ptr
       integer(c_int) :: nnz_total_dev_host_ptr
       type(c_ptr) :: myInfo
       type(c_ptr) :: temp_buffer
@@ -48114,9 +47894,9 @@ module hipfort_rocsparse
       integer(c_int) :: lda
       real(c_float) :: percentage
       type(c_ptr) :: descr
-      real(c_float),target,dimension(:,:) :: csr_val
-      integer(c_int),target,dimension(:,:) :: csr_row_ptr
-      integer(c_int),target,dimension(:,:) :: csr_col_ind
+      real(c_float),target,dimension(:) :: csr_val
+      integer(c_int),target,dimension(:) :: csr_row_ptr
+      integer(c_int),target,dimension(:) :: csr_col_ind
       type(c_ptr) :: myInfo
       type(c_ptr) :: temp_buffer
       !
@@ -48186,9 +47966,9 @@ module hipfort_rocsparse
       integer(c_int) :: lda
       real(c_double) :: percentage
       type(c_ptr) :: descr
-      real(c_double),target,dimension(:,:) :: csr_val
-      integer(c_int),target,dimension(:,:) :: csr_row_ptr
-      integer(c_int),target,dimension(:,:) :: csr_col_ind
+      real(c_double),target,dimension(:) :: csr_val
+      integer(c_int),target,dimension(:) :: csr_row_ptr
+      integer(c_int),target,dimension(:) :: csr_col_ind
       type(c_ptr) :: myInfo
       type(c_ptr) :: temp_buffer
       !
@@ -48251,10 +48031,10 @@ module hipfort_rocsparse
       type(c_ptr) :: descr
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: ld
-      integer(c_int),target,dimension(:,:) :: nnz_per_columns
-      real(c_float),target,dimension(:,:) :: csc_val
-      integer(c_int),target,dimension(:,:) :: csc_col_ptr
-      integer(c_int),target,dimension(:,:) :: csc_row_ind
+      integer(c_int),target,dimension(:) :: nnz_per_columns
+      real(c_float),target,dimension(:) :: csc_val
+      integer(c_int),target,dimension(:) :: csc_col_ptr
+      integer(c_int),target,dimension(:) :: csc_row_ind
       !
       rocsparse_sdense2csc_full_rank = rocsparse_sdense2csc_(handle,m,n,descr,c_loc(A),ld, &
         c_loc(nnz_per_columns),c_loc(csc_val),c_loc(csc_col_ptr),c_loc(csc_row_ind))
@@ -48314,10 +48094,10 @@ module hipfort_rocsparse
       type(c_ptr) :: descr
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: ld
-      integer(c_int),target,dimension(:,:) :: nnz_per_columns
-      real(c_double),target,dimension(:,:) :: csc_val
-      integer(c_int),target,dimension(:,:) :: csc_col_ptr
-      integer(c_int),target,dimension(:,:) :: csc_row_ind
+      integer(c_int),target,dimension(:) :: nnz_per_columns
+      real(c_double),target,dimension(:) :: csc_val
+      integer(c_int),target,dimension(:) :: csc_col_ptr
+      integer(c_int),target,dimension(:) :: csc_row_ind
       !
       rocsparse_ddense2csc_full_rank = rocsparse_ddense2csc_(handle,m,n,descr,c_loc(A),ld, &
         c_loc(nnz_per_columns),c_loc(csc_val),c_loc(csc_col_ptr),c_loc(csc_row_ind))
@@ -48377,10 +48157,10 @@ module hipfort_rocsparse
       type(c_ptr) :: descr
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: ld
-      integer(c_int),target,dimension(:,:) :: nnz_per_columns
-      complex(c_float_complex),target,dimension(:,:) :: csc_val
-      integer(c_int),target,dimension(:,:) :: csc_col_ptr
-      integer(c_int),target,dimension(:,:) :: csc_row_ind
+      integer(c_int),target,dimension(:) :: nnz_per_columns
+      complex(c_float_complex),target,dimension(:) :: csc_val
+      integer(c_int),target,dimension(:) :: csc_col_ptr
+      integer(c_int),target,dimension(:) :: csc_row_ind
       !
       rocsparse_cdense2csc_full_rank = rocsparse_cdense2csc_(handle,m,n,descr,c_loc(A),ld, &
         c_loc(nnz_per_columns),c_loc(csc_val),c_loc(csc_col_ptr),c_loc(csc_row_ind))
@@ -48440,10 +48220,10 @@ module hipfort_rocsparse
       type(c_ptr) :: descr
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: ld
-      integer(c_int),target,dimension(:,:) :: nnz_per_columns
-      complex(c_double_complex),target,dimension(:,:) :: csc_val
-      integer(c_int),target,dimension(:,:) :: csc_col_ptr
-      integer(c_int),target,dimension(:,:) :: csc_row_ind
+      integer(c_int),target,dimension(:) :: nnz_per_columns
+      complex(c_double_complex),target,dimension(:) :: csc_val
+      integer(c_int),target,dimension(:) :: csc_col_ptr
+      integer(c_int),target,dimension(:) :: csc_row_ind
       !
       rocsparse_zdense2csc_full_rank = rocsparse_zdense2csc_(handle,m,n,descr,c_loc(A),ld, &
         c_loc(nnz_per_columns),c_loc(csc_val),c_loc(csc_col_ptr),c_loc(csc_row_ind))
@@ -48503,10 +48283,10 @@ module hipfort_rocsparse
       type(c_ptr) :: descr
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: ld
-      integer(c_int),target,dimension(:,:) :: nnz_per_rows
-      real(c_float),target,dimension(:,:) :: coo_val
-      integer(c_int),target,dimension(:,:) :: coo_row_ind
-      integer(c_int),target,dimension(:,:) :: coo_col_ind
+      integer(c_int),target,dimension(:) :: nnz_per_rows
+      real(c_float),target,dimension(:) :: coo_val
+      integer(c_int),target,dimension(:) :: coo_row_ind
+      integer(c_int),target,dimension(:) :: coo_col_ind
       !
       rocsparse_sdense2coo_full_rank = rocsparse_sdense2coo_(handle,m,n,descr,c_loc(A),ld, &
         c_loc(nnz_per_rows),c_loc(coo_val),c_loc(coo_row_ind),c_loc(coo_col_ind))
@@ -48566,10 +48346,10 @@ module hipfort_rocsparse
       type(c_ptr) :: descr
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: ld
-      integer(c_int),target,dimension(:,:) :: nnz_per_rows
-      real(c_double),target,dimension(:,:) :: coo_val
-      integer(c_int),target,dimension(:,:) :: coo_row_ind
-      integer(c_int),target,dimension(:,:) :: coo_col_ind
+      integer(c_int),target,dimension(:) :: nnz_per_rows
+      real(c_double),target,dimension(:) :: coo_val
+      integer(c_int),target,dimension(:) :: coo_row_ind
+      integer(c_int),target,dimension(:) :: coo_col_ind
       !
       rocsparse_ddense2coo_full_rank = rocsparse_ddense2coo_(handle,m,n,descr,c_loc(A),ld, &
         c_loc(nnz_per_rows),c_loc(coo_val),c_loc(coo_row_ind),c_loc(coo_col_ind))
@@ -48629,10 +48409,10 @@ module hipfort_rocsparse
       type(c_ptr) :: descr
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: ld
-      integer(c_int),target,dimension(:,:) :: nnz_per_rows
-      complex(c_float_complex),target,dimension(:,:) :: coo_val
-      integer(c_int),target,dimension(:,:) :: coo_row_ind
-      integer(c_int),target,dimension(:,:) :: coo_col_ind
+      integer(c_int),target,dimension(:) :: nnz_per_rows
+      complex(c_float_complex),target,dimension(:) :: coo_val
+      integer(c_int),target,dimension(:) :: coo_row_ind
+      integer(c_int),target,dimension(:) :: coo_col_ind
       !
       rocsparse_cdense2coo_full_rank = rocsparse_cdense2coo_(handle,m,n,descr,c_loc(A),ld, &
         c_loc(nnz_per_rows),c_loc(coo_val),c_loc(coo_row_ind),c_loc(coo_col_ind))
@@ -48692,10 +48472,10 @@ module hipfort_rocsparse
       type(c_ptr) :: descr
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: ld
-      integer(c_int),target,dimension(:,:) :: nnz_per_rows
-      complex(c_double_complex),target,dimension(:,:) :: coo_val
-      integer(c_int),target,dimension(:,:) :: coo_row_ind
-      integer(c_int),target,dimension(:,:) :: coo_col_ind
+      integer(c_int),target,dimension(:) :: nnz_per_rows
+      complex(c_double_complex),target,dimension(:) :: coo_val
+      integer(c_int),target,dimension(:) :: coo_row_ind
+      integer(c_int),target,dimension(:) :: coo_col_ind
       !
       rocsparse_zdense2coo_full_rank = rocsparse_zdense2coo_(handle,m,n,descr,c_loc(A),ld, &
         c_loc(nnz_per_rows),c_loc(coo_val),c_loc(coo_row_ind),c_loc(coo_col_ind))
@@ -48748,9 +48528,9 @@ module hipfort_rocsparse
       integer(c_int) :: m
       integer(c_int) :: n
       type(c_ptr) :: descr
-      real(c_float),target,dimension(:,:) :: csr_val
-      integer(c_int),target,dimension(:,:) :: csr_row_ptr
-      integer(c_int),target,dimension(:,:) :: csr_col_ind
+      real(c_float),target,dimension(:) :: csr_val
+      integer(c_int),target,dimension(:) :: csr_row_ptr
+      integer(c_int),target,dimension(:) :: csr_col_ind
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: ld
       !
@@ -48805,9 +48585,9 @@ module hipfort_rocsparse
       integer(c_int) :: m
       integer(c_int) :: n
       type(c_ptr) :: descr
-      real(c_double),target,dimension(:,:) :: csr_val
-      integer(c_int),target,dimension(:,:) :: csr_row_ptr
-      integer(c_int),target,dimension(:,:) :: csr_col_ind
+      real(c_double),target,dimension(:) :: csr_val
+      integer(c_int),target,dimension(:) :: csr_row_ptr
+      integer(c_int),target,dimension(:) :: csr_col_ind
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: ld
       !
@@ -48862,9 +48642,9 @@ module hipfort_rocsparse
       integer(c_int) :: m
       integer(c_int) :: n
       type(c_ptr) :: descr
-      complex(c_float_complex),target,dimension(:,:) :: csr_val
-      integer(c_int),target,dimension(:,:) :: csr_row_ptr
-      integer(c_int),target,dimension(:,:) :: csr_col_ind
+      complex(c_float_complex),target,dimension(:) :: csr_val
+      integer(c_int),target,dimension(:) :: csr_row_ptr
+      integer(c_int),target,dimension(:) :: csr_col_ind
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: ld
       !
@@ -48919,9 +48699,9 @@ module hipfort_rocsparse
       integer(c_int) :: m
       integer(c_int) :: n
       type(c_ptr) :: descr
-      complex(c_double_complex),target,dimension(:,:) :: csr_val
-      integer(c_int),target,dimension(:,:) :: csr_row_ptr
-      integer(c_int),target,dimension(:,:) :: csr_col_ind
+      complex(c_double_complex),target,dimension(:) :: csr_val
+      integer(c_int),target,dimension(:) :: csr_row_ptr
+      integer(c_int),target,dimension(:) :: csr_col_ind
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: ld
       !
@@ -48976,9 +48756,9 @@ module hipfort_rocsparse
       integer(c_int) :: m
       integer(c_int) :: n
       type(c_ptr) :: descr
-      real(c_float),target,dimension(:,:) :: csc_val
-      integer(c_int),target,dimension(:,:) :: csc_col_ptr
-      integer(c_int),target,dimension(:,:) :: csc_row_ind
+      real(c_float),target,dimension(:) :: csc_val
+      integer(c_int),target,dimension(:) :: csc_col_ptr
+      integer(c_int),target,dimension(:) :: csc_row_ind
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: ld
       !
@@ -49033,9 +48813,9 @@ module hipfort_rocsparse
       integer(c_int) :: m
       integer(c_int) :: n
       type(c_ptr) :: descr
-      real(c_double),target,dimension(:,:) :: csc_val
-      integer(c_int),target,dimension(:,:) :: csc_col_ptr
-      integer(c_int),target,dimension(:,:) :: csc_row_ind
+      real(c_double),target,dimension(:) :: csc_val
+      integer(c_int),target,dimension(:) :: csc_col_ptr
+      integer(c_int),target,dimension(:) :: csc_row_ind
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: ld
       !
@@ -49090,9 +48870,9 @@ module hipfort_rocsparse
       integer(c_int) :: m
       integer(c_int) :: n
       type(c_ptr) :: descr
-      complex(c_float_complex),target,dimension(:,:) :: csc_val
-      integer(c_int),target,dimension(:,:) :: csc_col_ptr
-      integer(c_int),target,dimension(:,:) :: csc_row_ind
+      complex(c_float_complex),target,dimension(:) :: csc_val
+      integer(c_int),target,dimension(:) :: csc_col_ptr
+      integer(c_int),target,dimension(:) :: csc_row_ind
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: ld
       !
@@ -49147,9 +48927,9 @@ module hipfort_rocsparse
       integer(c_int) :: m
       integer(c_int) :: n
       type(c_ptr) :: descr
-      complex(c_double_complex),target,dimension(:,:) :: csc_val
-      integer(c_int),target,dimension(:,:) :: csc_col_ptr
-      integer(c_int),target,dimension(:,:) :: csc_row_ind
+      complex(c_double_complex),target,dimension(:) :: csc_val
+      integer(c_int),target,dimension(:) :: csc_col_ptr
+      integer(c_int),target,dimension(:) :: csc_row_ind
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: ld
       !
@@ -49208,9 +48988,9 @@ module hipfort_rocsparse
       integer(c_int) :: n
       integer(c_int) :: nnz
       type(c_ptr) :: descr
-      real(c_float),target,dimension(:,:) :: coo_val
-      integer(c_int),target,dimension(:,:) :: coo_row_ind
-      integer(c_int),target,dimension(:,:) :: coo_col_ind
+      real(c_float),target,dimension(:) :: coo_val
+      integer(c_int),target,dimension(:) :: coo_row_ind
+      integer(c_int),target,dimension(:) :: coo_col_ind
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: ld
       !
@@ -49269,9 +49049,9 @@ module hipfort_rocsparse
       integer(c_int) :: n
       integer(c_int) :: nnz
       type(c_ptr) :: descr
-      real(c_double),target,dimension(:,:) :: coo_val
-      integer(c_int),target,dimension(:,:) :: coo_row_ind
-      integer(c_int),target,dimension(:,:) :: coo_col_ind
+      real(c_double),target,dimension(:) :: coo_val
+      integer(c_int),target,dimension(:) :: coo_row_ind
+      integer(c_int),target,dimension(:) :: coo_col_ind
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: ld
       !
@@ -49330,9 +49110,9 @@ module hipfort_rocsparse
       integer(c_int) :: n
       integer(c_int) :: nnz
       type(c_ptr) :: descr
-      complex(c_float_complex),target,dimension(:,:) :: coo_val
-      integer(c_int),target,dimension(:,:) :: coo_row_ind
-      integer(c_int),target,dimension(:,:) :: coo_col_ind
+      complex(c_float_complex),target,dimension(:) :: coo_val
+      integer(c_int),target,dimension(:) :: coo_row_ind
+      integer(c_int),target,dimension(:) :: coo_col_ind
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: ld
       !
@@ -49391,9 +49171,9 @@ module hipfort_rocsparse
       integer(c_int) :: n
       integer(c_int) :: nnz
       type(c_ptr) :: descr
-      complex(c_double_complex),target,dimension(:,:) :: coo_val
-      integer(c_int),target,dimension(:,:) :: coo_row_ind
-      integer(c_int),target,dimension(:,:) :: coo_col_ind
+      complex(c_double_complex),target,dimension(:) :: coo_val
+      integer(c_int),target,dimension(:) :: coo_row_ind
+      integer(c_int),target,dimension(:) :: coo_col_ind
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: ld
       !
@@ -49838,11 +49618,11 @@ module hipfort_rocsparse
       integer(c_int),target :: bsr_col_ind
       integer(c_int) :: row_block_dim
       integer(c_int) :: col_block_dim
-      integer(c_size_t),target :: p_buffer_size
+      type(c_ptr) :: p_buffer_size
       !
       rocsparse_sgebsr2gebsc_buffer_size_rank_0 = rocsparse_sgebsr2gebsc_buffer_size_(handle,mb, &
         nb,nnzb,c_loc(bsr_val),c_loc(bsr_row_ptr),c_loc(bsr_col_ind),row_block_dim,col_block_dim, &
-        c_loc(p_buffer_size))
+        p_buffer_size)
     end function
 
     function rocsparse_sgebsr2gebsc_buffer_size_rank_1(handle,mb,nb,nnzb,bsr_val,bsr_row_ptr, &
@@ -49860,11 +49640,11 @@ module hipfort_rocsparse
       integer(c_int),target,dimension(:) :: bsr_col_ind
       integer(c_int) :: row_block_dim
       integer(c_int) :: col_block_dim
-      integer(c_size_t),target,dimension(:) :: p_buffer_size
+      type(c_ptr) :: p_buffer_size
       !
       rocsparse_sgebsr2gebsc_buffer_size_rank_1 = rocsparse_sgebsr2gebsc_buffer_size_(handle,mb, &
         nb,nnzb,c_loc(bsr_val),c_loc(bsr_row_ptr),c_loc(bsr_col_ind),row_block_dim,col_block_dim, &
-        c_loc(p_buffer_size))
+        p_buffer_size)
     end function
 
     function rocsparse_dgebsr2gebsc_buffer_size_rank_0(handle,mb,nb,nnzb,bsr_val,bsr_row_ptr, &
@@ -49882,11 +49662,11 @@ module hipfort_rocsparse
       integer(c_int),target :: bsr_col_ind
       integer(c_int) :: row_block_dim
       integer(c_int) :: col_block_dim
-      integer(c_size_t),target :: p_buffer_size
+      type(c_ptr) :: p_buffer_size
       !
       rocsparse_dgebsr2gebsc_buffer_size_rank_0 = rocsparse_dgebsr2gebsc_buffer_size_(handle,mb, &
         nb,nnzb,c_loc(bsr_val),c_loc(bsr_row_ptr),c_loc(bsr_col_ind),row_block_dim,col_block_dim, &
-        c_loc(p_buffer_size))
+        p_buffer_size)
     end function
 
     function rocsparse_dgebsr2gebsc_buffer_size_rank_1(handle,mb,nb,nnzb,bsr_val,bsr_row_ptr, &
@@ -49904,11 +49684,11 @@ module hipfort_rocsparse
       integer(c_int),target,dimension(:) :: bsr_col_ind
       integer(c_int) :: row_block_dim
       integer(c_int) :: col_block_dim
-      integer(c_size_t),target,dimension(:) :: p_buffer_size
+      type(c_ptr) :: p_buffer_size
       !
       rocsparse_dgebsr2gebsc_buffer_size_rank_1 = rocsparse_dgebsr2gebsc_buffer_size_(handle,mb, &
         nb,nnzb,c_loc(bsr_val),c_loc(bsr_row_ptr),c_loc(bsr_col_ind),row_block_dim,col_block_dim, &
-        c_loc(p_buffer_size))
+        p_buffer_size)
     end function
 
     function rocsparse_cgebsr2gebsc_buffer_size_rank_0(handle,mb,nb,nnzb,bsr_val,bsr_row_ptr, &
@@ -49926,11 +49706,11 @@ module hipfort_rocsparse
       integer(c_int),target :: bsr_col_ind
       integer(c_int) :: row_block_dim
       integer(c_int) :: col_block_dim
-      integer(c_size_t),target :: p_buffer_size
+      type(c_ptr) :: p_buffer_size
       !
       rocsparse_cgebsr2gebsc_buffer_size_rank_0 = rocsparse_cgebsr2gebsc_buffer_size_(handle,mb, &
         nb,nnzb,c_loc(bsr_val),c_loc(bsr_row_ptr),c_loc(bsr_col_ind),row_block_dim,col_block_dim, &
-        c_loc(p_buffer_size))
+        p_buffer_size)
     end function
 
     function rocsparse_cgebsr2gebsc_buffer_size_rank_1(handle,mb,nb,nnzb,bsr_val,bsr_row_ptr, &
@@ -49948,11 +49728,11 @@ module hipfort_rocsparse
       integer(c_int),target,dimension(:) :: bsr_col_ind
       integer(c_int) :: row_block_dim
       integer(c_int) :: col_block_dim
-      integer(c_size_t),target,dimension(:) :: p_buffer_size
+      type(c_ptr) :: p_buffer_size
       !
       rocsparse_cgebsr2gebsc_buffer_size_rank_1 = rocsparse_cgebsr2gebsc_buffer_size_(handle,mb, &
         nb,nnzb,c_loc(bsr_val),c_loc(bsr_row_ptr),c_loc(bsr_col_ind),row_block_dim,col_block_dim, &
-        c_loc(p_buffer_size))
+        p_buffer_size)
     end function
 
     function rocsparse_zgebsr2gebsc_buffer_size_rank_0(handle,mb,nb,nnzb,bsr_val,bsr_row_ptr, &
@@ -49970,11 +49750,11 @@ module hipfort_rocsparse
       integer(c_int),target :: bsr_col_ind
       integer(c_int) :: row_block_dim
       integer(c_int) :: col_block_dim
-      integer(c_size_t),target :: p_buffer_size
+      type(c_ptr) :: p_buffer_size
       !
       rocsparse_zgebsr2gebsc_buffer_size_rank_0 = rocsparse_zgebsr2gebsc_buffer_size_(handle,mb, &
         nb,nnzb,c_loc(bsr_val),c_loc(bsr_row_ptr),c_loc(bsr_col_ind),row_block_dim,col_block_dim, &
-        c_loc(p_buffer_size))
+        p_buffer_size)
     end function
 
     function rocsparse_zgebsr2gebsc_buffer_size_rank_1(handle,mb,nb,nnzb,bsr_val,bsr_row_ptr, &
@@ -49992,11 +49772,11 @@ module hipfort_rocsparse
       integer(c_int),target,dimension(:) :: bsr_col_ind
       integer(c_int) :: row_block_dim
       integer(c_int) :: col_block_dim
-      integer(c_size_t),target,dimension(:) :: p_buffer_size
+      type(c_ptr) :: p_buffer_size
       !
       rocsparse_zgebsr2gebsc_buffer_size_rank_1 = rocsparse_zgebsr2gebsc_buffer_size_(handle,mb, &
         nb,nnzb,c_loc(bsr_val),c_loc(bsr_row_ptr),c_loc(bsr_col_ind),row_block_dim,col_block_dim, &
-        c_loc(p_buffer_size))
+        p_buffer_size)
     end function
 
     function rocsparse_sgebsr2gebsc_rank_0(handle,mb,nb,nnzb,bsr_val,bsr_row_ptr,bsr_col_ind, &
@@ -50015,16 +49795,16 @@ module hipfort_rocsparse
       integer(c_int),target :: bsr_col_ind
       integer(c_int) :: row_block_dim
       integer(c_int) :: col_block_dim
-      real(c_float),target :: bsc_val
-      integer(c_int),target :: bsc_row_ind
-      integer(c_int),target :: bsc_col_ptr
+      type(c_ptr) :: bsc_val
+      type(c_ptr) :: bsc_row_ind
+      type(c_ptr) :: bsc_col_ptr
       integer(kind(rocsparse_action_symbolic)) :: copy_values
       integer(kind(rocsparse_index_base_zero)) :: idx_base
       type(c_ptr) :: temp_buffer
       !
       rocsparse_sgebsr2gebsc_rank_0 = rocsparse_sgebsr2gebsc_(handle,mb,nb,nnzb,c_loc(bsr_val), &
-        c_loc(bsr_row_ptr),c_loc(bsr_col_ind),row_block_dim,col_block_dim,c_loc(bsc_val), &
-        c_loc(bsc_row_ind),c_loc(bsc_col_ptr),copy_values,idx_base,temp_buffer)
+        c_loc(bsr_row_ptr),c_loc(bsr_col_ind),row_block_dim,col_block_dim,bsc_val,bsc_row_ind, &
+        bsc_col_ptr,copy_values,idx_base,temp_buffer)
     end function
 
     function rocsparse_sgebsr2gebsc_rank_1(handle,mb,nb,nnzb,bsr_val,bsr_row_ptr,bsr_col_ind, &
@@ -50043,16 +49823,16 @@ module hipfort_rocsparse
       integer(c_int),target,dimension(:) :: bsr_col_ind
       integer(c_int) :: row_block_dim
       integer(c_int) :: col_block_dim
-      real(c_float),target,dimension(:) :: bsc_val
-      integer(c_int),target,dimension(:) :: bsc_row_ind
-      integer(c_int),target,dimension(:) :: bsc_col_ptr
+      type(c_ptr) :: bsc_val
+      type(c_ptr) :: bsc_row_ind
+      type(c_ptr) :: bsc_col_ptr
       integer(kind(rocsparse_action_symbolic)) :: copy_values
       integer(kind(rocsparse_index_base_zero)) :: idx_base
       type(c_ptr) :: temp_buffer
       !
       rocsparse_sgebsr2gebsc_rank_1 = rocsparse_sgebsr2gebsc_(handle,mb,nb,nnzb,c_loc(bsr_val), &
-        c_loc(bsr_row_ptr),c_loc(bsr_col_ind),row_block_dim,col_block_dim,c_loc(bsc_val), &
-        c_loc(bsc_row_ind),c_loc(bsc_col_ptr),copy_values,idx_base,temp_buffer)
+        c_loc(bsr_row_ptr),c_loc(bsr_col_ind),row_block_dim,col_block_dim,bsc_val,bsc_row_ind, &
+        bsc_col_ptr,copy_values,idx_base,temp_buffer)
     end function
 
     function rocsparse_dgebsr2gebsc_rank_0(handle,mb,nb,nnzb,bsr_val,bsr_row_ptr,bsr_col_ind, &
@@ -50071,16 +49851,16 @@ module hipfort_rocsparse
       integer(c_int),target :: bsr_col_ind
       integer(c_int) :: row_block_dim
       integer(c_int) :: col_block_dim
-      real(c_double),target :: bsc_val
-      integer(c_int),target :: bsc_row_ind
-      integer(c_int),target :: bsc_col_ptr
+      type(c_ptr) :: bsc_val
+      type(c_ptr) :: bsc_row_ind
+      type(c_ptr) :: bsc_col_ptr
       integer(kind(rocsparse_action_symbolic)) :: copy_values
       integer(kind(rocsparse_index_base_zero)) :: idx_base
       type(c_ptr) :: temp_buffer
       !
       rocsparse_dgebsr2gebsc_rank_0 = rocsparse_dgebsr2gebsc_(handle,mb,nb,nnzb,c_loc(bsr_val), &
-        c_loc(bsr_row_ptr),c_loc(bsr_col_ind),row_block_dim,col_block_dim,c_loc(bsc_val), &
-        c_loc(bsc_row_ind),c_loc(bsc_col_ptr),copy_values,idx_base,temp_buffer)
+        c_loc(bsr_row_ptr),c_loc(bsr_col_ind),row_block_dim,col_block_dim,bsc_val,bsc_row_ind, &
+        bsc_col_ptr,copy_values,idx_base,temp_buffer)
     end function
 
     function rocsparse_dgebsr2gebsc_rank_1(handle,mb,nb,nnzb,bsr_val,bsr_row_ptr,bsr_col_ind, &
@@ -50099,16 +49879,16 @@ module hipfort_rocsparse
       integer(c_int),target,dimension(:) :: bsr_col_ind
       integer(c_int) :: row_block_dim
       integer(c_int) :: col_block_dim
-      real(c_double),target,dimension(:) :: bsc_val
-      integer(c_int),target,dimension(:) :: bsc_row_ind
-      integer(c_int),target,dimension(:) :: bsc_col_ptr
+      type(c_ptr) :: bsc_val
+      type(c_ptr) :: bsc_row_ind
+      type(c_ptr) :: bsc_col_ptr
       integer(kind(rocsparse_action_symbolic)) :: copy_values
       integer(kind(rocsparse_index_base_zero)) :: idx_base
       type(c_ptr) :: temp_buffer
       !
       rocsparse_dgebsr2gebsc_rank_1 = rocsparse_dgebsr2gebsc_(handle,mb,nb,nnzb,c_loc(bsr_val), &
-        c_loc(bsr_row_ptr),c_loc(bsr_col_ind),row_block_dim,col_block_dim,c_loc(bsc_val), &
-        c_loc(bsc_row_ind),c_loc(bsc_col_ptr),copy_values,idx_base,temp_buffer)
+        c_loc(bsr_row_ptr),c_loc(bsr_col_ind),row_block_dim,col_block_dim,bsc_val,bsc_row_ind, &
+        bsc_col_ptr,copy_values,idx_base,temp_buffer)
     end function
 
     function rocsparse_cgebsr2gebsc_rank_0(handle,mb,nb,nnzb,bsr_val,bsr_row_ptr,bsr_col_ind, &
@@ -50127,16 +49907,16 @@ module hipfort_rocsparse
       integer(c_int),target :: bsr_col_ind
       integer(c_int) :: row_block_dim
       integer(c_int) :: col_block_dim
-      complex(c_float_complex),target :: bsc_val
-      integer(c_int),target :: bsc_row_ind
-      integer(c_int),target :: bsc_col_ptr
+      type(c_ptr) :: bsc_val
+      type(c_ptr) :: bsc_row_ind
+      type(c_ptr) :: bsc_col_ptr
       integer(kind(rocsparse_action_symbolic)) :: copy_values
       integer(kind(rocsparse_index_base_zero)) :: idx_base
       type(c_ptr) :: temp_buffer
       !
       rocsparse_cgebsr2gebsc_rank_0 = rocsparse_cgebsr2gebsc_(handle,mb,nb,nnzb,c_loc(bsr_val), &
-        c_loc(bsr_row_ptr),c_loc(bsr_col_ind),row_block_dim,col_block_dim,c_loc(bsc_val), &
-        c_loc(bsc_row_ind),c_loc(bsc_col_ptr),copy_values,idx_base,temp_buffer)
+        c_loc(bsr_row_ptr),c_loc(bsr_col_ind),row_block_dim,col_block_dim,bsc_val,bsc_row_ind, &
+        bsc_col_ptr,copy_values,idx_base,temp_buffer)
     end function
 
     function rocsparse_cgebsr2gebsc_rank_1(handle,mb,nb,nnzb,bsr_val,bsr_row_ptr,bsr_col_ind, &
@@ -50155,16 +49935,16 @@ module hipfort_rocsparse
       integer(c_int),target,dimension(:) :: bsr_col_ind
       integer(c_int) :: row_block_dim
       integer(c_int) :: col_block_dim
-      complex(c_float_complex),target,dimension(:) :: bsc_val
-      integer(c_int),target,dimension(:) :: bsc_row_ind
-      integer(c_int),target,dimension(:) :: bsc_col_ptr
+      type(c_ptr) :: bsc_val
+      type(c_ptr) :: bsc_row_ind
+      type(c_ptr) :: bsc_col_ptr
       integer(kind(rocsparse_action_symbolic)) :: copy_values
       integer(kind(rocsparse_index_base_zero)) :: idx_base
       type(c_ptr) :: temp_buffer
       !
       rocsparse_cgebsr2gebsc_rank_1 = rocsparse_cgebsr2gebsc_(handle,mb,nb,nnzb,c_loc(bsr_val), &
-        c_loc(bsr_row_ptr),c_loc(bsr_col_ind),row_block_dim,col_block_dim,c_loc(bsc_val), &
-        c_loc(bsc_row_ind),c_loc(bsc_col_ptr),copy_values,idx_base,temp_buffer)
+        c_loc(bsr_row_ptr),c_loc(bsr_col_ind),row_block_dim,col_block_dim,bsc_val,bsc_row_ind, &
+        bsc_col_ptr,copy_values,idx_base,temp_buffer)
     end function
 
     function rocsparse_zgebsr2gebsc_rank_0(handle,mb,nb,nnzb,bsr_val,bsr_row_ptr,bsr_col_ind, &
@@ -50183,16 +49963,16 @@ module hipfort_rocsparse
       integer(c_int),target :: bsr_col_ind
       integer(c_int) :: row_block_dim
       integer(c_int) :: col_block_dim
-      complex(c_double_complex),target :: bsc_val
-      integer(c_int),target :: bsc_row_ind
-      integer(c_int),target :: bsc_col_ptr
+      type(c_ptr) :: bsc_val
+      type(c_ptr) :: bsc_row_ind
+      type(c_ptr) :: bsc_col_ptr
       integer(kind(rocsparse_action_symbolic)) :: copy_values
       integer(kind(rocsparse_index_base_zero)) :: idx_base
       type(c_ptr) :: temp_buffer
       !
       rocsparse_zgebsr2gebsc_rank_0 = rocsparse_zgebsr2gebsc_(handle,mb,nb,nnzb,c_loc(bsr_val), &
-        c_loc(bsr_row_ptr),c_loc(bsr_col_ind),row_block_dim,col_block_dim,c_loc(bsc_val), &
-        c_loc(bsc_row_ind),c_loc(bsc_col_ptr),copy_values,idx_base,temp_buffer)
+        c_loc(bsr_row_ptr),c_loc(bsr_col_ind),row_block_dim,col_block_dim,bsc_val,bsc_row_ind, &
+        bsc_col_ptr,copy_values,idx_base,temp_buffer)
     end function
 
     function rocsparse_zgebsr2gebsc_rank_1(handle,mb,nb,nnzb,bsr_val,bsr_row_ptr,bsr_col_ind, &
@@ -50211,16 +49991,16 @@ module hipfort_rocsparse
       integer(c_int),target,dimension(:) :: bsr_col_ind
       integer(c_int) :: row_block_dim
       integer(c_int) :: col_block_dim
-      complex(c_double_complex),target,dimension(:) :: bsc_val
-      integer(c_int),target,dimension(:) :: bsc_row_ind
-      integer(c_int),target,dimension(:) :: bsc_col_ptr
+      type(c_ptr) :: bsc_val
+      type(c_ptr) :: bsc_row_ind
+      type(c_ptr) :: bsc_col_ptr
       integer(kind(rocsparse_action_symbolic)) :: copy_values
       integer(kind(rocsparse_index_base_zero)) :: idx_base
       type(c_ptr) :: temp_buffer
       !
       rocsparse_zgebsr2gebsc_rank_1 = rocsparse_zgebsr2gebsc_(handle,mb,nb,nnzb,c_loc(bsr_val), &
-        c_loc(bsr_row_ptr),c_loc(bsr_col_ind),row_block_dim,col_block_dim,c_loc(bsc_val), &
-        c_loc(bsc_row_ind),c_loc(bsc_col_ptr),copy_values,idx_base,temp_buffer)
+        c_loc(bsr_row_ptr),c_loc(bsr_col_ind),row_block_dim,col_block_dim,bsc_val,bsc_row_ind, &
+        bsc_col_ptr,copy_values,idx_base,temp_buffer)
     end function
 
     function rocsparse_csr2ell_width_rank_0(handle,m,csr_descr,csr_row_ptr,ell_descr,ell_width)
@@ -51036,12 +50816,12 @@ module hipfort_rocsparse
       integer(c_int),target :: bsr_row_ptr
       integer(c_int) :: row_block_dim
       integer(c_int) :: col_block_dim
-      integer(c_int),target :: bsr_nnz_devhost
+      type(c_ptr) :: bsr_nnz_devhost
       type(c_ptr) :: temp_buffer
       !
       rocsparse_csr2gebsr_nnz_rank_0 = rocsparse_csr2gebsr_nnz_(handle,dir,m,n,csr_descr, &
         c_loc(csr_row_ptr),c_loc(csr_col_ind),bsr_descr,c_loc(bsr_row_ptr),row_block_dim, &
-        col_block_dim,c_loc(bsr_nnz_devhost),temp_buffer)
+        col_block_dim,bsr_nnz_devhost,temp_buffer)
     end function
 
     function rocsparse_csr2gebsr_nnz_rank_1(handle,dir,m,n,csr_descr,csr_row_ptr,csr_col_ind, &
@@ -51061,12 +50841,12 @@ module hipfort_rocsparse
       integer(c_int),target,dimension(:) :: bsr_row_ptr
       integer(c_int) :: row_block_dim
       integer(c_int) :: col_block_dim
-      integer(c_int),target,dimension(:) :: bsr_nnz_devhost
+      type(c_ptr) :: bsr_nnz_devhost
       type(c_ptr) :: temp_buffer
       !
       rocsparse_csr2gebsr_nnz_rank_1 = rocsparse_csr2gebsr_nnz_(handle,dir,m,n,csr_descr, &
         c_loc(csr_row_ptr),c_loc(csr_col_ind),bsr_descr,c_loc(bsr_row_ptr),row_block_dim, &
-        col_block_dim,c_loc(bsr_nnz_devhost),temp_buffer)
+        col_block_dim,bsr_nnz_devhost,temp_buffer)
     end function
 
     function rocsparse_scsr2gebsr_rank_0(handle,dir,m,n,csr_descr,csr_val,csr_row_ptr,csr_col_ind, &


### PR DESCRIPTION
Fixes Fortran generic-resolution regressions in the regenerated bindings: building `develop` currently fails several f2008 tests with *"no specific function for the generic …"* (the CI stops at the first one — hipBLAS — but rocBLAS, rocSOLVER, hipSOLVER, rocSPARSE, hipSPARSE are affected too, ~33 test sources total).

Two related root causes, both fixed in the generator and applied to the six affected libraries:

### 1. `_full_rank` gave every buffer the same rank (2-D)
Mixed vector/matrix Level-2 / LAPACK routines (`ger`, `gemv`, `symv`, `getrf`, …) need each buffer at its **natural** rank: a matrix (the buffer immediately followed by a leading-dimension `ld*` argument) is 2-D, a vector is 1-D. Previously `_full_rank` forced *every* buffer to `dimension(:,:)`, so a natural call like `X(…, x(:), …, y(:), …, A(:,:), …)` matched no specific.
`_full_rank` is also no longer emitted when it would be identical to `_rank_1` (all-vector routines) — that duplicate previously made the generic ambiguous (e.g. `gpsvInterleavedBatch`).

### 2. Scalar output pointers were turned into native arrays
`info` / `result` (renamed `myInfo` / `myResult`) are device `c_ptr` the caller supplies via `c_loc(...)`. They were being arrayified like real data buffers, so a call mixing native arrays with `c_loc(info)` resolved to nothing. They now stay pass-through `type(c_ptr)` in the native wrappers. This is **per-function** (bootstrapped from hipfort's hand-written wrappers): e.g. `myResult` is a `c_ptr` in rocBLAS `dot` but a plain scalar in rocSPARSE `doti`.

The net line reduction comes from dropping overloads that arrayified device pointers (unusable — you cannot pass a device pointer as a Fortran array) and the redundant all-vector `_full_rank` duplicates; the vast majority of native/rank overloads are unchanged.

### Validation
- **Full test suite compiles: 218/218 test sources, 0 generic-resolution errors** (on `develop` today it is ~185 pass / 33 fail).
- Library builds cleanly with gfortran (all modules, both install trees).
- Line length stays **≤ 132** — the recent 132-column wrapping is preserved.

Examples now correct:
- `hipblasDger_full_rank`: `x(:)`, `y(:)`, `AP(:,:)`
- `rocsolver_sgetrf_full_rank`: `A(:,:)`, `ipiv(:)`, `myInfo` as `type(c_ptr)`
