### PR TITLE
cmake: fix doubled install path for the hipfort-amdgcn library

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -38,13 +38,18 @@ set(HIPFORT_ARCH "amdgcn")
     ENDIF(CMAKE_Fortran_COMPILER_SUPPORTS_F08)
     target_compile_definitions(${HIPFORT_LIB} PRIVATE _HIPFORT_ARCH='${HIPFORT_ARCH}')
     # Install Target hipfort-amdgcn
+    # CMAKE_INSTALL_LIBDIR/INCLUDEDIR already carry the toolchain-specific
+    # subdirectory (see HIPFORT_MULTITOOLCHAIN_LAYOUT in the top-level
+    # CMakeLists.txt), so they must not be suffixed with FORTRAN_LIBRARY_SUBDIR
+    # again -- doing so nests the archive and mod files one level too deep
+    # (e.g. lib/fortran/<compiler>/fortran/<compiler>).
     rocm_install_targets(
         TARGETS ${HIPFORT_LIB}
         EXPORT hipfort-amdgcn-targets
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/${FORTRAN_LIBRARY_SUBDIR}
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/${FORTRAN_LIBRARY_SUBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${FORTRAN_LIBRARY_SUBDIR}
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
         INCLUDE
            ${CMAKE_Fortran_MODULE_DIRECTORY}
     )


### PR DESCRIPTION
## Summary

Under the default `HIPFORT_MULTITOOLCHAIN_LAYOUT`, the top-level `CMakeLists.txt` bakes the toolchain-specific subdirectory into the install dirs:

```cmake
set(FORTRAN_LIBRARY_SUBDIR "fortran/${FCNAME}")
set(CMAKE_INSTALL_LIBDIR     "lib/${FORTRAN_LIBRARY_SUBDIR}")      # lib/fortran/<compiler>
set(CMAKE_INSTALL_INCLUDEDIR "include/${FORTRAN_LIBRARY_SUBDIR}")  # include/fortran/<compiler>
```

But the `hipfort-amdgcn` install (`lib/CMakeLists.txt`) then suffixed those with `FORTRAN_LIBRARY_SUBDIR` **again**, so the static library and its `INCLUDES` destination landed one level too deep:

| Artifact | Before | After |
| --- | --- | --- |
| `libhipfort-amdgcn.a` | `lib/fortran/<compiler>/fortran/<compiler>` | `lib/fortran/<compiler>` |
| amdgcn `INCLUDES` dir | `include/fortran/<compiler>/fortran/<compiler>` | `include/fortran/<compiler>` |
| component targets | `lib/fortran/<compiler>` | (unchanged) |
| package config | `lib/fortran/<compiler>/cmake/hipfort` | (unchanged) |
| `.mod` files | `include/fortran/<compiler>/hipfort/amdgcn` | (unchanged) |

The doubling was self-consistent via the exported target (so it still linked), but placed the archive in an unexpected nested directory, inconsistent with everything else and defeating the clean side-by-side layout. Introduced in #291 (the same commit added the `CMAKE_INSTALL_LIBDIR` redefinition and the extra suffix).

## Fix

Install `hipfort-amdgcn` to `CMAKE_INSTALL_LIBDIR`/`CMAKE_INSTALL_INCLUDEDIR` directly, matching the component targets and the package config.

## Verification

Simulated the path expansion with `cmake -P` for both layouts:

- **MULTITOOLCHAIN=ON**: `.a → lib/fortran/<compiler>` (now matches components/config), `.mod → include/fortran/<compiler>/hipfort/amdgcn`.
- **MULTITOOLCHAIN=OFF**: `.a → lib`, `.mod → include/hipfort/amdgcn` (unchanged; `FORTRAN_LIBRARY_SUBDIR` was empty in this mode, so behavior is identical to before).

> Note: the misleading "symlink subdirectory" wording on `FORTRAN_LIBRARY_SUBDIR` does not correspond to any symlink logic in the tree.