### PR TITLE
Expose scalar-output getters by reference across ROCm libraries

### DIFF
--- a/lib/hipfort/hipfort_hipblas.F90
+++ b/lib/hipfort/hipfort_hipblas.F90
@@ -80,7 +80,7 @@ module hipfort_hipblas
       implicit none
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasGetVersion_
       type(c_ptr),value :: handle
-      type(c_ptr),value :: version
+      integer(c_int) :: version
     end function
   end interface
 

--- a/lib/hipfort/hipfort_hipfft.F90
+++ b/lib/hipfort/hipfort_hipfft.F90
@@ -246,14 +246,8 @@ module hipfort_hipfft
       integer(c_int),value :: nx
       integer(kind(HIPFFT_R2C)),value :: myType
       integer(c_int),value :: batch
-      type(c_ptr),value :: workSize
+      integer(c_size_t) :: workSize
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipfftMakePlan1d_rank_0,&
-      hipfftMakePlan1d_rank_1
-#endif
   end interface
 
   !>  @brief Initialize a new two-dimensional FFT plan.
@@ -283,14 +277,8 @@ module hipfort_hipfft
       integer(c_int),value :: nx
       integer(c_int),value :: ny
       integer(kind(HIPFFT_R2C)),value :: myType
-      type(c_ptr),value :: workSize
+      integer(c_size_t) :: workSize
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipfftMakePlan2d_rank_0,&
-      hipfftMakePlan2d_rank_1
-#endif
   end interface
 
   !>  @brief Initialize a new two-dimensional FFT plan.
@@ -322,14 +310,8 @@ module hipfort_hipfft
       integer(c_int),value :: ny
       integer(c_int),value :: nz
       integer(kind(HIPFFT_R2C)),value :: myType
-      type(c_ptr),value :: workSize
+      integer(c_size_t) :: workSize
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipfftMakePlan3d_rank_0,&
-      hipfftMakePlan3d_rank_1
-#endif
   end interface
 
   !>  @brief Initialize a new batched rank-dimensional FFT plan with advanced data layout.
@@ -393,7 +375,7 @@ module hipfort_hipfft
       integer(c_int),value :: odist
       integer(kind(HIPFFT_R2C)),value :: myType
       integer(c_int),value :: batch
-      type(c_ptr),value :: workSize
+      integer(c_size_t) :: workSize
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
@@ -428,7 +410,7 @@ module hipfort_hipfft
       integer(c_int64_t),value :: odist
       integer(kind(HIPFFT_R2C)),value :: myType
       integer(c_int64_t),value :: batch
-      type(c_ptr),value :: workSize
+      integer(c_size_t) :: workSize
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
@@ -457,14 +439,8 @@ module hipfort_hipfft
       integer(c_int),value :: nx
       integer(kind(HIPFFT_R2C)),value :: myType
       integer(c_int),value :: batch
-      type(c_ptr),value :: workSize
+      integer(c_size_t) :: workSize
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipfftEstimate1d_rank_0,&
-      hipfftEstimate1d_rank_1
-#endif
   end interface
 
   !>  @brief Return an estimate of the work area size required for a 2D plan.
@@ -486,14 +462,8 @@ module hipfort_hipfft
       integer(c_int),value :: nx
       integer(c_int),value :: ny
       integer(kind(HIPFFT_R2C)),value :: myType
-      type(c_ptr),value :: workSize
+      integer(c_size_t) :: workSize
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipfftEstimate2d_rank_0,&
-      hipfftEstimate2d_rank_1
-#endif
   end interface
 
   !>  @brief Return an estimate of the work area size required for a 3D plan.
@@ -517,14 +487,8 @@ module hipfort_hipfft
       integer(c_int),value :: ny
       integer(c_int),value :: nz
       integer(kind(HIPFFT_R2C)),value :: myType
-      type(c_ptr),value :: workSize
+      integer(c_size_t) :: workSize
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipfftEstimate3d_rank_0,&
-      hipfftEstimate3d_rank_1
-#endif
   end interface
 
   !>  @brief Return an estimate of the work area size required for a rank-dimensional plan.
@@ -564,7 +528,7 @@ module hipfort_hipfft
       integer(c_int),value :: odist
       integer(kind(HIPFFT_R2C)),value :: myType
       integer(c_int),value :: batch
-      type(c_ptr),value :: workSize
+      integer(c_size_t) :: workSize
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
@@ -595,14 +559,8 @@ module hipfort_hipfft
       integer(c_int),value :: nx
       integer(kind(HIPFFT_R2C)),value :: myType
       integer(c_int),value :: batch
-      type(c_ptr),value :: workSize
+      integer(c_size_t) :: workSize
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipfftGetSize1d_rank_0,&
-      hipfftGetSize1d_rank_1
-#endif
   end interface
 
   !>  @brief Return size of the work area size required for a 2D plan.
@@ -626,14 +584,8 @@ module hipfort_hipfft
       integer(c_int),value :: nx
       integer(c_int),value :: ny
       integer(kind(HIPFFT_R2C)),value :: myType
-      type(c_ptr),value :: workSize
+      integer(c_size_t) :: workSize
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipfftGetSize2d_rank_0,&
-      hipfftGetSize2d_rank_1
-#endif
   end interface
 
   !>  @brief Return size of the work area size required for a 3D plan.
@@ -659,14 +611,8 @@ module hipfort_hipfft
       integer(c_int),value :: ny
       integer(c_int),value :: nz
       integer(kind(HIPFFT_R2C)),value :: myType
-      type(c_ptr),value :: workSize
+      integer(c_size_t) :: workSize
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipfftGetSize3d_rank_0,&
-      hipfftGetSize3d_rank_1
-#endif
   end interface
 
   !>  @brief Return size of the work area size required for a rank-dimensional plan.
@@ -708,7 +654,7 @@ module hipfort_hipfft
       integer(c_int),value :: odist
       integer(kind(HIPFFT_R2C)),value :: myType
       integer(c_int),value :: batch
-      type(c_ptr),value :: workSize
+      integer(c_size_t) :: workSize
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
@@ -743,7 +689,7 @@ module hipfort_hipfft
       integer(c_int64_t),value :: odist
       integer(kind(HIPFFT_R2C)),value :: myType
       integer(c_int64_t),value :: batch
-      type(c_ptr),value :: workSize
+      integer(c_size_t) :: workSize
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
@@ -768,14 +714,8 @@ module hipfort_hipfft
       implicit none
       integer(kind(HIPFFT_SUCCESS)) :: hipfftGetSize_
       type(c_ptr),value :: plan
-      type(c_ptr),value :: workSize
+      integer(c_size_t) :: workSize
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipfftGetSize_rank_0,&
-      hipfftGetSize_rank_1
-#endif
   end interface
 
   !>  @brief Set the plan's auto-allocation flag.  The plan will allocate its own workarea.
@@ -1064,7 +1004,7 @@ module hipfort_hipfft
       use hipfort_hipfft_enums
       implicit none
       integer(kind(HIPFFT_SUCCESS)) :: hipfftGetVersion_
-      type(c_ptr),value :: version
+      integer(c_int) :: version
     end function
   end interface
 
@@ -1135,92 +1075,6 @@ module hipfort_hipfft
         c_loc(onembed),ostride,odist,myType,batch)
     end function
 
-    function hipfftMakePlan1d_rank_0(plan,nx,myType,batch,workSize)
-      use iso_c_binding
-      use hipfort_hipfft_enums
-      implicit none
-      integer(kind(HIPFFT_SUCCESS)) :: hipfftMakePlan1d_rank_0
-      type(c_ptr) :: plan
-      integer(c_int) :: nx
-      integer(kind(HIPFFT_R2C)) :: myType
-      integer(c_int) :: batch
-      integer(c_size_t),target :: workSize
-      !
-      hipfftMakePlan1d_rank_0 = hipfftMakePlan1d_(plan,nx,myType,batch,c_loc(workSize))
-    end function
-
-    function hipfftMakePlan1d_rank_1(plan,nx,myType,batch,workSize)
-      use iso_c_binding
-      use hipfort_hipfft_enums
-      implicit none
-      integer(kind(HIPFFT_SUCCESS)) :: hipfftMakePlan1d_rank_1
-      type(c_ptr) :: plan
-      integer(c_int) :: nx
-      integer(kind(HIPFFT_R2C)) :: myType
-      integer(c_int) :: batch
-      integer(c_size_t),target,dimension(:) :: workSize
-      !
-      hipfftMakePlan1d_rank_1 = hipfftMakePlan1d_(plan,nx,myType,batch,c_loc(workSize))
-    end function
-
-    function hipfftMakePlan2d_rank_0(plan,nx,ny,myType,workSize)
-      use iso_c_binding
-      use hipfort_hipfft_enums
-      implicit none
-      integer(kind(HIPFFT_SUCCESS)) :: hipfftMakePlan2d_rank_0
-      type(c_ptr) :: plan
-      integer(c_int) :: nx
-      integer(c_int) :: ny
-      integer(kind(HIPFFT_R2C)) :: myType
-      integer(c_size_t),target :: workSize
-      !
-      hipfftMakePlan2d_rank_0 = hipfftMakePlan2d_(plan,nx,ny,myType,c_loc(workSize))
-    end function
-
-    function hipfftMakePlan2d_rank_1(plan,nx,ny,myType,workSize)
-      use iso_c_binding
-      use hipfort_hipfft_enums
-      implicit none
-      integer(kind(HIPFFT_SUCCESS)) :: hipfftMakePlan2d_rank_1
-      type(c_ptr) :: plan
-      integer(c_int) :: nx
-      integer(c_int) :: ny
-      integer(kind(HIPFFT_R2C)) :: myType
-      integer(c_size_t),target,dimension(:) :: workSize
-      !
-      hipfftMakePlan2d_rank_1 = hipfftMakePlan2d_(plan,nx,ny,myType,c_loc(workSize))
-    end function
-
-    function hipfftMakePlan3d_rank_0(plan,nx,ny,nz,myType,workSize)
-      use iso_c_binding
-      use hipfort_hipfft_enums
-      implicit none
-      integer(kind(HIPFFT_SUCCESS)) :: hipfftMakePlan3d_rank_0
-      type(c_ptr) :: plan
-      integer(c_int) :: nx
-      integer(c_int) :: ny
-      integer(c_int) :: nz
-      integer(kind(HIPFFT_R2C)) :: myType
-      integer(c_size_t),target :: workSize
-      !
-      hipfftMakePlan3d_rank_0 = hipfftMakePlan3d_(plan,nx,ny,nz,myType,c_loc(workSize))
-    end function
-
-    function hipfftMakePlan3d_rank_1(plan,nx,ny,nz,myType,workSize)
-      use iso_c_binding
-      use hipfort_hipfft_enums
-      implicit none
-      integer(kind(HIPFFT_SUCCESS)) :: hipfftMakePlan3d_rank_1
-      type(c_ptr) :: plan
-      integer(c_int) :: nx
-      integer(c_int) :: ny
-      integer(c_int) :: nz
-      integer(kind(HIPFFT_R2C)) :: myType
-      integer(c_size_t),target,dimension(:) :: workSize
-      !
-      hipfftMakePlan3d_rank_1 = hipfftMakePlan3d_(plan,nx,ny,nz,myType,c_loc(workSize))
-    end function
-
     function hipfftMakePlanMany_rank_0(plan,rank,n,inembed,istride,idist,onembed,ostride,odist, &
         myType,batch,workSize)
       use iso_c_binding
@@ -1238,10 +1092,10 @@ module hipfort_hipfft
       integer(c_int) :: odist
       integer(kind(HIPFFT_R2C)) :: myType
       integer(c_int) :: batch
-      integer(c_size_t),target :: workSize
+      integer(c_size_t) :: workSize
       !
       hipfftMakePlanMany_rank_0 = hipfftMakePlanMany_(plan,rank,c_loc(n),c_loc(inembed),istride, &
-        idist,c_loc(onembed),ostride,odist,myType,batch,c_loc(workSize))
+        idist,c_loc(onembed),ostride,odist,myType,batch,workSize)
     end function
 
     function hipfftMakePlanMany_rank_1(plan,rank,n,inembed,istride,idist,onembed,ostride,odist, &
@@ -1261,10 +1115,10 @@ module hipfort_hipfft
       integer(c_int) :: odist
       integer(kind(HIPFFT_R2C)) :: myType
       integer(c_int) :: batch
-      integer(c_size_t),target,dimension(:) :: workSize
+      integer(c_size_t) :: workSize
       !
       hipfftMakePlanMany_rank_1 = hipfftMakePlanMany_(plan,rank,c_loc(n),c_loc(inembed),istride, &
-        idist,c_loc(onembed),ostride,odist,myType,batch,c_loc(workSize))
+        idist,c_loc(onembed),ostride,odist,myType,batch,workSize)
     end function
 
     function hipfftMakePlanMany64_rank_0(plan,rank,n,inembed,istride,idist,onembed,ostride,odist, &
@@ -1284,10 +1138,10 @@ module hipfort_hipfft
       integer(c_int64_t) :: odist
       integer(kind(HIPFFT_R2C)) :: myType
       integer(c_int64_t) :: batch
-      integer(c_size_t),target :: workSize
+      integer(c_size_t) :: workSize
       !
       hipfftMakePlanMany64_rank_0 = hipfftMakePlanMany64_(plan,rank,c_loc(n),c_loc(inembed), &
-        istride,idist,c_loc(onembed),ostride,odist,myType,batch,c_loc(workSize))
+        istride,idist,c_loc(onembed),ostride,odist,myType,batch,workSize)
     end function
 
     function hipfftMakePlanMany64_rank_1(plan,rank,n,inembed,istride,idist,onembed,ostride,odist, &
@@ -1307,90 +1161,10 @@ module hipfort_hipfft
       integer(c_int64_t) :: odist
       integer(kind(HIPFFT_R2C)) :: myType
       integer(c_int64_t) :: batch
-      integer(c_size_t),target,dimension(:) :: workSize
+      integer(c_size_t) :: workSize
       !
       hipfftMakePlanMany64_rank_1 = hipfftMakePlanMany64_(plan,rank,c_loc(n),c_loc(inembed), &
-        istride,idist,c_loc(onembed),ostride,odist,myType,batch,c_loc(workSize))
-    end function
-
-    function hipfftEstimate1d_rank_0(nx,myType,batch,workSize)
-      use iso_c_binding
-      use hipfort_hipfft_enums
-      implicit none
-      integer(kind(HIPFFT_SUCCESS)) :: hipfftEstimate1d_rank_0
-      integer(c_int) :: nx
-      integer(kind(HIPFFT_R2C)) :: myType
-      integer(c_int) :: batch
-      integer(c_size_t),target :: workSize
-      !
-      hipfftEstimate1d_rank_0 = hipfftEstimate1d_(nx,myType,batch,c_loc(workSize))
-    end function
-
-    function hipfftEstimate1d_rank_1(nx,myType,batch,workSize)
-      use iso_c_binding
-      use hipfort_hipfft_enums
-      implicit none
-      integer(kind(HIPFFT_SUCCESS)) :: hipfftEstimate1d_rank_1
-      integer(c_int) :: nx
-      integer(kind(HIPFFT_R2C)) :: myType
-      integer(c_int) :: batch
-      integer(c_size_t),target,dimension(:) :: workSize
-      !
-      hipfftEstimate1d_rank_1 = hipfftEstimate1d_(nx,myType,batch,c_loc(workSize))
-    end function
-
-    function hipfftEstimate2d_rank_0(nx,ny,myType,workSize)
-      use iso_c_binding
-      use hipfort_hipfft_enums
-      implicit none
-      integer(kind(HIPFFT_SUCCESS)) :: hipfftEstimate2d_rank_0
-      integer(c_int) :: nx
-      integer(c_int) :: ny
-      integer(kind(HIPFFT_R2C)) :: myType
-      integer(c_size_t),target :: workSize
-      !
-      hipfftEstimate2d_rank_0 = hipfftEstimate2d_(nx,ny,myType,c_loc(workSize))
-    end function
-
-    function hipfftEstimate2d_rank_1(nx,ny,myType,workSize)
-      use iso_c_binding
-      use hipfort_hipfft_enums
-      implicit none
-      integer(kind(HIPFFT_SUCCESS)) :: hipfftEstimate2d_rank_1
-      integer(c_int) :: nx
-      integer(c_int) :: ny
-      integer(kind(HIPFFT_R2C)) :: myType
-      integer(c_size_t),target,dimension(:) :: workSize
-      !
-      hipfftEstimate2d_rank_1 = hipfftEstimate2d_(nx,ny,myType,c_loc(workSize))
-    end function
-
-    function hipfftEstimate3d_rank_0(nx,ny,nz,myType,workSize)
-      use iso_c_binding
-      use hipfort_hipfft_enums
-      implicit none
-      integer(kind(HIPFFT_SUCCESS)) :: hipfftEstimate3d_rank_0
-      integer(c_int) :: nx
-      integer(c_int) :: ny
-      integer(c_int) :: nz
-      integer(kind(HIPFFT_R2C)) :: myType
-      integer(c_size_t),target :: workSize
-      !
-      hipfftEstimate3d_rank_0 = hipfftEstimate3d_(nx,ny,nz,myType,c_loc(workSize))
-    end function
-
-    function hipfftEstimate3d_rank_1(nx,ny,nz,myType,workSize)
-      use iso_c_binding
-      use hipfort_hipfft_enums
-      implicit none
-      integer(kind(HIPFFT_SUCCESS)) :: hipfftEstimate3d_rank_1
-      integer(c_int) :: nx
-      integer(c_int) :: ny
-      integer(c_int) :: nz
-      integer(kind(HIPFFT_R2C)) :: myType
-      integer(c_size_t),target,dimension(:) :: workSize
-      !
-      hipfftEstimate3d_rank_1 = hipfftEstimate3d_(nx,ny,nz,myType,c_loc(workSize))
+        istride,idist,c_loc(onembed),ostride,odist,myType,batch,workSize)
     end function
 
     function hipfftEstimateMany_rank_0(rank,n,inembed,istride,idist,onembed,ostride,odist,myType, &
@@ -1409,10 +1183,10 @@ module hipfort_hipfft
       integer(c_int) :: odist
       integer(kind(HIPFFT_R2C)) :: myType
       integer(c_int) :: batch
-      integer(c_size_t),target :: workSize
+      integer(c_size_t) :: workSize
       !
       hipfftEstimateMany_rank_0 = hipfftEstimateMany_(rank,c_loc(n),c_loc(inembed),istride,idist, &
-        c_loc(onembed),ostride,odist,myType,batch,c_loc(workSize))
+        c_loc(onembed),ostride,odist,myType,batch,workSize)
     end function
 
     function hipfftEstimateMany_rank_1(rank,n,inembed,istride,idist,onembed,ostride,odist,myType, &
@@ -1431,96 +1205,10 @@ module hipfort_hipfft
       integer(c_int) :: odist
       integer(kind(HIPFFT_R2C)) :: myType
       integer(c_int) :: batch
-      integer(c_size_t),target,dimension(:) :: workSize
+      integer(c_size_t) :: workSize
       !
       hipfftEstimateMany_rank_1 = hipfftEstimateMany_(rank,c_loc(n),c_loc(inembed),istride,idist, &
-        c_loc(onembed),ostride,odist,myType,batch,c_loc(workSize))
-    end function
-
-    function hipfftGetSize1d_rank_0(plan,nx,myType,batch,workSize)
-      use iso_c_binding
-      use hipfort_hipfft_enums
-      implicit none
-      integer(kind(HIPFFT_SUCCESS)) :: hipfftGetSize1d_rank_0
-      type(c_ptr) :: plan
-      integer(c_int) :: nx
-      integer(kind(HIPFFT_R2C)) :: myType
-      integer(c_int) :: batch
-      integer(c_size_t),target :: workSize
-      !
-      hipfftGetSize1d_rank_0 = hipfftGetSize1d_(plan,nx,myType,batch,c_loc(workSize))
-    end function
-
-    function hipfftGetSize1d_rank_1(plan,nx,myType,batch,workSize)
-      use iso_c_binding
-      use hipfort_hipfft_enums
-      implicit none
-      integer(kind(HIPFFT_SUCCESS)) :: hipfftGetSize1d_rank_1
-      type(c_ptr) :: plan
-      integer(c_int) :: nx
-      integer(kind(HIPFFT_R2C)) :: myType
-      integer(c_int) :: batch
-      integer(c_size_t),target,dimension(:) :: workSize
-      !
-      hipfftGetSize1d_rank_1 = hipfftGetSize1d_(plan,nx,myType,batch,c_loc(workSize))
-    end function
-
-    function hipfftGetSize2d_rank_0(plan,nx,ny,myType,workSize)
-      use iso_c_binding
-      use hipfort_hipfft_enums
-      implicit none
-      integer(kind(HIPFFT_SUCCESS)) :: hipfftGetSize2d_rank_0
-      type(c_ptr) :: plan
-      integer(c_int) :: nx
-      integer(c_int) :: ny
-      integer(kind(HIPFFT_R2C)) :: myType
-      integer(c_size_t),target :: workSize
-      !
-      hipfftGetSize2d_rank_0 = hipfftGetSize2d_(plan,nx,ny,myType,c_loc(workSize))
-    end function
-
-    function hipfftGetSize2d_rank_1(plan,nx,ny,myType,workSize)
-      use iso_c_binding
-      use hipfort_hipfft_enums
-      implicit none
-      integer(kind(HIPFFT_SUCCESS)) :: hipfftGetSize2d_rank_1
-      type(c_ptr) :: plan
-      integer(c_int) :: nx
-      integer(c_int) :: ny
-      integer(kind(HIPFFT_R2C)) :: myType
-      integer(c_size_t),target,dimension(:) :: workSize
-      !
-      hipfftGetSize2d_rank_1 = hipfftGetSize2d_(plan,nx,ny,myType,c_loc(workSize))
-    end function
-
-    function hipfftGetSize3d_rank_0(plan,nx,ny,nz,myType,workSize)
-      use iso_c_binding
-      use hipfort_hipfft_enums
-      implicit none
-      integer(kind(HIPFFT_SUCCESS)) :: hipfftGetSize3d_rank_0
-      type(c_ptr) :: plan
-      integer(c_int) :: nx
-      integer(c_int) :: ny
-      integer(c_int) :: nz
-      integer(kind(HIPFFT_R2C)) :: myType
-      integer(c_size_t),target :: workSize
-      !
-      hipfftGetSize3d_rank_0 = hipfftGetSize3d_(plan,nx,ny,nz,myType,c_loc(workSize))
-    end function
-
-    function hipfftGetSize3d_rank_1(plan,nx,ny,nz,myType,workSize)
-      use iso_c_binding
-      use hipfort_hipfft_enums
-      implicit none
-      integer(kind(HIPFFT_SUCCESS)) :: hipfftGetSize3d_rank_1
-      type(c_ptr) :: plan
-      integer(c_int) :: nx
-      integer(c_int) :: ny
-      integer(c_int) :: nz
-      integer(kind(HIPFFT_R2C)) :: myType
-      integer(c_size_t),target,dimension(:) :: workSize
-      !
-      hipfftGetSize3d_rank_1 = hipfftGetSize3d_(plan,nx,ny,nz,myType,c_loc(workSize))
+        c_loc(onembed),ostride,odist,myType,batch,workSize)
     end function
 
     function hipfftGetSizeMany_rank_0(plan,rank,n,inembed,istride,idist,onembed,ostride,odist, &
@@ -1540,10 +1228,10 @@ module hipfort_hipfft
       integer(c_int) :: odist
       integer(kind(HIPFFT_R2C)) :: myType
       integer(c_int) :: batch
-      integer(c_size_t),target :: workSize
+      integer(c_size_t) :: workSize
       !
       hipfftGetSizeMany_rank_0 = hipfftGetSizeMany_(plan,rank,c_loc(n),c_loc(inembed),istride, &
-        idist,c_loc(onembed),ostride,odist,myType,batch,c_loc(workSize))
+        idist,c_loc(onembed),ostride,odist,myType,batch,workSize)
     end function
 
     function hipfftGetSizeMany_rank_1(plan,rank,n,inembed,istride,idist,onembed,ostride,odist, &
@@ -1563,10 +1251,10 @@ module hipfort_hipfft
       integer(c_int) :: odist
       integer(kind(HIPFFT_R2C)) :: myType
       integer(c_int) :: batch
-      integer(c_size_t),target,dimension(:) :: workSize
+      integer(c_size_t) :: workSize
       !
       hipfftGetSizeMany_rank_1 = hipfftGetSizeMany_(plan,rank,c_loc(n),c_loc(inembed),istride, &
-        idist,c_loc(onembed),ostride,odist,myType,batch,c_loc(workSize))
+        idist,c_loc(onembed),ostride,odist,myType,batch,workSize)
     end function
 
     function hipfftGetSizeMany64_rank_0(plan,rank,n,inembed,istride,idist,onembed,ostride,odist, &
@@ -1586,10 +1274,10 @@ module hipfort_hipfft
       integer(c_int64_t) :: odist
       integer(kind(HIPFFT_R2C)) :: myType
       integer(c_int64_t) :: batch
-      integer(c_size_t),target :: workSize
+      integer(c_size_t) :: workSize
       !
       hipfftGetSizeMany64_rank_0 = hipfftGetSizeMany64_(plan,rank,c_loc(n),c_loc(inembed),istride, &
-        idist,c_loc(onembed),ostride,odist,myType,batch,c_loc(workSize))
+        idist,c_loc(onembed),ostride,odist,myType,batch,workSize)
     end function
 
     function hipfftGetSizeMany64_rank_1(plan,rank,n,inembed,istride,idist,onembed,ostride,odist, &
@@ -1609,32 +1297,10 @@ module hipfort_hipfft
       integer(c_int64_t) :: odist
       integer(kind(HIPFFT_R2C)) :: myType
       integer(c_int64_t) :: batch
-      integer(c_size_t),target,dimension(:) :: workSize
+      integer(c_size_t) :: workSize
       !
       hipfftGetSizeMany64_rank_1 = hipfftGetSizeMany64_(plan,rank,c_loc(n),c_loc(inembed),istride, &
-        idist,c_loc(onembed),ostride,odist,myType,batch,c_loc(workSize))
-    end function
-
-    function hipfftGetSize_rank_0(plan,workSize)
-      use iso_c_binding
-      use hipfort_hipfft_enums
-      implicit none
-      integer(kind(HIPFFT_SUCCESS)) :: hipfftGetSize_rank_0
-      type(c_ptr) :: plan
-      integer(c_size_t),target :: workSize
-      !
-      hipfftGetSize_rank_0 = hipfftGetSize_(plan,c_loc(workSize))
-    end function
-
-    function hipfftGetSize_rank_1(plan,workSize)
-      use iso_c_binding
-      use hipfort_hipfft_enums
-      implicit none
-      integer(kind(HIPFFT_SUCCESS)) :: hipfftGetSize_rank_1
-      type(c_ptr) :: plan
-      integer(c_size_t),target,dimension(:) :: workSize
-      !
-      hipfftGetSize_rank_1 = hipfftGetSize_(plan,c_loc(workSize))
+        idist,c_loc(onembed),ostride,odist,myType,batch,workSize)
     end function
 
     function hipfftExecC2C_rank_0(plan,idata,odata,direction)

--- a/lib/hipfort/hipfort_hiprand.F90
+++ b/lib/hipfort/hipfort_hiprand.F90
@@ -858,7 +858,7 @@ module hipfort_hiprand
       use hipfort_hiprand_enums
       implicit none
       integer(kind(HIPRAND_STATUS_SUCCESS)) :: hiprandGetVersion_
-      type(c_ptr),value :: version
+      integer(c_int) :: version
     end function
   end interface
 

--- a/lib/hipfort/hipfort_hipsolver.F90
+++ b/lib/hipfort/hipfort_hipsolver.F90
@@ -212,7 +212,7 @@ module hipfort_hipsolver
       integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverXgesvdjGetResidual_
       type(c_ptr),value :: handle
       type(c_ptr),value :: myInfo
-      type(c_ptr),value :: residual
+      real(c_double) :: residual
     end function
   end interface
 
@@ -230,7 +230,7 @@ module hipfort_hipsolver
       integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverXgesvdjGetSweeps_
       type(c_ptr),value :: handle
       type(c_ptr),value :: myInfo
-      type(c_ptr),value :: executed_sweeps
+      integer(c_int) :: executed_sweeps
     end function
   end interface
 
@@ -325,7 +325,7 @@ module hipfort_hipsolver
       integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverXsyevjGetResidual_
       type(c_ptr),value :: handle
       type(c_ptr),value :: myInfo
-      type(c_ptr),value :: residual
+      real(c_double) :: residual
     end function
   end interface
 
@@ -343,7 +343,7 @@ module hipfort_hipsolver
       integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverXsyevjGetSweeps_
       type(c_ptr),value :: handle
       type(c_ptr),value :: myInfo
-      type(c_ptr),value :: executed_sweeps
+      integer(c_int) :: executed_sweeps
     end function
   end interface
 
@@ -1881,7 +1881,7 @@ module hipfort_hipsolver
       integer(c_int),value :: ldb
       type(c_ptr),value :: X
       integer(c_int),value :: ldx
-      type(c_ptr),value :: lwork
+      integer(c_size_t) :: lwork
     end function
   end interface
 
@@ -1907,7 +1907,7 @@ module hipfort_hipsolver
       integer(c_int),value :: ldb
       type(c_ptr),value :: X
       integer(c_int),value :: ldx
-      type(c_ptr),value :: lwork
+      integer(c_size_t) :: lwork
     end function
   end interface
 
@@ -1933,7 +1933,7 @@ module hipfort_hipsolver
       integer(c_int),value :: ldb
       type(c_ptr),value :: X
       integer(c_int),value :: ldx
-      type(c_ptr),value :: lwork
+      integer(c_size_t) :: lwork
     end function
   end interface
 
@@ -1959,7 +1959,7 @@ module hipfort_hipsolver
       integer(c_int),value :: ldb
       type(c_ptr),value :: X
       integer(c_int),value :: ldx
-      type(c_ptr),value :: lwork
+      integer(c_size_t) :: lwork
     end function
   end interface
 
@@ -2608,7 +2608,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: jobv
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -2629,7 +2629,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: jobv
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -2650,7 +2650,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: jobv
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -2671,7 +2671,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: jobv
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -5209,7 +5209,7 @@ module hipfort_hipsolver
       integer(c_int),value :: iu
       type(c_ptr),value :: nev
       type(c_ptr),value :: W
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -7282,7 +7282,7 @@ module hipfort_hipsolver
       integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDnXgesvdjGetResidual_
       type(c_ptr),value :: handle
       type(c_ptr),value :: myInfo
-      type(c_ptr),value :: residual
+      real(c_double) :: residual
     end function
   end interface
 
@@ -7300,7 +7300,7 @@ module hipfort_hipsolver
       integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDnXgesvdjGetSweeps_
       type(c_ptr),value :: handle
       type(c_ptr),value :: myInfo
-      type(c_ptr),value :: executed_sweeps
+      integer(c_int) :: executed_sweeps
     end function
   end interface
 
@@ -7397,7 +7397,7 @@ module hipfort_hipsolver
       integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDnXsyevjGetResidual_
       type(c_ptr),value :: handle
       type(c_ptr),value :: myInfo
-      type(c_ptr),value :: residual
+      real(c_double) :: residual
     end function
   end interface
 
@@ -7415,7 +7415,7 @@ module hipfort_hipsolver
       integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDnXsyevjGetSweeps_
       type(c_ptr),value :: handle
       type(c_ptr),value :: myInfo
-      type(c_ptr),value :: executed_sweeps
+      integer(c_int) :: executed_sweeps
     end function
   end interface
 
@@ -7439,7 +7439,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: tau
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -7463,7 +7463,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: tau
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -7487,7 +7487,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: tau
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -7511,7 +7511,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: tau
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -7638,7 +7638,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: tau
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -7661,7 +7661,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: tau
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -7684,7 +7684,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: tau
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -7707,7 +7707,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: tau
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -7829,7 +7829,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: tau
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -7851,7 +7851,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: tau
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -7873,7 +7873,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: tau
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -7895,7 +7895,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: tau
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -8018,7 +8018,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: tau
       type(c_ptr),value :: C
       integer(c_int),value :: ldc
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -8045,7 +8045,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: tau
       type(c_ptr),value :: C
       integer(c_int),value :: ldc
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -8072,7 +8072,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: tau
       type(c_ptr),value :: C
       integer(c_int),value :: ldc
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -8099,7 +8099,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: tau
       type(c_ptr),value :: C
       integer(c_int),value :: ldc
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -8242,7 +8242,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: tau
       type(c_ptr),value :: C
       integer(c_int),value :: ldc
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -8269,7 +8269,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: tau
       type(c_ptr),value :: C
       integer(c_int),value :: ldc
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -8296,7 +8296,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: tau
       type(c_ptr),value :: C
       integer(c_int),value :: ldc
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -8323,7 +8323,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: tau
       type(c_ptr),value :: C
       integer(c_int),value :: ldc
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -8458,7 +8458,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -8477,7 +8477,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -8496,7 +8496,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -8515,7 +8515,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -8650,7 +8650,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: X
       integer(c_int),value :: ldx
       type(c_ptr),value :: work
-      type(c_ptr),value :: lwork
+      integer(c_size_t) :: lwork
     end function
   end interface
 
@@ -8677,7 +8677,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: X
       integer(c_int),value :: ldx
       type(c_ptr),value :: work
-      type(c_ptr),value :: lwork
+      integer(c_size_t) :: lwork
     end function
   end interface
 
@@ -8704,7 +8704,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: X
       integer(c_int),value :: ldx
       type(c_ptr),value :: work
-      type(c_ptr),value :: lwork
+      integer(c_size_t) :: lwork
     end function
   end interface
 
@@ -8731,7 +8731,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: X
       integer(c_int),value :: ldx
       type(c_ptr),value :: work
-      type(c_ptr),value :: lwork
+      integer(c_size_t) :: lwork
     end function
   end interface
 
@@ -8868,7 +8868,7 @@ module hipfort_hipsolver
       integer(c_int),value :: n
       type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -8889,7 +8889,7 @@ module hipfort_hipsolver
       integer(c_int),value :: n
       type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -8910,7 +8910,7 @@ module hipfort_hipsolver
       integer(c_int),value :: n
       type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -8931,7 +8931,7 @@ module hipfort_hipsolver
       integer(c_int),value :: n
       type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -9054,7 +9054,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: X
       integer(c_int),value :: ldx
       type(c_ptr),value :: work
-      type(c_ptr),value :: lwork
+      integer(c_size_t) :: lwork
     end function
   end interface
 
@@ -9081,7 +9081,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: X
       integer(c_int),value :: ldx
       type(c_ptr),value :: work
-      type(c_ptr),value :: lwork
+      integer(c_size_t) :: lwork
     end function
   end interface
 
@@ -9108,7 +9108,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: X
       integer(c_int),value :: ldx
       type(c_ptr),value :: work
-      type(c_ptr),value :: lwork
+      integer(c_size_t) :: lwork
     end function
   end interface
 
@@ -9135,7 +9135,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: X
       integer(c_int),value :: ldx
       type(c_ptr),value :: work
-      type(c_ptr),value :: lwork
+      integer(c_size_t) :: lwork
     end function
   end interface
 
@@ -9270,7 +9270,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -9289,7 +9289,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -9308,7 +9308,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -9327,7 +9327,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -9479,7 +9479,7 @@ module hipfort_hipsolver
       integer(c_int),value :: ldu
       type(c_ptr),value :: V
       integer(c_int),value :: ldv
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
       type(c_ptr),value :: params
     end function
   end interface
@@ -9508,7 +9508,7 @@ module hipfort_hipsolver
       integer(c_int),value :: ldu
       type(c_ptr),value :: V
       integer(c_int),value :: ldv
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
       type(c_ptr),value :: params
     end function
   end interface
@@ -9537,7 +9537,7 @@ module hipfort_hipsolver
       integer(c_int),value :: ldu
       type(c_ptr),value :: V
       integer(c_int),value :: ldv
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
       type(c_ptr),value :: params
     end function
   end interface
@@ -9566,7 +9566,7 @@ module hipfort_hipsolver
       integer(c_int),value :: ldu
       type(c_ptr),value :: V
       integer(c_int),value :: ldv
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
       type(c_ptr),value :: params
     end function
   end interface
@@ -9728,7 +9728,7 @@ module hipfort_hipsolver
       integer(c_int),value :: ldu
       type(c_ptr),value :: V
       integer(c_int),value :: ldv
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
       type(c_ptr),value :: params
       integer(c_int),value :: batch_count
     end function
@@ -9759,7 +9759,7 @@ module hipfort_hipsolver
       integer(c_int),value :: ldu
       type(c_ptr),value :: V
       integer(c_int),value :: ldv
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
       type(c_ptr),value :: params
       integer(c_int),value :: batch_count
     end function
@@ -9790,7 +9790,7 @@ module hipfort_hipsolver
       integer(c_int),value :: ldu
       type(c_ptr),value :: V
       integer(c_int),value :: ldv
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
       type(c_ptr),value :: params
       integer(c_int),value :: batch_count
     end function
@@ -9821,7 +9821,7 @@ module hipfort_hipsolver
       integer(c_int),value :: ldu
       type(c_ptr),value :: V
       integer(c_int),value :: ldv
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
       type(c_ptr),value :: params
       integer(c_int),value :: batch_count
     end function
@@ -9989,7 +9989,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: V
       integer(c_int),value :: ldv
       integer(c_int64_t),value :: strideV
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
       integer(c_int),value :: batch_count
     end function
   end interface
@@ -10024,7 +10024,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: V
       integer(c_int),value :: ldv
       integer(c_int64_t),value :: strideV
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
       integer(c_int),value :: batch_count
     end function
   end interface
@@ -10059,7 +10059,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: V
       integer(c_int),value :: ldv
       integer(c_int64_t),value :: strideV
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
       integer(c_int),value :: batch_count
     end function
   end interface
@@ -10094,7 +10094,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: V
       integer(c_int),value :: ldv
       integer(c_int64_t),value :: strideV
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
       integer(c_int),value :: batch_count
     end function
   end interface
@@ -10268,7 +10268,7 @@ module hipfort_hipsolver
       integer(c_int),value :: n
       type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -10289,7 +10289,7 @@ module hipfort_hipsolver
       integer(c_int),value :: n
       type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -10310,7 +10310,7 @@ module hipfort_hipsolver
       integer(c_int),value :: n
       type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -10331,7 +10331,7 @@ module hipfort_hipsolver
       integer(c_int),value :: n
       type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -10544,7 +10544,7 @@ module hipfort_hipsolver
       integer(c_int),value :: n
       type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -10565,7 +10565,7 @@ module hipfort_hipsolver
       integer(c_int),value :: n
       type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -10586,7 +10586,7 @@ module hipfort_hipsolver
       integer(c_int),value :: n
       type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -10607,7 +10607,7 @@ module hipfort_hipsolver
       integer(c_int),value :: n
       type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -10808,7 +10808,7 @@ module hipfort_hipsolver
       integer(c_int),value :: n
       type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -10829,7 +10829,7 @@ module hipfort_hipsolver
       integer(c_int),value :: n
       type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -10850,7 +10850,7 @@ module hipfort_hipsolver
       integer(c_int),value :: n
       type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -10871,7 +10871,7 @@ module hipfort_hipsolver
       integer(c_int),value :: n
       type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -11182,7 +11182,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: W
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -11205,7 +11205,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: W
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -11228,7 +11228,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: W
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -11251,7 +11251,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: W
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -11382,7 +11382,7 @@ module hipfort_hipsolver
       integer(c_int),value :: iu
       type(c_ptr),value :: nev
       type(c_ptr),value :: W
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -11413,7 +11413,7 @@ module hipfort_hipsolver
       integer(c_int),value :: iu
       type(c_ptr),value :: nev
       type(c_ptr),value :: W
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -11444,7 +11444,7 @@ module hipfort_hipsolver
       integer(c_int),value :: iu
       type(c_ptr),value :: nev
       type(c_ptr),value :: W
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -11475,7 +11475,7 @@ module hipfort_hipsolver
       integer(c_int),value :: iu
       type(c_ptr),value :: nev
       type(c_ptr),value :: W
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -11630,7 +11630,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: W
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
       type(c_ptr),value :: params
     end function
   end interface
@@ -11654,7 +11654,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: W
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
       type(c_ptr),value :: params
     end function
   end interface
@@ -11678,7 +11678,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: W
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
       type(c_ptr),value :: params
     end function
   end interface
@@ -11702,7 +11702,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: W
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
       type(c_ptr),value :: params
     end function
   end interface
@@ -11832,7 +11832,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: W
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
       type(c_ptr),value :: params
       integer(c_int),value :: batch_count
     end function
@@ -11859,7 +11859,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: W
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
       type(c_ptr),value :: params
       integer(c_int),value :: batch_count
     end function
@@ -11886,7 +11886,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: W
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
       type(c_ptr),value :: params
       integer(c_int),value :: batch_count
     end function
@@ -11913,7 +11913,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: W
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
       type(c_ptr),value :: params
       integer(c_int),value :: batch_count
     end function
@@ -12057,7 +12057,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: B
       integer(c_int),value :: ldb
       type(c_ptr),value :: W
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -12083,7 +12083,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: B
       integer(c_int),value :: ldb
       type(c_ptr),value :: W
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -12109,7 +12109,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: B
       integer(c_int),value :: ldb
       type(c_ptr),value :: W
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -12135,7 +12135,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: B
       integer(c_int),value :: ldb
       type(c_ptr),value :: W
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -12281,7 +12281,7 @@ module hipfort_hipsolver
       integer(c_int),value :: iu
       type(c_ptr),value :: nev
       type(c_ptr),value :: W
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -12315,7 +12315,7 @@ module hipfort_hipsolver
       integer(c_int),value :: iu
       type(c_ptr),value :: nev
       type(c_ptr),value :: W
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -12349,7 +12349,7 @@ module hipfort_hipsolver
       integer(c_int),value :: iu
       type(c_ptr),value :: nev
       type(c_ptr),value :: W
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -12383,7 +12383,7 @@ module hipfort_hipsolver
       integer(c_int),value :: iu
       type(c_ptr),value :: nev
       type(c_ptr),value :: W
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -12553,7 +12553,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: B
       integer(c_int),value :: ldb
       type(c_ptr),value :: W
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
       type(c_ptr),value :: params
     end function
   end interface
@@ -12580,7 +12580,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: B
       integer(c_int),value :: ldb
       type(c_ptr),value :: W
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
       type(c_ptr),value :: params
     end function
   end interface
@@ -12607,7 +12607,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: B
       integer(c_int),value :: ldb
       type(c_ptr),value :: W
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
       type(c_ptr),value :: params
     end function
   end interface
@@ -12634,7 +12634,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: B
       integer(c_int),value :: ldb
       type(c_ptr),value :: W
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
       type(c_ptr),value :: params
     end function
   end interface
@@ -12775,7 +12775,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: D
       type(c_ptr),value :: E
       type(c_ptr),value :: tau
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -12799,7 +12799,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: D
       type(c_ptr),value :: E
       type(c_ptr),value :: tau
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -12823,7 +12823,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: D
       type(c_ptr),value :: E
       type(c_ptr),value :: tau
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -12847,7 +12847,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: D
       type(c_ptr),value :: E
       type(c_ptr),value :: tau
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -12971,7 +12971,7 @@ module hipfort_hipsolver
       integer(c_int),value :: n
       type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -12991,7 +12991,7 @@ module hipfort_hipsolver
       integer(c_int),value :: n
       type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -13011,7 +13011,7 @@ module hipfort_hipsolver
       integer(c_int),value :: n
       type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -13031,7 +13031,7 @@ module hipfort_hipsolver
       integer(c_int),value :: n
       type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr),value :: lwork
+      integer(c_int) :: lwork
     end function
   end interface
 
@@ -14203,7 +14203,7 @@ module hipfort_hipsolver
       implicit none
       integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverRfBatchZeroPivot_
       type(c_ptr),value :: handle
-      type(c_ptr),value :: position
+      integer(c_int) :: position
     end function
   end interface
 

--- a/lib/hipfort/hipfort_hipsparse.F90
+++ b/lib/hipfort/hipfort_hipsparse.F90
@@ -142,7 +142,7 @@ module hipfort_hipsparse
       implicit none
       integer(kind(HIPSPARSE_STATUS_SUCCESS)) :: hipsparseGetVersion_
       type(c_ptr),value :: handle
-      type(c_ptr),value :: version
+      integer(c_int) :: version
     end function
   end interface
 
@@ -2507,7 +2507,7 @@ module hipfort_hipsparse
       type(c_ptr),value :: bsrSortedColIndA
       integer(c_int),value :: blockDim
       type(c_ptr),value :: myInfo
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
@@ -2542,7 +2542,7 @@ module hipfort_hipsparse
       type(c_ptr),value :: bsrSortedColIndA
       integer(c_int),value :: blockDim
       type(c_ptr),value :: myInfo
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
@@ -2577,7 +2577,7 @@ module hipfort_hipsparse
       type(c_ptr),value :: bsrSortedColIndA
       integer(c_int),value :: blockDim
       type(c_ptr),value :: myInfo
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
@@ -2612,7 +2612,7 @@ module hipfort_hipsparse
       type(c_ptr),value :: bsrSortedColIndA
       integer(c_int),value :: blockDim
       type(c_ptr),value :: myInfo
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
@@ -3863,7 +3863,7 @@ module hipfort_hipsparse
       type(c_ptr),value :: csrSortedRowPtrA
       type(c_ptr),value :: csrSortedColIndA
       type(c_ptr),value :: myInfo
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
@@ -3896,7 +3896,7 @@ module hipfort_hipsparse
       type(c_ptr),value :: csrSortedRowPtrA
       type(c_ptr),value :: csrSortedColIndA
       type(c_ptr),value :: myInfo
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
@@ -3929,7 +3929,7 @@ module hipfort_hipsparse
       type(c_ptr),value :: csrSortedRowPtrA
       type(c_ptr),value :: csrSortedColIndA
       type(c_ptr),value :: myInfo
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
@@ -3962,7 +3962,7 @@ module hipfort_hipsparse
       type(c_ptr),value :: csrSortedRowPtrA
       type(c_ptr),value :: csrSortedColIndA
       type(c_ptr),value :: myInfo
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
@@ -4460,7 +4460,7 @@ module hipfort_hipsparse
       integer(c_int),value :: m
       integer(c_int),value :: n
       integer(c_int),value :: nnz
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_int) :: pBufferSizeInBytes
     end function
   end interface
 
@@ -4481,7 +4481,7 @@ module hipfort_hipsparse
       integer(c_int),value :: m
       integer(c_int),value :: n
       integer(c_int),value :: nnz
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_int) :: pBufferSizeInBytes
     end function
   end interface
 
@@ -4502,7 +4502,7 @@ module hipfort_hipsparse
       integer(c_int),value :: m
       integer(c_int),value :: n
       integer(c_int),value :: nnz
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_int) :: pBufferSizeInBytes
     end function
   end interface
 
@@ -4523,7 +4523,7 @@ module hipfort_hipsparse
       integer(c_int),value :: m
       integer(c_int),value :: n
       integer(c_int),value :: nnz
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_int) :: pBufferSizeInBytes
     end function
   end interface
 
@@ -6741,7 +6741,7 @@ module hipfort_hipsparse
       integer(c_int),value :: m
       integer(c_int),value :: nrhs
       integer(c_int),value :: nnz
-      real(c_float) :: alpha
+      type(c_ptr),value :: alpha
       type(c_ptr),value :: descrA
       type(c_ptr),value :: csrSortedValA
       type(c_ptr),value :: csrSortedRowPtrA
@@ -6750,7 +6750,7 @@ module hipfort_hipsparse
       integer(c_int),value :: ldb
       type(c_ptr),value :: myInfo
       integer(kind(HIPSPARSE_SOLVE_POLICY_NO_LEVEL)),value :: policy
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
@@ -6782,7 +6782,7 @@ module hipfort_hipsparse
       integer(c_int),value :: m
       integer(c_int),value :: nrhs
       integer(c_int),value :: nnz
-      real(c_double) :: alpha
+      type(c_ptr),value :: alpha
       type(c_ptr),value :: descrA
       type(c_ptr),value :: csrSortedValA
       type(c_ptr),value :: csrSortedRowPtrA
@@ -6791,7 +6791,7 @@ module hipfort_hipsparse
       integer(c_int),value :: ldb
       type(c_ptr),value :: myInfo
       integer(kind(HIPSPARSE_SOLVE_POLICY_NO_LEVEL)),value :: policy
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
@@ -6823,7 +6823,7 @@ module hipfort_hipsparse
       integer(c_int),value :: m
       integer(c_int),value :: nrhs
       integer(c_int),value :: nnz
-      complex(c_float_complex) :: alpha
+      type(c_ptr),value :: alpha
       type(c_ptr),value :: descrA
       type(c_ptr),value :: csrSortedValA
       type(c_ptr),value :: csrSortedRowPtrA
@@ -6832,7 +6832,7 @@ module hipfort_hipsparse
       integer(c_int),value :: ldb
       type(c_ptr),value :: myInfo
       integer(kind(HIPSPARSE_SOLVE_POLICY_NO_LEVEL)),value :: policy
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
@@ -6864,7 +6864,7 @@ module hipfort_hipsparse
       integer(c_int),value :: m
       integer(c_int),value :: nrhs
       integer(c_int),value :: nnz
-      complex(c_double_complex) :: alpha
+      type(c_ptr),value :: alpha
       type(c_ptr),value :: descrA
       type(c_ptr),value :: csrSortedValA
       type(c_ptr),value :: csrSortedRowPtrA
@@ -6873,7 +6873,7 @@ module hipfort_hipsparse
       integer(c_int),value :: ldb
       type(c_ptr),value :: myInfo
       integer(kind(HIPSPARSE_SOLVE_POLICY_NO_LEVEL)),value :: policy
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
@@ -11509,7 +11509,7 @@ module hipfort_hipsparse
       type(c_ptr),value :: csrSortedRowPtrA
       type(c_ptr),value :: csrSortedColIndA
       type(c_ptr),value :: myInfo
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
@@ -11541,7 +11541,7 @@ module hipfort_hipsparse
       type(c_ptr),value :: csrSortedRowPtrA
       type(c_ptr),value :: csrSortedColIndA
       type(c_ptr),value :: myInfo
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
@@ -11573,7 +11573,7 @@ module hipfort_hipsparse
       type(c_ptr),value :: csrSortedRowPtrA
       type(c_ptr),value :: csrSortedColIndA
       type(c_ptr),value :: myInfo
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
@@ -11605,7 +11605,7 @@ module hipfort_hipsparse
       type(c_ptr),value :: csrSortedRowPtrA
       type(c_ptr),value :: csrSortedColIndA
       type(c_ptr),value :: myInfo
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
@@ -12473,7 +12473,7 @@ module hipfort_hipsparse
       type(c_ptr),value :: csrSortedRowPtrA
       type(c_ptr),value :: csrSortedColIndA
       type(c_ptr),value :: myInfo
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
@@ -12505,7 +12505,7 @@ module hipfort_hipsparse
       type(c_ptr),value :: csrSortedRowPtrA
       type(c_ptr),value :: csrSortedColIndA
       type(c_ptr),value :: myInfo
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
@@ -12537,7 +12537,7 @@ module hipfort_hipsparse
       type(c_ptr),value :: csrSortedRowPtrA
       type(c_ptr),value :: csrSortedColIndA
       type(c_ptr),value :: myInfo
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
@@ -12569,7 +12569,7 @@ module hipfort_hipsparse
       type(c_ptr),value :: csrSortedRowPtrA
       type(c_ptr),value :: csrSortedColIndA
       type(c_ptr),value :: myInfo
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
@@ -13836,7 +13836,7 @@ module hipfort_hipsparse
       type(c_ptr),value :: du
       type(c_ptr),value :: x
       integer(c_int),value :: batchCount
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
   end interface
 
@@ -13862,7 +13862,7 @@ module hipfort_hipsparse
       type(c_ptr),value :: du
       type(c_ptr),value :: x
       integer(c_int),value :: batchCount
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
   end interface
 
@@ -13888,7 +13888,7 @@ module hipfort_hipsparse
       type(c_ptr),value :: du
       type(c_ptr),value :: x
       integer(c_int),value :: batchCount
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
   end interface
 
@@ -13914,7 +13914,7 @@ module hipfort_hipsparse
       type(c_ptr),value :: du
       type(c_ptr),value :: x
       integer(c_int),value :: batchCount
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
   end interface
 
@@ -16592,7 +16592,7 @@ module hipfort_hipsparse
       integer(kind(HIPSPARSE_ACTION_SYMBOLIC)),value :: copyValues
       integer(kind(HIPSPARSE_INDEX_BASE_ZERO)),value :: idxBase
       integer(kind(HIPSPARSE_CSR2CSC_ALG_DEFAULT)),value :: alg
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
   end interface
 
@@ -17292,7 +17292,7 @@ module hipfort_hipsparse
       type(c_ptr),value :: csrColInd
       integer(c_int),value :: rowBlockDim
       integer(c_int),value :: colBlockDim
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
@@ -17326,7 +17326,7 @@ module hipfort_hipsparse
       type(c_ptr),value :: csrColInd
       integer(c_int),value :: rowBlockDim
       integer(c_int),value :: colBlockDim
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
@@ -17360,7 +17360,7 @@ module hipfort_hipsparse
       type(c_ptr),value :: csrColInd
       integer(c_int),value :: rowBlockDim
       integer(c_int),value :: colBlockDim
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
@@ -17394,7 +17394,7 @@ module hipfort_hipsparse
       type(c_ptr),value :: csrColInd
       integer(c_int),value :: rowBlockDim
       integer(c_int),value :: colBlockDim
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
@@ -19228,7 +19228,7 @@ module hipfort_hipsparse
       type(c_ptr),value :: bsrColInd
       integer(c_int),value :: rowBlockDim
       integer(c_int),value :: colBlockDim
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
   end interface
 
@@ -19255,7 +19255,7 @@ module hipfort_hipsparse
       type(c_ptr),value :: bsrColInd
       integer(c_int),value :: rowBlockDim
       integer(c_int),value :: colBlockDim
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
   end interface
 
@@ -19282,7 +19282,7 @@ module hipfort_hipsparse
       type(c_ptr),value :: bsrColInd
       integer(c_int),value :: rowBlockDim
       integer(c_int),value :: colBlockDim
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
   end interface
 
@@ -19309,7 +19309,7 @@ module hipfort_hipsparse
       type(c_ptr),value :: bsrColInd
       integer(c_int),value :: rowBlockDim
       integer(c_int),value :: colBlockDim
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
   end interface
 
@@ -19645,7 +19645,7 @@ module hipfort_hipsparse
       integer(c_int),value :: colBlockDimA
       integer(c_int),value :: rowBlockDimC
       integer(c_int),value :: colBlockDimC
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_int) :: pBufferSizeInBytes
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
@@ -19682,7 +19682,7 @@ module hipfort_hipsparse
       integer(c_int),value :: colBlockDimA
       integer(c_int),value :: rowBlockDimC
       integer(c_int),value :: colBlockDimC
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_int) :: pBufferSizeInBytes
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
@@ -19719,7 +19719,7 @@ module hipfort_hipsparse
       integer(c_int),value :: colBlockDimA
       integer(c_int),value :: rowBlockDimC
       integer(c_int),value :: colBlockDimC
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_int) :: pBufferSizeInBytes
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
@@ -19756,7 +19756,7 @@ module hipfort_hipsparse
       integer(c_int),value :: colBlockDimA
       integer(c_int),value :: rowBlockDimC
       integer(c_int),value :: colBlockDimC
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_int) :: pBufferSizeInBytes
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
@@ -20785,12 +20785,12 @@ module hipfort_hipsparse
       type(c_ptr),value :: csrValA
       type(c_ptr),value :: csrRowPtrA
       type(c_ptr),value :: csrColIndA
-      real(c_float) :: threshold
+      type(c_ptr),value :: threshold
       type(c_ptr),value :: descrC
       type(c_ptr),value :: csrValC
       type(c_ptr),value :: csrRowPtrC
       type(c_ptr),value :: csrColIndC
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
@@ -20822,12 +20822,12 @@ module hipfort_hipsparse
       type(c_ptr),value :: csrValA
       type(c_ptr),value :: csrRowPtrA
       type(c_ptr),value :: csrColIndA
-      real(c_double) :: threshold
+      type(c_ptr),value :: threshold
       type(c_ptr),value :: descrC
       type(c_ptr),value :: csrValC
       type(c_ptr),value :: csrRowPtrC
       type(c_ptr),value :: csrColIndC
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
@@ -20910,12 +20910,12 @@ module hipfort_hipsparse
       type(c_ptr),value :: csrValA
       type(c_ptr),value :: csrRowPtrA
       type(c_ptr),value :: csrColIndA
-      real(c_float) :: threshold
+      type(c_ptr),value :: threshold
       type(c_ptr),value :: descrC
       type(c_ptr),value :: csrValC
       type(c_ptr),value :: csrRowPtrC
       type(c_ptr),value :: csrColIndC
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
@@ -20947,12 +20947,12 @@ module hipfort_hipsparse
       type(c_ptr),value :: csrValA
       type(c_ptr),value :: csrRowPtrA
       type(c_ptr),value :: csrColIndA
-      real(c_double) :: threshold
+      type(c_ptr),value :: threshold
       type(c_ptr),value :: descrC
       type(c_ptr),value :: csrValC
       type(c_ptr),value :: csrRowPtrC
       type(c_ptr),value :: csrColIndC
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
@@ -21309,7 +21309,7 @@ module hipfort_hipsparse
       type(c_ptr),value :: csrRowPtrC
       type(c_ptr),value :: csrColIndC
       type(c_ptr),value :: myInfo
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
@@ -21349,7 +21349,7 @@ module hipfort_hipsparse
       type(c_ptr),value :: csrRowPtrC
       type(c_ptr),value :: csrColIndC
       type(c_ptr),value :: myInfo
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
@@ -21443,7 +21443,7 @@ module hipfort_hipsparse
       type(c_ptr),value :: csrRowPtrC
       type(c_ptr),value :: csrColIndC
       type(c_ptr),value :: myInfo
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
@@ -21483,7 +21483,7 @@ module hipfort_hipsparse
       type(c_ptr),value :: csrRowPtrC
       type(c_ptr),value :: csrColIndC
       type(c_ptr),value :: myInfo
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
@@ -21850,12 +21850,12 @@ module hipfort_hipsparse
       integer(c_int),value :: n
       type(c_ptr),value :: A
       integer(c_int),value :: lda
-      real(c_float) :: threshold
+      type(c_ptr),value :: threshold
       type(c_ptr),value :: descr
       type(c_ptr),value :: csrVal
       type(c_ptr),value :: csrRowPtr
       type(c_ptr),value :: csrColInd
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
@@ -21885,12 +21885,12 @@ module hipfort_hipsparse
       integer(c_int),value :: n
       type(c_ptr),value :: A
       integer(c_int),value :: lda
-      real(c_double) :: threshold
+      type(c_ptr),value :: threshold
       type(c_ptr),value :: descr
       type(c_ptr),value :: csrVal
       type(c_ptr),value :: csrRowPtr
       type(c_ptr),value :: csrColInd
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
@@ -21920,12 +21920,12 @@ module hipfort_hipsparse
       integer(c_int),value :: n
       type(c_ptr),value :: A
       integer(c_int),value :: lda
-      real(c_float) :: threshold
+      type(c_ptr),value :: threshold
       type(c_ptr),value :: descr
       type(c_ptr),value :: csrVal
       type(c_ptr),value :: csrRowPtr
       type(c_ptr),value :: csrColInd
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
@@ -21955,12 +21955,12 @@ module hipfort_hipsparse
       integer(c_int),value :: n
       type(c_ptr),value :: A
       integer(c_int),value :: lda
-      real(c_double) :: threshold
+      type(c_ptr),value :: threshold
       type(c_ptr),value :: descr
       type(c_ptr),value :: csrVal
       type(c_ptr),value :: csrRowPtr
       type(c_ptr),value :: csrColInd
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
@@ -22401,7 +22401,7 @@ module hipfort_hipsparse
       type(c_ptr),value :: csrRowPtr
       type(c_ptr),value :: csrColInd
       type(c_ptr),value :: myInfo
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
@@ -22437,7 +22437,7 @@ module hipfort_hipsparse
       type(c_ptr),value :: csrRowPtr
       type(c_ptr),value :: csrColInd
       type(c_ptr),value :: myInfo
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
@@ -22542,7 +22542,7 @@ module hipfort_hipsparse
       type(c_ptr),value :: csrRowPtr
       type(c_ptr),value :: csrColInd
       type(c_ptr),value :: myInfo
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
@@ -22578,7 +22578,7 @@ module hipfort_hipsparse
       type(c_ptr),value :: csrRowPtr
       type(c_ptr),value :: csrColInd
       type(c_ptr),value :: myInfo
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
@@ -23147,7 +23147,7 @@ module hipfort_hipsparse
       integer(kind(HIPSPARSE_STATUS_SUCCESS)) :: hipsparseSpVecGet_
       type(c_ptr),value :: spVecDescr
       type(c_ptr),value :: mySize
-      type(c_ptr),value :: nnz
+      integer(c_int64_t) :: nnz
       type(c_ptr) :: indices
       type(c_ptr) :: values
       type(c_ptr),value :: idxType
@@ -23172,7 +23172,7 @@ module hipfort_hipsparse
       integer(kind(HIPSPARSE_STATUS_SUCCESS)) :: hipsparseConstSpVecGet_
       type(c_ptr),value :: spVecDescr
       type(c_ptr),value :: mySize
-      type(c_ptr),value :: nnz
+      integer(c_int64_t) :: nnz
       type(c_ptr) :: indices
       type(c_ptr) :: values
       type(c_ptr),value :: idxType
@@ -23595,9 +23595,9 @@ module hipfort_hipsparse
       implicit none
       integer(kind(HIPSPARSE_STATUS_SUCCESS)) :: hipsparseCooGet_
       type(c_ptr),value :: spMatDescr
-      type(c_ptr),value :: rows
-      type(c_ptr),value :: cols
-      type(c_ptr),value :: nnz
+      integer(c_int64_t) :: rows
+      integer(c_int64_t) :: cols
+      integer(c_int64_t) :: nnz
       type(c_ptr) :: cooRowInd
       type(c_ptr) :: cooColInd
       type(c_ptr) :: cooValues
@@ -23622,9 +23622,9 @@ module hipfort_hipsparse
       implicit none
       integer(kind(HIPSPARSE_STATUS_SUCCESS)) :: hipsparseConstCooGet_
       type(c_ptr),value :: spMatDescr
-      type(c_ptr),value :: rows
-      type(c_ptr),value :: cols
-      type(c_ptr),value :: nnz
+      integer(c_int64_t) :: rows
+      integer(c_int64_t) :: cols
+      integer(c_int64_t) :: nnz
       type(c_ptr) :: cooRowInd
       type(c_ptr) :: cooColInd
       type(c_ptr) :: cooValues
@@ -23649,9 +23649,9 @@ module hipfort_hipsparse
       implicit none
       integer(kind(HIPSPARSE_STATUS_SUCCESS)) :: hipsparseCooAoSGet_
       type(c_ptr),value :: spMatDescr
-      type(c_ptr),value :: rows
-      type(c_ptr),value :: cols
-      type(c_ptr),value :: nnz
+      integer(c_int64_t) :: rows
+      integer(c_int64_t) :: cols
+      integer(c_int64_t) :: nnz
       type(c_ptr) :: cooInd
       type(c_ptr) :: cooValues
       type(c_ptr),value :: idxType
@@ -23675,9 +23675,9 @@ module hipfort_hipsparse
       implicit none
       integer(kind(HIPSPARSE_STATUS_SUCCESS)) :: hipsparseCsrGet_
       type(c_ptr),value :: spMatDescr
-      type(c_ptr),value :: rows
-      type(c_ptr),value :: cols
-      type(c_ptr),value :: nnz
+      integer(c_int64_t) :: rows
+      integer(c_int64_t) :: cols
+      integer(c_int64_t) :: nnz
       type(c_ptr) :: csrRowOffsets
       type(c_ptr) :: csrColInd
       type(c_ptr) :: csrValues
@@ -23703,9 +23703,9 @@ module hipfort_hipsparse
       implicit none
       integer(kind(HIPSPARSE_STATUS_SUCCESS)) :: hipsparseConstCsrGet_
       type(c_ptr),value :: spMatDescr
-      type(c_ptr),value :: rows
-      type(c_ptr),value :: cols
-      type(c_ptr),value :: nnz
+      integer(c_int64_t) :: rows
+      integer(c_int64_t) :: cols
+      integer(c_int64_t) :: nnz
       type(c_ptr) :: csrRowOffsets
       type(c_ptr) :: csrColInd
       type(c_ptr) :: csrValues
@@ -23731,9 +23731,9 @@ module hipfort_hipsparse
       implicit none
       integer(kind(HIPSPARSE_STATUS_SUCCESS)) :: hipsparseCscGet_
       type(c_ptr),value :: spMatDescr
-      type(c_ptr),value :: rows
-      type(c_ptr),value :: cols
-      type(c_ptr),value :: nnz
+      integer(c_int64_t) :: rows
+      integer(c_int64_t) :: cols
+      integer(c_int64_t) :: nnz
       type(c_ptr) :: cscColOffsets
       type(c_ptr) :: cscRowInd
       type(c_ptr) :: cscValues
@@ -23759,9 +23759,9 @@ module hipfort_hipsparse
       implicit none
       integer(kind(HIPSPARSE_STATUS_SUCCESS)) :: hipsparseConstCscGet_
       type(c_ptr),value :: spMatDescr
-      type(c_ptr),value :: rows
-      type(c_ptr),value :: cols
-      type(c_ptr),value :: nnz
+      integer(c_int64_t) :: rows
+      integer(c_int64_t) :: cols
+      integer(c_int64_t) :: nnz
       type(c_ptr) :: cscColOffsets
       type(c_ptr) :: cscRowInd
       type(c_ptr) :: cscValues
@@ -23787,8 +23787,8 @@ module hipfort_hipsparse
       implicit none
       integer(kind(HIPSPARSE_STATUS_SUCCESS)) :: hipsparseBlockedEllGet_
       type(c_ptr),value :: spMatDescr
-      type(c_ptr),value :: rows
-      type(c_ptr),value :: cols
+      integer(c_int64_t) :: rows
+      integer(c_int64_t) :: cols
       type(c_ptr),value :: ellBlockSize
       type(c_ptr),value :: ellCols
       type(c_ptr) :: ellColInd
@@ -23814,8 +23814,8 @@ module hipfort_hipsparse
       implicit none
       integer(kind(HIPSPARSE_STATUS_SUCCESS)) :: hipsparseConstBlockedEllGet_
       type(c_ptr),value :: spMatDescr
-      type(c_ptr),value :: rows
-      type(c_ptr),value :: cols
+      integer(c_int64_t) :: rows
+      integer(c_int64_t) :: cols
       type(c_ptr),value :: ellBlockSize
       type(c_ptr),value :: ellCols
       type(c_ptr) :: ellColInd
@@ -23909,9 +23909,9 @@ module hipfort_hipsparse
       implicit none
       integer(kind(HIPSPARSE_STATUS_SUCCESS)) :: hipsparseSpMatGetSize_
       type(c_ptr),value :: spMatDescr
-      type(c_ptr),value :: rows
-      type(c_ptr),value :: cols
-      type(c_ptr),value :: nnz
+      integer(c_int64_t) :: rows
+      integer(c_int64_t) :: cols
+      integer(c_int64_t) :: nnz
     end function
   end interface
 
@@ -24313,8 +24313,8 @@ module hipfort_hipsparse
       implicit none
       integer(kind(HIPSPARSE_STATUS_SUCCESS)) :: hipsparseDnMatGet_
       type(c_ptr),value :: dnMatDescr
-      type(c_ptr),value :: rows
-      type(c_ptr),value :: cols
+      integer(c_int64_t) :: rows
+      integer(c_int64_t) :: cols
       type(c_ptr),value :: ld
       type(c_ptr) :: values
       type(c_ptr),value :: valueType
@@ -24335,8 +24335,8 @@ module hipfort_hipsparse
       implicit none
       integer(kind(HIPSPARSE_STATUS_SUCCESS)) :: hipsparseConstDnMatGet_
       type(c_ptr),value :: dnMatDescr
-      type(c_ptr),value :: rows
-      type(c_ptr),value :: cols
+      integer(c_int64_t) :: rows
+      integer(c_int64_t) :: cols
       type(c_ptr),value :: ld
       type(c_ptr) :: values
       type(c_ptr),value :: valueType
@@ -24461,14 +24461,8 @@ module hipfort_hipsparse
       type(c_ptr),value :: matA
       type(c_ptr),value :: matB
       integer(kind(HIPSPARSE_DENSETOSPARSE_ALG_DEFAULT)),value :: alg
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipsparseDenseToSparse_bufferSize_rank_0,&
-      hipsparseDenseToSparse_bufferSize_rank_1
-#endif
   end interface
 
   interface hipsparseDenseToSparse_analysis
@@ -24586,7 +24580,7 @@ module hipfort_hipsparse
       type(c_ptr),value :: C
       integer(kind(HIP_R_32F)),value :: computeType
       integer(kind(HIPSPARSE_SDDMM_ALG_DEFAULT)),value :: alg
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
   end interface
 
@@ -24662,14 +24656,8 @@ module hipfort_hipsparse
       type(c_ptr),value :: matA
       type(c_ptr),value :: matB
       integer(kind(HIPSPARSE_SPARSETODENSE_ALG_DEFAULT)),value :: alg
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
-
-#ifdef USE_FPOINTER_INTERFACES
-    module procedure &
-      hipsparseSparseToDense_bufferSize_rank_0,&
-      hipsparseSparseToDense_bufferSize_rank_1
-#endif
   end interface
 
   interface hipsparseSparseToDense
@@ -24950,7 +24938,7 @@ module hipfort_hipsparse
       type(c_ptr),value :: matC
       integer(kind(HIP_R_32F)),value :: computeType
       integer(kind(HIPSPARSE_MM_ALG_DEFAULT)),value :: alg
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
   end interface
 
@@ -25036,7 +25024,7 @@ module hipfort_hipsparse
       type(c_ptr),value :: vecY
       integer(kind(HIP_R_32F)),value :: computeType
       integer(kind(HIPSPARSE_MV_ALG_DEFAULT)),value :: alg
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
   end interface
 
@@ -25147,7 +25135,7 @@ module hipfort_hipsparse
       integer(kind(HIP_R_32F)),value :: computeType
       integer(kind(HIPSPARSE_SPSM_ALG_DEFAULT)),value :: alg
       type(c_ptr),value :: spsmDescr
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
   end interface
 
@@ -25285,7 +25273,7 @@ module hipfort_hipsparse
       integer(kind(HIP_R_32F)),value :: computeType
       integer(kind(HIPSPARSE_SPSV_ALG_DEFAULT)),value :: alg
       type(c_ptr),value :: spsvDescr
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
   end interface
 
@@ -25363,7 +25351,7 @@ module hipfort_hipsparse
       type(c_ptr),value :: vecY
       type(c_ptr),value :: myResult
       integer(kind(HIP_R_32F)),value :: computeType
-      type(c_ptr),value :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
     end function
   end interface
 
@@ -26591,11 +26579,11 @@ module hipfort_hipsparse
       integer(c_int),target :: bsrSortedColIndA
       integer(c_int) :: blockDim
       type(c_ptr) :: myInfo
-      integer(c_size_t),target :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseSbsrsv2_bufferSizeExt_rank_0 = hipsparseSbsrsv2_bufferSizeExt_(handle,dirA,transA, &
         mb,nnzb,descrA,c_loc(bsrSortedValA),c_loc(bsrSortedRowPtrA),c_loc(bsrSortedColIndA), &
-        blockDim,myInfo,c_loc(pBufferSizeInBytes))
+        blockDim,myInfo,pBufferSizeInBytes)
     end function
 
     function hipsparseSbsrsv2_bufferSizeExt_rank_1(handle,dirA,transA,mb,nnzb,descrA, &
@@ -26615,11 +26603,11 @@ module hipfort_hipsparse
       integer(c_int),target,dimension(:) :: bsrSortedColIndA
       integer(c_int) :: blockDim
       type(c_ptr) :: myInfo
-      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseSbsrsv2_bufferSizeExt_rank_1 = hipsparseSbsrsv2_bufferSizeExt_(handle,dirA,transA, &
         mb,nnzb,descrA,c_loc(bsrSortedValA),c_loc(bsrSortedRowPtrA),c_loc(bsrSortedColIndA), &
-        blockDim,myInfo,c_loc(pBufferSizeInBytes))
+        blockDim,myInfo,pBufferSizeInBytes)
     end function
 
     function hipsparseDbsrsv2_bufferSizeExt_rank_0(handle,dirA,transA,mb,nnzb,descrA, &
@@ -26639,11 +26627,11 @@ module hipfort_hipsparse
       integer(c_int),target :: bsrSortedColIndA
       integer(c_int) :: blockDim
       type(c_ptr) :: myInfo
-      integer(c_size_t),target :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseDbsrsv2_bufferSizeExt_rank_0 = hipsparseDbsrsv2_bufferSizeExt_(handle,dirA,transA, &
         mb,nnzb,descrA,c_loc(bsrSortedValA),c_loc(bsrSortedRowPtrA),c_loc(bsrSortedColIndA), &
-        blockDim,myInfo,c_loc(pBufferSizeInBytes))
+        blockDim,myInfo,pBufferSizeInBytes)
     end function
 
     function hipsparseDbsrsv2_bufferSizeExt_rank_1(handle,dirA,transA,mb,nnzb,descrA, &
@@ -26663,11 +26651,11 @@ module hipfort_hipsparse
       integer(c_int),target,dimension(:) :: bsrSortedColIndA
       integer(c_int) :: blockDim
       type(c_ptr) :: myInfo
-      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseDbsrsv2_bufferSizeExt_rank_1 = hipsparseDbsrsv2_bufferSizeExt_(handle,dirA,transA, &
         mb,nnzb,descrA,c_loc(bsrSortedValA),c_loc(bsrSortedRowPtrA),c_loc(bsrSortedColIndA), &
-        blockDim,myInfo,c_loc(pBufferSizeInBytes))
+        blockDim,myInfo,pBufferSizeInBytes)
     end function
 
     function hipsparseCbsrsv2_bufferSizeExt_rank_0(handle,dirA,transA,mb,nnzb,descrA, &
@@ -26687,11 +26675,11 @@ module hipfort_hipsparse
       integer(c_int),target :: bsrSortedColIndA
       integer(c_int) :: blockDim
       type(c_ptr) :: myInfo
-      integer(c_size_t),target :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseCbsrsv2_bufferSizeExt_rank_0 = hipsparseCbsrsv2_bufferSizeExt_(handle,dirA,transA, &
         mb,nnzb,descrA,c_loc(bsrSortedValA),c_loc(bsrSortedRowPtrA),c_loc(bsrSortedColIndA), &
-        blockDim,myInfo,c_loc(pBufferSizeInBytes))
+        blockDim,myInfo,pBufferSizeInBytes)
     end function
 
     function hipsparseCbsrsv2_bufferSizeExt_rank_1(handle,dirA,transA,mb,nnzb,descrA, &
@@ -26711,11 +26699,11 @@ module hipfort_hipsparse
       integer(c_int),target,dimension(:) :: bsrSortedColIndA
       integer(c_int) :: blockDim
       type(c_ptr) :: myInfo
-      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseCbsrsv2_bufferSizeExt_rank_1 = hipsparseCbsrsv2_bufferSizeExt_(handle,dirA,transA, &
         mb,nnzb,descrA,c_loc(bsrSortedValA),c_loc(bsrSortedRowPtrA),c_loc(bsrSortedColIndA), &
-        blockDim,myInfo,c_loc(pBufferSizeInBytes))
+        blockDim,myInfo,pBufferSizeInBytes)
     end function
 
     function hipsparseZbsrsv2_bufferSizeExt_rank_0(handle,dirA,transA,mb,nnzb,descrA, &
@@ -26735,11 +26723,11 @@ module hipfort_hipsparse
       integer(c_int),target :: bsrSortedColIndA
       integer(c_int) :: blockDim
       type(c_ptr) :: myInfo
-      integer(c_size_t),target :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseZbsrsv2_bufferSizeExt_rank_0 = hipsparseZbsrsv2_bufferSizeExt_(handle,dirA,transA, &
         mb,nnzb,descrA,c_loc(bsrSortedValA),c_loc(bsrSortedRowPtrA),c_loc(bsrSortedColIndA), &
-        blockDim,myInfo,c_loc(pBufferSizeInBytes))
+        blockDim,myInfo,pBufferSizeInBytes)
     end function
 
     function hipsparseZbsrsv2_bufferSizeExt_rank_1(handle,dirA,transA,mb,nnzb,descrA, &
@@ -26759,11 +26747,11 @@ module hipfort_hipsparse
       integer(c_int),target,dimension(:) :: bsrSortedColIndA
       integer(c_int) :: blockDim
       type(c_ptr) :: myInfo
-      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseZbsrsv2_bufferSizeExt_rank_1 = hipsparseZbsrsv2_bufferSizeExt_(handle,dirA,transA, &
         mb,nnzb,descrA,c_loc(bsrSortedValA),c_loc(bsrSortedRowPtrA),c_loc(bsrSortedColIndA), &
-        blockDim,myInfo,c_loc(pBufferSizeInBytes))
+        blockDim,myInfo,pBufferSizeInBytes)
     end function
 
     function hipsparseSbsrsv2_analysis_rank_0(handle,dirA,transA,mb,nnzb,descrA,bsrSortedValA, &
@@ -27805,11 +27793,11 @@ module hipfort_hipsparse
       integer(c_int),target :: csrSortedRowPtrA
       integer(c_int),target :: csrSortedColIndA
       type(c_ptr) :: myInfo
-      integer(c_size_t),target :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseScsrsv2_bufferSizeExt_rank_0 = hipsparseScsrsv2_bufferSizeExt_(handle,transA,m,nnz, &
         descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),myInfo, &
-        c_loc(pBufferSizeInBytes))
+        pBufferSizeInBytes)
     end function
 
     function hipsparseScsrsv2_bufferSizeExt_rank_1(handle,transA,m,nnz,descrA,csrSortedValA, &
@@ -27827,11 +27815,11 @@ module hipfort_hipsparse
       integer(c_int),target,dimension(:) :: csrSortedRowPtrA
       integer(c_int),target,dimension(:) :: csrSortedColIndA
       type(c_ptr) :: myInfo
-      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseScsrsv2_bufferSizeExt_rank_1 = hipsparseScsrsv2_bufferSizeExt_(handle,transA,m,nnz, &
         descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),myInfo, &
-        c_loc(pBufferSizeInBytes))
+        pBufferSizeInBytes)
     end function
 
     function hipsparseDcsrsv2_bufferSizeExt_rank_0(handle,transA,m,nnz,descrA,csrSortedValA, &
@@ -27849,11 +27837,11 @@ module hipfort_hipsparse
       integer(c_int),target :: csrSortedRowPtrA
       integer(c_int),target :: csrSortedColIndA
       type(c_ptr) :: myInfo
-      integer(c_size_t),target :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseDcsrsv2_bufferSizeExt_rank_0 = hipsparseDcsrsv2_bufferSizeExt_(handle,transA,m,nnz, &
         descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),myInfo, &
-        c_loc(pBufferSizeInBytes))
+        pBufferSizeInBytes)
     end function
 
     function hipsparseDcsrsv2_bufferSizeExt_rank_1(handle,transA,m,nnz,descrA,csrSortedValA, &
@@ -27871,11 +27859,11 @@ module hipfort_hipsparse
       integer(c_int),target,dimension(:) :: csrSortedRowPtrA
       integer(c_int),target,dimension(:) :: csrSortedColIndA
       type(c_ptr) :: myInfo
-      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseDcsrsv2_bufferSizeExt_rank_1 = hipsparseDcsrsv2_bufferSizeExt_(handle,transA,m,nnz, &
         descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),myInfo, &
-        c_loc(pBufferSizeInBytes))
+        pBufferSizeInBytes)
     end function
 
     function hipsparseCcsrsv2_bufferSizeExt_rank_0(handle,transA,m,nnz,descrA,csrSortedValA, &
@@ -27893,11 +27881,11 @@ module hipfort_hipsparse
       integer(c_int),target :: csrSortedRowPtrA
       integer(c_int),target :: csrSortedColIndA
       type(c_ptr) :: myInfo
-      integer(c_size_t),target :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseCcsrsv2_bufferSizeExt_rank_0 = hipsparseCcsrsv2_bufferSizeExt_(handle,transA,m,nnz, &
         descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),myInfo, &
-        c_loc(pBufferSizeInBytes))
+        pBufferSizeInBytes)
     end function
 
     function hipsparseCcsrsv2_bufferSizeExt_rank_1(handle,transA,m,nnz,descrA,csrSortedValA, &
@@ -27915,11 +27903,11 @@ module hipfort_hipsparse
       integer(c_int),target,dimension(:) :: csrSortedRowPtrA
       integer(c_int),target,dimension(:) :: csrSortedColIndA
       type(c_ptr) :: myInfo
-      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseCcsrsv2_bufferSizeExt_rank_1 = hipsparseCcsrsv2_bufferSizeExt_(handle,transA,m,nnz, &
         descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),myInfo, &
-        c_loc(pBufferSizeInBytes))
+        pBufferSizeInBytes)
     end function
 
     function hipsparseZcsrsv2_bufferSizeExt_rank_0(handle,transA,m,nnz,descrA,csrSortedValA, &
@@ -27937,11 +27925,11 @@ module hipfort_hipsparse
       integer(c_int),target :: csrSortedRowPtrA
       integer(c_int),target :: csrSortedColIndA
       type(c_ptr) :: myInfo
-      integer(c_size_t),target :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseZcsrsv2_bufferSizeExt_rank_0 = hipsparseZcsrsv2_bufferSizeExt_(handle,transA,m,nnz, &
         descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),myInfo, &
-        c_loc(pBufferSizeInBytes))
+        pBufferSizeInBytes)
     end function
 
     function hipsparseZcsrsv2_bufferSizeExt_rank_1(handle,transA,m,nnz,descrA,csrSortedValA, &
@@ -27959,11 +27947,11 @@ module hipfort_hipsparse
       integer(c_int),target,dimension(:) :: csrSortedRowPtrA
       integer(c_int),target,dimension(:) :: csrSortedColIndA
       type(c_ptr) :: myInfo
-      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseZcsrsv2_bufferSizeExt_rank_1 = hipsparseZcsrsv2_bufferSizeExt_(handle,transA,m,nnz, &
         descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),myInfo, &
-        c_loc(pBufferSizeInBytes))
+        pBufferSizeInBytes)
     end function
 
     function hipsparseScsrsv2_analysis_rank_0(handle,transA,m,nnz,descrA,csrSortedValA, &
@@ -30664,7 +30652,7 @@ module hipfort_hipsparse
       integer(c_int) :: m
       integer(c_int) :: nrhs
       integer(c_int) :: nnz
-      real(c_float) :: alpha
+      real(c_float),target :: alpha
       type(c_ptr) :: descrA
       real(c_float),target :: csrSortedValA
       integer(c_int),target :: csrSortedRowPtrA
@@ -30673,11 +30661,11 @@ module hipfort_hipsparse
       integer(c_int) :: ldb
       type(c_ptr) :: myInfo
       integer(kind(HIPSPARSE_SOLVE_POLICY_NO_LEVEL)) :: policy
-      integer(c_size_t),target :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseScsrsm2_bufferSizeExt_rank_0 = hipsparseScsrsm2_bufferSizeExt_(handle,algo,transA, &
-        transB,m,nrhs,nnz,alpha,descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA), &
-        c_loc(csrSortedColIndA),c_loc(B),ldb,myInfo,policy,c_loc(pBufferSizeInBytes))
+        transB,m,nrhs,nnz,c_loc(alpha),descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA), &
+        c_loc(csrSortedColIndA),c_loc(B),ldb,myInfo,policy,pBufferSizeInBytes)
     end function
 
     function hipsparseScsrsm2_bufferSizeExt_rank_1(handle,algo,transA,transB,m,nrhs,nnz,alpha, &
@@ -30694,7 +30682,7 @@ module hipfort_hipsparse
       integer(c_int) :: m
       integer(c_int) :: nrhs
       integer(c_int) :: nnz
-      real(c_float) :: alpha
+      real(c_float),target,dimension(:) :: alpha
       type(c_ptr) :: descrA
       real(c_float),target,dimension(:) :: csrSortedValA
       integer(c_int),target,dimension(:) :: csrSortedRowPtrA
@@ -30703,11 +30691,11 @@ module hipfort_hipsparse
       integer(c_int) :: ldb
       type(c_ptr) :: myInfo
       integer(kind(HIPSPARSE_SOLVE_POLICY_NO_LEVEL)) :: policy
-      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseScsrsm2_bufferSizeExt_rank_1 = hipsparseScsrsm2_bufferSizeExt_(handle,algo,transA, &
-        transB,m,nrhs,nnz,alpha,descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA), &
-        c_loc(csrSortedColIndA),c_loc(B),ldb,myInfo,policy,c_loc(pBufferSizeInBytes))
+        transB,m,nrhs,nnz,c_loc(alpha),descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA), &
+        c_loc(csrSortedColIndA),c_loc(B),ldb,myInfo,policy,pBufferSizeInBytes)
     end function
 
     function hipsparseScsrsm2_bufferSizeExt_full_rank(handle,algo,transA,transB,m,nrhs,nnz,alpha, &
@@ -30724,7 +30712,7 @@ module hipfort_hipsparse
       integer(c_int) :: m
       integer(c_int) :: nrhs
       integer(c_int) :: nnz
-      real(c_float) :: alpha
+      real(c_float),target,dimension(:) :: alpha
       type(c_ptr) :: descrA
       real(c_float),target,dimension(:) :: csrSortedValA
       integer(c_int),target,dimension(:) :: csrSortedRowPtrA
@@ -30733,11 +30721,11 @@ module hipfort_hipsparse
       integer(c_int) :: ldb
       type(c_ptr) :: myInfo
       integer(kind(HIPSPARSE_SOLVE_POLICY_NO_LEVEL)) :: policy
-      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseScsrsm2_bufferSizeExt_full_rank = hipsparseScsrsm2_bufferSizeExt_(handle,algo, &
-        transA,transB,m,nrhs,nnz,alpha,descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA), &
-        c_loc(csrSortedColIndA),c_loc(B),ldb,myInfo,policy,c_loc(pBufferSizeInBytes))
+        transA,transB,m,nrhs,nnz,c_loc(alpha),descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA), &
+        c_loc(csrSortedColIndA),c_loc(B),ldb,myInfo,policy,pBufferSizeInBytes)
     end function
 
     function hipsparseDcsrsm2_bufferSizeExt_rank_0(handle,algo,transA,transB,m,nrhs,nnz,alpha, &
@@ -30754,7 +30742,7 @@ module hipfort_hipsparse
       integer(c_int) :: m
       integer(c_int) :: nrhs
       integer(c_int) :: nnz
-      real(c_double) :: alpha
+      real(c_double),target :: alpha
       type(c_ptr) :: descrA
       real(c_double),target :: csrSortedValA
       integer(c_int),target :: csrSortedRowPtrA
@@ -30763,11 +30751,11 @@ module hipfort_hipsparse
       integer(c_int) :: ldb
       type(c_ptr) :: myInfo
       integer(kind(HIPSPARSE_SOLVE_POLICY_NO_LEVEL)) :: policy
-      integer(c_size_t),target :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseDcsrsm2_bufferSizeExt_rank_0 = hipsparseDcsrsm2_bufferSizeExt_(handle,algo,transA, &
-        transB,m,nrhs,nnz,alpha,descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA), &
-        c_loc(csrSortedColIndA),c_loc(B),ldb,myInfo,policy,c_loc(pBufferSizeInBytes))
+        transB,m,nrhs,nnz,c_loc(alpha),descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA), &
+        c_loc(csrSortedColIndA),c_loc(B),ldb,myInfo,policy,pBufferSizeInBytes)
     end function
 
     function hipsparseDcsrsm2_bufferSizeExt_rank_1(handle,algo,transA,transB,m,nrhs,nnz,alpha, &
@@ -30784,7 +30772,7 @@ module hipfort_hipsparse
       integer(c_int) :: m
       integer(c_int) :: nrhs
       integer(c_int) :: nnz
-      real(c_double) :: alpha
+      real(c_double),target,dimension(:) :: alpha
       type(c_ptr) :: descrA
       real(c_double),target,dimension(:) :: csrSortedValA
       integer(c_int),target,dimension(:) :: csrSortedRowPtrA
@@ -30793,11 +30781,11 @@ module hipfort_hipsparse
       integer(c_int) :: ldb
       type(c_ptr) :: myInfo
       integer(kind(HIPSPARSE_SOLVE_POLICY_NO_LEVEL)) :: policy
-      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseDcsrsm2_bufferSizeExt_rank_1 = hipsparseDcsrsm2_bufferSizeExt_(handle,algo,transA, &
-        transB,m,nrhs,nnz,alpha,descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA), &
-        c_loc(csrSortedColIndA),c_loc(B),ldb,myInfo,policy,c_loc(pBufferSizeInBytes))
+        transB,m,nrhs,nnz,c_loc(alpha),descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA), &
+        c_loc(csrSortedColIndA),c_loc(B),ldb,myInfo,policy,pBufferSizeInBytes)
     end function
 
     function hipsparseDcsrsm2_bufferSizeExt_full_rank(handle,algo,transA,transB,m,nrhs,nnz,alpha, &
@@ -30814,7 +30802,7 @@ module hipfort_hipsparse
       integer(c_int) :: m
       integer(c_int) :: nrhs
       integer(c_int) :: nnz
-      real(c_double) :: alpha
+      real(c_double),target,dimension(:) :: alpha
       type(c_ptr) :: descrA
       real(c_double),target,dimension(:) :: csrSortedValA
       integer(c_int),target,dimension(:) :: csrSortedRowPtrA
@@ -30823,11 +30811,11 @@ module hipfort_hipsparse
       integer(c_int) :: ldb
       type(c_ptr) :: myInfo
       integer(kind(HIPSPARSE_SOLVE_POLICY_NO_LEVEL)) :: policy
-      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseDcsrsm2_bufferSizeExt_full_rank = hipsparseDcsrsm2_bufferSizeExt_(handle,algo, &
-        transA,transB,m,nrhs,nnz,alpha,descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA), &
-        c_loc(csrSortedColIndA),c_loc(B),ldb,myInfo,policy,c_loc(pBufferSizeInBytes))
+        transA,transB,m,nrhs,nnz,c_loc(alpha),descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA), &
+        c_loc(csrSortedColIndA),c_loc(B),ldb,myInfo,policy,pBufferSizeInBytes)
     end function
 
     function hipsparseCcsrsm2_bufferSizeExt_rank_0(handle,algo,transA,transB,m,nrhs,nnz,alpha, &
@@ -30844,7 +30832,7 @@ module hipfort_hipsparse
       integer(c_int) :: m
       integer(c_int) :: nrhs
       integer(c_int) :: nnz
-      complex(c_float_complex) :: alpha
+      complex(c_float_complex),target :: alpha
       type(c_ptr) :: descrA
       complex(c_float_complex),target :: csrSortedValA
       integer(c_int),target :: csrSortedRowPtrA
@@ -30853,11 +30841,11 @@ module hipfort_hipsparse
       integer(c_int) :: ldb
       type(c_ptr) :: myInfo
       integer(kind(HIPSPARSE_SOLVE_POLICY_NO_LEVEL)) :: policy
-      integer(c_size_t),target :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseCcsrsm2_bufferSizeExt_rank_0 = hipsparseCcsrsm2_bufferSizeExt_(handle,algo,transA, &
-        transB,m,nrhs,nnz,alpha,descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA), &
-        c_loc(csrSortedColIndA),c_loc(B),ldb,myInfo,policy,c_loc(pBufferSizeInBytes))
+        transB,m,nrhs,nnz,c_loc(alpha),descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA), &
+        c_loc(csrSortedColIndA),c_loc(B),ldb,myInfo,policy,pBufferSizeInBytes)
     end function
 
     function hipsparseCcsrsm2_bufferSizeExt_rank_1(handle,algo,transA,transB,m,nrhs,nnz,alpha, &
@@ -30874,7 +30862,7 @@ module hipfort_hipsparse
       integer(c_int) :: m
       integer(c_int) :: nrhs
       integer(c_int) :: nnz
-      complex(c_float_complex) :: alpha
+      complex(c_float_complex),target,dimension(:) :: alpha
       type(c_ptr) :: descrA
       complex(c_float_complex),target,dimension(:) :: csrSortedValA
       integer(c_int),target,dimension(:) :: csrSortedRowPtrA
@@ -30883,11 +30871,11 @@ module hipfort_hipsparse
       integer(c_int) :: ldb
       type(c_ptr) :: myInfo
       integer(kind(HIPSPARSE_SOLVE_POLICY_NO_LEVEL)) :: policy
-      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseCcsrsm2_bufferSizeExt_rank_1 = hipsparseCcsrsm2_bufferSizeExt_(handle,algo,transA, &
-        transB,m,nrhs,nnz,alpha,descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA), &
-        c_loc(csrSortedColIndA),c_loc(B),ldb,myInfo,policy,c_loc(pBufferSizeInBytes))
+        transB,m,nrhs,nnz,c_loc(alpha),descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA), &
+        c_loc(csrSortedColIndA),c_loc(B),ldb,myInfo,policy,pBufferSizeInBytes)
     end function
 
     function hipsparseCcsrsm2_bufferSizeExt_full_rank(handle,algo,transA,transB,m,nrhs,nnz,alpha, &
@@ -30904,7 +30892,7 @@ module hipfort_hipsparse
       integer(c_int) :: m
       integer(c_int) :: nrhs
       integer(c_int) :: nnz
-      complex(c_float_complex) :: alpha
+      complex(c_float_complex),target,dimension(:) :: alpha
       type(c_ptr) :: descrA
       complex(c_float_complex),target,dimension(:) :: csrSortedValA
       integer(c_int),target,dimension(:) :: csrSortedRowPtrA
@@ -30913,11 +30901,11 @@ module hipfort_hipsparse
       integer(c_int) :: ldb
       type(c_ptr) :: myInfo
       integer(kind(HIPSPARSE_SOLVE_POLICY_NO_LEVEL)) :: policy
-      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseCcsrsm2_bufferSizeExt_full_rank = hipsparseCcsrsm2_bufferSizeExt_(handle,algo, &
-        transA,transB,m,nrhs,nnz,alpha,descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA), &
-        c_loc(csrSortedColIndA),c_loc(B),ldb,myInfo,policy,c_loc(pBufferSizeInBytes))
+        transA,transB,m,nrhs,nnz,c_loc(alpha),descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA), &
+        c_loc(csrSortedColIndA),c_loc(B),ldb,myInfo,policy,pBufferSizeInBytes)
     end function
 
     function hipsparseZcsrsm2_bufferSizeExt_rank_0(handle,algo,transA,transB,m,nrhs,nnz,alpha, &
@@ -30934,7 +30922,7 @@ module hipfort_hipsparse
       integer(c_int) :: m
       integer(c_int) :: nrhs
       integer(c_int) :: nnz
-      complex(c_double_complex) :: alpha
+      complex(c_double_complex),target :: alpha
       type(c_ptr) :: descrA
       complex(c_double_complex),target :: csrSortedValA
       integer(c_int),target :: csrSortedRowPtrA
@@ -30943,11 +30931,11 @@ module hipfort_hipsparse
       integer(c_int) :: ldb
       type(c_ptr) :: myInfo
       integer(kind(HIPSPARSE_SOLVE_POLICY_NO_LEVEL)) :: policy
-      integer(c_size_t),target :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseZcsrsm2_bufferSizeExt_rank_0 = hipsparseZcsrsm2_bufferSizeExt_(handle,algo,transA, &
-        transB,m,nrhs,nnz,alpha,descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA), &
-        c_loc(csrSortedColIndA),c_loc(B),ldb,myInfo,policy,c_loc(pBufferSizeInBytes))
+        transB,m,nrhs,nnz,c_loc(alpha),descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA), &
+        c_loc(csrSortedColIndA),c_loc(B),ldb,myInfo,policy,pBufferSizeInBytes)
     end function
 
     function hipsparseZcsrsm2_bufferSizeExt_rank_1(handle,algo,transA,transB,m,nrhs,nnz,alpha, &
@@ -30964,7 +30952,7 @@ module hipfort_hipsparse
       integer(c_int) :: m
       integer(c_int) :: nrhs
       integer(c_int) :: nnz
-      complex(c_double_complex) :: alpha
+      complex(c_double_complex),target,dimension(:) :: alpha
       type(c_ptr) :: descrA
       complex(c_double_complex),target,dimension(:) :: csrSortedValA
       integer(c_int),target,dimension(:) :: csrSortedRowPtrA
@@ -30973,11 +30961,11 @@ module hipfort_hipsparse
       integer(c_int) :: ldb
       type(c_ptr) :: myInfo
       integer(kind(HIPSPARSE_SOLVE_POLICY_NO_LEVEL)) :: policy
-      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseZcsrsm2_bufferSizeExt_rank_1 = hipsparseZcsrsm2_bufferSizeExt_(handle,algo,transA, &
-        transB,m,nrhs,nnz,alpha,descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA), &
-        c_loc(csrSortedColIndA),c_loc(B),ldb,myInfo,policy,c_loc(pBufferSizeInBytes))
+        transB,m,nrhs,nnz,c_loc(alpha),descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA), &
+        c_loc(csrSortedColIndA),c_loc(B),ldb,myInfo,policy,pBufferSizeInBytes)
     end function
 
     function hipsparseZcsrsm2_bufferSizeExt_full_rank(handle,algo,transA,transB,m,nrhs,nnz,alpha, &
@@ -30994,7 +30982,7 @@ module hipfort_hipsparse
       integer(c_int) :: m
       integer(c_int) :: nrhs
       integer(c_int) :: nnz
-      complex(c_double_complex) :: alpha
+      complex(c_double_complex),target,dimension(:) :: alpha
       type(c_ptr) :: descrA
       complex(c_double_complex),target,dimension(:) :: csrSortedValA
       integer(c_int),target,dimension(:) :: csrSortedRowPtrA
@@ -31003,11 +30991,11 @@ module hipfort_hipsparse
       integer(c_int) :: ldb
       type(c_ptr) :: myInfo
       integer(kind(HIPSPARSE_SOLVE_POLICY_NO_LEVEL)) :: policy
-      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseZcsrsm2_bufferSizeExt_full_rank = hipsparseZcsrsm2_bufferSizeExt_(handle,algo, &
-        transA,transB,m,nrhs,nnz,alpha,descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA), &
-        c_loc(csrSortedColIndA),c_loc(B),ldb,myInfo,policy,c_loc(pBufferSizeInBytes))
+        transA,transB,m,nrhs,nnz,c_loc(alpha),descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA), &
+        c_loc(csrSortedColIndA),c_loc(B),ldb,myInfo,policy,pBufferSizeInBytes)
     end function
 
     function hipsparseScsrsm2_analysis_rank_0(handle,algo,transA,transB,m,nrhs,nnz,alpha,descrA, &
@@ -35208,11 +35196,11 @@ module hipfort_hipsparse
       integer(c_int),target :: csrSortedRowPtrA
       integer(c_int),target :: csrSortedColIndA
       type(c_ptr) :: myInfo
-      integer(c_size_t),target :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseScsric02_bufferSizeExt_rank_0 = hipsparseScsric02_bufferSizeExt_(handle,m,nnz, &
         descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),myInfo, &
-        c_loc(pBufferSizeInBytes))
+        pBufferSizeInBytes)
     end function
 
     function hipsparseScsric02_bufferSizeExt_rank_1(handle,m,nnz,descrA,csrSortedValA, &
@@ -35229,11 +35217,11 @@ module hipfort_hipsparse
       integer(c_int),target,dimension(:) :: csrSortedRowPtrA
       integer(c_int),target,dimension(:) :: csrSortedColIndA
       type(c_ptr) :: myInfo
-      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseScsric02_bufferSizeExt_rank_1 = hipsparseScsric02_bufferSizeExt_(handle,m,nnz, &
         descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),myInfo, &
-        c_loc(pBufferSizeInBytes))
+        pBufferSizeInBytes)
     end function
 
     function hipsparseDcsric02_bufferSizeExt_rank_0(handle,m,nnz,descrA,csrSortedValA, &
@@ -35250,11 +35238,11 @@ module hipfort_hipsparse
       integer(c_int),target :: csrSortedRowPtrA
       integer(c_int),target :: csrSortedColIndA
       type(c_ptr) :: myInfo
-      integer(c_size_t),target :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseDcsric02_bufferSizeExt_rank_0 = hipsparseDcsric02_bufferSizeExt_(handle,m,nnz, &
         descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),myInfo, &
-        c_loc(pBufferSizeInBytes))
+        pBufferSizeInBytes)
     end function
 
     function hipsparseDcsric02_bufferSizeExt_rank_1(handle,m,nnz,descrA,csrSortedValA, &
@@ -35271,11 +35259,11 @@ module hipfort_hipsparse
       integer(c_int),target,dimension(:) :: csrSortedRowPtrA
       integer(c_int),target,dimension(:) :: csrSortedColIndA
       type(c_ptr) :: myInfo
-      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseDcsric02_bufferSizeExt_rank_1 = hipsparseDcsric02_bufferSizeExt_(handle,m,nnz, &
         descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),myInfo, &
-        c_loc(pBufferSizeInBytes))
+        pBufferSizeInBytes)
     end function
 
     function hipsparseCcsric02_bufferSizeExt_rank_0(handle,m,nnz,descrA,csrSortedValA, &
@@ -35292,11 +35280,11 @@ module hipfort_hipsparse
       integer(c_int),target :: csrSortedRowPtrA
       integer(c_int),target :: csrSortedColIndA
       type(c_ptr) :: myInfo
-      integer(c_size_t),target :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseCcsric02_bufferSizeExt_rank_0 = hipsparseCcsric02_bufferSizeExt_(handle,m,nnz, &
         descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),myInfo, &
-        c_loc(pBufferSizeInBytes))
+        pBufferSizeInBytes)
     end function
 
     function hipsparseCcsric02_bufferSizeExt_rank_1(handle,m,nnz,descrA,csrSortedValA, &
@@ -35313,11 +35301,11 @@ module hipfort_hipsparse
       integer(c_int),target,dimension(:) :: csrSortedRowPtrA
       integer(c_int),target,dimension(:) :: csrSortedColIndA
       type(c_ptr) :: myInfo
-      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseCcsric02_bufferSizeExt_rank_1 = hipsparseCcsric02_bufferSizeExt_(handle,m,nnz, &
         descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),myInfo, &
-        c_loc(pBufferSizeInBytes))
+        pBufferSizeInBytes)
     end function
 
     function hipsparseZcsric02_bufferSizeExt_rank_0(handle,m,nnz,descrA,csrSortedValA, &
@@ -35334,11 +35322,11 @@ module hipfort_hipsparse
       integer(c_int),target :: csrSortedRowPtrA
       integer(c_int),target :: csrSortedColIndA
       type(c_ptr) :: myInfo
-      integer(c_size_t),target :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseZcsric02_bufferSizeExt_rank_0 = hipsparseZcsric02_bufferSizeExt_(handle,m,nnz, &
         descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),myInfo, &
-        c_loc(pBufferSizeInBytes))
+        pBufferSizeInBytes)
     end function
 
     function hipsparseZcsric02_bufferSizeExt_rank_1(handle,m,nnz,descrA,csrSortedValA, &
@@ -35355,11 +35343,11 @@ module hipfort_hipsparse
       integer(c_int),target,dimension(:) :: csrSortedRowPtrA
       integer(c_int),target,dimension(:) :: csrSortedColIndA
       type(c_ptr) :: myInfo
-      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseZcsric02_bufferSizeExt_rank_1 = hipsparseZcsric02_bufferSizeExt_(handle,m,nnz, &
         descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),myInfo, &
-        c_loc(pBufferSizeInBytes))
+        pBufferSizeInBytes)
     end function
 
     function hipsparseScsric02_analysis_rank_0(handle,m,nnz,descrA,csrSortedValA,csrSortedRowPtrA, &
@@ -35880,11 +35868,11 @@ module hipfort_hipsparse
       integer(c_int),target :: csrSortedRowPtrA
       integer(c_int),target :: csrSortedColIndA
       type(c_ptr) :: myInfo
-      integer(c_size_t),target :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseScsrilu02_bufferSizeExt_rank_0 = hipsparseScsrilu02_bufferSizeExt_(handle,m,nnz, &
         descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),myInfo, &
-        c_loc(pBufferSizeInBytes))
+        pBufferSizeInBytes)
     end function
 
     function hipsparseScsrilu02_bufferSizeExt_rank_1(handle,m,nnz,descrA,csrSortedValA, &
@@ -35901,11 +35889,11 @@ module hipfort_hipsparse
       integer(c_int),target,dimension(:) :: csrSortedRowPtrA
       integer(c_int),target,dimension(:) :: csrSortedColIndA
       type(c_ptr) :: myInfo
-      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseScsrilu02_bufferSizeExt_rank_1 = hipsparseScsrilu02_bufferSizeExt_(handle,m,nnz, &
         descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),myInfo, &
-        c_loc(pBufferSizeInBytes))
+        pBufferSizeInBytes)
     end function
 
     function hipsparseDcsrilu02_bufferSizeExt_rank_0(handle,m,nnz,descrA,csrSortedValA, &
@@ -35922,11 +35910,11 @@ module hipfort_hipsparse
       integer(c_int),target :: csrSortedRowPtrA
       integer(c_int),target :: csrSortedColIndA
       type(c_ptr) :: myInfo
-      integer(c_size_t),target :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseDcsrilu02_bufferSizeExt_rank_0 = hipsparseDcsrilu02_bufferSizeExt_(handle,m,nnz, &
         descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),myInfo, &
-        c_loc(pBufferSizeInBytes))
+        pBufferSizeInBytes)
     end function
 
     function hipsparseDcsrilu02_bufferSizeExt_rank_1(handle,m,nnz,descrA,csrSortedValA, &
@@ -35943,11 +35931,11 @@ module hipfort_hipsparse
       integer(c_int),target,dimension(:) :: csrSortedRowPtrA
       integer(c_int),target,dimension(:) :: csrSortedColIndA
       type(c_ptr) :: myInfo
-      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseDcsrilu02_bufferSizeExt_rank_1 = hipsparseDcsrilu02_bufferSizeExt_(handle,m,nnz, &
         descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),myInfo, &
-        c_loc(pBufferSizeInBytes))
+        pBufferSizeInBytes)
     end function
 
     function hipsparseCcsrilu02_bufferSizeExt_rank_0(handle,m,nnz,descrA,csrSortedValA, &
@@ -35964,11 +35952,11 @@ module hipfort_hipsparse
       integer(c_int),target :: csrSortedRowPtrA
       integer(c_int),target :: csrSortedColIndA
       type(c_ptr) :: myInfo
-      integer(c_size_t),target :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseCcsrilu02_bufferSizeExt_rank_0 = hipsparseCcsrilu02_bufferSizeExt_(handle,m,nnz, &
         descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),myInfo, &
-        c_loc(pBufferSizeInBytes))
+        pBufferSizeInBytes)
     end function
 
     function hipsparseCcsrilu02_bufferSizeExt_rank_1(handle,m,nnz,descrA,csrSortedValA, &
@@ -35985,11 +35973,11 @@ module hipfort_hipsparse
       integer(c_int),target,dimension(:) :: csrSortedRowPtrA
       integer(c_int),target,dimension(:) :: csrSortedColIndA
       type(c_ptr) :: myInfo
-      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseCcsrilu02_bufferSizeExt_rank_1 = hipsparseCcsrilu02_bufferSizeExt_(handle,m,nnz, &
         descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),myInfo, &
-        c_loc(pBufferSizeInBytes))
+        pBufferSizeInBytes)
     end function
 
     function hipsparseZcsrilu02_bufferSizeExt_rank_0(handle,m,nnz,descrA,csrSortedValA, &
@@ -36006,11 +35994,11 @@ module hipfort_hipsparse
       integer(c_int),target :: csrSortedRowPtrA
       integer(c_int),target :: csrSortedColIndA
       type(c_ptr) :: myInfo
-      integer(c_size_t),target :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseZcsrilu02_bufferSizeExt_rank_0 = hipsparseZcsrilu02_bufferSizeExt_(handle,m,nnz, &
         descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),myInfo, &
-        c_loc(pBufferSizeInBytes))
+        pBufferSizeInBytes)
     end function
 
     function hipsparseZcsrilu02_bufferSizeExt_rank_1(handle,m,nnz,descrA,csrSortedValA, &
@@ -36027,11 +36015,11 @@ module hipfort_hipsparse
       integer(c_int),target,dimension(:) :: csrSortedRowPtrA
       integer(c_int),target,dimension(:) :: csrSortedColIndA
       type(c_ptr) :: myInfo
-      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseZcsrilu02_bufferSizeExt_rank_1 = hipsparseZcsrilu02_bufferSizeExt_(handle,m,nnz, &
         descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),myInfo, &
-        c_loc(pBufferSizeInBytes))
+        pBufferSizeInBytes)
     end function
 
     function hipsparseScsrilu02_analysis_rank_0(handle,m,nnz,descrA,csrSortedValA, &
@@ -39710,11 +39698,11 @@ module hipfort_hipsparse
       integer(c_int),target :: csrColInd
       integer(c_int) :: rowBlockDim
       integer(c_int) :: colBlockDim
-      integer(c_size_t),target :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseScsr2gebsr_bufferSize_rank_0 = hipsparseScsr2gebsr_bufferSize_(handle,dir,m,n, &
         csr_descr,c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd),rowBlockDim,colBlockDim, &
-        c_loc(pBufferSizeInBytes))
+        pBufferSizeInBytes)
     end function
 
     function hipsparseScsr2gebsr_bufferSize_rank_1(handle,dir,m,n,csr_descr,csrVal,csrRowPtr, &
@@ -39733,11 +39721,11 @@ module hipfort_hipsparse
       integer(c_int),target,dimension(:) :: csrColInd
       integer(c_int) :: rowBlockDim
       integer(c_int) :: colBlockDim
-      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseScsr2gebsr_bufferSize_rank_1 = hipsparseScsr2gebsr_bufferSize_(handle,dir,m,n, &
         csr_descr,c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd),rowBlockDim,colBlockDim, &
-        c_loc(pBufferSizeInBytes))
+        pBufferSizeInBytes)
     end function
 
     function hipsparseDcsr2gebsr_bufferSize_rank_0(handle,dir,m,n,csr_descr,csrVal,csrRowPtr, &
@@ -39756,11 +39744,11 @@ module hipfort_hipsparse
       integer(c_int),target :: csrColInd
       integer(c_int) :: rowBlockDim
       integer(c_int) :: colBlockDim
-      integer(c_size_t),target :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseDcsr2gebsr_bufferSize_rank_0 = hipsparseDcsr2gebsr_bufferSize_(handle,dir,m,n, &
         csr_descr,c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd),rowBlockDim,colBlockDim, &
-        c_loc(pBufferSizeInBytes))
+        pBufferSizeInBytes)
     end function
 
     function hipsparseDcsr2gebsr_bufferSize_rank_1(handle,dir,m,n,csr_descr,csrVal,csrRowPtr, &
@@ -39779,11 +39767,11 @@ module hipfort_hipsparse
       integer(c_int),target,dimension(:) :: csrColInd
       integer(c_int) :: rowBlockDim
       integer(c_int) :: colBlockDim
-      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseDcsr2gebsr_bufferSize_rank_1 = hipsparseDcsr2gebsr_bufferSize_(handle,dir,m,n, &
         csr_descr,c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd),rowBlockDim,colBlockDim, &
-        c_loc(pBufferSizeInBytes))
+        pBufferSizeInBytes)
     end function
 
     function hipsparseCcsr2gebsr_bufferSize_rank_0(handle,dir,m,n,csr_descr,csrVal,csrRowPtr, &
@@ -39802,11 +39790,11 @@ module hipfort_hipsparse
       integer(c_int),target :: csrColInd
       integer(c_int) :: rowBlockDim
       integer(c_int) :: colBlockDim
-      integer(c_size_t),target :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseCcsr2gebsr_bufferSize_rank_0 = hipsparseCcsr2gebsr_bufferSize_(handle,dir,m,n, &
         csr_descr,c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd),rowBlockDim,colBlockDim, &
-        c_loc(pBufferSizeInBytes))
+        pBufferSizeInBytes)
     end function
 
     function hipsparseCcsr2gebsr_bufferSize_rank_1(handle,dir,m,n,csr_descr,csrVal,csrRowPtr, &
@@ -39825,11 +39813,11 @@ module hipfort_hipsparse
       integer(c_int),target,dimension(:) :: csrColInd
       integer(c_int) :: rowBlockDim
       integer(c_int) :: colBlockDim
-      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseCcsr2gebsr_bufferSize_rank_1 = hipsparseCcsr2gebsr_bufferSize_(handle,dir,m,n, &
         csr_descr,c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd),rowBlockDim,colBlockDim, &
-        c_loc(pBufferSizeInBytes))
+        pBufferSizeInBytes)
     end function
 
     function hipsparseZcsr2gebsr_bufferSize_rank_0(handle,dir,m,n,csr_descr,csrVal,csrRowPtr, &
@@ -39848,11 +39836,11 @@ module hipfort_hipsparse
       integer(c_int),target :: csrColInd
       integer(c_int) :: rowBlockDim
       integer(c_int) :: colBlockDim
-      integer(c_size_t),target :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseZcsr2gebsr_bufferSize_rank_0 = hipsparseZcsr2gebsr_bufferSize_(handle,dir,m,n, &
         csr_descr,c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd),rowBlockDim,colBlockDim, &
-        c_loc(pBufferSizeInBytes))
+        pBufferSizeInBytes)
     end function
 
     function hipsparseZcsr2gebsr_bufferSize_rank_1(handle,dir,m,n,csr_descr,csrVal,csrRowPtr, &
@@ -39871,11 +39859,11 @@ module hipfort_hipsparse
       integer(c_int),target,dimension(:) :: csrColInd
       integer(c_int) :: rowBlockDim
       integer(c_int) :: colBlockDim
-      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseZcsr2gebsr_bufferSize_rank_1 = hipsparseZcsr2gebsr_bufferSize_(handle,dir,m,n, &
         csr_descr,c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd),rowBlockDim,colBlockDim, &
-        c_loc(pBufferSizeInBytes))
+        pBufferSizeInBytes)
     end function
 
     function hipsparseXcsr2gebsrNnz_rank_0(handle,dir,m,n,csr_descr,csrRowPtr,csrColInd,bsr_descr, &
@@ -41438,11 +41426,11 @@ module hipfort_hipsparse
       integer(c_int) :: colBlockDimA
       integer(c_int) :: rowBlockDimC
       integer(c_int) :: colBlockDimC
-      integer(c_int),target :: pBufferSizeInBytes
+      integer(c_int) :: pBufferSizeInBytes
       !
       hipsparseSgebsr2gebsr_bufferSize_rank_0 = hipsparseSgebsr2gebsr_bufferSize_(handle,dirA,mb, &
         nb,nnzb,descrA,c_loc(bsrValA),c_loc(bsrRowPtrA),c_loc(bsrColIndA),rowBlockDimA, &
-        colBlockDimA,rowBlockDimC,colBlockDimC,c_loc(pBufferSizeInBytes))
+        colBlockDimA,rowBlockDimC,colBlockDimC,pBufferSizeInBytes)
     end function
 
     function hipsparseSgebsr2gebsr_bufferSize_rank_1(handle,dirA,mb,nb,nnzb,descrA,bsrValA, &
@@ -41465,11 +41453,11 @@ module hipfort_hipsparse
       integer(c_int) :: colBlockDimA
       integer(c_int) :: rowBlockDimC
       integer(c_int) :: colBlockDimC
-      integer(c_int),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_int) :: pBufferSizeInBytes
       !
       hipsparseSgebsr2gebsr_bufferSize_rank_1 = hipsparseSgebsr2gebsr_bufferSize_(handle,dirA,mb, &
         nb,nnzb,descrA,c_loc(bsrValA),c_loc(bsrRowPtrA),c_loc(bsrColIndA),rowBlockDimA, &
-        colBlockDimA,rowBlockDimC,colBlockDimC,c_loc(pBufferSizeInBytes))
+        colBlockDimA,rowBlockDimC,colBlockDimC,pBufferSizeInBytes)
     end function
 
     function hipsparseDgebsr2gebsr_bufferSize_rank_0(handle,dirA,mb,nb,nnzb,descrA,bsrValA, &
@@ -41492,11 +41480,11 @@ module hipfort_hipsparse
       integer(c_int) :: colBlockDimA
       integer(c_int) :: rowBlockDimC
       integer(c_int) :: colBlockDimC
-      integer(c_int),target :: pBufferSizeInBytes
+      integer(c_int) :: pBufferSizeInBytes
       !
       hipsparseDgebsr2gebsr_bufferSize_rank_0 = hipsparseDgebsr2gebsr_bufferSize_(handle,dirA,mb, &
         nb,nnzb,descrA,c_loc(bsrValA),c_loc(bsrRowPtrA),c_loc(bsrColIndA),rowBlockDimA, &
-        colBlockDimA,rowBlockDimC,colBlockDimC,c_loc(pBufferSizeInBytes))
+        colBlockDimA,rowBlockDimC,colBlockDimC,pBufferSizeInBytes)
     end function
 
     function hipsparseDgebsr2gebsr_bufferSize_rank_1(handle,dirA,mb,nb,nnzb,descrA,bsrValA, &
@@ -41519,11 +41507,11 @@ module hipfort_hipsparse
       integer(c_int) :: colBlockDimA
       integer(c_int) :: rowBlockDimC
       integer(c_int) :: colBlockDimC
-      integer(c_int),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_int) :: pBufferSizeInBytes
       !
       hipsparseDgebsr2gebsr_bufferSize_rank_1 = hipsparseDgebsr2gebsr_bufferSize_(handle,dirA,mb, &
         nb,nnzb,descrA,c_loc(bsrValA),c_loc(bsrRowPtrA),c_loc(bsrColIndA),rowBlockDimA, &
-        colBlockDimA,rowBlockDimC,colBlockDimC,c_loc(pBufferSizeInBytes))
+        colBlockDimA,rowBlockDimC,colBlockDimC,pBufferSizeInBytes)
     end function
 
     function hipsparseCgebsr2gebsr_bufferSize_rank_0(handle,dirA,mb,nb,nnzb,descrA,bsrValA, &
@@ -41546,11 +41534,11 @@ module hipfort_hipsparse
       integer(c_int) :: colBlockDimA
       integer(c_int) :: rowBlockDimC
       integer(c_int) :: colBlockDimC
-      integer(c_int),target :: pBufferSizeInBytes
+      integer(c_int) :: pBufferSizeInBytes
       !
       hipsparseCgebsr2gebsr_bufferSize_rank_0 = hipsparseCgebsr2gebsr_bufferSize_(handle,dirA,mb, &
         nb,nnzb,descrA,c_loc(bsrValA),c_loc(bsrRowPtrA),c_loc(bsrColIndA),rowBlockDimA, &
-        colBlockDimA,rowBlockDimC,colBlockDimC,c_loc(pBufferSizeInBytes))
+        colBlockDimA,rowBlockDimC,colBlockDimC,pBufferSizeInBytes)
     end function
 
     function hipsparseCgebsr2gebsr_bufferSize_rank_1(handle,dirA,mb,nb,nnzb,descrA,bsrValA, &
@@ -41573,11 +41561,11 @@ module hipfort_hipsparse
       integer(c_int) :: colBlockDimA
       integer(c_int) :: rowBlockDimC
       integer(c_int) :: colBlockDimC
-      integer(c_int),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_int) :: pBufferSizeInBytes
       !
       hipsparseCgebsr2gebsr_bufferSize_rank_1 = hipsparseCgebsr2gebsr_bufferSize_(handle,dirA,mb, &
         nb,nnzb,descrA,c_loc(bsrValA),c_loc(bsrRowPtrA),c_loc(bsrColIndA),rowBlockDimA, &
-        colBlockDimA,rowBlockDimC,colBlockDimC,c_loc(pBufferSizeInBytes))
+        colBlockDimA,rowBlockDimC,colBlockDimC,pBufferSizeInBytes)
     end function
 
     function hipsparseZgebsr2gebsr_bufferSize_rank_0(handle,dirA,mb,nb,nnzb,descrA,bsrValA, &
@@ -41600,11 +41588,11 @@ module hipfort_hipsparse
       integer(c_int) :: colBlockDimA
       integer(c_int) :: rowBlockDimC
       integer(c_int) :: colBlockDimC
-      integer(c_int),target :: pBufferSizeInBytes
+      integer(c_int) :: pBufferSizeInBytes
       !
       hipsparseZgebsr2gebsr_bufferSize_rank_0 = hipsparseZgebsr2gebsr_bufferSize_(handle,dirA,mb, &
         nb,nnzb,descrA,c_loc(bsrValA),c_loc(bsrRowPtrA),c_loc(bsrColIndA),rowBlockDimA, &
-        colBlockDimA,rowBlockDimC,colBlockDimC,c_loc(pBufferSizeInBytes))
+        colBlockDimA,rowBlockDimC,colBlockDimC,pBufferSizeInBytes)
     end function
 
     function hipsparseZgebsr2gebsr_bufferSize_rank_1(handle,dirA,mb,nb,nnzb,descrA,bsrValA, &
@@ -41627,11 +41615,11 @@ module hipfort_hipsparse
       integer(c_int) :: colBlockDimA
       integer(c_int) :: rowBlockDimC
       integer(c_int) :: colBlockDimC
-      integer(c_int),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_int) :: pBufferSizeInBytes
       !
       hipsparseZgebsr2gebsr_bufferSize_rank_1 = hipsparseZgebsr2gebsr_bufferSize_(handle,dirA,mb, &
         nb,nnzb,descrA,c_loc(bsrValA),c_loc(bsrRowPtrA),c_loc(bsrColIndA),rowBlockDimA, &
-        colBlockDimA,rowBlockDimC,colBlockDimC,c_loc(pBufferSizeInBytes))
+        colBlockDimA,rowBlockDimC,colBlockDimC,pBufferSizeInBytes)
     end function
 
     function hipsparseXgebsr2gebsrNnz_rank_0(handle,dirA,mb,nb,nnzb,descrA,bsrRowPtrA,bsrColIndA, &
@@ -42466,16 +42454,16 @@ module hipfort_hipsparse
       real(c_float),target :: csrValA
       integer(c_int),target :: csrRowPtrA
       integer(c_int),target :: csrColIndA
-      real(c_float) :: threshold
+      real(c_float),target :: threshold
       type(c_ptr) :: descrC
       real(c_float),target :: csrValC
       integer(c_int),target :: csrRowPtrC
       integer(c_int),target :: csrColIndC
-      integer(c_size_t),target :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseSpruneCsr2csr_bufferSize_rank_0 = hipsparseSpruneCsr2csr_bufferSize_(handle,m,n, &
-        nnzA,descrA,c_loc(csrValA),c_loc(csrRowPtrA),c_loc(csrColIndA),threshold,descrC, &
-        c_loc(csrValC),c_loc(csrRowPtrC),c_loc(csrColIndC),c_loc(pBufferSizeInBytes))
+        nnzA,descrA,c_loc(csrValA),c_loc(csrRowPtrA),c_loc(csrColIndA),c_loc(threshold),descrC, &
+        c_loc(csrValC),c_loc(csrRowPtrC),c_loc(csrColIndC),pBufferSizeInBytes)
     end function
 
     function hipsparseSpruneCsr2csr_bufferSize_rank_1(handle,m,n,nnzA,descrA,csrValA,csrRowPtrA, &
@@ -42492,16 +42480,16 @@ module hipfort_hipsparse
       real(c_float),target,dimension(:) :: csrValA
       integer(c_int),target,dimension(:) :: csrRowPtrA
       integer(c_int),target,dimension(:) :: csrColIndA
-      real(c_float) :: threshold
+      real(c_float),target,dimension(:) :: threshold
       type(c_ptr) :: descrC
       real(c_float),target,dimension(:) :: csrValC
       integer(c_int),target,dimension(:) :: csrRowPtrC
       integer(c_int),target,dimension(:) :: csrColIndC
-      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseSpruneCsr2csr_bufferSize_rank_1 = hipsparseSpruneCsr2csr_bufferSize_(handle,m,n, &
-        nnzA,descrA,c_loc(csrValA),c_loc(csrRowPtrA),c_loc(csrColIndA),threshold,descrC, &
-        c_loc(csrValC),c_loc(csrRowPtrC),c_loc(csrColIndC),c_loc(pBufferSizeInBytes))
+        nnzA,descrA,c_loc(csrValA),c_loc(csrRowPtrA),c_loc(csrColIndA),c_loc(threshold),descrC, &
+        c_loc(csrValC),c_loc(csrRowPtrC),c_loc(csrColIndC),pBufferSizeInBytes)
     end function
 
     function hipsparseDpruneCsr2csr_bufferSize_rank_0(handle,m,n,nnzA,descrA,csrValA,csrRowPtrA, &
@@ -42518,16 +42506,16 @@ module hipfort_hipsparse
       real(c_double),target :: csrValA
       integer(c_int),target :: csrRowPtrA
       integer(c_int),target :: csrColIndA
-      real(c_double) :: threshold
+      real(c_double),target :: threshold
       type(c_ptr) :: descrC
       real(c_double),target :: csrValC
       integer(c_int),target :: csrRowPtrC
       integer(c_int),target :: csrColIndC
-      integer(c_size_t),target :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseDpruneCsr2csr_bufferSize_rank_0 = hipsparseDpruneCsr2csr_bufferSize_(handle,m,n, &
-        nnzA,descrA,c_loc(csrValA),c_loc(csrRowPtrA),c_loc(csrColIndA),threshold,descrC, &
-        c_loc(csrValC),c_loc(csrRowPtrC),c_loc(csrColIndC),c_loc(pBufferSizeInBytes))
+        nnzA,descrA,c_loc(csrValA),c_loc(csrRowPtrA),c_loc(csrColIndA),c_loc(threshold),descrC, &
+        c_loc(csrValC),c_loc(csrRowPtrC),c_loc(csrColIndC),pBufferSizeInBytes)
     end function
 
     function hipsparseDpruneCsr2csr_bufferSize_rank_1(handle,m,n,nnzA,descrA,csrValA,csrRowPtrA, &
@@ -42544,16 +42532,16 @@ module hipfort_hipsparse
       real(c_double),target,dimension(:) :: csrValA
       integer(c_int),target,dimension(:) :: csrRowPtrA
       integer(c_int),target,dimension(:) :: csrColIndA
-      real(c_double) :: threshold
+      real(c_double),target,dimension(:) :: threshold
       type(c_ptr) :: descrC
       real(c_double),target,dimension(:) :: csrValC
       integer(c_int),target,dimension(:) :: csrRowPtrC
       integer(c_int),target,dimension(:) :: csrColIndC
-      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseDpruneCsr2csr_bufferSize_rank_1 = hipsparseDpruneCsr2csr_bufferSize_(handle,m,n, &
-        nnzA,descrA,c_loc(csrValA),c_loc(csrRowPtrA),c_loc(csrColIndA),threshold,descrC, &
-        c_loc(csrValC),c_loc(csrRowPtrC),c_loc(csrColIndC),c_loc(pBufferSizeInBytes))
+        nnzA,descrA,c_loc(csrValA),c_loc(csrRowPtrA),c_loc(csrColIndA),c_loc(threshold),descrC, &
+        c_loc(csrValC),c_loc(csrRowPtrC),c_loc(csrColIndC),pBufferSizeInBytes)
     end function
 
     function hipsparseSpruneCsr2csr_bufferSizeExt_rank_0(handle,m,n,nnzA,descrA,csrValA, &
@@ -42570,16 +42558,16 @@ module hipfort_hipsparse
       real(c_float),target :: csrValA
       integer(c_int),target :: csrRowPtrA
       integer(c_int),target :: csrColIndA
-      real(c_float) :: threshold
+      real(c_float),target :: threshold
       type(c_ptr) :: descrC
       real(c_float),target :: csrValC
       integer(c_int),target :: csrRowPtrC
       integer(c_int),target :: csrColIndC
-      integer(c_size_t),target :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseSpruneCsr2csr_bufferSizeExt_rank_0 = hipsparseSpruneCsr2csr_bufferSizeExt_(handle, &
-        m,n,nnzA,descrA,c_loc(csrValA),c_loc(csrRowPtrA),c_loc(csrColIndA),threshold,descrC, &
-        c_loc(csrValC),c_loc(csrRowPtrC),c_loc(csrColIndC),c_loc(pBufferSizeInBytes))
+        m,n,nnzA,descrA,c_loc(csrValA),c_loc(csrRowPtrA),c_loc(csrColIndA),c_loc(threshold), &
+        descrC,c_loc(csrValC),c_loc(csrRowPtrC),c_loc(csrColIndC),pBufferSizeInBytes)
     end function
 
     function hipsparseSpruneCsr2csr_bufferSizeExt_rank_1(handle,m,n,nnzA,descrA,csrValA, &
@@ -42596,16 +42584,16 @@ module hipfort_hipsparse
       real(c_float),target,dimension(:) :: csrValA
       integer(c_int),target,dimension(:) :: csrRowPtrA
       integer(c_int),target,dimension(:) :: csrColIndA
-      real(c_float) :: threshold
+      real(c_float),target,dimension(:) :: threshold
       type(c_ptr) :: descrC
       real(c_float),target,dimension(:) :: csrValC
       integer(c_int),target,dimension(:) :: csrRowPtrC
       integer(c_int),target,dimension(:) :: csrColIndC
-      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseSpruneCsr2csr_bufferSizeExt_rank_1 = hipsparseSpruneCsr2csr_bufferSizeExt_(handle, &
-        m,n,nnzA,descrA,c_loc(csrValA),c_loc(csrRowPtrA),c_loc(csrColIndA),threshold,descrC, &
-        c_loc(csrValC),c_loc(csrRowPtrC),c_loc(csrColIndC),c_loc(pBufferSizeInBytes))
+        m,n,nnzA,descrA,c_loc(csrValA),c_loc(csrRowPtrA),c_loc(csrColIndA),c_loc(threshold), &
+        descrC,c_loc(csrValC),c_loc(csrRowPtrC),c_loc(csrColIndC),pBufferSizeInBytes)
     end function
 
     function hipsparseDpruneCsr2csr_bufferSizeExt_rank_0(handle,m,n,nnzA,descrA,csrValA, &
@@ -42622,16 +42610,16 @@ module hipfort_hipsparse
       real(c_double),target :: csrValA
       integer(c_int),target :: csrRowPtrA
       integer(c_int),target :: csrColIndA
-      real(c_double) :: threshold
+      real(c_double),target :: threshold
       type(c_ptr) :: descrC
       real(c_double),target :: csrValC
       integer(c_int),target :: csrRowPtrC
       integer(c_int),target :: csrColIndC
-      integer(c_size_t),target :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseDpruneCsr2csr_bufferSizeExt_rank_0 = hipsparseDpruneCsr2csr_bufferSizeExt_(handle, &
-        m,n,nnzA,descrA,c_loc(csrValA),c_loc(csrRowPtrA),c_loc(csrColIndA),threshold,descrC, &
-        c_loc(csrValC),c_loc(csrRowPtrC),c_loc(csrColIndC),c_loc(pBufferSizeInBytes))
+        m,n,nnzA,descrA,c_loc(csrValA),c_loc(csrRowPtrA),c_loc(csrColIndA),c_loc(threshold), &
+        descrC,c_loc(csrValC),c_loc(csrRowPtrC),c_loc(csrColIndC),pBufferSizeInBytes)
     end function
 
     function hipsparseDpruneCsr2csr_bufferSizeExt_rank_1(handle,m,n,nnzA,descrA,csrValA, &
@@ -42648,16 +42636,16 @@ module hipfort_hipsparse
       real(c_double),target,dimension(:) :: csrValA
       integer(c_int),target,dimension(:) :: csrRowPtrA
       integer(c_int),target,dimension(:) :: csrColIndA
-      real(c_double) :: threshold
+      real(c_double),target,dimension(:) :: threshold
       type(c_ptr) :: descrC
       real(c_double),target,dimension(:) :: csrValC
       integer(c_int),target,dimension(:) :: csrRowPtrC
       integer(c_int),target,dimension(:) :: csrColIndC
-      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseDpruneCsr2csr_bufferSizeExt_rank_1 = hipsparseDpruneCsr2csr_bufferSizeExt_(handle, &
-        m,n,nnzA,descrA,c_loc(csrValA),c_loc(csrRowPtrA),c_loc(csrColIndA),threshold,descrC, &
-        c_loc(csrValC),c_loc(csrRowPtrC),c_loc(csrColIndC),c_loc(pBufferSizeInBytes))
+        m,n,nnzA,descrA,c_loc(csrValA),c_loc(csrRowPtrA),c_loc(csrColIndA),c_loc(threshold), &
+        descrC,c_loc(csrValC),c_loc(csrRowPtrC),c_loc(csrColIndC),pBufferSizeInBytes)
     end function
 
     function hipsparseSpruneCsr2csrNnz_rank_0(handle,m,n,nnzA,descrA,csrValA,csrRowPtrA, &
@@ -42885,12 +42873,12 @@ module hipfort_hipsparse
       integer(c_int),target :: csrRowPtrC
       integer(c_int),target :: csrColIndC
       type(c_ptr) :: myInfo
-      integer(c_size_t),target :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseSpruneCsr2csrByPercentage_bufferSize_rank_0 = &
         hipsparseSpruneCsr2csrByPercentage_bufferSize_(handle,m,n,nnzA,descrA,c_loc(csrValA), &
         c_loc(csrRowPtrA),c_loc(csrColIndA),percentage,descrC,c_loc(csrValC),c_loc(csrRowPtrC), &
-        c_loc(csrColIndC),myInfo,c_loc(pBufferSizeInBytes))
+        c_loc(csrColIndC),myInfo,pBufferSizeInBytes)
     end function
 
     function hipsparseSpruneCsr2csrByPercentage_bufferSize_rank_1(handle,m,n,nnzA,descrA,csrValA, &
@@ -42914,12 +42902,12 @@ module hipfort_hipsparse
       integer(c_int),target,dimension(:) :: csrRowPtrC
       integer(c_int),target,dimension(:) :: csrColIndC
       type(c_ptr) :: myInfo
-      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseSpruneCsr2csrByPercentage_bufferSize_rank_1 = &
         hipsparseSpruneCsr2csrByPercentage_bufferSize_(handle,m,n,nnzA,descrA,c_loc(csrValA), &
         c_loc(csrRowPtrA),c_loc(csrColIndA),percentage,descrC,c_loc(csrValC),c_loc(csrRowPtrC), &
-        c_loc(csrColIndC),myInfo,c_loc(pBufferSizeInBytes))
+        c_loc(csrColIndC),myInfo,pBufferSizeInBytes)
     end function
 
     function hipsparseDpruneCsr2csrByPercentage_bufferSize_rank_0(handle,m,n,nnzA,descrA,csrValA, &
@@ -42943,12 +42931,12 @@ module hipfort_hipsparse
       integer(c_int),target :: csrRowPtrC
       integer(c_int),target :: csrColIndC
       type(c_ptr) :: myInfo
-      integer(c_size_t),target :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseDpruneCsr2csrByPercentage_bufferSize_rank_0 = &
         hipsparseDpruneCsr2csrByPercentage_bufferSize_(handle,m,n,nnzA,descrA,c_loc(csrValA), &
         c_loc(csrRowPtrA),c_loc(csrColIndA),percentage,descrC,c_loc(csrValC),c_loc(csrRowPtrC), &
-        c_loc(csrColIndC),myInfo,c_loc(pBufferSizeInBytes))
+        c_loc(csrColIndC),myInfo,pBufferSizeInBytes)
     end function
 
     function hipsparseDpruneCsr2csrByPercentage_bufferSize_rank_1(handle,m,n,nnzA,descrA,csrValA, &
@@ -42972,12 +42960,12 @@ module hipfort_hipsparse
       integer(c_int),target,dimension(:) :: csrRowPtrC
       integer(c_int),target,dimension(:) :: csrColIndC
       type(c_ptr) :: myInfo
-      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseDpruneCsr2csrByPercentage_bufferSize_rank_1 = &
         hipsparseDpruneCsr2csrByPercentage_bufferSize_(handle,m,n,nnzA,descrA,c_loc(csrValA), &
         c_loc(csrRowPtrA),c_loc(csrColIndA),percentage,descrC,c_loc(csrValC),c_loc(csrRowPtrC), &
-        c_loc(csrColIndC),myInfo,c_loc(pBufferSizeInBytes))
+        c_loc(csrColIndC),myInfo,pBufferSizeInBytes)
     end function
 
     function hipsparseSpruneCsr2csrByPercentage_bufferSizeExt_rank_0(handle,m,n,nnzA,descrA, &
@@ -43001,12 +42989,12 @@ module hipfort_hipsparse
       integer(c_int),target :: csrRowPtrC
       integer(c_int),target :: csrColIndC
       type(c_ptr) :: myInfo
-      integer(c_size_t),target :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseSpruneCsr2csrByPercentage_bufferSizeExt_rank_0 = &
         hipsparseSpruneCsr2csrByPercentage_bufferSizeExt_(handle,m,n,nnzA,descrA,c_loc(csrValA), &
         c_loc(csrRowPtrA),c_loc(csrColIndA),percentage,descrC,c_loc(csrValC),c_loc(csrRowPtrC), &
-        c_loc(csrColIndC),myInfo,c_loc(pBufferSizeInBytes))
+        c_loc(csrColIndC),myInfo,pBufferSizeInBytes)
     end function
 
     function hipsparseSpruneCsr2csrByPercentage_bufferSizeExt_rank_1(handle,m,n,nnzA,descrA, &
@@ -43030,12 +43018,12 @@ module hipfort_hipsparse
       integer(c_int),target,dimension(:) :: csrRowPtrC
       integer(c_int),target,dimension(:) :: csrColIndC
       type(c_ptr) :: myInfo
-      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseSpruneCsr2csrByPercentage_bufferSizeExt_rank_1 = &
         hipsparseSpruneCsr2csrByPercentage_bufferSizeExt_(handle,m,n,nnzA,descrA,c_loc(csrValA), &
         c_loc(csrRowPtrA),c_loc(csrColIndA),percentage,descrC,c_loc(csrValC),c_loc(csrRowPtrC), &
-        c_loc(csrColIndC),myInfo,c_loc(pBufferSizeInBytes))
+        c_loc(csrColIndC),myInfo,pBufferSizeInBytes)
     end function
 
     function hipsparseDpruneCsr2csrByPercentage_bufferSizeExt_rank_0(handle,m,n,nnzA,descrA, &
@@ -43059,12 +43047,12 @@ module hipfort_hipsparse
       integer(c_int),target :: csrRowPtrC
       integer(c_int),target :: csrColIndC
       type(c_ptr) :: myInfo
-      integer(c_size_t),target :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseDpruneCsr2csrByPercentage_bufferSizeExt_rank_0 = &
         hipsparseDpruneCsr2csrByPercentage_bufferSizeExt_(handle,m,n,nnzA,descrA,c_loc(csrValA), &
         c_loc(csrRowPtrA),c_loc(csrColIndA),percentage,descrC,c_loc(csrValC),c_loc(csrRowPtrC), &
-        c_loc(csrColIndC),myInfo,c_loc(pBufferSizeInBytes))
+        c_loc(csrColIndC),myInfo,pBufferSizeInBytes)
     end function
 
     function hipsparseDpruneCsr2csrByPercentage_bufferSizeExt_rank_1(handle,m,n,nnzA,descrA, &
@@ -43088,12 +43076,12 @@ module hipfort_hipsparse
       integer(c_int),target,dimension(:) :: csrRowPtrC
       integer(c_int),target,dimension(:) :: csrColIndC
       type(c_ptr) :: myInfo
-      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseDpruneCsr2csrByPercentage_bufferSizeExt_rank_1 = &
         hipsparseDpruneCsr2csrByPercentage_bufferSizeExt_(handle,m,n,nnzA,descrA,c_loc(csrValA), &
         c_loc(csrRowPtrA),c_loc(csrColIndA),percentage,descrC,c_loc(csrValC),c_loc(csrRowPtrC), &
-        c_loc(csrColIndC),myInfo,c_loc(pBufferSizeInBytes))
+        c_loc(csrColIndC),myInfo,pBufferSizeInBytes)
     end function
 
     function hipsparseSpruneCsr2csrNnzByPercentage_rank_0(handle,m,n,nnzA,descrA,csrValA, &
@@ -43319,16 +43307,16 @@ module hipfort_hipsparse
       integer(c_int) :: n
       real(c_float),target :: A
       integer(c_int) :: lda
-      real(c_float) :: threshold
+      real(c_float),target :: threshold
       type(c_ptr) :: descr
       real(c_float),target :: csrVal
       integer(c_int),target :: csrRowPtr
       integer(c_int),target :: csrColInd
-      integer(c_size_t),target :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseSpruneDense2csr_bufferSize_rank_0 = hipsparseSpruneDense2csr_bufferSize_(handle,m, &
-        n,c_loc(A),lda,threshold,descr,c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd), &
-        c_loc(pBufferSizeInBytes))
+        n,c_loc(A),lda,c_loc(threshold),descr,c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd), &
+        pBufferSizeInBytes)
     end function
 
     function hipsparseSpruneDense2csr_bufferSize_rank_1(handle,m,n,A,lda,threshold,descr,csrVal, &
@@ -43342,16 +43330,16 @@ module hipfort_hipsparse
       integer(c_int) :: n
       real(c_float),target,dimension(:) :: A
       integer(c_int) :: lda
-      real(c_float) :: threshold
+      real(c_float),target,dimension(:) :: threshold
       type(c_ptr) :: descr
       real(c_float),target,dimension(:) :: csrVal
       integer(c_int),target,dimension(:) :: csrRowPtr
       integer(c_int),target,dimension(:) :: csrColInd
-      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseSpruneDense2csr_bufferSize_rank_1 = hipsparseSpruneDense2csr_bufferSize_(handle,m, &
-        n,c_loc(A),lda,threshold,descr,c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd), &
-        c_loc(pBufferSizeInBytes))
+        n,c_loc(A),lda,c_loc(threshold),descr,c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd), &
+        pBufferSizeInBytes)
     end function
 
     function hipsparseSpruneDense2csr_bufferSize_full_rank(handle,m,n,A,lda,threshold,descr, &
@@ -43365,16 +43353,16 @@ module hipfort_hipsparse
       integer(c_int) :: n
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float) :: threshold
+      real(c_float),target,dimension(:) :: threshold
       type(c_ptr) :: descr
       real(c_float),target,dimension(:) :: csrVal
       integer(c_int),target,dimension(:) :: csrRowPtr
       integer(c_int),target,dimension(:) :: csrColInd
-      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseSpruneDense2csr_bufferSize_full_rank = hipsparseSpruneDense2csr_bufferSize_(handle, &
-        m,n,c_loc(A),lda,threshold,descr,c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd), &
-        c_loc(pBufferSizeInBytes))
+        m,n,c_loc(A),lda,c_loc(threshold),descr,c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd), &
+        pBufferSizeInBytes)
     end function
 
     function hipsparseDpruneDense2csr_bufferSize_rank_0(handle,m,n,A,lda,threshold,descr,csrVal, &
@@ -43388,16 +43376,16 @@ module hipfort_hipsparse
       integer(c_int) :: n
       real(c_double),target :: A
       integer(c_int) :: lda
-      real(c_double) :: threshold
+      real(c_double),target :: threshold
       type(c_ptr) :: descr
       real(c_double),target :: csrVal
       integer(c_int),target :: csrRowPtr
       integer(c_int),target :: csrColInd
-      integer(c_size_t),target :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseDpruneDense2csr_bufferSize_rank_0 = hipsparseDpruneDense2csr_bufferSize_(handle,m, &
-        n,c_loc(A),lda,threshold,descr,c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd), &
-        c_loc(pBufferSizeInBytes))
+        n,c_loc(A),lda,c_loc(threshold),descr,c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd), &
+        pBufferSizeInBytes)
     end function
 
     function hipsparseDpruneDense2csr_bufferSize_rank_1(handle,m,n,A,lda,threshold,descr,csrVal, &
@@ -43411,16 +43399,16 @@ module hipfort_hipsparse
       integer(c_int) :: n
       real(c_double),target,dimension(:) :: A
       integer(c_int) :: lda
-      real(c_double) :: threshold
+      real(c_double),target,dimension(:) :: threshold
       type(c_ptr) :: descr
       real(c_double),target,dimension(:) :: csrVal
       integer(c_int),target,dimension(:) :: csrRowPtr
       integer(c_int),target,dimension(:) :: csrColInd
-      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseDpruneDense2csr_bufferSize_rank_1 = hipsparseDpruneDense2csr_bufferSize_(handle,m, &
-        n,c_loc(A),lda,threshold,descr,c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd), &
-        c_loc(pBufferSizeInBytes))
+        n,c_loc(A),lda,c_loc(threshold),descr,c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd), &
+        pBufferSizeInBytes)
     end function
 
     function hipsparseDpruneDense2csr_bufferSize_full_rank(handle,m,n,A,lda,threshold,descr, &
@@ -43434,16 +43422,16 @@ module hipfort_hipsparse
       integer(c_int) :: n
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double) :: threshold
+      real(c_double),target,dimension(:) :: threshold
       type(c_ptr) :: descr
       real(c_double),target,dimension(:) :: csrVal
       integer(c_int),target,dimension(:) :: csrRowPtr
       integer(c_int),target,dimension(:) :: csrColInd
-      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseDpruneDense2csr_bufferSize_full_rank = hipsparseDpruneDense2csr_bufferSize_(handle, &
-        m,n,c_loc(A),lda,threshold,descr,c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd), &
-        c_loc(pBufferSizeInBytes))
+        m,n,c_loc(A),lda,c_loc(threshold),descr,c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd), &
+        pBufferSizeInBytes)
     end function
 
     function hipsparseSpruneDense2csr_bufferSizeExt_rank_0(handle,m,n,A,lda,threshold,descr, &
@@ -43457,16 +43445,16 @@ module hipfort_hipsparse
       integer(c_int) :: n
       real(c_float),target :: A
       integer(c_int) :: lda
-      real(c_float) :: threshold
+      real(c_float),target :: threshold
       type(c_ptr) :: descr
       real(c_float),target :: csrVal
       integer(c_int),target :: csrRowPtr
       integer(c_int),target :: csrColInd
-      integer(c_size_t),target :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseSpruneDense2csr_bufferSizeExt_rank_0 = hipsparseSpruneDense2csr_bufferSizeExt_( &
-        handle,m,n,c_loc(A),lda,threshold,descr,c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd), &
-        c_loc(pBufferSizeInBytes))
+        handle,m,n,c_loc(A),lda,c_loc(threshold),descr,c_loc(csrVal),c_loc(csrRowPtr), &
+        c_loc(csrColInd),pBufferSizeInBytes)
     end function
 
     function hipsparseSpruneDense2csr_bufferSizeExt_rank_1(handle,m,n,A,lda,threshold,descr, &
@@ -43480,16 +43468,16 @@ module hipfort_hipsparse
       integer(c_int) :: n
       real(c_float),target,dimension(:) :: A
       integer(c_int) :: lda
-      real(c_float) :: threshold
+      real(c_float),target,dimension(:) :: threshold
       type(c_ptr) :: descr
       real(c_float),target,dimension(:) :: csrVal
       integer(c_int),target,dimension(:) :: csrRowPtr
       integer(c_int),target,dimension(:) :: csrColInd
-      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseSpruneDense2csr_bufferSizeExt_rank_1 = hipsparseSpruneDense2csr_bufferSizeExt_( &
-        handle,m,n,c_loc(A),lda,threshold,descr,c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd), &
-        c_loc(pBufferSizeInBytes))
+        handle,m,n,c_loc(A),lda,c_loc(threshold),descr,c_loc(csrVal),c_loc(csrRowPtr), &
+        c_loc(csrColInd),pBufferSizeInBytes)
     end function
 
     function hipsparseSpruneDense2csr_bufferSizeExt_full_rank(handle,m,n,A,lda,threshold,descr, &
@@ -43503,16 +43491,16 @@ module hipfort_hipsparse
       integer(c_int) :: n
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_float) :: threshold
+      real(c_float),target,dimension(:) :: threshold
       type(c_ptr) :: descr
       real(c_float),target,dimension(:) :: csrVal
       integer(c_int),target,dimension(:) :: csrRowPtr
       integer(c_int),target,dimension(:) :: csrColInd
-      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseSpruneDense2csr_bufferSizeExt_full_rank = hipsparseSpruneDense2csr_bufferSizeExt_( &
-        handle,m,n,c_loc(A),lda,threshold,descr,c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd), &
-        c_loc(pBufferSizeInBytes))
+        handle,m,n,c_loc(A),lda,c_loc(threshold),descr,c_loc(csrVal),c_loc(csrRowPtr), &
+        c_loc(csrColInd),pBufferSizeInBytes)
     end function
 
     function hipsparseDpruneDense2csr_bufferSizeExt_rank_0(handle,m,n,A,lda,threshold,descr, &
@@ -43526,16 +43514,16 @@ module hipfort_hipsparse
       integer(c_int) :: n
       real(c_double),target :: A
       integer(c_int) :: lda
-      real(c_double) :: threshold
+      real(c_double),target :: threshold
       type(c_ptr) :: descr
       real(c_double),target :: csrVal
       integer(c_int),target :: csrRowPtr
       integer(c_int),target :: csrColInd
-      integer(c_size_t),target :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseDpruneDense2csr_bufferSizeExt_rank_0 = hipsparseDpruneDense2csr_bufferSizeExt_( &
-        handle,m,n,c_loc(A),lda,threshold,descr,c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd), &
-        c_loc(pBufferSizeInBytes))
+        handle,m,n,c_loc(A),lda,c_loc(threshold),descr,c_loc(csrVal),c_loc(csrRowPtr), &
+        c_loc(csrColInd),pBufferSizeInBytes)
     end function
 
     function hipsparseDpruneDense2csr_bufferSizeExt_rank_1(handle,m,n,A,lda,threshold,descr, &
@@ -43549,16 +43537,16 @@ module hipfort_hipsparse
       integer(c_int) :: n
       real(c_double),target,dimension(:) :: A
       integer(c_int) :: lda
-      real(c_double) :: threshold
+      real(c_double),target,dimension(:) :: threshold
       type(c_ptr) :: descr
       real(c_double),target,dimension(:) :: csrVal
       integer(c_int),target,dimension(:) :: csrRowPtr
       integer(c_int),target,dimension(:) :: csrColInd
-      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseDpruneDense2csr_bufferSizeExt_rank_1 = hipsparseDpruneDense2csr_bufferSizeExt_( &
-        handle,m,n,c_loc(A),lda,threshold,descr,c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd), &
-        c_loc(pBufferSizeInBytes))
+        handle,m,n,c_loc(A),lda,c_loc(threshold),descr,c_loc(csrVal),c_loc(csrRowPtr), &
+        c_loc(csrColInd),pBufferSizeInBytes)
     end function
 
     function hipsparseDpruneDense2csr_bufferSizeExt_full_rank(handle,m,n,A,lda,threshold,descr, &
@@ -43572,16 +43560,16 @@ module hipfort_hipsparse
       integer(c_int) :: n
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
-      real(c_double) :: threshold
+      real(c_double),target,dimension(:) :: threshold
       type(c_ptr) :: descr
       real(c_double),target,dimension(:) :: csrVal
       integer(c_int),target,dimension(:) :: csrRowPtr
       integer(c_int),target,dimension(:) :: csrColInd
-      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseDpruneDense2csr_bufferSizeExt_full_rank = hipsparseDpruneDense2csr_bufferSizeExt_( &
-        handle,m,n,c_loc(A),lda,threshold,descr,c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd), &
-        c_loc(pBufferSizeInBytes))
+        handle,m,n,c_loc(A),lda,c_loc(threshold),descr,c_loc(csrVal),c_loc(csrRowPtr), &
+        c_loc(csrColInd),pBufferSizeInBytes)
     end function
 
     function hipsparseSpruneDense2csrNnz_rank_0(handle,m,n,A,lda,threshold,descr,csrRowPtr, &
@@ -43859,11 +43847,11 @@ module hipfort_hipsparse
       integer(c_int),target :: csrRowPtr
       integer(c_int),target :: csrColInd
       type(c_ptr) :: myInfo
-      integer(c_size_t),target :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseSpruneDense2csrByPercentage_bufferSize_rank_0 = &
         hipsparseSpruneDense2csrByPercentage_bufferSize_(handle,m,n,c_loc(A),lda,percentage,descr, &
-        c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd),myInfo,c_loc(pBufferSizeInBytes))
+        c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd),myInfo,pBufferSizeInBytes)
     end function
 
     function hipsparseSpruneDense2csrByPercentage_bufferSize_rank_1(handle,m,n,A,lda,percentage, &
@@ -43883,11 +43871,11 @@ module hipfort_hipsparse
       integer(c_int),target,dimension(:) :: csrRowPtr
       integer(c_int),target,dimension(:) :: csrColInd
       type(c_ptr) :: myInfo
-      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseSpruneDense2csrByPercentage_bufferSize_rank_1 = &
         hipsparseSpruneDense2csrByPercentage_bufferSize_(handle,m,n,c_loc(A),lda,percentage,descr, &
-        c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd),myInfo,c_loc(pBufferSizeInBytes))
+        c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd),myInfo,pBufferSizeInBytes)
     end function
 
     function hipsparseSpruneDense2csrByPercentage_bufferSize_full_rank(handle,m,n,A,lda, &
@@ -43907,11 +43895,11 @@ module hipfort_hipsparse
       integer(c_int),target,dimension(:) :: csrRowPtr
       integer(c_int),target,dimension(:) :: csrColInd
       type(c_ptr) :: myInfo
-      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseSpruneDense2csrByPercentage_bufferSize_full_rank = &
         hipsparseSpruneDense2csrByPercentage_bufferSize_(handle,m,n,c_loc(A),lda,percentage,descr, &
-        c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd),myInfo,c_loc(pBufferSizeInBytes))
+        c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd),myInfo,pBufferSizeInBytes)
     end function
 
     function hipsparseDpruneDense2csrByPercentage_bufferSize_rank_0(handle,m,n,A,lda,percentage, &
@@ -43931,11 +43919,11 @@ module hipfort_hipsparse
       integer(c_int),target :: csrRowPtr
       integer(c_int),target :: csrColInd
       type(c_ptr) :: myInfo
-      integer(c_size_t),target :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseDpruneDense2csrByPercentage_bufferSize_rank_0 = &
         hipsparseDpruneDense2csrByPercentage_bufferSize_(handle,m,n,c_loc(A),lda,percentage,descr, &
-        c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd),myInfo,c_loc(pBufferSizeInBytes))
+        c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd),myInfo,pBufferSizeInBytes)
     end function
 
     function hipsparseDpruneDense2csrByPercentage_bufferSize_rank_1(handle,m,n,A,lda,percentage, &
@@ -43955,11 +43943,11 @@ module hipfort_hipsparse
       integer(c_int),target,dimension(:) :: csrRowPtr
       integer(c_int),target,dimension(:) :: csrColInd
       type(c_ptr) :: myInfo
-      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseDpruneDense2csrByPercentage_bufferSize_rank_1 = &
         hipsparseDpruneDense2csrByPercentage_bufferSize_(handle,m,n,c_loc(A),lda,percentage,descr, &
-        c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd),myInfo,c_loc(pBufferSizeInBytes))
+        c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd),myInfo,pBufferSizeInBytes)
     end function
 
     function hipsparseDpruneDense2csrByPercentage_bufferSize_full_rank(handle,m,n,A,lda, &
@@ -43979,11 +43967,11 @@ module hipfort_hipsparse
       integer(c_int),target,dimension(:) :: csrRowPtr
       integer(c_int),target,dimension(:) :: csrColInd
       type(c_ptr) :: myInfo
-      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseDpruneDense2csrByPercentage_bufferSize_full_rank = &
         hipsparseDpruneDense2csrByPercentage_bufferSize_(handle,m,n,c_loc(A),lda,percentage,descr, &
-        c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd),myInfo,c_loc(pBufferSizeInBytes))
+        c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd),myInfo,pBufferSizeInBytes)
     end function
 
     function hipsparseSpruneDense2csrByPercentage_bufferSizeExt_rank_0(handle,m,n,A,lda, &
@@ -44003,11 +43991,11 @@ module hipfort_hipsparse
       integer(c_int),target :: csrRowPtr
       integer(c_int),target :: csrColInd
       type(c_ptr) :: myInfo
-      integer(c_size_t),target :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseSpruneDense2csrByPercentage_bufferSizeExt_rank_0 = &
         hipsparseSpruneDense2csrByPercentage_bufferSizeExt_(handle,m,n,c_loc(A),lda,percentage, &
-        descr,c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd),myInfo,c_loc(pBufferSizeInBytes))
+        descr,c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd),myInfo,pBufferSizeInBytes)
     end function
 
     function hipsparseSpruneDense2csrByPercentage_bufferSizeExt_rank_1(handle,m,n,A,lda, &
@@ -44027,11 +44015,11 @@ module hipfort_hipsparse
       integer(c_int),target,dimension(:) :: csrRowPtr
       integer(c_int),target,dimension(:) :: csrColInd
       type(c_ptr) :: myInfo
-      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseSpruneDense2csrByPercentage_bufferSizeExt_rank_1 = &
         hipsparseSpruneDense2csrByPercentage_bufferSizeExt_(handle,m,n,c_loc(A),lda,percentage, &
-        descr,c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd),myInfo,c_loc(pBufferSizeInBytes))
+        descr,c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd),myInfo,pBufferSizeInBytes)
     end function
 
     function hipsparseSpruneDense2csrByPercentage_bufferSizeExt_full_rank(handle,m,n,A,lda, &
@@ -44051,11 +44039,11 @@ module hipfort_hipsparse
       integer(c_int),target,dimension(:) :: csrRowPtr
       integer(c_int),target,dimension(:) :: csrColInd
       type(c_ptr) :: myInfo
-      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseSpruneDense2csrByPercentage_bufferSizeExt_full_rank = &
         hipsparseSpruneDense2csrByPercentage_bufferSizeExt_(handle,m,n,c_loc(A),lda,percentage, &
-        descr,c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd),myInfo,c_loc(pBufferSizeInBytes))
+        descr,c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd),myInfo,pBufferSizeInBytes)
     end function
 
     function hipsparseDpruneDense2csrByPercentage_bufferSizeExt_rank_0(handle,m,n,A,lda, &
@@ -44075,11 +44063,11 @@ module hipfort_hipsparse
       integer(c_int),target :: csrRowPtr
       integer(c_int),target :: csrColInd
       type(c_ptr) :: myInfo
-      integer(c_size_t),target :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseDpruneDense2csrByPercentage_bufferSizeExt_rank_0 = &
         hipsparseDpruneDense2csrByPercentage_bufferSizeExt_(handle,m,n,c_loc(A),lda,percentage, &
-        descr,c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd),myInfo,c_loc(pBufferSizeInBytes))
+        descr,c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd),myInfo,pBufferSizeInBytes)
     end function
 
     function hipsparseDpruneDense2csrByPercentage_bufferSizeExt_rank_1(handle,m,n,A,lda, &
@@ -44099,11 +44087,11 @@ module hipfort_hipsparse
       integer(c_int),target,dimension(:) :: csrRowPtr
       integer(c_int),target,dimension(:) :: csrColInd
       type(c_ptr) :: myInfo
-      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseDpruneDense2csrByPercentage_bufferSizeExt_rank_1 = &
         hipsparseDpruneDense2csrByPercentage_bufferSizeExt_(handle,m,n,c_loc(A),lda,percentage, &
-        descr,c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd),myInfo,c_loc(pBufferSizeInBytes))
+        descr,c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd),myInfo,pBufferSizeInBytes)
     end function
 
     function hipsparseDpruneDense2csrByPercentage_bufferSizeExt_full_rank(handle,m,n,A,lda, &
@@ -44123,11 +44111,11 @@ module hipfort_hipsparse
       integer(c_int),target,dimension(:) :: csrRowPtr
       integer(c_int),target,dimension(:) :: csrColInd
       type(c_ptr) :: myInfo
-      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
+      integer(c_size_t) :: pBufferSizeInBytes
       !
       hipsparseDpruneDense2csrByPercentage_bufferSizeExt_full_rank = &
         hipsparseDpruneDense2csrByPercentage_bufferSizeExt_(handle,m,n,c_loc(A),lda,percentage, &
-        descr,c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd),myInfo,c_loc(pBufferSizeInBytes))
+        descr,c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd),myInfo,pBufferSizeInBytes)
     end function
 
     function hipsparseSpruneDense2csrNnzByPercentage_rank_0(handle,m,n,A,lda,percentage,descr, &
@@ -44590,66 +44578,6 @@ module hipfort_hipsparse
       !
       hipsparseZcsrcolor_rank_1 = hipsparseZcsrcolor_(handle,m,nnz,descrA,c_loc(csrValA), &
         c_loc(csrRowPtrA),c_loc(csrColIndA),fractionToColor,ncolors,coloring,reordering,myInfo)
-    end function
-
-    function hipsparseDenseToSparse_bufferSize_rank_0(handle,matA,matB,alg,pBufferSizeInBytes)
-      use iso_c_binding
-      use hipfort_hipsparse_enums
-      implicit none
-      integer(kind(HIPSPARSE_STATUS_SUCCESS)) :: hipsparseDenseToSparse_bufferSize_rank_0
-      type(c_ptr) :: handle
-      type(c_ptr) :: matA
-      type(c_ptr) :: matB
-      integer(kind(HIPSPARSE_DENSETOSPARSE_ALG_DEFAULT)) :: alg
-      integer(c_size_t),target :: pBufferSizeInBytes
-      !
-      hipsparseDenseToSparse_bufferSize_rank_0 = hipsparseDenseToSparse_bufferSize_(handle,matA, &
-        matB,alg,c_loc(pBufferSizeInBytes))
-    end function
-
-    function hipsparseDenseToSparse_bufferSize_rank_1(handle,matA,matB,alg,pBufferSizeInBytes)
-      use iso_c_binding
-      use hipfort_hipsparse_enums
-      implicit none
-      integer(kind(HIPSPARSE_STATUS_SUCCESS)) :: hipsparseDenseToSparse_bufferSize_rank_1
-      type(c_ptr) :: handle
-      type(c_ptr) :: matA
-      type(c_ptr) :: matB
-      integer(kind(HIPSPARSE_DENSETOSPARSE_ALG_DEFAULT)) :: alg
-      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
-      !
-      hipsparseDenseToSparse_bufferSize_rank_1 = hipsparseDenseToSparse_bufferSize_(handle,matA, &
-        matB,alg,c_loc(pBufferSizeInBytes))
-    end function
-
-    function hipsparseSparseToDense_bufferSize_rank_0(handle,matA,matB,alg,pBufferSizeInBytes)
-      use iso_c_binding
-      use hipfort_hipsparse_enums
-      implicit none
-      integer(kind(HIPSPARSE_STATUS_SUCCESS)) :: hipsparseSparseToDense_bufferSize_rank_0
-      type(c_ptr) :: handle
-      type(c_ptr) :: matA
-      type(c_ptr) :: matB
-      integer(kind(HIPSPARSE_SPARSETODENSE_ALG_DEFAULT)) :: alg
-      integer(c_size_t),target :: pBufferSizeInBytes
-      !
-      hipsparseSparseToDense_bufferSize_rank_0 = hipsparseSparseToDense_bufferSize_(handle,matA, &
-        matB,alg,c_loc(pBufferSizeInBytes))
-    end function
-
-    function hipsparseSparseToDense_bufferSize_rank_1(handle,matA,matB,alg,pBufferSizeInBytes)
-      use iso_c_binding
-      use hipfort_hipsparse_enums
-      implicit none
-      integer(kind(HIPSPARSE_STATUS_SUCCESS)) :: hipsparseSparseToDense_bufferSize_rank_1
-      type(c_ptr) :: handle
-      type(c_ptr) :: matA
-      type(c_ptr) :: matB
-      integer(kind(HIPSPARSE_SPARSETODENSE_ALG_DEFAULT)) :: alg
-      integer(c_size_t),target,dimension(:) :: pBufferSizeInBytes
-      !
-      hipsparseSparseToDense_bufferSize_rank_1 = hipsparseSparseToDense_bufferSize_(handle,matA, &
-        matB,alg,c_loc(pBufferSizeInBytes))
     end function
 
 #endif

--- a/lib/hipfort/hipfort_rocblas.F90
+++ b/lib/hipfort/hipfort_rocblas.F90
@@ -697,7 +697,7 @@ module hipfort_rocblas
       implicit none
       integer(kind(rocblas_status_success)) :: rocblas_set_solution_fitness_query_
       type(c_ptr),value :: handle
-      type(c_ptr),value :: fitness
+      real(c_double) :: fitness
     end function
   end interface
 
@@ -38303,7 +38303,7 @@ module hipfort_rocblas
       use hipfort_rocblas_enums
       implicit none
       integer(kind(rocblas_status_success)) :: rocblas_get_version_string_size_
-      type(c_ptr),value :: len
+      integer(c_size_t) :: len
     end function
   end interface
 
@@ -38340,7 +38340,7 @@ module hipfort_rocblas
       use hipfort_rocblas_enums
       implicit none
       integer(kind(rocblas_status_success)) :: rocblas_get_commit_hash_string_size_
-      type(c_ptr),value :: len
+      integer(c_size_t) :: len
     end function
   end interface
 

--- a/lib/hipfort/hipfort_rocrand.F90
+++ b/lib/hipfort/hipfort_rocrand.F90
@@ -794,7 +794,7 @@ module hipfort_rocrand
       use hipfort_rocrand_enums
       implicit none
       integer(kind(ROCRAND_STATUS_SUCCESS)) :: rocrand_get_version_
-      type(c_ptr),value :: version
+      integer(c_int) :: version
     end function
   end interface
 

--- a/lib/hipfort/hipfort_rocsolver.F90
+++ b/lib/hipfort/hipfort_rocsolver.F90
@@ -63,7 +63,7 @@ module hipfort_rocsolver
       use hipfort_rocblas_enums
       implicit none
       integer(kind(rocblas_status_success)) :: rocsolver_get_version_string_size_
-      type(c_ptr),value :: len
+      integer(c_size_t) :: len
     end function
   end interface
 

--- a/lib/hipfort/hipfort_rocsparse.F90
+++ b/lib/hipfort/hipfort_rocsparse.F90
@@ -324,7 +324,7 @@ module hipfort_rocsparse
       implicit none
       integer(kind(rocsparse_status_success)) :: rocsparse_get_version_
       type(c_ptr),value :: handle
-      type(c_ptr),value :: version
+      integer(c_int) :: version
     end function
   end interface
 
@@ -1013,7 +1013,7 @@ module hipfort_rocsparse
       integer(kind(rocsparse_status_success)) :: rocsparse_spvec_get_
       type(c_ptr),value :: descr
       type(c_ptr),value :: mySize
-      type(c_ptr),value :: nnz
+      integer(c_int64_t) :: nnz
       type(c_ptr) :: indices
       type(c_ptr) :: values
       type(c_ptr),value :: idx_type
@@ -1032,7 +1032,7 @@ module hipfort_rocsparse
       integer(kind(rocsparse_status_success)) :: rocsparse_const_spvec_get_
       type(c_ptr),value :: descr
       type(c_ptr),value :: mySize
-      type(c_ptr),value :: nnz
+      integer(c_int64_t) :: nnz
       type(c_ptr) :: indices
       type(c_ptr) :: values
       type(c_ptr),value :: idx_type
@@ -2733,9 +2733,9 @@ module hipfort_rocsparse
       implicit none
       integer(kind(rocsparse_status_success)) :: rocsparse_coo_get_
       type(c_ptr),value :: descr
-      type(c_ptr),value :: rows
-      type(c_ptr),value :: cols
-      type(c_ptr),value :: nnz
+      integer(c_int64_t) :: rows
+      integer(c_int64_t) :: cols
+      integer(c_int64_t) :: nnz
       type(c_ptr) :: coo_row_ind
       type(c_ptr) :: coo_col_ind
       type(c_ptr) :: coo_val
@@ -2754,9 +2754,9 @@ module hipfort_rocsparse
       implicit none
       integer(kind(rocsparse_status_success)) :: rocsparse_const_coo_get_
       type(c_ptr),value :: descr
-      type(c_ptr),value :: rows
-      type(c_ptr),value :: cols
-      type(c_ptr),value :: nnz
+      integer(c_int64_t) :: rows
+      integer(c_int64_t) :: cols
+      integer(c_int64_t) :: nnz
       type(c_ptr) :: coo_row_ind
       type(c_ptr) :: coo_col_ind
       type(c_ptr) :: coo_val
@@ -2805,9 +2805,9 @@ module hipfort_rocsparse
       implicit none
       integer(kind(rocsparse_status_success)) :: rocsparse_coo_aos_get_
       type(c_ptr),value :: descr
-      type(c_ptr),value :: rows
-      type(c_ptr),value :: cols
-      type(c_ptr),value :: nnz
+      integer(c_int64_t) :: rows
+      integer(c_int64_t) :: cols
+      integer(c_int64_t) :: nnz
       type(c_ptr) :: coo_ind
       type(c_ptr) :: coo_val
       type(c_ptr),value :: idx_type
@@ -2825,9 +2825,9 @@ module hipfort_rocsparse
       implicit none
       integer(kind(rocsparse_status_success)) :: rocsparse_const_coo_aos_get_
       type(c_ptr),value :: descr
-      type(c_ptr),value :: rows
-      type(c_ptr),value :: cols
-      type(c_ptr),value :: nnz
+      integer(c_int64_t) :: rows
+      integer(c_int64_t) :: cols
+      integer(c_int64_t) :: nnz
       type(c_ptr) :: coo_ind
       type(c_ptr) :: coo_val
       type(c_ptr),value :: idx_type
@@ -2880,9 +2880,9 @@ module hipfort_rocsparse
       implicit none
       integer(kind(rocsparse_status_success)) :: rocsparse_csr_get_
       type(c_ptr),value :: descr
-      type(c_ptr),value :: rows
-      type(c_ptr),value :: cols
-      type(c_ptr),value :: nnz
+      integer(c_int64_t) :: rows
+      integer(c_int64_t) :: cols
+      integer(c_int64_t) :: nnz
       type(c_ptr) :: csr_row_ptr
       type(c_ptr) :: csr_col_ind
       type(c_ptr) :: csr_val
@@ -2902,9 +2902,9 @@ module hipfort_rocsparse
       implicit none
       integer(kind(rocsparse_status_success)) :: rocsparse_const_csr_get_
       type(c_ptr),value :: descr
-      type(c_ptr),value :: rows
-      type(c_ptr),value :: cols
-      type(c_ptr),value :: nnz
+      integer(c_int64_t) :: rows
+      integer(c_int64_t) :: cols
+      integer(c_int64_t) :: nnz
       type(c_ptr) :: csr_row_ptr
       type(c_ptr) :: csr_col_ind
       type(c_ptr) :: csr_val
@@ -2959,9 +2959,9 @@ module hipfort_rocsparse
       implicit none
       integer(kind(rocsparse_status_success)) :: rocsparse_csc_get_
       type(c_ptr),value :: descr
-      type(c_ptr),value :: rows
-      type(c_ptr),value :: cols
-      type(c_ptr),value :: nnz
+      integer(c_int64_t) :: rows
+      integer(c_int64_t) :: cols
+      integer(c_int64_t) :: nnz
       type(c_ptr) :: csc_col_ptr
       type(c_ptr) :: csc_row_ind
       type(c_ptr) :: csc_val
@@ -2981,9 +2981,9 @@ module hipfort_rocsparse
       implicit none
       integer(kind(rocsparse_status_success)) :: rocsparse_const_csc_get_
       type(c_ptr),value :: descr
-      type(c_ptr),value :: rows
-      type(c_ptr),value :: cols
-      type(c_ptr),value :: nnz
+      integer(c_int64_t) :: rows
+      integer(c_int64_t) :: cols
+      integer(c_int64_t) :: nnz
       type(c_ptr) :: csc_col_ptr
       type(c_ptr) :: csc_row_ind
       type(c_ptr) :: csc_val
@@ -3034,8 +3034,8 @@ module hipfort_rocsparse
       implicit none
       integer(kind(rocsparse_status_success)) :: rocsparse_ell_get_
       type(c_ptr),value :: descr
-      type(c_ptr),value :: rows
-      type(c_ptr),value :: cols
+      integer(c_int64_t) :: rows
+      integer(c_int64_t) :: cols
       type(c_ptr) :: ell_col_ind
       type(c_ptr) :: ell_val
       type(c_ptr),value :: ell_width
@@ -3054,8 +3054,8 @@ module hipfort_rocsparse
       implicit none
       integer(kind(rocsparse_status_success)) :: rocsparse_const_ell_get_
       type(c_ptr),value :: descr
-      type(c_ptr),value :: rows
-      type(c_ptr),value :: cols
+      integer(c_int64_t) :: rows
+      integer(c_int64_t) :: cols
       type(c_ptr) :: ell_col_ind
       type(c_ptr) :: ell_val
       type(c_ptr),value :: ell_width
@@ -3111,8 +3111,8 @@ module hipfort_rocsparse
       implicit none
       integer(kind(rocsparse_status_success)) :: rocsparse_bell_get_
       type(c_ptr),value :: descr
-      type(c_ptr),value :: rows
-      type(c_ptr),value :: cols
+      integer(c_int64_t) :: rows
+      integer(c_int64_t) :: cols
       type(c_ptr),value :: ell_block_dir
       type(c_ptr),value :: ell_block_dim
       type(c_ptr),value :: ell_cols
@@ -3133,8 +3133,8 @@ module hipfort_rocsparse
       implicit none
       integer(kind(rocsparse_status_success)) :: rocsparse_const_bell_get_
       type(c_ptr),value :: descr
-      type(c_ptr),value :: rows
-      type(c_ptr),value :: cols
+      integer(c_int64_t) :: rows
+      integer(c_int64_t) :: cols
       type(c_ptr),value :: ell_block_dir
       type(c_ptr),value :: ell_block_dim
       type(c_ptr),value :: ell_cols
@@ -3199,9 +3199,9 @@ module hipfort_rocsparse
       implicit none
       integer(kind(rocsparse_status_success)) :: rocsparse_sell_get_
       type(c_ptr),value :: descr
-      type(c_ptr),value :: rows
-      type(c_ptr),value :: cols
-      type(c_ptr),value :: nnz
+      integer(c_int64_t) :: rows
+      integer(c_int64_t) :: cols
+      integer(c_int64_t) :: nnz
       type(c_ptr),value :: sell_slice_size
       type(c_ptr),value :: sell_colval_size
       type(c_ptr) :: sell_slice_offsets
@@ -3224,9 +3224,9 @@ module hipfort_rocsparse
       implicit none
       integer(kind(rocsparse_status_success)) :: rocsparse_const_sell_get_
       type(c_ptr),value :: descr
-      type(c_ptr),value :: rows
-      type(c_ptr),value :: cols
-      type(c_ptr),value :: nnz
+      integer(c_int64_t) :: rows
+      integer(c_int64_t) :: cols
+      integer(c_int64_t) :: nnz
       type(c_ptr),value :: sell_slice_size
       type(c_ptr),value :: sell_colval_size
       type(c_ptr) :: sell_slice_offsets
@@ -3546,9 +3546,9 @@ module hipfort_rocsparse
       implicit none
       integer(kind(rocsparse_status_success)) :: rocsparse_spmat_get_size_
       type(c_ptr),value :: descr
-      type(c_ptr),value :: rows
-      type(c_ptr),value :: cols
-      type(c_ptr),value :: nnz
+      integer(c_int64_t) :: rows
+      integer(c_int64_t) :: cols
+      integer(c_int64_t) :: nnz
     end function
   end interface
 
@@ -3673,7 +3673,7 @@ module hipfort_rocsparse
       implicit none
       integer(kind(rocsparse_status_success)) :: rocsparse_spmat_get_nnz_
       type(c_ptr),value :: descr
-      type(c_ptr),value :: nnz
+      integer(c_int64_t) :: nnz
     end function
   end interface
 
@@ -4191,8 +4191,8 @@ module hipfort_rocsparse
       implicit none
       integer(kind(rocsparse_status_success)) :: rocsparse_dnmat_get_
       type(c_ptr),value :: descr
-      type(c_ptr),value :: rows
-      type(c_ptr),value :: cols
+      integer(c_int64_t) :: rows
+      integer(c_int64_t) :: cols
       type(c_ptr),value :: ld
       type(c_ptr) :: values
       type(c_ptr),value :: data_type
@@ -4208,8 +4208,8 @@ module hipfort_rocsparse
       implicit none
       integer(kind(rocsparse_status_success)) :: rocsparse_const_dnmat_get_
       type(c_ptr),value :: descr
-      type(c_ptr),value :: rows
-      type(c_ptr),value :: cols
+      integer(c_int64_t) :: rows
+      integer(c_int64_t) :: cols
       type(c_ptr),value :: ld
       type(c_ptr) :: values
       type(c_ptr),value :: data_type
@@ -6985,7 +6985,7 @@ module hipfort_rocsparse
       type(c_ptr),value :: csr_col_ind
       integer(c_int),value :: row_block_dim
       integer(c_int),value :: col_block_dim
-      type(c_ptr),value :: buffer_size
+      integer(c_size_t) :: buffer_size
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
@@ -7013,7 +7013,7 @@ module hipfort_rocsparse
       type(c_ptr),value :: csr_col_ind
       integer(c_int),value :: row_block_dim
       integer(c_int),value :: col_block_dim
-      type(c_ptr),value :: buffer_size
+      integer(c_size_t) :: buffer_size
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
@@ -7041,7 +7041,7 @@ module hipfort_rocsparse
       type(c_ptr),value :: csr_col_ind
       integer(c_int),value :: row_block_dim
       integer(c_int),value :: col_block_dim
-      type(c_ptr),value :: buffer_size
+      integer(c_size_t) :: buffer_size
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
@@ -7069,7 +7069,7 @@ module hipfort_rocsparse
       type(c_ptr),value :: csr_col_ind
       integer(c_int),value :: row_block_dim
       integer(c_int),value :: col_block_dim
-      type(c_ptr),value :: buffer_size
+      integer(c_size_t) :: buffer_size
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
@@ -12079,7 +12079,7 @@ module hipfort_rocsparse
       integer(c_int),value :: nb
       integer(c_int),value :: kb
       integer(c_int),value :: block_dim
-      real(c_float) :: alpha
+      type(c_ptr),value :: alpha
       type(c_ptr),value :: descr_A
       integer(c_int),value :: nnzb_A
       type(c_ptr),value :: bsr_row_ptr_A
@@ -12088,13 +12088,13 @@ module hipfort_rocsparse
       integer(c_int),value :: nnzb_B
       type(c_ptr),value :: bsr_row_ptr_B
       type(c_ptr),value :: bsr_col_ind_B
-      real(c_float) :: beta
+      type(c_ptr),value :: beta
       type(c_ptr),value :: descr_D
       integer(c_int),value :: nnzb_D
       type(c_ptr),value :: bsr_row_ptr_D
       type(c_ptr),value :: bsr_col_ind_D
       type(c_ptr),value :: info_C
-      type(c_ptr),value :: buffer_size
+      integer(c_size_t) :: buffer_size
     end function
   end interface
 
@@ -12115,7 +12115,7 @@ module hipfort_rocsparse
       integer(c_int),value :: nb
       integer(c_int),value :: kb
       integer(c_int),value :: block_dim
-      real(c_double) :: alpha
+      type(c_ptr),value :: alpha
       type(c_ptr),value :: descr_A
       integer(c_int),value :: nnzb_A
       type(c_ptr),value :: bsr_row_ptr_A
@@ -12124,13 +12124,13 @@ module hipfort_rocsparse
       integer(c_int),value :: nnzb_B
       type(c_ptr),value :: bsr_row_ptr_B
       type(c_ptr),value :: bsr_col_ind_B
-      real(c_double) :: beta
+      type(c_ptr),value :: beta
       type(c_ptr),value :: descr_D
       integer(c_int),value :: nnzb_D
       type(c_ptr),value :: bsr_row_ptr_D
       type(c_ptr),value :: bsr_col_ind_D
       type(c_ptr),value :: info_C
-      type(c_ptr),value :: buffer_size
+      integer(c_size_t) :: buffer_size
     end function
   end interface
 
@@ -12151,7 +12151,7 @@ module hipfort_rocsparse
       integer(c_int),value :: nb
       integer(c_int),value :: kb
       integer(c_int),value :: block_dim
-      complex(c_float_complex) :: alpha
+      type(c_ptr),value :: alpha
       type(c_ptr),value :: descr_A
       integer(c_int),value :: nnzb_A
       type(c_ptr),value :: bsr_row_ptr_A
@@ -12160,13 +12160,13 @@ module hipfort_rocsparse
       integer(c_int),value :: nnzb_B
       type(c_ptr),value :: bsr_row_ptr_B
       type(c_ptr),value :: bsr_col_ind_B
-      complex(c_float_complex) :: beta
+      type(c_ptr),value :: beta
       type(c_ptr),value :: descr_D
       integer(c_int),value :: nnzb_D
       type(c_ptr),value :: bsr_row_ptr_D
       type(c_ptr),value :: bsr_col_ind_D
       type(c_ptr),value :: info_C
-      type(c_ptr),value :: buffer_size
+      integer(c_size_t) :: buffer_size
     end function
   end interface
 
@@ -12187,7 +12187,7 @@ module hipfort_rocsparse
       integer(c_int),value :: nb
       integer(c_int),value :: kb
       integer(c_int),value :: block_dim
-      complex(c_double_complex) :: alpha
+      type(c_ptr),value :: alpha
       type(c_ptr),value :: descr_A
       integer(c_int),value :: nnzb_A
       type(c_ptr),value :: bsr_row_ptr_A
@@ -12196,13 +12196,13 @@ module hipfort_rocsparse
       integer(c_int),value :: nnzb_B
       type(c_ptr),value :: bsr_row_ptr_B
       type(c_ptr),value :: bsr_col_ind_B
-      complex(c_double_complex) :: beta
+      type(c_ptr),value :: beta
       type(c_ptr),value :: descr_D
       integer(c_int),value :: nnzb_D
       type(c_ptr),value :: bsr_row_ptr_D
       type(c_ptr),value :: bsr_col_ind_D
       type(c_ptr),value :: info_C
-      type(c_ptr),value :: buffer_size
+      integer(c_size_t) :: buffer_size
     end function
   end interface
 
@@ -14824,7 +14824,7 @@ module hipfort_rocsparse
       type(c_ptr),value :: mat
       type(c_ptr),value :: data_status
       integer(kind(rocsparse_check_spmat_stage_buffer_size)),value :: stage
-      type(c_ptr),value :: buffer_size
+      integer(c_size_t) :: buffer_size
       type(c_ptr),value :: temp_buffer
     end function
   end interface
@@ -15007,7 +15007,7 @@ module hipfort_rocsparse
       type(c_ptr),value :: source
       type(c_ptr),value :: target
       integer(kind(rocsparse_extract_stage_analysis)),value :: stage
-      type(c_ptr),value :: buffer_size_in_bytes
+      integer(c_size_t) :: buffer_size_in_bytes
     end function
   end interface
 
@@ -15045,7 +15045,7 @@ module hipfort_rocsparse
       integer(kind(rocsparse_status_success)) :: rocsparse_extract_nnz_
       type(c_ptr),value :: handle
       type(c_ptr),value :: descr
-      type(c_ptr),value :: nnz
+      integer(c_int64_t) :: nnz
     end function
   end interface
 
@@ -15864,7 +15864,7 @@ module hipfort_rocsparse
       type(c_ptr),value :: source
       type(c_ptr),value :: target
       integer(kind(rocsparse_sparse_to_sparse_stage_analysis)),value :: stage
-      type(c_ptr),value :: buffer_size_in_bytes
+      integer(c_size_t) :: buffer_size_in_bytes
     end function
   end interface
 
@@ -15966,7 +15966,7 @@ module hipfort_rocsparse
       type(c_ptr),value :: mat_B
       type(c_ptr),value :: mat_C
       integer(kind(rocsparse_spgeam_stage_analysis)),value :: stage
-      type(c_ptr),value :: buffer_size
+      integer(c_size_t) :: buffer_size
       type(c_ptr) :: error
     end function
   end interface
@@ -16824,7 +16824,7 @@ module hipfort_rocsparse
       integer(kind(rocsparse_datatype_f16_r)),value :: compute_type
       integer(kind(rocsparse_spitsv_alg_default)),value :: alg
       integer(kind(rocsparse_spitsv_stage_buffer_size)),value :: stage
-      type(c_ptr),value :: buffer_size
+      integer(c_size_t) :: buffer_size
       type(c_ptr),value :: temp_buffer
     end function
   end interface
@@ -17703,7 +17703,7 @@ module hipfort_rocsparse
       type(c_ptr),value :: X
       type(c_ptr),value :: Y
       integer(kind(rocsparse_sptrsm_stage_analysis)),value :: sptrsm_stage
-      type(c_ptr),value :: buffer_size_in_bytes
+      integer(c_size_t) :: buffer_size_in_bytes
       type(c_ptr) :: p_error
     end function
   end interface
@@ -17903,7 +17903,7 @@ module hipfort_rocsparse
       type(c_ptr),value :: x
       type(c_ptr),value :: y
       integer(kind(rocsparse_sptrsv_stage_analysis)),value :: sptrsv_stage
-      type(c_ptr),value :: buffer_size_in_bytes
+      integer(c_size_t) :: buffer_size_in_bytes
       type(c_ptr) :: p_error
     end function
   end interface
@@ -18186,7 +18186,7 @@ module hipfort_rocsparse
       type(c_ptr),value :: x
       type(c_ptr),value :: y
       integer(kind(rocsparse_v2_spmv_stage_analysis)),value :: stage
-      type(c_ptr),value :: buffer_size_in_bytes
+      integer(c_size_t) :: buffer_size_in_bytes
       type(c_ptr) :: error
     end function
   end interface
@@ -21082,7 +21082,7 @@ module hipfort_rocsparse
       type(c_ptr),value :: csr_row_ptr
       type(c_ptr),value :: csr_col_ind
       type(c_ptr),value :: myInfo
-      type(c_ptr),value :: buffer_size
+      integer(c_size_t) :: buffer_size
     end function
   end interface
 
@@ -21103,7 +21103,7 @@ module hipfort_rocsparse
       type(c_ptr),value :: csr_row_ptr
       type(c_ptr),value :: csr_col_ind
       type(c_ptr),value :: myInfo
-      type(c_ptr),value :: buffer_size
+      integer(c_size_t) :: buffer_size
     end function
   end interface
 
@@ -21124,7 +21124,7 @@ module hipfort_rocsparse
       type(c_ptr),value :: csr_row_ptr
       type(c_ptr),value :: csr_col_ind
       type(c_ptr),value :: myInfo
-      type(c_ptr),value :: buffer_size
+      integer(c_size_t) :: buffer_size
     end function
   end interface
 
@@ -21145,7 +21145,7 @@ module hipfort_rocsparse
       type(c_ptr),value :: csr_row_ptr
       type(c_ptr),value :: csr_col_ind
       type(c_ptr),value :: myInfo
-      type(c_ptr),value :: buffer_size
+      integer(c_size_t) :: buffer_size
     end function
   end interface
 
@@ -28313,7 +28313,7 @@ module hipfort_rocsparse
       integer(kind(rocsparse_status_success)) :: rocsparse_csric0_get_tolerance_
       type(c_ptr),value :: handle
       type(c_ptr),value :: myInfo
-      type(c_ptr),value :: tolerance
+      real(c_double) :: tolerance
     end function
   end interface
 
@@ -29082,7 +29082,7 @@ module hipfort_rocsparse
       integer(kind(rocsparse_status_success)) :: rocsparse_csrilu0_get_tolerance_
       type(c_ptr),value :: handle
       type(c_ptr),value :: myInfo
-      type(c_ptr),value :: tolerance
+      real(c_double) :: tolerance
     end function
   end interface
 
@@ -29958,7 +29958,7 @@ module hipfort_rocsparse
       type(c_ptr),value :: csr_col_ind
       integer(kind(rocsparse_index_base_zero)),value :: idx_base
       integer(kind(rocsparse_datatype_f16_r)),value :: datatype
-      type(c_ptr),value :: buffer_size
+      integer(c_size_t) :: buffer_size
     end function
   end interface
 
@@ -32041,7 +32041,7 @@ module hipfort_rocsparse
       type(c_ptr),value :: x
       integer(c_int),value :: batch_count
       integer(c_int),value :: batch_stride
-      type(c_ptr),value :: buffer_size
+      integer(c_size_t) :: buffer_size
     end function
   end interface
 
@@ -32062,7 +32062,7 @@ module hipfort_rocsparse
       type(c_ptr),value :: x
       integer(c_int),value :: batch_count
       integer(c_int),value :: batch_stride
-      type(c_ptr),value :: buffer_size
+      integer(c_size_t) :: buffer_size
     end function
   end interface
 
@@ -32083,7 +32083,7 @@ module hipfort_rocsparse
       type(c_ptr),value :: x
       integer(c_int),value :: batch_count
       integer(c_int),value :: batch_stride
-      type(c_ptr),value :: buffer_size
+      integer(c_size_t) :: buffer_size
     end function
   end interface
 
@@ -32104,7 +32104,7 @@ module hipfort_rocsparse
       type(c_ptr),value :: x
       integer(c_int),value :: batch_count
       integer(c_int),value :: batch_stride
-      type(c_ptr),value :: buffer_size
+      integer(c_size_t) :: buffer_size
     end function
   end interface
 
@@ -32547,7 +32547,7 @@ module hipfort_rocsparse
       integer(kind(rocsparse_matrix_type_general)),value :: matrix_type
       integer(kind(rocsparse_fill_mode_lower)),value :: uplo
       integer(kind(rocsparse_storage_mode_sorted)),value :: storage
-      type(c_ptr),value :: buffer_size
+      integer(c_size_t) :: buffer_size
     end function
   end interface
 
@@ -32570,7 +32570,7 @@ module hipfort_rocsparse
       integer(kind(rocsparse_matrix_type_general)),value :: matrix_type
       integer(kind(rocsparse_fill_mode_lower)),value :: uplo
       integer(kind(rocsparse_storage_mode_sorted)),value :: storage
-      type(c_ptr),value :: buffer_size
+      integer(c_size_t) :: buffer_size
     end function
   end interface
 
@@ -32593,7 +32593,7 @@ module hipfort_rocsparse
       integer(kind(rocsparse_matrix_type_general)),value :: matrix_type
       integer(kind(rocsparse_fill_mode_lower)),value :: uplo
       integer(kind(rocsparse_storage_mode_sorted)),value :: storage
-      type(c_ptr),value :: buffer_size
+      integer(c_size_t) :: buffer_size
     end function
   end interface
 
@@ -32616,7 +32616,7 @@ module hipfort_rocsparse
       integer(kind(rocsparse_matrix_type_general)),value :: matrix_type
       integer(kind(rocsparse_fill_mode_lower)),value :: uplo
       integer(kind(rocsparse_storage_mode_sorted)),value :: storage
-      type(c_ptr),value :: buffer_size
+      integer(c_size_t) :: buffer_size
     end function
   end interface
 
@@ -32904,7 +32904,7 @@ module hipfort_rocsparse
       integer(kind(rocsparse_matrix_type_general)),value :: matrix_type
       integer(kind(rocsparse_fill_mode_lower)),value :: uplo
       integer(kind(rocsparse_storage_mode_sorted)),value :: storage
-      type(c_ptr),value :: buffer_size
+      integer(c_size_t) :: buffer_size
     end function
   end interface
 
@@ -32927,7 +32927,7 @@ module hipfort_rocsparse
       integer(kind(rocsparse_matrix_type_general)),value :: matrix_type
       integer(kind(rocsparse_fill_mode_lower)),value :: uplo
       integer(kind(rocsparse_storage_mode_sorted)),value :: storage
-      type(c_ptr),value :: buffer_size
+      integer(c_size_t) :: buffer_size
     end function
   end interface
 
@@ -32950,7 +32950,7 @@ module hipfort_rocsparse
       integer(kind(rocsparse_matrix_type_general)),value :: matrix_type
       integer(kind(rocsparse_fill_mode_lower)),value :: uplo
       integer(kind(rocsparse_storage_mode_sorted)),value :: storage
-      type(c_ptr),value :: buffer_size
+      integer(c_size_t) :: buffer_size
     end function
   end interface
 
@@ -32973,7 +32973,7 @@ module hipfort_rocsparse
       integer(kind(rocsparse_matrix_type_general)),value :: matrix_type
       integer(kind(rocsparse_fill_mode_lower)),value :: uplo
       integer(kind(rocsparse_storage_mode_sorted)),value :: storage
-      type(c_ptr),value :: buffer_size
+      integer(c_size_t) :: buffer_size
     end function
   end interface
 
@@ -33264,7 +33264,7 @@ module hipfort_rocsparse
       integer(kind(rocsparse_matrix_type_general)),value :: matrix_type
       integer(kind(rocsparse_fill_mode_lower)),value :: uplo
       integer(kind(rocsparse_storage_mode_sorted)),value :: storage
-      type(c_ptr),value :: buffer_size
+      integer(c_size_t) :: buffer_size
     end function
   end interface
 
@@ -33287,7 +33287,7 @@ module hipfort_rocsparse
       integer(kind(rocsparse_matrix_type_general)),value :: matrix_type
       integer(kind(rocsparse_fill_mode_lower)),value :: uplo
       integer(kind(rocsparse_storage_mode_sorted)),value :: storage
-      type(c_ptr),value :: buffer_size
+      integer(c_size_t) :: buffer_size
     end function
   end interface
 
@@ -33310,7 +33310,7 @@ module hipfort_rocsparse
       integer(kind(rocsparse_matrix_type_general)),value :: matrix_type
       integer(kind(rocsparse_fill_mode_lower)),value :: uplo
       integer(kind(rocsparse_storage_mode_sorted)),value :: storage
-      type(c_ptr),value :: buffer_size
+      integer(c_size_t) :: buffer_size
     end function
   end interface
 
@@ -33333,7 +33333,7 @@ module hipfort_rocsparse
       integer(kind(rocsparse_matrix_type_general)),value :: matrix_type
       integer(kind(rocsparse_fill_mode_lower)),value :: uplo
       integer(kind(rocsparse_storage_mode_sorted)),value :: storage
-      type(c_ptr),value :: buffer_size
+      integer(c_size_t) :: buffer_size
     end function
   end interface
 
@@ -33619,7 +33619,7 @@ module hipfort_rocsparse
       integer(kind(rocsparse_matrix_type_general)),value :: matrix_type
       integer(kind(rocsparse_fill_mode_lower)),value :: uplo
       integer(kind(rocsparse_storage_mode_sorted)),value :: storage
-      type(c_ptr),value :: buffer_size
+      integer(c_size_t) :: buffer_size
     end function
   end interface
 
@@ -33641,7 +33641,7 @@ module hipfort_rocsparse
       integer(kind(rocsparse_matrix_type_general)),value :: matrix_type
       integer(kind(rocsparse_fill_mode_lower)),value :: uplo
       integer(kind(rocsparse_storage_mode_sorted)),value :: storage
-      type(c_ptr),value :: buffer_size
+      integer(c_size_t) :: buffer_size
     end function
   end interface
 
@@ -33663,7 +33663,7 @@ module hipfort_rocsparse
       integer(kind(rocsparse_matrix_type_general)),value :: matrix_type
       integer(kind(rocsparse_fill_mode_lower)),value :: uplo
       integer(kind(rocsparse_storage_mode_sorted)),value :: storage
-      type(c_ptr),value :: buffer_size
+      integer(c_size_t) :: buffer_size
     end function
   end interface
 
@@ -33685,7 +33685,7 @@ module hipfort_rocsparse
       integer(kind(rocsparse_matrix_type_general)),value :: matrix_type
       integer(kind(rocsparse_fill_mode_lower)),value :: uplo
       integer(kind(rocsparse_storage_mode_sorted)),value :: storage
-      type(c_ptr),value :: buffer_size
+      integer(c_size_t) :: buffer_size
     end function
   end interface
 
@@ -33915,7 +33915,7 @@ module hipfort_rocsparse
       integer(kind(rocsparse_matrix_type_general)),value :: matrix_type
       integer(kind(rocsparse_fill_mode_lower)),value :: uplo
       integer(kind(rocsparse_storage_mode_sorted)),value :: storage
-      type(c_ptr),value :: buffer_size
+      integer(c_size_t) :: buffer_size
     end function
   end interface
 
@@ -33942,7 +33942,7 @@ module hipfort_rocsparse
       integer(kind(rocsparse_matrix_type_general)),value :: matrix_type
       integer(kind(rocsparse_fill_mode_lower)),value :: uplo
       integer(kind(rocsparse_storage_mode_sorted)),value :: storage
-      type(c_ptr),value :: buffer_size
+      integer(c_size_t) :: buffer_size
     end function
   end interface
 
@@ -33969,7 +33969,7 @@ module hipfort_rocsparse
       integer(kind(rocsparse_matrix_type_general)),value :: matrix_type
       integer(kind(rocsparse_fill_mode_lower)),value :: uplo
       integer(kind(rocsparse_storage_mode_sorted)),value :: storage
-      type(c_ptr),value :: buffer_size
+      integer(c_size_t) :: buffer_size
     end function
   end interface
 
@@ -33996,7 +33996,7 @@ module hipfort_rocsparse
       integer(kind(rocsparse_matrix_type_general)),value :: matrix_type
       integer(kind(rocsparse_fill_mode_lower)),value :: uplo
       integer(kind(rocsparse_storage_mode_sorted)),value :: storage
-      type(c_ptr),value :: buffer_size
+      integer(c_size_t) :: buffer_size
     end function
   end interface
 
@@ -34255,7 +34255,7 @@ module hipfort_rocsparse
       integer(kind(rocsparse_matrix_type_general)),value :: matrix_type
       integer(kind(rocsparse_fill_mode_lower)),value :: uplo
       integer(kind(rocsparse_storage_mode_sorted)),value :: storage
-      type(c_ptr),value :: buffer_size
+      integer(c_size_t) :: buffer_size
     end function
   end interface
 
@@ -34282,7 +34282,7 @@ module hipfort_rocsparse
       integer(kind(rocsparse_matrix_type_general)),value :: matrix_type
       integer(kind(rocsparse_fill_mode_lower)),value :: uplo
       integer(kind(rocsparse_storage_mode_sorted)),value :: storage
-      type(c_ptr),value :: buffer_size
+      integer(c_size_t) :: buffer_size
     end function
   end interface
 
@@ -34309,7 +34309,7 @@ module hipfort_rocsparse
       integer(kind(rocsparse_matrix_type_general)),value :: matrix_type
       integer(kind(rocsparse_fill_mode_lower)),value :: uplo
       integer(kind(rocsparse_storage_mode_sorted)),value :: storage
-      type(c_ptr),value :: buffer_size
+      integer(c_size_t) :: buffer_size
     end function
   end interface
 
@@ -34336,7 +34336,7 @@ module hipfort_rocsparse
       integer(kind(rocsparse_matrix_type_general)),value :: matrix_type
       integer(kind(rocsparse_fill_mode_lower)),value :: uplo
       integer(kind(rocsparse_storage_mode_sorted)),value :: storage
-      type(c_ptr),value :: buffer_size
+      integer(c_size_t) :: buffer_size
     end function
   end interface
 
@@ -34631,7 +34631,7 @@ module hipfort_rocsparse
       integer(kind(rocsparse_matrix_type_general)),value :: matrix_type
       integer(kind(rocsparse_fill_mode_lower)),value :: uplo
       integer(kind(rocsparse_storage_mode_sorted)),value :: storage
-      type(c_ptr),value :: buffer_size
+      integer(c_size_t) :: buffer_size
     end function
   end interface
 
@@ -36788,11 +36788,11 @@ module hipfort_rocsparse
       integer(c_int),target :: csr_col_ind
       integer(c_int) :: row_block_dim
       integer(c_int) :: col_block_dim
-      integer(c_size_t),target :: buffer_size
+      integer(c_size_t) :: buffer_size
       !
       rocsparse_scsr2gebsr_buffer_size_rank_0 = rocsparse_scsr2gebsr_buffer_size_(handle,dir,m,n, &
         csr_descr,c_loc(csr_val),c_loc(csr_row_ptr),c_loc(csr_col_ind),row_block_dim, &
-        col_block_dim,c_loc(buffer_size))
+        col_block_dim,buffer_size)
     end function
 
     function rocsparse_scsr2gebsr_buffer_size_rank_1(handle,dir,m,n,csr_descr,csr_val,csr_row_ptr, &
@@ -36811,11 +36811,11 @@ module hipfort_rocsparse
       integer(c_int),target,dimension(:) :: csr_col_ind
       integer(c_int) :: row_block_dim
       integer(c_int) :: col_block_dim
-      integer(c_size_t),target,dimension(:) :: buffer_size
+      integer(c_size_t) :: buffer_size
       !
       rocsparse_scsr2gebsr_buffer_size_rank_1 = rocsparse_scsr2gebsr_buffer_size_(handle,dir,m,n, &
         csr_descr,c_loc(csr_val),c_loc(csr_row_ptr),c_loc(csr_col_ind),row_block_dim, &
-        col_block_dim,c_loc(buffer_size))
+        col_block_dim,buffer_size)
     end function
 
     function rocsparse_dcsr2gebsr_buffer_size_rank_0(handle,dir,m,n,csr_descr,csr_val,csr_row_ptr, &
@@ -36834,11 +36834,11 @@ module hipfort_rocsparse
       integer(c_int),target :: csr_col_ind
       integer(c_int) :: row_block_dim
       integer(c_int) :: col_block_dim
-      integer(c_size_t),target :: buffer_size
+      integer(c_size_t) :: buffer_size
       !
       rocsparse_dcsr2gebsr_buffer_size_rank_0 = rocsparse_dcsr2gebsr_buffer_size_(handle,dir,m,n, &
         csr_descr,c_loc(csr_val),c_loc(csr_row_ptr),c_loc(csr_col_ind),row_block_dim, &
-        col_block_dim,c_loc(buffer_size))
+        col_block_dim,buffer_size)
     end function
 
     function rocsparse_dcsr2gebsr_buffer_size_rank_1(handle,dir,m,n,csr_descr,csr_val,csr_row_ptr, &
@@ -36857,11 +36857,11 @@ module hipfort_rocsparse
       integer(c_int),target,dimension(:) :: csr_col_ind
       integer(c_int) :: row_block_dim
       integer(c_int) :: col_block_dim
-      integer(c_size_t),target,dimension(:) :: buffer_size
+      integer(c_size_t) :: buffer_size
       !
       rocsparse_dcsr2gebsr_buffer_size_rank_1 = rocsparse_dcsr2gebsr_buffer_size_(handle,dir,m,n, &
         csr_descr,c_loc(csr_val),c_loc(csr_row_ptr),c_loc(csr_col_ind),row_block_dim, &
-        col_block_dim,c_loc(buffer_size))
+        col_block_dim,buffer_size)
     end function
 
     function rocsparse_ccsr2gebsr_buffer_size_rank_0(handle,dir,m,n,csr_descr,csr_val,csr_row_ptr, &
@@ -36880,11 +36880,11 @@ module hipfort_rocsparse
       integer(c_int),target :: csr_col_ind
       integer(c_int) :: row_block_dim
       integer(c_int) :: col_block_dim
-      integer(c_size_t),target :: buffer_size
+      integer(c_size_t) :: buffer_size
       !
       rocsparse_ccsr2gebsr_buffer_size_rank_0 = rocsparse_ccsr2gebsr_buffer_size_(handle,dir,m,n, &
         csr_descr,c_loc(csr_val),c_loc(csr_row_ptr),c_loc(csr_col_ind),row_block_dim, &
-        col_block_dim,c_loc(buffer_size))
+        col_block_dim,buffer_size)
     end function
 
     function rocsparse_ccsr2gebsr_buffer_size_rank_1(handle,dir,m,n,csr_descr,csr_val,csr_row_ptr, &
@@ -36903,11 +36903,11 @@ module hipfort_rocsparse
       integer(c_int),target,dimension(:) :: csr_col_ind
       integer(c_int) :: row_block_dim
       integer(c_int) :: col_block_dim
-      integer(c_size_t),target,dimension(:) :: buffer_size
+      integer(c_size_t) :: buffer_size
       !
       rocsparse_ccsr2gebsr_buffer_size_rank_1 = rocsparse_ccsr2gebsr_buffer_size_(handle,dir,m,n, &
         csr_descr,c_loc(csr_val),c_loc(csr_row_ptr),c_loc(csr_col_ind),row_block_dim, &
-        col_block_dim,c_loc(buffer_size))
+        col_block_dim,buffer_size)
     end function
 
     function rocsparse_zcsr2gebsr_buffer_size_rank_0(handle,dir,m,n,csr_descr,csr_val,csr_row_ptr, &
@@ -36926,11 +36926,11 @@ module hipfort_rocsparse
       integer(c_int),target :: csr_col_ind
       integer(c_int) :: row_block_dim
       integer(c_int) :: col_block_dim
-      integer(c_size_t),target :: buffer_size
+      integer(c_size_t) :: buffer_size
       !
       rocsparse_zcsr2gebsr_buffer_size_rank_0 = rocsparse_zcsr2gebsr_buffer_size_(handle,dir,m,n, &
         csr_descr,c_loc(csr_val),c_loc(csr_row_ptr),c_loc(csr_col_ind),row_block_dim, &
-        col_block_dim,c_loc(buffer_size))
+        col_block_dim,buffer_size)
     end function
 
     function rocsparse_zcsr2gebsr_buffer_size_rank_1(handle,dir,m,n,csr_descr,csr_val,csr_row_ptr, &
@@ -36949,11 +36949,11 @@ module hipfort_rocsparse
       integer(c_int),target,dimension(:) :: csr_col_ind
       integer(c_int) :: row_block_dim
       integer(c_int) :: col_block_dim
-      integer(c_size_t),target,dimension(:) :: buffer_size
+      integer(c_size_t) :: buffer_size
       !
       rocsparse_zcsr2gebsr_buffer_size_rank_1 = rocsparse_zcsr2gebsr_buffer_size_(handle,dir,m,n, &
         csr_descr,c_loc(csr_val),c_loc(csr_row_ptr),c_loc(csr_col_ind),row_block_dim, &
-        col_block_dim,c_loc(buffer_size))
+        col_block_dim,buffer_size)
     end function
 
     function rocsparse_csr2gebsr_nnz_rank_0(handle,dir,m,n,csr_descr,csr_row_ptr,csr_col_ind, &


### PR DESCRIPTION
Follow-up to #239 (which fixed the HIP runtime): the same `type(c_ptr), value` → by-reference change for **host scalar outputs** across the math libraries, so queries take their result directly instead of `C_LOC(x)`:

```fortran
integer(c_size_t) :: sz
istat = hipsparseSpMV_bufferSize(..., sz)   ! was: C_LOC(sz)
```

Applied via each library's `.argkinds` (per-argument, so real device buffers in the same function keep `type(c_ptr)`). Categories, all unambiguously host:
- **buffer/work sizes** — `buffer_size`, `pBufferSizeInBytes`, `lwork`, `workSize` (the bulk: every `*_bufferSize`)
- **versions / string sizes** — `version`, `len`
- **descriptor dimensions** — `rows`, `cols`, `nnz` (from `rocsparse_csr_get` / `hipsparseCsrGet` & co.)
- **misc queries** — `tolerance`, `residual`/`executed_sweeps`/`position` (hipSOLVER getters), `fitness`

**Deliberately excluded:** rocSOLVER's `residual` in the Jacobi *compute* routines — the header documents it as *"pointer to real type on the GPU"* (device pointer), so it correctly stays `type(c_ptr)`.

**Side effect (correct):** a couple of size-only `*_bufferSize` functions had dubious `_rank_0/_rank_1` array overloads on the size argument (a size is never an array); making the size by-reference drops those overloads. No data-buffer overload is lost (verified). Builds clean.

**Behaviour change:** callers passing `C_LOC(x)` to these getters must pass `x` (loud compile-time error, trivial fix) — the by-reference form is the natural one.