### PR TITLE
Regenerate HIP runtime enums and derived types

### DIFF
--- a/lib/hipfort/hipfort_enums.F90
+++ b/lib/hipfort/hipfort_enums.F90
@@ -2,19 +2,19 @@
 ! ==============================================================================
 ! hipfort: FORTRAN Interfaces for GPU kernels
 ! ==============================================================================
-! Copyright (c) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+! Copyright (c) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
 ! [MITx11 License]
-! 
+!
 ! Permission is hereby granted, free of charge, to any person obtaining a copy
 ! of this software and associated documentation files (the "Software"), to deal
 ! in the Software without restriction, including without limitation the rights
 ! to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 ! copies of the Software, and to permit persons to whom the Software is
 ! furnished to do so, subject to the following conditions:
-! 
+!
 ! The above copyright notice and this permission notice shall be included in
 ! all copies or substantial portions of the Software.
-! 
+!
 ! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 ! IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 ! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
@@ -23,31 +23,154 @@
 ! OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 ! THE SOFTWARE.
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-          
-           
+
 module hipfort_enums
+  use, intrinsic :: iso_c_binding
   implicit none
 
+  ! hipDataType
   enum, bind(c)
-    enumerator :: HIP_SUCCESS = 0
-    enumerator :: HIP_ERROR_INVALID_VALUE
-    enumerator :: HIP_ERROR_NOT_INITIALIZED
-    enumerator :: HIP_ERROR_LAUNCH_OUT_OF_RESOURCES
+    enumerator :: HIP_R_32F = 0
+    enumerator :: HIP_R_64F = 1
+    enumerator :: HIP_R_16F = 2
+    enumerator :: HIP_R_8I = 3
+    enumerator :: HIP_C_32F = 4
+    enumerator :: HIP_C_64F = 5
+    enumerator :: HIP_C_16F = 6
+    enumerator :: HIP_C_8I = 7
+    enumerator :: HIP_R_8U = 8
+    enumerator :: HIP_C_8U = 9
+    enumerator :: HIP_R_32I = 10
+    enumerator :: HIP_C_32I = 11
+    enumerator :: HIP_R_32U = 12
+    enumerator :: HIP_C_32U = 13
+    enumerator :: HIP_R_16BF = 14
+    enumerator :: HIP_C_16BF = 15
+    enumerator :: HIP_R_4I = 16
+    enumerator :: HIP_C_4I = 17
+    enumerator :: HIP_R_4U = 18
+    enumerator :: HIP_C_4U = 19
+    enumerator :: HIP_R_16I = 20
+    enumerator :: HIP_C_16I = 21
+    enumerator :: HIP_R_16U = 22
+    enumerator :: HIP_C_16U = 23
+    enumerator :: HIP_R_64I = 24
+    enumerator :: HIP_C_64I = 25
+    enumerator :: HIP_R_64U = 26
+    enumerator :: HIP_C_64U = 27
+    enumerator :: HIP_R_8F_E4M3 = 28
+    enumerator :: HIP_R_8F_E5M2 = 29
+    enumerator :: HIP_R_8F_UE8M0 = 30
+    enumerator :: HIP_R_6F_E2M3 = 31
+    enumerator :: HIP_R_6F_E3M2 = 32
+    enumerator :: HIP_R_4F_E2M1 = 33
+    enumerator :: HIP_R_8F_E4M3_FNUZ = 1000
+    enumerator :: HIP_R_8F_E5M2_FNUZ = 1001
   end enum
 
+  ! hipLibraryPropertyType
   enum, bind(c)
-    enumerator :: hipMemoryTypeHost
-    enumerator :: hipMemoryTypeDevice
-    enumerator :: hipMemoryTypeArray
-    enumerator :: hipMemoryTypeUnified
+    enumerator :: HIP_LIBRARY_MAJOR_VERSION = 0
+    enumerator :: HIP_LIBRARY_MINOR_VERSION = 1
+    enumerator :: HIP_LIBRARY_PATCH_LEVEL = 2
   end enum
- 
+
+  ! hipJitOption
   enum, bind(c)
-    enumerator :: hipSuccess = 0 !> Successful completion.
-    enumerator :: hipErrorInvalidValue = 1 !> One or more of the parameters passed to the API call is NULL or not in an acceptable range.
-    enumerator :: hipErrorOutOfMemory = 2 !> Out of memory range.
-    enumerator :: hipErrorMemoryAllocation = 2 !> Memory allocation error.
-    enumerator :: hipErrorNotInitialized = 3 !> Invalid not initialized
+    enumerator :: hipJitOptionMaxRegisters = 0
+    enumerator :: hipJitOptionThreadsPerBlock = 1
+    enumerator :: hipJitOptionWallTime = 2
+    enumerator :: hipJitOptionInfoLogBuffer = 3
+    enumerator :: hipJitOptionInfoLogBufferSizeBytes = 4
+    enumerator :: hipJitOptionErrorLogBuffer = 5
+    enumerator :: hipJitOptionErrorLogBufferSizeBytes = 6
+    enumerator :: hipJitOptionOptimizationLevel = 7
+    enumerator :: hipJitOptionTargetFromContext = 8
+    enumerator :: hipJitOptionTarget = 9
+    enumerator :: hipJitOptionFallbackStrategy = 10
+    enumerator :: hipJitOptionGenerateDebugInfo = 11
+    enumerator :: hipJitOptionLogVerbose = 12
+    enumerator :: hipJitOptionGenerateLineInfo = 13
+    enumerator :: hipJitOptionCacheMode = 14
+    enumerator :: hipJitOptionSm3xOpt = 15
+    enumerator :: hipJitOptionFastCompile = 16
+    enumerator :: hipJitOptionGlobalSymbolNames = 17
+    enumerator :: hipJitOptionGlobalSymbolAddresses = 18
+    enumerator :: hipJitOptionGlobalSymbolCount = 19
+    enumerator :: hipJitOptionLto = 20
+    enumerator :: hipJitOptionFtz = 21
+    enumerator :: hipJitOptionPrecDiv = 22
+    enumerator :: hipJitOptionPrecSqrt = 23
+    enumerator :: hipJitOptionFma = 24
+    enumerator :: hipJitOptionPositionIndependentCode = 25
+    enumerator :: hipJitOptionMinCTAPerSM = 26
+    enumerator :: hipJitOptionMaxThreadsPerBlock = 27
+    enumerator :: hipJitOptionOverrideDirectiveValues = 28
+    enumerator :: hipJitOptionNumOptions = 29
+    enumerator :: hipJitOptionIRtoISAOptExt = 10000
+    enumerator :: hipJitOptionIRtoISAOptCountExt = 10001
+  end enum
+
+  ! hipJitInputType
+  enum, bind(c)
+    enumerator :: hipJitInputCubin = 0
+    enumerator :: hipJitInputPtx = 1
+    enumerator :: hipJitInputFatBinary = 2
+    enumerator :: hipJitInputObject = 3
+    enumerator :: hipJitInputLibrary = 4
+    enumerator :: hipJitInputNvvm = 5
+    enumerator :: hipJitNumLegacyInputTypes = 6
+    enumerator :: hipJitInputLLVMBitcode = 100
+    enumerator :: hipJitInputLLVMBundledBitcode = 101
+    enumerator :: hipJitInputLLVMArchivesOfBundledBitcode = 102
+    enumerator :: hipJitInputSpirv = 103
+    enumerator :: hipJitNumInputTypes = 10
+  end enum
+
+  ! hipJitCacheMode
+  enum, bind(c)
+    enumerator :: hipJitCacheOptionNone = 0
+    enumerator :: hipJitCacheOptionCG = 1
+    enumerator :: hipJitCacheOptionCA = 2
+  end enum
+
+  ! hipJitFallback
+  enum, bind(c)
+    enumerator :: hipJitPreferPTX = 0
+    enumerator :: hipJitPreferBinary = 1
+  end enum
+
+  ! hipLibraryOption_e
+  enum, bind(c)
+    enumerator :: hipLibraryHostUniversalFunctionAndDataTable = 0
+    enumerator :: hipLibraryBinaryIsPreserved = 1
+  end enum
+
+  ! enum (unnamed at /opt/rocm/include/hip/hip_runtime_api.h:49:1)
+  enum, bind(c)
+    enumerator :: HIP_SUCCESS = 0
+    enumerator :: HIP_ERROR_INVALID_VALUE = 1
+    enumerator :: HIP_ERROR_NOT_INITIALIZED = 2
+    enumerator :: HIP_ERROR_LAUNCH_OUT_OF_RESOURCES = 3
+  end enum
+
+  ! hipMemoryType
+  enum, bind(c)
+    enumerator :: hipMemoryTypeUnregistered = 0
+    enumerator :: hipMemoryTypeHost = 1
+    enumerator :: hipMemoryTypeDevice = 2
+    enumerator :: hipMemoryTypeManaged = 3
+    enumerator :: hipMemoryTypeArray = 10
+    enumerator :: hipMemoryTypeUnified = 11
+  end enum
+
+  ! hipError_t
+  enum, bind(c)
+    enumerator :: hipSuccess = 0
+    enumerator :: hipErrorInvalidValue = 1
+    enumerator :: hipErrorOutOfMemory = 2
+    enumerator :: hipErrorMemoryAllocation = 2
+    enumerator :: hipErrorNotInitialized = 3
     enumerator :: hipErrorInitializationError = 3
     enumerator :: hipErrorDeinitialized = 4
     enumerator :: hipErrorProfilerDisabled = 5
@@ -117,123 +240,145 @@ module hipfort_enums
     enumerator :: hipErrorCapturedEvent = 907
     enumerator :: hipErrorStreamCaptureWrongThread = 908
     enumerator :: hipErrorGraphExecUpdateFailure = 910
+    enumerator :: hipErrorInvalidChannelDescriptor = 911
+    enumerator :: hipErrorInvalidTexture = 912
     enumerator :: hipErrorUnknown = 999
     enumerator :: hipErrorRuntimeMemory = 1052
     enumerator :: hipErrorRuntimeOther = 1053
-    enumerator :: hipErrorTbd
+    enumerator :: hipErrorTbd = 1054
   end enum
 
+  ! hipDeviceAttribute_t
   enum, bind(c)
     enumerator :: hipDeviceAttributeCudaCompatibleBegin = 0
-    enumerator :: hipDeviceAttributeEccEnabled = hipDeviceAttributeCudaCompatibleBegin
-    enumerator :: hipDeviceAttributeAccessPolicyMaxWindowSize
-    enumerator :: hipDeviceAttributeAsyncEngineCount
-    enumerator :: hipDeviceAttributeCanMapHostMemory
-    enumerator :: hipDeviceAttributeCanUseHostPointerForRegisteredMem
-    enumerator :: hipDeviceAttributeClockRate
-    enumerator :: hipDeviceAttributeComputeMode
-    enumerator :: hipDeviceAttributeComputePreemptionSupported
-    enumerator :: hipDeviceAttributeConcurrentKernels
-    enumerator :: hipDeviceAttributeConcurrentManagedAccess
-    enumerator :: hipDeviceAttributeCooperativeLaunch
-    enumerator :: hipDeviceAttributeCooperativeMultiDeviceLaunch
-    enumerator :: hipDeviceAttributeDeviceOverlap
-    enumerator :: hipDeviceAttributeDirectManagedMemAccessFromHost
-    enumerator :: hipDeviceAttributeGlobalL1CacheSupported
-    enumerator :: hipDeviceAttributeHostNativeAtomicSupported
-    enumerator :: hipDeviceAttributeIntegrated
-    enumerator :: hipDeviceAttributeIsMultiGpuBoard
-    enumerator :: hipDeviceAttributeKernelExecTimeout
-    enumerator :: hipDeviceAttributeL2CacheSize
-    enumerator :: hipDeviceAttributeLocalL1CacheSupported
-    enumerator :: hipDeviceAttributeLuid
-    enumerator :: hipDeviceAttributeLuidDeviceNodeMask
-    enumerator :: hipDeviceAttributeComputeCapabilityMajor
-    enumerator :: hipDeviceAttributeManagedMemory
-    enumerator :: hipDeviceAttributeMaxBlocksPerMultiProcessor
-    enumerator :: hipDeviceAttributeMaxBlockDimX
-    enumerator :: hipDeviceAttributeMaxBlockDimY
-    enumerator :: hipDeviceAttributeMaxBlockDimZ
-    enumerator :: hipDeviceAttributeMaxGridDimX
-    enumerator :: hipDeviceAttributeMaxGridDimY
-    enumerator :: hipDeviceAttributeMaxGridDimZ
-    enumerator :: hipDeviceAttributeMaxSurface1D
-    enumerator :: hipDeviceAttributeMaxSurface1DLayered
-    enumerator :: hipDeviceAttributeMaxSurface2D
-    enumerator :: hipDeviceAttributeMaxSurface2DLayered
-    enumerator :: hipDeviceAttributeMaxSurface3D
-    enumerator :: hipDeviceAttributeMaxSurfaceCubemap
-    enumerator :: hipDeviceAttributeMaxSurfaceCubemapLayered
-    enumerator :: hipDeviceAttributeMaxTexture1DWidth
-    enumerator :: hipDeviceAttributeMaxTexture1DLayered
-    enumerator :: hipDeviceAttributeMaxTexture1DLinear
-    enumerator :: hipDeviceAttributeMaxTexture1DMipmap
-    enumerator :: hipDeviceAttributeMaxTexture2DWidth
-    enumerator :: hipDeviceAttributeMaxTexture2DHeight
-    enumerator :: hipDeviceAttributeMaxTexture2DGather
-    enumerator :: hipDeviceAttributeMaxTexture2DLayered
-    enumerator :: hipDeviceAttributeMaxTexture2DLinear
-    enumerator :: hipDeviceAttributeMaxTexture2DMipmap
-    enumerator :: hipDeviceAttributeMaxTexture3DWidth
-    enumerator :: hipDeviceAttributeMaxTexture3DHeight
-    enumerator :: hipDeviceAttributeMaxTexture3DDepth
-    enumerator :: hipDeviceAttributeMaxTexture3DAlt
-    enumerator :: hipDeviceAttributeMaxTextureCubemap
-    enumerator :: hipDeviceAttributeMaxTextureCubemapLayered
-    enumerator :: hipDeviceAttributeMaxThreadsDim
-    enumerator :: hipDeviceAttributeMaxThreadsPerBlock
-    enumerator :: hipDeviceAttributeMaxThreadsPerMultiProcessor
-    enumerator :: hipDeviceAttributeMaxPitch
-    enumerator :: hipDeviceAttributeMemoryBusWidth
-    enumerator :: hipDeviceAttributeMemoryClockRate
-    enumerator :: hipDeviceAttributeComputeCapabilityMinor
-    enumerator :: hipDeviceAttributeMultiGpuBoardGroupID
-    enumerator :: hipDeviceAttributeMultiprocessorCount
-    enumerator :: hipDeviceAttributeName
-    enumerator :: hipDeviceAttributePageableMemoryAccess
-    enumerator :: hipDeviceAttributePageableMemoryAccessUsesHostPageTables
-    enumerator :: hipDeviceAttributePciBusId
-    enumerator :: hipDeviceAttributePciDeviceId
-    enumerator :: hipDeviceAttributePciDomainID
-    enumerator :: hipDeviceAttributePersistingL2CacheMaxSize
-    enumerator :: hipDeviceAttributeMaxRegistersPerBlock
-    enumerator :: hipDeviceAttributeMaxRegistersPerMultiprocessor
-    enumerator :: hipDeviceAttributeReservedSharedMemPerBlock
-    enumerator :: hipDeviceAttributeMaxSharedMemoryPerBlock
-    enumerator :: hipDeviceAttributeSharedMemPerBlockOptin
-    enumerator :: hipDeviceAttributeSharedMemPerMultiprocessor
-    enumerator :: hipDeviceAttributeSingleToDoublePrecisionPerfRatio
-    enumerator :: hipDeviceAttributeStreamPrioritiesSupported
-    enumerator :: hipDeviceAttributeSurfaceAlignment
-    enumerator :: hipDeviceAttributeTccDriver
-    enumerator :: hipDeviceAttributeTextureAlignment
-    enumerator :: hipDeviceAttributeTexturePitchAlignment
-    enumerator :: hipDeviceAttributeTotalConstantMemory
-    enumerator :: hipDeviceAttributeTotalGlobalMem
-    enumerator :: hipDeviceAttributeUnifiedAddressing
-    enumerator :: hipDeviceAttributeUuid
-    enumerator :: hipDeviceAttributeWarpSize
+    enumerator :: hipDeviceAttributeEccEnabled = 0
+    enumerator :: hipDeviceAttributeAccessPolicyMaxWindowSize = 1
+    enumerator :: hipDeviceAttributeAsyncEngineCount = 2
+    enumerator :: hipDeviceAttributeCanMapHostMemory = 3
+    enumerator :: hipDeviceAttributeCanUseHostPointerForRegisteredMem = 4
+    enumerator :: hipDeviceAttributeClockRate = 5
+    enumerator :: hipDeviceAttributeComputeMode = 6
+    enumerator :: hipDeviceAttributeComputePreemptionSupported = 7
+    enumerator :: hipDeviceAttributeConcurrentKernels = 8
+    enumerator :: hipDeviceAttributeConcurrentManagedAccess = 9
+    enumerator :: hipDeviceAttributeCooperativeLaunch = 10
+    enumerator :: hipDeviceAttributeCooperativeMultiDeviceLaunch = 11
+    enumerator :: hipDeviceAttributeDeviceOverlap = 12
+    enumerator :: hipDeviceAttributeDirectManagedMemAccessFromHost = 13
+    enumerator :: hipDeviceAttributeGlobalL1CacheSupported = 14
+    enumerator :: hipDeviceAttributeHostNativeAtomicSupported = 15
+    enumerator :: hipDeviceAttributeIntegrated = 16
+    enumerator :: hipDeviceAttributeIsMultiGpuBoard = 17
+    enumerator :: hipDeviceAttributeKernelExecTimeout = 18
+    enumerator :: hipDeviceAttributeL2CacheSize = 19
+    enumerator :: hipDeviceAttributeLocalL1CacheSupported = 20
+    enumerator :: hipDeviceAttributeLuid = 21
+    enumerator :: hipDeviceAttributeLuidDeviceNodeMask = 22
+    enumerator :: hipDeviceAttributeComputeCapabilityMajor = 23
+    enumerator :: hipDeviceAttributeManagedMemory = 24
+    enumerator :: hipDeviceAttributeMaxBlocksPerMultiProcessor = 25
+    enumerator :: hipDeviceAttributeMaxBlockDimX = 26
+    enumerator :: hipDeviceAttributeMaxBlockDimY = 27
+    enumerator :: hipDeviceAttributeMaxBlockDimZ = 28
+    enumerator :: hipDeviceAttributeMaxGridDimX = 29
+    enumerator :: hipDeviceAttributeMaxGridDimY = 30
+    enumerator :: hipDeviceAttributeMaxGridDimZ = 31
+    enumerator :: hipDeviceAttributeMaxSurface1D = 32
+    enumerator :: hipDeviceAttributeMaxSurface1DLayered = 33
+    enumerator :: hipDeviceAttributeMaxSurface2D = 34
+    enumerator :: hipDeviceAttributeMaxSurface2DLayered = 35
+    enumerator :: hipDeviceAttributeMaxSurface3D = 36
+    enumerator :: hipDeviceAttributeMaxSurfaceCubemap = 37
+    enumerator :: hipDeviceAttributeMaxSurfaceCubemapLayered = 38
+    enumerator :: hipDeviceAttributeMaxTexture1DWidth = 39
+    enumerator :: hipDeviceAttributeMaxTexture1DLayered = 40
+    enumerator :: hipDeviceAttributeMaxTexture1DLinear = 41
+    enumerator :: hipDeviceAttributeMaxTexture1DMipmap = 42
+    enumerator :: hipDeviceAttributeMaxTexture2DWidth = 43
+    enumerator :: hipDeviceAttributeMaxTexture2DHeight = 44
+    enumerator :: hipDeviceAttributeMaxTexture2DGather = 45
+    enumerator :: hipDeviceAttributeMaxTexture2DLayered = 46
+    enumerator :: hipDeviceAttributeMaxTexture2DLinear = 47
+    enumerator :: hipDeviceAttributeMaxTexture2DMipmap = 48
+    enumerator :: hipDeviceAttributeMaxTexture3DWidth = 49
+    enumerator :: hipDeviceAttributeMaxTexture3DHeight = 50
+    enumerator :: hipDeviceAttributeMaxTexture3DDepth = 51
+    enumerator :: hipDeviceAttributeMaxTexture3DAlt = 52
+    enumerator :: hipDeviceAttributeMaxTextureCubemap = 53
+    enumerator :: hipDeviceAttributeMaxTextureCubemapLayered = 54
+    enumerator :: hipDeviceAttributeMaxThreadsDim = 55
+    enumerator :: hipDeviceAttributeMaxThreadsPerBlock = 56
+    enumerator :: hipDeviceAttributeMaxThreadsPerMultiProcessor = 57
+    enumerator :: hipDeviceAttributeMaxPitch = 58
+    enumerator :: hipDeviceAttributeMemoryBusWidth = 59
+    enumerator :: hipDeviceAttributeMemoryClockRate = 60
+    enumerator :: hipDeviceAttributeComputeCapabilityMinor = 61
+    enumerator :: hipDeviceAttributeMultiGpuBoardGroupID = 62
+    enumerator :: hipDeviceAttributeMultiprocessorCount = 63
+    enumerator :: hipDeviceAttributeUnused1 = 64
+    enumerator :: hipDeviceAttributePageableMemoryAccess = 65
+    enumerator :: hipDeviceAttributePageableMemoryAccessUsesHostPageTables = 66
+    enumerator :: hipDeviceAttributePciBusId = 67
+    enumerator :: hipDeviceAttributePciDeviceId = 68
+    enumerator :: hipDeviceAttributePciDomainId = 69
+    enumerator :: hipDeviceAttributePersistingL2CacheMaxSize = 70
+    enumerator :: hipDeviceAttributeMaxRegistersPerBlock = 71
+    enumerator :: hipDeviceAttributeMaxRegistersPerMultiprocessor = 72
+    enumerator :: hipDeviceAttributeReservedSharedMemPerBlock = 73
+    enumerator :: hipDeviceAttributeMaxSharedMemoryPerBlock = 74
+    enumerator :: hipDeviceAttributeSharedMemPerBlockOptin = 75
+    enumerator :: hipDeviceAttributeSharedMemPerMultiprocessor = 76
+    enumerator :: hipDeviceAttributeSingleToDoublePrecisionPerfRatio = 77
+    enumerator :: hipDeviceAttributeStreamPrioritiesSupported = 78
+    enumerator :: hipDeviceAttributeSurfaceAlignment = 79
+    enumerator :: hipDeviceAttributeTccDriver = 80
+    enumerator :: hipDeviceAttributeTextureAlignment = 81
+    enumerator :: hipDeviceAttributeTexturePitchAlignment = 82
+    enumerator :: hipDeviceAttributeTotalConstantMemory = 83
+    enumerator :: hipDeviceAttributeTotalGlobalMem = 84
+    enumerator :: hipDeviceAttributeUnifiedAddressing = 85
+    enumerator :: hipDeviceAttributeUnused2 = 86
+    enumerator :: hipDeviceAttributeWarpSize = 87
+    enumerator :: hipDeviceAttributeMemoryPoolsSupported = 88
+    enumerator :: hipDeviceAttributeVirtualMemoryManagementSupported = 89
+    enumerator :: hipDeviceAttributeHostRegisterSupported = 90
+    enumerator :: hipDeviceAttributeMemoryPoolSupportedHandleTypes = 91
+    enumerator :: hipDeviceAttributeHostNumaId = 92
     enumerator :: hipDeviceAttributeCudaCompatibleEnd = 9999
     enumerator :: hipDeviceAttributeAmdSpecificBegin = 10000
-    enumerator :: hipDeviceAttributeClockInstructionRate = hipDeviceAttributeAmdSpecificBegin
-    enumerator :: hipDeviceAttributeArch
-    enumerator :: hipDeviceAttributeMaxSharedMemoryPerMultiprocessor
-    enumerator :: hipDeviceAttributeGcnArch
-    enumerator :: hipDeviceAttributeGcnArchName
-    enumerator :: hipDeviceAttributeHdpMemFlushCntl
-    enumerator :: hipDeviceAttributeHdpRegFlushCntl
-    enumerator :: hipDeviceAttributeCooperativeMultiDeviceUnmatchedFunc
-    enumerator :: hipDeviceAttributeCooperativeMultiDeviceUnmatchedGridDim
-    enumerator :: hipDeviceAttributeCooperativeMultiDeviceUnmatchedBlockDim
-    enumerator :: hipDeviceAttributeCooperativeMultiDeviceUnmatchedSharedMem
-    enumerator :: hipDeviceAttributeIsLargeBar
-    enumerator :: hipDeviceAttributeAsicRevision
-    enumerator :: hipDeviceAttributeCanUseStreamWaitValue
-    enumerator :: hipDeviceAttributeImageSupport
+    enumerator :: hipDeviceAttributeClockInstructionRate = 10000
+    enumerator :: hipDeviceAttributeUnused3 = 10001
+    enumerator :: hipDeviceAttributeMaxSharedMemoryPerMultiprocessor = 10002
+    enumerator :: hipDeviceAttributeUnused4 = 10003
+    enumerator :: hipDeviceAttributeUnused5 = 10004
+    enumerator :: hipDeviceAttributeHdpMemFlushCntl = 10005
+    enumerator :: hipDeviceAttributeHdpRegFlushCntl = 10006
+    enumerator :: hipDeviceAttributeCooperativeMultiDeviceUnmatchedFunc = 10007
+    enumerator :: hipDeviceAttributeCooperativeMultiDeviceUnmatchedGridDim = 10008
+    enumerator :: hipDeviceAttributeCooperativeMultiDeviceUnmatchedBlockDim = 10009
+    enumerator :: hipDeviceAttributeCooperativeMultiDeviceUnmatchedSharedMem = 10010
+    enumerator :: hipDeviceAttributeIsLargeBar = 10011
+    enumerator :: hipDeviceAttributeAsicRevision = 10012
+    enumerator :: hipDeviceAttributeCanUseStreamWaitValue = 10013
+    enumerator :: hipDeviceAttributeImageSupport = 10014
+    enumerator :: hipDeviceAttributePhysicalMultiProcessorCount = 10015
+    enumerator :: hipDeviceAttributeFineGrainSupport = 10016
+    enumerator :: hipDeviceAttributeWallClockRate = 10017
+    enumerator :: hipDeviceAttributeNumberOfXccs = 10018
+    enumerator :: hipDeviceAttributeMaxAvailableVgprsPerThread = 10019
+    enumerator :: hipDeviceAttributePciChipId = 10020
     enumerator :: hipDeviceAttributeAmdSpecificEnd = 19999
     enumerator :: hipDeviceAttributeVendorSpecificBegin = 20000
   end enum
 
+  ! hipDriverProcAddressQueryResult
+  enum, bind(c)
+    enumerator :: HIP_GET_PROC_ADDRESS_SUCCESS = 0
+    enumerator :: HIP_GET_PROC_ADDRESS_SYMBOL_NOT_FOUND = 1
+    enumerator :: HIP_GET_PROC_ADDRESS_VERSION_NOT_SUFFICIENT = 2
+  end enum
+
+  ! hipComputeMode
   enum, bind(c)
     enumerator :: hipComputeModeDefault = 0
     enumerator :: hipComputeModeExclusive = 1
@@ -241,157 +386,20 @@ module hipfort_enums
     enumerator :: hipComputeModeExclusiveProcess = 3
   end enum
 
+  ! hipFlushGPUDirectRDMAWritesOptions
   enum, bind(c)
-    enumerator :: hipDevP2PAttrPerformanceRank = 0
-    enumerator :: hipDevP2PAttrAccessSupported
-    enumerator :: hipDevP2PAttrNativeAtomicSupported
-    enumerator :: hipDevP2PAttrHipArrayAccessSupported
+    enumerator :: hipFlushGPUDirectRDMAWritesOptionHost = 1
+    enumerator :: hipFlushGPUDirectRDMAWritesOptionMemOps = 2
   end enum
 
+  ! hipGPUDirectRDMAWritesOrdering
   enum, bind(c)
-    enumerator :: hipLimitPrintfFifoSize = 1
-    enumerator :: hipLimitMallocHeapSize = 2
+    enumerator :: hipGPUDirectRDMAWritesOrderingNone = 0
+    enumerator :: hipGPUDirectRDMAWritesOrderingOwner = 100
+    enumerator :: hipGPUDirectRDMAWritesOrderingAllDevices = 200
   end enum
 
-  enum, bind(c)
-    enumerator :: hipMemAdviseSetReadMostly = 1
-    enumerator :: hipMemAdviseUnsetReadMostly = 2
-    enumerator :: hipMemAdviseSetPreferredLocation = 3
-    enumerator :: hipMemAdviseUnsetPreferredLocation = 4
-    enumerator :: hipMemAdviseSetAccessedBy = 5
-    enumerator :: hipMemAdviseUnsetAccessedBy = 6
-    enumerator :: hipMemAdviseSetCoarseGrain = 100
-    enumerator :: hipMemAdviseUnsetCoarseGrain = 101
-  end enum
-
-  enum, bind(c)
-    enumerator :: hipMemRangeCoherencyModeFineGrain = 0
-    enumerator :: hipMemRangeCoherencyModeCoarseGrain = 1
-    enumerator :: hipMemRangeCoherencyModeIndeterminate = 2
-  end enum
-
-  enum, bind(c)
-    enumerator :: hipMemRangeAttributeReadMostly = 1
-    enumerator :: hipMemRangeAttributePreferredLocation = 2
-    enumerator :: hipMemRangeAttributeAccessedBy = 3
-    enumerator :: hipMemRangeAttributeLastPrefetchLocation = 4
-    enumerator :: hipMemRangeAttributeCoherencyMode = 100
-  end enum
-
-  enum, bind(c)
-    enumerator :: hipJitOptionMaxRegisters = 0
-    enumerator :: hipJitOptionThreadsPerBlock
-    enumerator :: hipJitOptionWallTime
-    enumerator :: hipJitOptionInfoLogBuffer
-    enumerator :: hipJitOptionInfoLogBufferSizeBytes
-    enumerator :: hipJitOptionErrorLogBuffer
-    enumerator :: hipJitOptionErrorLogBufferSizeBytes
-    enumerator :: hipJitOptionOptimizationLevel
-    enumerator :: hipJitOptionTargetFromContext
-    enumerator :: hipJitOptionTarget
-    enumerator :: hipJitOptionFallbackStrategy
-    enumerator :: hipJitOptionGenerateDebugInfo
-    enumerator :: hipJitOptionLogVerbose
-    enumerator :: hipJitOptionGenerateLineInfo
-    enumerator :: hipJitOptionCacheMode
-    enumerator :: hipJitOptionSm3xOpt
-    enumerator :: hipJitOptionFastCompile
-    enumerator :: hipJitOptionNumOptions
-  end enum
-
-  enum, bind(c)
-    enumerator :: hipFuncAttributeMaxDynamicSharedMemorySize = 8
-    enumerator :: hipFuncAttributePreferredSharedMemoryCarveout = 9
-    enumerator :: hipFuncAttributeMax
-  end enum
-
-  enum, bind(c)
-    enumerator :: hipFuncCachePreferNone
-    enumerator :: hipFuncCachePreferShared
-    enumerator :: hipFuncCachePreferL1
-    enumerator :: hipFuncCachePreferEqual
-  end enum
-
-  enum, bind(c)
-    enumerator :: hipSharedMemBankSizeDefault
-    enumerator :: hipSharedMemBankSizeFourByte
-    enumerator :: hipSharedMemBankSizeEightByte
-  end enum
-
-  enum, bind(c)
-    enumerator :: hipExternalMemoryHandleTypeOpaqueFd = 1
-    enumerator :: hipExternalMemoryHandleTypeOpaqueWin32 = 2
-    enumerator :: hipExternalMemoryHandleTypeOpaqueWin32Kmt = 3
-    enumerator :: hipExternalMemoryHandleTypeD3D12Heap = 4
-    enumerator :: hipExternalMemoryHandleTypeD3D12Resource = 5
-    enumerator :: hipExternalMemoryHandleTypeD3D11Resource = 6
-    enumerator :: hipExternalMemoryHandleTypeD3D11ResourceKmt = 7
-  end enum
-
-  enum, bind(c)
-    enumerator :: hipExternalSemaphoreHandleTypeOpaqueFd = 1
-    enumerator :: hipExternalSemaphoreHandleTypeOpaqueWin32 = 2
-    enumerator :: hipExternalSemaphoreHandleTypeOpaqueWin32Kmt = 3
-    enumerator :: hipExternalSemaphoreHandleTypeD3D12Fence = 4
-  end enum
-
-  enum, bind(c)
-    enumerator :: hipGLDeviceListAll = 1
-    enumerator :: hipGLDeviceListCurrentFrame = 2
-    enumerator :: hipGLDeviceListNextFrame = 3
-  end enum
-
-  enum, bind(c)
-    enumerator :: hipGraphicsRegisterFlagsNone = 0
-    enumerator :: hipGraphicsRegisterFlagsReadOnly = 1
-    enumerator :: hipGraphicsRegisterFlagsWriteDiscard = 2
-    enumerator :: hipGraphicsRegisterFlagsSurfaceLoadStore = 4
-    enumerator :: hipGraphicsRegisterFlagsTextureGather = 8
-  end enum
-
-  enum, bind(c)
-    enumerator :: hipGraphNodeTypeKernel = 1
-    enumerator :: hipGraphNodeTypeMemcpy = 2
-    enumerator :: hipGraphNodeTypeMemset = 3
-    enumerator :: hipGraphNodeTypeHost = 4
-    enumerator :: hipGraphNodeTypeGraph = 5
-    enumerator :: hipGraphNodeTypeEmpty = 6
-    enumerator :: hipGraphNodeTypeWaitEvent = 7
-    enumerator :: hipGraphNodeTypeEventRecord = 8
-    enumerator :: hipGraphNodeTypeMemcpy1D = 9
-    enumerator :: hipGraphNodeTypeMemcpyFromSymbol = 10
-    enumerator :: hipGraphNodeTypeMemcpyToSymbol = 11
-    enumerator :: hipGraphNodeTypeCount
-  end enum
-
-  enum, bind(c)
-    enumerator :: hipGraphExecUpdateSuccess = 0
-    enumerator :: hipGraphExecUpdateError = 1
-    enumerator :: hipGraphExecUpdateErrorTopologyChanged = 2
-    enumerator :: hipGraphExecUpdateErrorNodeTypeChanged = 3
-    enumerator :: hipGraphExecUpdateErrorFunctionChanged = 4
-    enumerator :: hipGraphExecUpdateErrorParametersChanged = 5
-    enumerator :: hipGraphExecUpdateErrorNotSupported = 6
-    enumerator :: hipGraphExecUpdateErrorUnsupportedFunctionChange = 7
-  end enum
-
-  enum, bind(c)
-    enumerator :: hipStreamCaptureModeGlobal = 0
-    enumerator :: hipStreamCaptureModeThreadLocal
-    enumerator :: hipStreamCaptureModeRelaxed
-  end enum
-
-  enum, bind(c)
-    enumerator :: hipStreamCaptureStatusNone = 0
-    enumerator :: hipStreamCaptureStatusActive
-    enumerator :: hipStreamCaptureStatusInvalidated
-  end enum
-
-  enum, bind(c)
-    enumerator :: hipStreamAddCaptureDependencies = 0
-    enumerator :: hipStreamSetCaptureDependencies
-  end enum
-
+  ! hipChannelFormatKind
   enum, bind(c)
     enumerator :: hipChannelFormatKindSigned = 0
     enumerator :: hipChannelFormatKindUnsigned = 1
@@ -399,6 +407,7 @@ module hipfort_enums
     enumerator :: hipChannelFormatKindNone = 3
   end enum
 
+  ! hipArray_Format
   enum, bind(c)
     enumerator :: HIP_AD_FORMAT_UNSIGNED_INT8 = 1
     enumerator :: HIP_AD_FORMAT_UNSIGNED_INT16 = 2
@@ -410,6 +419,7 @@ module hipfort_enums
     enumerator :: HIP_AD_FORMAT_FLOAT = 32
   end enum
 
+  ! hipResourceType
   enum, bind(c)
     enumerator :: hipResourceTypeArray = 0
     enumerator :: hipResourceTypeMipmappedArray = 1
@@ -417,6 +427,7 @@ module hipfort_enums
     enumerator :: hipResourceTypePitch2D = 3
   end enum
 
+  ! HIPresourcetype_enum
   enum, bind(c)
     enumerator :: HIP_RESOURCE_TYPE_ARRAY = 0
     enumerator :: HIP_RESOURCE_TYPE_MIPMAPPED_ARRAY = 1
@@ -424,6 +435,7 @@ module hipfort_enums
     enumerator :: HIP_RESOURCE_TYPE_PITCH2D = 3
   end enum
 
+  ! HIPaddress_mode_enum
   enum, bind(c)
     enumerator :: HIP_TR_ADDRESS_MODE_WRAP = 0
     enumerator :: HIP_TR_ADDRESS_MODE_CLAMP = 1
@@ -431,11 +443,13 @@ module hipfort_enums
     enumerator :: HIP_TR_ADDRESS_MODE_BORDER = 3
   end enum
 
+  ! HIPfilter_mode_enum
   enum, bind(c)
     enumerator :: HIP_TR_FILTER_MODE_POINT = 0
     enumerator :: HIP_TR_FILTER_MODE_LINEAR = 1
   end enum
 
+  ! hipResourceViewFormat
   enum, bind(c)
     enumerator :: hipResViewFormatNone = 0
     enumerator :: hipResViewFormatUnsignedChar1 = 1
@@ -474,6 +488,7 @@ module hipfort_enums
     enumerator :: hipResViewFormatUnsignedBlockCompressed7 = 34
   end enum
 
+  ! HIPresourceViewFormat_enum
   enum, bind(c)
     enumerator :: HIP_RES_VIEW_FORMAT_NONE = 0
     enumerator :: HIP_RES_VIEW_FORMAT_UINT_1X8 = 1
@@ -512,48 +527,85 @@ module hipfort_enums
     enumerator :: HIP_RES_VIEW_FORMAT_UNSIGNED_BC7 = 34
   end enum
 
+  ! hipMemcpyKind
   enum, bind(c)
     enumerator :: hipMemcpyHostToHost = 0
     enumerator :: hipMemcpyHostToDevice = 1
     enumerator :: hipMemcpyDeviceToHost = 2
     enumerator :: hipMemcpyDeviceToDevice = 3
     enumerator :: hipMemcpyDefault = 4
+    enumerator :: hipMemcpyDeviceToDeviceNoCU = 1024
   end enum
 
+  ! hipMemLocationType
   enum, bind(c)
-    enumerator :: HIP_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK
-    enumerator :: HIP_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES
-    enumerator :: HIP_FUNC_ATTRIBUTE_CONST_SIZE_BYTES
-    enumerator :: HIP_FUNC_ATTRIBUTE_LOCAL_SIZE_BYTES
-    enumerator :: HIP_FUNC_ATTRIBUTE_NUM_REGS
-    enumerator :: HIP_FUNC_ATTRIBUTE_PTX_VERSION
-    enumerator :: HIP_FUNC_ATTRIBUTE_BINARY_VERSION
-    enumerator :: HIP_FUNC_ATTRIBUTE_CACHE_MODE_CA
-    enumerator :: HIP_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES
-    enumerator :: HIP_FUNC_ATTRIBUTE_PREFERRED_SHARED_MEMORY_CARVEOUT
-    enumerator :: HIP_FUNC_ATTRIBUTE_MAX
+    enumerator :: hipMemLocationTypeInvalid = 0
+    enumerator :: hipMemLocationTypeNone = 0
+    enumerator :: hipMemLocationTypeDevice = 1
+    enumerator :: hipMemLocationTypeHost = 2
+    enumerator :: hipMemLocationTypeHostNuma = 3
+    enumerator :: hipMemLocationTypeHostNumaCurrent = 4
   end enum
 
+  ! hipMemcpyFlags
+  enum, bind(c)
+    enumerator :: hipMemcpyFlagDefault = 0
+    enumerator :: hipMemcpyFlagPreferOverlapWithCompute = 1
+  end enum
+
+  ! hipMemcpySrcAccessOrder
+  enum, bind(c)
+    enumerator :: hipMemcpySrcAccessOrderInvalid = 0
+    enumerator :: hipMemcpySrcAccessOrderStream = 1
+    enumerator :: hipMemcpySrcAccessOrderDuringApiCall = 2
+    enumerator :: hipMemcpySrcAccessOrderAny = 3
+    enumerator :: hipMemcpySrcAccessOrderMax = 2147483647
+  end enum
+
+  ! hipMemcpy3DOperandType
+  enum, bind(c)
+    enumerator :: hipMemcpyOperandTypePointer = 1
+    enumerator :: hipMemcpyOperandTypeArray = 2
+    enumerator :: hipMemcpyOperandTypeMax = 2147483647
+  end enum
+
+  ! hipFunction_attribute
+  enum, bind(c)
+    enumerator :: HIP_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK = 0
+    enumerator :: HIP_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES = 1
+    enumerator :: HIP_FUNC_ATTRIBUTE_CONST_SIZE_BYTES = 2
+    enumerator :: HIP_FUNC_ATTRIBUTE_LOCAL_SIZE_BYTES = 3
+    enumerator :: HIP_FUNC_ATTRIBUTE_NUM_REGS = 4
+    enumerator :: HIP_FUNC_ATTRIBUTE_PTX_VERSION = 5
+    enumerator :: HIP_FUNC_ATTRIBUTE_BINARY_VERSION = 6
+    enumerator :: HIP_FUNC_ATTRIBUTE_CACHE_MODE_CA = 7
+    enumerator :: HIP_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES = 8
+    enumerator :: HIP_FUNC_ATTRIBUTE_PREFERRED_SHARED_MEMORY_CARVEOUT = 9
+    enumerator :: HIP_FUNC_ATTRIBUTE_MAX = 10
+  end enum
+
+  ! hipPointer_attribute
   enum, bind(c)
     enumerator :: HIP_POINTER_ATTRIBUTE_CONTEXT = 1
-    enumerator :: HIP_POINTER_ATTRIBUTE_MEMORY_TYPE
-    enumerator :: HIP_POINTER_ATTRIBUTE_DEVICE_POINTER
-    enumerator :: HIP_POINTER_ATTRIBUTE_HOST_POINTER
-    enumerator :: HIP_POINTER_ATTRIBUTE_P2P_TOKENS
-    enumerator :: HIP_POINTER_ATTRIBUTE_SYNC_MEMOPS
-    enumerator :: HIP_POINTER_ATTRIBUTE_BUFFER_ID
-    enumerator :: HIP_POINTER_ATTRIBUTE_IS_MANAGED
-    enumerator :: HIP_POINTER_ATTRIBUTE_DEVICE_ORDINAL
-    enumerator :: HIP_POINTER_ATTRIBUTE_IS_LEGACY_HIP_IPC_CAPABLE
-    enumerator :: HIP_POINTER_ATTRIBUTE_RANGE_START_ADDR
-    enumerator :: HIP_POINTER_ATTRIBUTE_RANGE_SIZE
-    enumerator :: HIP_POINTER_ATTRIBUTE_MAPPED
-    enumerator :: HIP_POINTER_ATTRIBUTE_ALLOWED_HANDLE_TYPES
-    enumerator :: HIP_POINTER_ATTRIBUTE_IS_GPU_DIRECT_RDMA_CAPABLE
-    enumerator :: HIP_POINTER_ATTRIBUTE_ACCESS_FLAGS
-    enumerator :: HIP_POINTER_ATTRIBUTE_MEMPOOL_HANDLE
+    enumerator :: HIP_POINTER_ATTRIBUTE_MEMORY_TYPE = 2
+    enumerator :: HIP_POINTER_ATTRIBUTE_DEVICE_POINTER = 3
+    enumerator :: HIP_POINTER_ATTRIBUTE_HOST_POINTER = 4
+    enumerator :: HIP_POINTER_ATTRIBUTE_P2P_TOKENS = 5
+    enumerator :: HIP_POINTER_ATTRIBUTE_SYNC_MEMOPS = 6
+    enumerator :: HIP_POINTER_ATTRIBUTE_BUFFER_ID = 7
+    enumerator :: HIP_POINTER_ATTRIBUTE_IS_MANAGED = 8
+    enumerator :: HIP_POINTER_ATTRIBUTE_DEVICE_ORDINAL = 9
+    enumerator :: HIP_POINTER_ATTRIBUTE_IS_LEGACY_HIP_IPC_CAPABLE = 10
+    enumerator :: HIP_POINTER_ATTRIBUTE_RANGE_START_ADDR = 11
+    enumerator :: HIP_POINTER_ATTRIBUTE_RANGE_SIZE = 12
+    enumerator :: HIP_POINTER_ATTRIBUTE_MAPPED = 13
+    enumerator :: HIP_POINTER_ATTRIBUTE_ALLOWED_HANDLE_TYPES = 14
+    enumerator :: HIP_POINTER_ATTRIBUTE_IS_GPU_DIRECT_RDMA_CAPABLE = 15
+    enumerator :: HIP_POINTER_ATTRIBUTE_ACCESS_FLAGS = 16
+    enumerator :: HIP_POINTER_ATTRIBUTE_MEMPOOL_HANDLE = 17
   end enum
 
+  ! hipTextureAddressMode
   enum, bind(c)
     enumerator :: hipAddressModeWrap = 0
     enumerator :: hipAddressModeClamp = 1
@@ -561,59 +613,442 @@ module hipfort_enums
     enumerator :: hipAddressModeBorder = 3
   end enum
 
+  ! hipTextureFilterMode
   enum, bind(c)
     enumerator :: hipFilterModePoint = 0
     enumerator :: hipFilterModeLinear = 1
   end enum
 
+  ! hipTextureReadMode
   enum, bind(c)
     enumerator :: hipReadModeElementType = 0
     enumerator :: hipReadModeNormalizedFloat = 1
   end enum
 
+  ! hipSurfaceBoundaryMode
   enum, bind(c)
-    enumerator :: HIP_R_32F = 0
-    enumerator :: HIP_R_64F = 1
-    enumerator :: HIP_R_16F = 2
-    enumerator :: HIP_R_8I = 3
-    enumerator :: HIP_C_32F = 4
-    enumerator :: HIP_C_64F = 5
-    enumerator :: HIP_C_16F = 6
-    enumerator :: HIP_C_8I = 7
-    enumerator :: HIP_R_8U = 8
-    enumerator :: HIP_C_8U = 9
-    enumerator :: HIP_R_32I = 10
-    enumerator :: HIP_C_32I = 11
-    enumerator :: HIP_R_32U = 12
-    enumerator :: HIP_C_32U = 13
-    enumerator :: HIP_R_16BF = 14
-    enumerator :: HIP_C_16BF = 15
-    enumerator :: HIP_R_4I = 16
-    enumerator :: HIP_C_4I = 17
-    enumerator :: HIP_R_4U = 18
-    enumerator :: HIP_C_4U = 19
-    enumerator :: HIP_R_16I = 20
-    enumerator :: HIP_C_16I = 21
-    enumerator :: HIP_R_16U = 22
-    enumerator :: HIP_C_16U = 23
-    enumerator :: HIP_R_64I = 24
-    enumerator :: HIP_C_64I = 25
-    enumerator :: HIP_R_64U = 26
-    enumerator :: HIP_C_64U = 27
-    enumerator :: HIP_R_8F_E4M3_FNUZ = 1000
-    enumerator :: HIP_R_8F_E5M2_FNUZ = 1001
+    enumerator :: hipBoundaryModeZero = 0
+    enumerator :: hipBoundaryModeTrap = 1
+    enumerator :: hipBoundaryModeClamp = 2
   end enum
 
+  ! hipDeviceP2PAttr
   enum, bind(c)
-    enumerator :: HIP_LIBRARY_MAJOR_VERSION
-    enumerator :: HIP_LIBRARY_MINOR_VERSION
-    enumerator :: HIP_LIBRARY_PATCH_LEVEL
+    enumerator :: hipDevP2PAttrPerformanceRank = 0
+    enumerator :: hipDevP2PAttrAccessSupported = 1
+    enumerator :: hipDevP2PAttrNativeAtomicSupported = 2
+    enumerator :: hipDevP2PAttrHipArrayAccessSupported = 3
   end enum
 
- 
+  ! hipDriverEntryPointQueryResult
+  enum, bind(c)
+    enumerator :: hipDriverEntryPointSuccess = 0
+    enumerator :: hipDriverEntryPointSymbolNotFound = 1
+    enumerator :: hipDriverEntryPointVersionNotSufficent = 2
+  end enum
 
-#ifdef USE_FPOINTER_INTERFACES
+  ! hipLimit_t
+  enum, bind(c)
+    enumerator :: hipLimitStackSize = 0
+    enumerator :: hipLimitPrintfFifoSize = 1
+    enumerator :: hipLimitMallocHeapSize = 2
+    enumerator :: hipExtLimitScratchMin = 4096
+    enumerator :: hipExtLimitScratchMax = 4097
+    enumerator :: hipExtLimitScratchCurrent = 4098
+    enumerator :: hipLimitRange = 4099
+  end enum
 
-  
-#endif
+  ! hipStreamBatchMemOpType
+  enum, bind(c)
+    enumerator :: hipStreamMemOpWaitValue32 = 1
+    enumerator :: hipStreamMemOpWriteValue32 = 2
+    enumerator :: hipStreamMemOpWaitValue64 = 4
+    enumerator :: hipStreamMemOpWriteValue64 = 5
+    enumerator :: hipStreamMemOpBarrier = 6
+    enumerator :: hipStreamMemOpFlushRemoteWrites = 3
+  end enum
+
+  ! hipMemoryAdvise
+  enum, bind(c)
+    enumerator :: hipMemAdviseSetReadMostly = 1
+    enumerator :: hipMemAdviseUnsetReadMostly = 2
+    enumerator :: hipMemAdviseSetPreferredLocation = 3
+    enumerator :: hipMemAdviseUnsetPreferredLocation = 4
+    enumerator :: hipMemAdviseSetAccessedBy = 5
+    enumerator :: hipMemAdviseUnsetAccessedBy = 6
+    enumerator :: hipMemAdviseSetCoarseGrain = 100
+    enumerator :: hipMemAdviseUnsetCoarseGrain = 101
+  end enum
+
+  ! hipMemRangeCoherencyMode
+  enum, bind(c)
+    enumerator :: hipMemRangeCoherencyModeFineGrain = 0
+    enumerator :: hipMemRangeCoherencyModeCoarseGrain = 1
+    enumerator :: hipMemRangeCoherencyModeIndeterminate = 2
+  end enum
+
+  ! hipMemRangeAttribute
+  enum, bind(c)
+    enumerator :: hipMemRangeAttributeReadMostly = 1
+    enumerator :: hipMemRangeAttributePreferredLocation = 2
+    enumerator :: hipMemRangeAttributeAccessedBy = 3
+    enumerator :: hipMemRangeAttributeLastPrefetchLocation = 4
+    enumerator :: hipMemRangeAttributeCoherencyMode = 100
+  end enum
+
+  ! hipMemPoolAttr
+  enum, bind(c)
+    enumerator :: hipMemPoolReuseFollowEventDependencies = 1
+    enumerator :: hipMemPoolReuseAllowOpportunistic = 2
+    enumerator :: hipMemPoolReuseAllowInternalDependencies = 3
+    enumerator :: hipMemPoolAttrReleaseThreshold = 4
+    enumerator :: hipMemPoolAttrReservedMemCurrent = 5
+    enumerator :: hipMemPoolAttrReservedMemHigh = 6
+    enumerator :: hipMemPoolAttrUsedMemCurrent = 7
+    enumerator :: hipMemPoolAttrUsedMemHigh = 8
+  end enum
+
+  ! hipMemAccessFlags
+  enum, bind(c)
+    enumerator :: hipMemAccessFlagsProtNone = 0
+    enumerator :: hipMemAccessFlagsProtRead = 1
+    enumerator :: hipMemAccessFlagsProtReadWrite = 3
+  end enum
+
+  ! hipMemAllocationType
+  enum, bind(c)
+    enumerator :: hipMemAllocationTypeInvalid = 0
+    enumerator :: hipMemAllocationTypePinned = 1
+    enumerator :: hipMemAllocationTypeUncached = 1073741824
+    enumerator :: hipMemAllocationTypeMax = 2147483647
+  end enum
+
+  ! hipMemAllocationHandleType
+  enum, bind(c)
+    enumerator :: hipMemHandleTypeNone = 0
+    enumerator :: hipMemHandleTypePosixFileDescriptor = 1
+    enumerator :: hipMemHandleTypeWin32 = 2
+    enumerator :: hipMemHandleTypeWin32Kmt = 4
+  end enum
+
+  ! hipFuncAttribute
+  enum, bind(c)
+    enumerator :: hipFuncAttributeMaxDynamicSharedMemorySize = 8
+    enumerator :: hipFuncAttributePreferredSharedMemoryCarveout = 9
+    enumerator :: hipFuncAttributeMax = 10
+  end enum
+
+  ! hipFuncCache_t
+  enum, bind(c)
+    enumerator :: hipFuncCachePreferNone = 0
+    enumerator :: hipFuncCachePreferShared = 1
+    enumerator :: hipFuncCachePreferL1 = 2
+    enumerator :: hipFuncCachePreferEqual = 3
+  end enum
+
+  ! hipSharedMemConfig
+  enum, bind(c)
+    enumerator :: hipSharedMemBankSizeDefault = 0
+    enumerator :: hipSharedMemBankSizeFourByte = 1
+    enumerator :: hipSharedMemBankSizeEightByte = 2
+  end enum
+
+  ! hipExternalMemoryHandleType_enum
+  enum, bind(c)
+    enumerator :: hipExternalMemoryHandleTypeOpaqueFd = 1
+    enumerator :: hipExternalMemoryHandleTypeOpaqueWin32 = 2
+    enumerator :: hipExternalMemoryHandleTypeOpaqueWin32Kmt = 3
+    enumerator :: hipExternalMemoryHandleTypeD3D12Heap = 4
+    enumerator :: hipExternalMemoryHandleTypeD3D12Resource = 5
+    enumerator :: hipExternalMemoryHandleTypeD3D11Resource = 6
+    enumerator :: hipExternalMemoryHandleTypeD3D11ResourceKmt = 7
+    enumerator :: hipExternalMemoryHandleTypeNvSciBuf = 8
+  end enum
+
+  ! hipExternalSemaphoreHandleType_enum
+  enum, bind(c)
+    enumerator :: hipExternalSemaphoreHandleTypeOpaqueFd = 1
+    enumerator :: hipExternalSemaphoreHandleTypeOpaqueWin32 = 2
+    enumerator :: hipExternalSemaphoreHandleTypeOpaqueWin32Kmt = 3
+    enumerator :: hipExternalSemaphoreHandleTypeD3D12Fence = 4
+    enumerator :: hipExternalSemaphoreHandleTypeD3D11Fence = 5
+    enumerator :: hipExternalSemaphoreHandleTypeNvSciSync = 6
+    enumerator :: hipExternalSemaphoreHandleTypeKeyedMutex = 7
+    enumerator :: hipExternalSemaphoreHandleTypeKeyedMutexKmt = 8
+    enumerator :: hipExternalSemaphoreHandleTypeTimelineSemaphoreFd = 9
+    enumerator :: hipExternalSemaphoreHandleTypeTimelineSemaphoreWin32 = 10
+  end enum
+
+  ! hipGraphicsRegisterFlags
+  enum, bind(c)
+    enumerator :: hipGraphicsRegisterFlagsNone = 0
+    enumerator :: hipGraphicsRegisterFlagsReadOnly = 1
+    enumerator :: hipGraphicsRegisterFlagsWriteDiscard = 2
+    enumerator :: hipGraphicsRegisterFlagsSurfaceLoadStore = 4
+    enumerator :: hipGraphicsRegisterFlagsTextureGather = 8
+  end enum
+
+  ! hipGraphNodeType
+  enum, bind(c)
+    enumerator :: hipGraphNodeTypeKernel = 0
+    enumerator :: hipGraphNodeTypeMemcpy = 1
+    enumerator :: hipGraphNodeTypeMemset = 2
+    enumerator :: hipGraphNodeTypeHost = 3
+    enumerator :: hipGraphNodeTypeGraph = 4
+    enumerator :: hipGraphNodeTypeEmpty = 5
+    enumerator :: hipGraphNodeTypeWaitEvent = 6
+    enumerator :: hipGraphNodeTypeEventRecord = 7
+    enumerator :: hipGraphNodeTypeExtSemaphoreSignal = 8
+    enumerator :: hipGraphNodeTypeExtSemaphoreWait = 9
+    enumerator :: hipGraphNodeTypeMemAlloc = 10
+    enumerator :: hipGraphNodeTypeMemFree = 11
+    enumerator :: hipGraphNodeTypeMemcpyFromSymbol = 12
+    enumerator :: hipGraphNodeTypeMemcpyToSymbol = 13
+    enumerator :: hipGraphNodeTypeBatchMemOp = 14
+    enumerator :: hipGraphNodeTypeCount = 15
+  end enum
+
+  ! hipAccessProperty
+  enum, bind(c)
+    enumerator :: hipAccessPropertyNormal = 0
+    enumerator :: hipAccessPropertyStreaming = 1
+    enumerator :: hipAccessPropertyPersisting = 2
+  end enum
+
+  ! hipLaunchMemSyncDomain
+  enum, bind(c)
+    enumerator :: hipLaunchMemSyncDomainDefault = 0
+    enumerator :: hipLaunchMemSyncDomainRemote = 1
+  end enum
+
+  ! hipSynchronizationPolicy
+  enum, bind(c)
+    enumerator :: hipSyncPolicyAuto = 1
+    enumerator :: hipSyncPolicySpin = 2
+    enumerator :: hipSyncPolicyYield = 3
+    enumerator :: hipSyncPolicyBlockingSync = 4
+  end enum
+
+  ! hipLaunchAttributeID
+  enum, bind(c)
+    enumerator :: hipLaunchAttributeAccessPolicyWindow = 1
+    enumerator :: hipLaunchAttributeCooperative = 2
+    enumerator :: hipLaunchAttributeSynchronizationPolicy = 3
+    enumerator :: hipLaunchAttributePriority = 8
+    enumerator :: hipLaunchAttributeMemSyncDomainMap = 9
+    enumerator :: hipLaunchAttributeMemSyncDomain = 10
+    enumerator :: hipLaunchAttributeMax = 11
+  end enum
+
+  ! hipGraphExecUpdateResult
+  enum, bind(c)
+    enumerator :: hipGraphExecUpdateSuccess = 0
+    enumerator :: hipGraphExecUpdateError = 1
+    enumerator :: hipGraphExecUpdateErrorTopologyChanged = 2
+    enumerator :: hipGraphExecUpdateErrorNodeTypeChanged = 3
+    enumerator :: hipGraphExecUpdateErrorFunctionChanged = 4
+    enumerator :: hipGraphExecUpdateErrorParametersChanged = 5
+    enumerator :: hipGraphExecUpdateErrorNotSupported = 6
+    enumerator :: hipGraphExecUpdateErrorUnsupportedFunctionChange = 7
+  end enum
+
+  ! hipStreamCaptureMode
+  enum, bind(c)
+    enumerator :: hipStreamCaptureModeGlobal = 0
+    enumerator :: hipStreamCaptureModeThreadLocal = 1
+    enumerator :: hipStreamCaptureModeRelaxed = 2
+  end enum
+
+  ! hipStreamCaptureStatus
+  enum, bind(c)
+    enumerator :: hipStreamCaptureStatusNone = 0
+    enumerator :: hipStreamCaptureStatusActive = 1
+    enumerator :: hipStreamCaptureStatusInvalidated = 2
+  end enum
+
+  ! hipStreamUpdateCaptureDependenciesFlags
+  enum, bind(c)
+    enumerator :: hipStreamAddCaptureDependencies = 0
+    enumerator :: hipStreamSetCaptureDependencies = 1
+  end enum
+
+  ! hipGraphMemAttributeType
+  enum, bind(c)
+    enumerator :: hipGraphMemAttrUsedMemCurrent = 0
+    enumerator :: hipGraphMemAttrUsedMemHigh = 1
+    enumerator :: hipGraphMemAttrReservedMemCurrent = 2
+    enumerator :: hipGraphMemAttrReservedMemHigh = 3
+  end enum
+
+  ! hipUserObjectFlags
+  enum, bind(c)
+    enumerator :: hipUserObjectNoDestructorSync = 1
+  end enum
+
+  ! hipUserObjectRetainFlags
+  enum, bind(c)
+    enumerator :: hipGraphUserObjectMove = 1
+  end enum
+
+  ! hipGraphInstantiateFlags
+  enum, bind(c)
+    enumerator :: hipGraphInstantiateFlagAutoFreeOnLaunch = 1
+    enumerator :: hipGraphInstantiateFlagUpload = 2
+    enumerator :: hipGraphInstantiateFlagDeviceLaunch = 4
+    enumerator :: hipGraphInstantiateFlagUseNodePriority = 8
+  end enum
+
+  ! hipGraphDebugDotFlags
+  enum, bind(c)
+    enumerator :: hipGraphDebugDotFlagsVerbose = 1
+    enumerator :: hipGraphDebugDotFlagsKernelNodeParams = 4
+    enumerator :: hipGraphDebugDotFlagsMemcpyNodeParams = 8
+    enumerator :: hipGraphDebugDotFlagsMemsetNodeParams = 16
+    enumerator :: hipGraphDebugDotFlagsHostNodeParams = 32
+    enumerator :: hipGraphDebugDotFlagsEventNodeParams = 64
+    enumerator :: hipGraphDebugDotFlagsExtSemasSignalNodeParams = 128
+    enumerator :: hipGraphDebugDotFlagsExtSemasWaitNodeParams = 256
+    enumerator :: hipGraphDebugDotFlagsKernelNodeAttributes = 512
+    enumerator :: hipGraphDebugDotFlagsHandles = 1024
+  end enum
+
+  ! hipGraphInstantiateResult
+  enum, bind(c)
+    enumerator :: hipGraphInstantiateSuccess = 0
+    enumerator :: hipGraphInstantiateError = 1
+    enumerator :: hipGraphInstantiateInvalidStructure = 2
+    enumerator :: hipGraphInstantiateNodeOperationNotSupported = 3
+    enumerator :: hipGraphInstantiateMultipleDevicesNotSupported = 4
+  end enum
+
+  ! hipMemAllocationGranularity_flags
+  enum, bind(c)
+    enumerator :: hipMemAllocationGranularityMinimum = 0
+    enumerator :: hipMemAllocationGranularityRecommended = 1
+  end enum
+
+  ! hipMemHandleType
+  enum, bind(c)
+    enumerator :: hipMemHandleTypeGeneric = 0
+  end enum
+
+  ! hipMemOperationType
+  enum, bind(c)
+    enumerator :: hipMemOperationTypeMap = 1
+    enumerator :: hipMemOperationTypeUnmap = 2
+  end enum
+
+  ! hipArraySparseSubresourceType
+  enum, bind(c)
+    enumerator :: hipArraySparseSubresourceTypeSparseLevel = 0
+    enumerator :: hipArraySparseSubresourceTypeMiptail = 1
+  end enum
+
+  ! hipGraphDependencyType
+  enum, bind(c)
+    enumerator :: hipGraphDependencyTypeDefault = 0
+    enumerator :: hipGraphDependencyTypeProgrammatic = 1
+  end enum
+
+  ! hipMemRangeHandleType
+  enum, bind(c)
+    enumerator :: hipMemRangeHandleTypeDmaBufFd = 1
+    enumerator :: hipMemRangeHandleTypeMax = 2147483647
+  end enum
+
+  ! hipMemRangeFlags
+  enum, bind(c)
+    enumerator :: hipMemRangeFlagDmaBufMappingTypePcie = 1
+    enumerator :: hipMemRangeFlagsMax = 2147483647
+  end enum
+
+  integer(c_int), parameter :: HIP_VERSION_MAJOR = 7
+  integer(c_int), parameter :: HIP_VERSION_MINOR = 2
+  integer(c_int), parameter :: HIP_VERSION_PATCH = 53211
+  integer(c_int), parameter :: HIP_VERSION_BUILD_ID = 0
+  integer(c_int), parameter :: GENERIC_GRID_LAUNCH = 1
+  integer(c_int), parameter :: HIP_TRSA_OVERRIDE_FORMAT = 1
+  integer(c_int), parameter :: HIP_TRSF_READ_AS_INTEGER = 1
+  integer(c_int), parameter :: HIP_TRSF_NORMALIZED_COORDINATES = 2
+  integer(c_int), parameter :: HIP_TRSF_SRGB = 16
+  integer(c_int), parameter :: hipTextureType1D = 1
+  integer(c_int), parameter :: hipTextureType2D = 2
+  integer(c_int), parameter :: hipTextureType3D = 3
+  integer(c_int), parameter :: hipTextureTypeCubemap = 12
+  integer(c_int), parameter :: hipTextureType1DLayered = 241
+  integer(c_int), parameter :: hipTextureType2DLayered = 242
+  integer(c_int), parameter :: hipTextureTypeCubemapLayered = 252
+  integer(c_int), parameter :: HIP_IMAGE_OBJECT_SIZE_DWORD = 12
+  integer(c_int), parameter :: HIP_SAMPLER_OBJECT_SIZE_DWORD = 8
+  integer(c_int), parameter :: hipIpcMemLazyEnablePeerAccess = 1
+  integer(c_int), parameter :: HIP_IPC_HANDLE_SIZE = 64
+  integer(c_int), parameter :: hipStreamDefault = 0
+  integer(c_int), parameter :: hipStreamNonBlocking = 1
+  integer(c_int), parameter :: hipEventDefault = 0
+  integer(c_int), parameter :: hipEventBlockingSync = 1
+  integer(c_int), parameter :: hipEventDisableTiming = 2
+  integer(c_int), parameter :: hipEventInterprocess = 4
+  integer(c_int), parameter :: hipEventRecordDefault = 0
+  integer(c_int), parameter :: hipEventRecordExternal = 1
+  integer(c_int), parameter :: hipEventWaitDefault = 0
+  integer(c_int), parameter :: hipEventWaitExternal = 1
+  integer(c_int), parameter :: hipEventDisableSystemFence = 536870912
+  integer(c_int), parameter :: hipEventReleaseToDevice = 1073741824
+  integer(c_int64_t), parameter :: hipEventReleaseToSystem = 2147483648_c_int64_t
+  integer(c_int), parameter :: hipEnableDefault = 0
+  integer(c_int), parameter :: hipEnableLegacyStream = 1
+  integer(c_int), parameter :: hipEnablePerThreadDefaultStream = 2
+  integer(c_int), parameter :: hipHostAllocDefault = 0
+  integer(c_int), parameter :: hipHostMallocDefault = 0
+  integer(c_int), parameter :: hipHostAllocPortable = 1
+  integer(c_int), parameter :: hipHostMallocPortable = 1
+  integer(c_int), parameter :: hipHostAllocMapped = 2
+  integer(c_int), parameter :: hipHostMallocMapped = 2
+  integer(c_int), parameter :: hipHostAllocWriteCombined = 4
+  integer(c_int), parameter :: hipHostMallocWriteCombined = 4
+  integer(c_int), parameter :: hipHostMallocUncached = 268435456
+  integer(c_int), parameter :: hipHostMallocNumaUser = 536870912
+  integer(c_int), parameter :: hipHostMallocCoherent = 1073741824
+  integer(c_int64_t), parameter :: hipHostMallocNonCoherent = 2147483648_c_int64_t
+  integer(c_int), parameter :: hipMemAttachGlobal = 1
+  integer(c_int), parameter :: hipMemAttachHost = 2
+  integer(c_int), parameter :: hipMemAttachSingle = 4
+  integer(c_int), parameter :: hipDeviceMallocDefault = 0
+  integer(c_int), parameter :: hipDeviceMallocFinegrained = 1
+  integer(c_int), parameter :: hipMallocSignalMemory = 2
+  integer(c_int), parameter :: hipDeviceMallocUncached = 3
+  integer(c_int), parameter :: hipDeviceMallocContiguous = 4
+  integer(c_int), parameter :: hipHostRegisterDefault = 0
+  integer(c_int), parameter :: hipHostRegisterPortable = 1
+  integer(c_int), parameter :: hipHostRegisterMapped = 2
+  integer(c_int), parameter :: hipHostRegisterIoMemory = 4
+  integer(c_int), parameter :: hipHostRegisterReadOnly = 8
+  integer(c_int), parameter :: hipExtHostRegisterCoarseGrained = 8
+  integer(c_int64_t), parameter :: hipExtHostRegisterUncached = 2147483648_c_int64_t
+  integer(c_int), parameter :: hipDeviceScheduleAuto = 0
+  integer(c_int), parameter :: hipDeviceScheduleSpin = 1
+  integer(c_int), parameter :: hipDeviceScheduleYield = 2
+  integer(c_int), parameter :: hipDeviceScheduleBlockingSync = 4
+  integer(c_int), parameter :: hipDeviceScheduleMask = 7
+  integer(c_int), parameter :: hipDeviceMapHost = 8
+  integer(c_int), parameter :: hipDeviceLmemResizeToMax = 16
+  integer(c_int), parameter :: hipArrayDefault = 0
+  integer(c_int), parameter :: hipArrayLayered = 1
+  integer(c_int), parameter :: hipArraySurfaceLoadStore = 2
+  integer(c_int), parameter :: hipArrayCubemap = 4
+  integer(c_int), parameter :: hipArrayTextureGather = 8
+  integer(c_int), parameter :: hipOccupancyDefault = 0
+  integer(c_int), parameter :: hipOccupancyDisableCachingOverride = 1
+  integer(c_int), parameter :: hipCooperativeLaunchMultiDeviceNoPreSync = 1
+  integer(c_int), parameter :: hipCooperativeLaunchMultiDeviceNoPostSync = 2
+  integer(c_int), parameter :: hipExtAnyOrderLaunch = 1
+  integer(c_int), parameter :: hipStreamWaitValueGte = 0
+  integer(c_int), parameter :: hipStreamWaitValueEq = 1
+  integer(c_int), parameter :: hipStreamWaitValueAnd = 2
+  integer(c_int), parameter :: hipStreamWaitValueNor = 3
+  integer(c_int), parameter :: hipExternalMemoryDedicated = 1
+  integer(c_int), parameter :: hipGraphKernelNodePortDefault = 0
+  integer(c_int), parameter :: hipGraphKernelNodePortLaunchCompletion = 2
+  integer(c_int), parameter :: hipGraphKernelNodePortProgrammatic = 1
+
 end module hipfort_enums

--- a/lib/hipfort/hipfort_types.F90
+++ b/lib/hipfort/hipfort_types.F90
@@ -1,17 +1,47 @@
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! ==============================================================================
+! hipfort: FORTRAN Interfaces for GPU kernels
+! ==============================================================================
+! Copyright (c) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+! [MITx11 License]
+!
+! Permission is hereby granted, free of charge, to any person obtaining a copy
+! of this software and associated documentation files (the "Software"), to deal
+! in the Software without restriction, including without limitation the rights
+! to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+! copies of the Software, and to permit persons to whom the Software is
+! furnished to do so, subject to the following conditions:
+!
+! The above copyright notice and this permission notice shall be included in
+! all copies or substantial portions of the Software.
+!
+! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+! IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+! AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+! OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+! THE SOFTWARE.
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
 module hipfort_types
-  use iso_c_binding
+  use, intrinsic :: iso_c_binding
   implicit none
 
-  !> Derived type that can be mapped directly to a CUDA/HIP C++ dim3.  
-  type,bind(c) :: dim3
-     integer(c_int) :: x=1,y=1,z=1
-  end type dim3
+  type, bind(c) :: hipDeviceArch_t
+    integer(c_int32_t) :: opaque(1)
+  end type hipDeviceArch_t
 
+  type, bind(c) :: hipUUID
+    character(c_char) :: bytes(16)
+  end type hipUUID
 
 #ifdef USE_CUDA_NAMES
-  type,bind(c) :: hipDeviceProp_t  ! as of cuda 11.4
+  type,bind(c) :: hipDeviceProp_t  ! as of cuda 13.3 (CUDART 13030); ABI-stable across 13.3 updates
     character(kind=c_char) :: name(256)
     character(kind=c_char) :: uuid(16)
+    character(kind=c_char) :: luid(8)
+    integer(c_int) :: luidDeviceNodeMask
     integer(c_size_t) :: totalGlobalMem
     integer(c_size_t) :: sharedMemPerBlock
     integer(c_int) :: regsPerBlock
@@ -20,21 +50,16 @@ module hipfort_types
     integer(c_int) :: maxThreadsPerBlock
     integer(c_int) :: maxThreadsDim(3)
     integer(c_int) :: maxGridSize(3)
-    integer(c_int) :: clockRate
     integer(c_size_t) :: totalConstMem
     integer(c_int) :: major
     integer(c_int) :: minor
     integer(c_size_t) :: textureAlignment
     integer(c_size_t) :: texturePitchAlignment
-    integer(c_int) :: deviceOverlap
     integer(c_int) :: multiProcessorCount
-    integer(c_int) :: kernelExecTimeoutEnabled
     integer(c_int) :: integrated
     integer(c_int) :: canMapHostMemory
-    integer(c_int) :: computeMode
     integer(c_int) :: maxTexture1D
     integer(c_int) :: maxTexture1DMipmap
-    integer(c_int) :: maxTexture1DLinear
     integer(c_int) :: maxTexture2D(2)
     integer(c_int) :: maxTexture2DMipmap(2)
     integer(c_int) :: maxTexture2DLinear(3)
@@ -61,7 +86,6 @@ module hipfort_types
     integer(c_int) :: tccDriver
     integer(c_int) :: asyncEngineCount
     integer(c_int) :: unifiedAddressing
-    integer(c_int) :: memoryClockRate
     integer(c_int) :: memoryBusWidth
     integer(c_int) :: l2CacheSize
     integer(c_int) :: persistingL2CacheMaxSize
@@ -74,151 +98,631 @@ module hipfort_types
     integer(c_int) :: managedMemory
     integer(c_int) :: isMultiGpuBoard
     integer(c_int) :: multiGpuBoardGroupID
-    integer(c_int) :: singleToDoublePrecisionPerfRatio
+    integer(c_int) :: hostNativeAtomicSupported
     integer(c_int) :: pageableMemoryAccess
     integer(c_int) :: concurrentManagedAccess
     integer(c_int) :: computePreemptionSupported
     integer(c_int) :: canUseHostPointerForRegisteredMem
     integer(c_int) :: cooperativeLaunch
-    integer(c_int) :: cooperativeMultiDeviceLaunch
+    integer(c_size_t) :: sharedMemPerBlockOptin
     integer(c_int) :: pageableMemoryAccessUsesHostPageTables
     integer(c_int) :: directManagedMemAccessFromHost
+    integer(c_int) :: maxBlocksPerMultiProcessor
     integer(c_int) :: accessPolicyMaxWindowSize
-    character(kind=c_char) :: GPUFORT_PADDING(256) !< GPUFORT :Some extra bytes to prevent seg faults in newer versions
+    integer(c_size_t) :: reservedSharedMemPerBlock
+    integer(c_int) :: hostRegisterSupported
+    integer(c_int) :: sparseCudaArraySupported
+    integer(c_int) :: hostRegisterReadOnlySupported
+    integer(c_int) :: timelineSemaphoreInteropSupported
+    integer(c_int) :: memoryPoolsSupported
+    integer(c_int) :: gpuDirectRDMASupported
+    integer(c_int) :: gpuDirectRDMAFlushWritesOptions
+    integer(c_int) :: gpuDirectRDMAWritesOrdering
+    integer(c_int) :: memoryPoolSupportedHandleTypes
+    integer(c_int) :: deferredMappingCudaArraySupported
+    integer(c_int) :: ipcEventSupported
+    integer(c_int) :: clusterLaunch
+    integer(c_int) :: unifiedFunctionPointers
+    integer(c_int) :: deviceNumaConfig
+    integer(c_int) :: deviceNumaId
+    integer(c_int) :: mpsEnabled
+    integer(c_int) :: hostNumaId
+    integer(c_int) :: gpuPciDeviceID
+    integer(c_int) :: gpuPciSubsystemID
+    integer(c_int) :: hostNumaMultinodeIpcSupported
+    integer(c_int) :: reserved(56)
   end type hipDeviceProp_t
 #else
-  type,bind(c) :: hipDeviceProp_t ! as of ROCm 4.4
-    character(kind=c_char) :: name(256)            !< Device name.
-    integer(c_size_t) :: totalGlobalMem     !< Size of global memory region (in bytes).
-    integer(c_size_t) :: sharedMemPerBlock  !< Size of shared memory region (in bytes).
-    integer(c_int) :: regsPerBlock          !< Registers per block.
-    integer(c_int) :: warpSize              !< Warp size.
-    integer(c_int) :: maxThreadsPerBlock    !< Max work items per work group or workgroup max size.
-    integer(c_int) :: maxThreadsDim(3)      !< Max number of threads in each dimension (XYZ) of a block.
-    integer(c_int) :: maxGridSize(3)        !< Max grid dimensions (XYZ).
-    integer(c_int) :: clockRate             !< Max clock frequency of the multiProcessors in khz.
-    integer(c_int) :: memoryClockRate       !< Max global memory clock frequency in khz.
-    integer(c_int) :: memoryBusWidth        !< Global memory bus width in bits.
-    integer(c_size_t) :: totalConstMem      !< Size of shared memory region (in bytes).
-    integer(c_int) :: major  !< Major compute capability.  On HCC, this is an approximation and features may
-                !< differ from CUDA CC.  See the arch feature flags for portable ways to query
-                !< feature caps.
-    integer(c_int) :: minor  !< Minor compute capability.  On HCC, this is an approximation and features may
-                !< differ from CUDA CC.  See the arch feature flags for portable ways to query
-                !< feature caps.
-    integer(c_int) :: multiProcessorCount          !< Number of multi-processors (compute units).
-    integer(c_int) :: l2CacheSize                  !< L2 cache size.
-    integer(c_int) :: maxThreadsPerMultiProcessor  !< Maximum resident threads per multi-processor.
-    integer(c_int) :: computeMode                  !< Compute mode.
-    integer(c_int) :: clockInstructionRate  !< Frequency in khz of the timer used by the device-side "clock*"
-                               !< instructions.  New for HIP.
-    integer(c_int) arch       !< Architectural feature flags.  New for HIP. 
-    integer(c_int) :: concurrentKernels     !< Device can possibly execute multiple kernels concurrently.
-    integer(c_int) :: pciDomainID           !< PCI Domain ID
-    integer(c_int) :: pciBusID              !< PCI Bus ID.
-    integer(c_int) :: pciDeviceID           !< PCI Device ID.
-    integer(c_size_t) :: maxSharedMemoryPerMultiProcessor  !< Maximum Shared Memory Per Multiprocessor.
-    integer(c_int) :: isMultiGpuBoard                      !< 1 if device is on a multi-GPU board, 0 if not.
-    integer(c_int) :: canMapHostMemory                     !< Check whether HIP can map host memory
-    integer(c_int) :: gcnArch                              !< DEPRECATED: use gcnArchName instead
-    character(kind=c_char) :: gcnArchName(256)                    !< AMD GCN Arch Name.
-    integer(c_int) :: integrated            !< APU vs dGPU
-    integer(c_int) :: cooperativeLaunch            !< HIP device supports cooperative launch
+  type, bind(c) :: hipDeviceProp_t
+    character(c_char) :: name(256) !< Device name.
+    type(hipUUID) :: uuid !< UUID of a device
+    character(c_char) :: luid(8) !< 8-byte unique identifier. Only valid on windows
+    integer(c_int) :: luidDeviceNodeMask !< LUID node mask
+    integer(c_size_t) :: totalGlobalMem !< Size of global memory region (in bytes).
+    integer(c_size_t) :: sharedMemPerBlock !< Size of shared memory per block (in bytes).
+    integer(c_int) :: regsPerBlock !< Registers per block.
+    integer(c_int) :: warpSize !< Warp size.
+    integer(c_size_t) :: memPitch !< Maximum pitch in bytes allowed by memory copies pitched memory
+    integer(c_int) :: maxThreadsPerBlock !< Max work items per work group or workgroup max size.
+    integer(c_int) :: maxThreadsDim(3) !< Max number of threads in each dimension (XYZ) of a block.
+    integer(c_int) :: maxGridSize(3) !< Max grid dimensions (XYZ).
+    integer(c_int) :: clockRate !< Max clock frequency of the multiProcessors in khz.
+    integer(c_size_t) :: totalConstMem !< Size of shared constant memory region on the device (in bytes).
+    integer(c_int) :: major !< Major compute capability version. This indicates the core instruction set of the GPU architect...
+    integer(c_int) :: minor !< Minor compute capability version. This indicates a particular configuration, feature set, or v...
+    integer(c_size_t) :: textureAlignment !< Alignment requirement for textures
+    integer(c_size_t) :: texturePitchAlignment !< Pitch alignment requirement for texture references bound to
+    integer(c_int) :: deviceOverlap !< Deprecated. Use asyncEngineCount instead
+    integer(c_int) :: multiProcessorCount !< Number of multi-processors. When the GPU works in Compute Unit (CU) mode, this v...
+    integer(c_int) :: kernelExecTimeoutEnabled !< Run time limit for kernels executed on the device
+    integer(c_int) :: integrated !< APU vs dGPU
+    integer(c_int) :: canMapHostMemory !< Check whether HIP can map host memory
+    integer(c_int) :: computeMode !< Compute mode.
+    integer(c_int) :: maxTexture1D !< Maximum number of elements in 1D images
+    integer(c_int) :: maxTexture1DMipmap !< Maximum 1D mipmap texture size
+    integer(c_int) :: maxTexture1DLinear !< Maximum size for 1D textures bound to linear memory
+    integer(c_int) :: maxTexture2D(2) !< Maximum dimensions (width, height) of 2D images, in image elements
+    integer(c_int) :: maxTexture2DMipmap(2) !< Maximum number of elements in 2D array mipmap of images
+    integer(c_int) :: maxTexture2DLinear(3) !< Maximum 2D tex dimensions if tex are bound to pitched memory
+    integer(c_int) :: maxTexture2DGather(2) !< Maximum 2D tex dimensions if gather has to be performed
+    integer(c_int) :: maxTexture3D(3) !< Maximum dimensions (width, height, depth) of 3D images, in image elements
+    integer(c_int) :: maxTexture3DAlt(3) !< Maximum alternate 3D texture dims
+    integer(c_int) :: maxTextureCubemap !< Maximum cubemap texture dims
+    integer(c_int) :: maxTexture1DLayered(2) !< Maximum number of elements in 1D array images
+    integer(c_int) :: maxTexture2DLayered(3) !< Maximum number of elements in 2D array images
+    integer(c_int) :: maxTextureCubemapLayered(2) !< Maximum cubemaps layered texture dims
+    integer(c_int) :: maxSurface1D !< Maximum 1D surface size
+    integer(c_int) :: maxSurface2D(2) !< Maximum 2D surface size
+    integer(c_int) :: maxSurface3D(3) !< Maximum 3D surface size
+    integer(c_int) :: maxSurface1DLayered(2) !< Maximum 1D layered surface size
+    integer(c_int) :: maxSurface2DLayered(3) !< Maximum 2D layared surface size
+    integer(c_int) :: maxSurfaceCubemap !< Maximum cubemap surface size
+    integer(c_int) :: maxSurfaceCubemapLayered(2) !< Maximum cubemap layered surface size
+    integer(c_size_t) :: surfaceAlignment !< Alignment requirement for surface
+    integer(c_int) :: concurrentKernels !< Device can possibly execute multiple kernels concurrently.
+    integer(c_int) :: ECCEnabled !< Device has ECC support enabled
+    integer(c_int) :: pciBusID !< PCI Bus ID.
+    integer(c_int) :: pciDeviceID !< PCI Device ID
+    integer(c_int) :: pciDomainID !< PCI Domain ID
+    integer(c_int) :: tccDriver !< 1:If device is Tesla device using TCC driver, else 0
+    integer(c_int) :: asyncEngineCount !< Number of async engines
+    integer(c_int) :: unifiedAddressing !< Does device and host share unified address space
+    integer(c_int) :: memoryClockRate !< Max global memory clock frequency in khz.
+    integer(c_int) :: memoryBusWidth !< Global memory bus width in bits.
+    integer(c_int) :: l2CacheSize !< L2 cache size.
+    integer(c_int) :: persistingL2CacheMaxSize !< Device's max L2 persisting lines in bytes
+    integer(c_int) :: maxThreadsPerMultiProcessor !< Maximum resident threads per multi-processor.
+    integer(c_int) :: streamPrioritiesSupported !< Device supports stream priority
+    integer(c_int) :: globalL1CacheSupported !< Indicates globals are cached in L1
+    integer(c_int) :: localL1CacheSupported !< Locals are cahced in L1
+    integer(c_size_t) :: sharedMemPerMultiprocessor !< Amount of shared memory available per multiprocessor.
+    integer(c_int) :: regsPerMultiprocessor !< registers available per multiprocessor
+    integer(c_int) :: managedMemory !< Device supports allocating managed memory on this system
+    integer(c_int) :: isMultiGpuBoard !< 1 if device is on a multi-GPU board, 0 if not.
+    integer(c_int) :: multiGpuBoardGroupID !< Unique identifier for a group of devices on same multiboard GPU
+    integer(c_int) :: hostNativeAtomicSupported !< Link between host and device supports native atomics
+    integer(c_int) :: singleToDoublePrecisionPerfRatio !< Deprecated. CUDA only.
+    integer(c_int) :: pageableMemoryAccess !< Device supports coherently accessing pageable memory without calling hipHostReg...
+    integer(c_int) :: concurrentManagedAccess !< Device can coherently access managed memory concurrently with the CPU
+    integer(c_int) :: computePreemptionSupported !< Is compute preemption supported on the device
+    integer(c_int) :: canUseHostPointerForRegisteredMem !< Device can access host registered memory with same address as the ...
+    integer(c_int) :: cooperativeLaunch !< HIP device supports cooperative launch
     integer(c_int) :: cooperativeMultiDeviceLaunch !< HIP device supports cooperative launch on multiple devices
-    integer(c_int) :: maxTexture1DLinear    !< Maximum size for 1D textures bound to linear memory
-    integer(c_int) :: maxTexture1D          !< Maximum number of elements in 1D images
-    integer(c_int) :: maxTexture2D(2)       !< Maximum dimensions (width, height) of 2D images, in image elements
-    integer(c_int) :: maxTexture3D(3)       !< Maximum dimensions (width, height, depth) of 3D images, in image elements
-    type(c_ptr) :: hdpMemFlushCntl      !< Addres of HDP_MEM_COHERENCY_FLUSH_CNTL register
-    type(c_ptr) :: hdpRegFlushCntl      !< Addres of HDP_REG_COHERENCY_FLUSH_CNTL register
-    integer(c_size_t) :: memPitch                 !<Maximum pitch in bytes allowed by memory copies
-    integer(c_size_t) :: textureAlignment         !<Alignment requirement for textures
-    integer(c_size_t) :: texturePitchAlignment    !<Pitch alignment requirement for texture references bound to pitched memory
-    integer(c_int) :: kernelExecTimeoutEnabled    !<Run time limit for kernels executed on the device
-    integer(c_int) :: ECCEnabled                  !<Device has ECC support enabled
-    integer(c_int) :: tccDriver                   !< 1:If device is Tesla device using TCC driver, else 0
-    integer(c_int) :: cooperativeMultiDeviceUnmatchedFunc        !< HIP device supports cooperative launch on multiple
-                                                    !devices with unmatched functions
-    integer(c_int) :: cooperativeMultiDeviceUnmatchedGridDim     !< HIP device supports cooperative launch on multiple
-                                                    !devices with unmatched grid dimensions
-    integer(c_int) :: cooperativeMultiDeviceUnmatchedBlockDim    !< HIP device supports cooperative launch on multiple
-                                                    !devices with unmatched block dimensions
-    integer(c_int) :: cooperativeMultiDeviceUnmatchedSharedMem   !< HIP device supports cooperative launch on multiple
-                                                    !devices with unmatched shared memories
-    integer(c_int) :: isLargeBar                  !< 1: if it is a large PCI bar device, else 0
-    integer(c_int) :: asicRevision                !< Revision of the GPU in this device
-    integer(c_int) :: managedMemory               !< Device supports allocating managed memory on this system
-    integer(c_int) :: directManagedMemAccessFromHost !< Host can directly access managed memory on the device without migration
-    integer(c_int) :: concurrentManagedAccess     !< Device can coherently access managed memory concurrently with the CPU
-    integer(c_int) :: pageableMemoryAccess        !< Device supports coherently accessing pageable memory
-                                     !< without calling hipHostRegister on it
+    integer(c_size_t) :: sharedMemPerBlockOptin !< Per device m ax shared mem per block usable by special opt in
     integer(c_int) :: pageableMemoryAccessUsesHostPageTables !< Device accesses pageable memory via the host's page tables
-    character(kind=c_char) :: GPUFORT_PADDING(256) !< GPUFORT :Some extra bytes to prevent seg faults in newer versions
+    integer(c_int) :: directManagedMemAccessFromHost !< Host can directly access managed memory on the device without migration
+    integer(c_int) :: maxBlocksPerMultiProcessor !< Max number of blocks on CU
+    integer(c_int) :: accessPolicyMaxWindowSize !< Max value of access policy window
+    integer(c_size_t) :: reservedSharedMemPerBlock !< Shared memory reserved by driver per block
+    integer(c_int) :: hostRegisterSupported !< Device supports hipHostRegister
+    integer(c_int) :: sparseHipArraySupported !< Indicates if device supports sparse hip arrays
+    integer(c_int) :: hostRegisterReadOnlySupported !< Device supports using the hipHostRegisterReadOnly flag with hipHostReg...
+    integer(c_int) :: timelineSemaphoreInteropSupported !< Indicates external timeline semaphore support
+    integer(c_int) :: memoryPoolsSupported !< Indicates if device supports hipMallocAsync and hipMemPool APIs
+    integer(c_int) :: gpuDirectRDMASupported !< Indicates device support of RDMA APIs
+    integer(c_int) :: gpuDirectRDMAFlushWritesOptions !< Bitmask to be interpreted according to hipFlushGPUDirectRDMAWritesOp...
+    integer(c_int) :: gpuDirectRDMAWritesOrdering !< value of hipGPUDirectRDMAWritesOrdering
+    integer(c_int) :: memoryPoolSupportedHandleTypes !< Bitmask of handle types support with mempool based IPC
+    integer(c_int) :: deferredMappingHipArraySupported !< Device supports deferred mapping HIP arrays and HIP mipmapped arrays
+    integer(c_int) :: ipcEventSupported !< Device supports IPC events
+    integer(c_int) :: clusterLaunch !< Device supports cluster launch
+    integer(c_int) :: unifiedFunctionPointers !< Indicates device supports unified function pointers
+    integer(c_int) :: reserved(63) !< CUDA Reserved.
+    integer(c_int) :: hipReserved(32) !< Reserved for adding new entries for HIP/CUDA.
+    character(c_char) :: gcnArchName(256) !< AMD GCN Arch Name. HIP Only.
+    integer(c_size_t) :: maxSharedMemoryPerMultiProcessor !< Maximum Shared Memory Per CU. HIP Only.
+    integer(c_int) :: clockInstructionRate !< Frequency in khz of the timer used by the device-side "clock*" instructions. Ne...
+    type(hipDeviceArch_t) :: arch !< Architectural feature flags. New for HIP.
+    type(c_ptr) :: hdpMemFlushCntl !< Addres of HDP_MEM_COHERENCY_FLUSH_CNTL register
+    type(c_ptr) :: hdpRegFlushCntl !< Addres of HDP_REG_COHERENCY_FLUSH_CNTL register
+    integer(c_int) :: cooperativeMultiDeviceUnmatchedFunc !< HIP device supports cooperative launch on multiple
+    integer(c_int) :: cooperativeMultiDeviceUnmatchedGridDim !< HIP device supports cooperative launch on multiple
+    integer(c_int) :: cooperativeMultiDeviceUnmatchedBlockDim !< HIP device supports cooperative launch on multiple
+    integer(c_int) :: cooperativeMultiDeviceUnmatchedSharedMem !< HIP device supports cooperative launch on multiple
+    integer(c_int) :: isLargeBar !< 1: if it is a large PCI bar device, else 0
+    integer(c_int) :: asicRevision !< Revision of the GPU in this device
   end type hipDeviceProp_t
 #endif
 
-  ! runtime api parameters
+  type, bind(c) :: hipPointerAttribute_t
+    integer(c_int) :: type
+    integer(c_int) :: device
+    type(c_ptr) :: devicePointer
+    type(c_ptr) :: hostPointer
+    integer(c_int) :: isManaged
+    integer(c_int) :: allocationFlags
+  end type hipPointerAttribute_t
 
-  integer, parameter :: hipIpcMemLazyEnablePeerAccess =  0
+  type, bind(c) :: hipChannelFormatDesc
+    integer(c_int) :: x
+    integer(c_int) :: y
+    integer(c_int) :: z
+    integer(c_int) :: w
+    integer(c_int) :: f !< Channel format kind
+  end type hipChannelFormatDesc
 
-  integer, parameter :: hipStreamDefault = &
-      0  !< Default stream creation flags. These are used with hipStreamCreate = ().
-  integer, parameter :: hipStreamNonBlocking =  1  !< Stream does not implicitly synchronize with null stream
-  
-  integer, parameter :: hipEventDefault =  0  !< Default flags
-  integer, parameter :: hipEventBlockingSync = &
-      1  !< Waiting will yield CPU.  Power-friendly and usage-friendly but may increase latency.
-  integer, parameter :: hipEventDisableTiming = &
-      2  !< Disable event's capability to record timing information.  May improve performance.
-  integer, parameter :: hipEventInterprocess =  4  !< Event can support IPC.  @warning - not supported in HIP.
-  integer, parameter :: hipEventReleaseToDevice = &
-      1073741824 !< 0x40000000 - Use a device-scope release when recording this event.  This flag is useful to
-  !integer, parameter :: hipEventReleaseToSystem = &
-  !    2147483648 !< 0x80000000 - Use a system-scope release that when recording this event.  This flag is
-  integer, parameter :: hipHostMallocDefault =  0
-  integer, parameter :: hipHostMallocPortable =  1  !< Memory is considered allocated by all contexts.
-  integer, parameter :: hipHostMallocMapped = &
-      2  !< Map the allocation into the address space for the current device.  The device pointer
-  integer, parameter :: hipHostMallocWriteCombined =  4
-  integer, parameter :: hipHostMallocNumaUser = &
-      536870912 !< 0x20000000 - Host memory allocation will follow numa policy set by user
-  integer, parameter :: hipHostMallocCoherent = &
-      1073741824 !< 0x40000000 - Allocate coherent memory. Overrides HIP_COHERENT_HOST_ALLOC for specific
-  !integer, parameter :: hipHostMallocNonCoherent = &
-  !    2147483648 !< 0x80000000 - Allocate non-coherent memory. Overrides HIP_COHERENT_HOST_ALLOC for specific
-  integer, parameter :: hipMemAttachGlobal =   1    !< Memory can be accessed by any stream on any device
-  integer, parameter :: hipMemAttachHost =     2    !< Memory cannot be accessed by any stream on any device
-  integer, parameter :: hipMemAttachSingle =   4    !< Memory can only be accessed by a single stream on
-                                      !< the associated device
-  integer, parameter :: hipDeviceMallocDefault =  0
-  integer, parameter :: hipDeviceMallocFinegrained =  1  !< Memory is allocated in fine grained region of device.
-  
-  integer, parameter :: hipHostRegisterDefault =  0   !< Memory is Mapped and Portable
-  integer, parameter :: hipHostRegisterPortable =  1  !< Memory is considered registered by all contexts.
-  integer, parameter :: hipHostRegisterMapped = &
-      2  !< Map the allocation into the address space for the current device.  The device pointer
-  integer, parameter :: hipHostRegisterIoMemory =  4  !< Not supported.
-  integer, parameter :: hipExtHostRegisterCoarseGrained =  8  !< Coarse Grained host memory lock
-  
-  integer, parameter :: hipDeviceScheduleAuto =  0  !< Automatically select between Spin and Yield
-  integer, parameter :: hipDeviceScheduleSpin = &
-      1  !< Dedicate a CPU core to spin-wait.  Provides lowest latency, but burns a CPU core and
-  integer, parameter :: hipDeviceScheduleYield = &
-      2  !< Yield the CPU to the operating system when waiting.  May increase latency, but lowers
-  integer, parameter :: hipDeviceScheduleBlockingSync =  4
-  integer, parameter :: hipDeviceScheduleMask =  7
-  
-  integer, parameter :: hipDeviceMapHost =  8
-  integer, parameter :: hipDeviceLmemResizeToMax =  22 ! 16
-  
-  integer, parameter :: hipArrayDefault =  0  !< Default HIP array allocation flag
-  integer, parameter :: hipArrayLayered =  1
-  integer, parameter :: hipArraySurfaceLoadStore =  2
-  integer, parameter :: hipArrayCubemap =  4
-  integer, parameter :: hipArrayTextureGather =  8
-  
-  integer, parameter :: hipOccupancyDefault =  0
-  
-  integer, parameter :: hipCooperativeLaunchMultiDeviceNoPreSync =  1
-  integer, parameter :: hipCooperativeLaunchMultiDeviceNoPostSync =  2
+  type, bind(c) :: HIP_ARRAY_DESCRIPTOR
+    integer(c_size_t) :: Width !< Width of the array
+    integer(c_size_t) :: Height !< Height of the array
+    integer(c_int) :: Format !< Format of the array
+    integer(c_int) :: NumChannels !< Number of channels of the array
+  end type HIP_ARRAY_DESCRIPTOR
+
+  type, bind(c) :: HIP_ARRAY3D_DESCRIPTOR
+    integer(c_size_t) :: Width !< Width of the array
+    integer(c_size_t) :: Height !< Height of the array
+    integer(c_size_t) :: Depth !< Depth of the array
+    integer(c_int) :: Format !< Format of the array
+    integer(c_int) :: NumChannels !< Number of channels of the array
+    integer(c_int) :: Flags !< Flags of the array
+  end type HIP_ARRAY3D_DESCRIPTOR
+
+  type, bind(c) :: hip_Memcpy2D
+    integer(c_size_t) :: srcXInBytes !< Source width in bytes
+    integer(c_size_t) :: srcY !< Source height
+    integer(c_int) :: srcMemoryType !< Source memory type
+    type(c_ptr) :: srcHost !< Source pointer
+    type(c_ptr) :: srcDevice !< Source device
+    type(c_ptr) :: srcArray !< Source array
+    integer(c_size_t) :: srcPitch !< Source pitch
+    integer(c_size_t) :: dstXInBytes !< Destination width in bytes
+    integer(c_size_t) :: dstY !< Destination height
+    integer(c_int) :: dstMemoryType !< Destination memory type
+    type(c_ptr) :: dstHost !< Destination pointer
+    type(c_ptr) :: dstDevice !< Destination device
+    type(c_ptr) :: dstArray !< Destination array
+    integer(c_size_t) :: dstPitch !< Destination pitch
+    integer(c_size_t) :: WidthInBytes !< Width in bytes of the 2D memory copy
+    integer(c_size_t) :: Height !< Height of the 2D memory copy
+  end type hip_Memcpy2D
+
+  type, bind(c) :: hipMipmappedArray
+    type(c_ptr) :: data !< Data pointer of the mipmapped array
+    type(hipChannelFormatDesc) :: desc !< Description of the mipmapped array
+    integer(c_int) :: type !< Type of the mipmapped array
+    integer(c_int) :: width !< Width of the mipmapped array
+    integer(c_int) :: height !< Height of the mipmapped array
+    integer(c_int) :: depth !< Depth of the mipmapped array
+    integer(c_int) :: min_mipmap_level !< Minimum level of the mipmapped array
+    integer(c_int) :: max_mipmap_level !< Maximum level of the mipmapped array
+    integer(c_int) :: flags !< Flags of the mipmapped array
+    integer(c_int) :: format !< Format of the mipmapped array
+    integer(c_int) :: num_channels !< Number of channels of the mipmapped array
+  end type hipMipmappedArray
+
+  type, bind(c) :: HIP_TEXTURE_DESC
+    integer(c_int) :: addressMode(3) !< Address modes
+    integer(c_int) :: filterMode !< Filter mode
+    integer(c_int) :: flags !< Flags
+    integer(c_int) :: maxAnisotropy !< Maximum anisotropy ratio
+    integer(c_int) :: mipmapFilterMode !< Mipmap filter mode
+    real(c_float) :: mipmapLevelBias !< Mipmap level bias
+    real(c_float) :: minMipmapLevelClamp !< Mipmap minimum level clamp
+    real(c_float) :: maxMipmapLevelClamp !< Mipmap maximum level clamp
+    real(c_float) :: borderColor(4) !< Border Color
+    integer(c_int) :: reserved(12)
+  end type HIP_TEXTURE_DESC
+
+  type, bind(c) :: hipResourceDesc
+    integer(c_int64_t) :: opaque(8)
+  end type hipResourceDesc
+
+  type, bind(c) :: HIP_RESOURCE_DESC
+    integer(c_int64_t) :: opaque(18)
+  end type HIP_RESOURCE_DESC
+
+  type, bind(c) :: hipResourceViewDesc
+    integer(c_int) :: format !< Resource view format
+    integer(c_size_t) :: width !< Width of the resource view
+    integer(c_size_t) :: height !< Height of the resource view
+    integer(c_size_t) :: depth !< Depth of the resource view
+    integer(c_int) :: firstMipmapLevel !< First defined mipmap level
+    integer(c_int) :: lastMipmapLevel !< Last defined mipmap level
+    integer(c_int) :: firstLayer !< First layer index
+    integer(c_int) :: lastLayer !< Last layer index
+  end type hipResourceViewDesc
+
+  type, bind(c) :: HIP_RESOURCE_VIEW_DESC
+    integer(c_int) :: format !< Resource view format
+    integer(c_size_t) :: width !< Width of the resource view
+    integer(c_size_t) :: height !< Height of the resource view
+    integer(c_size_t) :: depth !< Depth of the resource view
+    integer(c_int) :: firstMipmapLevel !< First defined mipmap level
+    integer(c_int) :: lastMipmapLevel !< Last defined mipmap level
+    integer(c_int) :: firstLayer !< First layer index
+    integer(c_int) :: lastLayer !< Last layer index
+    integer(c_int) :: reserved(16)
+  end type HIP_RESOURCE_VIEW_DESC
+
+  type, bind(c) :: hipPitchedPtr
+    type(c_ptr) :: ptr !< Pointer to the allocated memory
+    integer(c_size_t) :: pitch !< Pitch in bytes
+    integer(c_size_t) :: xsize !< Logical size of the first dimension of allocation in elements
+    integer(c_size_t) :: ysize !< Logical size of the second dimension of allocation in elements
+  end type hipPitchedPtr
+
+  type, bind(c) :: hipExtent
+    integer(c_size_t) :: width
+    integer(c_size_t) :: height
+    integer(c_size_t) :: depth
+  end type hipExtent
+
+  type, bind(c) :: hipPos
+    integer(c_size_t) :: x !< X coordinate
+    integer(c_size_t) :: y !< Y coordinate
+    integer(c_size_t) :: z !< Z coordinate
+  end type hipPos
+
+  type, bind(c) :: hipMemcpy3DParms
+    type(c_ptr) :: srcArray !< Source array
+    type(hipPos) :: srcPos !< Source position
+    type(hipPitchedPtr) :: srcPtr !< Source pointer
+    type(c_ptr) :: dstArray !< Destination array
+    type(hipPos) :: dstPos !< Destination position
+    type(hipPitchedPtr) :: dstPtr !< Destination pointer
+    type(hipExtent) :: extent !< Extent of 3D memory copy
+    integer(c_int) :: kind !< Kind of 3D memory copy
+  end type hipMemcpy3DParms
+
+  type, bind(c) :: HIP_MEMCPY3D
+    integer(c_size_t) :: srcXInBytes !< Source X in bytes
+    integer(c_size_t) :: srcY !< Source Y
+    integer(c_size_t) :: srcZ !< Source Z
+    integer(c_size_t) :: srcLOD !< Source LOD
+    integer(c_int) :: srcMemoryType !< Source memory type
+    type(c_ptr) :: srcHost !< Source host pointer
+    type(c_ptr) :: srcDevice !< Source device
+    type(c_ptr) :: srcArray !< Source array
+    integer(c_size_t) :: srcPitch !< Source pitch
+    integer(c_size_t) :: srcHeight !< Source height
+    integer(c_size_t) :: dstXInBytes !< Destination X in bytes
+    integer(c_size_t) :: dstY !< Destination Y
+    integer(c_size_t) :: dstZ !< Destination Z
+    integer(c_size_t) :: dstLOD !< Destination LOD
+    integer(c_int) :: dstMemoryType !< Destination memory type
+    type(c_ptr) :: dstHost !< Destination host pointer
+    type(c_ptr) :: dstDevice !< Destination device
+    type(c_ptr) :: dstArray !< Destination array
+    integer(c_size_t) :: dstPitch !< Destination pitch
+    integer(c_size_t) :: dstHeight !< Destination height
+    integer(c_size_t) :: WidthInBytes !< Width in bytes of 3D memory copy
+    integer(c_size_t) :: Height !< Height in bytes of 3D memory copy
+    integer(c_size_t) :: Depth !< Depth in bytes of 3D memory copy
+  end type HIP_MEMCPY3D
+
+  type, bind(c) :: hipMemLocation
+    integer(c_int) :: type !< Specifies the location type, which describes the meaning of id
+    integer(c_int) :: id !< Identifier for the provided location type @p hipMemLocationType
+  end type hipMemLocation
+
+  type, bind(c) :: hipMemcpyAttributes
+    integer(c_int) :: srcAccessOrder !< Source access ordering to be observed for copies with this attribute.
+    type(hipMemLocation) :: srcLocHint !< Location hint for src operand.
+    type(hipMemLocation) :: dstLocHint !< Location hint for destination operand.
+    integer(c_int) :: flags !< Additional Flags for copies. See hipMemcpyFlags.
+  end type hipMemcpyAttributes
+
+  type, bind(c) :: hipOffset3D
+    integer(c_size_t) :: x
+    integer(c_size_t) :: y
+    integer(c_size_t) :: z
+  end type hipOffset3D
+
+  type, bind(c) :: hipMemcpy3DOperand
+    integer(c_int64_t) :: opaque(5)
+  end type hipMemcpy3DOperand
+
+  type, bind(c) :: hipMemcpy3DBatchOp
+    type(hipMemcpy3DOperand) :: src
+    type(hipMemcpy3DOperand) :: dst
+    type(hipExtent) :: extent
+    integer(c_int) :: srcAccessOrder
+    integer(c_int) :: flags
+  end type hipMemcpy3DBatchOp
+
+  type, bind(c) :: hipMemcpy3DPeerParms
+    type(c_ptr) :: srcArray !< Source memory address
+    type(hipPos) :: srcPos !< Source position offset
+    type(hipPitchedPtr) :: srcPtr !< Pitched source memory address
+    integer(c_int) :: srcDevice !< Source device
+    type(c_ptr) :: dstArray !< Destination memory address
+    type(hipPos) :: dstPos !< Destination position offset
+    type(hipPitchedPtr) :: dstPtr !< Pitched destination memory address
+    integer(c_int) :: dstDevice !< Destination device
+    type(hipExtent) :: extent !< Requested memory copy size
+  end type hipMemcpy3DPeerParms
+
+  type, bind(c) :: textureReference
+    integer(c_int) :: normalized
+    integer(c_int) :: readMode
+    integer(c_int) :: filterMode
+    integer(c_int) :: addressMode(3)
+    type(hipChannelFormatDesc) :: channelDesc
+    integer(c_int) :: sRGB
+    integer(c_int) :: maxAnisotropy
+    integer(c_int) :: mipmapFilterMode
+    real(c_float) :: mipmapLevelBias
+    real(c_float) :: minMipmapLevelClamp
+    real(c_float) :: maxMipmapLevelClamp
+    type(c_ptr) :: textureObject
+    integer(c_int) :: numChannels
+    integer(c_int) :: format
+  end type textureReference
+
+  type, bind(c) :: hipTextureDesc
+    integer(c_int) :: addressMode(3)
+    integer(c_int) :: filterMode
+    integer(c_int) :: readMode
+    integer(c_int) :: sRGB
+    real(c_float) :: borderColor(4)
+    integer(c_int) :: normalizedCoords
+    integer(c_int) :: maxAnisotropy
+    integer(c_int) :: mipmapFilterMode
+    real(c_float) :: mipmapLevelBias
+    real(c_float) :: minMipmapLevelClamp
+    real(c_float) :: maxMipmapLevelClamp
+  end type hipTextureDesc
+
+  type, bind(c) :: surfaceReference
+    type(c_ptr) :: surfaceObject
+  end type surfaceReference
+
+  type, bind(c) :: hipIpcMemHandle_t
+    character(c_char) :: reserved(64)
+  end type hipIpcMemHandle_t
+
+  type, bind(c) :: hipIpcEventHandle_t
+    character(c_char) :: reserved(64)
+  end type hipIpcEventHandle_t
+
+  type, bind(c) :: hipFuncAttributes
+    integer(c_int) :: binaryVersion
+    integer(c_int) :: cacheModeCA
+    integer(c_size_t) :: constSizeBytes
+    integer(c_size_t) :: localSizeBytes
+    integer(c_int) :: maxDynamicSharedSizeBytes
+    integer(c_int) :: maxThreadsPerBlock
+    integer(c_int) :: numRegs
+    integer(c_int) :: preferredShmemCarveout
+    integer(c_int) :: ptxVersion
+    integer(c_size_t) :: sharedSizeBytes
+  end type hipFuncAttributes
+
+  type, bind(c) :: hipBatchMemOpNodeParams
+    type(c_ptr) :: ctx
+    integer(c_int) :: count
+    type(c_ptr) :: paramArray
+    integer(c_int) :: flags
+  end type hipBatchMemOpNodeParams
+
+  type, bind(c) :: hipMemAccessDesc
+    type(hipMemLocation) :: location !< Location on which the accessibility has to change
+    integer(c_int) :: flags !< Accessibility flags to set
+  end type hipMemAccessDesc
+
+  type, bind(c) :: hipMemPoolProps
+    integer(c_int) :: allocType !< Allocation type. Currently must be specified as @p hipMemAllocationTypePinned
+    integer(c_int) :: handleTypes !< Handle types that will be supported by allocations from the pool
+    type(hipMemLocation) :: location !< Location where allocations should reside
+    type(c_ptr) :: win32SecurityAttributes !< Windows-specific LPSECURITYATTRIBUTES required when @p hipMemHandleTypeWin32 is...
+    integer(c_size_t) :: maxSize !< Maximum pool size. When set to 0, defaults to a system dependent value
+    type(c_ptr) :: reserved(56) !< Reserved for future use, must be 0
+  end type hipMemPoolProps
+
+  type, bind(c) :: hipMemPoolPtrExportData
+    type(c_ptr) :: reserved(64)
+  end type hipMemPoolPtrExportData
+
+  type, bind(c) :: dim3
+    integer(c_int32_t) :: x = 1 !< x
+    integer(c_int32_t) :: y = 1 !< y
+    integer(c_int32_t) :: z = 1 !< z
+  end type dim3
+
+  type, bind(c) :: hipLaunchParams
+    type(c_ptr) :: func !< Device function symbol
+    type(dim3) :: gridDim !< Grid dimensions
+    type(dim3) :: blockDim !< Block dimensions
+    type(c_ptr) :: args !< Arguments
+    integer(c_size_t) :: sharedMem !< Shared memory
+    type(c_ptr) :: stream !< Stream identifier
+  end type hipLaunchParams
+
+  type, bind(c) :: hipFunctionLaunchParams
+    type(c_ptr) :: function !< Kernel to launch
+    integer(c_int) :: gridDimX !< Width(X) of grid in blocks
+    integer(c_int) :: gridDimY !< Height(Y) of grid in blocks
+    integer(c_int) :: gridDimZ !< Depth(Z) of grid in blocks
+    integer(c_int) :: blockDimX !< X dimension of each thread block
+    integer(c_int) :: blockDimY !< Y dimension of each thread block
+    integer(c_int) :: blockDimZ !< Z dimension of each thread block
+    integer(c_int) :: sharedMemBytes !< Shared memory
+    type(c_ptr) :: hStream !< Stream identifier
+    type(c_ptr) :: kernelParams !< Kernel parameters
+  end type hipFunctionLaunchParams
+
+  type, bind(c) :: hipExternalMemoryHandleDesc
+    integer(c_int64_t) :: opaque(13)
+  end type hipExternalMemoryHandleDesc
+
+  type, bind(c) :: hipExternalMemoryBufferDesc
+    integer(c_int64_t) :: offset
+    integer(c_int64_t) :: size
+    integer(c_int) :: flags
+    integer(c_int) :: reserved(16)
+  end type hipExternalMemoryBufferDesc
+
+  type, bind(c) :: hipExternalMemoryMipmappedArrayDesc
+    integer(c_int64_t) :: offset
+    type(hipChannelFormatDesc) :: formatDesc
+    type(hipExtent) :: extent
+    integer(c_int) :: flags
+    integer(c_int) :: numLevels
+  end type hipExternalMemoryMipmappedArrayDesc
+
+  type, bind(c) :: hipExternalSemaphoreHandleDesc
+    integer(c_int64_t) :: opaque(12)
+  end type hipExternalSemaphoreHandleDesc
+
+  type, bind(c) :: hipExternalSemaphoreSignalParams
+    integer(c_int64_t) :: opaque(18)
+  end type hipExternalSemaphoreSignalParams
+
+  type, bind(c) :: hipExternalSemaphoreWaitParams
+    integer(c_int64_t) :: opaque(18)
+  end type hipExternalSemaphoreWaitParams
+
+  type, bind(c) :: hipHostNodeParams
+    type(c_funptr) :: fn
+    type(c_ptr) :: userData
+  end type hipHostNodeParams
+
+  type, bind(c) :: hipKernelNodeParams
+    type(dim3) :: blockDim
+    type(c_ptr) :: extra
+    type(c_ptr) :: func
+    type(dim3) :: gridDim
+    type(c_ptr) :: kernelParams
+    integer(c_int) :: sharedMemBytes
+  end type hipKernelNodeParams
+
+  type, bind(c) :: hipMemsetParams
+    type(c_ptr) :: dst
+    integer(c_int) :: elementSize
+    integer(c_size_t) :: height
+    integer(c_size_t) :: pitch
+    integer(c_int) :: value
+    integer(c_size_t) :: width
+  end type hipMemsetParams
+
+  type, bind(c) :: hipMemAllocNodeParams
+    type(hipMemPoolProps) :: poolProps !< Pool properties, which contain where the location should reside
+    type(c_ptr) :: accessDescs !< The number of memory access descriptors.
+    integer(c_size_t) :: accessDescCount !< The number of access descriptors. Must not be bigger than the number of GPUs
+    integer(c_size_t) :: bytesize !< The size of the requested allocation in bytes
+    type(c_ptr) :: dptr !< Returned device address of the allocation
+  end type hipMemAllocNodeParams
+
+  type, bind(c) :: hipAccessPolicyWindow
+    type(c_ptr) :: base_ptr !< Starting address of the access policy window
+    integer(c_int) :: hitProp !< hipAccessProperty set for hit
+    real(c_float) :: hitRatio !< hitRatio specifies percentage of lines assigned hitProp
+    integer(c_int) :: missProp !< hipAccessProperty set for miss
+    integer(c_size_t) :: num_bytes !< Size in bytes of the window policy.
+  end type hipAccessPolicyWindow
+
+  type, bind(c) :: hipLaunchMemSyncDomainMap
+    type(c_ptr) :: default_ !< The default domain ID to use for designated kernels
+    type(c_ptr) :: remote !< The remote domain ID to use for designated kernels
+  end type hipLaunchMemSyncDomainMap
+
+  type, bind(c) :: hipGraphInstantiateParams
+    type(c_ptr) :: errNode_out !< The node which caused instantiation to fail, if any
+    integer(c_int64_t) :: flags !< Instantiation flags
+    integer(c_int) :: result_out !< Whether instantiation was successful. If it failed, the reason why
+    type(c_ptr) :: uploadStream !< Upload stream
+  end type hipGraphInstantiateParams
+
+  type, bind(c) :: hipMemAllocationProp
+    integer(c_int64_t) :: opaque(4)
+  end type hipMemAllocationProp
+
+  type, bind(c) :: hipExternalSemaphoreSignalNodeParams
+    type(c_ptr) :: extSemArray
+    type(c_ptr) :: paramsArray
+    integer(c_int) :: numExtSems
+  end type hipExternalSemaphoreSignalNodeParams
+
+  type, bind(c) :: hipExternalSemaphoreWaitNodeParams
+    type(c_ptr) :: extSemArray
+    type(c_ptr) :: paramsArray
+    integer(c_int) :: numExtSems
+  end type hipExternalSemaphoreWaitNodeParams
+
+  type, bind(c) :: hipArrayMapInfo
+    integer(c_int64_t) :: opaque(19)
+  end type hipArrayMapInfo
+
+  type, bind(c) :: hipMemcpyNodeParams
+    integer(c_int) :: flags !< Must be zero.
+    integer(c_int) :: reserved(3) !< Must be zero.
+    type(hipMemcpy3DParms) :: copyParams !< Params set for the memory copy.
+  end type hipMemcpyNodeParams
+
+  type, bind(c) :: hipChildGraphNodeParams
+    type(c_ptr) :: graph !< Either the child graph to clone into the node, or a handle to the graph possesed by the node used...
+  end type hipChildGraphNodeParams
+
+  type, bind(c) :: hipEventWaitNodeParams
+    type(c_ptr) :: event !< Event to wait on
+  end type hipEventWaitNodeParams
+
+  type, bind(c) :: hipEventRecordNodeParams
+    type(c_ptr) :: event !< The event to be recorded when node executes
+  end type hipEventRecordNodeParams
+
+  type, bind(c) :: hipMemFreeNodeParams
+    type(c_ptr) :: dptr !< the pointer to be freed
+  end type hipMemFreeNodeParams
+
+  type, bind(c) :: hipGraphNodeParams
+    integer(c_int) :: type
+    integer(c_int) :: reserved0(3)
+    integer(c_int64_t) :: reserved2
+  end type hipGraphNodeParams
+
+  type, bind(c) :: hipGraphEdgeData
+    type(c_ptr) :: from_port !< This indicates when the dependency is triggered from the upstream node on the edge. The meani...
+    type(c_ptr) :: reserved(5) !< These bytes are unused and must be zeroed
+    type(c_ptr) :: to_port !< Currently no node types define non-zero ports. This field must be set to zero.
+    type(c_ptr) :: type !< This should be populated with a value from hipGraphDependencyType
+  end type hipGraphEdgeData
+
+  type, bind(c) :: hipLaunchAttribute
+    integer(c_int) :: id !< Identifier of the launch attribute
+    character(c_char) :: pad(4) !< Padding to align the structure to 8 bytes
+  end type hipLaunchAttribute
+
+  type, bind(c) :: hipLaunchConfig_t
+    type(dim3) :: gridDim !< Grid dimensions
+    type(dim3) :: blockDim !< Block dimensions
+    integer(c_size_t) :: dynamicSmemBytes !< Dynamic shared-memory size per thread block
+    type(c_ptr) :: stream !< Stream identifier
+    type(c_ptr) :: attrs !< Attributes list
+    integer(c_int) :: numAttrs !< Number of attributes
+  end type hipLaunchConfig_t
+
+  type, bind(c) :: HIP_LAUNCH_CONFIG
+    integer(c_int) :: gridDimX !< Grid width in blocks
+    integer(c_int) :: gridDimY !< Grid height in blocks
+    integer(c_int) :: gridDimZ !< Grid depth in blocks
+    integer(c_int) :: blockDimX !< Thread block dimension in X
+    integer(c_int) :: blockDimY !< Thread block dimension in Y
+    integer(c_int) :: blockDimZ !< Thread block dimension in Z
+    integer(c_int) :: sharedMemBytes !< Dynamic shared-memory size in bytes per block
+    type(c_ptr) :: hStream !< HIP stream identifier
+    type(c_ptr) :: attrs !< Attribute list
+    integer(c_int) :: numAttrs !< Number of attributes
+  end type HIP_LAUNCH_CONFIG
+
 end module hipfort_types


### PR DESCRIPTION
Part of the HIP runtime regeneration, split out of #326 for reviewability. Builds independently on `develop` (verified: full `hipfort-amdgcn` build) — the generic interface names are unchanged, so it composes with the current hand-written runtime files until the other parts land.

Refreshes `hipfort_enums.F90` and `hipfort_types.F90` from the current HIP headers (new enum constants + derived types). Foundational, no dependency on the other runtime files.