### PR TITLE
cmake: fix installed package config for hipfftw and roctx components

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
 # 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lib/hipfort-config.cmake.in
+++ b/lib/hipfort-config.cmake.in
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
 # 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -22,16 +22,27 @@
 
 include(CMakeFindDependencyMacro)
 
-set(_hipfort_supported_components hip
+set(_hipfort_supported_components hip roctx
   rocblas rocfft rocrand rocsolver rocsparse
   hipblas hipfft hipfftw hiprand hipsolver hipsparse)
+
+# Most components map 1:1 to a ROCm package of the same name. A few do not:
+# hipfftw is provided by the hipfft package (there is no standalone hipfftw
+# package), and roctx by rocprofiler-sdk-roctx.
+set(_hipfort_hipfftw_dependency hipfft)
+set(_hipfort_roctx_dependency rocprofiler-sdk-roctx)
 
 include("${CMAKE_CURRENT_LIST_DIR}/hipfort-amdgcn-targets.cmake")
 foreach(_comp ${hipfort_FIND_COMPONENTS})
   if (NOT _comp IN_LIST _hipfort_supported_components)
     set(hipfort_FOUND False)
     set(hipfort_NOT_FOUND_MESSAGE "Unsupported component: ${_comp}")
+    continue()
   endif()
   include("${CMAKE_CURRENT_LIST_DIR}/hipfort-${_comp}-targets.cmake")
-  find_dependency(${_comp})
+  if(DEFINED _hipfort_${_comp}_dependency)
+    find_dependency(${_hipfort_${_comp}_dependency})
+  else()
+    find_dependency(${_comp})
+  endif()
 endforeach()


### PR DESCRIPTION
## Summary

The installed `hipfort-config.cmake` looped over the requested components and ran `find_dependency(${component})` for each, assuming every component name maps to a ROCm package of the same name. Two components break that assumption:

- **hipfftw** is provided by the **hipfft** package (there is no standalone `hipfftw` package — its `hip::hipfftw`/`hip::hipfft` target comes from hipfft). So `find_package(hipfort REQUIRED COMPONENTS hipfftw)` failed with *"Could not find hipfftw"*. This regressed when hipFFTW was promoted to a first-class component.
- **roctx** is backed by the **rocprofiler-sdk-roctx** package. Its target is exported (`hipfort-roctx-targets.cmake`), but `roctx` was missing from the supported-components list, so it could not be requested at all.

## Changes (`lib/hipfort-config.cmake.in`)

- Add a small component → dependency map: `hipfftw → hipfft`, `roctx → rocprofiler-sdk-roctx`; other components keep the 1:1 default.
- Add `roctx` to `_hipfort_supported_components`.
- `continue()` on an unsupported component instead of falling through to a missing `include()`.
- Refresh copyright years.

## Verification

Exercised the config logic with a stubbed `cmake -P` run:

```
include(.../hipfort-hipfftw-targets.cmake) ; find_dependency(hipfft)
include(.../hipfort-roctx-targets.cmake)   ; find_dependency(rocprofiler-sdk-roctx)
include(.../hipfort-rocblas-targets.cmake) ; find_dependency(rocblas)
```

i.e. hipfftw and roctx now resolve to the correct packages, and 1:1 components are unchanged.