### PR TITLE
Add field doc comments to library derived types

### DIFF
--- a/lib/hipfort/hipfort_rocrand_types.F90
+++ b/lib/hipfort/hipfort_rocrand_types.F90
@@ -2,7 +2,7 @@
 ! ==============================================================================
 ! hipfort: FORTRAN Interfaces for GPU kernels
 ! ==============================================================================
-! Copyright (c) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+! Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 ! [MITx11 License]
 !
 ! Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -29,11 +29,11 @@ module hipfort_rocrand_types
   implicit none
 
   type, bind(c) :: rocrand_discrete_distribution_st
-    integer(c_int) :: size
-    integer(c_int) :: offset
-    type(c_ptr) :: alias
-    type(c_ptr) :: probability
-    type(c_ptr) :: cdf
+    integer(c_int) :: size !< Number of entries in the probability table
+    integer(c_int) :: offset !< The distribution can be offset
+    type(c_ptr) :: alias !< Alias table
+    type(c_ptr) :: probability !< Probability data for the alias table
+    type(c_ptr) :: cdf !< Cumulative distribution function
   end type rocrand_discrete_distribution_st
 
 end module hipfort_rocrand_types

--- a/lib/hipfort/hipfort_rocsparse_types.F90
+++ b/lib/hipfort/hipfort_rocsparse_types.F90
@@ -29,17 +29,17 @@ module hipfort_rocsparse_types
   implicit none
 
   type, bind(c) :: rocsparse_float_complex
-    real(c_float) :: x
-    real(c_float) :: y
+    real(c_float) :: x !< real part.
+    real(c_float) :: y !< imaginary part.
   end type rocsparse_float_complex
 
   type, bind(c) :: rocsparse_double_complex
-    real(c_double) :: x
-    real(c_double) :: y
+    real(c_double) :: x !< real part.
+    real(c_double) :: y !< imaginary part.
   end type rocsparse_double_complex
 
   type, bind(c) :: rocsparse_bfloat16
-    integer(c_int16_t) :: data
+    integer(c_int16_t) :: data !< brain float storage.
   end type rocsparse_bfloat16
 
 end module hipfort_rocsparse_types


### PR DESCRIPTION
Regenerates the library `*_types.F90` files so that C struct field documentation (`///<`) is carried onto the Fortran derived-type members as `!<` comments — matching what the runtime types already do.

Only two files gain comments (the only library structs whose headers document their fields):
- `hipfort_rocrand_types.F90`: `rocrand_discrete_distribution_st` fields
- `hipfort_rocsparse_types.F90`: complex/bfloat16 fields

The rocrand copyright line is also normalized to `2026` to match rocblas/rocsparse (generator output).

No structural or API changes.