### PR TITLE
Fix hipGetDeviceProperties ABI: bind to the R0600 symbol

### DIFF
--- a/lib/hipfort/hipfort_auxiliary.F90
+++ b/lib/hipfort/hipfort_auxiliary.F90
@@ -16,7 +16,7 @@ module hipfort_auxiliary
 #ifdef USE_CUDA_NAMES
     function hipGetDeviceProperties_(prop,deviceId) bind(c, name="cudaGetDeviceProperties")
 #else
-    function hipGetDeviceProperties_(prop,deviceId) bind(c, name="hipGetDeviceProperties")
+    function hipGetDeviceProperties_(prop,deviceId) bind(c, name="hipGetDevicePropertiesR0600")
 #endif
       use iso_c_binding
 #ifdef USE_CUDA_NAMES


### PR DESCRIPTION
`hipfort_auxiliary.F90` binds `hipGetDeviceProperties` to the legacy `hipGetDeviceProperties` symbol (`@@hip_4.2`), which fills the **old** `hipDeviceProp_t` layout. Since ROCm 6.0 the header `#define hipGetDeviceProperties hipGetDevicePropertiesR0600` redirects callers to a new symbol that fills the **larger R0600** layout, and `hipfort_types.F90`'s `hipDeviceProp_t` is now that R0600 struct (108 fields).

Binding to the old symbol while passing the R0600 struct is an ABI mismatch: the runtime writes the old field layout into a struct the Fortran side reads as R0600 → wrong/garbage field values.

Fix: bind the non-CUDA path to `hipGetDevicePropertiesR0600` (the symbol C callers actually reach today). Signature is identical (`prop, deviceId`); the CUDA path (`cudaGetDeviceProperties`) is unchanged.

libamdhip64 exposes all three: `hipGetDeviceProperties@@hip_4.2`, `hipGetDevicePropertiesR0000@@hip_4.2`, `hipGetDevicePropertiesR0600@@hip_6.0`.