### PR TITLE
Fix fftw_iodim64 to use c_ptrdiff_t

### DIFF
--- a/lib/hipfort/hipfort_hipfftw_types.F90
+++ b/lib/hipfort/hipfort_hipfftw_types.F90
@@ -35,9 +35,9 @@ module hipfort_hipfftw_types
   end type fftw_iodim
 
   type, bind(c) :: fftw_iodim64
-    integer(c_long) :: n
-    integer(c_long) :: is
-    integer(c_long) :: os
+    integer(c_ptrdiff_t) :: n
+    integer(c_ptrdiff_t) :: is
+    integer(c_ptrdiff_t) :: os
   end type fftw_iodim64
 
 end module hipfort_hipfftw_types


### PR DESCRIPTION
The FFTW guru64 API defines `fftw_iodim64` with `ptrdiff_t` members (`n`, `is`, `os`), but the Fortran binding declared them as `integer(c_long)`. On LLP64 platforms (Windows) `long` is 32-bit while `ptrdiff_t` is 64-bit, so the layout would be wrong. Use `integer(c_ptrdiff_t)` to match the C struct exactly.

(`fftw_iodim`, the 32-bit `int` variant, is unchanged.)