### PR TITLE
docs: document USE_FPOINTER_INTERFACES and broaden supported compilers

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ As the interfaces make use of the `iso_c_binding` module, the minimum requiremen
 that supports the Fortran 2003 standard (`f2003`).
 These interfaces typically require to pass `type(c_ptr)` variables and the number of bytes to memory
 management (e.g. `hipMalloc`) and math library routines (e.g. `hipblasDGEMM`).
+`gfortran` is the primary tested compiler, and AMD's `amdflang` (LLVM Flang) is also supported.
+Other standard-conforming Fortran compilers such as NVIDIA `nvfortran`, Intel `ifx`/`ifort`, and the
+Cray Fortran compiler (for example on LUMI) are not officially supported, but `hipfort` should
+build with them too. Please [open an issue](https://github.com/ROCm/hipfort/issues) if you run into problems.
 
 If your compiler understands the Fortran 2008 (`f2008`) code constructs that occur in `hipfort`'s source and test files, 
 additional interfaces are compiled into the `hipfort` modules and libraries. 

--- a/docs/how-to/using-hipfort.rst
+++ b/docs/how-to/using-hipfort.rst
@@ -49,7 +49,17 @@ These interfaces take Fortran (array) variables, the number of elements instead 
 and the number of bytes, respectively. Therefore, they reduce the chance of introducing compile-time and runtime errors
 into your code and make it easier to read.
 
-.. note:: 
+These additional interfaces are guarded by the ``USE_FPOINTER_INTERFACES`` preprocessor definition,
+which hipFORT enables automatically once it detects Fortran 2008 support in your compiler. By convention,
+application and test sources that rely on them use the ``.f08`` file extension (see the ``test/f2008``
+examples), while Fortran 2003 sources use ``.f03``.
+
+GFortran is the primary tested compiler, and AMD's ``amdflang`` (LLVM Flang) is also supported.
+Other standard-conforming Fortran compilers such as NVIDIA ``nvfortran``, Intel ``ifx``/``ifort``,
+and the Cray Fortran compiler (for example on LUMI) are not officially supported, but hipFORT
+should build with them too. Please open an issue at https://github.com/ROCm/hipfort/issues if you run into problems.
+
+.. note::
 
    If you plan to use the `f2008` interfaces, GFortran version 7.5.0 or newer is recommended.
    Problems can occur with older versions.

--- a/docs/install/install.rst
+++ b/docs/install/install.rst
@@ -12,8 +12,12 @@ It also provides information on how to build and run the tests.
 Prerequisites
 ===============
 
-hipFORT requires GFortran version 7.5.0 or newer.
-For more information, see the `GFortran website. <https://fortran-lang.org/learn/os_setup/install_gfortran/>`_
+hipFORT requires a Fortran compiler that supports at least the Fortran 2003 standard.
+GFortran version 7.5.0 or newer is the primary tested compiler (see the `GFortran website
+<https://fortran-lang.org/learn/os_setup/install_gfortran/>`_), and AMD ``amdflang`` (LLVM Flang) is
+also supported. Other standard-conforming compilers such as NVIDIA ``nvfortran``, Intel ``ifx``/``ifort``,
+and the Cray Fortran compiler (for example on LUMI) are not officially supported, but hipFORT should
+build with them too. Please open an issue at https://github.com/ROCm/hipfort/issues if you run into problems.
 
 .. _build-test-hipfort-from-source:
 

--- a/docs/install/quick-start.rst
+++ b/docs/install/quick-start.rst
@@ -11,8 +11,12 @@ This topic discusses how to quickly build hipFORT from source.
 Prerequisites
 ===============
 
-hipFORT requires GFortran version 7.5.0 or newer.
-For more information, see the `GFortran website. <https://fortran-lang.org/learn/os_setup/install_gfortran/>`_
+hipFORT requires a Fortran compiler that supports at least the Fortran 2003 standard.
+GFortran version 7.5.0 or newer is the primary tested compiler (see the `GFortran website
+<https://fortran-lang.org/learn/os_setup/install_gfortran/>`_), and AMD ``amdflang`` (LLVM Flang) is
+also supported. Other standard-conforming compilers such as NVIDIA ``nvfortran``, Intel ``ifx``/``ifort``,
+and the Cray Fortran compiler (for example on LUMI) are not officially supported, but hipFORT should
+build with them too. Please open an issue at https://github.com/ROCm/hipfort/issues if you run into problems.
 
 Building and testing hipFORT from source
 ==========================================


### PR DESCRIPTION
## Summary

Two related documentation-consistency fixes.

- **`USE_FPOINTER_INTERFACES` / `.f08` convention in the how-to guide.** The README already explains that the richer Fortran 2008 interfaces are guarded by the `USE_FPOINTER_INTERFACES` definition (enabled automatically when F2008 support is detected) and that sources using them carry the `.f08` extension. `docs/how-to/using-hipfort.rst` described the f2003/f2008 behavior but was missing that note — added it so the guide matches the README.
- **Broaden the supported-compiler statement.** The README and install docs only mentioned GFortran. Added a note that hipfort also builds with AMD `amdflang`, NVIDIA `nvfortran`, Intel `ifx`/`ifort`, and the Cray Fortran compiler (e.g. on LUMI), in `README.md`, `docs/install/install.rst`, `docs/install/quick-start.rst`, and `docs/how-to/using-hipfort.rst`. The GFortran 7.5.0+ recommendation for the f2008 interfaces is kept.

Documentation only.