### PR TITLE
Fix CUDA backend: drop bogus cu* name mappings across libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,20 @@ This is a FORTRAN interface library for accessing GPU Kernels.
 
 ## Known issues
 
-* The regular `hipSOLVER` interfaces (`hipsolver*`) are available for AMD GPUs only:
-  they have no native cuSOLVER equivalent (cuSOLVER's API differs), so they are
-  excluded from the CUDA/NVIDIA build. The `hipSOLVER` compat interfaces
-  (`hipsolverDn*`) map to `cusolverDn*` and are available on NVIDIA GPUs as well.
+* The CUDA/NVIDIA backend (`-DUSE_CUDA_NAMES`) does **not** cover every interface.
+  Functions with no equivalent in the corresponding CUDA library are compiled for
+  AMD only (guarded by `#ifndef USE_CUDA_NAMES`) rather than bound to a symbol that
+  does not exist. This affects, among others:
+  * the regular `hipSOLVER` API (`hipsolver*`) — cuSOLVER only exposes the
+    `cusolverDn*` dense API, which the `hipsolverDn*` compat interfaces *do* map;
+  * the legacy `hipSPARSE` API (removed from cuSPARSE in CUDA 12);
+  * several batched/strided `hipBLAS` extensions and a few HIP runtime / `hipRAND`
+    calls with no CUDA counterpart.
+
+  Core functionality (BLAS/SPARSE compute, FFT, `hipsolverDn*`, the HIP runtime)
+  maps to CUDA and is available on NVIDIA GPUs. The CUDA name maps are validated
+  symbol-by-symbol against the CUDA libraries, but the backend has not yet been
+  link/run-tested on NVIDIA hardware.
 * We recommend `gfortran` version 7.5.0 or newer as we have observed problems with older versions.
 
 ## Build and test hipfort from source

--- a/README.md
+++ b/README.md
@@ -10,20 +10,11 @@ This is a FORTRAN interface library for accessing GPU Kernels.
 
 ## Known issues
 
-* The CUDA/NVIDIA backend (`-DUSE_CUDA_NAMES`) does **not** cover every interface.
-  Functions with no equivalent in the corresponding CUDA library are compiled for
-  AMD only (guarded by `#ifndef USE_CUDA_NAMES`) rather than bound to a symbol that
-  does not exist. This affects, among others:
-  * the regular `hipSOLVER` API (`hipsolver*`) — cuSOLVER only exposes the
-    `cusolverDn*` dense API, which the `hipsolverDn*` compat interfaces *do* map;
-  * the legacy `hipSPARSE` API (removed from cuSPARSE in CUDA 12);
-  * several batched/strided `hipBLAS` extensions and a few HIP runtime / `hipRAND`
-    calls with no CUDA counterpart.
-
-  Core functionality (BLAS/SPARSE compute, FFT, `hipsolverDn*`, the HIP runtime)
-  maps to CUDA and is available on NVIDIA GPUs. The CUDA name maps are validated
-  symbol-by-symbol against the CUDA libraries, but the backend has not yet been
-  link/run-tested on NVIDIA hardware.
+* The `-DUSE_CUDA_NAMES` build targets NVIDIA machines with the CUDA toolkit but no
+  HIP/ROCm libraries: interfaces bind directly to the CUDA libraries (cuBLAS,
+  cuSOLVER, …) instead of HIP. Coverage is not complete — interfaces with no CUDA
+  equivalent (e.g. the regular `hipSOLVER` API, legacy `hipSPARSE`, some `hipBLAS`
+  extensions) are compiled for AMD only.
 * We recommend `gfortran` version 7.5.0 or newer as we have observed problems with older versions.
 
 ## Build and test hipfort from source

--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ This is a FORTRAN interface library for accessing GPU Kernels.
 
 ## Known issues
 
-* `hipSOLVER` interfaces will only work for AMD GPUs.
+* The regular `hipSOLVER` interfaces (`hipsolver*`) are available for AMD GPUs only:
+  they have no native cuSOLVER equivalent (cuSOLVER's API differs), so they are
+  excluded from the CUDA/NVIDIA build. The `hipSOLVER` compat interfaces
+  (`hipsolverDn*`) map to `cusolverDn*` and are available on NVIDIA GPUs as well.
 * We recommend `gfortran` version 7.5.0 or newer as we have observed problems with older versions.
 
 ## Build and test hipfort from source

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is a FORTRAN interface library for accessing GPU Kernels.
 
 * The `-DUSE_CUDA_NAMES` build targets NVIDIA machines with the CUDA toolkit but no
   HIP/ROCm libraries: interfaces bind directly to the CUDA libraries (cuBLAS,
-  cuSOLVER, …) instead of HIP. Coverage is not complete — interfaces with no CUDA
+  cuSOLVER, …) instead of HIP. Coverage is not complete, interfaces with no CUDA
   equivalent (e.g. the regular `hipSOLVER` API, legacy `hipSPARSE`, some `hipBLAS`
   extensions) are compiled for AMD only.
 * We recommend `gfortran` version 7.5.0 or newer as we have observed problems with older versions.

--- a/lib/hipfort/hipfort.F90
+++ b/lib/hipfort/hipfort.F90
@@ -73,12 +73,9 @@ module hipfort
   !>  This API provides control over the timing of the initialization.
   !>
   !>  @returns `hipSuccess`, `hipErrorInvalidValue`
+#ifndef USE_CUDA_NAMES
   interface hipInit
-#ifdef USE_CUDA_NAMES
-    function hipInit_(flags) bind(c, name="cudaInit")
-#else
     function hipInit_(flags) bind(c, name="hipInit")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -86,6 +83,7 @@ module hipfort
       integer(c_int),value :: flags
     end function
   end interface
+#endif
 
   !>  @brief Returns the approximate HIP driver version.
   !>
@@ -147,12 +145,9 @@ module hipfort
   !>  @param [in] ordinal Device ordinal
   !>
   !>  @returns `hipSuccess`, `hipErrorInvalidDevice`
+#ifndef USE_CUDA_NAMES
   interface hipDeviceGet
-#ifdef USE_CUDA_NAMES
-    function hipDeviceGet_(device,ordinal) bind(c, name="cudaDeviceGet")
-#else
     function hipDeviceGet_(device,ordinal) bind(c, name="hipDeviceGet")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -161,6 +156,7 @@ module hipfort
       integer(c_int),value :: ordinal
     end function
   end interface
+#endif
 
   !>  @brief Returns the compute capability of the device
   !>  @param [out] major Major compute capability version number
@@ -168,14 +164,10 @@ module hipfort
   !>  @param [in] device Device ordinal
   !>
   !>  @returns `hipSuccess`, `hipErrorInvalidDevice`
+#ifndef USE_CUDA_NAMES
   interface hipDeviceComputeCapability
-#ifdef USE_CUDA_NAMES
-    function hipDeviceComputeCapability_(major,minor,device) &
-        bind(c, name="cudaDeviceComputeCapability")
-#else
     function hipDeviceComputeCapability_(major,minor,device) &
         bind(c, name="hipDeviceComputeCapability")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -185,6 +177,7 @@ module hipfort
       integer(c_int),value :: device
     end function
   end interface
+#endif
 
   !>  @brief Returns an identifer string for the device.
   !>  @param [out] name String of the device name
@@ -192,12 +185,9 @@ module hipfort
   !>  @param [in] device Device ordinal
   !>
   !>  @returns `hipSuccess`, `hipErrorInvalidDevice`
+#ifndef USE_CUDA_NAMES
   interface hipDeviceGetName
-#ifdef USE_CUDA_NAMES
-    function hipDeviceGetName_(name,len,device) bind(c, name="cudaDeviceGetName")
-#else
     function hipDeviceGetName_(name,len,device) bind(c, name="hipDeviceGetName")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -207,6 +197,7 @@ module hipfort
       integer(c_int),value :: device
     end function
   end interface
+#endif
 
   !>  @brief Returns an UUID for the device.[BETA]
   !>  @param [out] uuid UUID for the device
@@ -307,12 +298,9 @@ module hipfort
   !>  @param [in] device The ordinal of the device
   !>
   !>  @returns `hipSuccess`, `hipErrorInvalidDevice`
+#ifndef USE_CUDA_NAMES
   interface hipDeviceTotalMem
-#ifdef USE_CUDA_NAMES
-    function hipDeviceTotalMem_(bytes,device) bind(c, name="cudaDeviceTotalMem")
-#else
     function hipDeviceTotalMem_(bytes,device) bind(c, name="hipDeviceTotalMem")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -321,6 +309,7 @@ module hipfort
       integer(c_int),value :: device
     end function
   end interface
+#endif
 
   !>   @defgroup Device Device Management
   !>
@@ -884,14 +873,10 @@ module hipfort
   !>  Queries and returns the HSA link type and the hop count between the two specified devices.
   !>
   !>  @returns `hipSuccess`, `hipErrorInvalidValue`
+#ifndef USE_CUDA_NAMES
   interface hipExtGetLinkTypeAndHopCount
-#ifdef USE_CUDA_NAMES
-    function hipExtGetLinkTypeAndHopCount_(device1,device2,linktype,hopcount) &
-        bind(c, name="cudaExtGetLinkTypeAndHopCount")
-#else
     function hipExtGetLinkTypeAndHopCount_(device1,device2,linktype,hopcount) &
         bind(c, name="hipExtGetLinkTypeAndHopCount")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -902,6 +887,7 @@ module hipfort
       integer(c_int32_t) :: hopcount
     end function
   end interface
+#endif
 
   !>  @brief Gets an interprocess memory handle for an existing device memory
   !>           allocation
@@ -1696,14 +1682,10 @@ module hipfort
   !>  hipStreamDestroy.
   !>
   !>  @see hipStreamCreate, hipStreamSynchronize, hipStreamWaitEvent, hipStreamDestroy
+#ifndef USE_CUDA_NAMES
   interface hipExtStreamCreateWithCUMask
-#ifdef USE_CUDA_NAMES
-    function hipExtStreamCreateWithCUMask_(stream,cuMaskSize,cuMask) &
-        bind(c, name="cudaExtStreamCreateWithCUMask")
-#else
     function hipExtStreamCreateWithCUMask_(stream,cuMaskSize,cuMask) &
         bind(c, name="hipExtStreamCreateWithCUMask")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -1713,6 +1695,7 @@ module hipfort
       type(c_ptr),value :: cuMask
     end function
   end interface
+#endif
 
   !>  @brief Gets CU mask associated with an asynchronous stream
   !>
@@ -1724,12 +1707,9 @@ module hipfort
   !>  @returns `hipSuccess`, `hipErrorInvalidHandle`, `hipErrorInvalidValue`
   !>
   !>  @see hipStreamCreate, hipStreamSynchronize, hipStreamWaitEvent, hipStreamDestroy
+#ifndef USE_CUDA_NAMES
   interface hipExtStreamGetCUMask
-#ifdef USE_CUDA_NAMES
-    function hipExtStreamGetCUMask_(stream,cuMaskSize,cuMask) bind(c, name="cudaExtStreamGetCUMask")
-#else
     function hipExtStreamGetCUMask_(stream,cuMaskSize,cuMask) bind(c, name="hipExtStreamGetCUMask")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -1739,6 +1719,7 @@ module hipfort
       type(c_ptr),value :: cuMask
     end function
   end interface
+#endif
 
   !>  @brief Adds a callback to be called on the host after all currently enqueued items in the
   !>  stream
@@ -1959,12 +1940,9 @@ module hipfort
   !>
   !>  @see hipExtMallocWithFlags, hipFree, hipStreamWriteValue32, hipStreamWaitValue32,
   !>  hipStreamWaitValue64
+#ifndef USE_CUDA_NAMES
   interface hipStreamWriteValue32
-#ifdef USE_CUDA_NAMES
-    function hipStreamWriteValue32_(stream,ptr,myValue,flags) bind(c, name="cudaStreamWriteValue32")
-#else
     function hipStreamWriteValue32_(stream,ptr,myValue,flags) bind(c, name="hipStreamWriteValue32")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -1975,6 +1953,7 @@ module hipfort
       integer(c_int),value :: flags
     end function
   end interface
+#endif
 
   !>  @brief Enqueues a write command to the stream.[BETA]
   !>
@@ -1994,12 +1973,9 @@ module hipfort
   !>
   !>  @see hipExtMallocWithFlags, hipFree, hipStreamWriteValue32, hipStreamWaitValue32,
   !>  hipStreamWaitValue64
+#ifndef USE_CUDA_NAMES
   interface hipStreamWriteValue64
-#ifdef USE_CUDA_NAMES
-    function hipStreamWriteValue64_(stream,ptr,myValue,flags) bind(c, name="cudaStreamWriteValue64")
-#else
     function hipStreamWriteValue64_(stream,ptr,myValue,flags) bind(c, name="hipStreamWriteValue64")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -2010,6 +1986,7 @@ module hipfort
       integer(c_int),value :: flags
     end function
   end interface
+#endif
 
   !>  @brief Enqueues an array of stream memory operations in the stream.[BETA]
   !>
@@ -2525,12 +2502,9 @@ module hipfort
   !>            change and might have outstanding issues.
   !>
   !>   @see hipPointerGetAttributes
+#ifndef USE_CUDA_NAMES
   interface hipPointerGetAttribute
-#ifdef USE_CUDA_NAMES
-    function hipPointerGetAttribute_(myData,attribute,ptr) bind(c, name="cudaPointerGetAttribute")
-#else
     function hipPointerGetAttribute_(myData,attribute,ptr) bind(c, name="hipPointerGetAttribute")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -2540,6 +2514,7 @@ module hipfort
       type(c_ptr),value :: ptr
     end function
   end interface
+#endif
 
   !>   @brief Returns information about the specified pointer.[BETA]
   !>
@@ -2555,14 +2530,10 @@ module hipfort
   !>            change and might have outstanding issues.
   !>
   !>   @see hipPointerGetAttribute
+#ifndef USE_CUDA_NAMES
   interface hipDrvPointerGetAttributes
-#ifdef USE_CUDA_NAMES
-    function hipDrvPointerGetAttributes_(numAttributes,attributes,myData,ptr) &
-        bind(c, name="cudaDrvPointerGetAttributes")
-#else
     function hipDrvPointerGetAttributes_(numAttributes,attributes,myData,ptr) &
         bind(c, name="hipDrvPointerGetAttributes")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -2573,6 +2544,7 @@ module hipfort
       type(c_ptr),value :: ptr
     end function
   end interface
+#endif
 
   !> -------------------------------------------------------------------------------------------------
   !> -------------------------------------------------------------------------------------------------
@@ -2824,12 +2796,9 @@ module hipfort
   !>
   !>   @see hipMallocPitch, hipFree, hipMallocArray, hipFreeArray, hipMalloc3D, hipMalloc3DArray,
   !>  hipHostFree, hiHostMalloc
+#ifndef USE_CUDA_NAMES
   interface hipExtMallocWithFlags
-#ifdef USE_CUDA_NAMES
-    function hipExtMallocWithFlags_(ptr,sizeBytes,flags) bind(c, name="cudaExtMallocWithFlags")
-#else
     function hipExtMallocWithFlags_(ptr,sizeBytes,flags) bind(c, name="hipExtMallocWithFlags")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -2839,6 +2808,7 @@ module hipfort
       integer(c_int),value :: flags
     end function
   end interface
+#endif
 
   !>   @brief Allocate pinned host memory [Deprecated]
   !>
@@ -2875,12 +2845,9 @@ module hipfort
   !>   @returns `hipSuccess`, `hipErrorOutOfMemory`
   !>
   !>   @warning  This API is deprecated, use hipHostMalloc() instead
+#ifndef USE_CUDA_NAMES
   interface hipMemAllocHost
-#ifdef USE_CUDA_NAMES
-    function hipMemAllocHost_(ptr,mySize) bind(c, name="cudaMemAllocHost")
-#else
     function hipMemAllocHost_(ptr,mySize) bind(c, name="hipMemAllocHost")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -2889,6 +2856,7 @@ module hipfort
       integer(c_size_t),value :: mySize
     end function
   end interface
+#endif
 
   !>  @brief Prefetches memory to the specified destination device using HIP.
   !>
@@ -3797,14 +3765,10 @@ module hipfort
   !>
   !>   @see hipMalloc, hipFree, hipMallocArray, hipFreeArray, hipHostFree, hipMalloc3D,
   !>  hipMalloc3DArray, hipHostMalloc
+#ifndef USE_CUDA_NAMES
   interface hipMemAllocPitch
-#ifdef USE_CUDA_NAMES
-    function hipMemAllocPitch_(dptr,pitch,widthInBytes,height,elementSizeBytes) &
-        bind(c, name="cudaMemAllocPitch")
-#else
     function hipMemAllocPitch_(dptr,pitch,widthInBytes,height,elementSizeBytes) &
         bind(c, name="hipMemAllocPitch")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -3816,6 +3780,7 @@ module hipfort
       integer(c_int),value :: elementSizeBytes
     end function
   end interface
+#endif
 
   !>   @brief Frees page-locked memory
   !>   This API performs an implicit hipDeviceSynchronize() call.
@@ -3852,14 +3817,10 @@ module hipfort
   !>
   !>   @see hipMemcpy, hipStreamCreate, hipStreamSynchronize, hipStreamDestroy, hipSetDevice,
   !>  hipLaunchKernelGGL
+#ifndef USE_CUDA_NAMES
   interface hipMemcpyWithStream
-#ifdef USE_CUDA_NAMES
-    function hipMemcpyWithStream_(dst,src,sizeBytes,myKind,stream) &
-        bind(c, name="cudaMemcpyWithStream")
-#else
     function hipMemcpyWithStream_(dst,src,sizeBytes,myKind,stream) &
         bind(c, name="hipMemcpyWithStream")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -3871,6 +3832,7 @@ module hipfort
       type(c_ptr),value :: stream
     end function
   end interface
+#endif
 
   !>   @brief Copy data from Host to Device
   !>
@@ -3888,12 +3850,9 @@ module hipfort
   !>  hipMemcpyDtoDAsync, hipMemcpyDtoH, hipMemcpyDtoHAsync, hipMemcpyHtoA, hipMemcpyHtoAAsync,
   !>  hipMemcpyHtoDAsync, hipMemFree, hipMemFreeHost, hipMemGetAddressRange, hipMemGetInfo,
   !>  hipMemHostAlloc, hipMemHostGetDevicePointer
+#ifndef USE_CUDA_NAMES
   interface hipMemcpyHtoD
-#ifdef USE_CUDA_NAMES
-    function hipMemcpyHtoD_(dst,src,sizeBytes) bind(c, name="cudaMemcpyHtoD")
-#else
     function hipMemcpyHtoD_(dst,src,sizeBytes) bind(c, name="hipMemcpyHtoD")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -3903,6 +3862,7 @@ module hipfort
       integer(c_size_t),value :: sizeBytes
     end function
   end interface
+#endif
 
   !>   @brief Copy data from Device to Host
   !>
@@ -3920,12 +3880,9 @@ module hipfort
   !>  hipMemcpyDtoDAsync, hipMemcpyDtoH, hipMemcpyDtoHAsync, hipMemcpyHtoA, hipMemcpyHtoAAsync,
   !>  hipMemcpyHtoDAsync, hipMemFree, hipMemFreeHost, hipMemGetAddressRange, hipMemGetInfo,
   !>  hipMemHostAlloc, hipMemHostGetDevicePointer
+#ifndef USE_CUDA_NAMES
   interface hipMemcpyDtoH
-#ifdef USE_CUDA_NAMES
-    function hipMemcpyDtoH_(dst,src,sizeBytes) bind(c, name="cudaMemcpyDtoH")
-#else
     function hipMemcpyDtoH_(dst,src,sizeBytes) bind(c, name="hipMemcpyDtoH")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -3935,6 +3892,7 @@ module hipfort
       integer(c_size_t),value :: sizeBytes
     end function
   end interface
+#endif
 
   !>   @brief Copy data from Device to Device
   !>
@@ -3952,12 +3910,9 @@ module hipfort
   !>  hipMemcpyDtoDAsync, hipMemcpyDtoH, hipMemcpyDtoHAsync, hipMemcpyHtoA, hipMemcpyHtoAAsync,
   !>  hipMemcpyHtoDAsync, hipMemFree, hipMemFreeHost, hipMemGetAddressRange, hipMemGetInfo,
   !>  hipMemHostAlloc, hipMemHostGetDevicePointer
+#ifndef USE_CUDA_NAMES
   interface hipMemcpyDtoD
-#ifdef USE_CUDA_NAMES
-    function hipMemcpyDtoD_(dst,src,sizeBytes) bind(c, name="cudaMemcpyDtoD")
-#else
     function hipMemcpyDtoD_(dst,src,sizeBytes) bind(c, name="hipMemcpyDtoD")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -3967,6 +3922,7 @@ module hipfort
       integer(c_size_t),value :: sizeBytes
     end function
   end interface
+#endif
 
   !>   @brief Copies from one 1D array to device memory.
   !>
@@ -4091,12 +4047,9 @@ module hipfort
   !>  hipMemcpyDtoDAsync, hipMemcpyDtoH, hipMemcpyDtoHAsync, hipMemcpyHtoA, hipMemcpyHtoAAsync,
   !>  hipMemcpyHtoDAsync, hipMemFree, hipMemFreeHost, hipMemGetAddressRange, hipMemGetInfo,
   !>  hipMemHostAlloc, hipMemHostGetDevicePointer
+#ifndef USE_CUDA_NAMES
   interface hipMemcpyHtoDAsync
-#ifdef USE_CUDA_NAMES
-    function hipMemcpyHtoDAsync_(dst,src,sizeBytes,stream) bind(c, name="cudaMemcpyHtoDAsync")
-#else
     function hipMemcpyHtoDAsync_(dst,src,sizeBytes,stream) bind(c, name="hipMemcpyHtoDAsync")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -4107,6 +4060,7 @@ module hipfort
       type(c_ptr),value :: stream
     end function
   end interface
+#endif
 
   !>   @brief Copy data from Device to Host asynchronously
   !>
@@ -4125,12 +4079,9 @@ module hipfort
   !>  hipMemcpyDtoDAsync, hipMemcpyDtoH, hipMemcpyDtoHAsync, hipMemcpyHtoA, hipMemcpyHtoAAsync,
   !>  hipMemcpyHtoDAsync, hipMemFree, hipMemFreeHost, hipMemGetAddressRange, hipMemGetInfo,
   !>  hipMemHostAlloc, hipMemHostGetDevicePointer
+#ifndef USE_CUDA_NAMES
   interface hipMemcpyDtoHAsync
-#ifdef USE_CUDA_NAMES
-    function hipMemcpyDtoHAsync_(dst,src,sizeBytes,stream) bind(c, name="cudaMemcpyDtoHAsync")
-#else
     function hipMemcpyDtoHAsync_(dst,src,sizeBytes,stream) bind(c, name="hipMemcpyDtoHAsync")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -4141,6 +4092,7 @@ module hipfort
       type(c_ptr),value :: stream
     end function
   end interface
+#endif
 
   !>   @brief Copy data from Device to Device asynchronously
   !>
@@ -4159,12 +4111,9 @@ module hipfort
   !>  hipMemcpyDtoDAsync, hipMemcpyDtoH, hipMemcpyDtoHAsync, hipMemcpyHtoA, hipMemcpyHtoAAsync,
   !>  hipMemcpyHtoDAsync, hipMemFree, hipMemFreeHost, hipMemGetAddressRange, hipMemGetInfo,
   !>  hipMemHostAlloc, hipMemHostGetDevicePointer
+#ifndef USE_CUDA_NAMES
   interface hipMemcpyDtoDAsync
-#ifdef USE_CUDA_NAMES
-    function hipMemcpyDtoDAsync_(dst,src,sizeBytes,stream) bind(c, name="cudaMemcpyDtoDAsync")
-#else
     function hipMemcpyDtoDAsync_(dst,src,sizeBytes,stream) bind(c, name="hipMemcpyDtoDAsync")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -4175,6 +4124,7 @@ module hipfort
       type(c_ptr),value :: stream
     end function
   end interface
+#endif
 
   !>  @brief Copies from one 1D array to host memory.
   !>
@@ -4266,12 +4216,9 @@ module hipfort
   !>   @param[in] name - Name of global to retrieve
   !>
   !>   @returns `hipSuccess`, `hipErrorInvalidValue`, `hipErrorNotFound`, `hipErrorInvalidContext`
+#ifndef USE_CUDA_NAMES
   interface hipModuleGetGlobal
-#ifdef USE_CUDA_NAMES
-    function hipModuleGetGlobal_(dptr,bytes,hmod,name) bind(c, name="cudaModuleGetGlobal")
-#else
     function hipModuleGetGlobal_(dptr,bytes,hmod,name) bind(c, name="hipModuleGetGlobal")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -4282,6 +4229,7 @@ module hipfort
       type(c_ptr),value :: name
     end function
   end interface
+#endif
 
   !>   @brief Gets device pointer associated with symbol on the device.
   !>
@@ -4525,12 +4473,9 @@ module hipfort
   !>   @param[in] myValue - Value to be set
   !>   @param[in] count - Number of values to be set
   !>   @returns `hipSuccess`, `hipErrorInvalidValue`, `hipErrorNotInitialized`
+#ifndef USE_CUDA_NAMES
   interface hipMemsetD8
-#ifdef USE_CUDA_NAMES
-    function hipMemsetD8_(dest,myValue,count) bind(c, name="cudaMemsetD8")
-#else
     function hipMemsetD8_(dest,myValue,count) bind(c, name="hipMemsetD8")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -4540,6 +4485,7 @@ module hipfort
       integer(c_size_t),value :: count
     end function
   end interface
+#endif
 
   !>   @brief Fills the first sizeBytes bytes of the memory area pointed to by dest with the
   !>   constant
@@ -4556,12 +4502,9 @@ module hipfort
   !>   @param[in] count - Number of values to be set
   !>   @param[in] stream - Stream identifier
   !>   @returns `hipSuccess`, `hipErrorInvalidValue`, `hipErrorNotInitialized`
+#ifndef USE_CUDA_NAMES
   interface hipMemsetD8Async
-#ifdef USE_CUDA_NAMES
-    function hipMemsetD8Async_(dest,myValue,count,stream) bind(c, name="cudaMemsetD8Async")
-#else
     function hipMemsetD8Async_(dest,myValue,count,stream) bind(c, name="hipMemsetD8Async")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -4572,6 +4515,7 @@ module hipfort
       type(c_ptr),value :: stream
     end function
   end interface
+#endif
 
   !>   @brief Fills the first sizeBytes bytes of the memory area pointed to by dest with the
   !>   constant
@@ -4581,12 +4525,9 @@ module hipfort
   !>   @param[in] myValue - Constant value to be set
   !>   @param[in] count - Number of values to be set
   !>   @returns `hipSuccess`, `hipErrorInvalidValue`, `hipErrorNotInitialized`
+#ifndef USE_CUDA_NAMES
   interface hipMemsetD16
-#ifdef USE_CUDA_NAMES
-    function hipMemsetD16_(dest,myValue,count) bind(c, name="cudaMemsetD16")
-#else
     function hipMemsetD16_(dest,myValue,count) bind(c, name="hipMemsetD16")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -4596,6 +4537,7 @@ module hipfort
       integer(c_size_t),value :: count
     end function
   end interface
+#endif
 
   !>   @brief Fills the first sizeBytes bytes of the memory area pointed to by dest with the
   !>   constant
@@ -4613,12 +4555,9 @@ module hipfort
   !>   @param[in] count - Number of values to be set
   !>   @param[in] stream - Stream identifier
   !>   @returns `hipSuccess`, `hipErrorInvalidValue`, `hipErrorNotInitialized`
+#ifndef USE_CUDA_NAMES
   interface hipMemsetD16Async
-#ifdef USE_CUDA_NAMES
-    function hipMemsetD16Async_(dest,myValue,count,stream) bind(c, name="cudaMemsetD16Async")
-#else
     function hipMemsetD16Async_(dest,myValue,count,stream) bind(c, name="hipMemsetD16Async")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -4629,6 +4568,7 @@ module hipfort
       type(c_ptr),value :: stream
     end function
   end interface
+#endif
 
   !>   @brief Fills the memory area pointed to by dest with the constant integer
   !>  value for specified number of times.
@@ -4637,12 +4577,9 @@ module hipfort
   !>   @param[in] myValue - Constant value to be set
   !>   @param[in] count - Number of values to be set
   !>   @returns `hipSuccess`, `hipErrorInvalidValue`, `hipErrorNotInitialized`
+#ifndef USE_CUDA_NAMES
   interface hipMemsetD32
-#ifdef USE_CUDA_NAMES
-    function hipMemsetD32_(dest,myValue,count) bind(c, name="cudaMemsetD32")
-#else
     function hipMemsetD32_(dest,myValue,count) bind(c, name="hipMemsetD32")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -4652,6 +4589,7 @@ module hipfort
       integer(c_size_t),value :: count
     end function
   end interface
+#endif
 
   !>   @brief Fills the first sizeBytes bytes of the memory area pointed to by dev with the constant
   !>  byte value value.
@@ -4699,12 +4637,9 @@ module hipfort
   !>   @param[in] count - Number of values to be set
   !>   @param[in] stream - Stream identifier
   !>   @return `hipSuccess`, `hipErrorInvalidValue`
+#ifndef USE_CUDA_NAMES
   interface hipMemsetD32Async
-#ifdef USE_CUDA_NAMES
-    function hipMemsetD32Async_(dst,myValue,count,stream) bind(c, name="cudaMemsetD32Async")
-#else
     function hipMemsetD32Async_(dst,myValue,count,stream) bind(c, name="hipMemsetD32Async")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -4715,6 +4650,7 @@ module hipfort
       type(c_ptr),value :: stream
     end function
   end interface
+#endif
 
   !>   @brief Fills the memory area pointed to by dst with the constant value.
   !>
@@ -5038,12 +4974,9 @@ module hipfort
   !>  @param[out] mySize - Returns the allocated memory size in bytes
   !>
   !>  @returns `hipSuccess`, `hipErrorInvalidValue`
+#ifndef USE_CUDA_NAMES
   interface hipMemPtrGetInfo
-#ifdef USE_CUDA_NAMES
-    function hipMemPtrGetInfo_(ptr,mySize) bind(c, name="cudaMemPtrGetInfo")
-#else
     function hipMemPtrGetInfo_(ptr,mySize) bind(c, name="hipMemPtrGetInfo")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -5052,6 +4985,7 @@ module hipfort
       integer(c_size_t) :: mySize
     end function
   end interface
+#endif
 
   !>   @brief Allocate an array on the device.
   !>
@@ -5090,12 +5024,9 @@ module hipfort
   !>   @returns     `hipSuccess`, `hipErrorInvalidValue`, `hipErrorNotSupported`
   !>
   !>   @see hipMallocArray, hipArrayDestroy, hipFreeArray
+#ifndef USE_CUDA_NAMES
   interface hipArrayCreate
-#ifdef USE_CUDA_NAMES
-    function hipArrayCreate_(pHandle,pAllocateArray) bind(c, name="cudaArrayCreate")
-#else
     function hipArrayCreate_(pHandle,pAllocateArray) bind(c, name="hipArrayCreate")
-#endif
       use iso_c_binding
       use hipfort_enums
       use hipfort_types
@@ -5105,6 +5036,7 @@ module hipfort
       type(HIP_ARRAY_DESCRIPTOR) :: pAllocateArray
     end function
   end interface
+#endif
 
   !>   @brief Destroy an array memory pointer on the device.
   !>
@@ -5113,12 +5045,9 @@ module hipfort
   !>   @returns     `hipSuccess`, `hipErrorInvalidValue`
   !>
   !>   @see hipArrayCreate, hipArrayDestroy, hipFreeArray
+#ifndef USE_CUDA_NAMES
   interface hipArrayDestroy
-#ifdef USE_CUDA_NAMES
-    function hipArrayDestroy_(array) bind(c, name="cudaArrayDestroy")
-#else
     function hipArrayDestroy_(array) bind(c, name="hipArrayDestroy")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -5126,6 +5055,7 @@ module hipfort
       type(c_ptr),value :: array
     end function
   end interface
+#endif
 
   !>   @brief Create a 3D array memory pointer on the device.
   !>
@@ -5135,12 +5065,9 @@ module hipfort
   !>   @returns     `hipSuccess`, `hipErrorInvalidValue`, `hipErrorNotSupported`
   !>
   !>   @see hipMallocArray, hipArrayDestroy, hipFreeArray
+#ifndef USE_CUDA_NAMES
   interface hipArray3DCreate
-#ifdef USE_CUDA_NAMES
-    function hipArray3DCreate_(array,pAllocateArray) bind(c, name="cudaArray3DCreate")
-#else
     function hipArray3DCreate_(array,pAllocateArray) bind(c, name="hipArray3DCreate")
-#endif
       use iso_c_binding
       use hipfort_enums
       use hipfort_types
@@ -5150,6 +5077,7 @@ module hipfort
       type(HIP_ARRAY3D_DESCRIPTOR) :: pAllocateArray
     end function
   end interface
+#endif
 
   !>   @brief Create a 3D memory pointer on the device.
   !>
@@ -5324,12 +5252,9 @@ module hipfort
   !>
   !>   @see hipMemcpy, hipMemcpy2D, hipMemcpyToArray, hipMemcpy2DToArray, hipMemcpyFromArray,
   !>  hipMemcpyToSymbol, hipMemcpyAsync
+#ifndef USE_CUDA_NAMES
   interface hipMemcpyParam2D
-#ifdef USE_CUDA_NAMES
-    function hipMemcpyParam2D_(pCopy) bind(c, name="cudaMemcpyParam2D")
-#else
     function hipMemcpyParam2D_(pCopy) bind(c, name="hipMemcpyParam2D")
-#endif
       use iso_c_binding
       use hipfort_enums
       use hipfort_types
@@ -5338,6 +5263,7 @@ module hipfort
       type(hip_Memcpy2D) :: pCopy
     end function
   end interface
+#endif
 
   !>   @brief Copies memory for 2D arrays.
   !>   @param[in] pCopy - Parameters for the memory copy
@@ -5347,12 +5273,9 @@ module hipfort
   !>
   !>   @see hipMemcpy, hipMemcpy2D, hipMemcpyToArray, hipMemcpy2DToArray, hipMemcpyFromArray,
   !>  hipMemcpyToSymbol, hipMemcpyAsync
+#ifndef USE_CUDA_NAMES
   interface hipMemcpyParam2DAsync
-#ifdef USE_CUDA_NAMES
-    function hipMemcpyParam2DAsync_(pCopy,stream) bind(c, name="cudaMemcpyParam2DAsync")
-#else
     function hipMemcpyParam2DAsync_(pCopy,stream) bind(c, name="hipMemcpyParam2DAsync")
-#endif
       use iso_c_binding
       use hipfort_enums
       use hipfort_types
@@ -5362,6 +5285,7 @@ module hipfort
       type(c_ptr),value :: stream
     end function
   end interface
+#endif
 
   !>   @brief Copies data between host and device.
   !>
@@ -5646,12 +5570,9 @@ module hipfort
   !>
   !>   @see hipMemcpy, hipMemcpy2DToArray, hipMemcpy2D, hipMemcpyFromArray, hipMemcpyToSymbol,
   !>  hipMemcpyAsync
+#ifndef USE_CUDA_NAMES
   interface hipMemcpyAtoH
-#ifdef USE_CUDA_NAMES
-    function hipMemcpyAtoH_(dst,srcArray,srcOffset,count) bind(c, name="cudaMemcpyAtoH")
-#else
     function hipMemcpyAtoH_(dst,srcArray,srcOffset,count) bind(c, name="hipMemcpyAtoH")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -5662,6 +5583,7 @@ module hipfort
       integer(c_size_t),value :: count
     end function
   end interface
+#endif
 
   !>   @brief Copies data between host and device.
   !>
@@ -5674,12 +5596,9 @@ module hipfort
   !>
   !>   @see hipMemcpy, hipMemcpy2DToArray, hipMemcpy2D, hipMemcpyFromArray, hipMemcpyToSymbol,
   !>  hipMemcpyAsync
+#ifndef USE_CUDA_NAMES
   interface hipMemcpyHtoA
-#ifdef USE_CUDA_NAMES
-    function hipMemcpyHtoA_(dstArray,dstOffset,srcHost,count) bind(c, name="cudaMemcpyHtoA")
-#else
     function hipMemcpyHtoA_(dstArray,dstOffset,srcHost,count) bind(c, name="hipMemcpyHtoA")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -5690,6 +5609,7 @@ module hipfort
       integer(c_size_t),value :: count
     end function
   end interface
+#endif
 
   !>   @brief Copies data between host and device.
   !>
@@ -5747,12 +5667,9 @@ module hipfort
   !>
   !>   @see hipMemcpy, hipMemcpy2DToArray, hipMemcpy2D, hipMemcpyFromArray, hipMemcpyToSymbol,
   !>  hipMemcpyAsync
+#ifndef USE_CUDA_NAMES
   interface hipDrvMemcpy3D
-#ifdef USE_CUDA_NAMES
-    function hipDrvMemcpy3D_(pCopy) bind(c, name="cudaDrvMemcpy3D")
-#else
     function hipDrvMemcpy3D_(pCopy) bind(c, name="hipDrvMemcpy3D")
-#endif
       use iso_c_binding
       use hipfort_enums
       use hipfort_types
@@ -5761,6 +5678,7 @@ module hipfort
       type(HIP_MEMCPY3D) :: pCopy
     end function
   end interface
+#endif
 
   !>   @brief Copies data between host and device asynchronously.
   !>
@@ -5771,12 +5689,9 @@ module hipfort
   !>
   !>   @see hipMemcpy, hipMemcpy2DToArray, hipMemcpy2D, hipMemcpyFromArray, hipMemcpyToSymbol,
   !>  hipMemcpyAsync
+#ifndef USE_CUDA_NAMES
   interface hipDrvMemcpy3DAsync
-#ifdef USE_CUDA_NAMES
-    function hipDrvMemcpy3DAsync_(pCopy,stream) bind(c, name="cudaDrvMemcpy3DAsync")
-#else
     function hipDrvMemcpy3DAsync_(pCopy,stream) bind(c, name="hipDrvMemcpy3DAsync")
-#endif
       use iso_c_binding
       use hipfort_enums
       use hipfort_types
@@ -5786,6 +5701,7 @@ module hipfort
       type(c_ptr),value :: stream
     end function
   end interface
+#endif
 
   !>  @brief Get information on memory allocations.
   !>
@@ -5797,12 +5713,9 @@ module hipfort
   !>
   !>  @see hipCtxCreate, hipCtxDestroy, hipCtxGetFlags, hipCtxPopCurrent, hipCtxGetCurrent,
   !>  hipCtxSetCurrent, hipCtxPushCurrent, hipCtxSetCacheConfig, hipCtxSynchronize, hipCtxGetDevice
+#ifndef USE_CUDA_NAMES
   interface hipMemGetAddressRange
-#ifdef USE_CUDA_NAMES
-    function hipMemGetAddressRange_(pbase,psize,dptr) bind(c, name="cudaMemGetAddressRange")
-#else
     function hipMemGetAddressRange_(pbase,psize,dptr) bind(c, name="hipMemGetAddressRange")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -5812,6 +5725,7 @@ module hipfort
       type(c_ptr),value :: dptr
     end function
   end interface
+#endif
 
   !>  @brief Perform Batch of 1D copies
   !>
@@ -6097,12 +6011,9 @@ module hipfort
   !>  @warning This API is deprecated on the AMD platform, only for equivalent cuCtx driver API on
   !>  the
   !>  NVIDIA platform.
+#ifndef USE_CUDA_NAMES
   interface hipCtxCreate
-#ifdef USE_CUDA_NAMES
-    function hipCtxCreate_(ctx,flags,device) bind(c, name="cudaCtxCreate")
-#else
     function hipCtxCreate_(ctx,flags,device) bind(c, name="hipCtxCreate")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -6112,6 +6023,7 @@ module hipfort
       integer(c_int),value :: device
     end function
   end interface
+#endif
 
   !>  @brief Destroy a HIP context [Deprecated]
   !>
@@ -6125,12 +6037,9 @@ module hipfort
   !>  @warning This API is deprecated on the AMD platform, only for equivalent cuCtx driver API on
   !>  the
   !>  NVIDIA platform.
+#ifndef USE_CUDA_NAMES
   interface hipCtxDestroy
-#ifdef USE_CUDA_NAMES
-    function hipCtxDestroy_(ctx) bind(c, name="cudaCtxDestroy")
-#else
     function hipCtxDestroy_(ctx) bind(c, name="hipCtxDestroy")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -6138,6 +6047,7 @@ module hipfort
       type(c_ptr),value :: ctx
     end function
   end interface
+#endif
 
   !>  @brief Pop the current/default context and return the popped context [Deprecated]
   !>
@@ -6151,12 +6061,9 @@ module hipfort
   !>  @warning This API is deprecated on the AMD platform, only for equivalent cuCtx driver API on
   !>  the
   !>  NVIDIA platform.
+#ifndef USE_CUDA_NAMES
   interface hipCtxPopCurrent
-#ifdef USE_CUDA_NAMES
-    function hipCtxPopCurrent_(ctx) bind(c, name="cudaCtxPopCurrent")
-#else
     function hipCtxPopCurrent_(ctx) bind(c, name="hipCtxPopCurrent")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -6164,6 +6071,7 @@ module hipfort
       type(c_ptr) :: ctx
     end function
   end interface
+#endif
 
   !>  @brief Push the context to be set as current/ default context [Deprecated]
   !>
@@ -6177,12 +6085,9 @@ module hipfort
   !>  @warning This API is deprecated on the AMD platform, only for equivalent cuCtx driver API on
   !>  the
   !>  NVIDIA platform.
+#ifndef USE_CUDA_NAMES
   interface hipCtxPushCurrent
-#ifdef USE_CUDA_NAMES
-    function hipCtxPushCurrent_(ctx) bind(c, name="cudaCtxPushCurrent")
-#else
     function hipCtxPushCurrent_(ctx) bind(c, name="hipCtxPushCurrent")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -6190,6 +6095,7 @@ module hipfort
       type(c_ptr),value :: ctx
     end function
   end interface
+#endif
 
   !>  @brief Set the passed context as current/default [Deprecated]
   !>
@@ -6203,12 +6109,9 @@ module hipfort
   !>  @warning This API is deprecated on the AMD platform, only for equivalent cuCtx driver API on
   !>  the
   !>  NVIDIA platform.
+#ifndef USE_CUDA_NAMES
   interface hipCtxSetCurrent
-#ifdef USE_CUDA_NAMES
-    function hipCtxSetCurrent_(ctx) bind(c, name="cudaCtxSetCurrent")
-#else
     function hipCtxSetCurrent_(ctx) bind(c, name="hipCtxSetCurrent")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -6216,6 +6119,7 @@ module hipfort
       type(c_ptr),value :: ctx
     end function
   end interface
+#endif
 
   !>  @brief Get the handle of the current/ default context [Deprecated]
   !>
@@ -6229,12 +6133,9 @@ module hipfort
   !>  @warning This API is deprecated on the AMD platform, only for equivalent cuCtx driver API on
   !>  the
   !>  NVIDIA platform.
+#ifndef USE_CUDA_NAMES
   interface hipCtxGetCurrent
-#ifdef USE_CUDA_NAMES
-    function hipCtxGetCurrent_(ctx) bind(c, name="cudaCtxGetCurrent")
-#else
     function hipCtxGetCurrent_(ctx) bind(c, name="hipCtxGetCurrent")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -6242,6 +6143,7 @@ module hipfort
       type(c_ptr) :: ctx
     end function
   end interface
+#endif
 
   !>  @brief Get the handle of the device associated with current/default context [Deprecated]
   !>
@@ -6255,12 +6157,9 @@ module hipfort
   !>  @warning This API is deprecated on the AMD platform, only for equivalent cuCtx driver API on
   !>  the
   !>  NVIDIA platform.
+#ifndef USE_CUDA_NAMES
   interface hipCtxGetDevice
-#ifdef USE_CUDA_NAMES
-    function hipCtxGetDevice_(device) bind(c, name="cudaCtxGetDevice")
-#else
     function hipCtxGetDevice_(device) bind(c, name="hipCtxGetDevice")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -6268,6 +6167,7 @@ module hipfort
       integer(c_int) :: device
     end function
   end interface
+#endif
 
   !>  @brief Returns the approximate HIP api version.
   !>
@@ -6288,12 +6188,9 @@ module hipfort
   !>  @warning This API is deprecated on the AMD platform, only for equivalent cuCtx driver API on
   !>  the
   !>  NVIDIA platform.
+#ifndef USE_CUDA_NAMES
   interface hipCtxGetApiVersion
-#ifdef USE_CUDA_NAMES
-    function hipCtxGetApiVersion_(ctx,apiVersion) bind(c, name="cudaCtxGetApiVersion")
-#else
     function hipCtxGetApiVersion_(ctx,apiVersion) bind(c, name="hipCtxGetApiVersion")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -6302,6 +6199,7 @@ module hipfort
       integer(c_int) :: apiVersion
     end function
   end interface
+#endif
 
   !>  @brief Get Cache configuration for a specific function [Deprecated]
   !>
@@ -6318,12 +6216,9 @@ module hipfort
   !>  @warning This API is deprecated on the AMD platform, only for equivalent cuCtx driver API on
   !>  the
   !>  NVIDIA platform.
+#ifndef USE_CUDA_NAMES
   interface hipCtxGetCacheConfig
-#ifdef USE_CUDA_NAMES
-    function hipCtxGetCacheConfig_(cacheConfig) bind(c, name="cudaCtxGetCacheConfig")
-#else
     function hipCtxGetCacheConfig_(cacheConfig) bind(c, name="hipCtxGetCacheConfig")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -6331,6 +6226,7 @@ module hipfort
       type(c_ptr),value :: cacheConfig
     end function
   end interface
+#endif
 
   !>  @brief Set L1/Shared cache partition [Deprecated]
   !>
@@ -6347,12 +6243,9 @@ module hipfort
   !>  @warning This API is deprecated on the AMD platform, only for equivalent cuCtx driver API on
   !>  the
   !>  NVIDIA platform.
+#ifndef USE_CUDA_NAMES
   interface hipCtxSetCacheConfig
-#ifdef USE_CUDA_NAMES
-    function hipCtxSetCacheConfig_(cacheConfig) bind(c, name="cudaCtxSetCacheConfig")
-#else
     function hipCtxSetCacheConfig_(cacheConfig) bind(c, name="hipCtxSetCacheConfig")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -6360,6 +6253,7 @@ module hipfort
       integer(kind(hipFuncCachePreferNone)),value :: cacheConfig
     end function
   end interface
+#endif
 
   !>  @brief Set Shared memory bank configuration  [Deprecated]
   !>
@@ -6376,12 +6270,9 @@ module hipfort
   !>  @warning This API is deprecated on the AMD platform, only for equivalent cuCtx driver API on
   !>  the
   !>  NVIDIA platform.
+#ifndef USE_CUDA_NAMES
   interface hipCtxSetSharedMemConfig
-#ifdef USE_CUDA_NAMES
-    function hipCtxSetSharedMemConfig_(config) bind(c, name="cudaCtxSetSharedMemConfig")
-#else
     function hipCtxSetSharedMemConfig_(config) bind(c, name="hipCtxSetSharedMemConfig")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -6389,6 +6280,7 @@ module hipfort
       integer(kind(hipSharedMemBankSizeDefault)),value :: config
     end function
   end interface
+#endif
 
   !>  @brief Get Shared memory bank configuration [Deprecated]
   !>
@@ -6405,12 +6297,9 @@ module hipfort
   !>  @warning This API is deprecated on the AMD platform, only for equivalent cuCtx driver API on
   !>  the
   !>  NVIDIA platform.
+#ifndef USE_CUDA_NAMES
   interface hipCtxGetSharedMemConfig
-#ifdef USE_CUDA_NAMES
-    function hipCtxGetSharedMemConfig_(pConfig) bind(c, name="cudaCtxGetSharedMemConfig")
-#else
     function hipCtxGetSharedMemConfig_(pConfig) bind(c, name="hipCtxGetSharedMemConfig")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -6418,6 +6307,7 @@ module hipfort
       type(c_ptr),value :: pConfig
     end function
   end interface
+#endif
 
   !>  @brief Blocks until the default context has completed all preceding requested tasks
   !>  [Deprecated]
@@ -6433,18 +6323,16 @@ module hipfort
   !>  @warning This API is deprecated on the AMD platform, only for equivalent cuCtx driver API on
   !>  the
   !>  NVIDIA platform.
+#ifndef USE_CUDA_NAMES
   interface hipCtxSynchronize
-#ifdef USE_CUDA_NAMES
-    function hipCtxSynchronize_() bind(c, name="cudaCtxSynchronize")
-#else
     function hipCtxSynchronize_() bind(c, name="hipCtxSynchronize")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
       integer(kind(hipSuccess)) :: hipCtxSynchronize_
     end function
   end interface
+#endif
 
   !>  @brief Return flags used for creating default context [Deprecated]
   !>
@@ -6458,12 +6346,9 @@ module hipfort
   !>  @warning This API is deprecated on the AMD platform, only for equivalent cuCtx driver API on
   !>  the
   !>  NVIDIA platform.
+#ifndef USE_CUDA_NAMES
   interface hipCtxGetFlags
-#ifdef USE_CUDA_NAMES
-    function hipCtxGetFlags_(flags) bind(c, name="cudaCtxGetFlags")
-#else
     function hipCtxGetFlags_(flags) bind(c, name="hipCtxGetFlags")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -6471,6 +6356,7 @@ module hipfort
       integer(c_int) :: flags
     end function
   end interface
+#endif
 
   !>  @brief Enables direct access to memory allocations in a peer context [Deprecated]
   !>
@@ -6494,12 +6380,9 @@ module hipfort
   !>  @warning This API is deprecated on the AMD platform, only for equivalent cuCtx driver API on
   !>  the
   !>  NVIDIA platform.
+#ifndef USE_CUDA_NAMES
   interface hipCtxEnablePeerAccess
-#ifdef USE_CUDA_NAMES
-    function hipCtxEnablePeerAccess_(peerCtx,flags) bind(c, name="cudaCtxEnablePeerAccess")
-#else
     function hipCtxEnablePeerAccess_(peerCtx,flags) bind(c, name="hipCtxEnablePeerAccess")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -6508,6 +6391,7 @@ module hipfort
       integer(c_int),value :: flags
     end function
   end interface
+#endif
 
   !>  @brief Disable direct access from current context's virtual address space to memory
   !>  allocations
@@ -6529,12 +6413,9 @@ module hipfort
   !>  @warning This API is deprecated on the AMD platform, only for equivalent cuCtx driver API on
   !>  the
   !>  NVIDIA platform.
+#ifndef USE_CUDA_NAMES
   interface hipCtxDisablePeerAccess
-#ifdef USE_CUDA_NAMES
-    function hipCtxDisablePeerAccess_(peerCtx) bind(c, name="cudaCtxDisablePeerAccess")
-#else
     function hipCtxDisablePeerAccess_(peerCtx) bind(c, name="hipCtxDisablePeerAccess")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -6542,6 +6423,7 @@ module hipfort
       type(c_ptr),value :: peerCtx
     end function
   end interface
+#endif
 
   !>  @brief Get the state of the primary context [Deprecated]
   !>
@@ -6556,14 +6438,10 @@ module hipfort
   !>
   !>  @warning  This API is deprecated on the AMD platform, only for equivalent driver API on the
   !>  NVIDIA platform.
+#ifndef USE_CUDA_NAMES
   interface hipDevicePrimaryCtxGetState
-#ifdef USE_CUDA_NAMES
-    function hipDevicePrimaryCtxGetState_(dev,flags,active) &
-        bind(c, name="cudaDevicePrimaryCtxGetState")
-#else
     function hipDevicePrimaryCtxGetState_(dev,flags,active) &
         bind(c, name="hipDevicePrimaryCtxGetState")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -6573,6 +6451,7 @@ module hipfort
       integer(c_int) :: active
     end function
   end interface
+#endif
 
   !>  @brief Release the primary context on the GPU.
   !>
@@ -6587,12 +6466,9 @@ module hipfort
   !>
   !>  @warning  This API is deprecated on the AMD platform, only for equivalent driver API on the
   !>  NVIDIA platform.
+#ifndef USE_CUDA_NAMES
   interface hipDevicePrimaryCtxRelease
-#ifdef USE_CUDA_NAMES
-    function hipDevicePrimaryCtxRelease_(dev) bind(c, name="cudaDevicePrimaryCtxRelease")
-#else
     function hipDevicePrimaryCtxRelease_(dev) bind(c, name="hipDevicePrimaryCtxRelease")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -6600,6 +6476,7 @@ module hipfort
       integer(c_int),value :: dev
     end function
   end interface
+#endif
 
   !>  @brief Retain the primary context on the GPU [Deprecated]
   !>
@@ -6613,12 +6490,9 @@ module hipfort
   !>
   !>  @warning  This API is deprecated on the AMD platform, only for equivalent driver API on the
   !>  NVIDIA platform.
+#ifndef USE_CUDA_NAMES
   interface hipDevicePrimaryCtxRetain
-#ifdef USE_CUDA_NAMES
-    function hipDevicePrimaryCtxRetain_(pctx,dev) bind(c, name="cudaDevicePrimaryCtxRetain")
-#else
     function hipDevicePrimaryCtxRetain_(pctx,dev) bind(c, name="hipDevicePrimaryCtxRetain")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -6627,6 +6501,7 @@ module hipfort
       integer(c_int),value :: dev
     end function
   end interface
+#endif
 
   !>  @brief Resets the primary context on the GPU [Deprecated]
   !>
@@ -6639,12 +6514,9 @@ module hipfort
   !>
   !>  @warning  This API is deprecated on the AMD platform, only for equivalent driver API on the
   !>  NVIDIA platform.
+#ifndef USE_CUDA_NAMES
   interface hipDevicePrimaryCtxReset
-#ifdef USE_CUDA_NAMES
-    function hipDevicePrimaryCtxReset_(dev) bind(c, name="cudaDevicePrimaryCtxReset")
-#else
     function hipDevicePrimaryCtxReset_(dev) bind(c, name="hipDevicePrimaryCtxReset")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -6652,6 +6524,7 @@ module hipfort
       integer(c_int),value :: dev
     end function
   end interface
+#endif
 
   !>  @brief Set flags for the primary context [Deprecated]
   !>
@@ -6665,12 +6538,9 @@ module hipfort
   !>
   !>  @warning  This API is deprecated on the AMD platform, only for equivalent driver API on the
   !>  NVIDIA platform.
+#ifndef USE_CUDA_NAMES
   interface hipDevicePrimaryCtxSetFlags
-#ifdef USE_CUDA_NAMES
-    function hipDevicePrimaryCtxSetFlags_(dev,flags) bind(c, name="cudaDevicePrimaryCtxSetFlags")
-#else
     function hipDevicePrimaryCtxSetFlags_(dev,flags) bind(c, name="hipDevicePrimaryCtxSetFlags")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -6679,6 +6549,7 @@ module hipfort
       integer(c_int),value :: flags
     end function
   end interface
+#endif
 
   !> -------------------------------------------------------------------------------------------------
   !> -------------------------------------------------------------------------------------------------
@@ -6725,12 +6596,9 @@ module hipfort
   !>  @returns `hipSuccess`, `hipErrorInvalidValue`, `hipErrorInvalidContext`,
   !>  `hipErrorFileNotFound`,
   !>  `hipErrorOutOfMemory`, `hipErrorSharedObjectInitFailed`, `hipErrorNotInitialized`
+#ifndef USE_CUDA_NAMES
   interface hipModuleLoad
-#ifdef USE_CUDA_NAMES
-    function hipModuleLoad_(myModule,fname) bind(c, name="cudaModuleLoad")
-#else
     function hipModuleLoad_(myModule,fname) bind(c, name="hipModuleLoad")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -6739,6 +6607,7 @@ module hipfort
       type(c_ptr),value :: fname
     end function
   end interface
+#endif
 
   !>  @brief Frees the module
   !>
@@ -6747,12 +6616,9 @@ module hipfort
   !>  @returns `hipSuccess`, `hipErrorInvalidResourceHandle`
   !>
   !>  The module is freed, and the code objects associated with it are destroyed.
+#ifndef USE_CUDA_NAMES
   interface hipModuleUnload
-#ifdef USE_CUDA_NAMES
-    function hipModuleUnload_(myModule) bind(c, name="cudaModuleUnload")
-#else
     function hipModuleUnload_(myModule) bind(c, name="hipModuleUnload")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -6760,6 +6626,7 @@ module hipfort
       type(c_ptr),value :: myModule
     end function
   end interface
+#endif
 
   !>  @brief Function with kname will be extracted if present in module
   !>
@@ -6770,12 +6637,9 @@ module hipfort
   !>  @returns `hipSuccess`, `hipErrorInvalidValue`, `hipErrorInvalidContext`,
   !>  `hipErrorNotInitialized`,
   !>  `hipErrorNotFound`,
+#ifndef USE_CUDA_NAMES
   interface hipModuleGetFunction
-#ifdef USE_CUDA_NAMES
-    function hipModuleGetFunction_(myFunction,myModule,kname) bind(c, name="cudaModuleGetFunction")
-#else
     function hipModuleGetFunction_(myFunction,myModule,kname) bind(c, name="hipModuleGetFunction")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -6785,6 +6649,7 @@ module hipfort
       type(c_ptr),value :: kname
     end function
   end interface
+#endif
 
   !>  @brief Returns the number of functions within a module.
   !>
@@ -7030,12 +6895,9 @@ module hipfort
   !>  @param [in]  hfunc  Function to get attributes from
   !>
   !>  @returns `hipSuccess`, `hipErrorInvalidValue`, `hipErrorInvalidDeviceFunction`
+#ifndef USE_CUDA_NAMES
   interface hipFuncGetAttribute
-#ifdef USE_CUDA_NAMES
-    function hipFuncGetAttribute_(myValue,attrib,hfunc) bind(c, name="cudaFuncGetAttribute")
-#else
     function hipFuncGetAttribute_(myValue,attrib,hfunc) bind(c, name="hipFuncGetAttribute")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -7045,6 +6907,7 @@ module hipfort
       type(c_ptr),value :: hfunc
     end function
   end interface
+#endif
 
   !>  @brief Gets pointer to device entry function that matches entry function symbolPtr.
   !>
@@ -7101,12 +6964,9 @@ module hipfort
   !>  @param [out] texRef  Pointer of texture reference
   !>
   !>  @returns `hipSuccess`, `hipErrorNotInitialized`, `hipErrorNotFound`, `hipErrorInvalidValue`
+#ifndef USE_CUDA_NAMES
   interface hipModuleGetTexRef
-#ifdef USE_CUDA_NAMES
-    function hipModuleGetTexRef_(texRef,hmod,name) bind(c, name="cudaModuleGetTexRef")
-#else
     function hipModuleGetTexRef_(texRef,hmod,name) bind(c, name="hipModuleGetTexRef")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -7116,6 +6976,7 @@ module hipfort
       type(c_ptr),value :: name
     end function
   end interface
+#endif
 
   !>  @brief builds module from code object data which resides in host memory.
   !>
@@ -7141,12 +7002,9 @@ module hipfort
   !>  @param [out] module  Retuned module
   !>
   !>  @returns hipSuccess, hipErrorNotInitialized, hipErrorOutOfMemory, hipErrorNotInitialized
+#ifndef USE_CUDA_NAMES
   interface hipModuleLoadData
-#ifdef USE_CUDA_NAMES
-    function hipModuleLoadData_(myModule,image) bind(c, name="cudaModuleLoadData")
-#else
     function hipModuleLoadData_(myModule,image) bind(c, name="hipModuleLoadData")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -7155,6 +7013,7 @@ module hipfort
       type(c_ptr),value :: image
     end function
   end interface
+#endif
 
   !>  @brief builds module from code object which resides in host memory. Image is pointer to that
   !>  location. Options are not used. hipModuleLoadData is called.
@@ -7166,14 +7025,10 @@ module hipfort
   !>  @param [in] optionValues  Option values for JIT
   !>
   !>  @returns hipSuccess, hipErrorNotInitialized, hipErrorOutOfMemory, hipErrorNotInitialized
+#ifndef USE_CUDA_NAMES
   interface hipModuleLoadDataEx
-#ifdef USE_CUDA_NAMES
-    function hipModuleLoadDataEx_(myModule,image,numOptions,options,optionValues) &
-        bind(c, name="cudaModuleLoadDataEx")
-#else
     function hipModuleLoadDataEx_(myModule,image,numOptions,options,optionValues) &
         bind(c, name="hipModuleLoadDataEx")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -7185,6 +7040,7 @@ module hipfort
       type(c_ptr) :: optionValues
     end function
   end interface
+#endif
 
   !>  @brief Adds bitcode data to be linked with options.
   !>  @param [in] state hip link state
@@ -7361,16 +7217,11 @@ module hipfort
   !>  and gridDim.z * blockDim.z are always less than 2^32.
   !>
   !>  @returns `hipSuccess`, `hipErrorNotInitialized`, `hipErrorInvalidValue`
+#ifndef USE_CUDA_NAMES
   interface hipModuleLaunchKernel
-#ifdef USE_CUDA_NAMES
-    function hipModuleLaunchKernel_(f,gridDimX,gridDimY,gridDimZ,blockDimX,blockDimY,blockDimZ, &
-        sharedMemBytes,stream,kernelParams,extra) &
-        bind(c, name="cudaModuleLaunchKernel")
-#else
     function hipModuleLaunchKernel_(f,gridDimX,gridDimY,gridDimZ,blockDimX,blockDimY,blockDimZ, &
         sharedMemBytes,stream,kernelParams,extra) &
         bind(c, name="hipModuleLaunchKernel")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -7388,6 +7239,7 @@ module hipfort
       type(c_ptr) :: extra
     end function
   end interface
+#endif
 
   !>  \addtogroup ModuleCooperativeG Cooperative groups kernel launch of Module management.
   !>  \ingroup Module
@@ -7523,14 +7375,10 @@ module hipfort
   !>
   !>  @returns `hipSuccess`, `hipErrorNotInitialized`, `hipErrorInvalidValue`,
   !>   `hipErrorCooperativeLaunchTooLarge`
+#ifndef USE_CUDA_NAMES
   interface hipLaunchCooperativeKernelMultiDevice
-#ifdef USE_CUDA_NAMES
-    function hipLaunchCooperativeKernelMultiDevice_(launchParamsList,numDevices,flags) &
-        bind(c, name="cudaLaunchCooperativeKernelMultiDevice")
-#else
     function hipLaunchCooperativeKernelMultiDevice_(launchParamsList,numDevices,flags) &
         bind(c, name="hipLaunchCooperativeKernelMultiDevice")
-#endif
       use iso_c_binding
       use hipfort_enums
       use hipfort_types
@@ -7541,6 +7389,7 @@ module hipfort
       integer(c_int),value :: flags
     end function
   end interface
+#endif
 
   !>  @brief Launches kernels on multiple devices and guarantees all specified kernels are
   !>  dispatched
@@ -7552,14 +7401,10 @@ module hipfort
   !>  @param [in] flags                    Flags to control launch behavior.
   !>
   !>  @returns `hipSuccess`, `hipErrorNotInitialized`, `hipErrorInvalidValue`
+#ifndef USE_CUDA_NAMES
   interface hipExtLaunchMultiKernelMultiDevice
-#ifdef USE_CUDA_NAMES
-    function hipExtLaunchMultiKernelMultiDevice_(launchParamsList,numDevices,flags) &
-        bind(c, name="cudaExtLaunchMultiKernelMultiDevice")
-#else
     function hipExtLaunchMultiKernelMultiDevice_(launchParamsList,numDevices,flags) &
         bind(c, name="hipExtLaunchMultiKernelMultiDevice")
-#endif
       use iso_c_binding
       use hipfort_enums
       use hipfort_types
@@ -7570,6 +7415,7 @@ module hipfort
       integer(c_int),value :: flags
     end function
   end interface
+#endif
 
   !>  @brief Launches a HIP kernel using a generic function pointer and the specified configuration.
   !>  @ingroup Execution
@@ -7685,16 +7531,11 @@ module hipfort
   !>  size gridDim x blockDim >= 2^32.
   !>
   !>  @returns `hipSuccess`, `hipErrorInvalidValue`
+#ifndef USE_CUDA_NAMES
   interface hipModuleOccupancyMaxPotentialBlockSize
-#ifdef USE_CUDA_NAMES
-    function hipModuleOccupancyMaxPotentialBlockSize_(gridSize,blockSize,f,dynSharedMemPerBlk, &
-        blockSizeLimit) &
-        bind(c, name="cudaModuleOccupancyMaxPotentialBlockSize")
-#else
     function hipModuleOccupancyMaxPotentialBlockSize_(gridSize,blockSize,f,dynSharedMemPerBlk, &
         blockSizeLimit) &
         bind(c, name="hipModuleOccupancyMaxPotentialBlockSize")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -7706,6 +7547,7 @@ module hipfort
       integer(c_int),value :: blockSizeLimit
     end function
   end interface
+#endif
 
   !>  @brief determine the grid and block sizes to achieves maximum occupancy for a kernel
   !>
@@ -7721,16 +7563,11 @@ module hipfort
   !>  size gridDim x blockDim >= 2^32.
   !>
   !>  @returns `hipSuccess`, `hipErrorInvalidValue`
+#ifndef USE_CUDA_NAMES
   interface hipModuleOccupancyMaxPotentialBlockSizeWithFlags
-#ifdef USE_CUDA_NAMES
-    function hipModuleOccupancyMaxPotentialBlockSizeWithFlags_(gridSize,blockSize,f, &
-        dynSharedMemPerBlk,blockSizeLimit,flags) &
-        bind(c, name="cudaModuleOccupancyMaxPotentialBlockSizeWithFlags")
-#else
     function hipModuleOccupancyMaxPotentialBlockSizeWithFlags_(gridSize,blockSize,f, &
         dynSharedMemPerBlk,blockSizeLimit,flags) &
         bind(c, name="hipModuleOccupancyMaxPotentialBlockSizeWithFlags")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -7743,6 +7580,7 @@ module hipfort
       integer(c_int),value :: flags
     end function
   end interface
+#endif
 
   !>  @brief Returns occupancy for a device function.
   !>
@@ -7751,16 +7589,11 @@ module hipfort
   !>  @param [in]  blockSize        Block size the kernel is intended to be launched with
   !>  @param [in]  dynSharedMemPerBlk Dynamic shared memory usage (in bytes) intended for each block
   !>  @returns  `hipSuccess`, `hipErrorInvalidValue`
+#ifndef USE_CUDA_NAMES
   interface hipModuleOccupancyMaxActiveBlocksPerMultiprocessor
-#ifdef USE_CUDA_NAMES
-    function hipModuleOccupancyMaxActiveBlocksPerMultiprocessor_(numBlocks,f,blockSize, &
-        dynSharedMemPerBlk) &
-        bind(c, name="cudaModuleOccupancyMaxActiveBlocksPerMultiprocessor")
-#else
     function hipModuleOccupancyMaxActiveBlocksPerMultiprocessor_(numBlocks,f,blockSize, &
         dynSharedMemPerBlk) &
         bind(c, name="hipModuleOccupancyMaxActiveBlocksPerMultiprocessor")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -7771,6 +7604,7 @@ module hipfort
       integer(c_size_t),value :: dynSharedMemPerBlk
     end function
   end interface
+#endif
 
   !>  @brief Returns occupancy for a device function.
   !>
@@ -7869,16 +7703,11 @@ module hipfort
   !>  size gridDim x blockDim >= 2^32.
   !>
   !>  @returns `hipSuccess`, `hipErrorInvalidValue`
+#ifndef USE_CUDA_NAMES
   interface hipOccupancyMaxPotentialBlockSize
-#ifdef USE_CUDA_NAMES
-    function hipOccupancyMaxPotentialBlockSize_(gridSize,blockSize,f,dynSharedMemPerBlk, &
-        blockSizeLimit) &
-        bind(c, name="cudaOccupancyMaxPotentialBlockSize")
-#else
     function hipOccupancyMaxPotentialBlockSize_(gridSize,blockSize,f,dynSharedMemPerBlk, &
         blockSizeLimit) &
         bind(c, name="hipOccupancyMaxPotentialBlockSize")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -7890,6 +7719,7 @@ module hipfort
       integer(c_int),value :: blockSizeLimit
     end function
   end interface
+#endif
 
   !>  @brief Returns dynamic shared memory available per block when launching numBlocks blocks on
   !>  SM.
@@ -7980,12 +7810,9 @@ module hipfort
   !>  size gridDim x blockDim >= 2^32.
   !>
   !>  @returns `hipSuccess`, `hipErrorNotInitialized`, `hipErrorInvalidValue`
+#ifndef USE_CUDA_NAMES
   interface hipConfigureCall
-#ifdef USE_CUDA_NAMES
-    function hipConfigureCall_(gridDim,blockDim,sharedMem,stream) bind(c, name="cudaConfigureCall")
-#else
     function hipConfigureCall_(gridDim,blockDim,sharedMem,stream) bind(c, name="hipConfigureCall")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -7996,6 +7823,7 @@ module hipfort
       type(c_ptr),value :: stream
     end function
   end interface
+#endif
 
   !>  @brief Set a kernel argument.
   !>
@@ -8004,12 +7832,9 @@ module hipfort
   !>  @param [in] arg    Pointer the argument in host memory.
   !>  @param [in] size   Size of the argument.
   !>  @param [in] offset Offset of the argument on the argument stack.
+#ifndef USE_CUDA_NAMES
   interface hipSetupArgument
-#ifdef USE_CUDA_NAMES
-    function hipSetupArgument_(arg,mySize,offset) bind(c, name="cudaSetupArgument")
-#else
     function hipSetupArgument_(arg,mySize,offset) bind(c, name="hipSetupArgument")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -8019,18 +7844,16 @@ module hipfort
       integer(c_size_t),value :: offset
     end function
   end interface
+#endif
 
   !>  @brief Launch a kernel.
   !>
   !>  @param [in] func Kernel to launch.
   !>
   !>  @returns `hipSuccess`, `hipErrorNotInitialized`, `hipErrorInvalidValue`
+#ifndef USE_CUDA_NAMES
   interface hipLaunchByPtr
-#ifdef USE_CUDA_NAMES
-    function hipLaunchByPtr_(func) bind(c, name="cudaLaunchByPtr")
-#else
     function hipLaunchByPtr_(func) bind(c, name="hipLaunchByPtr")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -8038,6 +7861,7 @@ module hipfort
       type(c_ptr),value :: func
     end function
   end interface
+#endif
 
   !>  @brief C compliant kernel launch API
   !>
@@ -8118,12 +7942,9 @@ module hipfort
   !>  @param pCopy - Parameters for the memory copy
   !>
   !>  @returns `hipSuccess`, `hipErrorInvalidValue`
+#ifndef USE_CUDA_NAMES
   interface hipDrvMemcpy2DUnaligned
-#ifdef USE_CUDA_NAMES
-    function hipDrvMemcpy2DUnaligned_(pCopy) bind(c, name="cudaDrvMemcpy2DUnaligned")
-#else
     function hipDrvMemcpy2DUnaligned_(pCopy) bind(c, name="hipDrvMemcpy2DUnaligned")
-#endif
       use iso_c_binding
       use hipfort_enums
       use hipfort_types
@@ -8132,6 +7953,7 @@ module hipfort
       type(hip_Memcpy2D) :: pCopy
     end function
   end interface
+#endif
 
   !>  @brief Launches kernel from the pointer address, with arguments and shared memory on stream.
   !>
@@ -8152,16 +7974,11 @@ module hipfort
   !>  @param [in] flags - The value of hipExtAnyOrderLaunch, signifies if kernel can be
   !>  launched in any order.
   !>  @returns `hipSuccess`, `hipErrorNotInitialized`, `hipErrorInvalidValue`.
+#ifndef USE_CUDA_NAMES
   interface hipExtLaunchKernel
-#ifdef USE_CUDA_NAMES
-    function hipExtLaunchKernel_(function_address,numBlocks,dimBlocks,args,sharedMemBytes,stream, &
-        startEvent,stopEvent,flags) &
-        bind(c, name="cudaExtLaunchKernel")
-#else
     function hipExtLaunchKernel_(function_address,numBlocks,dimBlocks,args,sharedMemBytes,stream, &
         startEvent,stopEvent,flags) &
         bind(c, name="hipExtLaunchKernel")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -8177,6 +7994,7 @@ module hipfort
       integer(c_int),value :: flags
     end function
   end interface
+#endif
 
   !>  @brief Creates a texture object.
   !>
@@ -8330,14 +8148,10 @@ module hipfort
   !>  @param [in] pResViewDesc  pointer to resource view descriptor
   !>
   !>  @returns `hipSuccess`, `hipErrorInvalidValue`
+#ifndef USE_CUDA_NAMES
   interface hipTexObjectCreate
-#ifdef USE_CUDA_NAMES
-    function hipTexObjectCreate_(pTexObject,pResDesc,pTexDesc,pResViewDesc) &
-        bind(c, name="cudaTexObjectCreate")
-#else
     function hipTexObjectCreate_(pTexObject,pResDesc,pTexDesc,pResViewDesc) &
         bind(c, name="hipTexObjectCreate")
-#endif
       use iso_c_binding
       use hipfort_enums
       use hipfort_types
@@ -8349,18 +8163,16 @@ module hipfort
       type(HIP_RESOURCE_VIEW_DESC) :: pResViewDesc
     end function
   end interface
+#endif
 
   !>  @brief Destroys a texture object.
   !>
   !>  @param [in] texObject  texture object to destroy
   !>
   !>  @returns `hipSuccess`, `hipErrorInvalidValue`
+#ifndef USE_CUDA_NAMES
   interface hipTexObjectDestroy
-#ifdef USE_CUDA_NAMES
-    function hipTexObjectDestroy_(texObject) bind(c, name="cudaTexObjectDestroy")
-#else
     function hipTexObjectDestroy_(texObject) bind(c, name="hipTexObjectDestroy")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -8368,6 +8180,7 @@ module hipfort
       type(c_ptr),value :: texObject
     end function
   end interface
+#endif
 
   !>  @brief Gets resource descriptor of a texture object.
   !>
@@ -8375,14 +8188,10 @@ module hipfort
   !>  @param [in] texObject  texture object
   !>
   !>  @returns `hipSuccess`, `hipErrorNotSupported`, `hipErrorInvalidValue`
+#ifndef USE_CUDA_NAMES
   interface hipTexObjectGetResourceDesc
-#ifdef USE_CUDA_NAMES
-    function hipTexObjectGetResourceDesc_(pResDesc,texObject) &
-        bind(c, name="cudaTexObjectGetResourceDesc")
-#else
     function hipTexObjectGetResourceDesc_(pResDesc,texObject) &
         bind(c, name="hipTexObjectGetResourceDesc")
-#endif
       use iso_c_binding
       use hipfort_enums
       use hipfort_types
@@ -8392,6 +8201,7 @@ module hipfort
       type(c_ptr),value :: texObject
     end function
   end interface
+#endif
 
   !>  @brief Gets resource view descriptor of a texture object.
   !>
@@ -8399,14 +8209,10 @@ module hipfort
   !>  @param [in] texObject  texture object
   !>
   !>  @returns `hipSuccess`, `hipErrorNotSupported`, `hipErrorInvalidValue`
+#ifndef USE_CUDA_NAMES
   interface hipTexObjectGetResourceViewDesc
-#ifdef USE_CUDA_NAMES
-    function hipTexObjectGetResourceViewDesc_(pResViewDesc,texObject) &
-        bind(c, name="cudaTexObjectGetResourceViewDesc")
-#else
     function hipTexObjectGetResourceViewDesc_(pResViewDesc,texObject) &
         bind(c, name="hipTexObjectGetResourceViewDesc")
-#endif
       use iso_c_binding
       use hipfort_enums
       use hipfort_types
@@ -8416,6 +8222,7 @@ module hipfort
       type(c_ptr),value :: texObject
     end function
   end interface
+#endif
 
   !>  @brief Gets texture descriptor of a texture object.
   !>
@@ -8423,14 +8230,10 @@ module hipfort
   !>  @param [in] texObject  texture object
   !>
   !>  @returns `hipSuccess`, `hipErrorNotSupported`, `hipErrorInvalidValue`
+#ifndef USE_CUDA_NAMES
   interface hipTexObjectGetTextureDesc
-#ifdef USE_CUDA_NAMES
-    function hipTexObjectGetTextureDesc_(pTexDesc,texObject) &
-        bind(c, name="cudaTexObjectGetTextureDesc")
-#else
     function hipTexObjectGetTextureDesc_(pTexDesc,texObject) &
         bind(c, name="hipTexObjectGetTextureDesc")
-#endif
       use iso_c_binding
       use hipfort_enums
       use hipfort_types
@@ -8440,6 +8243,7 @@ module hipfort
       type(c_ptr),value :: texObject
     end function
   end interface
+#endif
 
   !>  @brief Allocate a mipmapped array on the device.
   !>
@@ -8530,14 +8334,10 @@ module hipfort
   !>  @returns `hipSuccess`, `hipErrorNotSupported`, `hipErrorInvalidValue`
   !>
   !>  @note  This API is implemented on Linux and is under development on Microsoft Windows.
+#ifndef USE_CUDA_NAMES
   interface hipMipmappedArrayCreate
-#ifdef USE_CUDA_NAMES
-    function hipMipmappedArrayCreate_(pHandle,pMipmappedArrayDesc,numMipmapLevels) &
-        bind(c, name="cudaMipmappedArrayCreate")
-#else
     function hipMipmappedArrayCreate_(pHandle,pMipmappedArrayDesc,numMipmapLevels) &
         bind(c, name="hipMipmappedArrayCreate")
-#endif
       use iso_c_binding
       use hipfort_enums
       use hipfort_types
@@ -8548,6 +8348,7 @@ module hipfort
       integer(c_int),value :: numMipmapLevels
     end function
   end interface
+#endif
 
   !>  @brief Destroy a mipmapped array.
   !>
@@ -8556,12 +8357,9 @@ module hipfort
   !>  @returns `hipSuccess`, `hipErrorInvalidValue`
   !>
   !>  @note  This API is implemented on Linux and is under development on Microsoft Windows.
+#ifndef USE_CUDA_NAMES
   interface hipMipmappedArrayDestroy
-#ifdef USE_CUDA_NAMES
-    function hipMipmappedArrayDestroy_(hMipmappedArray) bind(c, name="cudaMipmappedArrayDestroy")
-#else
     function hipMipmappedArrayDestroy_(hMipmappedArray) bind(c, name="hipMipmappedArrayDestroy")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -8569,6 +8367,7 @@ module hipfort
       type(c_ptr),value :: hMipmappedArray
     end function
   end interface
+#endif
 
   !>  @brief Get a mipmapped array on a mipmapped level.
   !>
@@ -8579,14 +8378,10 @@ module hipfort
   !>  @returns `hipSuccess`, `hipErrorInvalidValue`
   !>
   !>  @note  This API is implemented on Linux and is under development on Microsoft Windows.
+#ifndef USE_CUDA_NAMES
   interface hipMipmappedArrayGetLevel
-#ifdef USE_CUDA_NAMES
-    function hipMipmappedArrayGetLevel_(pLevelArray,hMipMappedArray,level) &
-        bind(c, name="cudaMipmappedArrayGetLevel")
-#else
     function hipMipmappedArrayGetLevel_(pLevelArray,hMipMappedArray,level) &
         bind(c, name="hipMipmappedArrayGetLevel")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -8596,6 +8391,7 @@ module hipfort
       integer(c_int),value :: level
     end function
   end interface
+#endif
 
   !>  @brief  Binds a mipmapped array to a texture [Deprecated]
   !>
@@ -8604,14 +8400,10 @@ module hipfort
   !>  @param [in] desc  opointer to the channel format
   !>
   !>  @returns `hipSuccess`, `hipErrorInvalidValue`
+#ifndef USE_CUDA_NAMES
   interface hipBindTextureToMipmappedArray
-#ifdef USE_CUDA_NAMES
-    function hipBindTextureToMipmappedArray_(tex,mipmappedArray,desc) &
-        bind(c, name="cudaBindTextureToMipmappedArray")
-#else
     function hipBindTextureToMipmappedArray_(tex,mipmappedArray,desc) &
         bind(c, name="hipBindTextureToMipmappedArray")
-#endif
       use iso_c_binding
       use hipfort_enums
       use hipfort_types
@@ -8622,6 +8414,7 @@ module hipfort
       type(hipChannelFormatDesc) :: desc
     end function
   end interface
+#endif
 
   !>  @brief Gets the texture reference related with the symbol [Deprecated]
   !>
@@ -8698,12 +8491,9 @@ module hipfort
   !>
   !>  @returns `hipSuccess`, `hipErrorInvalidValue`
   !>  @warning This API is deprecated.
+#ifndef USE_CUDA_NAMES
   interface hipTexRefSetAddressMode
-#ifdef USE_CUDA_NAMES
-    function hipTexRefSetAddressMode_(texRef,dim,am) bind(c, name="cudaTexRefSetAddressMode")
-#else
     function hipTexRefSetAddressMode_(texRef,dim,am) bind(c, name="hipTexRefSetAddressMode")
-#endif
       use iso_c_binding
       use hipfort_enums
       use hipfort_types
@@ -8714,6 +8504,7 @@ module hipfort
       integer(kind(hipAddressModeWrap)),value :: am
     end function
   end interface
+#endif
 
   !>  @brief Binds an array as a texture reference [Deprecated]
   !>
@@ -8724,12 +8515,9 @@ module hipfort
   !>  @returns `hipSuccess`, `hipErrorInvalidValue`
   !>
   !>  @warning This API is deprecated.
+#ifndef USE_CUDA_NAMES
   interface hipTexRefSetArray
-#ifdef USE_CUDA_NAMES
-    function hipTexRefSetArray_(tex,array,flags) bind(c, name="cudaTexRefSetArray")
-#else
     function hipTexRefSetArray_(tex,array,flags) bind(c, name="hipTexRefSetArray")
-#endif
       use iso_c_binding
       use hipfort_enums
       use hipfort_types
@@ -8740,6 +8528,7 @@ module hipfort
       integer(c_int),value :: flags
     end function
   end interface
+#endif
 
   !>  @brief Set filter mode for a texture reference [Deprecated]
   !>
@@ -8749,12 +8538,9 @@ module hipfort
   !>  @returns `hipSuccess`, `hipErrorInvalidValue`
   !>
   !>  @warning This API is deprecated.
+#ifndef USE_CUDA_NAMES
   interface hipTexRefSetFilterMode
-#ifdef USE_CUDA_NAMES
-    function hipTexRefSetFilterMode_(texRef,fm) bind(c, name="cudaTexRefSetFilterMode")
-#else
     function hipTexRefSetFilterMode_(texRef,fm) bind(c, name="hipTexRefSetFilterMode")
-#endif
       use iso_c_binding
       use hipfort_enums
       use hipfort_types
@@ -8764,6 +8550,7 @@ module hipfort
       integer(kind(hipFilterModePoint)),value :: fm
     end function
   end interface
+#endif
 
   !>  @brief Set flags for a texture reference [Deprecated]
   !>
@@ -8773,12 +8560,9 @@ module hipfort
   !>  @returns `hipSuccess`, `hipErrorInvalidValue`
   !>
   !>  @warning This API is deprecated.
+#ifndef USE_CUDA_NAMES
   interface hipTexRefSetFlags
-#ifdef USE_CUDA_NAMES
-    function hipTexRefSetFlags_(texRef,Flags) bind(c, name="cudaTexRefSetFlags")
-#else
     function hipTexRefSetFlags_(texRef,Flags) bind(c, name="hipTexRefSetFlags")
-#endif
       use iso_c_binding
       use hipfort_enums
       use hipfort_types
@@ -8788,6 +8572,7 @@ module hipfort
       integer(c_int),value :: Flags
     end function
   end interface
+#endif
 
   !>  @brief Set format for a texture reference [Deprecated]
   !>
@@ -8798,12 +8583,9 @@ module hipfort
   !>  @returns `hipSuccess`, `hipErrorInvalidValue`
   !>
   !>  @warning This API is deprecated.
+#ifndef USE_CUDA_NAMES
   interface hipTexRefSetFormat
-#ifdef USE_CUDA_NAMES
-    function hipTexRefSetFormat_(texRef,fmt,NumPackedComponents) bind(c, name="cudaTexRefSetFormat")
-#else
     function hipTexRefSetFormat_(texRef,fmt,NumPackedComponents) bind(c, name="hipTexRefSetFormat")
-#endif
       use iso_c_binding
       use hipfort_enums
       use hipfort_types
@@ -8814,6 +8596,7 @@ module hipfort
       integer(c_int),value :: NumPackedComponents
     end function
   end interface
+#endif
 
   !>  @brief Binds a memory area to a texture [Deprecated]
   !>
@@ -8826,12 +8609,9 @@ module hipfort
   !>  @returns `hipSuccess`, `hipErrorInvalidValue`, `hipErrorNotSupported`
   !>
   !>  @warning This API is deprecated.
+#ifndef USE_CUDA_NAMES
   interface hipBindTexture
-#ifdef USE_CUDA_NAMES
-    function hipBindTexture_(offset,tex,devPtr,desc,mySize) bind(c, name="cudaBindTexture")
-#else
     function hipBindTexture_(offset,tex,devPtr,desc,mySize) bind(c, name="hipBindTexture")
-#endif
       use iso_c_binding
       use hipfort_enums
       use hipfort_types
@@ -8844,6 +8624,7 @@ module hipfort
       integer(c_size_t),value :: mySize
     end function
   end interface
+#endif
 
   !>  @brief Binds a 2D memory area to a texture [Deprecated]
   !>
@@ -8858,14 +8639,10 @@ module hipfort
   !>  @returns `hipSuccess`, `hipErrorInvalidValue`, `hipErrorNotSupported`
   !>
   !>  @warning This API is deprecated.
+#ifndef USE_CUDA_NAMES
   interface hipBindTexture2D
-#ifdef USE_CUDA_NAMES
-    function hipBindTexture2D_(offset,tex,devPtr,desc,width,height,pitch) &
-        bind(c, name="cudaBindTexture2D")
-#else
     function hipBindTexture2D_(offset,tex,devPtr,desc,width,height,pitch) &
         bind(c, name="hipBindTexture2D")
-#endif
       use iso_c_binding
       use hipfort_enums
       use hipfort_types
@@ -8880,6 +8657,7 @@ module hipfort
       integer(c_size_t),value :: pitch
     end function
   end interface
+#endif
 
   !>  @brief Binds a memory area to a texture [Deprecated]
   !>
@@ -8890,12 +8668,9 @@ module hipfort
   !>  @returns `hipSuccess`, `hipErrorInvalidValue`, `hipErrorNotSupported`
   !>
   !>  @warning This API is deprecated.
+#ifndef USE_CUDA_NAMES
   interface hipBindTextureToArray
-#ifdef USE_CUDA_NAMES
-    function hipBindTextureToArray_(tex,array,desc) bind(c, name="cudaBindTextureToArray")
-#else
     function hipBindTextureToArray_(tex,array,desc) bind(c, name="hipBindTextureToArray")
-#endif
       use iso_c_binding
       use hipfort_enums
       use hipfort_types
@@ -8906,6 +8681,7 @@ module hipfort
       type(hipChannelFormatDesc) :: desc
     end function
   end interface
+#endif
 
   !>  @brief Get the offset of the alignment in a texture [Deprecated]
   !>
@@ -8915,14 +8691,10 @@ module hipfort
   !>  @returns `hipSuccess`, `hipErrorInvalidValue`, `hipErrorNotSupported`
   !>
   !>  @warning This API is deprecated.
+#ifndef USE_CUDA_NAMES
   interface hipGetTextureAlignmentOffset
-#ifdef USE_CUDA_NAMES
-    function hipGetTextureAlignmentOffset_(offset,texref) &
-        bind(c, name="cudaGetTextureAlignmentOffset")
-#else
     function hipGetTextureAlignmentOffset_(offset,texref) &
         bind(c, name="hipGetTextureAlignmentOffset")
-#endif
       use iso_c_binding
       use hipfort_enums
       use hipfort_types
@@ -8932,6 +8704,7 @@ module hipfort
       type(textureReference) :: texref
     end function
   end interface
+#endif
 
   !>  @brief Unbinds a texture [Deprecated]
   !>
@@ -8940,12 +8713,9 @@ module hipfort
   !>  @returns `hipSuccess`, `hipErrorInvalidValue`, `hipErrorNotSupported`
   !>
   !>  @warning This API is deprecated.
+#ifndef USE_CUDA_NAMES
   interface hipUnbindTexture
-#ifdef USE_CUDA_NAMES
-    function hipUnbindTexture_(tex) bind(c, name="cudaUnbindTexture")
-#else
     function hipUnbindTexture_(tex) bind(c, name="hipUnbindTexture")
-#endif
       use iso_c_binding
       use hipfort_enums
       use hipfort_types
@@ -8954,6 +8724,7 @@ module hipfort
       type(textureReference) :: tex
     end function
   end interface
+#endif
 
   !>  @brief Gets the address for a texture reference [Deprecated]
   !>
@@ -8963,12 +8734,9 @@ module hipfort
   !>  @returns `hipSuccess`, `hipErrorInvalidValue`, `hipErrorNotSupported`
   !>
   !>  @warning This API is deprecated.
+#ifndef USE_CUDA_NAMES
   interface hipTexRefGetAddress
-#ifdef USE_CUDA_NAMES
-    function hipTexRefGetAddress_(dev_ptr,texRef) bind(c, name="cudaTexRefGetAddress")
-#else
     function hipTexRefGetAddress_(dev_ptr,texRef) bind(c, name="hipTexRefGetAddress")
-#endif
       use iso_c_binding
       use hipfort_enums
       use hipfort_types
@@ -8978,6 +8746,7 @@ module hipfort
       type(textureReference) :: texRef
     end function
   end interface
+#endif
 
   !>  @brief Gets the address mode for a texture reference [Deprecated]
   !>
@@ -8988,12 +8757,9 @@ module hipfort
   !>  @returns `hipSuccess`, `hipErrorInvalidValue`, `hipErrorNotSupported`
   !>
   !>  @warning This API is deprecated.
+#ifndef USE_CUDA_NAMES
   interface hipTexRefGetAddressMode
-#ifdef USE_CUDA_NAMES
-    function hipTexRefGetAddressMode_(pam,texRef,dim) bind(c, name="cudaTexRefGetAddressMode")
-#else
     function hipTexRefGetAddressMode_(pam,texRef,dim) bind(c, name="hipTexRefGetAddressMode")
-#endif
       use iso_c_binding
       use hipfort_enums
       use hipfort_types
@@ -9004,6 +8770,7 @@ module hipfort
       integer(c_int),value :: dim
     end function
   end interface
+#endif
 
   !>  @brief Gets filter mode for a texture reference [Deprecated]
   !>
@@ -9013,12 +8780,9 @@ module hipfort
   !>  @returns `hipSuccess`, `hipErrorInvalidValue`, `hipErrorNotSupported`
   !>
   !>  @warning This API is deprecated.
+#ifndef USE_CUDA_NAMES
   interface hipTexRefGetFilterMode
-#ifdef USE_CUDA_NAMES
-    function hipTexRefGetFilterMode_(pfm,texRef) bind(c, name="cudaTexRefGetFilterMode")
-#else
     function hipTexRefGetFilterMode_(pfm,texRef) bind(c, name="hipTexRefGetFilterMode")
-#endif
       use iso_c_binding
       use hipfort_enums
       use hipfort_types
@@ -9028,6 +8792,7 @@ module hipfort
       type(textureReference) :: texRef
     end function
   end interface
+#endif
 
   !>  @brief Gets flags for a texture reference [Deprecated]
   !>
@@ -9037,12 +8802,9 @@ module hipfort
   !>  @returns `hipSuccess`, `hipErrorInvalidValue`, `hipErrorNotSupported`
   !>
   !>  @warning This API is deprecated.
+#ifndef USE_CUDA_NAMES
   interface hipTexRefGetFlags
-#ifdef USE_CUDA_NAMES
-    function hipTexRefGetFlags_(pFlags,texRef) bind(c, name="cudaTexRefGetFlags")
-#else
     function hipTexRefGetFlags_(pFlags,texRef) bind(c, name="hipTexRefGetFlags")
-#endif
       use iso_c_binding
       use hipfort_enums
       use hipfort_types
@@ -9052,6 +8814,7 @@ module hipfort
       type(textureReference) :: texRef
     end function
   end interface
+#endif
 
   !>  @brief Gets texture format for a texture reference [Deprecated]
   !>
@@ -9062,12 +8825,9 @@ module hipfort
   !>  @returns `hipSuccess`, `hipErrorInvalidValue`, `hipErrorNotSupported`
   !>
   !>  @warning This API is deprecated.
+#ifndef USE_CUDA_NAMES
   interface hipTexRefGetFormat
-#ifdef USE_CUDA_NAMES
-    function hipTexRefGetFormat_(pFormat,pNumChannels,texRef) bind(c, name="cudaTexRefGetFormat")
-#else
     function hipTexRefGetFormat_(pFormat,pNumChannels,texRef) bind(c, name="hipTexRefGetFormat")
-#endif
       use iso_c_binding
       use hipfort_enums
       use hipfort_types
@@ -9078,6 +8838,7 @@ module hipfort
       type(textureReference) :: texRef
     end function
   end interface
+#endif
 
   !>  @brief Gets the maximum anisotropy for a texture reference [Deprecated]
   !>
@@ -9087,12 +8848,9 @@ module hipfort
   !>  @returns `hipErrorInvalidValue`, `hipErrorNotSupported`
   !>
   !>  @warning This API is deprecated.
+#ifndef USE_CUDA_NAMES
   interface hipTexRefGetMaxAnisotropy
-#ifdef USE_CUDA_NAMES
-    function hipTexRefGetMaxAnisotropy_(pmaxAnsio,texRef) bind(c, name="cudaTexRefGetMaxAnisotropy")
-#else
     function hipTexRefGetMaxAnisotropy_(pmaxAnsio,texRef) bind(c, name="hipTexRefGetMaxAnisotropy")
-#endif
       use iso_c_binding
       use hipfort_enums
       use hipfort_types
@@ -9102,6 +8860,7 @@ module hipfort
       type(textureReference) :: texRef
     end function
   end interface
+#endif
 
   !>  @brief Gets the mipmap filter mode for a texture reference [Deprecated]
   !>
@@ -9111,12 +8870,9 @@ module hipfort
   !>  @returns `hipErrorInvalidValue`, `hipErrorNotSupported`
   !>
   !>  @warning This API is deprecated.
+#ifndef USE_CUDA_NAMES
   interface hipTexRefGetMipmapFilterMode
-#ifdef USE_CUDA_NAMES
-    function hipTexRefGetMipmapFilterMode_(pfm,texRef) bind(c, name="cudaTexRefGetMipmapFilterMode")
-#else
     function hipTexRefGetMipmapFilterMode_(pfm,texRef) bind(c, name="hipTexRefGetMipmapFilterMode")
-#endif
       use iso_c_binding
       use hipfort_enums
       use hipfort_types
@@ -9126,6 +8882,7 @@ module hipfort
       type(textureReference) :: texRef
     end function
   end interface
+#endif
 
   !>  @brief Gets the mipmap level bias for a texture reference [Deprecated]
   !>
@@ -9135,12 +8892,9 @@ module hipfort
   !>  @returns `hipErrorInvalidValue`, `hipErrorNotSupported`
   !>
   !>  @warning This API is deprecated.
+#ifndef USE_CUDA_NAMES
   interface hipTexRefGetMipmapLevelBias
-#ifdef USE_CUDA_NAMES
-    function hipTexRefGetMipmapLevelBias_(pbias,texRef) bind(c, name="cudaTexRefGetMipmapLevelBias")
-#else
     function hipTexRefGetMipmapLevelBias_(pbias,texRef) bind(c, name="hipTexRefGetMipmapLevelBias")
-#endif
       use iso_c_binding
       use hipfort_enums
       use hipfort_types
@@ -9150,6 +8904,7 @@ module hipfort
       type(textureReference) :: texRef
     end function
   end interface
+#endif
 
   !>  @brief Gets the minimum and maximum mipmap level clamps for a texture reference [Deprecated]
   !>
@@ -9160,14 +8915,10 @@ module hipfort
   !>  @returns `hipErrorInvalidValue`, `hipErrorNotSupported`
   !>
   !>  @warning This API is deprecated.
+#ifndef USE_CUDA_NAMES
   interface hipTexRefGetMipmapLevelClamp
-#ifdef USE_CUDA_NAMES
-    function hipTexRefGetMipmapLevelClamp_(pminMipmapLevelClamp,pmaxMipmapLevelClamp,texRef) &
-        bind(c, name="cudaTexRefGetMipmapLevelClamp")
-#else
     function hipTexRefGetMipmapLevelClamp_(pminMipmapLevelClamp,pmaxMipmapLevelClamp,texRef) &
         bind(c, name="hipTexRefGetMipmapLevelClamp")
-#endif
       use iso_c_binding
       use hipfort_enums
       use hipfort_types
@@ -9178,6 +8929,7 @@ module hipfort
       type(textureReference) :: texRef
     end function
   end interface
+#endif
 
   !>  @brief Gets the mipmapped array bound to a texture reference [Deprecated]
   !>
@@ -9187,12 +8939,9 @@ module hipfort
   !>  @returns `hipSuccess`, `hipErrorInvalidValue`, `hipErrorNotSupported`
   !>
   !>  @warning This API is deprecated.
+#ifndef USE_CUDA_NAMES
   interface hipTexRefGetMipMappedArray
-#ifdef USE_CUDA_NAMES
-    function hipTexRefGetMipMappedArray_(pArray,texRef) bind(c, name="cudaTexRefGetMipMappedArray")
-#else
     function hipTexRefGetMipMappedArray_(pArray,texRef) bind(c, name="hipTexRefGetMipMappedArray")
-#endif
       use iso_c_binding
       use hipfort_enums
       use hipfort_types
@@ -9202,6 +8951,7 @@ module hipfort
       type(textureReference) :: texRef
     end function
   end interface
+#endif
 
   !>  @brief Sets an bound address for a texture reference [Deprecated]
   !>
@@ -9213,12 +8963,9 @@ module hipfort
   !>  @returns `hipSuccess`, `hipErrorInvalidValue`
   !>
   !>  @warning This API is deprecated.
+#ifndef USE_CUDA_NAMES
   interface hipTexRefSetAddress
-#ifdef USE_CUDA_NAMES
-    function hipTexRefSetAddress_(ByteOffset,texRef,dptr,bytes) bind(c, name="cudaTexRefSetAddress")
-#else
     function hipTexRefSetAddress_(ByteOffset,texRef,dptr,bytes) bind(c, name="hipTexRefSetAddress")
-#endif
       use iso_c_binding
       use hipfort_enums
       use hipfort_types
@@ -9230,6 +8977,7 @@ module hipfort
       integer(c_size_t),value :: bytes
     end function
   end interface
+#endif
 
   !>  @brief Set a bind an address as a 2D texture reference [Deprecated]
   !>
@@ -9241,12 +8989,9 @@ module hipfort
   !>  @returns `hipSuccess`, `hipErrorInvalidValue`, `hipErrorNotSupported`
   !>
   !>  @warning This API is deprecated.
+#ifndef USE_CUDA_NAMES
   interface hipTexRefSetAddress2D
-#ifdef USE_CUDA_NAMES
-    function hipTexRefSetAddress2D_(texRef,desc,dptr,Pitch) bind(c, name="cudaTexRefSetAddress2D")
-#else
     function hipTexRefSetAddress2D_(texRef,desc,dptr,Pitch) bind(c, name="hipTexRefSetAddress2D")
-#endif
       use iso_c_binding
       use hipfort_enums
       use hipfort_types
@@ -9258,6 +9003,7 @@ module hipfort
       integer(c_size_t),value :: Pitch
     end function
   end interface
+#endif
 
   !>  @brief Sets the maximum anisotropy for a texture reference [Deprecated]
   !>
@@ -9267,12 +9013,9 @@ module hipfort
   !>  @returns `hipSuccess`, `hipErrorInvalidValue`, `hipErrorNotSupported`
   !>
   !>  @warning This API is deprecated.
+#ifndef USE_CUDA_NAMES
   interface hipTexRefSetMaxAnisotropy
-#ifdef USE_CUDA_NAMES
-    function hipTexRefSetMaxAnisotropy_(texRef,maxAniso) bind(c, name="cudaTexRefSetMaxAnisotropy")
-#else
     function hipTexRefSetMaxAnisotropy_(texRef,maxAniso) bind(c, name="hipTexRefSetMaxAnisotropy")
-#endif
       use iso_c_binding
       use hipfort_enums
       use hipfort_types
@@ -9282,6 +9025,7 @@ module hipfort
       integer(c_int),value :: maxAniso
     end function
   end interface
+#endif
 
   !>  @brief Sets border color for a texture reference [Deprecated]
   !>
@@ -9291,12 +9035,9 @@ module hipfort
   !>  @returns `hipSuccess`, `hipErrorInvalidValue`, `hipErrorNotSupported`
   !>
   !>  @warning This API is deprecated.
+#ifndef USE_CUDA_NAMES
   interface hipTexRefSetBorderColor
-#ifdef USE_CUDA_NAMES
-    function hipTexRefSetBorderColor_(texRef,pBorderColor) bind(c, name="cudaTexRefSetBorderColor")
-#else
     function hipTexRefSetBorderColor_(texRef,pBorderColor) bind(c, name="hipTexRefSetBorderColor")
-#endif
       use iso_c_binding
       use hipfort_enums
       use hipfort_types
@@ -9306,6 +9047,7 @@ module hipfort
       type(c_ptr),value :: pBorderColor
     end function
   end interface
+#endif
 
   !>  @brief Sets mipmap filter mode for a texture reference [Deprecated]
   !>
@@ -9315,12 +9057,9 @@ module hipfort
   !>  @returns `hipSuccess`, `hipErrorInvalidValue`, `hipErrorNotSupported`
   !>
   !>  @warning This API is deprecated.
+#ifndef USE_CUDA_NAMES
   interface hipTexRefSetMipmapFilterMode
-#ifdef USE_CUDA_NAMES
-    function hipTexRefSetMipmapFilterMode_(texRef,fm) bind(c, name="cudaTexRefSetMipmapFilterMode")
-#else
     function hipTexRefSetMipmapFilterMode_(texRef,fm) bind(c, name="hipTexRefSetMipmapFilterMode")
-#endif
       use iso_c_binding
       use hipfort_enums
       use hipfort_types
@@ -9330,6 +9069,7 @@ module hipfort
       integer(kind(hipFilterModePoint)),value :: fm
     end function
   end interface
+#endif
 
   !>  @brief Sets mipmap level bias for a texture reference [Deprecated]
   !>
@@ -9339,12 +9079,9 @@ module hipfort
   !>  @returns `hipSuccess`, `hipErrorInvalidValue`, `hipErrorNotSupported`
   !>
   !>  @warning This API is deprecated.
+#ifndef USE_CUDA_NAMES
   interface hipTexRefSetMipmapLevelBias
-#ifdef USE_CUDA_NAMES
-    function hipTexRefSetMipmapLevelBias_(texRef,bias) bind(c, name="cudaTexRefSetMipmapLevelBias")
-#else
     function hipTexRefSetMipmapLevelBias_(texRef,bias) bind(c, name="hipTexRefSetMipmapLevelBias")
-#endif
       use iso_c_binding
       use hipfort_enums
       use hipfort_types
@@ -9354,6 +9091,7 @@ module hipfort
       real(c_float),value :: bias
     end function
   end interface
+#endif
 
   !>  @brief Sets mipmap level clamp for a texture reference [Deprecated]
   !>
@@ -9364,14 +9102,10 @@ module hipfort
   !>  @returns `hipSuccess`, `hipErrorInvalidValue`, `hipErrorNotSupported`
   !>
   !>  @warning This API is deprecated.
+#ifndef USE_CUDA_NAMES
   interface hipTexRefSetMipmapLevelClamp
-#ifdef USE_CUDA_NAMES
-    function hipTexRefSetMipmapLevelClamp_(texRef,minMipMapLevelClamp,maxMipMapLevelClamp) &
-        bind(c, name="cudaTexRefSetMipmapLevelClamp")
-#else
     function hipTexRefSetMipmapLevelClamp_(texRef,minMipMapLevelClamp,maxMipMapLevelClamp) &
         bind(c, name="hipTexRefSetMipmapLevelClamp")
-#endif
       use iso_c_binding
       use hipfort_enums
       use hipfort_types
@@ -9382,6 +9116,7 @@ module hipfort
       real(c_float),value :: maxMipMapLevelClamp
     end function
   end interface
+#endif
 
   !>  @brief Binds mipmapped array to a texture reference [Deprecated]
   !>
@@ -9392,14 +9127,10 @@ module hipfort
   !>  @returns `hipSuccess`, `hipErrorInvalidValue`
   !>
   !>  @warning This API is deprecated.
+#ifndef USE_CUDA_NAMES
   interface hipTexRefSetMipmappedArray
-#ifdef USE_CUDA_NAMES
-    function hipTexRefSetMipmappedArray_(texRef,mipmappedArray,Flags) &
-        bind(c, name="cudaTexRefSetMipmappedArray")
-#else
     function hipTexRefSetMipmappedArray_(texRef,mipmappedArray,Flags) &
         bind(c, name="hipTexRefSetMipmappedArray")
-#endif
       use iso_c_binding
       use hipfort_enums
       use hipfort_types
@@ -9410,6 +9141,7 @@ module hipfort
       integer(c_int),value :: Flags
     end function
   end interface
+#endif
 
   !>   @defgroup Callback Callback Activity APIs
   !>
@@ -9608,16 +9340,11 @@ module hipfort
   !>  @param [out] numDependencies_out - Returns size of the array returned in dependencies_out.
   !>
   !>  @returns `hipSuccess`, `hipErrorInvalidValue`, `hipErrorStreamCaptureImplicit`
+#ifndef USE_CUDA_NAMES
   interface hipStreamGetCaptureInfo_v2
-#ifdef USE_CUDA_NAMES
-    function hipStreamGetCaptureInfo_v2_(stream,captureStatus_out,id_out,graph_out, &
-        dependencies_out,numDependencies_out) &
-        bind(c, name="cudaStreamGetCaptureInfo_v2")
-#else
     function hipStreamGetCaptureInfo_v2_(stream,captureStatus_out,id_out,graph_out, &
         dependencies_out,numDependencies_out) &
         bind(c, name="hipStreamGetCaptureInfo_v2")
-#endif
       use iso_c_binding
       use hipfort_enums
       implicit none
@@ -9630,6 +9357,7 @@ module hipfort
       type(c_ptr),value :: numDependencies_out
     end function
   end interface
+#endif
 
   !>  @brief Get stream's capture state
   !>

--- a/lib/hipfort/hipfort_hipblas.F90
+++ b/lib/hipfort/hipfort_hipblas.F90
@@ -896,14 +896,10 @@ module hipfort_hipblas
   !>     result
   !>               device or host array of pointers of batchCount size for results.
   !>               Return value is 0 if n, incx<=0.
+#ifndef USE_CUDA_NAMES
   interface hipblasIsamaxBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasIsamaxBatched_(handle,n,x,incx,batchCount,myResult) &
-        bind(c, name="cublasIsamaxBatched")
-#else
     function hipblasIsamaxBatched_(handle,n,x,incx,batchCount,myResult) &
         bind(c, name="hipblasIsamaxBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -916,15 +912,12 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasIdamaxBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasIdamaxBatched_(handle,n,x,incx,batchCount,myResult) &
-        bind(c, name="cublasIdamaxBatched")
-#else
     function hipblasIdamaxBatched_(handle,n,x,incx,batchCount,myResult) &
         bind(c, name="hipblasIdamaxBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -937,15 +930,12 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasIcamaxBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasIcamaxBatched_(handle,n,x,incx,batchCount,myResult) &
-        bind(c, name="cublasIcamaxBatched")
-#else
     function hipblasIcamaxBatched_(handle,n,x,incx,batchCount,myResult) &
         bind(c, name="hipblasIcamaxBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -958,15 +948,12 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasIzamaxBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasIzamaxBatched_(handle,n,x,incx,batchCount,myResult) &
-        bind(c, name="cublasIzamaxBatched")
-#else
     function hipblasIzamaxBatched_(handle,n,x,incx,batchCount,myResult) &
         bind(c, name="hipblasIzamaxBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -979,15 +966,12 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasIsamaxBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasIsamaxBatched_64_(handle,n,x,incx,batchCount,myResult) &
-        bind(c, name="cublasIsamaxBatched_64")
-#else
     function hipblasIsamaxBatched_64_(handle,n,x,incx,batchCount,myResult) &
         bind(c, name="hipblasIsamaxBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -1000,15 +984,12 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasIdamaxBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasIdamaxBatched_64_(handle,n,x,incx,batchCount,myResult) &
-        bind(c, name="cublasIdamaxBatched_64")
-#else
     function hipblasIdamaxBatched_64_(handle,n,x,incx,batchCount,myResult) &
         bind(c, name="hipblasIdamaxBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -1021,15 +1002,12 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasIcamaxBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasIcamaxBatched_64_(handle,n,x,incx,batchCount,myResult) &
-        bind(c, name="cublasIcamaxBatched_64")
-#else
     function hipblasIcamaxBatched_64_(handle,n,x,incx,batchCount,myResult) &
         bind(c, name="hipblasIcamaxBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -1042,15 +1020,12 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasIzamaxBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasIzamaxBatched_64_(handle,n,x,incx,batchCount,myResult) &
-        bind(c, name="cublasIzamaxBatched_64")
-#else
     function hipblasIzamaxBatched_64_(handle,n,x,incx,batchCount,myResult) &
         bind(c, name="hipblasIzamaxBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -1063,6 +1038,7 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 1 API
   !>
@@ -1094,14 +1070,10 @@ module hipfort_hipblas
   !>     result
   !>               device or host pointer for storing contiguous batchCount results.
   !>               Return value is 0 if n <= 0, incx<=0.
+#ifndef USE_CUDA_NAMES
   interface hipblasIsamaxStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasIsamaxStridedBatched_(handle,n,x,incx,stridex,batchCount,myResult) &
-        bind(c, name="cublasIsamaxStridedBatched")
-#else
     function hipblasIsamaxStridedBatched_(handle,n,x,incx,stridex,batchCount,myResult) &
         bind(c, name="hipblasIsamaxStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -1121,15 +1093,12 @@ module hipfort_hipblas
       hipblasIsamaxStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasIdamaxStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasIdamaxStridedBatched_(handle,n,x,incx,stridex,batchCount,myResult) &
-        bind(c, name="cublasIdamaxStridedBatched")
-#else
     function hipblasIdamaxStridedBatched_(handle,n,x,incx,stridex,batchCount,myResult) &
         bind(c, name="hipblasIdamaxStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -1149,15 +1118,12 @@ module hipfort_hipblas
       hipblasIdamaxStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasIcamaxStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasIcamaxStridedBatched_(handle,n,x,incx,stridex,batchCount,myResult) &
-        bind(c, name="cublasIcamaxStridedBatched")
-#else
     function hipblasIcamaxStridedBatched_(handle,n,x,incx,stridex,batchCount,myResult) &
         bind(c, name="hipblasIcamaxStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -1177,15 +1143,12 @@ module hipfort_hipblas
       hipblasIcamaxStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasIzamaxStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasIzamaxStridedBatched_(handle,n,x,incx,stridex,batchCount,myResult) &
-        bind(c, name="cublasIzamaxStridedBatched")
-#else
     function hipblasIzamaxStridedBatched_(handle,n,x,incx,stridex,batchCount,myResult) &
         bind(c, name="hipblasIzamaxStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -1205,15 +1168,12 @@ module hipfort_hipblas
       hipblasIzamaxStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasIsamaxStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasIsamaxStridedBatched_64_(handle,n,x,incx,stridex,batchCount,myResult) &
-        bind(c, name="cublasIsamaxStridedBatched_64")
-#else
     function hipblasIsamaxStridedBatched_64_(handle,n,x,incx,stridex,batchCount,myResult) &
         bind(c, name="hipblasIsamaxStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -1227,15 +1187,12 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasIdamaxStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasIdamaxStridedBatched_64_(handle,n,x,incx,stridex,batchCount,myResult) &
-        bind(c, name="cublasIdamaxStridedBatched_64")
-#else
     function hipblasIdamaxStridedBatched_64_(handle,n,x,incx,stridex,batchCount,myResult) &
         bind(c, name="hipblasIdamaxStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -1249,15 +1206,12 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasIcamaxStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasIcamaxStridedBatched_64_(handle,n,x,incx,stridex,batchCount,myResult) &
-        bind(c, name="cublasIcamaxStridedBatched_64")
-#else
     function hipblasIcamaxStridedBatched_64_(handle,n,x,incx,stridex,batchCount,myResult) &
         bind(c, name="hipblasIcamaxStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -1271,15 +1225,12 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasIzamaxStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasIzamaxStridedBatched_64_(handle,n,x,incx,stridex,batchCount,myResult) &
-        bind(c, name="cublasIzamaxStridedBatched_64")
-#else
     function hipblasIzamaxStridedBatched_64_(handle,n,x,incx,stridex,batchCount,myResult) &
         bind(c, name="hipblasIzamaxStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -1293,6 +1244,7 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 1 API
   !>
@@ -1513,14 +1465,10 @@ module hipfort_hipblas
   !>     result
   !>               device or host pointers to array of batchCount size for results.
   !>               Return value is 0 if n, incx<=0.
+#ifndef USE_CUDA_NAMES
   interface hipblasIsaminBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasIsaminBatched_(handle,n,x,incx,batchCount,myResult) &
-        bind(c, name="cublasIsaminBatched")
-#else
     function hipblasIsaminBatched_(handle,n,x,incx,batchCount,myResult) &
         bind(c, name="hipblasIsaminBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -1533,15 +1481,12 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasIdaminBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasIdaminBatched_(handle,n,x,incx,batchCount,myResult) &
-        bind(c, name="cublasIdaminBatched")
-#else
     function hipblasIdaminBatched_(handle,n,x,incx,batchCount,myResult) &
         bind(c, name="hipblasIdaminBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -1554,15 +1499,12 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasIcaminBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasIcaminBatched_(handle,n,x,incx,batchCount,myResult) &
-        bind(c, name="cublasIcaminBatched")
-#else
     function hipblasIcaminBatched_(handle,n,x,incx,batchCount,myResult) &
         bind(c, name="hipblasIcaminBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -1575,15 +1517,12 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasIzaminBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasIzaminBatched_(handle,n,x,incx,batchCount,myResult) &
-        bind(c, name="cublasIzaminBatched")
-#else
     function hipblasIzaminBatched_(handle,n,x,incx,batchCount,myResult) &
         bind(c, name="hipblasIzaminBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -1596,15 +1535,12 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasIsaminBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasIsaminBatched_64_(handle,n,x,incx,batchCount,myResult) &
-        bind(c, name="cublasIsaminBatched_64")
-#else
     function hipblasIsaminBatched_64_(handle,n,x,incx,batchCount,myResult) &
         bind(c, name="hipblasIsaminBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -1617,15 +1553,12 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasIdaminBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasIdaminBatched_64_(handle,n,x,incx,batchCount,myResult) &
-        bind(c, name="cublasIdaminBatched_64")
-#else
     function hipblasIdaminBatched_64_(handle,n,x,incx,batchCount,myResult) &
         bind(c, name="hipblasIdaminBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -1638,15 +1571,12 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasIcaminBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasIcaminBatched_64_(handle,n,x,incx,batchCount,myResult) &
-        bind(c, name="cublasIcaminBatched_64")
-#else
     function hipblasIcaminBatched_64_(handle,n,x,incx,batchCount,myResult) &
         bind(c, name="hipblasIcaminBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -1659,15 +1589,12 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasIzaminBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasIzaminBatched_64_(handle,n,x,incx,batchCount,myResult) &
-        bind(c, name="cublasIzaminBatched_64")
-#else
     function hipblasIzaminBatched_64_(handle,n,x,incx,batchCount,myResult) &
         bind(c, name="hipblasIzaminBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -1680,6 +1607,7 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 1 API
   !>
@@ -1711,14 +1639,10 @@ module hipfort_hipblas
   !>     result
   !>               device or host pointer to array for storing contiguous batchCount results.
   !>               Return value is 0 if n <= 0, incx<=0.
+#ifndef USE_CUDA_NAMES
   interface hipblasIsaminStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasIsaminStridedBatched_(handle,n,x,incx,stridex,batchCount,myResult) &
-        bind(c, name="cublasIsaminStridedBatched")
-#else
     function hipblasIsaminStridedBatched_(handle,n,x,incx,stridex,batchCount,myResult) &
         bind(c, name="hipblasIsaminStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -1738,15 +1662,12 @@ module hipfort_hipblas
       hipblasIsaminStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasIdaminStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasIdaminStridedBatched_(handle,n,x,incx,stridex,batchCount,myResult) &
-        bind(c, name="cublasIdaminStridedBatched")
-#else
     function hipblasIdaminStridedBatched_(handle,n,x,incx,stridex,batchCount,myResult) &
         bind(c, name="hipblasIdaminStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -1766,15 +1687,12 @@ module hipfort_hipblas
       hipblasIdaminStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasIcaminStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasIcaminStridedBatched_(handle,n,x,incx,stridex,batchCount,myResult) &
-        bind(c, name="cublasIcaminStridedBatched")
-#else
     function hipblasIcaminStridedBatched_(handle,n,x,incx,stridex,batchCount,myResult) &
         bind(c, name="hipblasIcaminStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -1794,15 +1712,12 @@ module hipfort_hipblas
       hipblasIcaminStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasIzaminStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasIzaminStridedBatched_(handle,n,x,incx,stridex,batchCount,myResult) &
-        bind(c, name="cublasIzaminStridedBatched")
-#else
     function hipblasIzaminStridedBatched_(handle,n,x,incx,stridex,batchCount,myResult) &
         bind(c, name="hipblasIzaminStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -1822,15 +1737,12 @@ module hipfort_hipblas
       hipblasIzaminStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasIsaminStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasIsaminStridedBatched_64_(handle,n,x,incx,stridex,batchCount,myResult) &
-        bind(c, name="cublasIsaminStridedBatched_64")
-#else
     function hipblasIsaminStridedBatched_64_(handle,n,x,incx,stridex,batchCount,myResult) &
         bind(c, name="hipblasIsaminStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -1844,15 +1756,12 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasIdaminStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasIdaminStridedBatched_64_(handle,n,x,incx,stridex,batchCount,myResult) &
-        bind(c, name="cublasIdaminStridedBatched_64")
-#else
     function hipblasIdaminStridedBatched_64_(handle,n,x,incx,stridex,batchCount,myResult) &
         bind(c, name="hipblasIdaminStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -1866,15 +1775,12 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasIcaminStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasIcaminStridedBatched_64_(handle,n,x,incx,stridex,batchCount,myResult) &
-        bind(c, name="cublasIcaminStridedBatched_64")
-#else
     function hipblasIcaminStridedBatched_64_(handle,n,x,incx,stridex,batchCount,myResult) &
         bind(c, name="hipblasIcaminStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -1888,15 +1794,12 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasIzaminStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasIzaminStridedBatched_64_(handle,n,x,incx,stridex,batchCount,myResult) &
-        bind(c, name="cublasIzaminStridedBatched_64")
-#else
     function hipblasIzaminStridedBatched_64_(handle,n,x,incx,stridex,batchCount,myResult) &
         bind(c, name="hipblasIzaminStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -1910,6 +1813,7 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 1 API
   !>
@@ -2134,14 +2038,10 @@ module hipfort_hipblas
   !>     result
   !>               device array or host array of batchCount size for results.
   !>               Return value is 0.0 if n, incx<=0.
+#ifndef USE_CUDA_NAMES
   interface hipblasSasumBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasSasumBatched_(handle,n,x,incx,batchCount,myResult) &
-        bind(c, name="cublasSasumBatched")
-#else
     function hipblasSasumBatched_(handle,n,x,incx,batchCount,myResult) &
         bind(c, name="hipblasSasumBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -2154,15 +2054,12 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDasumBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDasumBatched_(handle,n,x,incx,batchCount,myResult) &
-        bind(c, name="cublasDasumBatched")
-#else
     function hipblasDasumBatched_(handle,n,x,incx,batchCount,myResult) &
         bind(c, name="hipblasDasumBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -2175,15 +2072,12 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasScasumBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasScasumBatched_(handle,n,x,incx,batchCount,myResult) &
-        bind(c, name="cublasScasumBatched")
-#else
     function hipblasScasumBatched_(handle,n,x,incx,batchCount,myResult) &
         bind(c, name="hipblasScasumBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -2196,15 +2090,12 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDzasumBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDzasumBatched_(handle,n,x,incx,batchCount,myResult) &
-        bind(c, name="cublasDzasumBatched")
-#else
     function hipblasDzasumBatched_(handle,n,x,incx,batchCount,myResult) &
         bind(c, name="hipblasDzasumBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -2217,15 +2108,12 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasSasumBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasSasumBatched_64_(handle,n,x,incx,batchCount,myResult) &
-        bind(c, name="cublasSasumBatched_64")
-#else
     function hipblasSasumBatched_64_(handle,n,x,incx,batchCount,myResult) &
         bind(c, name="hipblasSasumBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -2238,15 +2126,12 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDasumBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDasumBatched_64_(handle,n,x,incx,batchCount,myResult) &
-        bind(c, name="cublasDasumBatched_64")
-#else
     function hipblasDasumBatched_64_(handle,n,x,incx,batchCount,myResult) &
         bind(c, name="hipblasDasumBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -2259,15 +2144,12 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasScasumBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasScasumBatched_64_(handle,n,x,incx,batchCount,myResult) &
-        bind(c, name="cublasScasumBatched_64")
-#else
     function hipblasScasumBatched_64_(handle,n,x,incx,batchCount,myResult) &
         bind(c, name="hipblasScasumBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -2280,15 +2162,12 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDzasumBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDzasumBatched_64_(handle,n,x,incx,batchCount,myResult) &
-        bind(c, name="cublasDzasumBatched_64")
-#else
     function hipblasDzasumBatched_64_(handle,n,x,incx,batchCount,myResult) &
         bind(c, name="hipblasDzasumBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -2301,6 +2180,7 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 1 API
   !>
@@ -2339,14 +2219,10 @@ module hipfort_hipblas
   !>               device pointer or host pointer to array for storing contiguous batchCount
   !>               results.
   !>               Return value is 0.0 if n, incx<=0.
+#ifndef USE_CUDA_NAMES
   interface hipblasSasumStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasSasumStridedBatched_(handle,n,x,incx,stridex,batchCount,myResult) &
-        bind(c, name="cublasSasumStridedBatched")
-#else
     function hipblasSasumStridedBatched_(handle,n,x,incx,stridex,batchCount,myResult) &
         bind(c, name="hipblasSasumStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -2366,15 +2242,12 @@ module hipfort_hipblas
       hipblasSasumStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDasumStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDasumStridedBatched_(handle,n,x,incx,stridex,batchCount,myResult) &
-        bind(c, name="cublasDasumStridedBatched")
-#else
     function hipblasDasumStridedBatched_(handle,n,x,incx,stridex,batchCount,myResult) &
         bind(c, name="hipblasDasumStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -2394,15 +2267,12 @@ module hipfort_hipblas
       hipblasDasumStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasScasumStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasScasumStridedBatched_(handle,n,x,incx,stridex,batchCount,myResult) &
-        bind(c, name="cublasScasumStridedBatched")
-#else
     function hipblasScasumStridedBatched_(handle,n,x,incx,stridex,batchCount,myResult) &
         bind(c, name="hipblasScasumStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -2422,15 +2292,12 @@ module hipfort_hipblas
       hipblasScasumStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDzasumStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDzasumStridedBatched_(handle,n,x,incx,stridex,batchCount,myResult) &
-        bind(c, name="cublasDzasumStridedBatched")
-#else
     function hipblasDzasumStridedBatched_(handle,n,x,incx,stridex,batchCount,myResult) &
         bind(c, name="hipblasDzasumStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -2450,15 +2317,12 @@ module hipfort_hipblas
       hipblasDzasumStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasSasumStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasSasumStridedBatched_64_(handle,n,x,incx,stridex,batchCount,myResult) &
-        bind(c, name="cublasSasumStridedBatched_64")
-#else
     function hipblasSasumStridedBatched_64_(handle,n,x,incx,stridex,batchCount,myResult) &
         bind(c, name="hipblasSasumStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -2472,15 +2336,12 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDasumStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDasumStridedBatched_64_(handle,n,x,incx,stridex,batchCount,myResult) &
-        bind(c, name="cublasDasumStridedBatched_64")
-#else
     function hipblasDasumStridedBatched_64_(handle,n,x,incx,stridex,batchCount,myResult) &
         bind(c, name="hipblasDasumStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -2494,15 +2355,12 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasScasumStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasScasumStridedBatched_64_(handle,n,x,incx,stridex,batchCount,myResult) &
-        bind(c, name="cublasScasumStridedBatched_64")
-#else
     function hipblasScasumStridedBatched_64_(handle,n,x,incx,stridex,batchCount,myResult) &
         bind(c, name="hipblasScasumStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -2516,15 +2374,12 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDzasumStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDzasumStridedBatched_64_(handle,n,x,incx,stridex,batchCount,myResult) &
-        bind(c, name="cublasDzasumStridedBatched_64")
-#else
     function hipblasDzasumStridedBatched_64_(handle,n,x,incx,stridex,batchCount,myResult) &
         bind(c, name="hipblasDzasumStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -2538,6 +2393,7 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 1 API
   !>
@@ -2838,14 +2694,10 @@ module hipfort_hipblas
   end interface
 #endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasSaxpyBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasSaxpyBatched_(handle,n,alpha,x,incx,y,incy,batchCount) &
-        bind(c, name="cublasSaxpyBatched")
-#else
     function hipblasSaxpyBatched_(handle,n,alpha,x,incx,y,incy,batchCount) &
         bind(c, name="hipblasSaxpyBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -2860,15 +2712,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDaxpyBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDaxpyBatched_(handle,n,alpha,x,incx,y,incy,batchCount) &
-        bind(c, name="cublasDaxpyBatched")
-#else
     function hipblasDaxpyBatched_(handle,n,alpha,x,incx,y,incy,batchCount) &
         bind(c, name="hipblasDaxpyBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -2883,15 +2732,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCaxpyBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCaxpyBatched_(handle,n,alpha,x,incx,y,incy,batchCount) &
-        bind(c, name="cublasCaxpyBatched")
-#else
     function hipblasCaxpyBatched_(handle,n,alpha,x,incx,y,incy,batchCount) &
         bind(c, name="hipblasCaxpyBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -2906,15 +2752,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZaxpyBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZaxpyBatched_(handle,n,alpha,x,incx,y,incy,batchCount) &
-        bind(c, name="cublasZaxpyBatched")
-#else
     function hipblasZaxpyBatched_(handle,n,alpha,x,incx,y,incy,batchCount) &
         bind(c, name="hipblasZaxpyBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -2929,6 +2772,7 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
 #ifndef USE_CUDA_NAMES
   interface hipblasHaxpyBatched_64
@@ -2950,14 +2794,10 @@ module hipfort_hipblas
   end interface
 #endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasSaxpyBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasSaxpyBatched_64_(handle,n,alpha,x,incx,y,incy,batchCount) &
-        bind(c, name="cublasSaxpyBatched_64")
-#else
     function hipblasSaxpyBatched_64_(handle,n,alpha,x,incx,y,incy,batchCount) &
         bind(c, name="hipblasSaxpyBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -2972,15 +2812,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDaxpyBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDaxpyBatched_64_(handle,n,alpha,x,incx,y,incy,batchCount) &
-        bind(c, name="cublasDaxpyBatched_64")
-#else
     function hipblasDaxpyBatched_64_(handle,n,alpha,x,incx,y,incy,batchCount) &
         bind(c, name="hipblasDaxpyBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -2995,15 +2832,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCaxpyBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCaxpyBatched_64_(handle,n,alpha,x,incx,y,incy,batchCount) &
-        bind(c, name="cublasCaxpyBatched_64")
-#else
     function hipblasCaxpyBatched_64_(handle,n,alpha,x,incx,y,incy,batchCount) &
         bind(c, name="hipblasCaxpyBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -3018,15 +2852,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZaxpyBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZaxpyBatched_64_(handle,n,alpha,x,incx,y,incy,batchCount) &
-        bind(c, name="cublasZaxpyBatched_64")
-#else
     function hipblasZaxpyBatched_64_(handle,n,alpha,x,incx,y,incy,batchCount) &
         bind(c, name="hipblasZaxpyBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -3041,6 +2872,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 1 API
   !>
@@ -3100,14 +2932,10 @@ module hipfort_hipblas
   end interface
 #endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasSaxpyStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasSaxpyStridedBatched_(handle,n,alpha,x,incx,stridex,y,incy,stridey,batchCount) &
-        bind(c, name="cublasSaxpyStridedBatched")
-#else
     function hipblasSaxpyStridedBatched_(handle,n,alpha,x,incx,stridex,y,incy,stridey,batchCount) &
         bind(c, name="hipblasSaxpyStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -3130,15 +2958,12 @@ module hipfort_hipblas
       hipblasSaxpyStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDaxpyStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDaxpyStridedBatched_(handle,n,alpha,x,incx,stridex,y,incy,stridey,batchCount) &
-        bind(c, name="cublasDaxpyStridedBatched")
-#else
     function hipblasDaxpyStridedBatched_(handle,n,alpha,x,incx,stridex,y,incy,stridey,batchCount) &
         bind(c, name="hipblasDaxpyStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -3161,15 +2986,12 @@ module hipfort_hipblas
       hipblasDaxpyStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCaxpyStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCaxpyStridedBatched_(handle,n,alpha,x,incx,stridex,y,incy,stridey,batchCount) &
-        bind(c, name="cublasCaxpyStridedBatched")
-#else
     function hipblasCaxpyStridedBatched_(handle,n,alpha,x,incx,stridex,y,incy,stridey,batchCount) &
         bind(c, name="hipblasCaxpyStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -3192,15 +3014,12 @@ module hipfort_hipblas
       hipblasCaxpyStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZaxpyStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZaxpyStridedBatched_(handle,n,alpha,x,incx,stridex,y,incy,stridey,batchCount) &
-        bind(c, name="cublasZaxpyStridedBatched")
-#else
     function hipblasZaxpyStridedBatched_(handle,n,alpha,x,incx,stridex,y,incy,stridey,batchCount) &
         bind(c, name="hipblasZaxpyStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -3223,6 +3042,7 @@ module hipfort_hipblas
       hipblasZaxpyStridedBatched_rank_1
 #endif
   end interface
+#endif
 
 #ifndef USE_CUDA_NAMES
   interface hipblasHaxpyStridedBatched_64
@@ -3247,16 +3067,11 @@ module hipfort_hipblas
   end interface
 #endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasSaxpyStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasSaxpyStridedBatched_64_(handle,n,alpha,x,incx,stridex,y,incy,stridey, &
-        batchCount) &
-        bind(c, name="cublasSaxpyStridedBatched_64")
-#else
     function hipblasSaxpyStridedBatched_64_(handle,n,alpha,x,incx,stridex,y,incy,stridey, &
         batchCount) &
         bind(c, name="hipblasSaxpyStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -3273,17 +3088,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDaxpyStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDaxpyStridedBatched_64_(handle,n,alpha,x,incx,stridex,y,incy,stridey, &
-        batchCount) &
-        bind(c, name="cublasDaxpyStridedBatched_64")
-#else
     function hipblasDaxpyStridedBatched_64_(handle,n,alpha,x,incx,stridex,y,incy,stridey, &
         batchCount) &
         bind(c, name="hipblasDaxpyStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -3300,17 +3111,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCaxpyStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCaxpyStridedBatched_64_(handle,n,alpha,x,incx,stridex,y,incy,stridey, &
-        batchCount) &
-        bind(c, name="cublasCaxpyStridedBatched_64")
-#else
     function hipblasCaxpyStridedBatched_64_(handle,n,alpha,x,incx,stridex,y,incy,stridey, &
         batchCount) &
         bind(c, name="hipblasCaxpyStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -3327,17 +3134,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZaxpyStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZaxpyStridedBatched_64_(handle,n,alpha,x,incx,stridex,y,incy,stridey, &
-        batchCount) &
-        bind(c, name="cublasZaxpyStridedBatched_64")
-#else
     function hipblasZaxpyStridedBatched_64_(handle,n,alpha,x,incx,stridex,y,incy,stridey, &
         batchCount) &
         bind(c, name="hipblasZaxpyStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -3354,6 +3157,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 1 API
   !>
@@ -3590,14 +3394,10 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasScopyBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasScopyBatched_(handle,n,x,incx,y,incy,batchCount) &
-        bind(c, name="cublasScopyBatched")
-#else
     function hipblasScopyBatched_(handle,n,x,incx,y,incy,batchCount) &
         bind(c, name="hipblasScopyBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -3611,15 +3411,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDcopyBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDcopyBatched_(handle,n,x,incx,y,incy,batchCount) &
-        bind(c, name="cublasDcopyBatched")
-#else
     function hipblasDcopyBatched_(handle,n,x,incx,y,incy,batchCount) &
         bind(c, name="hipblasDcopyBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -3633,15 +3430,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCcopyBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCcopyBatched_(handle,n,x,incx,y,incy,batchCount) &
-        bind(c, name="cublasCcopyBatched")
-#else
     function hipblasCcopyBatched_(handle,n,x,incx,y,incy,batchCount) &
         bind(c, name="hipblasCcopyBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -3655,15 +3449,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZcopyBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZcopyBatched_(handle,n,x,incx,y,incy,batchCount) &
-        bind(c, name="cublasZcopyBatched")
-#else
     function hipblasZcopyBatched_(handle,n,x,incx,y,incy,batchCount) &
         bind(c, name="hipblasZcopyBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -3677,15 +3468,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasScopyBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasScopyBatched_64_(handle,n,x,incx,y,incy,batchCount) &
-        bind(c, name="cublasScopyBatched_64")
-#else
     function hipblasScopyBatched_64_(handle,n,x,incx,y,incy,batchCount) &
         bind(c, name="hipblasScopyBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -3699,15 +3487,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDcopyBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDcopyBatched_64_(handle,n,x,incx,y,incy,batchCount) &
-        bind(c, name="cublasDcopyBatched_64")
-#else
     function hipblasDcopyBatched_64_(handle,n,x,incx,y,incy,batchCount) &
         bind(c, name="hipblasDcopyBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -3721,15 +3506,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCcopyBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCcopyBatched_64_(handle,n,x,incx,y,incy,batchCount) &
-        bind(c, name="cublasCcopyBatched_64")
-#else
     function hipblasCcopyBatched_64_(handle,n,x,incx,y,incy,batchCount) &
         bind(c, name="hipblasCcopyBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -3743,15 +3525,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZcopyBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZcopyBatched_64_(handle,n,x,incx,y,incy,batchCount) &
-        bind(c, name="cublasZcopyBatched_64")
-#else
     function hipblasZcopyBatched_64_(handle,n,x,incx,y,incy,batchCount) &
         bind(c, name="hipblasZcopyBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -3765,6 +3544,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief   BLAS Level 1 API
   !>
@@ -3811,14 +3591,10 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasScopyStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasScopyStridedBatched_(handle,n,x,incx,stridex,y,incy,stridey,batchCount) &
-        bind(c, name="cublasScopyStridedBatched")
-#else
     function hipblasScopyStridedBatched_(handle,n,x,incx,stridex,y,incy,stridey,batchCount) &
         bind(c, name="hipblasScopyStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -3840,15 +3616,12 @@ module hipfort_hipblas
       hipblasScopyStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDcopyStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDcopyStridedBatched_(handle,n,x,incx,stridex,y,incy,stridey,batchCount) &
-        bind(c, name="cublasDcopyStridedBatched")
-#else
     function hipblasDcopyStridedBatched_(handle,n,x,incx,stridex,y,incy,stridey,batchCount) &
         bind(c, name="hipblasDcopyStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -3870,15 +3643,12 @@ module hipfort_hipblas
       hipblasDcopyStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCcopyStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCcopyStridedBatched_(handle,n,x,incx,stridex,y,incy,stridey,batchCount) &
-        bind(c, name="cublasCcopyStridedBatched")
-#else
     function hipblasCcopyStridedBatched_(handle,n,x,incx,stridex,y,incy,stridey,batchCount) &
         bind(c, name="hipblasCcopyStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -3900,15 +3670,12 @@ module hipfort_hipblas
       hipblasCcopyStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZcopyStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZcopyStridedBatched_(handle,n,x,incx,stridex,y,incy,stridey,batchCount) &
-        bind(c, name="cublasZcopyStridedBatched")
-#else
     function hipblasZcopyStridedBatched_(handle,n,x,incx,stridex,y,incy,stridey,batchCount) &
         bind(c, name="hipblasZcopyStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -3930,15 +3697,12 @@ module hipfort_hipblas
       hipblasZcopyStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasScopyStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasScopyStridedBatched_64_(handle,n,x,incx,stridex,y,incy,stridey,batchCount) &
-        bind(c, name="cublasScopyStridedBatched_64")
-#else
     function hipblasScopyStridedBatched_64_(handle,n,x,incx,stridex,y,incy,stridey,batchCount) &
         bind(c, name="hipblasScopyStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -3954,15 +3718,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDcopyStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDcopyStridedBatched_64_(handle,n,x,incx,stridex,y,incy,stridey,batchCount) &
-        bind(c, name="cublasDcopyStridedBatched_64")
-#else
     function hipblasDcopyStridedBatched_64_(handle,n,x,incx,stridex,y,incy,stridey,batchCount) &
         bind(c, name="hipblasDcopyStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -3978,15 +3739,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCcopyStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCcopyStridedBatched_64_(handle,n,x,incx,stridex,y,incy,stridey,batchCount) &
-        bind(c, name="cublasCcopyStridedBatched_64")
-#else
     function hipblasCcopyStridedBatched_64_(handle,n,x,incx,stridex,y,incy,stridey,batchCount) &
         bind(c, name="hipblasCcopyStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -4002,15 +3760,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZcopyStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZcopyStridedBatched_64_(handle,n,x,incx,stridex,y,incy,stridey,batchCount) &
-        bind(c, name="cublasZcopyStridedBatched_64")
-#else
     function hipblasZcopyStridedBatched_64_(handle,n,x,incx,stridex,y,incy,stridey,batchCount) &
         bind(c, name="hipblasZcopyStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -4026,6 +3781,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 1 API
   !>
@@ -4492,14 +4248,10 @@ module hipfort_hipblas
   end interface
 #endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasSdotBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasSdotBatched_(handle,n,x,incx,y,incy,batchCount,myResult) &
-        bind(c, name="cublasSdotBatched")
-#else
     function hipblasSdotBatched_(handle,n,x,incx,y,incy,batchCount,myResult) &
         bind(c, name="hipblasSdotBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -4514,15 +4266,12 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDdotBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDdotBatched_(handle,n,x,incx,y,incy,batchCount,myResult) &
-        bind(c, name="cublasDdotBatched")
-#else
     function hipblasDdotBatched_(handle,n,x,incx,y,incy,batchCount,myResult) &
         bind(c, name="hipblasDdotBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -4537,15 +4286,12 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCdotcBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCdotcBatched_(handle,n,x,incx,y,incy,batchCount,myResult) &
-        bind(c, name="cublasCdotcBatched")
-#else
     function hipblasCdotcBatched_(handle,n,x,incx,y,incy,batchCount,myResult) &
         bind(c, name="hipblasCdotcBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -4560,15 +4306,12 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCdotuBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCdotuBatched_(handle,n,x,incx,y,incy,batchCount,myResult) &
-        bind(c, name="cublasCdotuBatched")
-#else
     function hipblasCdotuBatched_(handle,n,x,incx,y,incy,batchCount,myResult) &
         bind(c, name="hipblasCdotuBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -4583,15 +4326,12 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZdotcBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZdotcBatched_(handle,n,x,incx,y,incy,batchCount,myResult) &
-        bind(c, name="cublasZdotcBatched")
-#else
     function hipblasZdotcBatched_(handle,n,x,incx,y,incy,batchCount,myResult) &
         bind(c, name="hipblasZdotcBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -4606,15 +4346,12 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZdotuBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZdotuBatched_(handle,n,x,incx,y,incy,batchCount,myResult) &
-        bind(c, name="cublasZdotuBatched")
-#else
     function hipblasZdotuBatched_(handle,n,x,incx,y,incy,batchCount,myResult) &
         bind(c, name="hipblasZdotuBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -4629,6 +4366,7 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
 #ifndef USE_CUDA_NAMES
   interface hipblasHdotBatched_64
@@ -4670,14 +4408,10 @@ module hipfort_hipblas
   end interface
 #endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasSdotBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasSdotBatched_64_(handle,n,x,incx,y,incy,batchCount,myResult) &
-        bind(c, name="cublasSdotBatched_64")
-#else
     function hipblasSdotBatched_64_(handle,n,x,incx,y,incy,batchCount,myResult) &
         bind(c, name="hipblasSdotBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -4692,15 +4426,12 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDdotBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDdotBatched_64_(handle,n,x,incx,y,incy,batchCount,myResult) &
-        bind(c, name="cublasDdotBatched_64")
-#else
     function hipblasDdotBatched_64_(handle,n,x,incx,y,incy,batchCount,myResult) &
         bind(c, name="hipblasDdotBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -4715,15 +4446,12 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCdotcBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCdotcBatched_64_(handle,n,x,incx,y,incy,batchCount,myResult) &
-        bind(c, name="cublasCdotcBatched_64")
-#else
     function hipblasCdotcBatched_64_(handle,n,x,incx,y,incy,batchCount,myResult) &
         bind(c, name="hipblasCdotcBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -4738,15 +4466,12 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCdotuBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCdotuBatched_64_(handle,n,x,incx,y,incy,batchCount,myResult) &
-        bind(c, name="cublasCdotuBatched_64")
-#else
     function hipblasCdotuBatched_64_(handle,n,x,incx,y,incy,batchCount,myResult) &
         bind(c, name="hipblasCdotuBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -4761,15 +4486,12 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZdotcBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZdotcBatched_64_(handle,n,x,incx,y,incy,batchCount,myResult) &
-        bind(c, name="cublasZdotcBatched_64")
-#else
     function hipblasZdotcBatched_64_(handle,n,x,incx,y,incy,batchCount,myResult) &
         bind(c, name="hipblasZdotcBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -4784,15 +4506,12 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZdotuBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZdotuBatched_64_(handle,n,x,incx,y,incy,batchCount,myResult) &
-        bind(c, name="cublasZdotuBatched_64")
-#else
     function hipblasZdotuBatched_64_(handle,n,x,incx,y,incy,batchCount,myResult) &
         bind(c, name="hipblasZdotuBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -4807,6 +4526,7 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 1 API
   !>
@@ -4903,16 +4623,11 @@ module hipfort_hipblas
   end interface
 #endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasSdotStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasSdotStridedBatched_(handle,n,x,incx,stridex,y,incy,stridey,batchCount, &
-        myResult) &
-        bind(c, name="cublasSdotStridedBatched")
-#else
     function hipblasSdotStridedBatched_(handle,n,x,incx,stridex,y,incy,stridey,batchCount, &
         myResult) &
         bind(c, name="hipblasSdotStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -4935,17 +4650,13 @@ module hipfort_hipblas
       hipblasSdotStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDdotStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDdotStridedBatched_(handle,n,x,incx,stridex,y,incy,stridey,batchCount, &
-        myResult) &
-        bind(c, name="cublasDdotStridedBatched")
-#else
     function hipblasDdotStridedBatched_(handle,n,x,incx,stridex,y,incy,stridey,batchCount, &
         myResult) &
         bind(c, name="hipblasDdotStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -4968,17 +4679,13 @@ module hipfort_hipblas
       hipblasDdotStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCdotcStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCdotcStridedBatched_(handle,n,x,incx,stridex,y,incy,stridey,batchCount, &
-        myResult) &
-        bind(c, name="cublasCdotcStridedBatched")
-#else
     function hipblasCdotcStridedBatched_(handle,n,x,incx,stridex,y,incy,stridey,batchCount, &
         myResult) &
         bind(c, name="hipblasCdotcStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -5001,17 +4708,13 @@ module hipfort_hipblas
       hipblasCdotcStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCdotuStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCdotuStridedBatched_(handle,n,x,incx,stridex,y,incy,stridey,batchCount, &
-        myResult) &
-        bind(c, name="cublasCdotuStridedBatched")
-#else
     function hipblasCdotuStridedBatched_(handle,n,x,incx,stridex,y,incy,stridey,batchCount, &
         myResult) &
         bind(c, name="hipblasCdotuStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -5034,17 +4737,13 @@ module hipfort_hipblas
       hipblasCdotuStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZdotcStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZdotcStridedBatched_(handle,n,x,incx,stridex,y,incy,stridey,batchCount, &
-        myResult) &
-        bind(c, name="cublasZdotcStridedBatched")
-#else
     function hipblasZdotcStridedBatched_(handle,n,x,incx,stridex,y,incy,stridey,batchCount, &
         myResult) &
         bind(c, name="hipblasZdotcStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -5067,17 +4766,13 @@ module hipfort_hipblas
       hipblasZdotcStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZdotuStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZdotuStridedBatched_(handle,n,x,incx,stridex,y,incy,stridey,batchCount, &
-        myResult) &
-        bind(c, name="cublasZdotuStridedBatched")
-#else
     function hipblasZdotuStridedBatched_(handle,n,x,incx,stridex,y,incy,stridey,batchCount, &
         myResult) &
         bind(c, name="hipblasZdotuStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -5100,6 +4795,7 @@ module hipfort_hipblas
       hipblasZdotuStridedBatched_rank_1
 #endif
   end interface
+#endif
 
 #ifndef USE_CUDA_NAMES
   interface hipblasHdotStridedBatched_64
@@ -5147,16 +4843,11 @@ module hipfort_hipblas
   end interface
 #endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasSdotStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasSdotStridedBatched_64_(handle,n,x,incx,stridex,y,incy,stridey,batchCount, &
-        myResult) &
-        bind(c, name="cublasSdotStridedBatched_64")
-#else
     function hipblasSdotStridedBatched_64_(handle,n,x,incx,stridex,y,incy,stridey,batchCount, &
         myResult) &
         bind(c, name="hipblasSdotStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -5173,17 +4864,13 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDdotStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDdotStridedBatched_64_(handle,n,x,incx,stridex,y,incy,stridey,batchCount, &
-        myResult) &
-        bind(c, name="cublasDdotStridedBatched_64")
-#else
     function hipblasDdotStridedBatched_64_(handle,n,x,incx,stridex,y,incy,stridey,batchCount, &
         myResult) &
         bind(c, name="hipblasDdotStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -5200,17 +4887,13 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCdotcStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCdotcStridedBatched_64_(handle,n,x,incx,stridex,y,incy,stridey,batchCount, &
-        myResult) &
-        bind(c, name="cublasCdotcStridedBatched_64")
-#else
     function hipblasCdotcStridedBatched_64_(handle,n,x,incx,stridex,y,incy,stridey,batchCount, &
         myResult) &
         bind(c, name="hipblasCdotcStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -5227,17 +4910,13 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCdotuStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCdotuStridedBatched_64_(handle,n,x,incx,stridex,y,incy,stridey,batchCount, &
-        myResult) &
-        bind(c, name="cublasCdotuStridedBatched_64")
-#else
     function hipblasCdotuStridedBatched_64_(handle,n,x,incx,stridex,y,incy,stridey,batchCount, &
         myResult) &
         bind(c, name="hipblasCdotuStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -5254,17 +4933,13 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZdotcStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZdotcStridedBatched_64_(handle,n,x,incx,stridex,y,incy,stridey,batchCount, &
-        myResult) &
-        bind(c, name="cublasZdotcStridedBatched_64")
-#else
     function hipblasZdotcStridedBatched_64_(handle,n,x,incx,stridex,y,incy,stridey,batchCount, &
         myResult) &
         bind(c, name="hipblasZdotcStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -5281,17 +4956,13 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZdotuStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZdotuStridedBatched_64_(handle,n,x,incx,stridex,y,incy,stridey,batchCount, &
-        myResult) &
-        bind(c, name="cublasZdotuStridedBatched_64")
-#else
     function hipblasZdotuStridedBatched_64_(handle,n,x,incx,stridex,y,incy,stridey,batchCount, &
         myResult) &
         bind(c, name="hipblasZdotuStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -5308,6 +4979,7 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 1 API
   !>
@@ -5533,14 +5205,10 @@ module hipfort_hipblas
   !>     result
   !>               device pointer or host pointer to array of batchCount size for nrm2 results.
   !>               Return value is 0.0 for each element if n <= 0, incx<=0.
+#ifndef USE_CUDA_NAMES
   interface hipblasSnrm2Batched
-#ifdef USE_CUDA_NAMES
-    function hipblasSnrm2Batched_(handle,n,x,incx,batchCount,myResult) &
-        bind(c, name="cublasSnrm2Batched")
-#else
     function hipblasSnrm2Batched_(handle,n,x,incx,batchCount,myResult) &
         bind(c, name="hipblasSnrm2Batched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -5553,15 +5221,12 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDnrm2Batched
-#ifdef USE_CUDA_NAMES
-    function hipblasDnrm2Batched_(handle,n,x,incx,batchCount,myResult) &
-        bind(c, name="cublasDnrm2Batched")
-#else
     function hipblasDnrm2Batched_(handle,n,x,incx,batchCount,myResult) &
         bind(c, name="hipblasDnrm2Batched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -5574,15 +5239,12 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasScnrm2Batched
-#ifdef USE_CUDA_NAMES
-    function hipblasScnrm2Batched_(handle,n,x,incx,batchCount,myResult) &
-        bind(c, name="cublasScnrm2Batched")
-#else
     function hipblasScnrm2Batched_(handle,n,x,incx,batchCount,myResult) &
         bind(c, name="hipblasScnrm2Batched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -5595,15 +5257,12 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDznrm2Batched
-#ifdef USE_CUDA_NAMES
-    function hipblasDznrm2Batched_(handle,n,x,incx,batchCount,myResult) &
-        bind(c, name="cublasDznrm2Batched")
-#else
     function hipblasDznrm2Batched_(handle,n,x,incx,batchCount,myResult) &
         bind(c, name="hipblasDznrm2Batched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -5616,15 +5275,12 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasSnrm2Batched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasSnrm2Batched_64_(handle,n,x,incx,batchCount,myResult) &
-        bind(c, name="cublasSnrm2Batched_64")
-#else
     function hipblasSnrm2Batched_64_(handle,n,x,incx,batchCount,myResult) &
         bind(c, name="hipblasSnrm2Batched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -5637,15 +5293,12 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDnrm2Batched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDnrm2Batched_64_(handle,n,x,incx,batchCount,myResult) &
-        bind(c, name="cublasDnrm2Batched_64")
-#else
     function hipblasDnrm2Batched_64_(handle,n,x,incx,batchCount,myResult) &
         bind(c, name="hipblasDnrm2Batched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -5658,15 +5311,12 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasScnrm2Batched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasScnrm2Batched_64_(handle,n,x,incx,batchCount,myResult) &
-        bind(c, name="cublasScnrm2Batched_64")
-#else
     function hipblasScnrm2Batched_64_(handle,n,x,incx,batchCount,myResult) &
         bind(c, name="hipblasScnrm2Batched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -5679,15 +5329,12 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDznrm2Batched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDznrm2Batched_64_(handle,n,x,incx,batchCount,myResult) &
-        bind(c, name="cublasDznrm2Batched_64")
-#else
     function hipblasDznrm2Batched_64_(handle,n,x,incx,batchCount,myResult) &
         bind(c, name="hipblasDznrm2Batched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -5700,6 +5347,7 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 1 API
   !>
@@ -5738,14 +5386,10 @@ module hipfort_hipblas
   !>               device pointer or host pointer to array for storing contiguous batchCount
   !>               results.
   !>               Return value is 0.0 for each element if n <= 0, incx<=0.
+#ifndef USE_CUDA_NAMES
   interface hipblasSnrm2StridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasSnrm2StridedBatched_(handle,n,x,incx,stridex,batchCount,myResult) &
-        bind(c, name="cublasSnrm2StridedBatched")
-#else
     function hipblasSnrm2StridedBatched_(handle,n,x,incx,stridex,batchCount,myResult) &
         bind(c, name="hipblasSnrm2StridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -5765,15 +5409,12 @@ module hipfort_hipblas
       hipblasSnrm2StridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDnrm2StridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDnrm2StridedBatched_(handle,n,x,incx,stridex,batchCount,myResult) &
-        bind(c, name="cublasDnrm2StridedBatched")
-#else
     function hipblasDnrm2StridedBatched_(handle,n,x,incx,stridex,batchCount,myResult) &
         bind(c, name="hipblasDnrm2StridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -5793,15 +5434,12 @@ module hipfort_hipblas
       hipblasDnrm2StridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasScnrm2StridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasScnrm2StridedBatched_(handle,n,x,incx,stridex,batchCount,myResult) &
-        bind(c, name="cublasScnrm2StridedBatched")
-#else
     function hipblasScnrm2StridedBatched_(handle,n,x,incx,stridex,batchCount,myResult) &
         bind(c, name="hipblasScnrm2StridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -5821,15 +5459,12 @@ module hipfort_hipblas
       hipblasScnrm2StridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDznrm2StridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDznrm2StridedBatched_(handle,n,x,incx,stridex,batchCount,myResult) &
-        bind(c, name="cublasDznrm2StridedBatched")
-#else
     function hipblasDznrm2StridedBatched_(handle,n,x,incx,stridex,batchCount,myResult) &
         bind(c, name="hipblasDznrm2StridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -5849,15 +5484,12 @@ module hipfort_hipblas
       hipblasDznrm2StridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasSnrm2StridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasSnrm2StridedBatched_64_(handle,n,x,incx,stridex,batchCount,myResult) &
-        bind(c, name="cublasSnrm2StridedBatched_64")
-#else
     function hipblasSnrm2StridedBatched_64_(handle,n,x,incx,stridex,batchCount,myResult) &
         bind(c, name="hipblasSnrm2StridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -5871,15 +5503,12 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDnrm2StridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDnrm2StridedBatched_64_(handle,n,x,incx,stridex,batchCount,myResult) &
-        bind(c, name="cublasDnrm2StridedBatched_64")
-#else
     function hipblasDnrm2StridedBatched_64_(handle,n,x,incx,stridex,batchCount,myResult) &
         bind(c, name="hipblasDnrm2StridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -5893,15 +5522,12 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasScnrm2StridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasScnrm2StridedBatched_64_(handle,n,x,incx,stridex,batchCount,myResult) &
-        bind(c, name="cublasScnrm2StridedBatched_64")
-#else
     function hipblasScnrm2StridedBatched_64_(handle,n,x,incx,stridex,batchCount,myResult) &
         bind(c, name="hipblasScnrm2StridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -5915,15 +5541,12 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDznrm2StridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDznrm2StridedBatched_64_(handle,n,x,incx,stridex,batchCount,myResult) &
-        bind(c, name="cublasDznrm2StridedBatched_64")
-#else
     function hipblasDznrm2StridedBatched_64_(handle,n,x,incx,stridex,batchCount,myResult) &
         bind(c, name="hipblasDznrm2StridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -5937,6 +5560,7 @@ module hipfort_hipblas
       type(c_ptr),value :: myResult
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 1 API
   !>
@@ -6293,14 +5917,10 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 the number of x and y arrays, that is, the number of batches.
+#ifndef USE_CUDA_NAMES
   interface hipblasSrotBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasSrotBatched_(handle,n,x,incx,y,incy,c,s,batchCount) &
-        bind(c, name="cublasSrotBatched")
-#else
     function hipblasSrotBatched_(handle,n,x,incx,y,incy,c,s,batchCount) &
         bind(c, name="hipblasSrotBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -6316,15 +5936,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDrotBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDrotBatched_(handle,n,x,incx,y,incy,c,s,batchCount) &
-        bind(c, name="cublasDrotBatched")
-#else
     function hipblasDrotBatched_(handle,n,x,incx,y,incy,c,s,batchCount) &
         bind(c, name="hipblasDrotBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -6340,15 +5957,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCrotBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCrotBatched_(handle,n,x,incx,y,incy,c,s,batchCount) &
-        bind(c, name="cublasCrotBatched")
-#else
     function hipblasCrotBatched_(handle,n,x,incx,y,incy,c,s,batchCount) &
         bind(c, name="hipblasCrotBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -6364,15 +5978,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCsrotBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCsrotBatched_(handle,n,x,incx,y,incy,c,s,batchCount) &
-        bind(c, name="cublasCsrotBatched")
-#else
     function hipblasCsrotBatched_(handle,n,x,incx,y,incy,c,s,batchCount) &
         bind(c, name="hipblasCsrotBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -6388,15 +5999,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZrotBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZrotBatched_(handle,n,x,incx,y,incy,c,s,batchCount) &
-        bind(c, name="cublasZrotBatched")
-#else
     function hipblasZrotBatched_(handle,n,x,incx,y,incy,c,s,batchCount) &
         bind(c, name="hipblasZrotBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -6412,15 +6020,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZdrotBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZdrotBatched_(handle,n,x,incx,y,incy,c,s,batchCount) &
-        bind(c, name="cublasZdrotBatched")
-#else
     function hipblasZdrotBatched_(handle,n,x,incx,y,incy,c,s,batchCount) &
         bind(c, name="hipblasZdrotBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -6436,15 +6041,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasSrotBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasSrotBatched_64_(handle,n,x,incx,y,incy,c,s,batchCount) &
-        bind(c, name="cublasSrotBatched_64")
-#else
     function hipblasSrotBatched_64_(handle,n,x,incx,y,incy,c,s,batchCount) &
         bind(c, name="hipblasSrotBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -6460,15 +6062,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDrotBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDrotBatched_64_(handle,n,x,incx,y,incy,c,s,batchCount) &
-        bind(c, name="cublasDrotBatched_64")
-#else
     function hipblasDrotBatched_64_(handle,n,x,incx,y,incy,c,s,batchCount) &
         bind(c, name="hipblasDrotBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -6484,15 +6083,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCrotBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCrotBatched_64_(handle,n,x,incx,y,incy,c,s,batchCount) &
-        bind(c, name="cublasCrotBatched_64")
-#else
     function hipblasCrotBatched_64_(handle,n,x,incx,y,incy,c,s,batchCount) &
         bind(c, name="hipblasCrotBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -6508,15 +6104,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCsrotBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCsrotBatched_64_(handle,n,x,incx,y,incy,c,s,batchCount) &
-        bind(c, name="cublasCsrotBatched_64")
-#else
     function hipblasCsrotBatched_64_(handle,n,x,incx,y,incy,c,s,batchCount) &
         bind(c, name="hipblasCsrotBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -6532,15 +6125,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZrotBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZrotBatched_64_(handle,n,x,incx,y,incy,c,s,batchCount) &
-        bind(c, name="cublasZrotBatched_64")
-#else
     function hipblasZrotBatched_64_(handle,n,x,incx,y,incy,c,s,batchCount) &
         bind(c, name="hipblasZrotBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -6556,15 +6146,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZdrotBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZdrotBatched_64_(handle,n,x,incx,y,incy,c,s,batchCount) &
-        bind(c, name="cublasZdrotBatched_64")
-#else
     function hipblasZdrotBatched_64_(handle,n,x,incx,y,incy,c,s,batchCount) &
         bind(c, name="hipblasZdrotBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -6580,6 +6167,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 1 API
   !>
@@ -6622,14 +6210,10 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>             the number of x and y arrays, that is, the number of batches.
+#ifndef USE_CUDA_NAMES
   interface hipblasSrotStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasSrotStridedBatched_(handle,n,x,incx,stridex,y,incy,stridey,c,s,batchCount) &
-        bind(c, name="cublasSrotStridedBatched")
-#else
     function hipblasSrotStridedBatched_(handle,n,x,incx,stridex,y,incy,stridey,c,s,batchCount) &
         bind(c, name="hipblasSrotStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -6653,15 +6237,12 @@ module hipfort_hipblas
       hipblasSrotStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDrotStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDrotStridedBatched_(handle,n,x,incx,stridex,y,incy,stridey,c,s,batchCount) &
-        bind(c, name="cublasDrotStridedBatched")
-#else
     function hipblasDrotStridedBatched_(handle,n,x,incx,stridex,y,incy,stridey,c,s,batchCount) &
         bind(c, name="hipblasDrotStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -6685,15 +6266,12 @@ module hipfort_hipblas
       hipblasDrotStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCrotStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCrotStridedBatched_(handle,n,x,incx,stridex,y,incy,stridey,c,s,batchCount) &
-        bind(c, name="cublasCrotStridedBatched")
-#else
     function hipblasCrotStridedBatched_(handle,n,x,incx,stridex,y,incy,stridey,c,s,batchCount) &
         bind(c, name="hipblasCrotStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -6717,15 +6295,12 @@ module hipfort_hipblas
       hipblasCrotStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCsrotStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCsrotStridedBatched_(handle,n,x,incx,stridex,y,incy,stridey,c,s,batchCount) &
-        bind(c, name="cublasCsrotStridedBatched")
-#else
     function hipblasCsrotStridedBatched_(handle,n,x,incx,stridex,y,incy,stridey,c,s,batchCount) &
         bind(c, name="hipblasCsrotStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -6749,15 +6324,12 @@ module hipfort_hipblas
       hipblasCsrotStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZrotStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZrotStridedBatched_(handle,n,x,incx,stridex,y,incy,stridey,c,s,batchCount) &
-        bind(c, name="cublasZrotStridedBatched")
-#else
     function hipblasZrotStridedBatched_(handle,n,x,incx,stridex,y,incy,stridey,c,s,batchCount) &
         bind(c, name="hipblasZrotStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -6781,15 +6353,12 @@ module hipfort_hipblas
       hipblasZrotStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZdrotStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZdrotStridedBatched_(handle,n,x,incx,stridex,y,incy,stridey,c,s,batchCount) &
-        bind(c, name="cublasZdrotStridedBatched")
-#else
     function hipblasZdrotStridedBatched_(handle,n,x,incx,stridex,y,incy,stridey,c,s,batchCount) &
         bind(c, name="hipblasZdrotStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -6813,15 +6382,12 @@ module hipfort_hipblas
       hipblasZdrotStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasSrotStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasSrotStridedBatched_64_(handle,n,x,incx,stridex,y,incy,stridey,c,s,batchCount) &
-        bind(c, name="cublasSrotStridedBatched_64")
-#else
     function hipblasSrotStridedBatched_64_(handle,n,x,incx,stridex,y,incy,stridey,c,s,batchCount) &
         bind(c, name="hipblasSrotStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -6839,15 +6405,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDrotStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDrotStridedBatched_64_(handle,n,x,incx,stridex,y,incy,stridey,c,s,batchCount) &
-        bind(c, name="cublasDrotStridedBatched_64")
-#else
     function hipblasDrotStridedBatched_64_(handle,n,x,incx,stridex,y,incy,stridey,c,s,batchCount) &
         bind(c, name="hipblasDrotStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -6865,15 +6428,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCrotStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCrotStridedBatched_64_(handle,n,x,incx,stridex,y,incy,stridey,c,s,batchCount) &
-        bind(c, name="cublasCrotStridedBatched_64")
-#else
     function hipblasCrotStridedBatched_64_(handle,n,x,incx,stridex,y,incy,stridey,c,s,batchCount) &
         bind(c, name="hipblasCrotStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -6891,15 +6451,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCsrotStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCsrotStridedBatched_64_(handle,n,x,incx,stridex,y,incy,stridey,c,s,batchCount) &
-        bind(c, name="cublasCsrotStridedBatched_64")
-#else
     function hipblasCsrotStridedBatched_64_(handle,n,x,incx,stridex,y,incy,stridey,c,s,batchCount) &
         bind(c, name="hipblasCsrotStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -6917,15 +6474,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZrotStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZrotStridedBatched_64_(handle,n,x,incx,stridex,y,incy,stridey,c,s,batchCount) &
-        bind(c, name="cublasZrotStridedBatched_64")
-#else
     function hipblasZrotStridedBatched_64_(handle,n,x,incx,stridex,y,incy,stridey,c,s,batchCount) &
         bind(c, name="hipblasZrotStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -6943,15 +6497,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZdrotStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZdrotStridedBatched_64_(handle,n,x,incx,stridex,y,incy,stridey,c,s,batchCount) &
-        bind(c, name="cublasZdrotStridedBatched_64")
-#else
     function hipblasZdrotStridedBatched_64_(handle,n,x,incx,stridex,y,incy,stridey,c,s,batchCount) &
         bind(c, name="hipblasZdrotStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -6969,6 +6520,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 1 API
   !>
@@ -7164,12 +6716,9 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of batches (length of arrays a, b, c, and s).
+#ifndef USE_CUDA_NAMES
   interface hipblasSrotgBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasSrotgBatched_(handle,a,b,c,s,batchCount) bind(c, name="cublasSrotgBatched")
-#else
     function hipblasSrotgBatched_(handle,a,b,c,s,batchCount) bind(c, name="hipblasSrotgBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -7182,13 +6731,11 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
-
-  interface hipblasDrotgBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDrotgBatched_(handle,a,b,c,s,batchCount) bind(c, name="cublasDrotgBatched")
-#else
-    function hipblasDrotgBatched_(handle,a,b,c,s,batchCount) bind(c, name="hipblasDrotgBatched")
 #endif
+
+#ifndef USE_CUDA_NAMES
+  interface hipblasDrotgBatched
+    function hipblasDrotgBatched_(handle,a,b,c,s,batchCount) bind(c, name="hipblasDrotgBatched")
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -7201,13 +6748,11 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
-
-  interface hipblasCrotgBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCrotgBatched_(handle,a,b,c,s,batchCount) bind(c, name="cublasCrotgBatched")
-#else
-    function hipblasCrotgBatched_(handle,a,b,c,s,batchCount) bind(c, name="hipblasCrotgBatched")
 #endif
+
+#ifndef USE_CUDA_NAMES
+  interface hipblasCrotgBatched
+    function hipblasCrotgBatched_(handle,a,b,c,s,batchCount) bind(c, name="hipblasCrotgBatched")
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -7220,13 +6765,11 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
-
-  interface hipblasZrotgBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZrotgBatched_(handle,a,b,c,s,batchCount) bind(c, name="cublasZrotgBatched")
-#else
-    function hipblasZrotgBatched_(handle,a,b,c,s,batchCount) bind(c, name="hipblasZrotgBatched")
 #endif
+
+#ifndef USE_CUDA_NAMES
+  interface hipblasZrotgBatched
+    function hipblasZrotgBatched_(handle,a,b,c,s,batchCount) bind(c, name="hipblasZrotgBatched")
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -7239,15 +6782,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasSrotgBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasSrotgBatched_64_(handle,a,b,c,s,batchCount) &
-        bind(c, name="cublasSrotgBatched_64")
-#else
     function hipblasSrotgBatched_64_(handle,a,b,c,s,batchCount) &
         bind(c, name="hipblasSrotgBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -7260,15 +6800,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDrotgBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDrotgBatched_64_(handle,a,b,c,s,batchCount) &
-        bind(c, name="cublasDrotgBatched_64")
-#else
     function hipblasDrotgBatched_64_(handle,a,b,c,s,batchCount) &
         bind(c, name="hipblasDrotgBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -7281,15 +6818,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCrotgBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCrotgBatched_64_(handle,a,b,c,s,batchCount) &
-        bind(c, name="cublasCrotgBatched_64")
-#else
     function hipblasCrotgBatched_64_(handle,a,b,c,s,batchCount) &
         bind(c, name="hipblasCrotgBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -7302,15 +6836,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZrotgBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZrotgBatched_64_(handle,a,b,c,s,batchCount) &
-        bind(c, name="cublasZrotgBatched_64")
-#else
     function hipblasZrotgBatched_64_(handle,a,b,c,s,batchCount) &
         bind(c, name="hipblasZrotgBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -7323,6 +6854,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 1 API
   !>
@@ -7369,16 +6901,11 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of batches (length of arrays a, b, c, and s).
+#ifndef USE_CUDA_NAMES
   interface hipblasSrotgStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasSrotgStridedBatched_(handle,a,stridea,b,strideb,c,stridec,s,strides, &
-        batchCount) &
-        bind(c, name="cublasSrotgStridedBatched")
-#else
     function hipblasSrotgStridedBatched_(handle,a,stridea,b,strideb,c,stridec,s,strides, &
         batchCount) &
         bind(c, name="hipblasSrotgStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -7395,17 +6922,13 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDrotgStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDrotgStridedBatched_(handle,a,stridea,b,strideb,c,stridec,s,strides, &
-        batchCount) &
-        bind(c, name="cublasDrotgStridedBatched")
-#else
     function hipblasDrotgStridedBatched_(handle,a,stridea,b,strideb,c,stridec,s,strides, &
         batchCount) &
         bind(c, name="hipblasDrotgStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -7422,17 +6945,13 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCrotgStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCrotgStridedBatched_(handle,a,stridea,b,strideb,c,stridec,s,strides, &
-        batchCount) &
-        bind(c, name="cublasCrotgStridedBatched")
-#else
     function hipblasCrotgStridedBatched_(handle,a,stridea,b,strideb,c,stridec,s,strides, &
         batchCount) &
         bind(c, name="hipblasCrotgStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -7449,17 +6968,13 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZrotgStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZrotgStridedBatched_(handle,a,stridea,b,strideb,c,stridec,s,strides, &
-        batchCount) &
-        bind(c, name="cublasZrotgStridedBatched")
-#else
     function hipblasZrotgStridedBatched_(handle,a,stridea,b,strideb,c,stridec,s,strides, &
         batchCount) &
         bind(c, name="hipblasZrotgStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -7476,17 +6991,13 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasSrotgStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasSrotgStridedBatched_64_(handle,a,stridea,b,strideb,c,stridec,s,strides, &
-        batchCount) &
-        bind(c, name="cublasSrotgStridedBatched_64")
-#else
     function hipblasSrotgStridedBatched_64_(handle,a,stridea,b,strideb,c,stridec,s,strides, &
         batchCount) &
         bind(c, name="hipblasSrotgStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -7503,17 +7014,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDrotgStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDrotgStridedBatched_64_(handle,a,stridea,b,strideb,c,stridec,s,strides, &
-        batchCount) &
-        bind(c, name="cublasDrotgStridedBatched_64")
-#else
     function hipblasDrotgStridedBatched_64_(handle,a,stridea,b,strideb,c,stridec,s,strides, &
         batchCount) &
         bind(c, name="hipblasDrotgStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -7530,17 +7037,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCrotgStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCrotgStridedBatched_64_(handle,a,stridea,b,strideb,c,stridec,s,strides, &
-        batchCount) &
-        bind(c, name="cublasCrotgStridedBatched_64")
-#else
     function hipblasCrotgStridedBatched_64_(handle,a,stridea,b,strideb,c,stridec,s,strides, &
         batchCount) &
         bind(c, name="hipblasCrotgStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -7557,17 +7060,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZrotgStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZrotgStridedBatched_64_(handle,a,stridea,b,strideb,c,stridec,s,strides, &
-        batchCount) &
-        bind(c, name="cublasZrotgStridedBatched_64")
-#else
     function hipblasZrotgStridedBatched_64_(handle,a,stridea,b,strideb,c,stridec,s,strides, &
         batchCount) &
         bind(c, name="hipblasZrotgStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -7584,6 +7083,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 1 API
   !>
@@ -7757,14 +7257,10 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 the number of x and y arrays, that is, the number of batches.
+#ifndef USE_CUDA_NAMES
   interface hipblasSrotmBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasSrotmBatched_(handle,n,x,incx,y,incy,param,batchCount) &
-        bind(c, name="cublasSrotmBatched")
-#else
     function hipblasSrotmBatched_(handle,n,x,incx,y,incy,param,batchCount) &
         bind(c, name="hipblasSrotmBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -7779,15 +7275,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDrotmBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDrotmBatched_(handle,n,x,incx,y,incy,param,batchCount) &
-        bind(c, name="cublasDrotmBatched")
-#else
     function hipblasDrotmBatched_(handle,n,x,incx,y,incy,param,batchCount) &
         bind(c, name="hipblasDrotmBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -7802,15 +7295,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasSrotmBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasSrotmBatched_64_(handle,n,x,incx,y,incy,param,batchCount) &
-        bind(c, name="cublasSrotmBatched_64")
-#else
     function hipblasSrotmBatched_64_(handle,n,x,incx,y,incy,param,batchCount) &
         bind(c, name="hipblasSrotmBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -7825,15 +7315,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDrotmBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDrotmBatched_64_(handle,n,x,incx,y,incy,param,batchCount) &
-        bind(c, name="cublasDrotmBatched_64")
-#else
     function hipblasDrotmBatched_64_(handle,n,x,incx,y,incy,param,batchCount) &
         bind(c, name="hipblasDrotmBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -7848,6 +7335,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 1 API
   !>
@@ -7902,16 +7390,11 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 the number of x and y arrays, that is, the number of batches.
+#ifndef USE_CUDA_NAMES
   interface hipblasSrotmStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasSrotmStridedBatched_(handle,n,x,incx,stridex,y,incy,stridey,param,strideParam, &
-        batchCount) &
-        bind(c, name="cublasSrotmStridedBatched")
-#else
     function hipblasSrotmStridedBatched_(handle,n,x,incx,stridex,y,incy,stridey,param,strideParam, &
         batchCount) &
         bind(c, name="hipblasSrotmStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -7935,17 +7418,13 @@ module hipfort_hipblas
       hipblasSrotmStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDrotmStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDrotmStridedBatched_(handle,n,x,incx,stridex,y,incy,stridey,param,strideParam, &
-        batchCount) &
-        bind(c, name="cublasDrotmStridedBatched")
-#else
     function hipblasDrotmStridedBatched_(handle,n,x,incx,stridex,y,incy,stridey,param,strideParam, &
         batchCount) &
         bind(c, name="hipblasDrotmStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -7969,17 +7448,13 @@ module hipfort_hipblas
       hipblasDrotmStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasSrotmStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasSrotmStridedBatched_64_(handle,n,x,incx,stridex,y,incy,stridey,param, &
-        strideParam,batchCount) &
-        bind(c, name="cublasSrotmStridedBatched_64")
-#else
     function hipblasSrotmStridedBatched_64_(handle,n,x,incx,stridex,y,incy,stridey,param, &
         strideParam,batchCount) &
         bind(c, name="hipblasSrotmStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -7997,17 +7472,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDrotmStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDrotmStridedBatched_64_(handle,n,x,incx,stridex,y,incy,stridey,param, &
-        strideParam,batchCount) &
-        bind(c, name="cublasDrotmStridedBatched_64")
-#else
     function hipblasDrotmStridedBatched_64_(handle,n,x,incx,stridex,y,incy,stridey,param, &
         strideParam,batchCount) &
         bind(c, name="hipblasDrotmStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -8025,6 +7496,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 1 API
   !>
@@ -8182,14 +7654,10 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 the number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasSrotmgBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasSrotmgBatched_(handle,d1,d2,x1,y1,param,batchCount) &
-        bind(c, name="cublasSrotmgBatched")
-#else
     function hipblasSrotmgBatched_(handle,d1,d2,x1,y1,param,batchCount) &
         bind(c, name="hipblasSrotmgBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -8203,15 +7671,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDrotmgBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDrotmgBatched_(handle,d1,d2,x1,y1,param,batchCount) &
-        bind(c, name="cublasDrotmgBatched")
-#else
     function hipblasDrotmgBatched_(handle,d1,d2,x1,y1,param,batchCount) &
         bind(c, name="hipblasDrotmgBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -8225,15 +7690,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasSrotmgBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasSrotmgBatched_64_(handle,d1,d2,x1,y1,param,batchCount) &
-        bind(c, name="cublasSrotmgBatched_64")
-#else
     function hipblasSrotmgBatched_64_(handle,d1,d2,x1,y1,param,batchCount) &
         bind(c, name="hipblasSrotmgBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -8247,15 +7709,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDrotmgBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDrotmgBatched_64_(handle,d1,d2,x1,y1,param,batchCount) &
-        bind(c, name="cublasDrotmgBatched_64")
-#else
     function hipblasDrotmgBatched_64_(handle,d1,d2,x1,y1,param,batchCount) &
         bind(c, name="hipblasDrotmgBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -8269,6 +7728,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 1 API
   !>
@@ -8332,16 +7792,11 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 the number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasSrotmgStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasSrotmgStridedBatched_(handle,d1,strided1,d2,strided2,x1,stridex1,y1,stridey1, &
-        param,strideParam,batchCount) &
-        bind(c, name="cublasSrotmgStridedBatched")
-#else
     function hipblasSrotmgStridedBatched_(handle,d1,strided1,d2,strided2,x1,stridex1,y1,stridey1, &
         param,strideParam,batchCount) &
         bind(c, name="hipblasSrotmgStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -8360,17 +7815,13 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDrotmgStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDrotmgStridedBatched_(handle,d1,strided1,d2,strided2,x1,stridex1,y1,stridey1, &
-        param,strideParam,batchCount) &
-        bind(c, name="cublasDrotmgStridedBatched")
-#else
     function hipblasDrotmgStridedBatched_(handle,d1,strided1,d2,strided2,x1,stridex1,y1,stridey1, &
         param,strideParam,batchCount) &
         bind(c, name="hipblasDrotmgStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -8389,17 +7840,13 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasSrotmgStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasSrotmgStridedBatched_64_(handle,d1,strided1,d2,strided2,x1,stridex1,y1, &
-        stridey1,param,strideParam,batchCount) &
-        bind(c, name="cublasSrotmgStridedBatched_64")
-#else
     function hipblasSrotmgStridedBatched_64_(handle,d1,strided1,d2,strided2,x1,stridex1,y1, &
         stridey1,param,strideParam,batchCount) &
         bind(c, name="hipblasSrotmgStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -8418,17 +7865,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDrotmgStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDrotmgStridedBatched_64_(handle,d1,strided1,d2,strided2,x1,stridex1,y1, &
-        stridey1,param,strideParam,batchCount) &
-        bind(c, name="cublasDrotmgStridedBatched_64")
-#else
     function hipblasDrotmgStridedBatched_64_(handle,d1,strided1,d2,strided2,x1,stridex1,y1, &
         stridey1,param,strideParam,batchCount) &
         bind(c, name="hipblasDrotmgStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -8447,6 +7890,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief   BLAS Level 1 API
   !>
@@ -8751,14 +8195,10 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 specifies the number of batches in x.
+#ifndef USE_CUDA_NAMES
   interface hipblasSscalBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasSscalBatched_(handle,n,alpha,x,incx,batchCount) &
-        bind(c, name="cublasSscalBatched")
-#else
     function hipblasSscalBatched_(handle,n,alpha,x,incx,batchCount) &
         bind(c, name="hipblasSscalBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -8771,15 +8211,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDscalBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDscalBatched_(handle,n,alpha,x,incx,batchCount) &
-        bind(c, name="cublasDscalBatched")
-#else
     function hipblasDscalBatched_(handle,n,alpha,x,incx,batchCount) &
         bind(c, name="hipblasDscalBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -8792,15 +8229,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCscalBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCscalBatched_(handle,n,alpha,x,incx,batchCount) &
-        bind(c, name="cublasCscalBatched")
-#else
     function hipblasCscalBatched_(handle,n,alpha,x,incx,batchCount) &
         bind(c, name="hipblasCscalBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -8813,15 +8247,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZscalBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZscalBatched_(handle,n,alpha,x,incx,batchCount) &
-        bind(c, name="cublasZscalBatched")
-#else
     function hipblasZscalBatched_(handle,n,alpha,x,incx,batchCount) &
         bind(c, name="hipblasZscalBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -8834,15 +8265,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCsscalBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCsscalBatched_(handle,n,alpha,x,incx,batchCount) &
-        bind(c, name="cublasCsscalBatched")
-#else
     function hipblasCsscalBatched_(handle,n,alpha,x,incx,batchCount) &
         bind(c, name="hipblasCsscalBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -8855,15 +8283,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZdscalBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZdscalBatched_(handle,n,alpha,x,incx,batchCount) &
-        bind(c, name="cublasZdscalBatched")
-#else
     function hipblasZdscalBatched_(handle,n,alpha,x,incx,batchCount) &
         bind(c, name="hipblasZdscalBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -8876,15 +8301,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasSscalBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasSscalBatched_64_(handle,n,alpha,x,incx,batchCount) &
-        bind(c, name="cublasSscalBatched_64")
-#else
     function hipblasSscalBatched_64_(handle,n,alpha,x,incx,batchCount) &
         bind(c, name="hipblasSscalBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -8897,15 +8319,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDscalBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDscalBatched_64_(handle,n,alpha,x,incx,batchCount) &
-        bind(c, name="cublasDscalBatched_64")
-#else
     function hipblasDscalBatched_64_(handle,n,alpha,x,incx,batchCount) &
         bind(c, name="hipblasDscalBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -8918,15 +8337,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCscalBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCscalBatched_64_(handle,n,alpha,x,incx,batchCount) &
-        bind(c, name="cublasCscalBatched_64")
-#else
     function hipblasCscalBatched_64_(handle,n,alpha,x,incx,batchCount) &
         bind(c, name="hipblasCscalBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -8939,15 +8355,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZscalBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZscalBatched_64_(handle,n,alpha,x,incx,batchCount) &
-        bind(c, name="cublasZscalBatched_64")
-#else
     function hipblasZscalBatched_64_(handle,n,alpha,x,incx,batchCount) &
         bind(c, name="hipblasZscalBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -8960,15 +8373,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCsscalBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCsscalBatched_64_(handle,n,alpha,x,incx,batchCount) &
-        bind(c, name="cublasCsscalBatched_64")
-#else
     function hipblasCsscalBatched_64_(handle,n,alpha,x,incx,batchCount) &
         bind(c, name="hipblasCsscalBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -8981,15 +8391,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZdscalBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZdscalBatched_64_(handle,n,alpha,x,incx,batchCount) &
-        bind(c, name="cublasZdscalBatched_64")
-#else
     function hipblasZdscalBatched_64_(handle,n,alpha,x,incx,batchCount) &
         bind(c, name="hipblasZdscalBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -9002,6 +8409,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 1 API
   !>     \details
@@ -9037,14 +8445,10 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 specifies the number of batches in x.
+#ifndef USE_CUDA_NAMES
   interface hipblasSscalStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasSscalStridedBatched_(handle,n,alpha,x,incx,stridex,batchCount) &
-        bind(c, name="cublasSscalStridedBatched")
-#else
     function hipblasSscalStridedBatched_(handle,n,alpha,x,incx,stridex,batchCount) &
         bind(c, name="hipblasSscalStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -9064,15 +8468,12 @@ module hipfort_hipblas
       hipblasSscalStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDscalStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDscalStridedBatched_(handle,n,alpha,x,incx,stridex,batchCount) &
-        bind(c, name="cublasDscalStridedBatched")
-#else
     function hipblasDscalStridedBatched_(handle,n,alpha,x,incx,stridex,batchCount) &
         bind(c, name="hipblasDscalStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -9092,15 +8493,12 @@ module hipfort_hipblas
       hipblasDscalStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCscalStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCscalStridedBatched_(handle,n,alpha,x,incx,stridex,batchCount) &
-        bind(c, name="cublasCscalStridedBatched")
-#else
     function hipblasCscalStridedBatched_(handle,n,alpha,x,incx,stridex,batchCount) &
         bind(c, name="hipblasCscalStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -9120,15 +8518,12 @@ module hipfort_hipblas
       hipblasCscalStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZscalStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZscalStridedBatched_(handle,n,alpha,x,incx,stridex,batchCount) &
-        bind(c, name="cublasZscalStridedBatched")
-#else
     function hipblasZscalStridedBatched_(handle,n,alpha,x,incx,stridex,batchCount) &
         bind(c, name="hipblasZscalStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -9148,15 +8543,12 @@ module hipfort_hipblas
       hipblasZscalStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCsscalStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCsscalStridedBatched_(handle,n,alpha,x,incx,stridex,batchCount) &
-        bind(c, name="cublasCsscalStridedBatched")
-#else
     function hipblasCsscalStridedBatched_(handle,n,alpha,x,incx,stridex,batchCount) &
         bind(c, name="hipblasCsscalStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -9176,15 +8568,12 @@ module hipfort_hipblas
       hipblasCsscalStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZdscalStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZdscalStridedBatched_(handle,n,alpha,x,incx,stridex,batchCount) &
-        bind(c, name="cublasZdscalStridedBatched")
-#else
     function hipblasZdscalStridedBatched_(handle,n,alpha,x,incx,stridex,batchCount) &
         bind(c, name="hipblasZdscalStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -9204,15 +8593,12 @@ module hipfort_hipblas
       hipblasZdscalStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasSscalStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasSscalStridedBatched_64_(handle,n,alpha,x,incx,stridex,batchCount) &
-        bind(c, name="cublasSscalStridedBatched_64")
-#else
     function hipblasSscalStridedBatched_64_(handle,n,alpha,x,incx,stridex,batchCount) &
         bind(c, name="hipblasSscalStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -9226,15 +8612,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDscalStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDscalStridedBatched_64_(handle,n,alpha,x,incx,stridex,batchCount) &
-        bind(c, name="cublasDscalStridedBatched_64")
-#else
     function hipblasDscalStridedBatched_64_(handle,n,alpha,x,incx,stridex,batchCount) &
         bind(c, name="hipblasDscalStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -9248,15 +8631,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCscalStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCscalStridedBatched_64_(handle,n,alpha,x,incx,stridex,batchCount) &
-        bind(c, name="cublasCscalStridedBatched_64")
-#else
     function hipblasCscalStridedBatched_64_(handle,n,alpha,x,incx,stridex,batchCount) &
         bind(c, name="hipblasCscalStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -9270,15 +8650,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZscalStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZscalStridedBatched_64_(handle,n,alpha,x,incx,stridex,batchCount) &
-        bind(c, name="cublasZscalStridedBatched_64")
-#else
     function hipblasZscalStridedBatched_64_(handle,n,alpha,x,incx,stridex,batchCount) &
         bind(c, name="hipblasZscalStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -9292,15 +8669,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCsscalStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCsscalStridedBatched_64_(handle,n,alpha,x,incx,stridex,batchCount) &
-        bind(c, name="cublasCsscalStridedBatched_64")
-#else
     function hipblasCsscalStridedBatched_64_(handle,n,alpha,x,incx,stridex,batchCount) &
         bind(c, name="hipblasCsscalStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -9314,15 +8688,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZdscalStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZdscalStridedBatched_64_(handle,n,alpha,x,incx,stridex,batchCount) &
-        bind(c, name="cublasZdscalStridedBatched_64")
-#else
     function hipblasZdscalStridedBatched_64_(handle,n,alpha,x,incx,stridex,batchCount) &
         bind(c, name="hipblasZdscalStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -9336,6 +8707,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 1 API
   !>
@@ -9569,14 +8941,10 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasSswapBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasSswapBatched_(handle,n,x,incx,y,incy,batchCount) &
-        bind(c, name="cublasSswapBatched")
-#else
     function hipblasSswapBatched_(handle,n,x,incx,y,incy,batchCount) &
         bind(c, name="hipblasSswapBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -9590,15 +8958,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDswapBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDswapBatched_(handle,n,x,incx,y,incy,batchCount) &
-        bind(c, name="cublasDswapBatched")
-#else
     function hipblasDswapBatched_(handle,n,x,incx,y,incy,batchCount) &
         bind(c, name="hipblasDswapBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -9612,15 +8977,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCswapBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCswapBatched_(handle,n,x,incx,y,incy,batchCount) &
-        bind(c, name="cublasCswapBatched")
-#else
     function hipblasCswapBatched_(handle,n,x,incx,y,incy,batchCount) &
         bind(c, name="hipblasCswapBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -9634,15 +8996,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZswapBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZswapBatched_(handle,n,x,incx,y,incy,batchCount) &
-        bind(c, name="cublasZswapBatched")
-#else
     function hipblasZswapBatched_(handle,n,x,incx,y,incy,batchCount) &
         bind(c, name="hipblasZswapBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -9656,15 +9015,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasSswapBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasSswapBatched_64_(handle,n,x,incx,y,incy,batchCount) &
-        bind(c, name="cublasSswapBatched_64")
-#else
     function hipblasSswapBatched_64_(handle,n,x,incx,y,incy,batchCount) &
         bind(c, name="hipblasSswapBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -9678,15 +9034,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDswapBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDswapBatched_64_(handle,n,x,incx,y,incy,batchCount) &
-        bind(c, name="cublasDswapBatched_64")
-#else
     function hipblasDswapBatched_64_(handle,n,x,incx,y,incy,batchCount) &
         bind(c, name="hipblasDswapBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -9700,15 +9053,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCswapBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCswapBatched_64_(handle,n,x,incx,y,incy,batchCount) &
-        bind(c, name="cublasCswapBatched_64")
-#else
     function hipblasCswapBatched_64_(handle,n,x,incx,y,incy,batchCount) &
         bind(c, name="hipblasCswapBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -9722,15 +9072,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZswapBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZswapBatched_64_(handle,n,x,incx,y,incy,batchCount) &
-        bind(c, name="cublasZswapBatched_64")
-#else
     function hipblasZswapBatched_64_(handle,n,x,incx,y,incy,batchCount) &
         bind(c, name="hipblasZswapBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -9744,6 +9091,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 1 API
   !>
@@ -9787,14 +9135,10 @@ module hipfort_hipblas
   !>      @param[in]
   !>      batchCount [int]
   !>                  number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasSswapStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasSswapStridedBatched_(handle,n,x,incx,stridex,y,incy,stridey,batchCount) &
-        bind(c, name="cublasSswapStridedBatched")
-#else
     function hipblasSswapStridedBatched_(handle,n,x,incx,stridex,y,incy,stridey,batchCount) &
         bind(c, name="hipblasSswapStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -9816,15 +9160,12 @@ module hipfort_hipblas
       hipblasSswapStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDswapStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDswapStridedBatched_(handle,n,x,incx,stridex,y,incy,stridey,batchCount) &
-        bind(c, name="cublasDswapStridedBatched")
-#else
     function hipblasDswapStridedBatched_(handle,n,x,incx,stridex,y,incy,stridey,batchCount) &
         bind(c, name="hipblasDswapStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -9846,15 +9187,12 @@ module hipfort_hipblas
       hipblasDswapStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCswapStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCswapStridedBatched_(handle,n,x,incx,stridex,y,incy,stridey,batchCount) &
-        bind(c, name="cublasCswapStridedBatched")
-#else
     function hipblasCswapStridedBatched_(handle,n,x,incx,stridex,y,incy,stridey,batchCount) &
         bind(c, name="hipblasCswapStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -9876,15 +9214,12 @@ module hipfort_hipblas
       hipblasCswapStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZswapStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZswapStridedBatched_(handle,n,x,incx,stridex,y,incy,stridey,batchCount) &
-        bind(c, name="cublasZswapStridedBatched")
-#else
     function hipblasZswapStridedBatched_(handle,n,x,incx,stridex,y,incy,stridey,batchCount) &
         bind(c, name="hipblasZswapStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -9906,15 +9241,12 @@ module hipfort_hipblas
       hipblasZswapStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasSswapStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasSswapStridedBatched_64_(handle,n,x,incx,stridex,y,incy,stridey,batchCount) &
-        bind(c, name="cublasSswapStridedBatched_64")
-#else
     function hipblasSswapStridedBatched_64_(handle,n,x,incx,stridex,y,incy,stridey,batchCount) &
         bind(c, name="hipblasSswapStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -9930,15 +9262,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDswapStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDswapStridedBatched_64_(handle,n,x,incx,stridex,y,incy,stridey,batchCount) &
-        bind(c, name="cublasDswapStridedBatched_64")
-#else
     function hipblasDswapStridedBatched_64_(handle,n,x,incx,stridex,y,incy,stridey,batchCount) &
         bind(c, name="hipblasDswapStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -9954,15 +9283,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCswapStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCswapStridedBatched_64_(handle,n,x,incx,stridex,y,incy,stridey,batchCount) &
-        bind(c, name="cublasCswapStridedBatched_64")
-#else
     function hipblasCswapStridedBatched_64_(handle,n,x,incx,stridex,y,incy,stridey,batchCount) &
         bind(c, name="hipblasCswapStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -9978,15 +9304,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZswapStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZswapStridedBatched_64_(handle,n,x,incx,stridex,y,incy,stridey,batchCount) &
-        bind(c, name="cublasZswapStridedBatched_64")
-#else
     function hipblasZswapStridedBatched_64_(handle,n,x,incx,stridex,y,incy,stridey,batchCount) &
         bind(c, name="hipblasZswapStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -10002,6 +9325,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 2 API
   !>
@@ -10402,16 +9726,11 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 specifies the number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasSgbmvBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasSgbmvBatched_(handle,trans,m,n,kl,ku,alpha,AP,lda,x,incx,beta,y,incy, &
-        batchCount) &
-        bind(c, name="cublasSgbmvBatched")
-#else
     function hipblasSgbmvBatched_(handle,trans,m,n,kl,ku,alpha,AP,lda,x,incx,beta,y,incy, &
         batchCount) &
         bind(c, name="hipblasSgbmvBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -10433,17 +9752,13 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDgbmvBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDgbmvBatched_(handle,trans,m,n,kl,ku,alpha,AP,lda,x,incx,beta,y,incy, &
-        batchCount) &
-        bind(c, name="cublasDgbmvBatched")
-#else
     function hipblasDgbmvBatched_(handle,trans,m,n,kl,ku,alpha,AP,lda,x,incx,beta,y,incy, &
         batchCount) &
         bind(c, name="hipblasDgbmvBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -10465,17 +9780,13 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCgbmvBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCgbmvBatched_(handle,trans,m,n,kl,ku,alpha,AP,lda,x,incx,beta,y,incy, &
-        batchCount) &
-        bind(c, name="cublasCgbmvBatched")
-#else
     function hipblasCgbmvBatched_(handle,trans,m,n,kl,ku,alpha,AP,lda,x,incx,beta,y,incy, &
         batchCount) &
         bind(c, name="hipblasCgbmvBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -10497,17 +9808,13 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZgbmvBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZgbmvBatched_(handle,trans,m,n,kl,ku,alpha,AP,lda,x,incx,beta,y,incy, &
-        batchCount) &
-        bind(c, name="cublasZgbmvBatched")
-#else
     function hipblasZgbmvBatched_(handle,trans,m,n,kl,ku,alpha,AP,lda,x,incx,beta,y,incy, &
         batchCount) &
         bind(c, name="hipblasZgbmvBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -10529,17 +9836,13 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasSgbmvBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasSgbmvBatched_64_(handle,trans,m,n,kl,ku,alpha,AP,lda,x,incx,beta,y,incy, &
-        batchCount) &
-        bind(c, name="cublasSgbmvBatched_64")
-#else
     function hipblasSgbmvBatched_64_(handle,trans,m,n,kl,ku,alpha,AP,lda,x,incx,beta,y,incy, &
         batchCount) &
         bind(c, name="hipblasSgbmvBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -10561,17 +9864,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDgbmvBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDgbmvBatched_64_(handle,trans,m,n,kl,ku,alpha,AP,lda,x,incx,beta,y,incy, &
-        batchCount) &
-        bind(c, name="cublasDgbmvBatched_64")
-#else
     function hipblasDgbmvBatched_64_(handle,trans,m,n,kl,ku,alpha,AP,lda,x,incx,beta,y,incy, &
         batchCount) &
         bind(c, name="hipblasDgbmvBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -10593,17 +9892,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCgbmvBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCgbmvBatched_64_(handle,trans,m,n,kl,ku,alpha,AP,lda,x,incx,beta,y,incy, &
-        batchCount) &
-        bind(c, name="cublasCgbmvBatched_64")
-#else
     function hipblasCgbmvBatched_64_(handle,trans,m,n,kl,ku,alpha,AP,lda,x,incx,beta,y,incy, &
         batchCount) &
         bind(c, name="hipblasCgbmvBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -10625,17 +9920,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZgbmvBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZgbmvBatched_64_(handle,trans,m,n,kl,ku,alpha,AP,lda,x,incx,beta,y,incy, &
-        batchCount) &
-        bind(c, name="cublasZgbmvBatched_64")
-#else
     function hipblasZgbmvBatched_64_(handle,trans,m,n,kl,ku,alpha,AP,lda,x,incx,beta,y,incy, &
         batchCount) &
         bind(c, name="hipblasZgbmvBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -10657,6 +9948,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 2 API
   !>
@@ -10739,16 +10031,11 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 specifies the number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasSgbmvStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasSgbmvStridedBatched_(handle,trans,m,n,kl,ku,alpha,AP,lda,strideA,x,incx, &
-        stridex,beta,y,incy,stridey,batchCount) &
-        bind(c, name="cublasSgbmvStridedBatched")
-#else
     function hipblasSgbmvStridedBatched_(handle,trans,m,n,kl,ku,alpha,AP,lda,strideA,x,incx, &
         stridex,beta,y,incy,stridey,batchCount) &
         bind(c, name="hipblasSgbmvStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -10780,17 +10067,13 @@ module hipfort_hipblas
       hipblasSgbmvStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDgbmvStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDgbmvStridedBatched_(handle,trans,m,n,kl,ku,alpha,AP,lda,strideA,x,incx, &
-        stridex,beta,y,incy,stridey,batchCount) &
-        bind(c, name="cublasDgbmvStridedBatched")
-#else
     function hipblasDgbmvStridedBatched_(handle,trans,m,n,kl,ku,alpha,AP,lda,strideA,x,incx, &
         stridex,beta,y,incy,stridey,batchCount) &
         bind(c, name="hipblasDgbmvStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -10822,17 +10105,13 @@ module hipfort_hipblas
       hipblasDgbmvStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCgbmvStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCgbmvStridedBatched_(handle,trans,m,n,kl,ku,alpha,AP,lda,strideA,x,incx, &
-        stridex,beta,y,incy,stridey,batchCount) &
-        bind(c, name="cublasCgbmvStridedBatched")
-#else
     function hipblasCgbmvStridedBatched_(handle,trans,m,n,kl,ku,alpha,AP,lda,strideA,x,incx, &
         stridex,beta,y,incy,stridey,batchCount) &
         bind(c, name="hipblasCgbmvStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -10864,17 +10143,13 @@ module hipfort_hipblas
       hipblasCgbmvStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZgbmvStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZgbmvStridedBatched_(handle,trans,m,n,kl,ku,alpha,AP,lda,strideA,x,incx, &
-        stridex,beta,y,incy,stridey,batchCount) &
-        bind(c, name="cublasZgbmvStridedBatched")
-#else
     function hipblasZgbmvStridedBatched_(handle,trans,m,n,kl,ku,alpha,AP,lda,strideA,x,incx, &
         stridex,beta,y,incy,stridey,batchCount) &
         bind(c, name="hipblasZgbmvStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -10906,17 +10181,13 @@ module hipfort_hipblas
       hipblasZgbmvStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasSgbmvStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasSgbmvStridedBatched_64_(handle,trans,m,n,kl,ku,alpha,AP,lda,strideA,x,incx, &
-        stridex,beta,y,incy,stridey,batchCount) &
-        bind(c, name="cublasSgbmvStridedBatched_64")
-#else
     function hipblasSgbmvStridedBatched_64_(handle,trans,m,n,kl,ku,alpha,AP,lda,strideA,x,incx, &
         stridex,beta,y,incy,stridey,batchCount) &
         bind(c, name="hipblasSgbmvStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -10941,17 +10212,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDgbmvStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDgbmvStridedBatched_64_(handle,trans,m,n,kl,ku,alpha,AP,lda,strideA,x,incx, &
-        stridex,beta,y,incy,stridey,batchCount) &
-        bind(c, name="cublasDgbmvStridedBatched_64")
-#else
     function hipblasDgbmvStridedBatched_64_(handle,trans,m,n,kl,ku,alpha,AP,lda,strideA,x,incx, &
         stridex,beta,y,incy,stridey,batchCount) &
         bind(c, name="hipblasDgbmvStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -10976,17 +10243,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCgbmvStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCgbmvStridedBatched_64_(handle,trans,m,n,kl,ku,alpha,AP,lda,strideA,x,incx, &
-        stridex,beta,y,incy,stridey,batchCount) &
-        bind(c, name="cublasCgbmvStridedBatched_64")
-#else
     function hipblasCgbmvStridedBatched_64_(handle,trans,m,n,kl,ku,alpha,AP,lda,strideA,x,incx, &
         stridex,beta,y,incy,stridey,batchCount) &
         bind(c, name="hipblasCgbmvStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -11011,17 +10274,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZgbmvStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZgbmvStridedBatched_64_(handle,trans,m,n,kl,ku,alpha,AP,lda,strideA,x,incx, &
-        stridex,beta,y,incy,stridey,batchCount) &
-        bind(c, name="cublasZgbmvStridedBatched_64")
-#else
     function hipblasZgbmvStridedBatched_64_(handle,trans,m,n,kl,ku,alpha,AP,lda,strideA,x,incx, &
         stridex,beta,y,incy,stridey,batchCount) &
         bind(c, name="hipblasZgbmvStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -11046,6 +10305,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 2 API
   !>
@@ -12378,14 +11638,10 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasSgerBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasSgerBatched_(handle,m,n,alpha,x,incx,y,incy,AP,lda,batchCount) &
-        bind(c, name="cublasSgerBatched")
-#else
     function hipblasSgerBatched_(handle,m,n,alpha,x,incx,y,incy,AP,lda,batchCount) &
         bind(c, name="hipblasSgerBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -12403,15 +11659,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDgerBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDgerBatched_(handle,m,n,alpha,x,incx,y,incy,AP,lda,batchCount) &
-        bind(c, name="cublasDgerBatched")
-#else
     function hipblasDgerBatched_(handle,m,n,alpha,x,incx,y,incy,AP,lda,batchCount) &
         bind(c, name="hipblasDgerBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -12429,15 +11682,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCgeruBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCgeruBatched_(handle,m,n,alpha,x,incx,y,incy,AP,lda,batchCount) &
-        bind(c, name="cublasCgeruBatched")
-#else
     function hipblasCgeruBatched_(handle,m,n,alpha,x,incx,y,incy,AP,lda,batchCount) &
         bind(c, name="hipblasCgeruBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -12455,15 +11705,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCgercBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCgercBatched_(handle,m,n,alpha,x,incx,y,incy,AP,lda,batchCount) &
-        bind(c, name="cublasCgercBatched")
-#else
     function hipblasCgercBatched_(handle,m,n,alpha,x,incx,y,incy,AP,lda,batchCount) &
         bind(c, name="hipblasCgercBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -12481,15 +11728,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZgeruBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZgeruBatched_(handle,m,n,alpha,x,incx,y,incy,AP,lda,batchCount) &
-        bind(c, name="cublasZgeruBatched")
-#else
     function hipblasZgeruBatched_(handle,m,n,alpha,x,incx,y,incy,AP,lda,batchCount) &
         bind(c, name="hipblasZgeruBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -12507,15 +11751,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZgercBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZgercBatched_(handle,m,n,alpha,x,incx,y,incy,AP,lda,batchCount) &
-        bind(c, name="cublasZgercBatched")
-#else
     function hipblasZgercBatched_(handle,m,n,alpha,x,incx,y,incy,AP,lda,batchCount) &
         bind(c, name="hipblasZgercBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -12533,15 +11774,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasSgerBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasSgerBatched_64_(handle,m,n,alpha,x,incx,y,incy,AP,lda,batchCount) &
-        bind(c, name="cublasSgerBatched_64")
-#else
     function hipblasSgerBatched_64_(handle,m,n,alpha,x,incx,y,incy,AP,lda,batchCount) &
         bind(c, name="hipblasSgerBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -12559,15 +11797,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDgerBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDgerBatched_64_(handle,m,n,alpha,x,incx,y,incy,AP,lda,batchCount) &
-        bind(c, name="cublasDgerBatched_64")
-#else
     function hipblasDgerBatched_64_(handle,m,n,alpha,x,incx,y,incy,AP,lda,batchCount) &
         bind(c, name="hipblasDgerBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -12585,15 +11820,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCgeruBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCgeruBatched_64_(handle,m,n,alpha,x,incx,y,incy,AP,lda,batchCount) &
-        bind(c, name="cublasCgeruBatched_64")
-#else
     function hipblasCgeruBatched_64_(handle,m,n,alpha,x,incx,y,incy,AP,lda,batchCount) &
         bind(c, name="hipblasCgeruBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -12611,15 +11843,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCgercBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCgercBatched_64_(handle,m,n,alpha,x,incx,y,incy,AP,lda,batchCount) &
-        bind(c, name="cublasCgercBatched_64")
-#else
     function hipblasCgercBatched_64_(handle,m,n,alpha,x,incx,y,incy,AP,lda,batchCount) &
         bind(c, name="hipblasCgercBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -12637,15 +11866,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZgeruBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZgeruBatched_64_(handle,m,n,alpha,x,incx,y,incy,AP,lda,batchCount) &
-        bind(c, name="cublasZgeruBatched_64")
-#else
     function hipblasZgeruBatched_64_(handle,m,n,alpha,x,incx,y,incy,AP,lda,batchCount) &
         bind(c, name="hipblasZgeruBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -12663,15 +11889,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZgercBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZgercBatched_64_(handle,m,n,alpha,x,incx,y,incy,AP,lda,batchCount) &
-        bind(c, name="cublasZgercBatched_64")
-#else
     function hipblasZgercBatched_64_(handle,m,n,alpha,x,incx,y,incy,AP,lda,batchCount) &
         bind(c, name="hipblasZgercBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -12689,6 +11912,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 2 API
   !>
@@ -12751,16 +11975,11 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasSgerStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasSgerStridedBatched_(handle,m,n,alpha,x,incx,stridex,y,incy,stridey,AP,lda, &
-        strideA,batchCount) &
-        bind(c, name="cublasSgerStridedBatched")
-#else
     function hipblasSgerStridedBatched_(handle,m,n,alpha,x,incx,stridex,y,incy,stridey,AP,lda, &
         strideA,batchCount) &
         bind(c, name="hipblasSgerStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -12788,17 +12007,13 @@ module hipfort_hipblas
       hipblasSgerStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDgerStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDgerStridedBatched_(handle,m,n,alpha,x,incx,stridex,y,incy,stridey,AP,lda, &
-        strideA,batchCount) &
-        bind(c, name="cublasDgerStridedBatched")
-#else
     function hipblasDgerStridedBatched_(handle,m,n,alpha,x,incx,stridex,y,incy,stridey,AP,lda, &
         strideA,batchCount) &
         bind(c, name="hipblasDgerStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -12826,17 +12041,13 @@ module hipfort_hipblas
       hipblasDgerStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCgeruStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCgeruStridedBatched_(handle,m,n,alpha,x,incx,stridex,y,incy,stridey,AP,lda, &
-        strideA,batchCount) &
-        bind(c, name="cublasCgeruStridedBatched")
-#else
     function hipblasCgeruStridedBatched_(handle,m,n,alpha,x,incx,stridex,y,incy,stridey,AP,lda, &
         strideA,batchCount) &
         bind(c, name="hipblasCgeruStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -12864,17 +12075,13 @@ module hipfort_hipblas
       hipblasCgeruStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCgercStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCgercStridedBatched_(handle,m,n,alpha,x,incx,stridex,y,incy,stridey,AP,lda, &
-        strideA,batchCount) &
-        bind(c, name="cublasCgercStridedBatched")
-#else
     function hipblasCgercStridedBatched_(handle,m,n,alpha,x,incx,stridex,y,incy,stridey,AP,lda, &
         strideA,batchCount) &
         bind(c, name="hipblasCgercStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -12902,17 +12109,13 @@ module hipfort_hipblas
       hipblasCgercStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZgeruStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZgeruStridedBatched_(handle,m,n,alpha,x,incx,stridex,y,incy,stridey,AP,lda, &
-        strideA,batchCount) &
-        bind(c, name="cublasZgeruStridedBatched")
-#else
     function hipblasZgeruStridedBatched_(handle,m,n,alpha,x,incx,stridex,y,incy,stridey,AP,lda, &
         strideA,batchCount) &
         bind(c, name="hipblasZgeruStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -12940,17 +12143,13 @@ module hipfort_hipblas
       hipblasZgeruStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZgercStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZgercStridedBatched_(handle,m,n,alpha,x,incx,stridex,y,incy,stridey,AP,lda, &
-        strideA,batchCount) &
-        bind(c, name="cublasZgercStridedBatched")
-#else
     function hipblasZgercStridedBatched_(handle,m,n,alpha,x,incx,stridex,y,incy,stridey,AP,lda, &
         strideA,batchCount) &
         bind(c, name="hipblasZgercStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -12978,17 +12177,13 @@ module hipfort_hipblas
       hipblasZgercStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasSgerStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasSgerStridedBatched_64_(handle,m,n,alpha,x,incx,stridex,y,incy,stridey,AP,lda, &
-        strideA,batchCount) &
-        bind(c, name="cublasSgerStridedBatched_64")
-#else
     function hipblasSgerStridedBatched_64_(handle,m,n,alpha,x,incx,stridex,y,incy,stridey,AP,lda, &
         strideA,batchCount) &
         bind(c, name="hipblasSgerStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -13009,17 +12204,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDgerStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDgerStridedBatched_64_(handle,m,n,alpha,x,incx,stridex,y,incy,stridey,AP,lda, &
-        strideA,batchCount) &
-        bind(c, name="cublasDgerStridedBatched_64")
-#else
     function hipblasDgerStridedBatched_64_(handle,m,n,alpha,x,incx,stridex,y,incy,stridey,AP,lda, &
         strideA,batchCount) &
         bind(c, name="hipblasDgerStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -13040,17 +12231,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCgeruStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCgeruStridedBatched_64_(handle,m,n,alpha,x,incx,stridex,y,incy,stridey,AP,lda, &
-        strideA,batchCount) &
-        bind(c, name="cublasCgeruStridedBatched_64")
-#else
     function hipblasCgeruStridedBatched_64_(handle,m,n,alpha,x,incx,stridex,y,incy,stridey,AP,lda, &
         strideA,batchCount) &
         bind(c, name="hipblasCgeruStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -13071,17 +12258,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCgercStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCgercStridedBatched_64_(handle,m,n,alpha,x,incx,stridex,y,incy,stridey,AP,lda, &
-        strideA,batchCount) &
-        bind(c, name="cublasCgercStridedBatched_64")
-#else
     function hipblasCgercStridedBatched_64_(handle,m,n,alpha,x,incx,stridex,y,incy,stridey,AP,lda, &
         strideA,batchCount) &
         bind(c, name="hipblasCgercStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -13102,17 +12285,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZgeruStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZgeruStridedBatched_64_(handle,m,n,alpha,x,incx,stridex,y,incy,stridey,AP,lda, &
-        strideA,batchCount) &
-        bind(c, name="cublasZgeruStridedBatched_64")
-#else
     function hipblasZgeruStridedBatched_64_(handle,m,n,alpha,x,incx,stridex,y,incy,stridey,AP,lda, &
         strideA,batchCount) &
         bind(c, name="hipblasZgeruStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -13133,17 +12312,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZgercStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZgercStridedBatched_64_(handle,m,n,alpha,x,incx,stridex,y,incy,stridey,AP,lda, &
-        strideA,batchCount) &
-        bind(c, name="cublasZgercStridedBatched_64")
-#else
     function hipblasZgercStridedBatched_64_(handle,m,n,alpha,x,incx,stridex,y,incy,stridey,AP,lda, &
         strideA,batchCount) &
         bind(c, name="hipblasZgercStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -13164,6 +12339,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 2 API
   !>
@@ -13437,14 +12613,10 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasChbmvBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasChbmvBatched_(handle,uplo,n,k,alpha,AP,lda,x,incx,beta,y,incy,batchCount) &
-        bind(c, name="cublasChbmvBatched")
-#else
     function hipblasChbmvBatched_(handle,uplo,n,k,alpha,AP,lda,x,incx,beta,y,incy,batchCount) &
         bind(c, name="hipblasChbmvBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -13464,15 +12636,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZhbmvBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZhbmvBatched_(handle,uplo,n,k,alpha,AP,lda,x,incx,beta,y,incy,batchCount) &
-        bind(c, name="cublasZhbmvBatched")
-#else
     function hipblasZhbmvBatched_(handle,uplo,n,k,alpha,AP,lda,x,incx,beta,y,incy,batchCount) &
         bind(c, name="hipblasZhbmvBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -13492,15 +12661,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasChbmvBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasChbmvBatched_64_(handle,uplo,n,k,alpha,AP,lda,x,incx,beta,y,incy,batchCount) &
-        bind(c, name="cublasChbmvBatched_64")
-#else
     function hipblasChbmvBatched_64_(handle,uplo,n,k,alpha,AP,lda,x,incx,beta,y,incy,batchCount) &
         bind(c, name="hipblasChbmvBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -13520,15 +12686,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZhbmvBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZhbmvBatched_64_(handle,uplo,n,k,alpha,AP,lda,x,incx,beta,y,incy,batchCount) &
-        bind(c, name="cublasZhbmvBatched_64")
-#else
     function hipblasZhbmvBatched_64_(handle,uplo,n,k,alpha,AP,lda,x,incx,beta,y,incy,batchCount) &
         bind(c, name="hipblasZhbmvBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -13548,6 +12711,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 2 API
   !>
@@ -13636,16 +12800,11 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasChbmvStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasChbmvStridedBatched_(handle,uplo,n,k,alpha,AP,lda,strideA,x,incx,stridex,beta, &
-        y,incy,stridey,batchCount) &
-        bind(c, name="cublasChbmvStridedBatched")
-#else
     function hipblasChbmvStridedBatched_(handle,uplo,n,k,alpha,AP,lda,strideA,x,incx,stridex,beta, &
         y,incy,stridey,batchCount) &
         bind(c, name="hipblasChbmvStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -13675,17 +12834,13 @@ module hipfort_hipblas
       hipblasChbmvStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZhbmvStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZhbmvStridedBatched_(handle,uplo,n,k,alpha,AP,lda,strideA,x,incx,stridex,beta, &
-        y,incy,stridey,batchCount) &
-        bind(c, name="cublasZhbmvStridedBatched")
-#else
     function hipblasZhbmvStridedBatched_(handle,uplo,n,k,alpha,AP,lda,strideA,x,incx,stridex,beta, &
         y,incy,stridey,batchCount) &
         bind(c, name="hipblasZhbmvStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -13715,17 +12870,13 @@ module hipfort_hipblas
       hipblasZhbmvStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasChbmvStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasChbmvStridedBatched_64_(handle,uplo,n,k,alpha,AP,lda,strideA,x,incx,stridex, &
-        beta,y,incy,stridey,batchCount) &
-        bind(c, name="cublasChbmvStridedBatched_64")
-#else
     function hipblasChbmvStridedBatched_64_(handle,uplo,n,k,alpha,AP,lda,strideA,x,incx,stridex, &
         beta,y,incy,stridey,batchCount) &
         bind(c, name="hipblasChbmvStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -13748,17 +12899,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZhbmvStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZhbmvStridedBatched_64_(handle,uplo,n,k,alpha,AP,lda,strideA,x,incx,stridex, &
-        beta,y,incy,stridey,batchCount) &
-        bind(c, name="cublasZhbmvStridedBatched_64")
-#else
     function hipblasZhbmvStridedBatched_64_(handle,uplo,n,k,alpha,AP,lda,strideA,x,incx,stridex, &
         beta,y,incy,stridey,batchCount) &
         bind(c, name="hipblasZhbmvStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -13781,6 +12928,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 2 API
   !>
@@ -14013,14 +13161,10 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasChemvBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasChemvBatched_(handle,uplo,n,alpha,AP,lda,x,incx,beta,y,incy,batchCount) &
-        bind(c, name="cublasChemvBatched")
-#else
     function hipblasChemvBatched_(handle,uplo,n,alpha,AP,lda,x,incx,beta,y,incy,batchCount) &
         bind(c, name="hipblasChemvBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -14039,15 +13183,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZhemvBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZhemvBatched_(handle,uplo,n,alpha,AP,lda,x,incx,beta,y,incy,batchCount) &
-        bind(c, name="cublasZhemvBatched")
-#else
     function hipblasZhemvBatched_(handle,uplo,n,alpha,AP,lda,x,incx,beta,y,incy,batchCount) &
         bind(c, name="hipblasZhemvBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -14066,15 +13207,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasChemvBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasChemvBatched_64_(handle,uplo,n,alpha,AP,lda,x,incx,beta,y,incy,batchCount) &
-        bind(c, name="cublasChemvBatched_64")
-#else
     function hipblasChemvBatched_64_(handle,uplo,n,alpha,AP,lda,x,incx,beta,y,incy,batchCount) &
         bind(c, name="hipblasChemvBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -14093,15 +13231,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZhemvBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZhemvBatched_64_(handle,uplo,n,alpha,AP,lda,x,incx,beta,y,incy,batchCount) &
-        bind(c, name="cublasZhemvBatched_64")
-#else
     function hipblasZhemvBatched_64_(handle,uplo,n,alpha,AP,lda,x,incx,beta,y,incy,batchCount) &
         bind(c, name="hipblasZhemvBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -14120,6 +13255,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 2 API
   !>
@@ -14189,16 +13325,11 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasChemvStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasChemvStridedBatched_(handle,uplo,n,alpha,AP,lda,strideA,x,incx,stridex,beta,y, &
-        incy,stridey,batchCount) &
-        bind(c, name="cublasChemvStridedBatched")
-#else
     function hipblasChemvStridedBatched_(handle,uplo,n,alpha,AP,lda,strideA,x,incx,stridex,beta,y, &
         incy,stridey,batchCount) &
         bind(c, name="hipblasChemvStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -14227,17 +13358,13 @@ module hipfort_hipblas
       hipblasChemvStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZhemvStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZhemvStridedBatched_(handle,uplo,n,alpha,AP,lda,strideA,x,incx,stridex,beta,y, &
-        incy,stridey,batchCount) &
-        bind(c, name="cublasZhemvStridedBatched")
-#else
     function hipblasZhemvStridedBatched_(handle,uplo,n,alpha,AP,lda,strideA,x,incx,stridex,beta,y, &
         incy,stridey,batchCount) &
         bind(c, name="hipblasZhemvStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -14266,17 +13393,13 @@ module hipfort_hipblas
       hipblasZhemvStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasChemvStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasChemvStridedBatched_64_(handle,uplo,n,alpha,AP,lda,strideA,x,incx,stridex, &
-        beta,y,incy,stridey,batchCount) &
-        bind(c, name="cublasChemvStridedBatched_64")
-#else
     function hipblasChemvStridedBatched_64_(handle,uplo,n,alpha,AP,lda,strideA,x,incx,stridex, &
         beta,y,incy,stridey,batchCount) &
         bind(c, name="hipblasChemvStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -14298,17 +13421,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZhemvStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZhemvStridedBatched_64_(handle,uplo,n,alpha,AP,lda,strideA,x,incx,stridex, &
-        beta,y,incy,stridey,batchCount) &
-        bind(c, name="cublasZhemvStridedBatched_64")
-#else
     function hipblasZhemvStridedBatched_64_(handle,uplo,n,alpha,AP,lda,strideA,x,incx,stridex, &
         beta,y,incy,stridey,batchCount) &
         bind(c, name="hipblasZhemvStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -14330,6 +13449,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 2 API
   !>
@@ -14533,14 +13653,10 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasCherBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCherBatched_(handle,uplo,n,alpha,x,incx,AP,lda,batchCount) &
-        bind(c, name="cublasCherBatched")
-#else
     function hipblasCherBatched_(handle,uplo,n,alpha,x,incx,AP,lda,batchCount) &
         bind(c, name="hipblasCherBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -14556,15 +13672,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZherBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZherBatched_(handle,uplo,n,alpha,x,incx,AP,lda,batchCount) &
-        bind(c, name="cublasZherBatched")
-#else
     function hipblasZherBatched_(handle,uplo,n,alpha,x,incx,AP,lda,batchCount) &
         bind(c, name="hipblasZherBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -14580,15 +13693,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCherBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCherBatched_64_(handle,uplo,n,alpha,x,incx,AP,lda,batchCount) &
-        bind(c, name="cublasCherBatched_64")
-#else
     function hipblasCherBatched_64_(handle,uplo,n,alpha,x,incx,AP,lda,batchCount) &
         bind(c, name="hipblasCherBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -14604,15 +13714,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZherBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZherBatched_64_(handle,uplo,n,alpha,x,incx,AP,lda,batchCount) &
-        bind(c, name="cublasZherBatched_64")
-#else
     function hipblasZherBatched_64_(handle,uplo,n,alpha,x,incx,AP,lda,batchCount) &
         bind(c, name="hipblasZherBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -14628,6 +13735,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 2 API
   !>
@@ -14690,16 +13798,11 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasCherStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCherStridedBatched_(handle,uplo,n,alpha,x,incx,stridex,AP,lda,strideA, &
-        batchCount) &
-        bind(c, name="cublasCherStridedBatched")
-#else
     function hipblasCherStridedBatched_(handle,uplo,n,alpha,x,incx,stridex,AP,lda,strideA, &
         batchCount) &
         bind(c, name="hipblasCherStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -14724,17 +13827,13 @@ module hipfort_hipblas
       hipblasCherStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZherStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZherStridedBatched_(handle,uplo,n,alpha,x,incx,stridex,AP,lda,strideA, &
-        batchCount) &
-        bind(c, name="cublasZherStridedBatched")
-#else
     function hipblasZherStridedBatched_(handle,uplo,n,alpha,x,incx,stridex,AP,lda,strideA, &
         batchCount) &
         bind(c, name="hipblasZherStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -14759,17 +13858,13 @@ module hipfort_hipblas
       hipblasZherStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCherStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCherStridedBatched_64_(handle,uplo,n,alpha,x,incx,stridex,AP,lda,strideA, &
-        batchCount) &
-        bind(c, name="cublasCherStridedBatched_64")
-#else
     function hipblasCherStridedBatched_64_(handle,uplo,n,alpha,x,incx,stridex,AP,lda,strideA, &
         batchCount) &
         bind(c, name="hipblasCherStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -14787,17 +13882,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZherStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZherStridedBatched_64_(handle,uplo,n,alpha,x,incx,stridex,AP,lda,strideA, &
-        batchCount) &
-        bind(c, name="cublasZherStridedBatched_64")
-#else
     function hipblasZherStridedBatched_64_(handle,uplo,n,alpha,x,incx,stridex,AP,lda,strideA, &
         batchCount) &
         bind(c, name="hipblasZherStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -14815,6 +13906,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 2 API
   !>
@@ -15039,14 +14131,10 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasCher2Batched
-#ifdef USE_CUDA_NAMES
-    function hipblasCher2Batched_(handle,uplo,n,alpha,x,incx,y,incy,AP,lda,batchCount) &
-        bind(c, name="cublasCher2Batched")
-#else
     function hipblasCher2Batched_(handle,uplo,n,alpha,x,incx,y,incy,AP,lda,batchCount) &
         bind(c, name="hipblasCher2Batched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -15064,15 +14152,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZher2Batched
-#ifdef USE_CUDA_NAMES
-    function hipblasZher2Batched_(handle,uplo,n,alpha,x,incx,y,incy,AP,lda,batchCount) &
-        bind(c, name="cublasZher2Batched")
-#else
     function hipblasZher2Batched_(handle,uplo,n,alpha,x,incx,y,incy,AP,lda,batchCount) &
         bind(c, name="hipblasZher2Batched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -15090,15 +14175,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCher2Batched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCher2Batched_64_(handle,uplo,n,alpha,x,incx,y,incy,AP,lda,batchCount) &
-        bind(c, name="cublasCher2Batched_64")
-#else
     function hipblasCher2Batched_64_(handle,uplo,n,alpha,x,incx,y,incy,AP,lda,batchCount) &
         bind(c, name="hipblasCher2Batched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -15116,15 +14198,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZher2Batched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZher2Batched_64_(handle,uplo,n,alpha,x,incx,y,incy,AP,lda,batchCount) &
-        bind(c, name="cublasZher2Batched_64")
-#else
     function hipblasZher2Batched_64_(handle,uplo,n,alpha,x,incx,y,incy,AP,lda,batchCount) &
         bind(c, name="hipblasZher2Batched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -15142,6 +14221,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 2 API
   !>
@@ -15214,16 +14294,11 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasCher2StridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCher2StridedBatched_(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey,AP,lda, &
-        strideA,batchCount) &
-        bind(c, name="cublasCher2StridedBatched")
-#else
     function hipblasCher2StridedBatched_(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey,AP,lda, &
         strideA,batchCount) &
         bind(c, name="hipblasCher2StridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -15251,17 +14326,13 @@ module hipfort_hipblas
       hipblasCher2StridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZher2StridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZher2StridedBatched_(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey,AP,lda, &
-        strideA,batchCount) &
-        bind(c, name="cublasZher2StridedBatched")
-#else
     function hipblasZher2StridedBatched_(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey,AP,lda, &
         strideA,batchCount) &
         bind(c, name="hipblasZher2StridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -15289,17 +14360,13 @@ module hipfort_hipblas
       hipblasZher2StridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCher2StridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCher2StridedBatched_64_(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey,AP, &
-        lda,strideA,batchCount) &
-        bind(c, name="cublasCher2StridedBatched_64")
-#else
     function hipblasCher2StridedBatched_64_(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey,AP, &
         lda,strideA,batchCount) &
         bind(c, name="hipblasCher2StridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -15320,17 +14387,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZher2StridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZher2StridedBatched_64_(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey,AP, &
-        lda,strideA,batchCount) &
-        bind(c, name="cublasZher2StridedBatched_64")
-#else
     function hipblasZher2StridedBatched_64_(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey,AP, &
         lda,strideA,batchCount) &
         bind(c, name="hipblasZher2StridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -15351,6 +14414,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 2 API
   !>
@@ -15605,14 +14669,10 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasChpmvBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasChpmvBatched_(handle,uplo,n,alpha,AP,x,incx,beta,y,incy,batchCount) &
-        bind(c, name="cublasChpmvBatched")
-#else
     function hipblasChpmvBatched_(handle,uplo,n,alpha,AP,x,incx,beta,y,incy,batchCount) &
         bind(c, name="hipblasChpmvBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -15630,15 +14690,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZhpmvBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZhpmvBatched_(handle,uplo,n,alpha,AP,x,incx,beta,y,incy,batchCount) &
-        bind(c, name="cublasZhpmvBatched")
-#else
     function hipblasZhpmvBatched_(handle,uplo,n,alpha,AP,x,incx,beta,y,incy,batchCount) &
         bind(c, name="hipblasZhpmvBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -15656,15 +14713,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasChpmvBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasChpmvBatched_64_(handle,uplo,n,alpha,AP,x,incx,beta,y,incy,batchCount) &
-        bind(c, name="cublasChpmvBatched_64")
-#else
     function hipblasChpmvBatched_64_(handle,uplo,n,alpha,AP,x,incx,beta,y,incy,batchCount) &
         bind(c, name="hipblasChpmvBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -15682,15 +14736,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZhpmvBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZhpmvBatched_64_(handle,uplo,n,alpha,AP,x,incx,beta,y,incy,batchCount) &
-        bind(c, name="cublasZhpmvBatched_64")
-#else
     function hipblasZhpmvBatched_64_(handle,uplo,n,alpha,AP,x,incx,beta,y,incy,batchCount) &
         bind(c, name="hipblasZhpmvBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -15708,6 +14759,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 2 API
   !>
@@ -15793,16 +14845,11 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasChpmvStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasChpmvStridedBatched_(handle,uplo,n,alpha,AP,strideA,x,incx,stridex,beta,y, &
-        incy,stridey,batchCount) &
-        bind(c, name="cublasChpmvStridedBatched")
-#else
     function hipblasChpmvStridedBatched_(handle,uplo,n,alpha,AP,strideA,x,incx,stridex,beta,y, &
         incy,stridey,batchCount) &
         bind(c, name="hipblasChpmvStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -15829,17 +14876,13 @@ module hipfort_hipblas
       hipblasChpmvStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZhpmvStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZhpmvStridedBatched_(handle,uplo,n,alpha,AP,strideA,x,incx,stridex,beta,y, &
-        incy,stridey,batchCount) &
-        bind(c, name="cublasZhpmvStridedBatched")
-#else
     function hipblasZhpmvStridedBatched_(handle,uplo,n,alpha,AP,strideA,x,incx,stridex,beta,y, &
         incy,stridey,batchCount) &
         bind(c, name="hipblasZhpmvStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -15866,17 +14909,13 @@ module hipfort_hipblas
       hipblasZhpmvStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasChpmvStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasChpmvStridedBatched_64_(handle,uplo,n,alpha,AP,strideA,x,incx,stridex,beta,y, &
-        incy,stridey,batchCount) &
-        bind(c, name="cublasChpmvStridedBatched_64")
-#else
     function hipblasChpmvStridedBatched_64_(handle,uplo,n,alpha,AP,strideA,x,incx,stridex,beta,y, &
         incy,stridey,batchCount) &
         bind(c, name="hipblasChpmvStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -15897,17 +14936,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZhpmvStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZhpmvStridedBatched_64_(handle,uplo,n,alpha,AP,strideA,x,incx,stridex,beta,y, &
-        incy,stridey,batchCount) &
-        bind(c, name="cublasZhpmvStridedBatched_64")
-#else
     function hipblasZhpmvStridedBatched_64_(handle,uplo,n,alpha,AP,strideA,x,incx,stridex,beta,y, &
         incy,stridey,batchCount) &
         bind(c, name="hipblasZhpmvStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -15928,6 +14963,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 2 API
   !>
@@ -16155,14 +15191,10 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasChprBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasChprBatched_(handle,uplo,n,alpha,x,incx,AP,batchCount) &
-        bind(c, name="cublasChprBatched")
-#else
     function hipblasChprBatched_(handle,uplo,n,alpha,x,incx,AP,batchCount) &
         bind(c, name="hipblasChprBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -16177,15 +15209,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZhprBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZhprBatched_(handle,uplo,n,alpha,x,incx,AP,batchCount) &
-        bind(c, name="cublasZhprBatched")
-#else
     function hipblasZhprBatched_(handle,uplo,n,alpha,x,incx,AP,batchCount) &
         bind(c, name="hipblasZhprBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -16200,15 +15229,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasChprBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasChprBatched_64_(handle,uplo,n,alpha,x,incx,AP,batchCount) &
-        bind(c, name="cublasChprBatched_64")
-#else
     function hipblasChprBatched_64_(handle,uplo,n,alpha,x,incx,AP,batchCount) &
         bind(c, name="hipblasChprBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -16223,15 +15249,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZhprBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZhprBatched_64_(handle,uplo,n,alpha,x,incx,AP,batchCount) &
-        bind(c, name="cublasZhprBatched_64")
-#else
     function hipblasZhprBatched_64_(handle,uplo,n,alpha,x,incx,AP,batchCount) &
         bind(c, name="hipblasZhprBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -16246,6 +15269,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief   BLAS Level 2 API
   !>
@@ -16323,14 +15347,10 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasChprStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasChprStridedBatched_(handle,uplo,n,alpha,x,incx,stridex,AP,strideA,batchCount) &
-        bind(c, name="cublasChprStridedBatched")
-#else
     function hipblasChprStridedBatched_(handle,uplo,n,alpha,x,incx,stridex,AP,strideA,batchCount) &
         bind(c, name="hipblasChprStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -16353,15 +15373,12 @@ module hipfort_hipblas
       hipblasChprStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZhprStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZhprStridedBatched_(handle,uplo,n,alpha,x,incx,stridex,AP,strideA,batchCount) &
-        bind(c, name="cublasZhprStridedBatched")
-#else
     function hipblasZhprStridedBatched_(handle,uplo,n,alpha,x,incx,stridex,AP,strideA,batchCount) &
         bind(c, name="hipblasZhprStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -16384,17 +15401,13 @@ module hipfort_hipblas
       hipblasZhprStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasChprStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasChprStridedBatched_64_(handle,uplo,n,alpha,x,incx,stridex,AP,strideA, &
-        batchCount) &
-        bind(c, name="cublasChprStridedBatched_64")
-#else
     function hipblasChprStridedBatched_64_(handle,uplo,n,alpha,x,incx,stridex,AP,strideA, &
         batchCount) &
         bind(c, name="hipblasChprStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -16411,17 +15424,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZhprStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZhprStridedBatched_64_(handle,uplo,n,alpha,x,incx,stridex,AP,strideA, &
-        batchCount) &
-        bind(c, name="cublasZhprStridedBatched_64")
-#else
     function hipblasZhprStridedBatched_64_(handle,uplo,n,alpha,x,incx,stridex,AP,strideA, &
         batchCount) &
         bind(c, name="hipblasZhprStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -16438,6 +15447,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 2 API
   !>
@@ -16685,14 +15695,10 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasChpr2Batched
-#ifdef USE_CUDA_NAMES
-    function hipblasChpr2Batched_(handle,uplo,n,alpha,x,incx,y,incy,AP,batchCount) &
-        bind(c, name="cublasChpr2Batched")
-#else
     function hipblasChpr2Batched_(handle,uplo,n,alpha,x,incx,y,incy,AP,batchCount) &
         bind(c, name="hipblasChpr2Batched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -16709,15 +15715,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZhpr2Batched
-#ifdef USE_CUDA_NAMES
-    function hipblasZhpr2Batched_(handle,uplo,n,alpha,x,incx,y,incy,AP,batchCount) &
-        bind(c, name="cublasZhpr2Batched")
-#else
     function hipblasZhpr2Batched_(handle,uplo,n,alpha,x,incx,y,incy,AP,batchCount) &
         bind(c, name="hipblasZhpr2Batched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -16734,15 +15737,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasChpr2Batched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasChpr2Batched_64_(handle,uplo,n,alpha,x,incx,y,incy,AP,batchCount) &
-        bind(c, name="cublasChpr2Batched_64")
-#else
     function hipblasChpr2Batched_64_(handle,uplo,n,alpha,x,incx,y,incy,AP,batchCount) &
         bind(c, name="hipblasChpr2Batched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -16759,15 +15759,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZhpr2Batched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZhpr2Batched_64_(handle,uplo,n,alpha,x,incx,y,incy,AP,batchCount) &
-        bind(c, name="cublasZhpr2Batched_64")
-#else
     function hipblasZhpr2Batched_64_(handle,uplo,n,alpha,x,incx,y,incy,AP,batchCount) &
         bind(c, name="hipblasZhpr2Batched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -16784,6 +15781,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 2 API
   !>
@@ -16869,16 +15867,11 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasChpr2StridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasChpr2StridedBatched_(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey,AP, &
-        strideA,batchCount) &
-        bind(c, name="cublasChpr2StridedBatched")
-#else
     function hipblasChpr2StridedBatched_(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey,AP, &
         strideA,batchCount) &
         bind(c, name="hipblasChpr2StridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -16904,17 +15897,13 @@ module hipfort_hipblas
       hipblasChpr2StridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZhpr2StridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZhpr2StridedBatched_(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey,AP, &
-        strideA,batchCount) &
-        bind(c, name="cublasZhpr2StridedBatched")
-#else
     function hipblasZhpr2StridedBatched_(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey,AP, &
         strideA,batchCount) &
         bind(c, name="hipblasZhpr2StridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -16940,17 +15929,13 @@ module hipfort_hipblas
       hipblasZhpr2StridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasChpr2StridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasChpr2StridedBatched_64_(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey,AP, &
-        strideA,batchCount) &
-        bind(c, name="cublasChpr2StridedBatched_64")
-#else
     function hipblasChpr2StridedBatched_64_(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey,AP, &
         strideA,batchCount) &
         bind(c, name="hipblasChpr2StridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -16970,17 +15955,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZhpr2StridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZhpr2StridedBatched_64_(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey,AP, &
-        strideA,batchCount) &
-        bind(c, name="cublasZhpr2StridedBatched_64")
-#else
     function hipblasZhpr2StridedBatched_64_(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey,AP, &
         strideA,batchCount) &
         bind(c, name="hipblasZhpr2StridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -17000,6 +15981,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 2 API
   !>
@@ -17223,14 +16205,10 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasSsbmvBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasSsbmvBatched_(handle,uplo,n,k,alpha,AP,lda,x,incx,beta,y,incy,batchCount) &
-        bind(c, name="cublasSsbmvBatched")
-#else
     function hipblasSsbmvBatched_(handle,uplo,n,k,alpha,AP,lda,x,incx,beta,y,incy,batchCount) &
         bind(c, name="hipblasSsbmvBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -17250,15 +16228,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDsbmvBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDsbmvBatched_(handle,uplo,n,k,alpha,AP,lda,x,incx,beta,y,incy,batchCount) &
-        bind(c, name="cublasDsbmvBatched")
-#else
     function hipblasDsbmvBatched_(handle,uplo,n,k,alpha,AP,lda,x,incx,beta,y,incy,batchCount) &
         bind(c, name="hipblasDsbmvBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -17278,15 +16253,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasSsbmvBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasSsbmvBatched_64_(handle,uplo,n,k,alpha,AP,lda,x,incx,beta,y,incy,batchCount) &
-        bind(c, name="cublasSsbmvBatched_64")
-#else
     function hipblasSsbmvBatched_64_(handle,uplo,n,k,alpha,AP,lda,x,incx,beta,y,incy,batchCount) &
         bind(c, name="hipblasSsbmvBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -17306,15 +16278,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDsbmvBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDsbmvBatched_64_(handle,uplo,n,k,alpha,AP,lda,x,incx,beta,y,incy,batchCount) &
-        bind(c, name="cublasDsbmvBatched_64")
-#else
     function hipblasDsbmvBatched_64_(handle,uplo,n,k,alpha,AP,lda,x,incx,beta,y,incy,batchCount) &
         bind(c, name="hipblasDsbmvBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -17334,6 +16303,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 2 API
   !>
@@ -17403,16 +16373,11 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasSsbmvStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasSsbmvStridedBatched_(handle,uplo,n,k,alpha,AP,lda,strideA,x,incx,stridex,beta, &
-        y,incy,stridey,batchCount) &
-        bind(c, name="cublasSsbmvStridedBatched")
-#else
     function hipblasSsbmvStridedBatched_(handle,uplo,n,k,alpha,AP,lda,strideA,x,incx,stridex,beta, &
         y,incy,stridey,batchCount) &
         bind(c, name="hipblasSsbmvStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -17442,17 +16407,13 @@ module hipfort_hipblas
       hipblasSsbmvStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDsbmvStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDsbmvStridedBatched_(handle,uplo,n,k,alpha,AP,lda,strideA,x,incx,stridex,beta, &
-        y,incy,stridey,batchCount) &
-        bind(c, name="cublasDsbmvStridedBatched")
-#else
     function hipblasDsbmvStridedBatched_(handle,uplo,n,k,alpha,AP,lda,strideA,x,incx,stridex,beta, &
         y,incy,stridey,batchCount) &
         bind(c, name="hipblasDsbmvStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -17482,17 +16443,13 @@ module hipfort_hipblas
       hipblasDsbmvStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasSsbmvStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasSsbmvStridedBatched_64_(handle,uplo,n,k,alpha,AP,lda,strideA,x,incx,stridex, &
-        beta,y,incy,stridey,batchCount) &
-        bind(c, name="cublasSsbmvStridedBatched_64")
-#else
     function hipblasSsbmvStridedBatched_64_(handle,uplo,n,k,alpha,AP,lda,strideA,x,incx,stridex, &
         beta,y,incy,stridey,batchCount) &
         bind(c, name="hipblasSsbmvStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -17515,17 +16472,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDsbmvStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDsbmvStridedBatched_64_(handle,uplo,n,k,alpha,AP,lda,strideA,x,incx,stridex, &
-        beta,y,incy,stridey,batchCount) &
-        bind(c, name="cublasDsbmvStridedBatched_64")
-#else
     function hipblasDsbmvStridedBatched_64_(handle,uplo,n,k,alpha,AP,lda,strideA,x,incx,stridex, &
         beta,y,incy,stridey,batchCount) &
         bind(c, name="hipblasDsbmvStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -17548,6 +16501,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 2 API
   !>
@@ -17745,14 +16699,10 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasSspmvBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasSspmvBatched_(handle,uplo,n,alpha,AP,x,incx,beta,y,incy,batchCount) &
-        bind(c, name="cublasSspmvBatched")
-#else
     function hipblasSspmvBatched_(handle,uplo,n,alpha,AP,x,incx,beta,y,incy,batchCount) &
         bind(c, name="hipblasSspmvBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -17770,15 +16720,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDspmvBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDspmvBatched_(handle,uplo,n,alpha,AP,x,incx,beta,y,incy,batchCount) &
-        bind(c, name="cublasDspmvBatched")
-#else
     function hipblasDspmvBatched_(handle,uplo,n,alpha,AP,x,incx,beta,y,incy,batchCount) &
         bind(c, name="hipblasDspmvBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -17796,15 +16743,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasSspmvBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasSspmvBatched_64_(handle,uplo,n,alpha,AP,x,incx,beta,y,incy,batchCount) &
-        bind(c, name="cublasSspmvBatched_64")
-#else
     function hipblasSspmvBatched_64_(handle,uplo,n,alpha,AP,x,incx,beta,y,incy,batchCount) &
         bind(c, name="hipblasSspmvBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -17822,15 +16766,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDspmvBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDspmvBatched_64_(handle,uplo,n,alpha,AP,x,incx,beta,y,incy,batchCount) &
-        bind(c, name="cublasDspmvBatched_64")
-#else
     function hipblasDspmvBatched_64_(handle,uplo,n,alpha,AP,x,incx,beta,y,incy,batchCount) &
         bind(c, name="hipblasDspmvBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -17848,6 +16789,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 2 API
   !>
@@ -17911,16 +16853,11 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasSspmvStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasSspmvStridedBatched_(handle,uplo,n,alpha,AP,strideA,x,incx,stridex,beta,y, &
-        incy,stridey,batchCount) &
-        bind(c, name="cublasSspmvStridedBatched")
-#else
     function hipblasSspmvStridedBatched_(handle,uplo,n,alpha,AP,strideA,x,incx,stridex,beta,y, &
         incy,stridey,batchCount) &
         bind(c, name="hipblasSspmvStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -17947,17 +16884,13 @@ module hipfort_hipblas
       hipblasSspmvStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDspmvStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDspmvStridedBatched_(handle,uplo,n,alpha,AP,strideA,x,incx,stridex,beta,y, &
-        incy,stridey,batchCount) &
-        bind(c, name="cublasDspmvStridedBatched")
-#else
     function hipblasDspmvStridedBatched_(handle,uplo,n,alpha,AP,strideA,x,incx,stridex,beta,y, &
         incy,stridey,batchCount) &
         bind(c, name="hipblasDspmvStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -17984,17 +16917,13 @@ module hipfort_hipblas
       hipblasDspmvStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasSspmvStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasSspmvStridedBatched_64_(handle,uplo,n,alpha,AP,strideA,x,incx,stridex,beta,y, &
-        incy,stridey,batchCount) &
-        bind(c, name="cublasSspmvStridedBatched_64")
-#else
     function hipblasSspmvStridedBatched_64_(handle,uplo,n,alpha,AP,strideA,x,incx,stridex,beta,y, &
         incy,stridey,batchCount) &
         bind(c, name="hipblasSspmvStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -18015,17 +16944,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDspmvStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDspmvStridedBatched_64_(handle,uplo,n,alpha,AP,strideA,x,incx,stridex,beta,y, &
-        incy,stridey,batchCount) &
-        bind(c, name="cublasDspmvStridedBatched_64")
-#else
     function hipblasDspmvStridedBatched_64_(handle,uplo,n,alpha,AP,strideA,x,incx,stridex,beta,y, &
         incy,stridey,batchCount) &
         bind(c, name="hipblasDspmvStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -18046,6 +16971,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief   BLAS Level 2 API
   !>
@@ -18161,12 +17087,9 @@ module hipfort_hipblas
 #endif
   end interface
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCspr
-#ifdef USE_CUDA_NAMES
-    function hipblasCspr_(handle,uplo,n,alpha,x,incx,AP) bind(c, name="cublasCspr")
-#else
     function hipblasCspr_(handle,uplo,n,alpha,x,incx,AP) bind(c, name="hipblasCspr")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -18186,13 +17109,11 @@ module hipfort_hipblas
       hipblasCspr_rank_1
 #endif
   end interface
-
-  interface hipblasZspr
-#ifdef USE_CUDA_NAMES
-    function hipblasZspr_(handle,uplo,n,alpha,x,incx,AP) bind(c, name="cublasZspr")
-#else
-    function hipblasZspr_(handle,uplo,n,alpha,x,incx,AP) bind(c, name="hipblasZspr")
 #endif
+
+#ifndef USE_CUDA_NAMES
+  interface hipblasZspr
+    function hipblasZspr_(handle,uplo,n,alpha,x,incx,AP) bind(c, name="hipblasZspr")
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -18212,6 +17133,7 @@ module hipfort_hipblas
       hipblasZspr_rank_1
 #endif
   end interface
+#endif
 
   interface hipblasSspr_64
 #ifdef USE_CUDA_NAMES
@@ -18253,12 +17175,9 @@ module hipfort_hipblas
     end function
   end interface
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCspr_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCspr_64_(handle,uplo,n,alpha,x,incx,AP) bind(c, name="cublasCspr_64")
-#else
     function hipblasCspr_64_(handle,uplo,n,alpha,x,incx,AP) bind(c, name="hipblasCspr_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -18272,13 +17191,11 @@ module hipfort_hipblas
       type(c_ptr),value :: AP
     end function
   end interface
-
-  interface hipblasZspr_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZspr_64_(handle,uplo,n,alpha,x,incx,AP) bind(c, name="cublasZspr_64")
-#else
-    function hipblasZspr_64_(handle,uplo,n,alpha,x,incx,AP) bind(c, name="hipblasZspr_64")
 #endif
+
+#ifndef USE_CUDA_NAMES
+  interface hipblasZspr_64
+    function hipblasZspr_64_(handle,uplo,n,alpha,x,incx,AP) bind(c, name="hipblasZspr_64")
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -18292,6 +17209,7 @@ module hipfort_hipblas
       type(c_ptr),value :: AP
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 2 API
   !>
@@ -18363,14 +17281,10 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasSsprBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasSsprBatched_(handle,uplo,n,alpha,x,incx,AP,batchCount) &
-        bind(c, name="cublasSsprBatched")
-#else
     function hipblasSsprBatched_(handle,uplo,n,alpha,x,incx,AP,batchCount) &
         bind(c, name="hipblasSsprBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -18385,15 +17299,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDsprBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDsprBatched_(handle,uplo,n,alpha,x,incx,AP,batchCount) &
-        bind(c, name="cublasDsprBatched")
-#else
     function hipblasDsprBatched_(handle,uplo,n,alpha,x,incx,AP,batchCount) &
         bind(c, name="hipblasDsprBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -18408,15 +17319,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCsprBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCsprBatched_(handle,uplo,n,alpha,x,incx,AP,batchCount) &
-        bind(c, name="cublasCsprBatched")
-#else
     function hipblasCsprBatched_(handle,uplo,n,alpha,x,incx,AP,batchCount) &
         bind(c, name="hipblasCsprBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -18431,15 +17339,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZsprBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZsprBatched_(handle,uplo,n,alpha,x,incx,AP,batchCount) &
-        bind(c, name="cublasZsprBatched")
-#else
     function hipblasZsprBatched_(handle,uplo,n,alpha,x,incx,AP,batchCount) &
         bind(c, name="hipblasZsprBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -18454,15 +17359,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasSsprBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasSsprBatched_64_(handle,uplo,n,alpha,x,incx,AP,batchCount) &
-        bind(c, name="cublasSsprBatched_64")
-#else
     function hipblasSsprBatched_64_(handle,uplo,n,alpha,x,incx,AP,batchCount) &
         bind(c, name="hipblasSsprBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -18477,15 +17379,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDsprBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDsprBatched_64_(handle,uplo,n,alpha,x,incx,AP,batchCount) &
-        bind(c, name="cublasDsprBatched_64")
-#else
     function hipblasDsprBatched_64_(handle,uplo,n,alpha,x,incx,AP,batchCount) &
         bind(c, name="hipblasDsprBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -18500,15 +17399,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCsprBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCsprBatched_64_(handle,uplo,n,alpha,x,incx,AP,batchCount) &
-        bind(c, name="cublasCsprBatched_64")
-#else
     function hipblasCsprBatched_64_(handle,uplo,n,alpha,x,incx,AP,batchCount) &
         bind(c, name="hipblasCsprBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -18523,15 +17419,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZsprBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZsprBatched_64_(handle,uplo,n,alpha,x,incx,AP,batchCount) &
-        bind(c, name="cublasZsprBatched_64")
-#else
     function hipblasZsprBatched_64_(handle,uplo,n,alpha,x,incx,AP,batchCount) &
         bind(c, name="hipblasZsprBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -18546,6 +17439,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief   BLAS Level 2 API
   !>
@@ -18621,14 +17515,10 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasSsprStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasSsprStridedBatched_(handle,uplo,n,alpha,x,incx,stridex,AP,strideA,batchCount) &
-        bind(c, name="cublasSsprStridedBatched")
-#else
     function hipblasSsprStridedBatched_(handle,uplo,n,alpha,x,incx,stridex,AP,strideA,batchCount) &
         bind(c, name="hipblasSsprStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -18651,15 +17541,12 @@ module hipfort_hipblas
       hipblasSsprStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDsprStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDsprStridedBatched_(handle,uplo,n,alpha,x,incx,stridex,AP,strideA,batchCount) &
-        bind(c, name="cublasDsprStridedBatched")
-#else
     function hipblasDsprStridedBatched_(handle,uplo,n,alpha,x,incx,stridex,AP,strideA,batchCount) &
         bind(c, name="hipblasDsprStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -18682,15 +17569,12 @@ module hipfort_hipblas
       hipblasDsprStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCsprStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCsprStridedBatched_(handle,uplo,n,alpha,x,incx,stridex,AP,strideA,batchCount) &
-        bind(c, name="cublasCsprStridedBatched")
-#else
     function hipblasCsprStridedBatched_(handle,uplo,n,alpha,x,incx,stridex,AP,strideA,batchCount) &
         bind(c, name="hipblasCsprStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -18713,15 +17597,12 @@ module hipfort_hipblas
       hipblasCsprStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZsprStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZsprStridedBatched_(handle,uplo,n,alpha,x,incx,stridex,AP,strideA,batchCount) &
-        bind(c, name="cublasZsprStridedBatched")
-#else
     function hipblasZsprStridedBatched_(handle,uplo,n,alpha,x,incx,stridex,AP,strideA,batchCount) &
         bind(c, name="hipblasZsprStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -18744,17 +17625,13 @@ module hipfort_hipblas
       hipblasZsprStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasSsprStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasSsprStridedBatched_64_(handle,uplo,n,alpha,x,incx,stridex,AP,strideA, &
-        batchCount) &
-        bind(c, name="cublasSsprStridedBatched_64")
-#else
     function hipblasSsprStridedBatched_64_(handle,uplo,n,alpha,x,incx,stridex,AP,strideA, &
         batchCount) &
         bind(c, name="hipblasSsprStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -18771,17 +17648,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDsprStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDsprStridedBatched_64_(handle,uplo,n,alpha,x,incx,stridex,AP,strideA, &
-        batchCount) &
-        bind(c, name="cublasDsprStridedBatched_64")
-#else
     function hipblasDsprStridedBatched_64_(handle,uplo,n,alpha,x,incx,stridex,AP,strideA, &
         batchCount) &
         bind(c, name="hipblasDsprStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -18798,17 +17671,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCsprStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCsprStridedBatched_64_(handle,uplo,n,alpha,x,incx,stridex,AP,strideA, &
-        batchCount) &
-        bind(c, name="cublasCsprStridedBatched_64")
-#else
     function hipblasCsprStridedBatched_64_(handle,uplo,n,alpha,x,incx,stridex,AP,strideA, &
         batchCount) &
         bind(c, name="hipblasCsprStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -18825,17 +17694,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZsprStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZsprStridedBatched_64_(handle,uplo,n,alpha,x,incx,stridex,AP,strideA, &
-        batchCount) &
-        bind(c, name="cublasZsprStridedBatched_64")
-#else
     function hipblasZsprStridedBatched_64_(handle,uplo,n,alpha,x,incx,stridex,AP,strideA, &
         batchCount) &
         bind(c, name="hipblasZsprStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -18852,6 +17717,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 2 API
   !>
@@ -19097,14 +17963,10 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasSspr2Batched
-#ifdef USE_CUDA_NAMES
-    function hipblasSspr2Batched_(handle,uplo,n,alpha,x,incx,y,incy,AP,batchCount) &
-        bind(c, name="cublasSspr2Batched")
-#else
     function hipblasSspr2Batched_(handle,uplo,n,alpha,x,incx,y,incy,AP,batchCount) &
         bind(c, name="hipblasSspr2Batched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -19121,15 +17983,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDspr2Batched
-#ifdef USE_CUDA_NAMES
-    function hipblasDspr2Batched_(handle,uplo,n,alpha,x,incx,y,incy,AP,batchCount) &
-        bind(c, name="cublasDspr2Batched")
-#else
     function hipblasDspr2Batched_(handle,uplo,n,alpha,x,incx,y,incy,AP,batchCount) &
         bind(c, name="hipblasDspr2Batched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -19146,15 +18005,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasSspr2Batched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasSspr2Batched_64_(handle,uplo,n,alpha,x,incx,y,incy,AP,batchCount) &
-        bind(c, name="cublasSspr2Batched_64")
-#else
     function hipblasSspr2Batched_64_(handle,uplo,n,alpha,x,incx,y,incy,AP,batchCount) &
         bind(c, name="hipblasSspr2Batched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -19171,15 +18027,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDspr2Batched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDspr2Batched_64_(handle,uplo,n,alpha,x,incx,y,incy,AP,batchCount) &
-        bind(c, name="cublasDspr2Batched_64")
-#else
     function hipblasDspr2Batched_64_(handle,uplo,n,alpha,x,incx,y,incy,AP,batchCount) &
         bind(c, name="hipblasDspr2Batched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -19196,6 +18049,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 2 API
   !>
@@ -19279,16 +18133,11 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasSspr2StridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasSspr2StridedBatched_(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey,AP, &
-        strideA,batchCount) &
-        bind(c, name="cublasSspr2StridedBatched")
-#else
     function hipblasSspr2StridedBatched_(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey,AP, &
         strideA,batchCount) &
         bind(c, name="hipblasSspr2StridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -19314,17 +18163,13 @@ module hipfort_hipblas
       hipblasSspr2StridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDspr2StridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDspr2StridedBatched_(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey,AP, &
-        strideA,batchCount) &
-        bind(c, name="cublasDspr2StridedBatched")
-#else
     function hipblasDspr2StridedBatched_(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey,AP, &
         strideA,batchCount) &
         bind(c, name="hipblasDspr2StridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -19350,17 +18195,13 @@ module hipfort_hipblas
       hipblasDspr2StridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasSspr2StridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasSspr2StridedBatched_64_(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey,AP, &
-        strideA,batchCount) &
-        bind(c, name="cublasSspr2StridedBatched_64")
-#else
     function hipblasSspr2StridedBatched_64_(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey,AP, &
         strideA,batchCount) &
         bind(c, name="hipblasSspr2StridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -19380,17 +18221,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDspr2StridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDspr2StridedBatched_64_(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey,AP, &
-        strideA,batchCount) &
-        bind(c, name="cublasDspr2StridedBatched_64")
-#else
     function hipblasDspr2StridedBatched_64_(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey,AP, &
         strideA,batchCount) &
         bind(c, name="hipblasDspr2StridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -19410,6 +18247,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief   BLAS Level 2 API
   !>
@@ -19742,14 +18580,10 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasSsymvBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasSsymvBatched_(handle,uplo,n,alpha,AP,lda,x,incx,beta,y,incy,batchCount) &
-        bind(c, name="cublasSsymvBatched")
-#else
     function hipblasSsymvBatched_(handle,uplo,n,alpha,AP,lda,x,incx,beta,y,incy,batchCount) &
         bind(c, name="hipblasSsymvBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -19768,15 +18602,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDsymvBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDsymvBatched_(handle,uplo,n,alpha,AP,lda,x,incx,beta,y,incy,batchCount) &
-        bind(c, name="cublasDsymvBatched")
-#else
     function hipblasDsymvBatched_(handle,uplo,n,alpha,AP,lda,x,incx,beta,y,incy,batchCount) &
         bind(c, name="hipblasDsymvBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -19795,15 +18626,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCsymvBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCsymvBatched_(handle,uplo,n,alpha,AP,lda,x,incx,beta,y,incy,batchCount) &
-        bind(c, name="cublasCsymvBatched")
-#else
     function hipblasCsymvBatched_(handle,uplo,n,alpha,AP,lda,x,incx,beta,y,incy,batchCount) &
         bind(c, name="hipblasCsymvBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -19822,15 +18650,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZsymvBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZsymvBatched_(handle,uplo,n,alpha,AP,lda,x,incx,beta,y,incy,batchCount) &
-        bind(c, name="cublasZsymvBatched")
-#else
     function hipblasZsymvBatched_(handle,uplo,n,alpha,AP,lda,x,incx,beta,y,incy,batchCount) &
         bind(c, name="hipblasZsymvBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -19849,15 +18674,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasSsymvBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasSsymvBatched_64_(handle,uplo,n,alpha,AP,lda,x,incx,beta,y,incy,batchCount) &
-        bind(c, name="cublasSsymvBatched_64")
-#else
     function hipblasSsymvBatched_64_(handle,uplo,n,alpha,AP,lda,x,incx,beta,y,incy,batchCount) &
         bind(c, name="hipblasSsymvBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -19876,15 +18698,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDsymvBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDsymvBatched_64_(handle,uplo,n,alpha,AP,lda,x,incx,beta,y,incy,batchCount) &
-        bind(c, name="cublasDsymvBatched_64")
-#else
     function hipblasDsymvBatched_64_(handle,uplo,n,alpha,AP,lda,x,incx,beta,y,incy,batchCount) &
         bind(c, name="hipblasDsymvBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -19903,15 +18722,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCsymvBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCsymvBatched_64_(handle,uplo,n,alpha,AP,lda,x,incx,beta,y,incy,batchCount) &
-        bind(c, name="cublasCsymvBatched_64")
-#else
     function hipblasCsymvBatched_64_(handle,uplo,n,alpha,AP,lda,x,incx,beta,y,incy,batchCount) &
         bind(c, name="hipblasCsymvBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -19930,15 +18746,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZsymvBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZsymvBatched_64_(handle,uplo,n,alpha,AP,lda,x,incx,beta,y,incy,batchCount) &
-        bind(c, name="cublasZsymvBatched_64")
-#else
     function hipblasZsymvBatched_64_(handle,uplo,n,alpha,AP,lda,x,incx,beta,y,incy,batchCount) &
         bind(c, name="hipblasZsymvBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -19957,6 +18770,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 2 API
   !>
@@ -20024,16 +18838,11 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasSsymvStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasSsymvStridedBatched_(handle,uplo,n,alpha,AP,lda,strideA,x,incx,stridex,beta,y, &
-        incy,stridey,batchCount) &
-        bind(c, name="cublasSsymvStridedBatched")
-#else
     function hipblasSsymvStridedBatched_(handle,uplo,n,alpha,AP,lda,strideA,x,incx,stridex,beta,y, &
         incy,stridey,batchCount) &
         bind(c, name="hipblasSsymvStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -20062,17 +18871,13 @@ module hipfort_hipblas
       hipblasSsymvStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDsymvStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDsymvStridedBatched_(handle,uplo,n,alpha,AP,lda,strideA,x,incx,stridex,beta,y, &
-        incy,stridey,batchCount) &
-        bind(c, name="cublasDsymvStridedBatched")
-#else
     function hipblasDsymvStridedBatched_(handle,uplo,n,alpha,AP,lda,strideA,x,incx,stridex,beta,y, &
         incy,stridey,batchCount) &
         bind(c, name="hipblasDsymvStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -20101,17 +18906,13 @@ module hipfort_hipblas
       hipblasDsymvStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCsymvStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCsymvStridedBatched_(handle,uplo,n,alpha,AP,lda,strideA,x,incx,stridex,beta,y, &
-        incy,stridey,batchCount) &
-        bind(c, name="cublasCsymvStridedBatched")
-#else
     function hipblasCsymvStridedBatched_(handle,uplo,n,alpha,AP,lda,strideA,x,incx,stridex,beta,y, &
         incy,stridey,batchCount) &
         bind(c, name="hipblasCsymvStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -20140,17 +18941,13 @@ module hipfort_hipblas
       hipblasCsymvStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZsymvStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZsymvStridedBatched_(handle,uplo,n,alpha,AP,lda,strideA,x,incx,stridex,beta,y, &
-        incy,stridey,batchCount) &
-        bind(c, name="cublasZsymvStridedBatched")
-#else
     function hipblasZsymvStridedBatched_(handle,uplo,n,alpha,AP,lda,strideA,x,incx,stridex,beta,y, &
         incy,stridey,batchCount) &
         bind(c, name="hipblasZsymvStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -20179,17 +18976,13 @@ module hipfort_hipblas
       hipblasZsymvStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasSsymvStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasSsymvStridedBatched_64_(handle,uplo,n,alpha,AP,lda,strideA,x,incx,stridex, &
-        beta,y,incy,stridey,batchCount) &
-        bind(c, name="cublasSsymvStridedBatched_64")
-#else
     function hipblasSsymvStridedBatched_64_(handle,uplo,n,alpha,AP,lda,strideA,x,incx,stridex, &
         beta,y,incy,stridey,batchCount) &
         bind(c, name="hipblasSsymvStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -20211,17 +19004,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDsymvStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDsymvStridedBatched_64_(handle,uplo,n,alpha,AP,lda,strideA,x,incx,stridex, &
-        beta,y,incy,stridey,batchCount) &
-        bind(c, name="cublasDsymvStridedBatched_64")
-#else
     function hipblasDsymvStridedBatched_64_(handle,uplo,n,alpha,AP,lda,strideA,x,incx,stridex, &
         beta,y,incy,stridey,batchCount) &
         bind(c, name="hipblasDsymvStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -20243,17 +19032,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCsymvStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCsymvStridedBatched_64_(handle,uplo,n,alpha,AP,lda,strideA,x,incx,stridex, &
-        beta,y,incy,stridey,batchCount) &
-        bind(c, name="cublasCsymvStridedBatched_64")
-#else
     function hipblasCsymvStridedBatched_64_(handle,uplo,n,alpha,AP,lda,strideA,x,incx,stridex, &
         beta,y,incy,stridey,batchCount) &
         bind(c, name="hipblasCsymvStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -20275,17 +19060,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZsymvStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZsymvStridedBatched_64_(handle,uplo,n,alpha,AP,lda,strideA,x,incx,stridex, &
-        beta,y,incy,stridey,batchCount) &
-        bind(c, name="cublasZsymvStridedBatched_64")
-#else
     function hipblasZsymvStridedBatched_64_(handle,uplo,n,alpha,AP,lda,strideA,x,incx,stridex, &
         beta,y,incy,stridey,batchCount) &
         bind(c, name="hipblasZsymvStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -20307,6 +19088,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 2 API
   !>
@@ -20584,14 +19366,10 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasSsyrBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasSsyrBatched_(handle,uplo,n,alpha,x,incx,AP,lda,batchCount) &
-        bind(c, name="cublasSsyrBatched")
-#else
     function hipblasSsyrBatched_(handle,uplo,n,alpha,x,incx,AP,lda,batchCount) &
         bind(c, name="hipblasSsyrBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -20607,15 +19385,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDsyrBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDsyrBatched_(handle,uplo,n,alpha,x,incx,AP,lda,batchCount) &
-        bind(c, name="cublasDsyrBatched")
-#else
     function hipblasDsyrBatched_(handle,uplo,n,alpha,x,incx,AP,lda,batchCount) &
         bind(c, name="hipblasDsyrBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -20631,15 +19406,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCsyrBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCsyrBatched_(handle,uplo,n,alpha,x,incx,AP,lda,batchCount) &
-        bind(c, name="cublasCsyrBatched")
-#else
     function hipblasCsyrBatched_(handle,uplo,n,alpha,x,incx,AP,lda,batchCount) &
         bind(c, name="hipblasCsyrBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -20655,15 +19427,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZsyrBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZsyrBatched_(handle,uplo,n,alpha,x,incx,AP,lda,batchCount) &
-        bind(c, name="cublasZsyrBatched")
-#else
     function hipblasZsyrBatched_(handle,uplo,n,alpha,x,incx,AP,lda,batchCount) &
         bind(c, name="hipblasZsyrBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -20679,15 +19448,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasSsyrBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasSsyrBatched_64_(handle,uplo,n,alpha,x,incx,AP,lda,batchCount) &
-        bind(c, name="cublasSsyrBatched_64")
-#else
     function hipblasSsyrBatched_64_(handle,uplo,n,alpha,x,incx,AP,lda,batchCount) &
         bind(c, name="hipblasSsyrBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -20703,15 +19469,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDsyrBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDsyrBatched_64_(handle,uplo,n,alpha,x,incx,AP,lda,batchCount) &
-        bind(c, name="cublasDsyrBatched_64")
-#else
     function hipblasDsyrBatched_64_(handle,uplo,n,alpha,x,incx,AP,lda,batchCount) &
         bind(c, name="hipblasDsyrBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -20727,15 +19490,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCsyrBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCsyrBatched_64_(handle,uplo,n,alpha,x,incx,AP,lda,batchCount) &
-        bind(c, name="cublasCsyrBatched_64")
-#else
     function hipblasCsyrBatched_64_(handle,uplo,n,alpha,x,incx,AP,lda,batchCount) &
         bind(c, name="hipblasCsyrBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -20751,15 +19511,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZsyrBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZsyrBatched_64_(handle,uplo,n,alpha,x,incx,AP,lda,batchCount) &
-        bind(c, name="cublasZsyrBatched_64")
-#else
     function hipblasZsyrBatched_64_(handle,uplo,n,alpha,x,incx,AP,lda,batchCount) &
         bind(c, name="hipblasZsyrBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -20775,6 +19532,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief   BLAS Level 2 API
   !>
@@ -20824,16 +19582,11 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>               number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasSsyrStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasSsyrStridedBatched_(handle,uplo,n,alpha,x,incx,stridex,AP,lda,strideA, &
-        batchCount) &
-        bind(c, name="cublasSsyrStridedBatched")
-#else
     function hipblasSsyrStridedBatched_(handle,uplo,n,alpha,x,incx,stridex,AP,lda,strideA, &
         batchCount) &
         bind(c, name="hipblasSsyrStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -20858,17 +19611,13 @@ module hipfort_hipblas
       hipblasSsyrStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDsyrStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDsyrStridedBatched_(handle,uplo,n,alpha,x,incx,stridex,AP,lda,strideA, &
-        batchCount) &
-        bind(c, name="cublasDsyrStridedBatched")
-#else
     function hipblasDsyrStridedBatched_(handle,uplo,n,alpha,x,incx,stridex,AP,lda,strideA, &
         batchCount) &
         bind(c, name="hipblasDsyrStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -20893,17 +19642,13 @@ module hipfort_hipblas
       hipblasDsyrStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCsyrStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCsyrStridedBatched_(handle,uplo,n,alpha,x,incx,stridex,AP,lda,strideA, &
-        batchCount) &
-        bind(c, name="cublasCsyrStridedBatched")
-#else
     function hipblasCsyrStridedBatched_(handle,uplo,n,alpha,x,incx,stridex,AP,lda,strideA, &
         batchCount) &
         bind(c, name="hipblasCsyrStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -20928,17 +19673,13 @@ module hipfort_hipblas
       hipblasCsyrStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZsyrStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZsyrStridedBatched_(handle,uplo,n,alpha,x,incx,stridex,AP,lda,strideA, &
-        batchCount) &
-        bind(c, name="cublasZsyrStridedBatched")
-#else
     function hipblasZsyrStridedBatched_(handle,uplo,n,alpha,x,incx,stridex,AP,lda,strideA, &
         batchCount) &
         bind(c, name="hipblasZsyrStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -20963,17 +19704,13 @@ module hipfort_hipblas
       hipblasZsyrStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasSsyrStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasSsyrStridedBatched_64_(handle,uplo,n,alpha,x,incx,stridex,AP,lda,strideA, &
-        batchCount) &
-        bind(c, name="cublasSsyrStridedBatched_64")
-#else
     function hipblasSsyrStridedBatched_64_(handle,uplo,n,alpha,x,incx,stridex,AP,lda,strideA, &
         batchCount) &
         bind(c, name="hipblasSsyrStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -20991,17 +19728,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDsyrStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDsyrStridedBatched_64_(handle,uplo,n,alpha,x,incx,stridex,AP,lda,strideA, &
-        batchCount) &
-        bind(c, name="cublasDsyrStridedBatched_64")
-#else
     function hipblasDsyrStridedBatched_64_(handle,uplo,n,alpha,x,incx,stridex,AP,lda,strideA, &
         batchCount) &
         bind(c, name="hipblasDsyrStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -21019,17 +19752,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCsyrStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCsyrStridedBatched_64_(handle,uplo,n,alpha,x,incx,stridex,AP,lda,strideA, &
-        batchCount) &
-        bind(c, name="cublasCsyrStridedBatched_64")
-#else
     function hipblasCsyrStridedBatched_64_(handle,uplo,n,alpha,x,incx,stridex,AP,lda,strideA, &
         batchCount) &
         bind(c, name="hipblasCsyrStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -21047,17 +19776,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZsyrStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZsyrStridedBatched_64_(handle,uplo,n,alpha,x,incx,stridex,AP,lda,strideA, &
-        batchCount) &
-        bind(c, name="cublasZsyrStridedBatched_64")
-#else
     function hipblasZsyrStridedBatched_64_(handle,uplo,n,alpha,x,incx,stridex,AP,lda,strideA, &
         batchCount) &
         bind(c, name="hipblasZsyrStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -21075,6 +19800,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 2 API
   !>
@@ -21386,14 +20112,10 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasSsyr2Batched
-#ifdef USE_CUDA_NAMES
-    function hipblasSsyr2Batched_(handle,uplo,n,alpha,x,incx,y,incy,AP,lda,batchCount) &
-        bind(c, name="cublasSsyr2Batched")
-#else
     function hipblasSsyr2Batched_(handle,uplo,n,alpha,x,incx,y,incy,AP,lda,batchCount) &
         bind(c, name="hipblasSsyr2Batched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -21411,15 +20133,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDsyr2Batched
-#ifdef USE_CUDA_NAMES
-    function hipblasDsyr2Batched_(handle,uplo,n,alpha,x,incx,y,incy,AP,lda,batchCount) &
-        bind(c, name="cublasDsyr2Batched")
-#else
     function hipblasDsyr2Batched_(handle,uplo,n,alpha,x,incx,y,incy,AP,lda,batchCount) &
         bind(c, name="hipblasDsyr2Batched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -21437,15 +20156,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCsyr2Batched
-#ifdef USE_CUDA_NAMES
-    function hipblasCsyr2Batched_(handle,uplo,n,alpha,x,incx,y,incy,AP,lda,batchCount) &
-        bind(c, name="cublasCsyr2Batched")
-#else
     function hipblasCsyr2Batched_(handle,uplo,n,alpha,x,incx,y,incy,AP,lda,batchCount) &
         bind(c, name="hipblasCsyr2Batched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -21463,15 +20179,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZsyr2Batched
-#ifdef USE_CUDA_NAMES
-    function hipblasZsyr2Batched_(handle,uplo,n,alpha,x,incx,y,incy,AP,lda,batchCount) &
-        bind(c, name="cublasZsyr2Batched")
-#else
     function hipblasZsyr2Batched_(handle,uplo,n,alpha,x,incx,y,incy,AP,lda,batchCount) &
         bind(c, name="hipblasZsyr2Batched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -21489,15 +20202,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasSsyr2Batched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasSsyr2Batched_64_(handle,uplo,n,alpha,x,incx,y,incy,AP,lda,batchCount) &
-        bind(c, name="cublasSsyr2Batched_64")
-#else
     function hipblasSsyr2Batched_64_(handle,uplo,n,alpha,x,incx,y,incy,AP,lda,batchCount) &
         bind(c, name="hipblasSsyr2Batched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -21515,15 +20225,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDsyr2Batched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDsyr2Batched_64_(handle,uplo,n,alpha,x,incx,y,incy,AP,lda,batchCount) &
-        bind(c, name="cublasDsyr2Batched_64")
-#else
     function hipblasDsyr2Batched_64_(handle,uplo,n,alpha,x,incx,y,incy,AP,lda,batchCount) &
         bind(c, name="hipblasDsyr2Batched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -21541,15 +20248,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCsyr2Batched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCsyr2Batched_64_(handle,uplo,n,alpha,x,incx,y,incy,AP,lda,batchCount) &
-        bind(c, name="cublasCsyr2Batched_64")
-#else
     function hipblasCsyr2Batched_64_(handle,uplo,n,alpha,x,incx,y,incy,AP,lda,batchCount) &
         bind(c, name="hipblasCsyr2Batched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -21567,15 +20271,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZsyr2Batched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZsyr2Batched_64_(handle,uplo,n,alpha,x,incx,y,incy,AP,lda,batchCount) &
-        bind(c, name="cublasZsyr2Batched_64")
-#else
     function hipblasZsyr2Batched_64_(handle,uplo,n,alpha,x,incx,y,incy,AP,lda,batchCount) &
         bind(c, name="hipblasZsyr2Batched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -21593,6 +20294,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 2 API
   !>
@@ -21649,16 +20351,11 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>               number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasSsyr2StridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasSsyr2StridedBatched_(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey,AP,lda, &
-        strideA,batchCount) &
-        bind(c, name="cublasSsyr2StridedBatched")
-#else
     function hipblasSsyr2StridedBatched_(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey,AP,lda, &
         strideA,batchCount) &
         bind(c, name="hipblasSsyr2StridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -21686,17 +20383,13 @@ module hipfort_hipblas
       hipblasSsyr2StridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDsyr2StridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDsyr2StridedBatched_(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey,AP,lda, &
-        strideA,batchCount) &
-        bind(c, name="cublasDsyr2StridedBatched")
-#else
     function hipblasDsyr2StridedBatched_(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey,AP,lda, &
         strideA,batchCount) &
         bind(c, name="hipblasDsyr2StridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -21724,17 +20417,13 @@ module hipfort_hipblas
       hipblasDsyr2StridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCsyr2StridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCsyr2StridedBatched_(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey,AP,lda, &
-        strideA,batchCount) &
-        bind(c, name="cublasCsyr2StridedBatched")
-#else
     function hipblasCsyr2StridedBatched_(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey,AP,lda, &
         strideA,batchCount) &
         bind(c, name="hipblasCsyr2StridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -21762,17 +20451,13 @@ module hipfort_hipblas
       hipblasCsyr2StridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZsyr2StridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZsyr2StridedBatched_(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey,AP,lda, &
-        strideA,batchCount) &
-        bind(c, name="cublasZsyr2StridedBatched")
-#else
     function hipblasZsyr2StridedBatched_(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey,AP,lda, &
         strideA,batchCount) &
         bind(c, name="hipblasZsyr2StridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -21800,17 +20485,13 @@ module hipfort_hipblas
       hipblasZsyr2StridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasSsyr2StridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasSsyr2StridedBatched_64_(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey,AP, &
-        lda,strideA,batchCount) &
-        bind(c, name="cublasSsyr2StridedBatched_64")
-#else
     function hipblasSsyr2StridedBatched_64_(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey,AP, &
         lda,strideA,batchCount) &
         bind(c, name="hipblasSsyr2StridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -21831,17 +20512,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDsyr2StridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDsyr2StridedBatched_64_(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey,AP, &
-        lda,strideA,batchCount) &
-        bind(c, name="cublasDsyr2StridedBatched_64")
-#else
     function hipblasDsyr2StridedBatched_64_(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey,AP, &
         lda,strideA,batchCount) &
         bind(c, name="hipblasDsyr2StridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -21862,17 +20539,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCsyr2StridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCsyr2StridedBatched_64_(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey,AP, &
-        lda,strideA,batchCount) &
-        bind(c, name="cublasCsyr2StridedBatched_64")
-#else
     function hipblasCsyr2StridedBatched_64_(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey,AP, &
         lda,strideA,batchCount) &
         bind(c, name="hipblasCsyr2StridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -21893,17 +20566,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZsyr2StridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZsyr2StridedBatched_64_(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey,AP, &
-        lda,strideA,batchCount) &
-        bind(c, name="cublasZsyr2StridedBatched_64")
-#else
     function hipblasZsyr2StridedBatched_64_(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey,AP, &
         lda,strideA,batchCount) &
         bind(c, name="hipblasZsyr2StridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -21924,6 +20593,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief BLAS Level 2 API
   !>
@@ -22301,14 +20971,10 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasStbmvBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasStbmvBatched_(handle,uplo,transA,diag,n,k,AP,lda,x,incx,batchCount) &
-        bind(c, name="cublasStbmvBatched")
-#else
     function hipblasStbmvBatched_(handle,uplo,transA,diag,n,k,AP,lda,x,incx,batchCount) &
         bind(c, name="hipblasStbmvBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -22326,15 +20992,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDtbmvBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDtbmvBatched_(handle,uplo,transA,diag,n,k,AP,lda,x,incx,batchCount) &
-        bind(c, name="cublasDtbmvBatched")
-#else
     function hipblasDtbmvBatched_(handle,uplo,transA,diag,n,k,AP,lda,x,incx,batchCount) &
         bind(c, name="hipblasDtbmvBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -22352,15 +21015,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCtbmvBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCtbmvBatched_(handle,uplo,transA,diag,n,k,AP,lda,x,incx,batchCount) &
-        bind(c, name="cublasCtbmvBatched")
-#else
     function hipblasCtbmvBatched_(handle,uplo,transA,diag,n,k,AP,lda,x,incx,batchCount) &
         bind(c, name="hipblasCtbmvBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -22378,15 +21038,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZtbmvBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZtbmvBatched_(handle,uplo,transA,diag,n,k,AP,lda,x,incx,batchCount) &
-        bind(c, name="cublasZtbmvBatched")
-#else
     function hipblasZtbmvBatched_(handle,uplo,transA,diag,n,k,AP,lda,x,incx,batchCount) &
         bind(c, name="hipblasZtbmvBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -22404,15 +21061,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasStbmvBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasStbmvBatched_64_(handle,uplo,transA,diag,n,k,AP,lda,x,incx,batchCount) &
-        bind(c, name="cublasStbmvBatched_64")
-#else
     function hipblasStbmvBatched_64_(handle,uplo,transA,diag,n,k,AP,lda,x,incx,batchCount) &
         bind(c, name="hipblasStbmvBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -22430,15 +21084,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDtbmvBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDtbmvBatched_64_(handle,uplo,transA,diag,n,k,AP,lda,x,incx,batchCount) &
-        bind(c, name="cublasDtbmvBatched_64")
-#else
     function hipblasDtbmvBatched_64_(handle,uplo,transA,diag,n,k,AP,lda,x,incx,batchCount) &
         bind(c, name="hipblasDtbmvBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -22456,15 +21107,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCtbmvBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCtbmvBatched_64_(handle,uplo,transA,diag,n,k,AP,lda,x,incx,batchCount) &
-        bind(c, name="cublasCtbmvBatched_64")
-#else
     function hipblasCtbmvBatched_64_(handle,uplo,transA,diag,n,k,AP,lda,x,incx,batchCount) &
         bind(c, name="hipblasCtbmvBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -22482,15 +21130,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZtbmvBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZtbmvBatched_64_(handle,uplo,transA,diag,n,k,AP,lda,x,incx,batchCount) &
-        bind(c, name="cublasZtbmvBatched_64")
-#else
     function hipblasZtbmvBatched_64_(handle,uplo,transA,diag,n,k,AP,lda,x,incx,batchCount) &
         bind(c, name="hipblasZtbmvBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -22508,6 +21153,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 2 API
   !>
@@ -22596,16 +21242,11 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasStbmvStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasStbmvStridedBatched_(handle,uplo,transA,diag,n,k,AP,lda,strideA,x,incx, &
-        stridex,batchCount) &
-        bind(c, name="cublasStbmvStridedBatched")
-#else
     function hipblasStbmvStridedBatched_(handle,uplo,transA,diag,n,k,AP,lda,strideA,x,incx, &
         stridex,batchCount) &
         bind(c, name="hipblasStbmvStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -22632,17 +21273,13 @@ module hipfort_hipblas
       hipblasStbmvStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDtbmvStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDtbmvStridedBatched_(handle,uplo,transA,diag,n,k,AP,lda,strideA,x,incx, &
-        stridex,batchCount) &
-        bind(c, name="cublasDtbmvStridedBatched")
-#else
     function hipblasDtbmvStridedBatched_(handle,uplo,transA,diag,n,k,AP,lda,strideA,x,incx, &
         stridex,batchCount) &
         bind(c, name="hipblasDtbmvStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -22669,17 +21306,13 @@ module hipfort_hipblas
       hipblasDtbmvStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCtbmvStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCtbmvStridedBatched_(handle,uplo,transA,diag,n,k,AP,lda,strideA,x,incx, &
-        stridex,batchCount) &
-        bind(c, name="cublasCtbmvStridedBatched")
-#else
     function hipblasCtbmvStridedBatched_(handle,uplo,transA,diag,n,k,AP,lda,strideA,x,incx, &
         stridex,batchCount) &
         bind(c, name="hipblasCtbmvStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -22706,17 +21339,13 @@ module hipfort_hipblas
       hipblasCtbmvStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZtbmvStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZtbmvStridedBatched_(handle,uplo,transA,diag,n,k,AP,lda,strideA,x,incx, &
-        stridex,batchCount) &
-        bind(c, name="cublasZtbmvStridedBatched")
-#else
     function hipblasZtbmvStridedBatched_(handle,uplo,transA,diag,n,k,AP,lda,strideA,x,incx, &
         stridex,batchCount) &
         bind(c, name="hipblasZtbmvStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -22743,17 +21372,13 @@ module hipfort_hipblas
       hipblasZtbmvStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasStbmvStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasStbmvStridedBatched_64_(handle,uplo,transA,diag,n,k,AP,lda,strideA,x,incx, &
-        stridex,batchCount) &
-        bind(c, name="cublasStbmvStridedBatched_64")
-#else
     function hipblasStbmvStridedBatched_64_(handle,uplo,transA,diag,n,k,AP,lda,strideA,x,incx, &
         stridex,batchCount) &
         bind(c, name="hipblasStbmvStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -22773,17 +21398,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDtbmvStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDtbmvStridedBatched_64_(handle,uplo,transA,diag,n,k,AP,lda,strideA,x,incx, &
-        stridex,batchCount) &
-        bind(c, name="cublasDtbmvStridedBatched_64")
-#else
     function hipblasDtbmvStridedBatched_64_(handle,uplo,transA,diag,n,k,AP,lda,strideA,x,incx, &
         stridex,batchCount) &
         bind(c, name="hipblasDtbmvStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -22803,17 +21424,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCtbmvStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCtbmvStridedBatched_64_(handle,uplo,transA,diag,n,k,AP,lda,strideA,x,incx, &
-        stridex,batchCount) &
-        bind(c, name="cublasCtbmvStridedBatched_64")
-#else
     function hipblasCtbmvStridedBatched_64_(handle,uplo,transA,diag,n,k,AP,lda,strideA,x,incx, &
         stridex,batchCount) &
         bind(c, name="hipblasCtbmvStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -22833,17 +21450,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZtbmvStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZtbmvStridedBatched_64_(handle,uplo,transA,diag,n,k,AP,lda,strideA,x,incx, &
-        stridex,batchCount) &
-        bind(c, name="cublasZtbmvStridedBatched_64")
-#else
     function hipblasZtbmvStridedBatched_64_(handle,uplo,transA,diag,n,k,AP,lda,strideA,x,incx, &
         stridex,batchCount) &
         bind(c, name="hipblasZtbmvStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -22863,6 +21476,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 2 API
   !>
@@ -23209,14 +21823,10 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasStbsvBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasStbsvBatched_(handle,uplo,transA,diag,n,k,AP,lda,x,incx,batchCount) &
-        bind(c, name="cublasStbsvBatched")
-#else
     function hipblasStbsvBatched_(handle,uplo,transA,diag,n,k,AP,lda,x,incx,batchCount) &
         bind(c, name="hipblasStbsvBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -23234,15 +21844,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDtbsvBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDtbsvBatched_(handle,uplo,transA,diag,n,k,AP,lda,x,incx,batchCount) &
-        bind(c, name="cublasDtbsvBatched")
-#else
     function hipblasDtbsvBatched_(handle,uplo,transA,diag,n,k,AP,lda,x,incx,batchCount) &
         bind(c, name="hipblasDtbsvBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -23260,15 +21867,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCtbsvBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCtbsvBatched_(handle,uplo,transA,diag,n,k,AP,lda,x,incx,batchCount) &
-        bind(c, name="cublasCtbsvBatched")
-#else
     function hipblasCtbsvBatched_(handle,uplo,transA,diag,n,k,AP,lda,x,incx,batchCount) &
         bind(c, name="hipblasCtbsvBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -23286,15 +21890,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZtbsvBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZtbsvBatched_(handle,uplo,transA,diag,n,k,AP,lda,x,incx,batchCount) &
-        bind(c, name="cublasZtbsvBatched")
-#else
     function hipblasZtbsvBatched_(handle,uplo,transA,diag,n,k,AP,lda,x,incx,batchCount) &
         bind(c, name="hipblasZtbsvBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -23312,15 +21913,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasStbsvBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasStbsvBatched_64_(handle,uplo,transA,diag,n,k,AP,lda,x,incx,batchCount) &
-        bind(c, name="cublasStbsvBatched_64")
-#else
     function hipblasStbsvBatched_64_(handle,uplo,transA,diag,n,k,AP,lda,x,incx,batchCount) &
         bind(c, name="hipblasStbsvBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -23338,15 +21936,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDtbsvBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDtbsvBatched_64_(handle,uplo,transA,diag,n,k,AP,lda,x,incx,batchCount) &
-        bind(c, name="cublasDtbsvBatched_64")
-#else
     function hipblasDtbsvBatched_64_(handle,uplo,transA,diag,n,k,AP,lda,x,incx,batchCount) &
         bind(c, name="hipblasDtbsvBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -23364,15 +21959,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCtbsvBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCtbsvBatched_64_(handle,uplo,transA,diag,n,k,AP,lda,x,incx,batchCount) &
-        bind(c, name="cublasCtbsvBatched_64")
-#else
     function hipblasCtbsvBatched_64_(handle,uplo,transA,diag,n,k,AP,lda,x,incx,batchCount) &
         bind(c, name="hipblasCtbsvBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -23390,15 +21982,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZtbsvBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZtbsvBatched_64_(handle,uplo,transA,diag,n,k,AP,lda,x,incx,batchCount) &
-        bind(c, name="cublasZtbsvBatched_64")
-#else
     function hipblasZtbsvBatched_64_(handle,uplo,transA,diag,n,k,AP,lda,x,incx,batchCount) &
         bind(c, name="hipblasZtbsvBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -23416,6 +22005,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 2 API
   !>
@@ -23489,16 +22079,11 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasStbsvStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasStbsvStridedBatched_(handle,uplo,transA,diag,n,k,AP,lda,strideA,x,incx, &
-        stridex,batchCount) &
-        bind(c, name="cublasStbsvStridedBatched")
-#else
     function hipblasStbsvStridedBatched_(handle,uplo,transA,diag,n,k,AP,lda,strideA,x,incx, &
         stridex,batchCount) &
         bind(c, name="hipblasStbsvStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -23525,17 +22110,13 @@ module hipfort_hipblas
       hipblasStbsvStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDtbsvStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDtbsvStridedBatched_(handle,uplo,transA,diag,n,k,AP,lda,strideA,x,incx, &
-        stridex,batchCount) &
-        bind(c, name="cublasDtbsvStridedBatched")
-#else
     function hipblasDtbsvStridedBatched_(handle,uplo,transA,diag,n,k,AP,lda,strideA,x,incx, &
         stridex,batchCount) &
         bind(c, name="hipblasDtbsvStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -23562,17 +22143,13 @@ module hipfort_hipblas
       hipblasDtbsvStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCtbsvStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCtbsvStridedBatched_(handle,uplo,transA,diag,n,k,AP,lda,strideA,x,incx, &
-        stridex,batchCount) &
-        bind(c, name="cublasCtbsvStridedBatched")
-#else
     function hipblasCtbsvStridedBatched_(handle,uplo,transA,diag,n,k,AP,lda,strideA,x,incx, &
         stridex,batchCount) &
         bind(c, name="hipblasCtbsvStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -23599,17 +22176,13 @@ module hipfort_hipblas
       hipblasCtbsvStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZtbsvStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZtbsvStridedBatched_(handle,uplo,transA,diag,n,k,AP,lda,strideA,x,incx, &
-        stridex,batchCount) &
-        bind(c, name="cublasZtbsvStridedBatched")
-#else
     function hipblasZtbsvStridedBatched_(handle,uplo,transA,diag,n,k,AP,lda,strideA,x,incx, &
         stridex,batchCount) &
         bind(c, name="hipblasZtbsvStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -23636,17 +22209,13 @@ module hipfort_hipblas
       hipblasZtbsvStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasStbsvStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasStbsvStridedBatched_64_(handle,uplo,transA,diag,n,k,AP,lda,strideA,x,incx, &
-        stridex,batchCount) &
-        bind(c, name="cublasStbsvStridedBatched_64")
-#else
     function hipblasStbsvStridedBatched_64_(handle,uplo,transA,diag,n,k,AP,lda,strideA,x,incx, &
         stridex,batchCount) &
         bind(c, name="hipblasStbsvStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -23666,17 +22235,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDtbsvStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDtbsvStridedBatched_64_(handle,uplo,transA,diag,n,k,AP,lda,strideA,x,incx, &
-        stridex,batchCount) &
-        bind(c, name="cublasDtbsvStridedBatched_64")
-#else
     function hipblasDtbsvStridedBatched_64_(handle,uplo,transA,diag,n,k,AP,lda,strideA,x,incx, &
         stridex,batchCount) &
         bind(c, name="hipblasDtbsvStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -23696,17 +22261,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCtbsvStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCtbsvStridedBatched_64_(handle,uplo,transA,diag,n,k,AP,lda,strideA,x,incx, &
-        stridex,batchCount) &
-        bind(c, name="cublasCtbsvStridedBatched_64")
-#else
     function hipblasCtbsvStridedBatched_64_(handle,uplo,transA,diag,n,k,AP,lda,strideA,x,incx, &
         stridex,batchCount) &
         bind(c, name="hipblasCtbsvStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -23726,17 +22287,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZtbsvStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZtbsvStridedBatched_64_(handle,uplo,transA,diag,n,k,AP,lda,strideA,x,incx, &
-        stridex,batchCount) &
-        bind(c, name="cublasZtbsvStridedBatched_64")
-#else
     function hipblasZtbsvStridedBatched_64_(handle,uplo,transA,diag,n,k,AP,lda,strideA,x,incx, &
         stridex,batchCount) &
         bind(c, name="hipblasZtbsvStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -23756,6 +22313,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 2 API
   !>
@@ -24055,14 +22613,10 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>               The number of batched matrices/vectors.
+#ifndef USE_CUDA_NAMES
   interface hipblasStpmvBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasStpmvBatched_(handle,uplo,transA,diag,n,AP,x,incx,batchCount) &
-        bind(c, name="cublasStpmvBatched")
-#else
     function hipblasStpmvBatched_(handle,uplo,transA,diag,n,AP,x,incx,batchCount) &
         bind(c, name="hipblasStpmvBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -24078,15 +22632,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDtpmvBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDtpmvBatched_(handle,uplo,transA,diag,n,AP,x,incx,batchCount) &
-        bind(c, name="cublasDtpmvBatched")
-#else
     function hipblasDtpmvBatched_(handle,uplo,transA,diag,n,AP,x,incx,batchCount) &
         bind(c, name="hipblasDtpmvBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -24102,15 +22653,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCtpmvBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCtpmvBatched_(handle,uplo,transA,diag,n,AP,x,incx,batchCount) &
-        bind(c, name="cublasCtpmvBatched")
-#else
     function hipblasCtpmvBatched_(handle,uplo,transA,diag,n,AP,x,incx,batchCount) &
         bind(c, name="hipblasCtpmvBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -24126,15 +22674,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZtpmvBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZtpmvBatched_(handle,uplo,transA,diag,n,AP,x,incx,batchCount) &
-        bind(c, name="cublasZtpmvBatched")
-#else
     function hipblasZtpmvBatched_(handle,uplo,transA,diag,n,AP,x,incx,batchCount) &
         bind(c, name="hipblasZtpmvBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -24150,15 +22695,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasStpmvBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasStpmvBatched_64_(handle,uplo,transA,diag,n,AP,x,incx,batchCount) &
-        bind(c, name="cublasStpmvBatched_64")
-#else
     function hipblasStpmvBatched_64_(handle,uplo,transA,diag,n,AP,x,incx,batchCount) &
         bind(c, name="hipblasStpmvBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -24174,15 +22716,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDtpmvBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDtpmvBatched_64_(handle,uplo,transA,diag,n,AP,x,incx,batchCount) &
-        bind(c, name="cublasDtpmvBatched_64")
-#else
     function hipblasDtpmvBatched_64_(handle,uplo,transA,diag,n,AP,x,incx,batchCount) &
         bind(c, name="hipblasDtpmvBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -24198,15 +22737,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCtpmvBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCtpmvBatched_64_(handle,uplo,transA,diag,n,AP,x,incx,batchCount) &
-        bind(c, name="cublasCtpmvBatched_64")
-#else
     function hipblasCtpmvBatched_64_(handle,uplo,transA,diag,n,AP,x,incx,batchCount) &
         bind(c, name="hipblasCtpmvBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -24222,15 +22758,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZtpmvBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZtpmvBatched_64_(handle,uplo,transA,diag,n,AP,x,incx,batchCount) &
-        bind(c, name="cublasZtpmvBatched_64")
-#else
     function hipblasZtpmvBatched_64_(handle,uplo,transA,diag,n,AP,x,incx,batchCount) &
         bind(c, name="hipblasZtpmvBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -24246,6 +22779,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief   BLAS Level 2 API
   !>
@@ -24307,16 +22841,11 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>               The number of batched matrices/vectors.
+#ifndef USE_CUDA_NAMES
   interface hipblasStpmvStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasStpmvStridedBatched_(handle,uplo,transA,diag,n,AP,strideA,x,incx,stridex, &
-        batchCount) &
-        bind(c, name="cublasStpmvStridedBatched")
-#else
     function hipblasStpmvStridedBatched_(handle,uplo,transA,diag,n,AP,strideA,x,incx,stridex, &
         batchCount) &
         bind(c, name="hipblasStpmvStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -24340,17 +22869,13 @@ module hipfort_hipblas
       hipblasStpmvStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDtpmvStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDtpmvStridedBatched_(handle,uplo,transA,diag,n,AP,strideA,x,incx,stridex, &
-        batchCount) &
-        bind(c, name="cublasDtpmvStridedBatched")
-#else
     function hipblasDtpmvStridedBatched_(handle,uplo,transA,diag,n,AP,strideA,x,incx,stridex, &
         batchCount) &
         bind(c, name="hipblasDtpmvStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -24374,17 +22899,13 @@ module hipfort_hipblas
       hipblasDtpmvStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCtpmvStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCtpmvStridedBatched_(handle,uplo,transA,diag,n,AP,strideA,x,incx,stridex, &
-        batchCount) &
-        bind(c, name="cublasCtpmvStridedBatched")
-#else
     function hipblasCtpmvStridedBatched_(handle,uplo,transA,diag,n,AP,strideA,x,incx,stridex, &
         batchCount) &
         bind(c, name="hipblasCtpmvStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -24408,17 +22929,13 @@ module hipfort_hipblas
       hipblasCtpmvStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZtpmvStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZtpmvStridedBatched_(handle,uplo,transA,diag,n,AP,strideA,x,incx,stridex, &
-        batchCount) &
-        bind(c, name="cublasZtpmvStridedBatched")
-#else
     function hipblasZtpmvStridedBatched_(handle,uplo,transA,diag,n,AP,strideA,x,incx,stridex, &
         batchCount) &
         bind(c, name="hipblasZtpmvStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -24442,17 +22959,13 @@ module hipfort_hipblas
       hipblasZtpmvStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasStpmvStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasStpmvStridedBatched_64_(handle,uplo,transA,diag,n,AP,strideA,x,incx,stridex, &
-        batchCount) &
-        bind(c, name="cublasStpmvStridedBatched_64")
-#else
     function hipblasStpmvStridedBatched_64_(handle,uplo,transA,diag,n,AP,strideA,x,incx,stridex, &
         batchCount) &
         bind(c, name="hipblasStpmvStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -24470,17 +22983,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDtpmvStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDtpmvStridedBatched_64_(handle,uplo,transA,diag,n,AP,strideA,x,incx,stridex, &
-        batchCount) &
-        bind(c, name="cublasDtpmvStridedBatched_64")
-#else
     function hipblasDtpmvStridedBatched_64_(handle,uplo,transA,diag,n,AP,strideA,x,incx,stridex, &
         batchCount) &
         bind(c, name="hipblasDtpmvStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -24498,17 +23007,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCtpmvStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCtpmvStridedBatched_64_(handle,uplo,transA,diag,n,AP,strideA,x,incx,stridex, &
-        batchCount) &
-        bind(c, name="cublasCtpmvStridedBatched_64")
-#else
     function hipblasCtpmvStridedBatched_64_(handle,uplo,transA,diag,n,AP,strideA,x,incx,stridex, &
         batchCount) &
         bind(c, name="hipblasCtpmvStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -24526,17 +23031,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZtpmvStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZtpmvStridedBatched_64_(handle,uplo,transA,diag,n,AP,strideA,x,incx,stridex, &
-        batchCount) &
-        bind(c, name="cublasZtpmvStridedBatched_64")
-#else
     function hipblasZtpmvStridedBatched_64_(handle,uplo,transA,diag,n,AP,strideA,x,incx,stridex, &
         batchCount) &
         bind(c, name="hipblasZtpmvStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -24554,6 +23055,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 2 API
   !>
@@ -24854,14 +23356,10 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 specifies the number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasStpsvBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasStpsvBatched_(handle,uplo,transA,diag,n,AP,x,incx,batchCount) &
-        bind(c, name="cublasStpsvBatched")
-#else
     function hipblasStpsvBatched_(handle,uplo,transA,diag,n,AP,x,incx,batchCount) &
         bind(c, name="hipblasStpsvBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -24877,15 +23375,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDtpsvBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDtpsvBatched_(handle,uplo,transA,diag,n,AP,x,incx,batchCount) &
-        bind(c, name="cublasDtpsvBatched")
-#else
     function hipblasDtpsvBatched_(handle,uplo,transA,diag,n,AP,x,incx,batchCount) &
         bind(c, name="hipblasDtpsvBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -24901,15 +23396,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCtpsvBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCtpsvBatched_(handle,uplo,transA,diag,n,AP,x,incx,batchCount) &
-        bind(c, name="cublasCtpsvBatched")
-#else
     function hipblasCtpsvBatched_(handle,uplo,transA,diag,n,AP,x,incx,batchCount) &
         bind(c, name="hipblasCtpsvBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -24925,15 +23417,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZtpsvBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZtpsvBatched_(handle,uplo,transA,diag,n,AP,x,incx,batchCount) &
-        bind(c, name="cublasZtpsvBatched")
-#else
     function hipblasZtpsvBatched_(handle,uplo,transA,diag,n,AP,x,incx,batchCount) &
         bind(c, name="hipblasZtpsvBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -24949,15 +23438,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasStpsvBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasStpsvBatched_64_(handle,uplo,transA,diag,n,AP,x,incx,batchCount) &
-        bind(c, name="cublasStpsvBatched_64")
-#else
     function hipblasStpsvBatched_64_(handle,uplo,transA,diag,n,AP,x,incx,batchCount) &
         bind(c, name="hipblasStpsvBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -24973,15 +23459,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDtpsvBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDtpsvBatched_64_(handle,uplo,transA,diag,n,AP,x,incx,batchCount) &
-        bind(c, name="cublasDtpsvBatched_64")
-#else
     function hipblasDtpsvBatched_64_(handle,uplo,transA,diag,n,AP,x,incx,batchCount) &
         bind(c, name="hipblasDtpsvBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -24997,15 +23480,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCtpsvBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCtpsvBatched_64_(handle,uplo,transA,diag,n,AP,x,incx,batchCount) &
-        bind(c, name="cublasCtpsvBatched_64")
-#else
     function hipblasCtpsvBatched_64_(handle,uplo,transA,diag,n,AP,x,incx,batchCount) &
         bind(c, name="hipblasCtpsvBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -25021,15 +23501,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZtpsvBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZtpsvBatched_64_(handle,uplo,transA,diag,n,AP,x,incx,batchCount) &
-        bind(c, name="cublasZtpsvBatched_64")
-#else
     function hipblasZtpsvBatched_64_(handle,uplo,transA,diag,n,AP,x,incx,batchCount) &
         bind(c, name="hipblasZtpsvBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -25045,6 +23522,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 2 API
   !>
@@ -25108,16 +23586,11 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 specifies the number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasStpsvStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasStpsvStridedBatched_(handle,uplo,transA,diag,n,AP,strideA,x,incx,stridex, &
-        batchCount) &
-        bind(c, name="cublasStpsvStridedBatched")
-#else
     function hipblasStpsvStridedBatched_(handle,uplo,transA,diag,n,AP,strideA,x,incx,stridex, &
         batchCount) &
         bind(c, name="hipblasStpsvStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -25141,17 +23614,13 @@ module hipfort_hipblas
       hipblasStpsvStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDtpsvStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDtpsvStridedBatched_(handle,uplo,transA,diag,n,AP,strideA,x,incx,stridex, &
-        batchCount) &
-        bind(c, name="cublasDtpsvStridedBatched")
-#else
     function hipblasDtpsvStridedBatched_(handle,uplo,transA,diag,n,AP,strideA,x,incx,stridex, &
         batchCount) &
         bind(c, name="hipblasDtpsvStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -25175,17 +23644,13 @@ module hipfort_hipblas
       hipblasDtpsvStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCtpsvStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCtpsvStridedBatched_(handle,uplo,transA,diag,n,AP,strideA,x,incx,stridex, &
-        batchCount) &
-        bind(c, name="cublasCtpsvStridedBatched")
-#else
     function hipblasCtpsvStridedBatched_(handle,uplo,transA,diag,n,AP,strideA,x,incx,stridex, &
         batchCount) &
         bind(c, name="hipblasCtpsvStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -25209,17 +23674,13 @@ module hipfort_hipblas
       hipblasCtpsvStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZtpsvStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZtpsvStridedBatched_(handle,uplo,transA,diag,n,AP,strideA,x,incx,stridex, &
-        batchCount) &
-        bind(c, name="cublasZtpsvStridedBatched")
-#else
     function hipblasZtpsvStridedBatched_(handle,uplo,transA,diag,n,AP,strideA,x,incx,stridex, &
         batchCount) &
         bind(c, name="hipblasZtpsvStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -25243,17 +23704,13 @@ module hipfort_hipblas
       hipblasZtpsvStridedBatched_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasStpsvStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasStpsvStridedBatched_64_(handle,uplo,transA,diag,n,AP,strideA,x,incx,stridex, &
-        batchCount) &
-        bind(c, name="cublasStpsvStridedBatched_64")
-#else
     function hipblasStpsvStridedBatched_64_(handle,uplo,transA,diag,n,AP,strideA,x,incx,stridex, &
         batchCount) &
         bind(c, name="hipblasStpsvStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -25271,17 +23728,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDtpsvStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDtpsvStridedBatched_64_(handle,uplo,transA,diag,n,AP,strideA,x,incx,stridex, &
-        batchCount) &
-        bind(c, name="cublasDtpsvStridedBatched_64")
-#else
     function hipblasDtpsvStridedBatched_64_(handle,uplo,transA,diag,n,AP,strideA,x,incx,stridex, &
         batchCount) &
         bind(c, name="hipblasDtpsvStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -25299,17 +23752,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCtpsvStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCtpsvStridedBatched_64_(handle,uplo,transA,diag,n,AP,strideA,x,incx,stridex, &
-        batchCount) &
-        bind(c, name="cublasCtpsvStridedBatched_64")
-#else
     function hipblasCtpsvStridedBatched_64_(handle,uplo,transA,diag,n,AP,strideA,x,incx,stridex, &
         batchCount) &
         bind(c, name="hipblasCtpsvStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -25327,17 +23776,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZtpsvStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZtpsvStridedBatched_64_(handle,uplo,transA,diag,n,AP,strideA,x,incx,stridex, &
-        batchCount) &
-        bind(c, name="cublasZtpsvStridedBatched_64")
-#else
     function hipblasZtpsvStridedBatched_64_(handle,uplo,transA,diag,n,AP,strideA,x,incx,stridex, &
         batchCount) &
         bind(c, name="hipblasZtpsvStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -25355,6 +23800,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 2 API
   !>
@@ -25674,14 +24120,10 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>               The number of batched matrices/vectors.
+#ifndef USE_CUDA_NAMES
   interface hipblasStrmvBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasStrmvBatched_(handle,uplo,transA,diag,n,AP,lda,x,incx,batchCount) &
-        bind(c, name="cublasStrmvBatched")
-#else
     function hipblasStrmvBatched_(handle,uplo,transA,diag,n,AP,lda,x,incx,batchCount) &
         bind(c, name="hipblasStrmvBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -25698,15 +24140,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDtrmvBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDtrmvBatched_(handle,uplo,transA,diag,n,AP,lda,x,incx,batchCount) &
-        bind(c, name="cublasDtrmvBatched")
-#else
     function hipblasDtrmvBatched_(handle,uplo,transA,diag,n,AP,lda,x,incx,batchCount) &
         bind(c, name="hipblasDtrmvBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -25723,15 +24162,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCtrmvBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCtrmvBatched_(handle,uplo,transA,diag,n,AP,lda,x,incx,batchCount) &
-        bind(c, name="cublasCtrmvBatched")
-#else
     function hipblasCtrmvBatched_(handle,uplo,transA,diag,n,AP,lda,x,incx,batchCount) &
         bind(c, name="hipblasCtrmvBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -25748,15 +24184,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZtrmvBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZtrmvBatched_(handle,uplo,transA,diag,n,AP,lda,x,incx,batchCount) &
-        bind(c, name="cublasZtrmvBatched")
-#else
     function hipblasZtrmvBatched_(handle,uplo,transA,diag,n,AP,lda,x,incx,batchCount) &
         bind(c, name="hipblasZtrmvBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -25773,15 +24206,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasStrmvBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasStrmvBatched_64_(handle,uplo,transA,diag,n,AP,lda,x,incx,batchCount) &
-        bind(c, name="cublasStrmvBatched_64")
-#else
     function hipblasStrmvBatched_64_(handle,uplo,transA,diag,n,AP,lda,x,incx,batchCount) &
         bind(c, name="hipblasStrmvBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -25798,15 +24228,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDtrmvBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDtrmvBatched_64_(handle,uplo,transA,diag,n,AP,lda,x,incx,batchCount) &
-        bind(c, name="cublasDtrmvBatched_64")
-#else
     function hipblasDtrmvBatched_64_(handle,uplo,transA,diag,n,AP,lda,x,incx,batchCount) &
         bind(c, name="hipblasDtrmvBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -25823,15 +24250,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCtrmvBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCtrmvBatched_64_(handle,uplo,transA,diag,n,AP,lda,x,incx,batchCount) &
-        bind(c, name="cublasCtrmvBatched_64")
-#else
     function hipblasCtrmvBatched_64_(handle,uplo,transA,diag,n,AP,lda,x,incx,batchCount) &
         bind(c, name="hipblasCtrmvBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -25848,15 +24272,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZtrmvBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZtrmvBatched_64_(handle,uplo,transA,diag,n,AP,lda,x,incx,batchCount) &
-        bind(c, name="cublasZtrmvBatched_64")
-#else
     function hipblasZtrmvBatched_64_(handle,uplo,transA,diag,n,AP,lda,x,incx,batchCount) &
         bind(c, name="hipblasZtrmvBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -25873,6 +24294,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief   BLAS Level 2 API
   !>
@@ -25939,16 +24361,11 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>               The number of batched matrices/vectors.
+#ifndef USE_CUDA_NAMES
   interface hipblasStrmvStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasStrmvStridedBatched_(handle,uplo,transA,diag,n,AP,lda,strideA,x,incx,stridex, &
-        batchCount) &
-        bind(c, name="cublasStrmvStridedBatched")
-#else
     function hipblasStrmvStridedBatched_(handle,uplo,transA,diag,n,AP,lda,strideA,x,incx,stridex, &
         batchCount) &
         bind(c, name="hipblasStrmvStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -25974,17 +24391,13 @@ module hipfort_hipblas
       hipblasStrmvStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDtrmvStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDtrmvStridedBatched_(handle,uplo,transA,diag,n,AP,lda,strideA,x,incx,stridex, &
-        batchCount) &
-        bind(c, name="cublasDtrmvStridedBatched")
-#else
     function hipblasDtrmvStridedBatched_(handle,uplo,transA,diag,n,AP,lda,strideA,x,incx,stridex, &
         batchCount) &
         bind(c, name="hipblasDtrmvStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -26010,17 +24423,13 @@ module hipfort_hipblas
       hipblasDtrmvStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCtrmvStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCtrmvStridedBatched_(handle,uplo,transA,diag,n,AP,lda,strideA,x,incx,stridex, &
-        batchCount) &
-        bind(c, name="cublasCtrmvStridedBatched")
-#else
     function hipblasCtrmvStridedBatched_(handle,uplo,transA,diag,n,AP,lda,strideA,x,incx,stridex, &
         batchCount) &
         bind(c, name="hipblasCtrmvStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -26046,17 +24455,13 @@ module hipfort_hipblas
       hipblasCtrmvStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZtrmvStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZtrmvStridedBatched_(handle,uplo,transA,diag,n,AP,lda,strideA,x,incx,stridex, &
-        batchCount) &
-        bind(c, name="cublasZtrmvStridedBatched")
-#else
     function hipblasZtrmvStridedBatched_(handle,uplo,transA,diag,n,AP,lda,strideA,x,incx,stridex, &
         batchCount) &
         bind(c, name="hipblasZtrmvStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -26082,17 +24487,13 @@ module hipfort_hipblas
       hipblasZtrmvStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasStrmvStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasStrmvStridedBatched_64_(handle,uplo,transA,diag,n,AP,lda,strideA,x,incx, &
-        stridex,batchCount) &
-        bind(c, name="cublasStrmvStridedBatched_64")
-#else
     function hipblasStrmvStridedBatched_64_(handle,uplo,transA,diag,n,AP,lda,strideA,x,incx, &
         stridex,batchCount) &
         bind(c, name="hipblasStrmvStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -26111,17 +24512,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDtrmvStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDtrmvStridedBatched_64_(handle,uplo,transA,diag,n,AP,lda,strideA,x,incx, &
-        stridex,batchCount) &
-        bind(c, name="cublasDtrmvStridedBatched_64")
-#else
     function hipblasDtrmvStridedBatched_64_(handle,uplo,transA,diag,n,AP,lda,strideA,x,incx, &
         stridex,batchCount) &
         bind(c, name="hipblasDtrmvStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -26140,17 +24537,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCtrmvStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCtrmvStridedBatched_64_(handle,uplo,transA,diag,n,AP,lda,strideA,x,incx, &
-        stridex,batchCount) &
-        bind(c, name="cublasCtrmvStridedBatched_64")
-#else
     function hipblasCtrmvStridedBatched_64_(handle,uplo,transA,diag,n,AP,lda,strideA,x,incx, &
         stridex,batchCount) &
         bind(c, name="hipblasCtrmvStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -26169,17 +24562,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZtrmvStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZtrmvStridedBatched_64_(handle,uplo,transA,diag,n,AP,lda,strideA,x,incx, &
-        stridex,batchCount) &
-        bind(c, name="cublasZtrmvStridedBatched_64")
-#else
     function hipblasZtrmvStridedBatched_64_(handle,uplo,transA,diag,n,AP,lda,strideA,x,incx, &
         stridex,batchCount) &
         bind(c, name="hipblasZtrmvStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -26198,6 +24587,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 2 API
   !>
@@ -26516,14 +24906,10 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances in the batch
+#ifndef USE_CUDA_NAMES
   interface hipblasStrsvBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasStrsvBatched_(handle,uplo,transA,diag,n,AP,lda,x,incx,batchCount) &
-        bind(c, name="cublasStrsvBatched")
-#else
     function hipblasStrsvBatched_(handle,uplo,transA,diag,n,AP,lda,x,incx,batchCount) &
         bind(c, name="hipblasStrsvBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -26540,15 +24926,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDtrsvBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDtrsvBatched_(handle,uplo,transA,diag,n,AP,lda,x,incx,batchCount) &
-        bind(c, name="cublasDtrsvBatched")
-#else
     function hipblasDtrsvBatched_(handle,uplo,transA,diag,n,AP,lda,x,incx,batchCount) &
         bind(c, name="hipblasDtrsvBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -26565,15 +24948,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCtrsvBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCtrsvBatched_(handle,uplo,transA,diag,n,AP,lda,x,incx,batchCount) &
-        bind(c, name="cublasCtrsvBatched")
-#else
     function hipblasCtrsvBatched_(handle,uplo,transA,diag,n,AP,lda,x,incx,batchCount) &
         bind(c, name="hipblasCtrsvBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -26590,15 +24970,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZtrsvBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZtrsvBatched_(handle,uplo,transA,diag,n,AP,lda,x,incx,batchCount) &
-        bind(c, name="cublasZtrsvBatched")
-#else
     function hipblasZtrsvBatched_(handle,uplo,transA,diag,n,AP,lda,x,incx,batchCount) &
         bind(c, name="hipblasZtrsvBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -26615,15 +24992,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasStrsvBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasStrsvBatched_64_(handle,uplo,transA,diag,n,AP,lda,x,incx,batchCount) &
-        bind(c, name="cublasStrsvBatched_64")
-#else
     function hipblasStrsvBatched_64_(handle,uplo,transA,diag,n,AP,lda,x,incx,batchCount) &
         bind(c, name="hipblasStrsvBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -26640,15 +25014,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDtrsvBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDtrsvBatched_64_(handle,uplo,transA,diag,n,AP,lda,x,incx,batchCount) &
-        bind(c, name="cublasDtrsvBatched_64")
-#else
     function hipblasDtrsvBatched_64_(handle,uplo,transA,diag,n,AP,lda,x,incx,batchCount) &
         bind(c, name="hipblasDtrsvBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -26665,15 +25036,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCtrsvBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCtrsvBatched_64_(handle,uplo,transA,diag,n,AP,lda,x,incx,batchCount) &
-        bind(c, name="cublasCtrsvBatched_64")
-#else
     function hipblasCtrsvBatched_64_(handle,uplo,transA,diag,n,AP,lda,x,incx,batchCount) &
         bind(c, name="hipblasCtrsvBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -26690,15 +25058,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZtrsvBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZtrsvBatched_64_(handle,uplo,transA,diag,n,AP,lda,x,incx,batchCount) &
-        bind(c, name="cublasZtrsvBatched_64")
-#else
     function hipblasZtrsvBatched_64_(handle,uplo,transA,diag,n,AP,lda,x,incx,batchCount) &
         bind(c, name="hipblasZtrsvBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -26715,6 +25080,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 2 API
   !>
@@ -26779,16 +25145,11 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasStrsvStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasStrsvStridedBatched_(handle,uplo,transA,diag,n,AP,lda,strideA,x,incx,stridex, &
-        batchCount) &
-        bind(c, name="cublasStrsvStridedBatched")
-#else
     function hipblasStrsvStridedBatched_(handle,uplo,transA,diag,n,AP,lda,strideA,x,incx,stridex, &
         batchCount) &
         bind(c, name="hipblasStrsvStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -26814,17 +25175,13 @@ module hipfort_hipblas
       hipblasStrsvStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDtrsvStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDtrsvStridedBatched_(handle,uplo,transA,diag,n,AP,lda,strideA,x,incx,stridex, &
-        batchCount) &
-        bind(c, name="cublasDtrsvStridedBatched")
-#else
     function hipblasDtrsvStridedBatched_(handle,uplo,transA,diag,n,AP,lda,strideA,x,incx,stridex, &
         batchCount) &
         bind(c, name="hipblasDtrsvStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -26850,17 +25207,13 @@ module hipfort_hipblas
       hipblasDtrsvStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCtrsvStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCtrsvStridedBatched_(handle,uplo,transA,diag,n,AP,lda,strideA,x,incx,stridex, &
-        batchCount) &
-        bind(c, name="cublasCtrsvStridedBatched")
-#else
     function hipblasCtrsvStridedBatched_(handle,uplo,transA,diag,n,AP,lda,strideA,x,incx,stridex, &
         batchCount) &
         bind(c, name="hipblasCtrsvStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -26886,17 +25239,13 @@ module hipfort_hipblas
       hipblasCtrsvStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZtrsvStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZtrsvStridedBatched_(handle,uplo,transA,diag,n,AP,lda,strideA,x,incx,stridex, &
-        batchCount) &
-        bind(c, name="cublasZtrsvStridedBatched")
-#else
     function hipblasZtrsvStridedBatched_(handle,uplo,transA,diag,n,AP,lda,strideA,x,incx,stridex, &
         batchCount) &
         bind(c, name="hipblasZtrsvStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -26922,17 +25271,13 @@ module hipfort_hipblas
       hipblasZtrsvStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasStrsvStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasStrsvStridedBatched_64_(handle,uplo,transA,diag,n,AP,lda,strideA,x,incx, &
-        stridex,batchCount) &
-        bind(c, name="cublasStrsvStridedBatched_64")
-#else
     function hipblasStrsvStridedBatched_64_(handle,uplo,transA,diag,n,AP,lda,strideA,x,incx, &
         stridex,batchCount) &
         bind(c, name="hipblasStrsvStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -26951,17 +25296,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDtrsvStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDtrsvStridedBatched_64_(handle,uplo,transA,diag,n,AP,lda,strideA,x,incx, &
-        stridex,batchCount) &
-        bind(c, name="cublasDtrsvStridedBatched_64")
-#else
     function hipblasDtrsvStridedBatched_64_(handle,uplo,transA,diag,n,AP,lda,strideA,x,incx, &
         stridex,batchCount) &
         bind(c, name="hipblasDtrsvStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -26980,17 +25321,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCtrsvStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCtrsvStridedBatched_64_(handle,uplo,transA,diag,n,AP,lda,strideA,x,incx, &
-        stridex,batchCount) &
-        bind(c, name="cublasCtrsvStridedBatched_64")
-#else
     function hipblasCtrsvStridedBatched_64_(handle,uplo,transA,diag,n,AP,lda,strideA,x,incx, &
         stridex,batchCount) &
         bind(c, name="hipblasCtrsvStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -27009,17 +25346,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZtrsvStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZtrsvStridedBatched_64_(handle,uplo,transA,diag,n,AP,lda,strideA,x,incx, &
-        stridex,batchCount) &
-        bind(c, name="cublasZtrsvStridedBatched_64")
-#else
     function hipblasZtrsvStridedBatched_64_(handle,uplo,transA,diag,n,AP,lda,strideA,x,incx, &
         stridex,batchCount) &
         bind(c, name="hipblasZtrsvStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -27038,6 +25371,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 3 API
   !>
@@ -28508,14 +26842,10 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasCherkBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCherkBatched_(handle,uplo,transA,n,k,alpha,AP,lda,beta,CP,ldc,batchCount) &
-        bind(c, name="cublasCherkBatched")
-#else
     function hipblasCherkBatched_(handle,uplo,transA,n,k,alpha,AP,lda,beta,CP,ldc,batchCount) &
         bind(c, name="hipblasCherkBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -28534,15 +26864,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZherkBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZherkBatched_(handle,uplo,transA,n,k,alpha,AP,lda,beta,CP,ldc,batchCount) &
-        bind(c, name="cublasZherkBatched")
-#else
     function hipblasZherkBatched_(handle,uplo,transA,n,k,alpha,AP,lda,beta,CP,ldc,batchCount) &
         bind(c, name="hipblasZherkBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -28561,15 +26888,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCherkBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCherkBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,beta,CP,ldc,batchCount) &
-        bind(c, name="cublasCherkBatched_64")
-#else
     function hipblasCherkBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,beta,CP,ldc,batchCount) &
         bind(c, name="hipblasCherkBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -28588,15 +26912,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZherkBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZherkBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,beta,CP,ldc,batchCount) &
-        bind(c, name="cublasZherkBatched_64")
-#else
     function hipblasZherkBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,beta,CP,ldc,batchCount) &
         bind(c, name="hipblasZherkBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -28615,6 +26936,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 3 API
   !>
@@ -28697,16 +27019,11 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasCherkStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCherkStridedBatched_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,beta,CP,ldc, &
-        strideC,batchCount) &
-        bind(c, name="cublasCherkStridedBatched")
-#else
     function hipblasCherkStridedBatched_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,beta,CP,ldc, &
         strideC,batchCount) &
         bind(c, name="hipblasCherkStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -28734,17 +27051,13 @@ module hipfort_hipblas
       hipblasCherkStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZherkStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZherkStridedBatched_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,beta,CP,ldc, &
-        strideC,batchCount) &
-        bind(c, name="cublasZherkStridedBatched")
-#else
     function hipblasZherkStridedBatched_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,beta,CP,ldc, &
         strideC,batchCount) &
         bind(c, name="hipblasZherkStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -28772,17 +27085,13 @@ module hipfort_hipblas
       hipblasZherkStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCherkStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCherkStridedBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,beta,CP, &
-        ldc,strideC,batchCount) &
-        bind(c, name="cublasCherkStridedBatched_64")
-#else
     function hipblasCherkStridedBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,beta,CP, &
         ldc,strideC,batchCount) &
         bind(c, name="hipblasCherkStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -28803,17 +27112,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZherkStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZherkStridedBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,beta,CP, &
-        ldc,strideC,batchCount) &
-        bind(c, name="cublasZherkStridedBatched_64")
-#else
     function hipblasZherkStridedBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,beta,CP, &
         ldc,strideC,batchCount) &
         bind(c, name="hipblasZherkStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -28834,6 +27139,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 3 API
   !>
@@ -29130,16 +27436,11 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasCherkxBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCherkxBatched_(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
-        batchCount) &
-        bind(c, name="cublasCherkxBatched")
-#else
     function hipblasCherkxBatched_(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
         batchCount) &
         bind(c, name="hipblasCherkxBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -29160,17 +27461,13 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZherkxBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZherkxBatched_(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
-        batchCount) &
-        bind(c, name="cublasZherkxBatched")
-#else
     function hipblasZherkxBatched_(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
         batchCount) &
         bind(c, name="hipblasZherkxBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -29191,17 +27488,13 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCherkxBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCherkxBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
-        batchCount) &
-        bind(c, name="cublasCherkxBatched_64")
-#else
     function hipblasCherkxBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
         batchCount) &
         bind(c, name="hipblasCherkxBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -29222,17 +27515,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZherkxBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZherkxBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
-        batchCount) &
-        bind(c, name="cublasZherkxBatched_64")
-#else
     function hipblasZherkxBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
         batchCount) &
         bind(c, name="hipblasZherkxBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -29253,6 +27542,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief   BLAS Level 3 API
   !>
@@ -29353,16 +27643,11 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasCherkxStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCherkxStridedBatched_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP,ldb, &
-        strideB,beta,CP,ldc,strideC,batchCount) &
-        bind(c, name="cublasCherkxStridedBatched")
-#else
     function hipblasCherkxStridedBatched_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP,ldb, &
         strideB,beta,CP,ldc,strideC,batchCount) &
         bind(c, name="hipblasCherkxStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -29393,17 +27678,13 @@ module hipfort_hipblas
       hipblasCherkxStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZherkxStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZherkxStridedBatched_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP,ldb, &
-        strideB,beta,CP,ldc,strideC,batchCount) &
-        bind(c, name="cublasZherkxStridedBatched")
-#else
     function hipblasZherkxStridedBatched_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP,ldb, &
         strideB,beta,CP,ldc,strideC,batchCount) &
         bind(c, name="hipblasZherkxStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -29434,17 +27715,13 @@ module hipfort_hipblas
       hipblasZherkxStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCherkxStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCherkxStridedBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP,ldb, &
-        strideB,beta,CP,ldc,strideC,batchCount) &
-        bind(c, name="cublasCherkxStridedBatched_64")
-#else
     function hipblasCherkxStridedBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP,ldb, &
         strideB,beta,CP,ldc,strideC,batchCount) &
         bind(c, name="hipblasCherkxStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -29468,17 +27745,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZherkxStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZherkxStridedBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP,ldb, &
-        strideB,beta,CP,ldc,strideC,batchCount) &
-        bind(c, name="cublasZherkxStridedBatched_64")
-#else
     function hipblasZherkxStridedBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP,ldb, &
         strideB,beta,CP,ldc,strideC,batchCount) &
         bind(c, name="hipblasZherkxStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -29502,6 +27775,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 3 API
   !>
@@ -29791,16 +28065,11 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasCher2kBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCher2kBatched_(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
-        batchCount) &
-        bind(c, name="cublasCher2kBatched")
-#else
     function hipblasCher2kBatched_(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
         batchCount) &
         bind(c, name="hipblasCher2kBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -29821,17 +28090,13 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZher2kBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZher2kBatched_(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
-        batchCount) &
-        bind(c, name="cublasZher2kBatched")
-#else
     function hipblasZher2kBatched_(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
         batchCount) &
         bind(c, name="hipblasZher2kBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -29852,17 +28117,13 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCher2kBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCher2kBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
-        batchCount) &
-        bind(c, name="cublasCher2kBatched_64")
-#else
     function hipblasCher2kBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
         batchCount) &
         bind(c, name="hipblasCher2kBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -29883,17 +28144,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZher2kBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZher2kBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
-        batchCount) &
-        bind(c, name="cublasZher2kBatched_64")
-#else
     function hipblasZher2kBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
         batchCount) &
         bind(c, name="hipblasZher2kBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -29914,6 +28171,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 3 API
   !>
@@ -30012,16 +28270,11 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasCher2kStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCher2kStridedBatched_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP,ldb, &
-        strideB,beta,CP,ldc,strideC,batchCount) &
-        bind(c, name="cublasCher2kStridedBatched")
-#else
     function hipblasCher2kStridedBatched_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP,ldb, &
         strideB,beta,CP,ldc,strideC,batchCount) &
         bind(c, name="hipblasCher2kStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -30052,17 +28305,13 @@ module hipfort_hipblas
       hipblasCher2kStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZher2kStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZher2kStridedBatched_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP,ldb, &
-        strideB,beta,CP,ldc,strideC,batchCount) &
-        bind(c, name="cublasZher2kStridedBatched")
-#else
     function hipblasZher2kStridedBatched_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP,ldb, &
         strideB,beta,CP,ldc,strideC,batchCount) &
         bind(c, name="hipblasZher2kStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -30093,17 +28342,13 @@ module hipfort_hipblas
       hipblasZher2kStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCher2kStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCher2kStridedBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP,ldb, &
-        strideB,beta,CP,ldc,strideC,batchCount) &
-        bind(c, name="cublasCher2kStridedBatched_64")
-#else
     function hipblasCher2kStridedBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP,ldb, &
         strideB,beta,CP,ldc,strideC,batchCount) &
         bind(c, name="hipblasCher2kStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -30127,17 +28372,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZher2kStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZher2kStridedBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP,ldb, &
-        strideB,beta,CP,ldc,strideC,batchCount) &
-        bind(c, name="cublasZher2kStridedBatched_64")
-#else
     function hipblasZher2kStridedBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP,ldb, &
         strideB,beta,CP,ldc,strideC,batchCount) &
         bind(c, name="hipblasZher2kStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -30161,6 +28402,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 3 API
   !>
@@ -30567,14 +28809,10 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasSsymmBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasSsymmBatched_(handle,side,uplo,m,n,alpha,AP,lda,BP,ldb,beta,CP,ldc,batchCount) &
-        bind(c, name="cublasSsymmBatched")
-#else
     function hipblasSsymmBatched_(handle,side,uplo,m,n,alpha,AP,lda,BP,ldb,beta,CP,ldc,batchCount) &
         bind(c, name="hipblasSsymmBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -30595,15 +28833,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDsymmBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDsymmBatched_(handle,side,uplo,m,n,alpha,AP,lda,BP,ldb,beta,CP,ldc,batchCount) &
-        bind(c, name="cublasDsymmBatched")
-#else
     function hipblasDsymmBatched_(handle,side,uplo,m,n,alpha,AP,lda,BP,ldb,beta,CP,ldc,batchCount) &
         bind(c, name="hipblasDsymmBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -30624,15 +28859,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCsymmBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCsymmBatched_(handle,side,uplo,m,n,alpha,AP,lda,BP,ldb,beta,CP,ldc,batchCount) &
-        bind(c, name="cublasCsymmBatched")
-#else
     function hipblasCsymmBatched_(handle,side,uplo,m,n,alpha,AP,lda,BP,ldb,beta,CP,ldc,batchCount) &
         bind(c, name="hipblasCsymmBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -30653,15 +28885,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZsymmBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZsymmBatched_(handle,side,uplo,m,n,alpha,AP,lda,BP,ldb,beta,CP,ldc,batchCount) &
-        bind(c, name="cublasZsymmBatched")
-#else
     function hipblasZsymmBatched_(handle,side,uplo,m,n,alpha,AP,lda,BP,ldb,beta,CP,ldc,batchCount) &
         bind(c, name="hipblasZsymmBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -30682,17 +28911,13 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasSsymmBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasSsymmBatched_64_(handle,side,uplo,m,n,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
-        batchCount) &
-        bind(c, name="cublasSsymmBatched_64")
-#else
     function hipblasSsymmBatched_64_(handle,side,uplo,m,n,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
         batchCount) &
         bind(c, name="hipblasSsymmBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -30713,17 +28938,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDsymmBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDsymmBatched_64_(handle,side,uplo,m,n,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
-        batchCount) &
-        bind(c, name="cublasDsymmBatched_64")
-#else
     function hipblasDsymmBatched_64_(handle,side,uplo,m,n,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
         batchCount) &
         bind(c, name="hipblasDsymmBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -30744,17 +28965,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCsymmBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCsymmBatched_64_(handle,side,uplo,m,n,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
-        batchCount) &
-        bind(c, name="cublasCsymmBatched_64")
-#else
     function hipblasCsymmBatched_64_(handle,side,uplo,m,n,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
         batchCount) &
         bind(c, name="hipblasCsymmBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -30775,17 +28992,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZsymmBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZsymmBatched_64_(handle,side,uplo,m,n,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
-        batchCount) &
-        bind(c, name="cublasZsymmBatched_64")
-#else
     function hipblasZsymmBatched_64_(handle,side,uplo,m,n,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
         batchCount) &
         bind(c, name="hipblasZsymmBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -30806,6 +29019,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 3 API
   !>
@@ -30895,16 +29109,11 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasSsymmStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasSsymmStridedBatched_(handle,side,uplo,m,n,alpha,AP,lda,strideA,BP,ldb,strideB, &
-        beta,CP,ldc,strideC,batchCount) &
-        bind(c, name="cublasSsymmStridedBatched")
-#else
     function hipblasSsymmStridedBatched_(handle,side,uplo,m,n,alpha,AP,lda,strideA,BP,ldb,strideB, &
         beta,CP,ldc,strideC,batchCount) &
         bind(c, name="hipblasSsymmStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -30935,17 +29144,13 @@ module hipfort_hipblas
       hipblasSsymmStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDsymmStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDsymmStridedBatched_(handle,side,uplo,m,n,alpha,AP,lda,strideA,BP,ldb,strideB, &
-        beta,CP,ldc,strideC,batchCount) &
-        bind(c, name="cublasDsymmStridedBatched")
-#else
     function hipblasDsymmStridedBatched_(handle,side,uplo,m,n,alpha,AP,lda,strideA,BP,ldb,strideB, &
         beta,CP,ldc,strideC,batchCount) &
         bind(c, name="hipblasDsymmStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -30976,17 +29181,13 @@ module hipfort_hipblas
       hipblasDsymmStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCsymmStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCsymmStridedBatched_(handle,side,uplo,m,n,alpha,AP,lda,strideA,BP,ldb,strideB, &
-        beta,CP,ldc,strideC,batchCount) &
-        bind(c, name="cublasCsymmStridedBatched")
-#else
     function hipblasCsymmStridedBatched_(handle,side,uplo,m,n,alpha,AP,lda,strideA,BP,ldb,strideB, &
         beta,CP,ldc,strideC,batchCount) &
         bind(c, name="hipblasCsymmStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -31017,17 +29218,13 @@ module hipfort_hipblas
       hipblasCsymmStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZsymmStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZsymmStridedBatched_(handle,side,uplo,m,n,alpha,AP,lda,strideA,BP,ldb,strideB, &
-        beta,CP,ldc,strideC,batchCount) &
-        bind(c, name="cublasZsymmStridedBatched")
-#else
     function hipblasZsymmStridedBatched_(handle,side,uplo,m,n,alpha,AP,lda,strideA,BP,ldb,strideB, &
         beta,CP,ldc,strideC,batchCount) &
         bind(c, name="hipblasZsymmStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -31058,17 +29255,13 @@ module hipfort_hipblas
       hipblasZsymmStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasSsymmStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasSsymmStridedBatched_64_(handle,side,uplo,m,n,alpha,AP,lda,strideA,BP,ldb, &
-        strideB,beta,CP,ldc,strideC,batchCount) &
-        bind(c, name="cublasSsymmStridedBatched_64")
-#else
     function hipblasSsymmStridedBatched_64_(handle,side,uplo,m,n,alpha,AP,lda,strideA,BP,ldb, &
         strideB,beta,CP,ldc,strideC,batchCount) &
         bind(c, name="hipblasSsymmStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -31092,17 +29285,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDsymmStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDsymmStridedBatched_64_(handle,side,uplo,m,n,alpha,AP,lda,strideA,BP,ldb, &
-        strideB,beta,CP,ldc,strideC,batchCount) &
-        bind(c, name="cublasDsymmStridedBatched_64")
-#else
     function hipblasDsymmStridedBatched_64_(handle,side,uplo,m,n,alpha,AP,lda,strideA,BP,ldb, &
         strideB,beta,CP,ldc,strideC,batchCount) &
         bind(c, name="hipblasDsymmStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -31126,17 +29315,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCsymmStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCsymmStridedBatched_64_(handle,side,uplo,m,n,alpha,AP,lda,strideA,BP,ldb, &
-        strideB,beta,CP,ldc,strideC,batchCount) &
-        bind(c, name="cublasCsymmStridedBatched_64")
-#else
     function hipblasCsymmStridedBatched_64_(handle,side,uplo,m,n,alpha,AP,lda,strideA,BP,ldb, &
         strideB,beta,CP,ldc,strideC,batchCount) &
         bind(c, name="hipblasCsymmStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -31160,17 +29345,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZsymmStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZsymmStridedBatched_64_(handle,side,uplo,m,n,alpha,AP,lda,strideA,BP,ldb, &
-        strideB,beta,CP,ldc,strideC,batchCount) &
-        bind(c, name="cublasZsymmStridedBatched_64")
-#else
     function hipblasZsymmStridedBatched_64_(handle,side,uplo,m,n,alpha,AP,lda,strideA,BP,ldb, &
         strideB,beta,CP,ldc,strideC,batchCount) &
         bind(c, name="hipblasZsymmStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -31194,6 +29375,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 3 API
   !>
@@ -31575,14 +29757,10 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasSsyrkBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasSsyrkBatched_(handle,uplo,transA,n,k,alpha,AP,lda,beta,CP,ldc,batchCount) &
-        bind(c, name="cublasSsyrkBatched")
-#else
     function hipblasSsyrkBatched_(handle,uplo,transA,n,k,alpha,AP,lda,beta,CP,ldc,batchCount) &
         bind(c, name="hipblasSsyrkBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -31601,15 +29779,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDsyrkBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDsyrkBatched_(handle,uplo,transA,n,k,alpha,AP,lda,beta,CP,ldc,batchCount) &
-        bind(c, name="cublasDsyrkBatched")
-#else
     function hipblasDsyrkBatched_(handle,uplo,transA,n,k,alpha,AP,lda,beta,CP,ldc,batchCount) &
         bind(c, name="hipblasDsyrkBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -31628,15 +29803,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCsyrkBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCsyrkBatched_(handle,uplo,transA,n,k,alpha,AP,lda,beta,CP,ldc,batchCount) &
-        bind(c, name="cublasCsyrkBatched")
-#else
     function hipblasCsyrkBatched_(handle,uplo,transA,n,k,alpha,AP,lda,beta,CP,ldc,batchCount) &
         bind(c, name="hipblasCsyrkBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -31655,15 +29827,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZsyrkBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZsyrkBatched_(handle,uplo,transA,n,k,alpha,AP,lda,beta,CP,ldc,batchCount) &
-        bind(c, name="cublasZsyrkBatched")
-#else
     function hipblasZsyrkBatched_(handle,uplo,transA,n,k,alpha,AP,lda,beta,CP,ldc,batchCount) &
         bind(c, name="hipblasZsyrkBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -31682,15 +29851,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasSsyrkBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasSsyrkBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,beta,CP,ldc,batchCount) &
-        bind(c, name="cublasSsyrkBatched_64")
-#else
     function hipblasSsyrkBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,beta,CP,ldc,batchCount) &
         bind(c, name="hipblasSsyrkBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -31709,15 +29875,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDsyrkBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDsyrkBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,beta,CP,ldc,batchCount) &
-        bind(c, name="cublasDsyrkBatched_64")
-#else
     function hipblasDsyrkBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,beta,CP,ldc,batchCount) &
         bind(c, name="hipblasDsyrkBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -31736,15 +29899,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCsyrkBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCsyrkBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,beta,CP,ldc,batchCount) &
-        bind(c, name="cublasCsyrkBatched_64")
-#else
     function hipblasCsyrkBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,beta,CP,ldc,batchCount) &
         bind(c, name="hipblasCsyrkBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -31763,15 +29923,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZsyrkBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZsyrkBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,beta,CP,ldc,batchCount) &
-        bind(c, name="cublasZsyrkBatched_64")
-#else
     function hipblasZsyrkBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,beta,CP,ldc,batchCount) &
         bind(c, name="hipblasZsyrkBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -31790,6 +29947,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 3 API
   !>
@@ -31873,16 +30031,11 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasSsyrkStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasSsyrkStridedBatched_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,beta,CP,ldc, &
-        strideC,batchCount) &
-        bind(c, name="cublasSsyrkStridedBatched")
-#else
     function hipblasSsyrkStridedBatched_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,beta,CP,ldc, &
         strideC,batchCount) &
         bind(c, name="hipblasSsyrkStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -31910,17 +30063,13 @@ module hipfort_hipblas
       hipblasSsyrkStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDsyrkStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDsyrkStridedBatched_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,beta,CP,ldc, &
-        strideC,batchCount) &
-        bind(c, name="cublasDsyrkStridedBatched")
-#else
     function hipblasDsyrkStridedBatched_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,beta,CP,ldc, &
         strideC,batchCount) &
         bind(c, name="hipblasDsyrkStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -31948,17 +30097,13 @@ module hipfort_hipblas
       hipblasDsyrkStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCsyrkStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCsyrkStridedBatched_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,beta,CP,ldc, &
-        strideC,batchCount) &
-        bind(c, name="cublasCsyrkStridedBatched")
-#else
     function hipblasCsyrkStridedBatched_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,beta,CP,ldc, &
         strideC,batchCount) &
         bind(c, name="hipblasCsyrkStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -31986,17 +30131,13 @@ module hipfort_hipblas
       hipblasCsyrkStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZsyrkStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZsyrkStridedBatched_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,beta,CP,ldc, &
-        strideC,batchCount) &
-        bind(c, name="cublasZsyrkStridedBatched")
-#else
     function hipblasZsyrkStridedBatched_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,beta,CP,ldc, &
         strideC,batchCount) &
         bind(c, name="hipblasZsyrkStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -32024,17 +30165,13 @@ module hipfort_hipblas
       hipblasZsyrkStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasSsyrkStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasSsyrkStridedBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,beta,CP, &
-        ldc,strideC,batchCount) &
-        bind(c, name="cublasSsyrkStridedBatched_64")
-#else
     function hipblasSsyrkStridedBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,beta,CP, &
         ldc,strideC,batchCount) &
         bind(c, name="hipblasSsyrkStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -32055,17 +30192,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDsyrkStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDsyrkStridedBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,beta,CP, &
-        ldc,strideC,batchCount) &
-        bind(c, name="cublasDsyrkStridedBatched_64")
-#else
     function hipblasDsyrkStridedBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,beta,CP, &
         ldc,strideC,batchCount) &
         bind(c, name="hipblasDsyrkStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -32086,17 +30219,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCsyrkStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCsyrkStridedBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,beta,CP, &
-        ldc,strideC,batchCount) &
-        bind(c, name="cublasCsyrkStridedBatched_64")
-#else
     function hipblasCsyrkStridedBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,beta,CP, &
         ldc,strideC,batchCount) &
         bind(c, name="hipblasCsyrkStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -32117,17 +30246,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZsyrkStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZsyrkStridedBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,beta,CP, &
-        ldc,strideC,batchCount) &
-        bind(c, name="cublasZsyrkStridedBatched_64")
-#else
     function hipblasZsyrkStridedBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,beta,CP, &
         ldc,strideC,batchCount) &
         bind(c, name="hipblasZsyrkStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -32148,6 +30273,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 3 API
   !>
@@ -32558,16 +30684,11 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasSsyr2kBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasSsyr2kBatched_(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
-        batchCount) &
-        bind(c, name="cublasSsyr2kBatched")
-#else
     function hipblasSsyr2kBatched_(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
         batchCount) &
         bind(c, name="hipblasSsyr2kBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -32588,17 +30709,13 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDsyr2kBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDsyr2kBatched_(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
-        batchCount) &
-        bind(c, name="cublasDsyr2kBatched")
-#else
     function hipblasDsyr2kBatched_(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
         batchCount) &
         bind(c, name="hipblasDsyr2kBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -32619,17 +30736,13 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCsyr2kBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCsyr2kBatched_(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
-        batchCount) &
-        bind(c, name="cublasCsyr2kBatched")
-#else
     function hipblasCsyr2kBatched_(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
         batchCount) &
         bind(c, name="hipblasCsyr2kBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -32650,17 +30763,13 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZsyr2kBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZsyr2kBatched_(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
-        batchCount) &
-        bind(c, name="cublasZsyr2kBatched")
-#else
     function hipblasZsyr2kBatched_(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
         batchCount) &
         bind(c, name="hipblasZsyr2kBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -32681,17 +30790,13 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasSsyr2kBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasSsyr2kBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
-        batchCount) &
-        bind(c, name="cublasSsyr2kBatched_64")
-#else
     function hipblasSsyr2kBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
         batchCount) &
         bind(c, name="hipblasSsyr2kBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -32712,17 +30817,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDsyr2kBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDsyr2kBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
-        batchCount) &
-        bind(c, name="cublasDsyr2kBatched_64")
-#else
     function hipblasDsyr2kBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
         batchCount) &
         bind(c, name="hipblasDsyr2kBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -32743,17 +30844,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCsyr2kBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCsyr2kBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
-        batchCount) &
-        bind(c, name="cublasCsyr2kBatched_64")
-#else
     function hipblasCsyr2kBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
         batchCount) &
         bind(c, name="hipblasCsyr2kBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -32774,17 +30871,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZsyr2kBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZsyr2kBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
-        batchCount) &
-        bind(c, name="cublasZsyr2kBatched_64")
-#else
     function hipblasZsyr2kBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
         batchCount) &
         bind(c, name="hipblasZsyr2kBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -32805,6 +30898,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 3 API
   !>
@@ -32901,16 +30995,11 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasSsyr2kStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasSsyr2kStridedBatched_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP,ldb, &
-        strideB,beta,CP,ldc,strideC,batchCount) &
-        bind(c, name="cublasSsyr2kStridedBatched")
-#else
     function hipblasSsyr2kStridedBatched_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP,ldb, &
         strideB,beta,CP,ldc,strideC,batchCount) &
         bind(c, name="hipblasSsyr2kStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -32941,17 +31030,13 @@ module hipfort_hipblas
       hipblasSsyr2kStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDsyr2kStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDsyr2kStridedBatched_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP,ldb, &
-        strideB,beta,CP,ldc,strideC,batchCount) &
-        bind(c, name="cublasDsyr2kStridedBatched")
-#else
     function hipblasDsyr2kStridedBatched_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP,ldb, &
         strideB,beta,CP,ldc,strideC,batchCount) &
         bind(c, name="hipblasDsyr2kStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -32982,17 +31067,13 @@ module hipfort_hipblas
       hipblasDsyr2kStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCsyr2kStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCsyr2kStridedBatched_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP,ldb, &
-        strideB,beta,CP,ldc,strideC,batchCount) &
-        bind(c, name="cublasCsyr2kStridedBatched")
-#else
     function hipblasCsyr2kStridedBatched_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP,ldb, &
         strideB,beta,CP,ldc,strideC,batchCount) &
         bind(c, name="hipblasCsyr2kStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -33023,17 +31104,13 @@ module hipfort_hipblas
       hipblasCsyr2kStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZsyr2kStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZsyr2kStridedBatched_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP,ldb, &
-        strideB,beta,CP,ldc,strideC,batchCount) &
-        bind(c, name="cublasZsyr2kStridedBatched")
-#else
     function hipblasZsyr2kStridedBatched_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP,ldb, &
         strideB,beta,CP,ldc,strideC,batchCount) &
         bind(c, name="hipblasZsyr2kStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -33064,17 +31141,13 @@ module hipfort_hipblas
       hipblasZsyr2kStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasSsyr2kStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasSsyr2kStridedBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP,ldb, &
-        strideB,beta,CP,ldc,strideC,batchCount) &
-        bind(c, name="cublasSsyr2kStridedBatched_64")
-#else
     function hipblasSsyr2kStridedBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP,ldb, &
         strideB,beta,CP,ldc,strideC,batchCount) &
         bind(c, name="hipblasSsyr2kStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -33098,17 +31171,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDsyr2kStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDsyr2kStridedBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP,ldb, &
-        strideB,beta,CP,ldc,strideC,batchCount) &
-        bind(c, name="cublasDsyr2kStridedBatched_64")
-#else
     function hipblasDsyr2kStridedBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP,ldb, &
         strideB,beta,CP,ldc,strideC,batchCount) &
         bind(c, name="hipblasDsyr2kStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -33132,17 +31201,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCsyr2kStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCsyr2kStridedBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP,ldb, &
-        strideB,beta,CP,ldc,strideC,batchCount) &
-        bind(c, name="cublasCsyr2kStridedBatched_64")
-#else
     function hipblasCsyr2kStridedBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP,ldb, &
         strideB,beta,CP,ldc,strideC,batchCount) &
         bind(c, name="hipblasCsyr2kStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -33166,17 +31231,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZsyr2kStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZsyr2kStridedBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP,ldb, &
-        strideB,beta,CP,ldc,strideC,batchCount) &
-        bind(c, name="cublasZsyr2kStridedBatched_64")
-#else
     function hipblasZsyr2kStridedBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP,ldb, &
         strideB,beta,CP,ldc,strideC,batchCount) &
         bind(c, name="hipblasZsyr2kStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -33200,6 +31261,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 3 API
   !>
@@ -33620,16 +31682,11 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>             number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasSsyrkxBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasSsyrkxBatched_(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
-        batchCount) &
-        bind(c, name="cublasSsyrkxBatched")
-#else
     function hipblasSsyrkxBatched_(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
         batchCount) &
         bind(c, name="hipblasSsyrkxBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -33650,17 +31707,13 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDsyrkxBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDsyrkxBatched_(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
-        batchCount) &
-        bind(c, name="cublasDsyrkxBatched")
-#else
     function hipblasDsyrkxBatched_(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
         batchCount) &
         bind(c, name="hipblasDsyrkxBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -33681,17 +31734,13 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCsyrkxBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCsyrkxBatched_(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
-        batchCount) &
-        bind(c, name="cublasCsyrkxBatched")
-#else
     function hipblasCsyrkxBatched_(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
         batchCount) &
         bind(c, name="hipblasCsyrkxBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -33712,17 +31761,13 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZsyrkxBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZsyrkxBatched_(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
-        batchCount) &
-        bind(c, name="cublasZsyrkxBatched")
-#else
     function hipblasZsyrkxBatched_(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
         batchCount) &
         bind(c, name="hipblasZsyrkxBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -33743,17 +31788,13 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasSsyrkxBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasSsyrkxBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
-        batchCount) &
-        bind(c, name="cublasSsyrkxBatched_64")
-#else
     function hipblasSsyrkxBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
         batchCount) &
         bind(c, name="hipblasSsyrkxBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -33774,17 +31815,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDsyrkxBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDsyrkxBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
-        batchCount) &
-        bind(c, name="cublasDsyrkxBatched_64")
-#else
     function hipblasDsyrkxBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
         batchCount) &
         bind(c, name="hipblasDsyrkxBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -33805,17 +31842,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCsyrkxBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCsyrkxBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
-        batchCount) &
-        bind(c, name="cublasCsyrkxBatched_64")
-#else
     function hipblasCsyrkxBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
         batchCount) &
         bind(c, name="hipblasCsyrkxBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -33836,17 +31869,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZsyrkxBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZsyrkxBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
-        batchCount) &
-        bind(c, name="cublasZsyrkxBatched_64")
-#else
     function hipblasZsyrkxBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
         batchCount) &
         bind(c, name="hipblasZsyrkxBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -33867,6 +31896,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief   BLAS Level 3 API
   !>
@@ -33965,16 +31995,11 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasSsyrkxStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasSsyrkxStridedBatched_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP,ldb, &
-        strideB,beta,CP,ldc,strideC,batchCount) &
-        bind(c, name="cublasSsyrkxStridedBatched")
-#else
     function hipblasSsyrkxStridedBatched_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP,ldb, &
         strideB,beta,CP,ldc,strideC,batchCount) &
         bind(c, name="hipblasSsyrkxStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -34005,17 +32030,13 @@ module hipfort_hipblas
       hipblasSsyrkxStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDsyrkxStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDsyrkxStridedBatched_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP,ldb, &
-        strideB,beta,CP,ldc,strideC,batchCount) &
-        bind(c, name="cublasDsyrkxStridedBatched")
-#else
     function hipblasDsyrkxStridedBatched_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP,ldb, &
         strideB,beta,CP,ldc,strideC,batchCount) &
         bind(c, name="hipblasDsyrkxStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -34046,17 +32067,13 @@ module hipfort_hipblas
       hipblasDsyrkxStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCsyrkxStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCsyrkxStridedBatched_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP,ldb, &
-        strideB,beta,CP,ldc,strideC,batchCount) &
-        bind(c, name="cublasCsyrkxStridedBatched")
-#else
     function hipblasCsyrkxStridedBatched_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP,ldb, &
         strideB,beta,CP,ldc,strideC,batchCount) &
         bind(c, name="hipblasCsyrkxStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -34087,17 +32104,13 @@ module hipfort_hipblas
       hipblasCsyrkxStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZsyrkxStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZsyrkxStridedBatched_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP,ldb, &
-        strideB,beta,CP,ldc,strideC,batchCount) &
-        bind(c, name="cublasZsyrkxStridedBatched")
-#else
     function hipblasZsyrkxStridedBatched_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP,ldb, &
         strideB,beta,CP,ldc,strideC,batchCount) &
         bind(c, name="hipblasZsyrkxStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -34128,17 +32141,13 @@ module hipfort_hipblas
       hipblasZsyrkxStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasSsyrkxStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasSsyrkxStridedBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP,ldb, &
-        strideB,beta,CP,ldc,strideC,batchCount) &
-        bind(c, name="cublasSsyrkxStridedBatched_64")
-#else
     function hipblasSsyrkxStridedBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP,ldb, &
         strideB,beta,CP,ldc,strideC,batchCount) &
         bind(c, name="hipblasSsyrkxStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -34162,17 +32171,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDsyrkxStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDsyrkxStridedBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP,ldb, &
-        strideB,beta,CP,ldc,strideC,batchCount) &
-        bind(c, name="cublasDsyrkxStridedBatched_64")
-#else
     function hipblasDsyrkxStridedBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP,ldb, &
         strideB,beta,CP,ldc,strideC,batchCount) &
         bind(c, name="hipblasDsyrkxStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -34196,17 +32201,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCsyrkxStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCsyrkxStridedBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP,ldb, &
-        strideB,beta,CP,ldc,strideC,batchCount) &
-        bind(c, name="cublasCsyrkxStridedBatched_64")
-#else
     function hipblasCsyrkxStridedBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP,ldb, &
         strideB,beta,CP,ldc,strideC,batchCount) &
         bind(c, name="hipblasCsyrkxStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -34230,17 +32231,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZsyrkxStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZsyrkxStridedBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP,ldb, &
-        strideB,beta,CP,ldc,strideC,batchCount) &
-        bind(c, name="cublasZsyrkxStridedBatched_64")
-#else
     function hipblasZsyrkxStridedBatched_64_(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP,ldb, &
         strideB,beta,CP,ldc,strideC,batchCount) &
         bind(c, name="hipblasZsyrkxStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -34264,6 +32261,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 3 API
   !>
@@ -34633,16 +32631,11 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances i in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasSgeamBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasSgeamBatched_(handle,transA,transB,m,n,alpha,AP,lda,beta,BP,ldb,CP,ldc, &
-        batchCount) &
-        bind(c, name="cublasSgeamBatched")
-#else
     function hipblasSgeamBatched_(handle,transA,transB,m,n,alpha,AP,lda,beta,BP,ldb,CP,ldc, &
         batchCount) &
         bind(c, name="hipblasSgeamBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -34663,17 +32656,13 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDgeamBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDgeamBatched_(handle,transA,transB,m,n,alpha,AP,lda,beta,BP,ldb,CP,ldc, &
-        batchCount) &
-        bind(c, name="cublasDgeamBatched")
-#else
     function hipblasDgeamBatched_(handle,transA,transB,m,n,alpha,AP,lda,beta,BP,ldb,CP,ldc, &
         batchCount) &
         bind(c, name="hipblasDgeamBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -34694,17 +32683,13 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCgeamBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCgeamBatched_(handle,transA,transB,m,n,alpha,AP,lda,beta,BP,ldb,CP,ldc, &
-        batchCount) &
-        bind(c, name="cublasCgeamBatched")
-#else
     function hipblasCgeamBatched_(handle,transA,transB,m,n,alpha,AP,lda,beta,BP,ldb,CP,ldc, &
         batchCount) &
         bind(c, name="hipblasCgeamBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -34725,17 +32710,13 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZgeamBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZgeamBatched_(handle,transA,transB,m,n,alpha,AP,lda,beta,BP,ldb,CP,ldc, &
-        batchCount) &
-        bind(c, name="cublasZgeamBatched")
-#else
     function hipblasZgeamBatched_(handle,transA,transB,m,n,alpha,AP,lda,beta,BP,ldb,CP,ldc, &
         batchCount) &
         bind(c, name="hipblasZgeamBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -34756,17 +32737,13 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasSgeamBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasSgeamBatched_64_(handle,transA,transB,m,n,alpha,AP,lda,beta,BP,ldb,CP,ldc, &
-        batchCount) &
-        bind(c, name="cublasSgeamBatched_64")
-#else
     function hipblasSgeamBatched_64_(handle,transA,transB,m,n,alpha,AP,lda,beta,BP,ldb,CP,ldc, &
         batchCount) &
         bind(c, name="hipblasSgeamBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -34787,17 +32764,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDgeamBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDgeamBatched_64_(handle,transA,transB,m,n,alpha,AP,lda,beta,BP,ldb,CP,ldc, &
-        batchCount) &
-        bind(c, name="cublasDgeamBatched_64")
-#else
     function hipblasDgeamBatched_64_(handle,transA,transB,m,n,alpha,AP,lda,beta,BP,ldb,CP,ldc, &
         batchCount) &
         bind(c, name="hipblasDgeamBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -34818,17 +32791,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCgeamBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCgeamBatched_64_(handle,transA,transB,m,n,alpha,AP,lda,beta,BP,ldb,CP,ldc, &
-        batchCount) &
-        bind(c, name="cublasCgeamBatched_64")
-#else
     function hipblasCgeamBatched_64_(handle,transA,transB,m,n,alpha,AP,lda,beta,BP,ldb,CP,ldc, &
         batchCount) &
         bind(c, name="hipblasCgeamBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -34849,17 +32818,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZgeamBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZgeamBatched_64_(handle,transA,transB,m,n,alpha,AP,lda,beta,BP,ldb,CP,ldc, &
-        batchCount) &
-        bind(c, name="cublasZgeamBatched_64")
-#else
     function hipblasZgeamBatched_64_(handle,transA,transB,m,n,alpha,AP,lda,beta,BP,ldb,CP,ldc, &
         batchCount) &
         bind(c, name="hipblasZgeamBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -34880,6 +32845,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 3 API
   !>
@@ -34968,16 +32934,11 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances i in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasSgeamStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasSgeamStridedBatched_(handle,transA,transB,m,n,alpha,AP,lda,strideA,beta,BP, &
-        ldb,strideB,CP,ldc,strideC,batchCount) &
-        bind(c, name="cublasSgeamStridedBatched")
-#else
     function hipblasSgeamStridedBatched_(handle,transA,transB,m,n,alpha,AP,lda,strideA,beta,BP, &
         ldb,strideB,CP,ldc,strideC,batchCount) &
         bind(c, name="hipblasSgeamStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -35008,17 +32969,13 @@ module hipfort_hipblas
       hipblasSgeamStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDgeamStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDgeamStridedBatched_(handle,transA,transB,m,n,alpha,AP,lda,strideA,beta,BP, &
-        ldb,strideB,CP,ldc,strideC,batchCount) &
-        bind(c, name="cublasDgeamStridedBatched")
-#else
     function hipblasDgeamStridedBatched_(handle,transA,transB,m,n,alpha,AP,lda,strideA,beta,BP, &
         ldb,strideB,CP,ldc,strideC,batchCount) &
         bind(c, name="hipblasDgeamStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -35049,17 +33006,13 @@ module hipfort_hipblas
       hipblasDgeamStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCgeamStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCgeamStridedBatched_(handle,transA,transB,m,n,alpha,AP,lda,strideA,beta,BP, &
-        ldb,strideB,CP,ldc,strideC,batchCount) &
-        bind(c, name="cublasCgeamStridedBatched")
-#else
     function hipblasCgeamStridedBatched_(handle,transA,transB,m,n,alpha,AP,lda,strideA,beta,BP, &
         ldb,strideB,CP,ldc,strideC,batchCount) &
         bind(c, name="hipblasCgeamStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -35090,17 +33043,13 @@ module hipfort_hipblas
       hipblasCgeamStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZgeamStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZgeamStridedBatched_(handle,transA,transB,m,n,alpha,AP,lda,strideA,beta,BP, &
-        ldb,strideB,CP,ldc,strideC,batchCount) &
-        bind(c, name="cublasZgeamStridedBatched")
-#else
     function hipblasZgeamStridedBatched_(handle,transA,transB,m,n,alpha,AP,lda,strideA,beta,BP, &
         ldb,strideB,CP,ldc,strideC,batchCount) &
         bind(c, name="hipblasZgeamStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -35131,17 +33080,13 @@ module hipfort_hipblas
       hipblasZgeamStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasSgeamStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasSgeamStridedBatched_64_(handle,transA,transB,m,n,alpha,AP,lda,strideA,beta,BP, &
-        ldb,strideB,CP,ldc,strideC,batchCount) &
-        bind(c, name="cublasSgeamStridedBatched_64")
-#else
     function hipblasSgeamStridedBatched_64_(handle,transA,transB,m,n,alpha,AP,lda,strideA,beta,BP, &
         ldb,strideB,CP,ldc,strideC,batchCount) &
         bind(c, name="hipblasSgeamStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -35165,17 +33110,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDgeamStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDgeamStridedBatched_64_(handle,transA,transB,m,n,alpha,AP,lda,strideA,beta,BP, &
-        ldb,strideB,CP,ldc,strideC,batchCount) &
-        bind(c, name="cublasDgeamStridedBatched_64")
-#else
     function hipblasDgeamStridedBatched_64_(handle,transA,transB,m,n,alpha,AP,lda,strideA,beta,BP, &
         ldb,strideB,CP,ldc,strideC,batchCount) &
         bind(c, name="hipblasDgeamStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -35199,17 +33140,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCgeamStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCgeamStridedBatched_64_(handle,transA,transB,m,n,alpha,AP,lda,strideA,beta,BP, &
-        ldb,strideB,CP,ldc,strideC,batchCount) &
-        bind(c, name="cublasCgeamStridedBatched_64")
-#else
     function hipblasCgeamStridedBatched_64_(handle,transA,transB,m,n,alpha,AP,lda,strideA,beta,BP, &
         ldb,strideB,CP,ldc,strideC,batchCount) &
         bind(c, name="hipblasCgeamStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -35233,17 +33170,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZgeamStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZgeamStridedBatched_64_(handle,transA,transB,m,n,alpha,AP,lda,strideA,beta,BP, &
-        ldb,strideB,CP,ldc,strideC,batchCount) &
-        bind(c, name="cublasZgeamStridedBatched_64")
-#else
     function hipblasZgeamStridedBatched_64_(handle,transA,transB,m,n,alpha,AP,lda,strideA,beta,BP, &
         ldb,strideB,CP,ldc,strideC,batchCount) &
         bind(c, name="hipblasZgeamStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -35267,6 +33200,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 3 API
   !>
@@ -35549,14 +33483,10 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasChemmBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasChemmBatched_(handle,side,uplo,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc,batchCount) &
-        bind(c, name="cublasChemmBatched")
-#else
     function hipblasChemmBatched_(handle,side,uplo,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc,batchCount) &
         bind(c, name="hipblasChemmBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -35577,15 +33507,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZhemmBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZhemmBatched_(handle,side,uplo,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc,batchCount) &
-        bind(c, name="cublasZhemmBatched")
-#else
     function hipblasZhemmBatched_(handle,side,uplo,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc,batchCount) &
         bind(c, name="hipblasZhemmBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -35606,17 +33533,13 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasChemmBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasChemmBatched_64_(handle,side,uplo,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
-        batchCount) &
-        bind(c, name="cublasChemmBatched_64")
-#else
     function hipblasChemmBatched_64_(handle,side,uplo,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
         batchCount) &
         bind(c, name="hipblasChemmBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -35637,17 +33560,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZhemmBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZhemmBatched_64_(handle,side,uplo,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
-        batchCount) &
-        bind(c, name="cublasZhemmBatched_64")
-#else
     function hipblasZhemmBatched_64_(handle,side,uplo,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc, &
         batchCount) &
         bind(c, name="hipblasZhemmBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -35668,6 +33587,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 3 API
   !>
@@ -35761,16 +33681,11 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasChemmStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasChemmStridedBatched_(handle,side,uplo,n,k,alpha,AP,lda,strideA,BP,ldb,strideB, &
-        beta,CP,ldc,strideC,batchCount) &
-        bind(c, name="cublasChemmStridedBatched")
-#else
     function hipblasChemmStridedBatched_(handle,side,uplo,n,k,alpha,AP,lda,strideA,BP,ldb,strideB, &
         beta,CP,ldc,strideC,batchCount) &
         bind(c, name="hipblasChemmStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -35801,17 +33716,13 @@ module hipfort_hipblas
       hipblasChemmStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZhemmStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZhemmStridedBatched_(handle,side,uplo,n,k,alpha,AP,lda,strideA,BP,ldb,strideB, &
-        beta,CP,ldc,strideC,batchCount) &
-        bind(c, name="cublasZhemmStridedBatched")
-#else
     function hipblasZhemmStridedBatched_(handle,side,uplo,n,k,alpha,AP,lda,strideA,BP,ldb,strideB, &
         beta,CP,ldc,strideC,batchCount) &
         bind(c, name="hipblasZhemmStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -35842,17 +33753,13 @@ module hipfort_hipblas
       hipblasZhemmStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasChemmStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasChemmStridedBatched_64_(handle,side,uplo,n,k,alpha,AP,lda,strideA,BP,ldb, &
-        strideB,beta,CP,ldc,strideC,batchCount) &
-        bind(c, name="cublasChemmStridedBatched_64")
-#else
     function hipblasChemmStridedBatched_64_(handle,side,uplo,n,k,alpha,AP,lda,strideA,BP,ldb, &
         strideB,beta,CP,ldc,strideC,batchCount) &
         bind(c, name="hipblasChemmStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -35876,17 +33783,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZhemmStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZhemmStridedBatched_64_(handle,side,uplo,n,k,alpha,AP,lda,strideA,BP,ldb, &
-        strideB,beta,CP,ldc,strideC,batchCount) &
-        bind(c, name="cublasZhemmStridedBatched_64")
-#else
     function hipblasZhemmStridedBatched_64_(handle,side,uplo,n,k,alpha,AP,lda,strideA,BP,ldb, &
         strideB,beta,CP,ldc,strideC,batchCount) &
         bind(c, name="hipblasZhemmStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -35910,6 +33813,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 3 API
   !>
@@ -36376,16 +34280,11 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances i in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasStrmmBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasStrmmBatched_(handle,side,uplo,transA,diag,m,n,alpha,A,lda,B,ldb,C,ldc, &
-        batchCount) &
-        bind(c, name="cublasStrmmBatched")
-#else
     function hipblasStrmmBatched_(handle,side,uplo,transA,diag,m,n,alpha,A,lda,B,ldb,C,ldc, &
         batchCount) &
         bind(c, name="hipblasStrmmBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -36407,17 +34306,13 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDtrmmBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDtrmmBatched_(handle,side,uplo,transA,diag,m,n,alpha,A,lda,B,ldb,C,ldc, &
-        batchCount) &
-        bind(c, name="cublasDtrmmBatched")
-#else
     function hipblasDtrmmBatched_(handle,side,uplo,transA,diag,m,n,alpha,A,lda,B,ldb,C,ldc, &
         batchCount) &
         bind(c, name="hipblasDtrmmBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -36439,17 +34334,13 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCtrmmBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCtrmmBatched_(handle,side,uplo,transA,diag,m,n,alpha,A,lda,B,ldb,C,ldc, &
-        batchCount) &
-        bind(c, name="cublasCtrmmBatched")
-#else
     function hipblasCtrmmBatched_(handle,side,uplo,transA,diag,m,n,alpha,A,lda,B,ldb,C,ldc, &
         batchCount) &
         bind(c, name="hipblasCtrmmBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -36471,17 +34362,13 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZtrmmBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZtrmmBatched_(handle,side,uplo,transA,diag,m,n,alpha,A,lda,B,ldb,C,ldc, &
-        batchCount) &
-        bind(c, name="cublasZtrmmBatched")
-#else
     function hipblasZtrmmBatched_(handle,side,uplo,transA,diag,m,n,alpha,A,lda,B,ldb,C,ldc, &
         batchCount) &
         bind(c, name="hipblasZtrmmBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -36503,17 +34390,13 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasStrmmBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasStrmmBatched_64_(handle,side,uplo,transA,diag,m,n,alpha,A,lda,B,ldb,C,ldc, &
-        batchCount) &
-        bind(c, name="cublasStrmmBatched_64")
-#else
     function hipblasStrmmBatched_64_(handle,side,uplo,transA,diag,m,n,alpha,A,lda,B,ldb,C,ldc, &
         batchCount) &
         bind(c, name="hipblasStrmmBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -36535,17 +34418,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDtrmmBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDtrmmBatched_64_(handle,side,uplo,transA,diag,m,n,alpha,A,lda,B,ldb,C,ldc, &
-        batchCount) &
-        bind(c, name="cublasDtrmmBatched_64")
-#else
     function hipblasDtrmmBatched_64_(handle,side,uplo,transA,diag,m,n,alpha,A,lda,B,ldb,C,ldc, &
         batchCount) &
         bind(c, name="hipblasDtrmmBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -36567,17 +34446,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCtrmmBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCtrmmBatched_64_(handle,side,uplo,transA,diag,m,n,alpha,A,lda,B,ldb,C,ldc, &
-        batchCount) &
-        bind(c, name="cublasCtrmmBatched_64")
-#else
     function hipblasCtrmmBatched_64_(handle,side,uplo,transA,diag,m,n,alpha,A,lda,B,ldb,C,ldc, &
         batchCount) &
         bind(c, name="hipblasCtrmmBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -36599,17 +34474,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZtrmmBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZtrmmBatched_64_(handle,side,uplo,transA,diag,m,n,alpha,A,lda,B,ldb,C,ldc, &
-        batchCount) &
-        bind(c, name="cublasZtrmmBatched_64")
-#else
     function hipblasZtrmmBatched_64_(handle,side,uplo,transA,diag,m,n,alpha,A,lda,B,ldb,C,ldc, &
         batchCount) &
         bind(c, name="hipblasZtrmmBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -36631,6 +34502,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 3 API
   !>
@@ -36751,16 +34623,11 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances i in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasStrmmStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasStrmmStridedBatched_(handle,side,uplo,transA,diag,m,n,alpha,A,lda,strideA,B, &
-        ldb,strideB,C,ldc,strideC,batchCount) &
-        bind(c, name="cublasStrmmStridedBatched")
-#else
     function hipblasStrmmStridedBatched_(handle,side,uplo,transA,diag,m,n,alpha,A,lda,strideA,B, &
         ldb,strideB,C,ldc,strideC,batchCount) &
         bind(c, name="hipblasStrmmStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -36792,17 +34659,13 @@ module hipfort_hipblas
       hipblasStrmmStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDtrmmStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDtrmmStridedBatched_(handle,side,uplo,transA,diag,m,n,alpha,A,lda,strideA,B, &
-        ldb,strideB,C,ldc,strideC,batchCount) &
-        bind(c, name="cublasDtrmmStridedBatched")
-#else
     function hipblasDtrmmStridedBatched_(handle,side,uplo,transA,diag,m,n,alpha,A,lda,strideA,B, &
         ldb,strideB,C,ldc,strideC,batchCount) &
         bind(c, name="hipblasDtrmmStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -36834,17 +34697,13 @@ module hipfort_hipblas
       hipblasDtrmmStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCtrmmStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCtrmmStridedBatched_(handle,side,uplo,transA,diag,m,n,alpha,A,lda,strideA,B, &
-        ldb,strideB,C,ldc,strideC,batchCount) &
-        bind(c, name="cublasCtrmmStridedBatched")
-#else
     function hipblasCtrmmStridedBatched_(handle,side,uplo,transA,diag,m,n,alpha,A,lda,strideA,B, &
         ldb,strideB,C,ldc,strideC,batchCount) &
         bind(c, name="hipblasCtrmmStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -36876,17 +34735,13 @@ module hipfort_hipblas
       hipblasCtrmmStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZtrmmStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZtrmmStridedBatched_(handle,side,uplo,transA,diag,m,n,alpha,A,lda,strideA,B, &
-        ldb,strideB,C,ldc,strideC,batchCount) &
-        bind(c, name="cublasZtrmmStridedBatched")
-#else
     function hipblasZtrmmStridedBatched_(handle,side,uplo,transA,diag,m,n,alpha,A,lda,strideA,B, &
         ldb,strideB,C,ldc,strideC,batchCount) &
         bind(c, name="hipblasZtrmmStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -36918,17 +34773,13 @@ module hipfort_hipblas
       hipblasZtrmmStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasStrmmStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasStrmmStridedBatched_64_(handle,side,uplo,transA,diag,m,n,alpha,A,lda,strideA, &
-        B,ldb,strideB,C,ldc,strideC,batchCount) &
-        bind(c, name="cublasStrmmStridedBatched_64")
-#else
     function hipblasStrmmStridedBatched_64_(handle,side,uplo,transA,diag,m,n,alpha,A,lda,strideA, &
         B,ldb,strideB,C,ldc,strideC,batchCount) &
         bind(c, name="hipblasStrmmStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -36953,17 +34804,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDtrmmStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDtrmmStridedBatched_64_(handle,side,uplo,transA,diag,m,n,alpha,A,lda,strideA, &
-        B,ldb,strideB,C,ldc,strideC,batchCount) &
-        bind(c, name="cublasDtrmmStridedBatched_64")
-#else
     function hipblasDtrmmStridedBatched_64_(handle,side,uplo,transA,diag,m,n,alpha,A,lda,strideA, &
         B,ldb,strideB,C,ldc,strideC,batchCount) &
         bind(c, name="hipblasDtrmmStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -36988,17 +34835,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCtrmmStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCtrmmStridedBatched_64_(handle,side,uplo,transA,diag,m,n,alpha,A,lda,strideA, &
-        B,ldb,strideB,C,ldc,strideC,batchCount) &
-        bind(c, name="cublasCtrmmStridedBatched_64")
-#else
     function hipblasCtrmmStridedBatched_64_(handle,side,uplo,transA,diag,m,n,alpha,A,lda,strideA, &
         B,ldb,strideB,C,ldc,strideC,batchCount) &
         bind(c, name="hipblasCtrmmStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -37023,17 +34866,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZtrmmStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZtrmmStridedBatched_64_(handle,side,uplo,transA,diag,m,n,alpha,A,lda,strideA, &
-        B,ldb,strideB,C,ldc,strideC,batchCount) &
-        bind(c, name="cublasZtrmmStridedBatched_64")
-#else
     function hipblasZtrmmStridedBatched_64_(handle,side,uplo,transA,diag,m,n,alpha,A,lda,strideA, &
         B,ldb,strideB,C,ldc,strideC,batchCount) &
         bind(c, name="hipblasZtrmmStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -37058,6 +34897,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 3 API
   !>
@@ -37774,16 +35614,11 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of trsm operatons in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasStrsmStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasStrsmStridedBatched_(handle,side,uplo,transA,diag,m,n,alpha,AP,lda,strideA,BP, &
-        ldb,strideB,batchCount) &
-        bind(c, name="cublasStrsmStridedBatched")
-#else
     function hipblasStrsmStridedBatched_(handle,side,uplo,transA,diag,m,n,alpha,AP,lda,strideA,BP, &
         ldb,strideB,batchCount) &
         bind(c, name="hipblasStrsmStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -37812,17 +35647,13 @@ module hipfort_hipblas
       hipblasStrsmStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDtrsmStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDtrsmStridedBatched_(handle,side,uplo,transA,diag,m,n,alpha,AP,lda,strideA,BP, &
-        ldb,strideB,batchCount) &
-        bind(c, name="cublasDtrsmStridedBatched")
-#else
     function hipblasDtrsmStridedBatched_(handle,side,uplo,transA,diag,m,n,alpha,AP,lda,strideA,BP, &
         ldb,strideB,batchCount) &
         bind(c, name="hipblasDtrsmStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -37851,17 +35682,13 @@ module hipfort_hipblas
       hipblasDtrsmStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCtrsmStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCtrsmStridedBatched_(handle,side,uplo,transA,diag,m,n,alpha,AP,lda,strideA,BP, &
-        ldb,strideB,batchCount) &
-        bind(c, name="cublasCtrsmStridedBatched")
-#else
     function hipblasCtrsmStridedBatched_(handle,side,uplo,transA,diag,m,n,alpha,AP,lda,strideA,BP, &
         ldb,strideB,batchCount) &
         bind(c, name="hipblasCtrsmStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -37890,17 +35717,13 @@ module hipfort_hipblas
       hipblasCtrsmStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZtrsmStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZtrsmStridedBatched_(handle,side,uplo,transA,diag,m,n,alpha,AP,lda,strideA,BP, &
-        ldb,strideB,batchCount) &
-        bind(c, name="cublasZtrsmStridedBatched")
-#else
     function hipblasZtrsmStridedBatched_(handle,side,uplo,transA,diag,m,n,alpha,AP,lda,strideA,BP, &
         ldb,strideB,batchCount) &
         bind(c, name="hipblasZtrsmStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -37929,17 +35752,13 @@ module hipfort_hipblas
       hipblasZtrsmStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasStrsmStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasStrsmStridedBatched_64_(handle,side,uplo,transA,diag,m,n,alpha,AP,lda,strideA, &
-        BP,ldb,strideB,batchCount) &
-        bind(c, name="cublasStrsmStridedBatched_64")
-#else
     function hipblasStrsmStridedBatched_64_(handle,side,uplo,transA,diag,m,n,alpha,AP,lda,strideA, &
         BP,ldb,strideB,batchCount) &
         bind(c, name="hipblasStrsmStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -37961,17 +35780,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDtrsmStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDtrsmStridedBatched_64_(handle,side,uplo,transA,diag,m,n,alpha,AP,lda,strideA, &
-        BP,ldb,strideB,batchCount) &
-        bind(c, name="cublasDtrsmStridedBatched_64")
-#else
     function hipblasDtrsmStridedBatched_64_(handle,side,uplo,transA,diag,m,n,alpha,AP,lda,strideA, &
         BP,ldb,strideB,batchCount) &
         bind(c, name="hipblasDtrsmStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -37993,17 +35808,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCtrsmStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCtrsmStridedBatched_64_(handle,side,uplo,transA,diag,m,n,alpha,AP,lda,strideA, &
-        BP,ldb,strideB,batchCount) &
-        bind(c, name="cublasCtrsmStridedBatched_64")
-#else
     function hipblasCtrsmStridedBatched_64_(handle,side,uplo,transA,diag,m,n,alpha,AP,lda,strideA, &
         BP,ldb,strideB,batchCount) &
         bind(c, name="hipblasCtrsmStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -38025,17 +35836,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZtrsmStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZtrsmStridedBatched_64_(handle,side,uplo,transA,diag,m,n,alpha,AP,lda,strideA, &
-        BP,ldb,strideB,batchCount) &
-        bind(c, name="cublasZtrsmStridedBatched_64")
-#else
     function hipblasZtrsmStridedBatched_64_(handle,side,uplo,transA,diag,m,n,alpha,AP,lda,strideA, &
         BP,ldb,strideB,batchCount) &
         bind(c, name="hipblasZtrsmStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -38057,6 +35864,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 3 API
   !>
@@ -38096,12 +35904,9 @@ module hipfort_hipblas
   !>     @param[in]
   !>     ldinvA    [int]
   !>               specifies the leading dimension of invA.
+#ifndef USE_CUDA_NAMES
   interface hipblasStrtri
-#ifdef USE_CUDA_NAMES
-    function hipblasStrtri_(handle,uplo,diag,n,AP,lda,invA,ldinvA) bind(c, name="cublasStrtri")
-#else
     function hipblasStrtri_(handle,uplo,diag,n,AP,lda,invA,ldinvA) bind(c, name="hipblasStrtri")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -38123,13 +35928,11 @@ module hipfort_hipblas
       hipblasStrtri_full_rank
 #endif
   end interface
-
-  interface hipblasDtrtri
-#ifdef USE_CUDA_NAMES
-    function hipblasDtrtri_(handle,uplo,diag,n,AP,lda,invA,ldinvA) bind(c, name="cublasDtrtri")
-#else
-    function hipblasDtrtri_(handle,uplo,diag,n,AP,lda,invA,ldinvA) bind(c, name="hipblasDtrtri")
 #endif
+
+#ifndef USE_CUDA_NAMES
+  interface hipblasDtrtri
+    function hipblasDtrtri_(handle,uplo,diag,n,AP,lda,invA,ldinvA) bind(c, name="hipblasDtrtri")
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -38151,13 +35954,11 @@ module hipfort_hipblas
       hipblasDtrtri_full_rank
 #endif
   end interface
-
-  interface hipblasCtrtri
-#ifdef USE_CUDA_NAMES
-    function hipblasCtrtri_(handle,uplo,diag,n,AP,lda,invA,ldinvA) bind(c, name="cublasCtrtri")
-#else
-    function hipblasCtrtri_(handle,uplo,diag,n,AP,lda,invA,ldinvA) bind(c, name="hipblasCtrtri")
 #endif
+
+#ifndef USE_CUDA_NAMES
+  interface hipblasCtrtri
+    function hipblasCtrtri_(handle,uplo,diag,n,AP,lda,invA,ldinvA) bind(c, name="hipblasCtrtri")
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -38179,13 +35980,11 @@ module hipfort_hipblas
       hipblasCtrtri_full_rank
 #endif
   end interface
-
-  interface hipblasZtrtri
-#ifdef USE_CUDA_NAMES
-    function hipblasZtrtri_(handle,uplo,diag,n,AP,lda,invA,ldinvA) bind(c, name="cublasZtrtri")
-#else
-    function hipblasZtrtri_(handle,uplo,diag,n,AP,lda,invA,ldinvA) bind(c, name="hipblasZtrtri")
 #endif
+
+#ifndef USE_CUDA_NAMES
+  interface hipblasZtrtri
+    function hipblasZtrtri_(handle,uplo,diag,n,AP,lda,invA,ldinvA) bind(c, name="hipblasZtrtri")
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -38207,6 +36006,7 @@ module hipfort_hipblas
       hipblasZtrtri_full_rank
 #endif
   end interface
+#endif
 
   !>     \brief  BLAS Level 3 API
   !>
@@ -38251,14 +36051,10 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>               numbers of matrices in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasStrtriBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasStrtriBatched_(handle,uplo,diag,n,AP,lda,invA,ldinvA,batchCount) &
-        bind(c, name="cublasStrtriBatched")
-#else
     function hipblasStrtriBatched_(handle,uplo,diag,n,AP,lda,invA,ldinvA,batchCount) &
         bind(c, name="hipblasStrtriBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -38274,15 +36070,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDtrtriBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDtrtriBatched_(handle,uplo,diag,n,AP,lda,invA,ldinvA,batchCount) &
-        bind(c, name="cublasDtrtriBatched")
-#else
     function hipblasDtrtriBatched_(handle,uplo,diag,n,AP,lda,invA,ldinvA,batchCount) &
         bind(c, name="hipblasDtrtriBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -38298,15 +36091,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCtrtriBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCtrtriBatched_(handle,uplo,diag,n,AP,lda,invA,ldinvA,batchCount) &
-        bind(c, name="cublasCtrtriBatched")
-#else
     function hipblasCtrtriBatched_(handle,uplo,diag,n,AP,lda,invA,ldinvA,batchCount) &
         bind(c, name="hipblasCtrtriBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -38322,15 +36112,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZtrtriBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZtrtriBatched_(handle,uplo,diag,n,AP,lda,invA,ldinvA,batchCount) &
-        bind(c, name="cublasZtrtriBatched")
-#else
     function hipblasZtrtriBatched_(handle,uplo,diag,n,AP,lda,invA,ldinvA,batchCount) &
         bind(c, name="hipblasZtrtriBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -38346,6 +36133,7 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 3 API
   !>
@@ -38398,16 +36186,11 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount  [int]
   !>                  numbers of matrices in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasStrtriStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasStrtriStridedBatched_(handle,uplo,diag,n,AP,lda,strideA,invA,ldinvA, &
-        stride_invA,batchCount) &
-        bind(c, name="cublasStrtriStridedBatched")
-#else
     function hipblasStrtriStridedBatched_(handle,uplo,diag,n,AP,lda,strideA,invA,ldinvA, &
         stride_invA,batchCount) &
         bind(c, name="hipblasStrtriStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -38432,17 +36215,13 @@ module hipfort_hipblas
       hipblasStrtriStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDtrtriStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDtrtriStridedBatched_(handle,uplo,diag,n,AP,lda,strideA,invA,ldinvA, &
-        stride_invA,batchCount) &
-        bind(c, name="cublasDtrtriStridedBatched")
-#else
     function hipblasDtrtriStridedBatched_(handle,uplo,diag,n,AP,lda,strideA,invA,ldinvA, &
         stride_invA,batchCount) &
         bind(c, name="hipblasDtrtriStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -38467,17 +36246,13 @@ module hipfort_hipblas
       hipblasDtrtriStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCtrtriStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCtrtriStridedBatched_(handle,uplo,diag,n,AP,lda,strideA,invA,ldinvA, &
-        stride_invA,batchCount) &
-        bind(c, name="cublasCtrtriStridedBatched")
-#else
     function hipblasCtrtriStridedBatched_(handle,uplo,diag,n,AP,lda,strideA,invA,ldinvA, &
         stride_invA,batchCount) &
         bind(c, name="hipblasCtrtriStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -38502,17 +36277,13 @@ module hipfort_hipblas
       hipblasCtrtriStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZtrtriStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZtrtriStridedBatched_(handle,uplo,diag,n,AP,lda,strideA,invA,ldinvA, &
-        stride_invA,batchCount) &
-        bind(c, name="cublasZtrtriStridedBatched")
-#else
     function hipblasZtrtriStridedBatched_(handle,uplo,diag,n,AP,lda,strideA,invA,ldinvA, &
         stride_invA,batchCount) &
         bind(c, name="hipblasZtrtriStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -38537,6 +36308,7 @@ module hipfort_hipblas
       hipblasZtrtriStridedBatched_full_rank
 #endif
   end interface
+#endif
 
   !>     \brief  BLAS Level 3 API
   !>
@@ -38845,14 +36617,10 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasSdgmmBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasSdgmmBatched_(handle,side,m,n,AP,lda,x,incx,CP,ldc,batchCount) &
-        bind(c, name="cublasSdgmmBatched")
-#else
     function hipblasSdgmmBatched_(handle,side,m,n,AP,lda,x,incx,CP,ldc,batchCount) &
         bind(c, name="hipblasSdgmmBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -38870,15 +36638,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDdgmmBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDdgmmBatched_(handle,side,m,n,AP,lda,x,incx,CP,ldc,batchCount) &
-        bind(c, name="cublasDdgmmBatched")
-#else
     function hipblasDdgmmBatched_(handle,side,m,n,AP,lda,x,incx,CP,ldc,batchCount) &
         bind(c, name="hipblasDdgmmBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -38896,15 +36661,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCdgmmBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCdgmmBatched_(handle,side,m,n,AP,lda,x,incx,CP,ldc,batchCount) &
-        bind(c, name="cublasCdgmmBatched")
-#else
     function hipblasCdgmmBatched_(handle,side,m,n,AP,lda,x,incx,CP,ldc,batchCount) &
         bind(c, name="hipblasCdgmmBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -38922,15 +36684,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZdgmmBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZdgmmBatched_(handle,side,m,n,AP,lda,x,incx,CP,ldc,batchCount) &
-        bind(c, name="cublasZdgmmBatched")
-#else
     function hipblasZdgmmBatched_(handle,side,m,n,AP,lda,x,incx,CP,ldc,batchCount) &
         bind(c, name="hipblasZdgmmBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -38948,15 +36707,12 @@ module hipfort_hipblas
       integer(c_int),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasSdgmmBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasSdgmmBatched_64_(handle,side,m,n,AP,lda,x,incx,CP,ldc,batchCount) &
-        bind(c, name="cublasSdgmmBatched_64")
-#else
     function hipblasSdgmmBatched_64_(handle,side,m,n,AP,lda,x,incx,CP,ldc,batchCount) &
         bind(c, name="hipblasSdgmmBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -38974,15 +36730,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDdgmmBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDdgmmBatched_64_(handle,side,m,n,AP,lda,x,incx,CP,ldc,batchCount) &
-        bind(c, name="cublasDdgmmBatched_64")
-#else
     function hipblasDdgmmBatched_64_(handle,side,m,n,AP,lda,x,incx,CP,ldc,batchCount) &
         bind(c, name="hipblasDdgmmBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -39000,15 +36753,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCdgmmBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCdgmmBatched_64_(handle,side,m,n,AP,lda,x,incx,CP,ldc,batchCount) &
-        bind(c, name="cublasCdgmmBatched_64")
-#else
     function hipblasCdgmmBatched_64_(handle,side,m,n,AP,lda,x,incx,CP,ldc,batchCount) &
         bind(c, name="hipblasCdgmmBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -39026,15 +36776,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZdgmmBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZdgmmBatched_64_(handle,side,m,n,AP,lda,x,incx,CP,ldc,batchCount) &
-        bind(c, name="cublasZdgmmBatched_64")
-#else
     function hipblasZdgmmBatched_64_(handle,side,m,n,AP,lda,x,incx,CP,ldc,batchCount) &
         bind(c, name="hipblasZdgmmBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -39052,6 +36799,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  BLAS Level 3 API
   !>
@@ -39113,16 +36861,11 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount [int]
   !>                 number of instances i in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasSdgmmStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasSdgmmStridedBatched_(handle,side,m,n,AP,lda,strideA,x,incx,stridex,CP,ldc, &
-        strideC,batchCount) &
-        bind(c, name="cublasSdgmmStridedBatched")
-#else
     function hipblasSdgmmStridedBatched_(handle,side,m,n,AP,lda,strideA,x,incx,stridex,CP,ldc, &
         strideC,batchCount) &
         bind(c, name="hipblasSdgmmStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -39150,17 +36893,13 @@ module hipfort_hipblas
       hipblasSdgmmStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDdgmmStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDdgmmStridedBatched_(handle,side,m,n,AP,lda,strideA,x,incx,stridex,CP,ldc, &
-        strideC,batchCount) &
-        bind(c, name="cublasDdgmmStridedBatched")
-#else
     function hipblasDdgmmStridedBatched_(handle,side,m,n,AP,lda,strideA,x,incx,stridex,CP,ldc, &
         strideC,batchCount) &
         bind(c, name="hipblasDdgmmStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -39188,17 +36927,13 @@ module hipfort_hipblas
       hipblasDdgmmStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCdgmmStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCdgmmStridedBatched_(handle,side,m,n,AP,lda,strideA,x,incx,stridex,CP,ldc, &
-        strideC,batchCount) &
-        bind(c, name="cublasCdgmmStridedBatched")
-#else
     function hipblasCdgmmStridedBatched_(handle,side,m,n,AP,lda,strideA,x,incx,stridex,CP,ldc, &
         strideC,batchCount) &
         bind(c, name="hipblasCdgmmStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -39226,17 +36961,13 @@ module hipfort_hipblas
       hipblasCdgmmStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZdgmmStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZdgmmStridedBatched_(handle,side,m,n,AP,lda,strideA,x,incx,stridex,CP,ldc, &
-        strideC,batchCount) &
-        bind(c, name="cublasZdgmmStridedBatched")
-#else
     function hipblasZdgmmStridedBatched_(handle,side,m,n,AP,lda,strideA,x,incx,stridex,CP,ldc, &
         strideC,batchCount) &
         bind(c, name="hipblasZdgmmStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -39264,17 +36995,13 @@ module hipfort_hipblas
       hipblasZdgmmStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasSdgmmStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasSdgmmStridedBatched_64_(handle,side,m,n,AP,lda,strideA,x,incx,stridex,CP,ldc, &
-        strideC,batchCount) &
-        bind(c, name="cublasSdgmmStridedBatched_64")
-#else
     function hipblasSdgmmStridedBatched_64_(handle,side,m,n,AP,lda,strideA,x,incx,stridex,CP,ldc, &
         strideC,batchCount) &
         bind(c, name="hipblasSdgmmStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -39295,17 +37022,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDdgmmStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDdgmmStridedBatched_64_(handle,side,m,n,AP,lda,strideA,x,incx,stridex,CP,ldc, &
-        strideC,batchCount) &
-        bind(c, name="cublasDdgmmStridedBatched_64")
-#else
     function hipblasDdgmmStridedBatched_64_(handle,side,m,n,AP,lda,strideA,x,incx,stridex,CP,ldc, &
         strideC,batchCount) &
         bind(c, name="hipblasDdgmmStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -39326,17 +37049,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCdgmmStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasCdgmmStridedBatched_64_(handle,side,m,n,AP,lda,strideA,x,incx,stridex,CP,ldc, &
-        strideC,batchCount) &
-        bind(c, name="cublasCdgmmStridedBatched_64")
-#else
     function hipblasCdgmmStridedBatched_64_(handle,side,m,n,AP,lda,strideA,x,incx,stridex,CP,ldc, &
         strideC,batchCount) &
         bind(c, name="hipblasCdgmmStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -39357,17 +37076,13 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZdgmmStridedBatched_64
-#ifdef USE_CUDA_NAMES
-    function hipblasZdgmmStridedBatched_64_(handle,side,m,n,AP,lda,strideA,x,incx,stridex,CP,ldc, &
-        strideC,batchCount) &
-        bind(c, name="cublasZdgmmStridedBatched_64")
-#else
     function hipblasZdgmmStridedBatched_64_(handle,side,m,n,AP,lda,strideA,x,incx,stridex,CP,ldc, &
         strideC,batchCount) &
         bind(c, name="hipblasZdgmmStridedBatched_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -39388,6 +37103,7 @@ module hipfort_hipblas
       integer(c_int64_t),value :: batchCount
     end function
   end interface
+#endif
 
   !>     \brief  SOLVER API
   !>
@@ -39439,12 +37155,9 @@ module hipfort_hipblas
   !>     info      pointer to a int on the GPU.
   !>               - If info = 0, successful exit.
   !>               - If info = j > 0, U is singular. U[j,j] is the first zero pivot.
+#ifndef USE_CUDA_NAMES
   interface hipblasSgetrf
-#ifdef USE_CUDA_NAMES
-    function hipblasSgetrf_(handle,n,A,lda,ipiv,myInfo) bind(c, name="cublasSgetrf")
-#else
     function hipblasSgetrf_(handle,n,A,lda,ipiv,myInfo) bind(c, name="hipblasSgetrf")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -39464,13 +37177,11 @@ module hipfort_hipblas
       hipblasSgetrf_full_rank
 #endif
   end interface
-
-  interface hipblasDgetrf
-#ifdef USE_CUDA_NAMES
-    function hipblasDgetrf_(handle,n,A,lda,ipiv,myInfo) bind(c, name="cublasDgetrf")
-#else
-    function hipblasDgetrf_(handle,n,A,lda,ipiv,myInfo) bind(c, name="hipblasDgetrf")
 #endif
+
+#ifndef USE_CUDA_NAMES
+  interface hipblasDgetrf
+    function hipblasDgetrf_(handle,n,A,lda,ipiv,myInfo) bind(c, name="hipblasDgetrf")
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -39490,13 +37201,11 @@ module hipfort_hipblas
       hipblasDgetrf_full_rank
 #endif
   end interface
-
-  interface hipblasCgetrf
-#ifdef USE_CUDA_NAMES
-    function hipblasCgetrf_(handle,n,A,lda,ipiv,myInfo) bind(c, name="cublasCgetrf")
-#else
-    function hipblasCgetrf_(handle,n,A,lda,ipiv,myInfo) bind(c, name="hipblasCgetrf")
 #endif
+
+#ifndef USE_CUDA_NAMES
+  interface hipblasCgetrf
+    function hipblasCgetrf_(handle,n,A,lda,ipiv,myInfo) bind(c, name="hipblasCgetrf")
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -39516,13 +37225,11 @@ module hipfort_hipblas
       hipblasCgetrf_full_rank
 #endif
   end interface
-
-  interface hipblasZgetrf
-#ifdef USE_CUDA_NAMES
-    function hipblasZgetrf_(handle,n,A,lda,ipiv,myInfo) bind(c, name="cublasZgetrf")
-#else
-    function hipblasZgetrf_(handle,n,A,lda,ipiv,myInfo) bind(c, name="hipblasZgetrf")
 #endif
+
+#ifndef USE_CUDA_NAMES
+  interface hipblasZgetrf
+    function hipblasZgetrf_(handle,n,A,lda,ipiv,myInfo) bind(c, name="hipblasZgetrf")
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -39542,6 +37249,7 @@ module hipfort_hipblas
       hipblasZgetrf_full_rank
 #endif
   end interface
+#endif
 
   !>     \brief  SOLVER API
   !>
@@ -39753,14 +37461,10 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount int. batchCount >= 0.
   !>                 Number of matrices in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasSgetrfStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasSgetrfStridedBatched_(handle,n,A,lda,strideA,ipiv,strideP,myInfo,batchCount) &
-        bind(c, name="cublasSgetrfStridedBatched")
-#else
     function hipblasSgetrfStridedBatched_(handle,n,A,lda,strideA,ipiv,strideP,myInfo,batchCount) &
         bind(c, name="hipblasSgetrfStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -39783,15 +37487,12 @@ module hipfort_hipblas
       hipblasSgetrfStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDgetrfStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDgetrfStridedBatched_(handle,n,A,lda,strideA,ipiv,strideP,myInfo,batchCount) &
-        bind(c, name="cublasDgetrfStridedBatched")
-#else
     function hipblasDgetrfStridedBatched_(handle,n,A,lda,strideA,ipiv,strideP,myInfo,batchCount) &
         bind(c, name="hipblasDgetrfStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -39814,15 +37515,12 @@ module hipfort_hipblas
       hipblasDgetrfStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCgetrfStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCgetrfStridedBatched_(handle,n,A,lda,strideA,ipiv,strideP,myInfo,batchCount) &
-        bind(c, name="cublasCgetrfStridedBatched")
-#else
     function hipblasCgetrfStridedBatched_(handle,n,A,lda,strideA,ipiv,strideP,myInfo,batchCount) &
         bind(c, name="hipblasCgetrfStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -39845,15 +37543,12 @@ module hipfort_hipblas
       hipblasCgetrfStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZgetrfStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZgetrfStridedBatched_(handle,n,A,lda,strideA,ipiv,strideP,myInfo,batchCount) &
-        bind(c, name="cublasZgetrfStridedBatched")
-#else
     function hipblasZgetrfStridedBatched_(handle,n,A,lda,strideA,ipiv,strideP,myInfo,batchCount) &
         bind(c, name="hipblasZgetrfStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -39876,6 +37571,7 @@ module hipfort_hipblas
       hipblasZgetrfStridedBatched_full_rank
 #endif
   end interface
+#endif
 
   !>     \brief  SOLVER API
   !>
@@ -39932,14 +37628,10 @@ module hipfort_hipblas
   !>     info      pointer to a int on the host.
   !>               - If info = 0, successful exit.
   !>               - If info = j < 0, the argument at position -j is invalid.
+#ifndef USE_CUDA_NAMES
   interface hipblasSgetrs
-#ifdef USE_CUDA_NAMES
-    function hipblasSgetrs_(handle,trans,n,nrhs,A,lda,ipiv,B,ldb,myInfo) &
-        bind(c, name="cublasSgetrs")
-#else
     function hipblasSgetrs_(handle,trans,n,nrhs,A,lda,ipiv,B,ldb,myInfo) &
         bind(c, name="hipblasSgetrs")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -39963,15 +37655,12 @@ module hipfort_hipblas
       hipblasSgetrs_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDgetrs
-#ifdef USE_CUDA_NAMES
-    function hipblasDgetrs_(handle,trans,n,nrhs,A,lda,ipiv,B,ldb,myInfo) &
-        bind(c, name="cublasDgetrs")
-#else
     function hipblasDgetrs_(handle,trans,n,nrhs,A,lda,ipiv,B,ldb,myInfo) &
         bind(c, name="hipblasDgetrs")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -39995,15 +37684,12 @@ module hipfort_hipblas
       hipblasDgetrs_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCgetrs
-#ifdef USE_CUDA_NAMES
-    function hipblasCgetrs_(handle,trans,n,nrhs,A,lda,ipiv,B,ldb,myInfo) &
-        bind(c, name="cublasCgetrs")
-#else
     function hipblasCgetrs_(handle,trans,n,nrhs,A,lda,ipiv,B,ldb,myInfo) &
         bind(c, name="hipblasCgetrs")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -40027,15 +37713,12 @@ module hipfort_hipblas
       hipblasCgetrs_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZgetrs
-#ifdef USE_CUDA_NAMES
-    function hipblasZgetrs_(handle,trans,n,nrhs,A,lda,ipiv,B,ldb,myInfo) &
-        bind(c, name="cublasZgetrs")
-#else
     function hipblasZgetrs_(handle,trans,n,nrhs,A,lda,ipiv,B,ldb,myInfo) &
         bind(c, name="hipblasZgetrs")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -40059,6 +37742,7 @@ module hipfort_hipblas
       hipblasZgetrs_full_rank
 #endif
   end interface
+#endif
 
   !>     \brief  SOLVER API
   !>
@@ -40302,16 +37986,11 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount int. batchCount >= 0.
   !>                 Number of instances (systems) in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasSgetrsStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasSgetrsStridedBatched_(handle,trans,n,nrhs,A,lda,strideA,ipiv,strideP,B,ldb, &
-        strideB,myInfo,batchCount) &
-        bind(c, name="cublasSgetrsStridedBatched")
-#else
     function hipblasSgetrsStridedBatched_(handle,trans,n,nrhs,A,lda,strideA,ipiv,strideP,B,ldb, &
         strideB,myInfo,batchCount) &
         bind(c, name="hipblasSgetrsStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -40339,17 +38018,13 @@ module hipfort_hipblas
       hipblasSgetrsStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDgetrsStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDgetrsStridedBatched_(handle,trans,n,nrhs,A,lda,strideA,ipiv,strideP,B,ldb, &
-        strideB,myInfo,batchCount) &
-        bind(c, name="cublasDgetrsStridedBatched")
-#else
     function hipblasDgetrsStridedBatched_(handle,trans,n,nrhs,A,lda,strideA,ipiv,strideP,B,ldb, &
         strideB,myInfo,batchCount) &
         bind(c, name="hipblasDgetrsStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -40377,17 +38052,13 @@ module hipfort_hipblas
       hipblasDgetrsStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCgetrsStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCgetrsStridedBatched_(handle,trans,n,nrhs,A,lda,strideA,ipiv,strideP,B,ldb, &
-        strideB,myInfo,batchCount) &
-        bind(c, name="cublasCgetrsStridedBatched")
-#else
     function hipblasCgetrsStridedBatched_(handle,trans,n,nrhs,A,lda,strideA,ipiv,strideP,B,ldb, &
         strideB,myInfo,batchCount) &
         bind(c, name="hipblasCgetrsStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -40415,17 +38086,13 @@ module hipfort_hipblas
       hipblasCgetrsStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZgetrsStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZgetrsStridedBatched_(handle,trans,n,nrhs,A,lda,strideA,ipiv,strideP,B,ldb, &
-        strideB,myInfo,batchCount) &
-        bind(c, name="cublasZgetrsStridedBatched")
-#else
     function hipblasZgetrsStridedBatched_(handle,trans,n,nrhs,A,lda,strideA,ipiv,strideP,B,ldb, &
         strideB,myInfo,batchCount) &
         bind(c, name="hipblasZgetrsStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -40453,6 +38120,7 @@ module hipfort_hipblas
       hipblasZgetrsStridedBatched_full_rank
 #endif
   end interface
+#endif
 
   !>     \brief  SOLVER API
   !>
@@ -41215,12 +38883,9 @@ module hipfort_hipblas
   !>     info      pointer to a int on the host.
   !>               - If info = 0, successful exit.
   !>               - If info = j < 0, the argument at position -j is invalid.
+#ifndef USE_CUDA_NAMES
   interface hipblasSgeqrf
-#ifdef USE_CUDA_NAMES
-    function hipblasSgeqrf_(handle,m,n,A,lda,ipiv,myInfo) bind(c, name="cublasSgeqrf")
-#else
     function hipblasSgeqrf_(handle,m,n,A,lda,ipiv,myInfo) bind(c, name="hipblasSgeqrf")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -41241,13 +38906,11 @@ module hipfort_hipblas
       hipblasSgeqrf_full_rank
 #endif
   end interface
-
-  interface hipblasDgeqrf
-#ifdef USE_CUDA_NAMES
-    function hipblasDgeqrf_(handle,m,n,A,lda,ipiv,myInfo) bind(c, name="cublasDgeqrf")
-#else
-    function hipblasDgeqrf_(handle,m,n,A,lda,ipiv,myInfo) bind(c, name="hipblasDgeqrf")
 #endif
+
+#ifndef USE_CUDA_NAMES
+  interface hipblasDgeqrf
+    function hipblasDgeqrf_(handle,m,n,A,lda,ipiv,myInfo) bind(c, name="hipblasDgeqrf")
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -41268,13 +38931,11 @@ module hipfort_hipblas
       hipblasDgeqrf_full_rank
 #endif
   end interface
-
-  interface hipblasCgeqrf
-#ifdef USE_CUDA_NAMES
-    function hipblasCgeqrf_(handle,m,n,A,lda,ipiv,myInfo) bind(c, name="cublasCgeqrf")
-#else
-    function hipblasCgeqrf_(handle,m,n,A,lda,ipiv,myInfo) bind(c, name="hipblasCgeqrf")
 #endif
+
+#ifndef USE_CUDA_NAMES
+  interface hipblasCgeqrf
+    function hipblasCgeqrf_(handle,m,n,A,lda,ipiv,myInfo) bind(c, name="hipblasCgeqrf")
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -41295,13 +38956,11 @@ module hipfort_hipblas
       hipblasCgeqrf_full_rank
 #endif
   end interface
-
-  interface hipblasZgeqrf
-#ifdef USE_CUDA_NAMES
-    function hipblasZgeqrf_(handle,m,n,A,lda,ipiv,myInfo) bind(c, name="cublasZgeqrf")
-#else
-    function hipblasZgeqrf_(handle,m,n,A,lda,ipiv,myInfo) bind(c, name="hipblasZgeqrf")
 #endif
+
+#ifndef USE_CUDA_NAMES
+  interface hipblasZgeqrf
+    function hipblasZgeqrf_(handle,m,n,A,lda,ipiv,myInfo) bind(c, name="hipblasZgeqrf")
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -41322,6 +38981,7 @@ module hipfort_hipblas
       hipblasZgeqrf_full_rank
 #endif
   end interface
+#endif
 
   !>     \brief  SOLVER API
   !>
@@ -41550,14 +39210,10 @@ module hipfort_hipblas
   !>     @param[in]
   !>     batchCount  int. batchCount >= 0.
   !>                  Number of matrices in the batch.
+#ifndef USE_CUDA_NAMES
   interface hipblasSgeqrfStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasSgeqrfStridedBatched_(handle,m,n,A,lda,strideA,ipiv,strideP,myInfo,batchCount) &
-        bind(c, name="cublasSgeqrfStridedBatched")
-#else
     function hipblasSgeqrfStridedBatched_(handle,m,n,A,lda,strideA,ipiv,strideP,myInfo,batchCount) &
         bind(c, name="hipblasSgeqrfStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -41581,15 +39237,12 @@ module hipfort_hipblas
       hipblasSgeqrfStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDgeqrfStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasDgeqrfStridedBatched_(handle,m,n,A,lda,strideA,ipiv,strideP,myInfo,batchCount) &
-        bind(c, name="cublasDgeqrfStridedBatched")
-#else
     function hipblasDgeqrfStridedBatched_(handle,m,n,A,lda,strideA,ipiv,strideP,myInfo,batchCount) &
         bind(c, name="hipblasDgeqrfStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -41613,15 +39266,12 @@ module hipfort_hipblas
       hipblasDgeqrfStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasCgeqrfStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasCgeqrfStridedBatched_(handle,m,n,A,lda,strideA,ipiv,strideP,myInfo,batchCount) &
-        bind(c, name="cublasCgeqrfStridedBatched")
-#else
     function hipblasCgeqrfStridedBatched_(handle,m,n,A,lda,strideA,ipiv,strideP,myInfo,batchCount) &
         bind(c, name="hipblasCgeqrfStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -41645,15 +39295,12 @@ module hipfort_hipblas
       hipblasCgeqrfStridedBatched_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasZgeqrfStridedBatched
-#ifdef USE_CUDA_NAMES
-    function hipblasZgeqrfStridedBatched_(handle,m,n,A,lda,strideA,ipiv,strideP,myInfo,batchCount) &
-        bind(c, name="cublasZgeqrfStridedBatched")
-#else
     function hipblasZgeqrfStridedBatched_(handle,m,n,A,lda,strideA,ipiv,strideP,myInfo,batchCount) &
         bind(c, name="hipblasZgeqrfStridedBatched")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       implicit none
@@ -41677,6 +39324,7 @@ module hipfort_hipblas
       hipblasZgeqrfStridedBatched_full_rank
 #endif
   end interface
+#endif
 
   !>  \brief  BLAS EX API
   !>
@@ -42650,16 +40298,11 @@ module hipfort_hipblas
   !>     computeType
   !>     [hipDataType]
   !>             specifies the datatype of computation.
+#ifndef USE_CUDA_NAMES
   interface hipblasTrsmEx
-#ifdef USE_CUDA_NAMES
-    function hipblasTrsmEx_(handle,side,uplo,transA,diag,m,n,alpha,A,lda,B,ldb,invA,invAsize, &
-        computeType) &
-        bind(c, name="cublasTrsmEx")
-#else
     function hipblasTrsmEx_(handle,side,uplo,transA,diag,m,n,alpha,A,lda,B,ldb,invA,invAsize, &
         computeType) &
         bind(c, name="hipblasTrsmEx")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       use hipfort_enums
@@ -42682,6 +40325,7 @@ module hipfort_hipblas
       integer(kind(HIP_R_32F)),value :: computeType
     end function
   end interface
+#endif
 
   !>  \brief  BLAS EX API
   !>
@@ -42908,16 +40552,11 @@ module hipfort_hipblas
   !>     computeType
   !>     [hipDataType]
   !>             specifies the datatype of computation.
+#ifndef USE_CUDA_NAMES
   interface hipblasTrsmBatchedEx
-#ifdef USE_CUDA_NAMES
-    function hipblasTrsmBatchedEx_(handle,side,uplo,transA,diag,m,n,alpha,A,lda,B,ldb,batchCount, &
-        invA,invAsize,computeType) &
-        bind(c, name="cublasTrsmBatchedEx")
-#else
     function hipblasTrsmBatchedEx_(handle,side,uplo,transA,diag,m,n,alpha,A,lda,B,ldb,batchCount, &
         invA,invAsize,computeType) &
         bind(c, name="hipblasTrsmBatchedEx")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       use hipfort_enums
@@ -42941,6 +40580,7 @@ module hipfort_hipblas
       integer(kind(HIP_R_32F)),value :: computeType
     end function
   end interface
+#endif
 
   !>  \brief   BLAS EX API
   !>
@@ -43087,16 +40727,11 @@ module hipfort_hipblas
   !>     computeType
   !>     [hipDataType]
   !>             specifies the datatype of computation.
+#ifndef USE_CUDA_NAMES
   interface hipblasTrsmStridedBatchedEx
-#ifdef USE_CUDA_NAMES
-    function hipblasTrsmStridedBatchedEx_(handle,side,uplo,transA,diag,m,n,alpha,A,lda,strideA,B, &
-        ldb,strideB,batchCount,invA,invAsize,strideInvA,computeType) &
-        bind(c, name="cublasTrsmStridedBatchedEx")
-#else
     function hipblasTrsmStridedBatchedEx_(handle,side,uplo,transA,diag,m,n,alpha,A,lda,strideA,B, &
         ldb,strideB,batchCount,invA,invAsize,strideInvA,computeType) &
         bind(c, name="hipblasTrsmStridedBatchedEx")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       use hipfort_enums
@@ -43123,6 +40758,7 @@ module hipfort_hipblas
       integer(kind(HIP_R_32F)),value :: computeType
     end function
   end interface
+#endif
 
   !>  \brief  BLAS EX API
   !>
@@ -43270,16 +40906,11 @@ module hipfort_hipblas
   !>     executionType
   !>     [hipDataType]
   !>               specifies the datatype of computation.
+#ifndef USE_CUDA_NAMES
   interface hipblasAxpyBatchedEx
-#ifdef USE_CUDA_NAMES
-    function hipblasAxpyBatchedEx_(handle,n,alpha,alphaType,x,xType,incx,y,yType,incy,batchCount, &
-        executionType) &
-        bind(c, name="cublasAxpyBatchedEx")
-#else
     function hipblasAxpyBatchedEx_(handle,n,alpha,alphaType,x,xType,incx,y,yType,incy,batchCount, &
         executionType) &
         bind(c, name="hipblasAxpyBatchedEx")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       use hipfort_enums
@@ -43299,17 +40930,13 @@ module hipfort_hipblas
       integer(kind(HIP_R_32F)),value :: executionType
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasAxpyBatchedEx_64
-#ifdef USE_CUDA_NAMES
-    function hipblasAxpyBatchedEx_64_(handle,n,alpha,alphaType,x,xType,incx,y,yType,incy, &
-        batchCount,executionType) &
-        bind(c, name="cublasAxpyBatchedEx_64")
-#else
     function hipblasAxpyBatchedEx_64_(handle,n,alpha,alphaType,x,xType,incx,y,yType,incy, &
         batchCount,executionType) &
         bind(c, name="hipblasAxpyBatchedEx_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       use hipfort_enums
@@ -43329,6 +40956,7 @@ module hipfort_hipblas
       integer(kind(HIP_R_32F)),value :: executionType
     end function
   end interface
+#endif
 
   !>  \brief  BLAS EX API
   !>
@@ -43390,16 +41018,11 @@ module hipfort_hipblas
   !>     executionType
   !>     [hipDataType]
   !>               specifies the datatype of computation.
+#ifndef USE_CUDA_NAMES
   interface hipblasAxpyStridedBatchedEx
-#ifdef USE_CUDA_NAMES
-    function hipblasAxpyStridedBatchedEx_(handle,n,alpha,alphaType,x,xType,incx,stridex,y,yType, &
-        incy,stridey,batchCount,executionType) &
-        bind(c, name="cublasAxpyStridedBatchedEx")
-#else
     function hipblasAxpyStridedBatchedEx_(handle,n,alpha,alphaType,x,xType,incx,stridex,y,yType, &
         incy,stridey,batchCount,executionType) &
         bind(c, name="hipblasAxpyStridedBatchedEx")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       use hipfort_enums
@@ -43421,17 +41044,13 @@ module hipfort_hipblas
       integer(kind(HIP_R_32F)),value :: executionType
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasAxpyStridedBatchedEx_64
-#ifdef USE_CUDA_NAMES
-    function hipblasAxpyStridedBatchedEx_64_(handle,n,alpha,alphaType,x,xType,incx,stridex,y, &
-        yType,incy,stridey,batchCount,executionType) &
-        bind(c, name="cublasAxpyStridedBatchedEx_64")
-#else
     function hipblasAxpyStridedBatchedEx_64_(handle,n,alpha,alphaType,x,xType,incx,stridex,y, &
         yType,incy,stridey,batchCount,executionType) &
         bind(c, name="hipblasAxpyStridedBatchedEx_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       use hipfort_enums
@@ -43453,6 +41072,7 @@ module hipfort_hipblas
       integer(kind(HIP_R_32F)),value :: executionType
     end function
   end interface
+#endif
 
   !>     \brief  BLAS EX API
   !>
@@ -43673,16 +41293,11 @@ module hipfort_hipblas
   !>     executionType
   !>     [hipDataType]
   !>               specifies the datatype of computation.
+#ifndef USE_CUDA_NAMES
   interface hipblasDotBatchedEx
-#ifdef USE_CUDA_NAMES
-    function hipblasDotBatchedEx_(handle,n,x,xType,incx,y,yType,incy,batchCount,myResult, &
-        resultType,executionType) &
-        bind(c, name="cublasDotBatchedEx")
-#else
     function hipblasDotBatchedEx_(handle,n,x,xType,incx,y,yType,incy,batchCount,myResult, &
         resultType,executionType) &
         bind(c, name="hipblasDotBatchedEx")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       use hipfort_enums
@@ -43702,17 +41317,13 @@ module hipfort_hipblas
       integer(kind(HIP_R_32F)),value :: executionType
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDotcBatchedEx
-#ifdef USE_CUDA_NAMES
-    function hipblasDotcBatchedEx_(handle,n,x,xType,incx,y,yType,incy,batchCount,myResult, &
-        resultType,executionType) &
-        bind(c, name="cublasDotcBatchedEx")
-#else
     function hipblasDotcBatchedEx_(handle,n,x,xType,incx,y,yType,incy,batchCount,myResult, &
         resultType,executionType) &
         bind(c, name="hipblasDotcBatchedEx")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       use hipfort_enums
@@ -43732,17 +41343,13 @@ module hipfort_hipblas
       integer(kind(HIP_R_32F)),value :: executionType
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDotBatchedEx_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDotBatchedEx_64_(handle,n,x,xType,incx,y,yType,incy,batchCount,myResult, &
-        resultType,executionType) &
-        bind(c, name="cublasDotBatchedEx_64")
-#else
     function hipblasDotBatchedEx_64_(handle,n,x,xType,incx,y,yType,incy,batchCount,myResult, &
         resultType,executionType) &
         bind(c, name="hipblasDotBatchedEx_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       use hipfort_enums
@@ -43762,17 +41369,13 @@ module hipfort_hipblas
       integer(kind(HIP_R_32F)),value :: executionType
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDotcBatchedEx_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDotcBatchedEx_64_(handle,n,x,xType,incx,y,yType,incy,batchCount,myResult, &
-        resultType,executionType) &
-        bind(c, name="cublasDotcBatchedEx_64")
-#else
     function hipblasDotcBatchedEx_64_(handle,n,x,xType,incx,y,yType,incy,batchCount,myResult, &
         resultType,executionType) &
         bind(c, name="hipblasDotcBatchedEx_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       use hipfort_enums
@@ -43792,6 +41395,7 @@ module hipfort_hipblas
       integer(kind(HIP_R_32F)),value :: executionType
     end function
   end interface
+#endif
 
   !>     \brief  BLAS EX API
   !>
@@ -43857,16 +41461,11 @@ module hipfort_hipblas
   !>     executionType
   !>     [hipDataType]
   !>               specifies the datatype of computation.
+#ifndef USE_CUDA_NAMES
   interface hipblasDotStridedBatchedEx
-#ifdef USE_CUDA_NAMES
-    function hipblasDotStridedBatchedEx_(handle,n,x,xType,incx,stridex,y,yType,incy,stridey, &
-        batchCount,myResult,resultType,executionType) &
-        bind(c, name="cublasDotStridedBatchedEx")
-#else
     function hipblasDotStridedBatchedEx_(handle,n,x,xType,incx,stridex,y,yType,incy,stridey, &
         batchCount,myResult,resultType,executionType) &
         bind(c, name="hipblasDotStridedBatchedEx")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       use hipfort_enums
@@ -43888,17 +41487,13 @@ module hipfort_hipblas
       integer(kind(HIP_R_32F)),value :: executionType
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDotcStridedBatchedEx
-#ifdef USE_CUDA_NAMES
-    function hipblasDotcStridedBatchedEx_(handle,n,x,xType,incx,stridex,y,yType,incy,stridey, &
-        batchCount,myResult,resultType,executionType) &
-        bind(c, name="cublasDotcStridedBatchedEx")
-#else
     function hipblasDotcStridedBatchedEx_(handle,n,x,xType,incx,stridex,y,yType,incy,stridey, &
         batchCount,myResult,resultType,executionType) &
         bind(c, name="hipblasDotcStridedBatchedEx")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       use hipfort_enums
@@ -43920,17 +41515,13 @@ module hipfort_hipblas
       integer(kind(HIP_R_32F)),value :: executionType
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDotStridedBatchedEx_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDotStridedBatchedEx_64_(handle,n,x,xType,incx,stridex,y,yType,incy,stridey, &
-        batchCount,myResult,resultType,executionType) &
-        bind(c, name="cublasDotStridedBatchedEx_64")
-#else
     function hipblasDotStridedBatchedEx_64_(handle,n,x,xType,incx,stridex,y,yType,incy,stridey, &
         batchCount,myResult,resultType,executionType) &
         bind(c, name="hipblasDotStridedBatchedEx_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       use hipfort_enums
@@ -43952,17 +41543,13 @@ module hipfort_hipblas
       integer(kind(HIP_R_32F)),value :: executionType
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasDotcStridedBatchedEx_64
-#ifdef USE_CUDA_NAMES
-    function hipblasDotcStridedBatchedEx_64_(handle,n,x,xType,incx,stridex,y,yType,incy,stridey, &
-        batchCount,myResult,resultType,executionType) &
-        bind(c, name="cublasDotcStridedBatchedEx_64")
-#else
     function hipblasDotcStridedBatchedEx_64_(handle,n,x,xType,incx,stridex,y,yType,incy,stridey, &
         batchCount,myResult,resultType,executionType) &
         bind(c, name="hipblasDotcStridedBatchedEx_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       use hipfort_enums
@@ -43984,6 +41571,7 @@ module hipfort_hipblas
       integer(kind(HIP_R_32F)),value :: executionType
     end function
   end interface
+#endif
 
   !>  \brief   BLAS EX API
   !>
@@ -44111,16 +41699,11 @@ module hipfort_hipblas
   !>     executionType
   !>     [hipDataType]
   !>               specifies the datatype of computation.
+#ifndef USE_CUDA_NAMES
   interface hipblasNrm2BatchedEx
-#ifdef USE_CUDA_NAMES
-    function hipblasNrm2BatchedEx_(handle,n,x,xType,incx,batchCount,myResult,resultType, &
-        executionType) &
-        bind(c, name="cublasNrm2BatchedEx")
-#else
     function hipblasNrm2BatchedEx_(handle,n,x,xType,incx,batchCount,myResult,resultType, &
         executionType) &
         bind(c, name="hipblasNrm2BatchedEx")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       use hipfort_enums
@@ -44137,17 +41720,13 @@ module hipfort_hipblas
       integer(kind(HIP_R_32F)),value :: executionType
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasNrm2BatchedEx_64
-#ifdef USE_CUDA_NAMES
-    function hipblasNrm2BatchedEx_64_(handle,n,x,xType,incx,batchCount,myResult,resultType, &
-        executionType) &
-        bind(c, name="cublasNrm2BatchedEx_64")
-#else
     function hipblasNrm2BatchedEx_64_(handle,n,x,xType,incx,batchCount,myResult,resultType, &
         executionType) &
         bind(c, name="hipblasNrm2BatchedEx_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       use hipfort_enums
@@ -44164,6 +41743,7 @@ module hipfort_hipblas
       integer(kind(HIP_R_32F)),value :: executionType
     end function
   end interface
+#endif
 
   !>  \brief   BLAS EX API
   !>
@@ -44213,16 +41793,11 @@ module hipfort_hipblas
   !>     executionType
   !>     [hipDataType]
   !>               specifies the datatype of computation.
+#ifndef USE_CUDA_NAMES
   interface hipblasNrm2StridedBatchedEx
-#ifdef USE_CUDA_NAMES
-    function hipblasNrm2StridedBatchedEx_(handle,n,x,xType,incx,stridex,batchCount,myResult, &
-        resultType,executionType) &
-        bind(c, name="cublasNrm2StridedBatchedEx")
-#else
     function hipblasNrm2StridedBatchedEx_(handle,n,x,xType,incx,stridex,batchCount,myResult, &
         resultType,executionType) &
         bind(c, name="hipblasNrm2StridedBatchedEx")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       use hipfort_enums
@@ -44240,17 +41815,13 @@ module hipfort_hipblas
       integer(kind(HIP_R_32F)),value :: executionType
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasNrm2StridedBatchedEx_64
-#ifdef USE_CUDA_NAMES
-    function hipblasNrm2StridedBatchedEx_64_(handle,n,x,xType,incx,stridex,batchCount,myResult, &
-        resultType,executionType) &
-        bind(c, name="cublasNrm2StridedBatchedEx_64")
-#else
     function hipblasNrm2StridedBatchedEx_64_(handle,n,x,xType,incx,stridex,batchCount,myResult, &
         resultType,executionType) &
         bind(c, name="hipblasNrm2StridedBatchedEx_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       use hipfort_enums
@@ -44268,6 +41839,7 @@ module hipfort_hipblas
       integer(kind(HIP_R_32F)),value :: executionType
     end function
   end interface
+#endif
 
   !>  \brief  BLAS EX API
   !>
@@ -44441,16 +42013,11 @@ module hipfort_hipblas
   !>     executionType
   !>     [hipDataType]
   !>             specifies the datatype of computation.
+#ifndef USE_CUDA_NAMES
   interface hipblasRotBatchedEx
-#ifdef USE_CUDA_NAMES
-    function hipblasRotBatchedEx_(handle,n,x,xType,incx,y,yType,incy,c,s,csType,batchCount, &
-        executionType) &
-        bind(c, name="cublasRotBatchedEx")
-#else
     function hipblasRotBatchedEx_(handle,n,x,xType,incx,y,yType,incy,c,s,csType,batchCount, &
         executionType) &
         bind(c, name="hipblasRotBatchedEx")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       use hipfort_enums
@@ -44471,17 +42038,13 @@ module hipfort_hipblas
       integer(kind(HIP_R_32F)),value :: executionType
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasRotBatchedEx_64
-#ifdef USE_CUDA_NAMES
-    function hipblasRotBatchedEx_64_(handle,n,x,xType,incx,y,yType,incy,c,s,csType,batchCount, &
-        executionType) &
-        bind(c, name="cublasRotBatchedEx_64")
-#else
     function hipblasRotBatchedEx_64_(handle,n,x,xType,incx,y,yType,incy,c,s,csType,batchCount, &
         executionType) &
         bind(c, name="hipblasRotBatchedEx_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       use hipfort_enums
@@ -44502,6 +42065,7 @@ module hipfort_hipblas
       integer(kind(HIP_R_32F)),value :: executionType
     end function
   end interface
+#endif
 
   !>  \brief  BLAS EX API
   !>
@@ -44569,16 +42133,11 @@ module hipfort_hipblas
   !>     executionType
   !>     [hipDataType]
   !>             specifies the datatype of computation.
+#ifndef USE_CUDA_NAMES
   interface hipblasRotStridedBatchedEx
-#ifdef USE_CUDA_NAMES
-    function hipblasRotStridedBatchedEx_(handle,n,x,xType,incx,stridex,y,yType,incy,stridey,c,s, &
-        csType,batchCount,executionType) &
-        bind(c, name="cublasRotStridedBatchedEx")
-#else
     function hipblasRotStridedBatchedEx_(handle,n,x,xType,incx,stridex,y,yType,incy,stridey,c,s, &
         csType,batchCount,executionType) &
         bind(c, name="hipblasRotStridedBatchedEx")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       use hipfort_enums
@@ -44601,17 +42160,13 @@ module hipfort_hipblas
       integer(kind(HIP_R_32F)),value :: executionType
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasRotStridedBatchedEx_64
-#ifdef USE_CUDA_NAMES
-    function hipblasRotStridedBatchedEx_64_(handle,n,x,xType,incx,stridex,y,yType,incy,stridey,c, &
-        s,csType,batchCount,executionType) &
-        bind(c, name="cublasRotStridedBatchedEx_64")
-#else
     function hipblasRotStridedBatchedEx_64_(handle,n,x,xType,incx,stridex,y,yType,incy,stridey,c, &
         s,csType,batchCount,executionType) &
         bind(c, name="hipblasRotStridedBatchedEx_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       use hipfort_enums
@@ -44634,6 +42189,7 @@ module hipfort_hipblas
       integer(kind(HIP_R_32F)),value :: executionType
     end function
   end interface
+#endif
 
   !>  \brief  BLAS EX API
   !>
@@ -44755,14 +42311,10 @@ module hipfort_hipblas
   !>     executionType
   !>     [hipDataType]
   !>                    specifies the datatype of computation.
+#ifndef USE_CUDA_NAMES
   interface hipblasScalBatchedEx
-#ifdef USE_CUDA_NAMES
-    function hipblasScalBatchedEx_(handle,n,alpha,alphaType,x,xType,incx,batchCount,executionType) &
-        bind(c, name="cublasScalBatchedEx")
-#else
     function hipblasScalBatchedEx_(handle,n,alpha,alphaType,x,xType,incx,batchCount,executionType) &
         bind(c, name="hipblasScalBatchedEx")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       use hipfort_enums
@@ -44779,17 +42331,13 @@ module hipfort_hipblas
       integer(kind(HIP_R_32F)),value :: executionType
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasScalBatchedEx_64
-#ifdef USE_CUDA_NAMES
-    function hipblasScalBatchedEx_64_(handle,n,alpha,alphaType,x,xType,incx,batchCount, &
-        executionType) &
-        bind(c, name="cublasScalBatchedEx_64")
-#else
     function hipblasScalBatchedEx_64_(handle,n,alpha,alphaType,x,xType,incx,batchCount, &
         executionType) &
         bind(c, name="hipblasScalBatchedEx_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       use hipfort_enums
@@ -44806,6 +42354,7 @@ module hipfort_hipblas
       integer(kind(HIP_R_32F)),value :: executionType
     end function
   end interface
+#endif
 
   !>  \brief  BLAS EX API
   !>
@@ -44852,16 +42401,11 @@ module hipfort_hipblas
   !>     executionType
   !>     [hipDataType]
   !>                    specifies the datatype of computation.
+#ifndef USE_CUDA_NAMES
   interface hipblasScalStridedBatchedEx
-#ifdef USE_CUDA_NAMES
-    function hipblasScalStridedBatchedEx_(handle,n,alpha,alphaType,x,xType,incx,stridex, &
-        batchCount,executionType) &
-        bind(c, name="cublasScalStridedBatchedEx")
-#else
     function hipblasScalStridedBatchedEx_(handle,n,alpha,alphaType,x,xType,incx,stridex, &
         batchCount,executionType) &
         bind(c, name="hipblasScalStridedBatchedEx")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       use hipfort_enums
@@ -44879,17 +42423,13 @@ module hipfort_hipblas
       integer(kind(HIP_R_32F)),value :: executionType
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipblasScalStridedBatchedEx_64
-#ifdef USE_CUDA_NAMES
-    function hipblasScalStridedBatchedEx_64_(handle,n,alpha,alphaType,x,xType,incx,stridex, &
-        batchCount,executionType) &
-        bind(c, name="cublasScalStridedBatchedEx_64")
-#else
     function hipblasScalStridedBatchedEx_64_(handle,n,alpha,alphaType,x,xType,incx,stridex, &
         batchCount,executionType) &
         bind(c, name="hipblasScalStridedBatchedEx_64")
-#endif
       use iso_c_binding
       use hipfort_hipblas_enums
       use hipfort_enums
@@ -44907,6 +42447,7 @@ module hipfort_hipblas
       integer(kind(HIP_R_32F)),value :: executionType
     end function
   end interface
+#endif
 
   !>  \brief  Auxiliary API
   !>

--- a/lib/hipfort/hipfort_hiprand.F90
+++ b/lib/hipfort/hipfort_hiprand.F90
@@ -193,12 +193,9 @@ module hipfort_hiprand
   !>  - HIPRAND_STATUS_NOT_INITIALIZED if the generator was not initialized
   !>  - HIPRAND_STATUS_LAUNCH_FAILURE if generator failed to launch kernel
   !>  - HIPRAND_STATUS_SUCCESS if random numbers were successfully generated
+#ifndef USE_CUDA_NAMES
   interface hiprandGenerateChar
-#ifdef USE_CUDA_NAMES
-    function hiprandGenerateChar_(generator,output_data,n) bind(c, name="curandGenerateChar")
-#else
     function hiprandGenerateChar_(generator,output_data,n) bind(c, name="hiprandGenerateChar")
-#endif
       use iso_c_binding
       use hipfort_hiprand_enums
       implicit none
@@ -208,6 +205,7 @@ module hipfort_hiprand
       integer(c_size_t),value :: n
     end function
   end interface
+#endif
 
   !>  \brief Generates uniformly distributed 16-bit unsigned integers.
   !>
@@ -225,12 +223,9 @@ module hipfort_hiprand
   !>  - HIPRAND_STATUS_NOT_INITIALIZED if the generator was not initialized
   !>  - HIPRAND_STATUS_LAUNCH_FAILURE if generator failed to launch kernel
   !>  - HIPRAND_STATUS_SUCCESS if random numbers were successfully generated
+#ifndef USE_CUDA_NAMES
   interface hiprandGenerateShort
-#ifdef USE_CUDA_NAMES
-    function hiprandGenerateShort_(generator,output_data,n) bind(c, name="curandGenerateShort")
-#else
     function hiprandGenerateShort_(generator,output_data,n) bind(c, name="hiprandGenerateShort")
-#endif
       use iso_c_binding
       use hipfort_hiprand_enums
       implicit none
@@ -240,6 +235,7 @@ module hipfort_hiprand
       integer(c_size_t),value :: n
     end function
   end interface
+#endif
 
   !>  \brief Generates uniformly distributed 64-bit unsigned integers.
   !>

--- a/lib/hipfort/hipfort_hipsolver.F90
+++ b/lib/hipfort/hipfort_hipsolver.F90
@@ -28,12 +28,9 @@ module hipfort_hipsolver
   use hipfort_hipsolver_enums
   implicit none
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverCreate
-#ifdef USE_CUDA_NAMES
-    function hipsolverCreate_(handle) bind(c, name="cusolverCreate")
-#else
     function hipsolverCreate_(handle) bind(c, name="hipsolverCreate")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -41,13 +38,11 @@ module hipfort_hipsolver
       type(c_ptr) :: handle
     end function
   end interface
-
-  interface hipsolverDestroy
-#ifdef USE_CUDA_NAMES
-    function hipsolverDestroy_(handle) bind(c, name="cusolverDestroy")
-#else
-    function hipsolverDestroy_(handle) bind(c, name="hipsolverDestroy")
 #endif
+
+#ifndef USE_CUDA_NAMES
+  interface hipsolverDestroy
+    function hipsolverDestroy_(handle) bind(c, name="hipsolverDestroy")
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -55,13 +50,11 @@ module hipfort_hipsolver
       type(c_ptr),value :: handle
     end function
   end interface
-
-  interface hipsolverSetStream
-#ifdef USE_CUDA_NAMES
-    function hipsolverSetStream_(handle,streamId) bind(c, name="cusolverSetStream")
-#else
-    function hipsolverSetStream_(handle,streamId) bind(c, name="hipsolverSetStream")
 #endif
+
+#ifndef USE_CUDA_NAMES
+  interface hipsolverSetStream
+    function hipsolverSetStream_(handle,streamId) bind(c, name="hipsolverSetStream")
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -70,13 +63,11 @@ module hipfort_hipsolver
       type(c_ptr),value :: streamId
     end function
   end interface
-
-  interface hipsolverGetStream
-#ifdef USE_CUDA_NAMES
-    function hipsolverGetStream_(handle,streamId) bind(c, name="cusolverGetStream")
-#else
-    function hipsolverGetStream_(handle,streamId) bind(c, name="hipsolverGetStream")
 #endif
+
+#ifndef USE_CUDA_NAMES
+  interface hipsolverGetStream
+    function hipsolverGetStream_(handle,streamId) bind(c, name="hipsolverGetStream")
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -85,15 +76,12 @@ module hipfort_hipsolver
       type(c_ptr) :: streamId
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverSetDeterministicMode
-#ifdef USE_CUDA_NAMES
-    function hipsolverSetDeterministicMode_(handle,mode) &
-        bind(c, name="cusolverSetDeterministicMode")
-#else
     function hipsolverSetDeterministicMode_(handle,mode) &
         bind(c, name="hipsolverSetDeterministicMode")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -102,15 +90,12 @@ module hipfort_hipsolver
       integer(kind(HIPSOLVER_DETERMINISTIC_RESULTS)),value :: mode
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverGetDeterministicMode
-#ifdef USE_CUDA_NAMES
-    function hipsolverGetDeterministicMode_(handle,mode) &
-        bind(c, name="cusolverGetDeterministicMode")
-#else
     function hipsolverGetDeterministicMode_(handle,mode) &
         bind(c, name="hipsolverGetDeterministicMode")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -119,6 +104,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: mode
     end function
   end interface
+#endif
 
   interface hipsolverCreateGesvdjInfo
 #ifdef USE_CUDA_NAMES
@@ -347,14 +333,10 @@ module hipfort_hipsolver
     end function
   end interface
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverSorgbr_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverSorgbr_bufferSize_(handle,side,m,n,k,A,lda,tau,lwork) &
-        bind(c, name="cusolverSorgbr_bufferSize")
-#else
     function hipsolverSorgbr_bufferSize_(handle,side,m,n,k,A,lda,tau,lwork) &
         bind(c, name="hipsolverSorgbr_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -377,15 +359,12 @@ module hipfort_hipsolver
       hipsolverSorgbr_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverDorgbr_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverDorgbr_bufferSize_(handle,side,m,n,k,A,lda,tau,lwork) &
-        bind(c, name="cusolverDorgbr_bufferSize")
-#else
     function hipsolverDorgbr_bufferSize_(handle,side,m,n,k,A,lda,tau,lwork) &
         bind(c, name="hipsolverDorgbr_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -408,15 +387,12 @@ module hipfort_hipsolver
       hipsolverDorgbr_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverCungbr_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverCungbr_bufferSize_(handle,side,m,n,k,A,lda,tau,lwork) &
-        bind(c, name="cusolverCungbr_bufferSize")
-#else
     function hipsolverCungbr_bufferSize_(handle,side,m,n,k,A,lda,tau,lwork) &
         bind(c, name="hipsolverCungbr_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -439,15 +415,12 @@ module hipfort_hipsolver
       hipsolverCungbr_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverZungbr_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverZungbr_bufferSize_(handle,side,m,n,k,A,lda,tau,lwork) &
-        bind(c, name="cusolverZungbr_bufferSize")
-#else
     function hipsolverZungbr_bufferSize_(handle,side,m,n,k,A,lda,tau,lwork) &
         bind(c, name="hipsolverZungbr_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -470,15 +443,12 @@ module hipfort_hipsolver
       hipsolverZungbr_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverSorgbr
-#ifdef USE_CUDA_NAMES
-    function hipsolverSorgbr_(handle,side,m,n,k,A,lda,tau,work,lwork,devInfo) &
-        bind(c, name="cusolverSorgbr")
-#else
     function hipsolverSorgbr_(handle,side,m,n,k,A,lda,tau,work,lwork,devInfo) &
         bind(c, name="hipsolverSorgbr")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -503,15 +473,12 @@ module hipfort_hipsolver
       hipsolverSorgbr_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverDorgbr
-#ifdef USE_CUDA_NAMES
-    function hipsolverDorgbr_(handle,side,m,n,k,A,lda,tau,work,lwork,devInfo) &
-        bind(c, name="cusolverDorgbr")
-#else
     function hipsolverDorgbr_(handle,side,m,n,k,A,lda,tau,work,lwork,devInfo) &
         bind(c, name="hipsolverDorgbr")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -536,15 +503,12 @@ module hipfort_hipsolver
       hipsolverDorgbr_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverCungbr
-#ifdef USE_CUDA_NAMES
-    function hipsolverCungbr_(handle,side,m,n,k,A,lda,tau,work,lwork,devInfo) &
-        bind(c, name="cusolverCungbr")
-#else
     function hipsolverCungbr_(handle,side,m,n,k,A,lda,tau,work,lwork,devInfo) &
         bind(c, name="hipsolverCungbr")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -569,15 +533,12 @@ module hipfort_hipsolver
       hipsolverCungbr_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverZungbr
-#ifdef USE_CUDA_NAMES
-    function hipsolverZungbr_(handle,side,m,n,k,A,lda,tau,work,lwork,devInfo) &
-        bind(c, name="cusolverZungbr")
-#else
     function hipsolverZungbr_(handle,side,m,n,k,A,lda,tau,work,lwork,devInfo) &
         bind(c, name="hipsolverZungbr")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -602,15 +563,12 @@ module hipfort_hipsolver
       hipsolverZungbr_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverSorgqr_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverSorgqr_bufferSize_(handle,m,n,k,A,lda,tau,lwork) &
-        bind(c, name="cusolverSorgqr_bufferSize")
-#else
     function hipsolverSorgqr_bufferSize_(handle,m,n,k,A,lda,tau,lwork) &
         bind(c, name="hipsolverSorgqr_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -632,15 +590,12 @@ module hipfort_hipsolver
       hipsolverSorgqr_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverDorgqr_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverDorgqr_bufferSize_(handle,m,n,k,A,lda,tau,lwork) &
-        bind(c, name="cusolverDorgqr_bufferSize")
-#else
     function hipsolverDorgqr_bufferSize_(handle,m,n,k,A,lda,tau,lwork) &
         bind(c, name="hipsolverDorgqr_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -662,15 +617,12 @@ module hipfort_hipsolver
       hipsolverDorgqr_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverCungqr_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverCungqr_bufferSize_(handle,m,n,k,A,lda,tau,lwork) &
-        bind(c, name="cusolverCungqr_bufferSize")
-#else
     function hipsolverCungqr_bufferSize_(handle,m,n,k,A,lda,tau,lwork) &
         bind(c, name="hipsolverCungqr_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -692,15 +644,12 @@ module hipfort_hipsolver
       hipsolverCungqr_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverZungqr_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverZungqr_bufferSize_(handle,m,n,k,A,lda,tau,lwork) &
-        bind(c, name="cusolverZungqr_bufferSize")
-#else
     function hipsolverZungqr_bufferSize_(handle,m,n,k,A,lda,tau,lwork) &
         bind(c, name="hipsolverZungqr_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -722,15 +671,12 @@ module hipfort_hipsolver
       hipsolverZungqr_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverSorgqr
-#ifdef USE_CUDA_NAMES
-    function hipsolverSorgqr_(handle,m,n,k,A,lda,tau,work,lwork,devInfo) &
-        bind(c, name="cusolverSorgqr")
-#else
     function hipsolverSorgqr_(handle,m,n,k,A,lda,tau,work,lwork,devInfo) &
         bind(c, name="hipsolverSorgqr")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -754,15 +700,12 @@ module hipfort_hipsolver
       hipsolverSorgqr_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverDorgqr
-#ifdef USE_CUDA_NAMES
-    function hipsolverDorgqr_(handle,m,n,k,A,lda,tau,work,lwork,devInfo) &
-        bind(c, name="cusolverDorgqr")
-#else
     function hipsolverDorgqr_(handle,m,n,k,A,lda,tau,work,lwork,devInfo) &
         bind(c, name="hipsolverDorgqr")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -786,15 +729,12 @@ module hipfort_hipsolver
       hipsolverDorgqr_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverCungqr
-#ifdef USE_CUDA_NAMES
-    function hipsolverCungqr_(handle,m,n,k,A,lda,tau,work,lwork,devInfo) &
-        bind(c, name="cusolverCungqr")
-#else
     function hipsolverCungqr_(handle,m,n,k,A,lda,tau,work,lwork,devInfo) &
         bind(c, name="hipsolverCungqr")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -818,15 +758,12 @@ module hipfort_hipsolver
       hipsolverCungqr_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverZungqr
-#ifdef USE_CUDA_NAMES
-    function hipsolverZungqr_(handle,m,n,k,A,lda,tau,work,lwork,devInfo) &
-        bind(c, name="cusolverZungqr")
-#else
     function hipsolverZungqr_(handle,m,n,k,A,lda,tau,work,lwork,devInfo) &
         bind(c, name="hipsolverZungqr")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -850,15 +787,12 @@ module hipfort_hipsolver
       hipsolverZungqr_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverSorgtr_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverSorgtr_bufferSize_(handle,uplo,n,A,lda,tau,lwork) &
-        bind(c, name="cusolverSorgtr_bufferSize")
-#else
     function hipsolverSorgtr_bufferSize_(handle,uplo,n,A,lda,tau,lwork) &
         bind(c, name="hipsolverSorgtr_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -879,15 +813,12 @@ module hipfort_hipsolver
       hipsolverSorgtr_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverDorgtr_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverDorgtr_bufferSize_(handle,uplo,n,A,lda,tau,lwork) &
-        bind(c, name="cusolverDorgtr_bufferSize")
-#else
     function hipsolverDorgtr_bufferSize_(handle,uplo,n,A,lda,tau,lwork) &
         bind(c, name="hipsolverDorgtr_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -908,15 +839,12 @@ module hipfort_hipsolver
       hipsolverDorgtr_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverCungtr_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverCungtr_bufferSize_(handle,uplo,n,A,lda,tau,lwork) &
-        bind(c, name="cusolverCungtr_bufferSize")
-#else
     function hipsolverCungtr_bufferSize_(handle,uplo,n,A,lda,tau,lwork) &
         bind(c, name="hipsolverCungtr_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -937,15 +865,12 @@ module hipfort_hipsolver
       hipsolverCungtr_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverZungtr_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverZungtr_bufferSize_(handle,uplo,n,A,lda,tau,lwork) &
-        bind(c, name="cusolverZungtr_bufferSize")
-#else
     function hipsolverZungtr_bufferSize_(handle,uplo,n,A,lda,tau,lwork) &
         bind(c, name="hipsolverZungtr_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -966,15 +891,12 @@ module hipfort_hipsolver
       hipsolverZungtr_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverSorgtr
-#ifdef USE_CUDA_NAMES
-    function hipsolverSorgtr_(handle,uplo,n,A,lda,tau,work,lwork,devInfo) &
-        bind(c, name="cusolverSorgtr")
-#else
     function hipsolverSorgtr_(handle,uplo,n,A,lda,tau,work,lwork,devInfo) &
         bind(c, name="hipsolverSorgtr")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -997,15 +919,12 @@ module hipfort_hipsolver
       hipsolverSorgtr_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverDorgtr
-#ifdef USE_CUDA_NAMES
-    function hipsolverDorgtr_(handle,uplo,n,A,lda,tau,work,lwork,devInfo) &
-        bind(c, name="cusolverDorgtr")
-#else
     function hipsolverDorgtr_(handle,uplo,n,A,lda,tau,work,lwork,devInfo) &
         bind(c, name="hipsolverDorgtr")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -1028,15 +947,12 @@ module hipfort_hipsolver
       hipsolverDorgtr_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverCungtr
-#ifdef USE_CUDA_NAMES
-    function hipsolverCungtr_(handle,uplo,n,A,lda,tau,work,lwork,devInfo) &
-        bind(c, name="cusolverCungtr")
-#else
     function hipsolverCungtr_(handle,uplo,n,A,lda,tau,work,lwork,devInfo) &
         bind(c, name="hipsolverCungtr")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -1059,15 +975,12 @@ module hipfort_hipsolver
       hipsolverCungtr_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverZungtr
-#ifdef USE_CUDA_NAMES
-    function hipsolverZungtr_(handle,uplo,n,A,lda,tau,work,lwork,devInfo) &
-        bind(c, name="cusolverZungtr")
-#else
     function hipsolverZungtr_(handle,uplo,n,A,lda,tau,work,lwork,devInfo) &
         bind(c, name="hipsolverZungtr")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -1090,15 +1003,12 @@ module hipfort_hipsolver
       hipsolverZungtr_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverSormqr_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverSormqr_bufferSize_(handle,side,trans,m,n,k,A,lda,tau,C,ldc,lwork) &
-        bind(c, name="cusolverSormqr_bufferSize")
-#else
     function hipsolverSormqr_bufferSize_(handle,side,trans,m,n,k,A,lda,tau,C,ldc,lwork) &
         bind(c, name="hipsolverSormqr_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -1124,15 +1034,12 @@ module hipfort_hipsolver
       hipsolverSormqr_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverDormqr_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverDormqr_bufferSize_(handle,side,trans,m,n,k,A,lda,tau,C,ldc,lwork) &
-        bind(c, name="cusolverDormqr_bufferSize")
-#else
     function hipsolverDormqr_bufferSize_(handle,side,trans,m,n,k,A,lda,tau,C,ldc,lwork) &
         bind(c, name="hipsolverDormqr_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -1158,15 +1065,12 @@ module hipfort_hipsolver
       hipsolverDormqr_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverCunmqr_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverCunmqr_bufferSize_(handle,side,trans,m,n,k,A,lda,tau,C,ldc,lwork) &
-        bind(c, name="cusolverCunmqr_bufferSize")
-#else
     function hipsolverCunmqr_bufferSize_(handle,side,trans,m,n,k,A,lda,tau,C,ldc,lwork) &
         bind(c, name="hipsolverCunmqr_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -1192,15 +1096,12 @@ module hipfort_hipsolver
       hipsolverCunmqr_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverZunmqr_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverZunmqr_bufferSize_(handle,side,trans,m,n,k,A,lda,tau,C,ldc,lwork) &
-        bind(c, name="cusolverZunmqr_bufferSize")
-#else
     function hipsolverZunmqr_bufferSize_(handle,side,trans,m,n,k,A,lda,tau,C,ldc,lwork) &
         bind(c, name="hipsolverZunmqr_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -1226,15 +1127,12 @@ module hipfort_hipsolver
       hipsolverZunmqr_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverSormqr
-#ifdef USE_CUDA_NAMES
-    function hipsolverSormqr_(handle,side,trans,m,n,k,A,lda,tau,C,ldc,work,lwork,devInfo) &
-        bind(c, name="cusolverSormqr")
-#else
     function hipsolverSormqr_(handle,side,trans,m,n,k,A,lda,tau,C,ldc,work,lwork,devInfo) &
         bind(c, name="hipsolverSormqr")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -1262,15 +1160,12 @@ module hipfort_hipsolver
       hipsolverSormqr_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverDormqr
-#ifdef USE_CUDA_NAMES
-    function hipsolverDormqr_(handle,side,trans,m,n,k,A,lda,tau,C,ldc,work,lwork,devInfo) &
-        bind(c, name="cusolverDormqr")
-#else
     function hipsolverDormqr_(handle,side,trans,m,n,k,A,lda,tau,C,ldc,work,lwork,devInfo) &
         bind(c, name="hipsolverDormqr")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -1298,15 +1193,12 @@ module hipfort_hipsolver
       hipsolverDormqr_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverCunmqr
-#ifdef USE_CUDA_NAMES
-    function hipsolverCunmqr_(handle,side,trans,m,n,k,A,lda,tau,C,ldc,work,lwork,devInfo) &
-        bind(c, name="cusolverCunmqr")
-#else
     function hipsolverCunmqr_(handle,side,trans,m,n,k,A,lda,tau,C,ldc,work,lwork,devInfo) &
         bind(c, name="hipsolverCunmqr")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -1334,15 +1226,12 @@ module hipfort_hipsolver
       hipsolverCunmqr_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverZunmqr
-#ifdef USE_CUDA_NAMES
-    function hipsolverZunmqr_(handle,side,trans,m,n,k,A,lda,tau,C,ldc,work,lwork,devInfo) &
-        bind(c, name="cusolverZunmqr")
-#else
     function hipsolverZunmqr_(handle,side,trans,m,n,k,A,lda,tau,C,ldc,work,lwork,devInfo) &
         bind(c, name="hipsolverZunmqr")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -1370,15 +1259,12 @@ module hipfort_hipsolver
       hipsolverZunmqr_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverSormtr_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverSormtr_bufferSize_(handle,side,uplo,trans,m,n,A,lda,tau,C,ldc,lwork) &
-        bind(c, name="cusolverSormtr_bufferSize")
-#else
     function hipsolverSormtr_bufferSize_(handle,side,uplo,trans,m,n,A,lda,tau,C,ldc,lwork) &
         bind(c, name="hipsolverSormtr_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -1404,15 +1290,12 @@ module hipfort_hipsolver
       hipsolverSormtr_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverDormtr_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverDormtr_bufferSize_(handle,side,uplo,trans,m,n,A,lda,tau,C,ldc,lwork) &
-        bind(c, name="cusolverDormtr_bufferSize")
-#else
     function hipsolverDormtr_bufferSize_(handle,side,uplo,trans,m,n,A,lda,tau,C,ldc,lwork) &
         bind(c, name="hipsolverDormtr_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -1438,15 +1321,12 @@ module hipfort_hipsolver
       hipsolverDormtr_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverCunmtr_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverCunmtr_bufferSize_(handle,side,uplo,trans,m,n,A,lda,tau,C,ldc,lwork) &
-        bind(c, name="cusolverCunmtr_bufferSize")
-#else
     function hipsolverCunmtr_bufferSize_(handle,side,uplo,trans,m,n,A,lda,tau,C,ldc,lwork) &
         bind(c, name="hipsolverCunmtr_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -1472,15 +1352,12 @@ module hipfort_hipsolver
       hipsolverCunmtr_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverZunmtr_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverZunmtr_bufferSize_(handle,side,uplo,trans,m,n,A,lda,tau,C,ldc,lwork) &
-        bind(c, name="cusolverZunmtr_bufferSize")
-#else
     function hipsolverZunmtr_bufferSize_(handle,side,uplo,trans,m,n,A,lda,tau,C,ldc,lwork) &
         bind(c, name="hipsolverZunmtr_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -1506,15 +1383,12 @@ module hipfort_hipsolver
       hipsolverZunmtr_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverSormtr
-#ifdef USE_CUDA_NAMES
-    function hipsolverSormtr_(handle,side,uplo,trans,m,n,A,lda,tau,C,ldc,work,lwork,devInfo) &
-        bind(c, name="cusolverSormtr")
-#else
     function hipsolverSormtr_(handle,side,uplo,trans,m,n,A,lda,tau,C,ldc,work,lwork,devInfo) &
         bind(c, name="hipsolverSormtr")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -1542,15 +1416,12 @@ module hipfort_hipsolver
       hipsolverSormtr_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverDormtr
-#ifdef USE_CUDA_NAMES
-    function hipsolverDormtr_(handle,side,uplo,trans,m,n,A,lda,tau,C,ldc,work,lwork,devInfo) &
-        bind(c, name="cusolverDormtr")
-#else
     function hipsolverDormtr_(handle,side,uplo,trans,m,n,A,lda,tau,C,ldc,work,lwork,devInfo) &
         bind(c, name="hipsolverDormtr")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -1578,15 +1449,12 @@ module hipfort_hipsolver
       hipsolverDormtr_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverCunmtr
-#ifdef USE_CUDA_NAMES
-    function hipsolverCunmtr_(handle,side,uplo,trans,m,n,A,lda,tau,C,ldc,work,lwork,devInfo) &
-        bind(c, name="cusolverCunmtr")
-#else
     function hipsolverCunmtr_(handle,side,uplo,trans,m,n,A,lda,tau,C,ldc,work,lwork,devInfo) &
         bind(c, name="hipsolverCunmtr")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -1614,15 +1482,12 @@ module hipfort_hipsolver
       hipsolverCunmtr_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverZunmtr
-#ifdef USE_CUDA_NAMES
-    function hipsolverZunmtr_(handle,side,uplo,trans,m,n,A,lda,tau,C,ldc,work,lwork,devInfo) &
-        bind(c, name="cusolverZunmtr")
-#else
     function hipsolverZunmtr_(handle,side,uplo,trans,m,n,A,lda,tau,C,ldc,work,lwork,devInfo) &
         bind(c, name="hipsolverZunmtr")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -1650,14 +1515,12 @@ module hipfort_hipsolver
       hipsolverZunmtr_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverSgebrd_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverSgebrd_bufferSize_(handle,m,n,lwork) bind(c, name="cusolverSgebrd_bufferSize")
-#else
     function hipsolverSgebrd_bufferSize_(handle,m,n,lwork) &
         bind(c, name="hipsolverSgebrd_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -1668,14 +1531,12 @@ module hipfort_hipsolver
       integer(c_int) :: lwork
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverDgebrd_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverDgebrd_bufferSize_(handle,m,n,lwork) bind(c, name="cusolverDgebrd_bufferSize")
-#else
     function hipsolverDgebrd_bufferSize_(handle,m,n,lwork) &
         bind(c, name="hipsolverDgebrd_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -1686,14 +1547,12 @@ module hipfort_hipsolver
       integer(c_int) :: lwork
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverCgebrd_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverCgebrd_bufferSize_(handle,m,n,lwork) bind(c, name="cusolverCgebrd_bufferSize")
-#else
     function hipsolverCgebrd_bufferSize_(handle,m,n,lwork) &
         bind(c, name="hipsolverCgebrd_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -1704,14 +1563,12 @@ module hipfort_hipsolver
       integer(c_int) :: lwork
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverZgebrd_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverZgebrd_bufferSize_(handle,m,n,lwork) bind(c, name="cusolverZgebrd_bufferSize")
-#else
     function hipsolverZgebrd_bufferSize_(handle,m,n,lwork) &
         bind(c, name="hipsolverZgebrd_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -1722,15 +1579,12 @@ module hipfort_hipsolver
       integer(c_int) :: lwork
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverSgebrd
-#ifdef USE_CUDA_NAMES
-    function hipsolverSgebrd_(handle,m,n,A,lda,D,E,tauq,taup,work,lwork,devInfo) &
-        bind(c, name="cusolverSgebrd")
-#else
     function hipsolverSgebrd_(handle,m,n,A,lda,D,E,tauq,taup,work,lwork,devInfo) &
         bind(c, name="hipsolverSgebrd")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -1756,15 +1610,12 @@ module hipfort_hipsolver
       hipsolverSgebrd_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverDgebrd
-#ifdef USE_CUDA_NAMES
-    function hipsolverDgebrd_(handle,m,n,A,lda,D,E,tauq,taup,work,lwork,devInfo) &
-        bind(c, name="cusolverDgebrd")
-#else
     function hipsolverDgebrd_(handle,m,n,A,lda,D,E,tauq,taup,work,lwork,devInfo) &
         bind(c, name="hipsolverDgebrd")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -1790,15 +1641,12 @@ module hipfort_hipsolver
       hipsolverDgebrd_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverCgebrd
-#ifdef USE_CUDA_NAMES
-    function hipsolverCgebrd_(handle,m,n,A,lda,D,E,tauq,taup,work,lwork,devInfo) &
-        bind(c, name="cusolverCgebrd")
-#else
     function hipsolverCgebrd_(handle,m,n,A,lda,D,E,tauq,taup,work,lwork,devInfo) &
         bind(c, name="hipsolverCgebrd")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -1824,15 +1672,12 @@ module hipfort_hipsolver
       hipsolverCgebrd_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverZgebrd
-#ifdef USE_CUDA_NAMES
-    function hipsolverZgebrd_(handle,m,n,A,lda,D,E,tauq,taup,work,lwork,devInfo) &
-        bind(c, name="cusolverZgebrd")
-#else
     function hipsolverZgebrd_(handle,m,n,A,lda,D,E,tauq,taup,work,lwork,devInfo) &
         bind(c, name="hipsolverZgebrd")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -1858,6 +1703,7 @@ module hipfort_hipsolver
       hipsolverZgebrd_full_rank
 #endif
   end interface
+#endif
 
   interface hipsolverSSgels_bufferSize
 #ifdef USE_CUDA_NAMES
@@ -2079,14 +1925,10 @@ module hipfort_hipsolver
     end function
   end interface
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverSgeqrf_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverSgeqrf_bufferSize_(handle,m,n,A,lda,lwork) &
-        bind(c, name="cusolverSgeqrf_bufferSize")
-#else
     function hipsolverSgeqrf_bufferSize_(handle,m,n,A,lda,lwork) &
         bind(c, name="hipsolverSgeqrf_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -2106,15 +1948,12 @@ module hipfort_hipsolver
       hipsolverSgeqrf_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverDgeqrf_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverDgeqrf_bufferSize_(handle,m,n,A,lda,lwork) &
-        bind(c, name="cusolverDgeqrf_bufferSize")
-#else
     function hipsolverDgeqrf_bufferSize_(handle,m,n,A,lda,lwork) &
         bind(c, name="hipsolverDgeqrf_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -2134,15 +1973,12 @@ module hipfort_hipsolver
       hipsolverDgeqrf_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverCgeqrf_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverCgeqrf_bufferSize_(handle,m,n,A,lda,lwork) &
-        bind(c, name="cusolverCgeqrf_bufferSize")
-#else
     function hipsolverCgeqrf_bufferSize_(handle,m,n,A,lda,lwork) &
         bind(c, name="hipsolverCgeqrf_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -2162,15 +1998,12 @@ module hipfort_hipsolver
       hipsolverCgeqrf_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverZgeqrf_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverZgeqrf_bufferSize_(handle,m,n,A,lda,lwork) &
-        bind(c, name="cusolverZgeqrf_bufferSize")
-#else
     function hipsolverZgeqrf_bufferSize_(handle,m,n,A,lda,lwork) &
         bind(c, name="hipsolverZgeqrf_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -2190,15 +2023,12 @@ module hipfort_hipsolver
       hipsolverZgeqrf_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverSgeqrf
-#ifdef USE_CUDA_NAMES
-    function hipsolverSgeqrf_(handle,m,n,A,lda,tau,work,lwork,devInfo) &
-        bind(c, name="cusolverSgeqrf")
-#else
     function hipsolverSgeqrf_(handle,m,n,A,lda,tau,work,lwork,devInfo) &
         bind(c, name="hipsolverSgeqrf")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -2221,15 +2051,12 @@ module hipfort_hipsolver
       hipsolverSgeqrf_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverDgeqrf
-#ifdef USE_CUDA_NAMES
-    function hipsolverDgeqrf_(handle,m,n,A,lda,tau,work,lwork,devInfo) &
-        bind(c, name="cusolverDgeqrf")
-#else
     function hipsolverDgeqrf_(handle,m,n,A,lda,tau,work,lwork,devInfo) &
         bind(c, name="hipsolverDgeqrf")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -2252,15 +2079,12 @@ module hipfort_hipsolver
       hipsolverDgeqrf_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverCgeqrf
-#ifdef USE_CUDA_NAMES
-    function hipsolverCgeqrf_(handle,m,n,A,lda,tau,work,lwork,devInfo) &
-        bind(c, name="cusolverCgeqrf")
-#else
     function hipsolverCgeqrf_(handle,m,n,A,lda,tau,work,lwork,devInfo) &
         bind(c, name="hipsolverCgeqrf")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -2283,15 +2107,12 @@ module hipfort_hipsolver
       hipsolverCgeqrf_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverZgeqrf
-#ifdef USE_CUDA_NAMES
-    function hipsolverZgeqrf_(handle,m,n,A,lda,tau,work,lwork,devInfo) &
-        bind(c, name="cusolverZgeqrf")
-#else
     function hipsolverZgeqrf_(handle,m,n,A,lda,tau,work,lwork,devInfo) &
         bind(c, name="hipsolverZgeqrf")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -2314,15 +2135,12 @@ module hipfort_hipsolver
       hipsolverZgeqrf_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverSSgesv_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverSSgesv_bufferSize_(handle,n,nrhs,A,lda,devIpiv,B,ldb,X,ldx,lwork) &
-        bind(c, name="cusolverSSgesv_bufferSize")
-#else
     function hipsolverSSgesv_bufferSize_(handle,n,nrhs,A,lda,devIpiv,B,ldb,X,ldx,lwork) &
         bind(c, name="hipsolverSSgesv_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -2347,15 +2165,12 @@ module hipfort_hipsolver
       hipsolverSSgesv_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverDDgesv_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverDDgesv_bufferSize_(handle,n,nrhs,A,lda,devIpiv,B,ldb,X,ldx,lwork) &
-        bind(c, name="cusolverDDgesv_bufferSize")
-#else
     function hipsolverDDgesv_bufferSize_(handle,n,nrhs,A,lda,devIpiv,B,ldb,X,ldx,lwork) &
         bind(c, name="hipsolverDDgesv_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -2380,15 +2195,12 @@ module hipfort_hipsolver
       hipsolverDDgesv_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverCCgesv_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverCCgesv_bufferSize_(handle,n,nrhs,A,lda,devIpiv,B,ldb,X,ldx,lwork) &
-        bind(c, name="cusolverCCgesv_bufferSize")
-#else
     function hipsolverCCgesv_bufferSize_(handle,n,nrhs,A,lda,devIpiv,B,ldb,X,ldx,lwork) &
         bind(c, name="hipsolverCCgesv_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -2413,15 +2225,12 @@ module hipfort_hipsolver
       hipsolverCCgesv_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverZZgesv_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverZZgesv_bufferSize_(handle,n,nrhs,A,lda,devIpiv,B,ldb,X,ldx,lwork) &
-        bind(c, name="cusolverZZgesv_bufferSize")
-#else
     function hipsolverZZgesv_bufferSize_(handle,n,nrhs,A,lda,devIpiv,B,ldb,X,ldx,lwork) &
         bind(c, name="hipsolverZZgesv_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -2446,15 +2255,12 @@ module hipfort_hipsolver
       hipsolverZZgesv_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverSSgesv
-#ifdef USE_CUDA_NAMES
-    function hipsolverSSgesv_(handle,n,nrhs,A,lda,devIpiv,B,ldb,X,ldx,work,lwork,niters,devInfo) &
-        bind(c, name="cusolverSSgesv")
-#else
     function hipsolverSSgesv_(handle,n,nrhs,A,lda,devIpiv,B,ldb,X,ldx,work,lwork,niters,devInfo) &
         bind(c, name="hipsolverSSgesv")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -2482,15 +2288,12 @@ module hipfort_hipsolver
       hipsolverSSgesv_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverDDgesv
-#ifdef USE_CUDA_NAMES
-    function hipsolverDDgesv_(handle,n,nrhs,A,lda,devIpiv,B,ldb,X,ldx,work,lwork,niters,devInfo) &
-        bind(c, name="cusolverDDgesv")
-#else
     function hipsolverDDgesv_(handle,n,nrhs,A,lda,devIpiv,B,ldb,X,ldx,work,lwork,niters,devInfo) &
         bind(c, name="hipsolverDDgesv")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -2518,15 +2321,12 @@ module hipfort_hipsolver
       hipsolverDDgesv_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverCCgesv
-#ifdef USE_CUDA_NAMES
-    function hipsolverCCgesv_(handle,n,nrhs,A,lda,devIpiv,B,ldb,X,ldx,work,lwork,niters,devInfo) &
-        bind(c, name="cusolverCCgesv")
-#else
     function hipsolverCCgesv_(handle,n,nrhs,A,lda,devIpiv,B,ldb,X,ldx,work,lwork,niters,devInfo) &
         bind(c, name="hipsolverCCgesv")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -2554,15 +2354,12 @@ module hipfort_hipsolver
       hipsolverCCgesv_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverZZgesv
-#ifdef USE_CUDA_NAMES
-    function hipsolverZZgesv_(handle,n,nrhs,A,lda,devIpiv,B,ldb,X,ldx,work,lwork,niters,devInfo) &
-        bind(c, name="cusolverZZgesv")
-#else
     function hipsolverZZgesv_(handle,n,nrhs,A,lda,devIpiv,B,ldb,X,ldx,work,lwork,niters,devInfo) &
         bind(c, name="hipsolverZZgesv")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -2590,6 +2387,7 @@ module hipfort_hipsolver
       hipsolverZZgesv_full_rank
 #endif
   end interface
+#endif
 
   interface hipsolverSgesvd_bufferSize
 #ifdef USE_CUDA_NAMES
@@ -2799,14 +2597,10 @@ module hipfort_hipsolver
     end function
   end interface
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverSgesvdj_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverSgesvdj_bufferSize_(handle,jobz,econ,m,n,A,lda,S,U,ldu,V,ldv,lwork,params) &
-        bind(c, name="cusolverSgesvdj_bufferSize")
-#else
     function hipsolverSgesvdj_bufferSize_(handle,jobz,econ,m,n,A,lda,S,U,ldu,V,ldv,lwork,params) &
         bind(c, name="hipsolverSgesvdj_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -2827,15 +2621,12 @@ module hipfort_hipsolver
       type(c_ptr),value :: params
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverDgesvdj_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverDgesvdj_bufferSize_(handle,jobz,econ,m,n,A,lda,S,U,ldu,V,ldv,lwork,params) &
-        bind(c, name="cusolverDgesvdj_bufferSize")
-#else
     function hipsolverDgesvdj_bufferSize_(handle,jobz,econ,m,n,A,lda,S,U,ldu,V,ldv,lwork,params) &
         bind(c, name="hipsolverDgesvdj_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -2856,15 +2647,12 @@ module hipfort_hipsolver
       type(c_ptr),value :: params
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverCgesvdj_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverCgesvdj_bufferSize_(handle,jobz,econ,m,n,A,lda,S,U,ldu,V,ldv,lwork,params) &
-        bind(c, name="cusolverCgesvdj_bufferSize")
-#else
     function hipsolverCgesvdj_bufferSize_(handle,jobz,econ,m,n,A,lda,S,U,ldu,V,ldv,lwork,params) &
         bind(c, name="hipsolverCgesvdj_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -2885,15 +2673,12 @@ module hipfort_hipsolver
       type(c_ptr),value :: params
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverZgesvdj_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverZgesvdj_bufferSize_(handle,jobz,econ,m,n,A,lda,S,U,ldu,V,ldv,lwork,params) &
-        bind(c, name="cusolverZgesvdj_bufferSize")
-#else
     function hipsolverZgesvdj_bufferSize_(handle,jobz,econ,m,n,A,lda,S,U,ldu,V,ldv,lwork,params) &
         bind(c, name="hipsolverZgesvdj_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -2914,15 +2699,12 @@ module hipfort_hipsolver
       type(c_ptr),value :: params
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverSgesvdj
-#ifdef USE_CUDA_NAMES
-    function hipsolverSgesvdj_(handle,jobz,econ,m,n,A,lda,S,U,ldu,V,ldv,work,lwork,devInfo,params) &
-        bind(c, name="cusolverSgesvdj")
-#else
     function hipsolverSgesvdj_(handle,jobz,econ,m,n,A,lda,S,U,ldu,V,ldv,work,lwork,devInfo,params) &
         bind(c, name="hipsolverSgesvdj")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -2945,15 +2727,12 @@ module hipfort_hipsolver
       type(c_ptr),value :: params
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverDgesvdj
-#ifdef USE_CUDA_NAMES
-    function hipsolverDgesvdj_(handle,jobz,econ,m,n,A,lda,S,U,ldu,V,ldv,work,lwork,devInfo,params) &
-        bind(c, name="cusolverDgesvdj")
-#else
     function hipsolverDgesvdj_(handle,jobz,econ,m,n,A,lda,S,U,ldu,V,ldv,work,lwork,devInfo,params) &
         bind(c, name="hipsolverDgesvdj")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -2976,15 +2755,12 @@ module hipfort_hipsolver
       type(c_ptr),value :: params
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverCgesvdj
-#ifdef USE_CUDA_NAMES
-    function hipsolverCgesvdj_(handle,jobz,econ,m,n,A,lda,S,U,ldu,V,ldv,work,lwork,devInfo,params) &
-        bind(c, name="cusolverCgesvdj")
-#else
     function hipsolverCgesvdj_(handle,jobz,econ,m,n,A,lda,S,U,ldu,V,ldv,work,lwork,devInfo,params) &
         bind(c, name="hipsolverCgesvdj")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -3007,15 +2783,12 @@ module hipfort_hipsolver
       type(c_ptr),value :: params
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverZgesvdj
-#ifdef USE_CUDA_NAMES
-    function hipsolverZgesvdj_(handle,jobz,econ,m,n,A,lda,S,U,ldu,V,ldv,work,lwork,devInfo,params) &
-        bind(c, name="cusolverZgesvdj")
-#else
     function hipsolverZgesvdj_(handle,jobz,econ,m,n,A,lda,S,U,ldu,V,ldv,work,lwork,devInfo,params) &
         bind(c, name="hipsolverZgesvdj")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -3038,17 +2811,13 @@ module hipfort_hipsolver
       type(c_ptr),value :: params
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverSgesvdjBatched_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverSgesvdjBatched_bufferSize_(handle,jobz,m,n,A,lda,S,U,ldu,V,ldv,lwork,params, &
-        batch_count) &
-        bind(c, name="cusolverSgesvdjBatched_bufferSize")
-#else
     function hipsolverSgesvdjBatched_bufferSize_(handle,jobz,m,n,A,lda,S,U,ldu,V,ldv,lwork,params, &
         batch_count) &
         bind(c, name="hipsolverSgesvdjBatched_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -3069,17 +2838,13 @@ module hipfort_hipsolver
       integer(c_int),value :: batch_count
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverDgesvdjBatched_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverDgesvdjBatched_bufferSize_(handle,jobz,m,n,A,lda,S,U,ldu,V,ldv,lwork,params, &
-        batch_count) &
-        bind(c, name="cusolverDgesvdjBatched_bufferSize")
-#else
     function hipsolverDgesvdjBatched_bufferSize_(handle,jobz,m,n,A,lda,S,U,ldu,V,ldv,lwork,params, &
         batch_count) &
         bind(c, name="hipsolverDgesvdjBatched_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -3100,17 +2865,13 @@ module hipfort_hipsolver
       integer(c_int),value :: batch_count
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverCgesvdjBatched_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverCgesvdjBatched_bufferSize_(handle,jobz,m,n,A,lda,S,U,ldu,V,ldv,lwork,params, &
-        batch_count) &
-        bind(c, name="cusolverCgesvdjBatched_bufferSize")
-#else
     function hipsolverCgesvdjBatched_bufferSize_(handle,jobz,m,n,A,lda,S,U,ldu,V,ldv,lwork,params, &
         batch_count) &
         bind(c, name="hipsolverCgesvdjBatched_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -3131,17 +2892,13 @@ module hipfort_hipsolver
       integer(c_int),value :: batch_count
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverZgesvdjBatched_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverZgesvdjBatched_bufferSize_(handle,jobz,m,n,A,lda,S,U,ldu,V,ldv,lwork,params, &
-        batch_count) &
-        bind(c, name="cusolverZgesvdjBatched_bufferSize")
-#else
     function hipsolverZgesvdjBatched_bufferSize_(handle,jobz,m,n,A,lda,S,U,ldu,V,ldv,lwork,params, &
         batch_count) &
         bind(c, name="hipsolverZgesvdjBatched_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -3162,17 +2919,13 @@ module hipfort_hipsolver
       integer(c_int),value :: batch_count
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverSgesvdjBatched
-#ifdef USE_CUDA_NAMES
-    function hipsolverSgesvdjBatched_(handle,jobz,m,n,A,lda,S,U,ldu,V,ldv,work,lwork,devInfo, &
-        params,batch_count) &
-        bind(c, name="cusolverSgesvdjBatched")
-#else
     function hipsolverSgesvdjBatched_(handle,jobz,m,n,A,lda,S,U,ldu,V,ldv,work,lwork,devInfo, &
         params,batch_count) &
         bind(c, name="hipsolverSgesvdjBatched")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -3195,17 +2948,13 @@ module hipfort_hipsolver
       integer(c_int),value :: batch_count
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverDgesvdjBatched
-#ifdef USE_CUDA_NAMES
-    function hipsolverDgesvdjBatched_(handle,jobz,m,n,A,lda,S,U,ldu,V,ldv,work,lwork,devInfo, &
-        params,batch_count) &
-        bind(c, name="cusolverDgesvdjBatched")
-#else
     function hipsolverDgesvdjBatched_(handle,jobz,m,n,A,lda,S,U,ldu,V,ldv,work,lwork,devInfo, &
         params,batch_count) &
         bind(c, name="hipsolverDgesvdjBatched")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -3228,17 +2977,13 @@ module hipfort_hipsolver
       integer(c_int),value :: batch_count
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverCgesvdjBatched
-#ifdef USE_CUDA_NAMES
-    function hipsolverCgesvdjBatched_(handle,jobz,m,n,A,lda,S,U,ldu,V,ldv,work,lwork,devInfo, &
-        params,batch_count) &
-        bind(c, name="cusolverCgesvdjBatched")
-#else
     function hipsolverCgesvdjBatched_(handle,jobz,m,n,A,lda,S,U,ldu,V,ldv,work,lwork,devInfo, &
         params,batch_count) &
         bind(c, name="hipsolverCgesvdjBatched")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -3261,17 +3006,13 @@ module hipfort_hipsolver
       integer(c_int),value :: batch_count
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverZgesvdjBatched
-#ifdef USE_CUDA_NAMES
-    function hipsolverZgesvdjBatched_(handle,jobz,m,n,A,lda,S,U,ldu,V,ldv,work,lwork,devInfo, &
-        params,batch_count) &
-        bind(c, name="cusolverZgesvdjBatched")
-#else
     function hipsolverZgesvdjBatched_(handle,jobz,m,n,A,lda,S,U,ldu,V,ldv,work,lwork,devInfo, &
         params,batch_count) &
         bind(c, name="hipsolverZgesvdjBatched")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -3294,15 +3035,12 @@ module hipfort_hipsolver
       integer(c_int),value :: batch_count
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverSgetrf_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverSgetrf_bufferSize_(handle,m,n,A,lda,lwork) &
-        bind(c, name="cusolverSgetrf_bufferSize")
-#else
     function hipsolverSgetrf_bufferSize_(handle,m,n,A,lda,lwork) &
         bind(c, name="hipsolverSgetrf_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -3322,15 +3060,12 @@ module hipfort_hipsolver
       hipsolverSgetrf_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverDgetrf_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverDgetrf_bufferSize_(handle,m,n,A,lda,lwork) &
-        bind(c, name="cusolverDgetrf_bufferSize")
-#else
     function hipsolverDgetrf_bufferSize_(handle,m,n,A,lda,lwork) &
         bind(c, name="hipsolverDgetrf_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -3350,15 +3085,12 @@ module hipfort_hipsolver
       hipsolverDgetrf_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverCgetrf_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverCgetrf_bufferSize_(handle,m,n,A,lda,lwork) &
-        bind(c, name="cusolverCgetrf_bufferSize")
-#else
     function hipsolverCgetrf_bufferSize_(handle,m,n,A,lda,lwork) &
         bind(c, name="hipsolverCgetrf_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -3378,15 +3110,12 @@ module hipfort_hipsolver
       hipsolverCgetrf_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverZgetrf_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverZgetrf_bufferSize_(handle,m,n,A,lda,lwork) &
-        bind(c, name="cusolverZgetrf_bufferSize")
-#else
     function hipsolverZgetrf_bufferSize_(handle,m,n,A,lda,lwork) &
         bind(c, name="hipsolverZgetrf_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -3406,15 +3135,12 @@ module hipfort_hipsolver
       hipsolverZgetrf_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverSgetrf
-#ifdef USE_CUDA_NAMES
-    function hipsolverSgetrf_(handle,m,n,A,lda,work,lwork,devIpiv,devInfo) &
-        bind(c, name="cusolverSgetrf")
-#else
     function hipsolverSgetrf_(handle,m,n,A,lda,work,lwork,devIpiv,devInfo) &
         bind(c, name="hipsolverSgetrf")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -3437,15 +3163,12 @@ module hipfort_hipsolver
       hipsolverSgetrf_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverDgetrf
-#ifdef USE_CUDA_NAMES
-    function hipsolverDgetrf_(handle,m,n,A,lda,work,lwork,devIpiv,devInfo) &
-        bind(c, name="cusolverDgetrf")
-#else
     function hipsolverDgetrf_(handle,m,n,A,lda,work,lwork,devIpiv,devInfo) &
         bind(c, name="hipsolverDgetrf")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -3468,15 +3191,12 @@ module hipfort_hipsolver
       hipsolverDgetrf_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverCgetrf
-#ifdef USE_CUDA_NAMES
-    function hipsolverCgetrf_(handle,m,n,A,lda,work,lwork,devIpiv,devInfo) &
-        bind(c, name="cusolverCgetrf")
-#else
     function hipsolverCgetrf_(handle,m,n,A,lda,work,lwork,devIpiv,devInfo) &
         bind(c, name="hipsolverCgetrf")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -3499,15 +3219,12 @@ module hipfort_hipsolver
       hipsolverCgetrf_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverZgetrf
-#ifdef USE_CUDA_NAMES
-    function hipsolverZgetrf_(handle,m,n,A,lda,work,lwork,devIpiv,devInfo) &
-        bind(c, name="cusolverZgetrf")
-#else
     function hipsolverZgetrf_(handle,m,n,A,lda,work,lwork,devIpiv,devInfo) &
         bind(c, name="hipsolverZgetrf")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -3530,15 +3247,12 @@ module hipfort_hipsolver
       hipsolverZgetrf_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverSgetrs_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverSgetrs_bufferSize_(handle,trans,n,nrhs,A,lda,devIpiv,B,ldb,lwork) &
-        bind(c, name="cusolverSgetrs_bufferSize")
-#else
     function hipsolverSgetrs_bufferSize_(handle,trans,n,nrhs,A,lda,devIpiv,B,ldb,lwork) &
         bind(c, name="hipsolverSgetrs_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -3562,15 +3276,12 @@ module hipfort_hipsolver
       hipsolverSgetrs_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverDgetrs_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverDgetrs_bufferSize_(handle,trans,n,nrhs,A,lda,devIpiv,B,ldb,lwork) &
-        bind(c, name="cusolverDgetrs_bufferSize")
-#else
     function hipsolverDgetrs_bufferSize_(handle,trans,n,nrhs,A,lda,devIpiv,B,ldb,lwork) &
         bind(c, name="hipsolverDgetrs_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -3594,15 +3305,12 @@ module hipfort_hipsolver
       hipsolverDgetrs_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverCgetrs_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverCgetrs_bufferSize_(handle,trans,n,nrhs,A,lda,devIpiv,B,ldb,lwork) &
-        bind(c, name="cusolverCgetrs_bufferSize")
-#else
     function hipsolverCgetrs_bufferSize_(handle,trans,n,nrhs,A,lda,devIpiv,B,ldb,lwork) &
         bind(c, name="hipsolverCgetrs_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -3626,15 +3334,12 @@ module hipfort_hipsolver
       hipsolverCgetrs_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverZgetrs_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverZgetrs_bufferSize_(handle,trans,n,nrhs,A,lda,devIpiv,B,ldb,lwork) &
-        bind(c, name="cusolverZgetrs_bufferSize")
-#else
     function hipsolverZgetrs_bufferSize_(handle,trans,n,nrhs,A,lda,devIpiv,B,ldb,lwork) &
         bind(c, name="hipsolverZgetrs_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -3658,15 +3363,12 @@ module hipfort_hipsolver
       hipsolverZgetrs_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverSgetrs
-#ifdef USE_CUDA_NAMES
-    function hipsolverSgetrs_(handle,trans,n,nrhs,A,lda,devIpiv,B,ldb,work,lwork,devInfo) &
-        bind(c, name="cusolverSgetrs")
-#else
     function hipsolverSgetrs_(handle,trans,n,nrhs,A,lda,devIpiv,B,ldb,work,lwork,devInfo) &
         bind(c, name="hipsolverSgetrs")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -3692,15 +3394,12 @@ module hipfort_hipsolver
       hipsolverSgetrs_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverDgetrs
-#ifdef USE_CUDA_NAMES
-    function hipsolverDgetrs_(handle,trans,n,nrhs,A,lda,devIpiv,B,ldb,work,lwork,devInfo) &
-        bind(c, name="cusolverDgetrs")
-#else
     function hipsolverDgetrs_(handle,trans,n,nrhs,A,lda,devIpiv,B,ldb,work,lwork,devInfo) &
         bind(c, name="hipsolverDgetrs")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -3726,15 +3425,12 @@ module hipfort_hipsolver
       hipsolverDgetrs_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverCgetrs
-#ifdef USE_CUDA_NAMES
-    function hipsolverCgetrs_(handle,trans,n,nrhs,A,lda,devIpiv,B,ldb,work,lwork,devInfo) &
-        bind(c, name="cusolverCgetrs")
-#else
     function hipsolverCgetrs_(handle,trans,n,nrhs,A,lda,devIpiv,B,ldb,work,lwork,devInfo) &
         bind(c, name="hipsolverCgetrs")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -3760,15 +3456,12 @@ module hipfort_hipsolver
       hipsolverCgetrs_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverZgetrs
-#ifdef USE_CUDA_NAMES
-    function hipsolverZgetrs_(handle,trans,n,nrhs,A,lda,devIpiv,B,ldb,work,lwork,devInfo) &
-        bind(c, name="cusolverZgetrs")
-#else
     function hipsolverZgetrs_(handle,trans,n,nrhs,A,lda,devIpiv,B,ldb,work,lwork,devInfo) &
         bind(c, name="hipsolverZgetrs")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -3794,15 +3487,12 @@ module hipfort_hipsolver
       hipsolverZgetrs_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverSpotrf_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverSpotrf_bufferSize_(handle,uplo,n,A,lda,lwork) &
-        bind(c, name="cusolverSpotrf_bufferSize")
-#else
     function hipsolverSpotrf_bufferSize_(handle,uplo,n,A,lda,lwork) &
         bind(c, name="hipsolverSpotrf_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -3822,15 +3512,12 @@ module hipfort_hipsolver
       hipsolverSpotrf_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverDpotrf_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverDpotrf_bufferSize_(handle,uplo,n,A,lda,lwork) &
-        bind(c, name="cusolverDpotrf_bufferSize")
-#else
     function hipsolverDpotrf_bufferSize_(handle,uplo,n,A,lda,lwork) &
         bind(c, name="hipsolverDpotrf_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -3850,15 +3537,12 @@ module hipfort_hipsolver
       hipsolverDpotrf_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverCpotrf_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverCpotrf_bufferSize_(handle,uplo,n,A,lda,lwork) &
-        bind(c, name="cusolverCpotrf_bufferSize")
-#else
     function hipsolverCpotrf_bufferSize_(handle,uplo,n,A,lda,lwork) &
         bind(c, name="hipsolverCpotrf_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -3878,15 +3562,12 @@ module hipfort_hipsolver
       hipsolverCpotrf_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverZpotrf_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverZpotrf_bufferSize_(handle,uplo,n,A,lda,lwork) &
-        bind(c, name="cusolverZpotrf_bufferSize")
-#else
     function hipsolverZpotrf_bufferSize_(handle,uplo,n,A,lda,lwork) &
         bind(c, name="hipsolverZpotrf_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -3906,14 +3587,12 @@ module hipfort_hipsolver
       hipsolverZpotrf_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverSpotrf
-#ifdef USE_CUDA_NAMES
-    function hipsolverSpotrf_(handle,uplo,n,A,lda,work,lwork,devInfo) bind(c, name="cusolverSpotrf")
-#else
     function hipsolverSpotrf_(handle,uplo,n,A,lda,work,lwork,devInfo) &
         bind(c, name="hipsolverSpotrf")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -3935,14 +3614,12 @@ module hipfort_hipsolver
       hipsolverSpotrf_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverDpotrf
-#ifdef USE_CUDA_NAMES
-    function hipsolverDpotrf_(handle,uplo,n,A,lda,work,lwork,devInfo) bind(c, name="cusolverDpotrf")
-#else
     function hipsolverDpotrf_(handle,uplo,n,A,lda,work,lwork,devInfo) &
         bind(c, name="hipsolverDpotrf")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -3964,14 +3641,12 @@ module hipfort_hipsolver
       hipsolverDpotrf_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverCpotrf
-#ifdef USE_CUDA_NAMES
-    function hipsolverCpotrf_(handle,uplo,n,A,lda,work,lwork,devInfo) bind(c, name="cusolverCpotrf")
-#else
     function hipsolverCpotrf_(handle,uplo,n,A,lda,work,lwork,devInfo) &
         bind(c, name="hipsolverCpotrf")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -3993,14 +3668,12 @@ module hipfort_hipsolver
       hipsolverCpotrf_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverZpotrf
-#ifdef USE_CUDA_NAMES
-    function hipsolverZpotrf_(handle,uplo,n,A,lda,work,lwork,devInfo) bind(c, name="cusolverZpotrf")
-#else
     function hipsolverZpotrf_(handle,uplo,n,A,lda,work,lwork,devInfo) &
         bind(c, name="hipsolverZpotrf")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -4022,15 +3695,12 @@ module hipfort_hipsolver
       hipsolverZpotrf_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverSpotrfBatched_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverSpotrfBatched_bufferSize_(handle,uplo,n,A,lda,lwork,batch_count) &
-        bind(c, name="cusolverSpotrfBatched_bufferSize")
-#else
     function hipsolverSpotrfBatched_bufferSize_(handle,uplo,n,A,lda,lwork,batch_count) &
         bind(c, name="hipsolverSpotrfBatched_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -4044,15 +3714,12 @@ module hipfort_hipsolver
       integer(c_int),value :: batch_count
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverDpotrfBatched_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverDpotrfBatched_bufferSize_(handle,uplo,n,A,lda,lwork,batch_count) &
-        bind(c, name="cusolverDpotrfBatched_bufferSize")
-#else
     function hipsolverDpotrfBatched_bufferSize_(handle,uplo,n,A,lda,lwork,batch_count) &
         bind(c, name="hipsolverDpotrfBatched_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -4066,15 +3733,12 @@ module hipfort_hipsolver
       integer(c_int),value :: batch_count
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverCpotrfBatched_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverCpotrfBatched_bufferSize_(handle,uplo,n,A,lda,lwork,batch_count) &
-        bind(c, name="cusolverCpotrfBatched_bufferSize")
-#else
     function hipsolverCpotrfBatched_bufferSize_(handle,uplo,n,A,lda,lwork,batch_count) &
         bind(c, name="hipsolverCpotrfBatched_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -4088,15 +3752,12 @@ module hipfort_hipsolver
       integer(c_int),value :: batch_count
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverZpotrfBatched_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverZpotrfBatched_bufferSize_(handle,uplo,n,A,lda,lwork,batch_count) &
-        bind(c, name="cusolverZpotrfBatched_bufferSize")
-#else
     function hipsolverZpotrfBatched_bufferSize_(handle,uplo,n,A,lda,lwork,batch_count) &
         bind(c, name="hipsolverZpotrfBatched_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -4110,15 +3771,12 @@ module hipfort_hipsolver
       integer(c_int),value :: batch_count
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverSpotrfBatched
-#ifdef USE_CUDA_NAMES
-    function hipsolverSpotrfBatched_(handle,uplo,n,A,lda,work,lwork,devInfo,batch_count) &
-        bind(c, name="cusolverSpotrfBatched")
-#else
     function hipsolverSpotrfBatched_(handle,uplo,n,A,lda,work,lwork,devInfo,batch_count) &
         bind(c, name="hipsolverSpotrfBatched")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -4134,15 +3792,12 @@ module hipfort_hipsolver
       integer(c_int),value :: batch_count
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverDpotrfBatched
-#ifdef USE_CUDA_NAMES
-    function hipsolverDpotrfBatched_(handle,uplo,n,A,lda,work,lwork,devInfo,batch_count) &
-        bind(c, name="cusolverDpotrfBatched")
-#else
     function hipsolverDpotrfBatched_(handle,uplo,n,A,lda,work,lwork,devInfo,batch_count) &
         bind(c, name="hipsolverDpotrfBatched")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -4158,15 +3813,12 @@ module hipfort_hipsolver
       integer(c_int),value :: batch_count
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverCpotrfBatched
-#ifdef USE_CUDA_NAMES
-    function hipsolverCpotrfBatched_(handle,uplo,n,A,lda,work,lwork,devInfo,batch_count) &
-        bind(c, name="cusolverCpotrfBatched")
-#else
     function hipsolverCpotrfBatched_(handle,uplo,n,A,lda,work,lwork,devInfo,batch_count) &
         bind(c, name="hipsolverCpotrfBatched")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -4182,15 +3834,12 @@ module hipfort_hipsolver
       integer(c_int),value :: batch_count
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverZpotrfBatched
-#ifdef USE_CUDA_NAMES
-    function hipsolverZpotrfBatched_(handle,uplo,n,A,lda,work,lwork,devInfo,batch_count) &
-        bind(c, name="cusolverZpotrfBatched")
-#else
     function hipsolverZpotrfBatched_(handle,uplo,n,A,lda,work,lwork,devInfo,batch_count) &
         bind(c, name="hipsolverZpotrfBatched")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -4206,15 +3855,12 @@ module hipfort_hipsolver
       integer(c_int),value :: batch_count
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverSpotri_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverSpotri_bufferSize_(handle,uplo,n,A,lda,lwork) &
-        bind(c, name="cusolverSpotri_bufferSize")
-#else
     function hipsolverSpotri_bufferSize_(handle,uplo,n,A,lda,lwork) &
         bind(c, name="hipsolverSpotri_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -4234,15 +3880,12 @@ module hipfort_hipsolver
       hipsolverSpotri_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverDpotri_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverDpotri_bufferSize_(handle,uplo,n,A,lda,lwork) &
-        bind(c, name="cusolverDpotri_bufferSize")
-#else
     function hipsolverDpotri_bufferSize_(handle,uplo,n,A,lda,lwork) &
         bind(c, name="hipsolverDpotri_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -4262,15 +3905,12 @@ module hipfort_hipsolver
       hipsolverDpotri_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverCpotri_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverCpotri_bufferSize_(handle,uplo,n,A,lda,lwork) &
-        bind(c, name="cusolverCpotri_bufferSize")
-#else
     function hipsolverCpotri_bufferSize_(handle,uplo,n,A,lda,lwork) &
         bind(c, name="hipsolverCpotri_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -4290,15 +3930,12 @@ module hipfort_hipsolver
       hipsolverCpotri_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverZpotri_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverZpotri_bufferSize_(handle,uplo,n,A,lda,lwork) &
-        bind(c, name="cusolverZpotri_bufferSize")
-#else
     function hipsolverZpotri_bufferSize_(handle,uplo,n,A,lda,lwork) &
         bind(c, name="hipsolverZpotri_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -4318,14 +3955,12 @@ module hipfort_hipsolver
       hipsolverZpotri_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverSpotri
-#ifdef USE_CUDA_NAMES
-    function hipsolverSpotri_(handle,uplo,n,A,lda,work,lwork,devInfo) bind(c, name="cusolverSpotri")
-#else
     function hipsolverSpotri_(handle,uplo,n,A,lda,work,lwork,devInfo) &
         bind(c, name="hipsolverSpotri")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -4347,14 +3982,12 @@ module hipfort_hipsolver
       hipsolverSpotri_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverDpotri
-#ifdef USE_CUDA_NAMES
-    function hipsolverDpotri_(handle,uplo,n,A,lda,work,lwork,devInfo) bind(c, name="cusolverDpotri")
-#else
     function hipsolverDpotri_(handle,uplo,n,A,lda,work,lwork,devInfo) &
         bind(c, name="hipsolverDpotri")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -4376,14 +4009,12 @@ module hipfort_hipsolver
       hipsolverDpotri_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverCpotri
-#ifdef USE_CUDA_NAMES
-    function hipsolverCpotri_(handle,uplo,n,A,lda,work,lwork,devInfo) bind(c, name="cusolverCpotri")
-#else
     function hipsolverCpotri_(handle,uplo,n,A,lda,work,lwork,devInfo) &
         bind(c, name="hipsolverCpotri")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -4405,14 +4036,12 @@ module hipfort_hipsolver
       hipsolverCpotri_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverZpotri
-#ifdef USE_CUDA_NAMES
-    function hipsolverZpotri_(handle,uplo,n,A,lda,work,lwork,devInfo) bind(c, name="cusolverZpotri")
-#else
     function hipsolverZpotri_(handle,uplo,n,A,lda,work,lwork,devInfo) &
         bind(c, name="hipsolverZpotri")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -4434,15 +4063,12 @@ module hipfort_hipsolver
       hipsolverZpotri_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverSpotrs_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverSpotrs_bufferSize_(handle,uplo,n,nrhs,A,lda,B,ldb,lwork) &
-        bind(c, name="cusolverSpotrs_bufferSize")
-#else
     function hipsolverSpotrs_bufferSize_(handle,uplo,n,nrhs,A,lda,B,ldb,lwork) &
         bind(c, name="hipsolverSpotrs_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -4465,15 +4091,12 @@ module hipfort_hipsolver
       hipsolverSpotrs_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverDpotrs_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverDpotrs_bufferSize_(handle,uplo,n,nrhs,A,lda,B,ldb,lwork) &
-        bind(c, name="cusolverDpotrs_bufferSize")
-#else
     function hipsolverDpotrs_bufferSize_(handle,uplo,n,nrhs,A,lda,B,ldb,lwork) &
         bind(c, name="hipsolverDpotrs_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -4496,15 +4119,12 @@ module hipfort_hipsolver
       hipsolverDpotrs_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverCpotrs_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverCpotrs_bufferSize_(handle,uplo,n,nrhs,A,lda,B,ldb,lwork) &
-        bind(c, name="cusolverCpotrs_bufferSize")
-#else
     function hipsolverCpotrs_bufferSize_(handle,uplo,n,nrhs,A,lda,B,ldb,lwork) &
         bind(c, name="hipsolverCpotrs_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -4527,15 +4147,12 @@ module hipfort_hipsolver
       hipsolverCpotrs_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverZpotrs_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverZpotrs_bufferSize_(handle,uplo,n,nrhs,A,lda,B,ldb,lwork) &
-        bind(c, name="cusolverZpotrs_bufferSize")
-#else
     function hipsolverZpotrs_bufferSize_(handle,uplo,n,nrhs,A,lda,B,ldb,lwork) &
         bind(c, name="hipsolverZpotrs_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -4558,15 +4175,12 @@ module hipfort_hipsolver
       hipsolverZpotrs_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverSpotrs
-#ifdef USE_CUDA_NAMES
-    function hipsolverSpotrs_(handle,uplo,n,nrhs,A,lda,B,ldb,work,lwork,devInfo) &
-        bind(c, name="cusolverSpotrs")
-#else
     function hipsolverSpotrs_(handle,uplo,n,nrhs,A,lda,B,ldb,work,lwork,devInfo) &
         bind(c, name="hipsolverSpotrs")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -4591,15 +4205,12 @@ module hipfort_hipsolver
       hipsolverSpotrs_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverDpotrs
-#ifdef USE_CUDA_NAMES
-    function hipsolverDpotrs_(handle,uplo,n,nrhs,A,lda,B,ldb,work,lwork,devInfo) &
-        bind(c, name="cusolverDpotrs")
-#else
     function hipsolverDpotrs_(handle,uplo,n,nrhs,A,lda,B,ldb,work,lwork,devInfo) &
         bind(c, name="hipsolverDpotrs")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -4624,15 +4235,12 @@ module hipfort_hipsolver
       hipsolverDpotrs_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverCpotrs
-#ifdef USE_CUDA_NAMES
-    function hipsolverCpotrs_(handle,uplo,n,nrhs,A,lda,B,ldb,work,lwork,devInfo) &
-        bind(c, name="cusolverCpotrs")
-#else
     function hipsolverCpotrs_(handle,uplo,n,nrhs,A,lda,B,ldb,work,lwork,devInfo) &
         bind(c, name="hipsolverCpotrs")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -4657,15 +4265,12 @@ module hipfort_hipsolver
       hipsolverCpotrs_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverZpotrs
-#ifdef USE_CUDA_NAMES
-    function hipsolverZpotrs_(handle,uplo,n,nrhs,A,lda,B,ldb,work,lwork,devInfo) &
-        bind(c, name="cusolverZpotrs")
-#else
     function hipsolverZpotrs_(handle,uplo,n,nrhs,A,lda,B,ldb,work,lwork,devInfo) &
         bind(c, name="hipsolverZpotrs")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -4690,15 +4295,12 @@ module hipfort_hipsolver
       hipsolverZpotrs_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverSpotrsBatched_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverSpotrsBatched_bufferSize_(handle,uplo,n,nrhs,A,lda,B,ldb,lwork,batch_count) &
-        bind(c, name="cusolverSpotrsBatched_bufferSize")
-#else
     function hipsolverSpotrsBatched_bufferSize_(handle,uplo,n,nrhs,A,lda,B,ldb,lwork,batch_count) &
         bind(c, name="hipsolverSpotrsBatched_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -4715,15 +4317,12 @@ module hipfort_hipsolver
       integer(c_int),value :: batch_count
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverDpotrsBatched_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverDpotrsBatched_bufferSize_(handle,uplo,n,nrhs,A,lda,B,ldb,lwork,batch_count) &
-        bind(c, name="cusolverDpotrsBatched_bufferSize")
-#else
     function hipsolverDpotrsBatched_bufferSize_(handle,uplo,n,nrhs,A,lda,B,ldb,lwork,batch_count) &
         bind(c, name="hipsolverDpotrsBatched_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -4740,15 +4339,12 @@ module hipfort_hipsolver
       integer(c_int),value :: batch_count
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverCpotrsBatched_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverCpotrsBatched_bufferSize_(handle,uplo,n,nrhs,A,lda,B,ldb,lwork,batch_count) &
-        bind(c, name="cusolverCpotrsBatched_bufferSize")
-#else
     function hipsolverCpotrsBatched_bufferSize_(handle,uplo,n,nrhs,A,lda,B,ldb,lwork,batch_count) &
         bind(c, name="hipsolverCpotrsBatched_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -4765,15 +4361,12 @@ module hipfort_hipsolver
       integer(c_int),value :: batch_count
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverZpotrsBatched_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverZpotrsBatched_bufferSize_(handle,uplo,n,nrhs,A,lda,B,ldb,lwork,batch_count) &
-        bind(c, name="cusolverZpotrsBatched_bufferSize")
-#else
     function hipsolverZpotrsBatched_bufferSize_(handle,uplo,n,nrhs,A,lda,B,ldb,lwork,batch_count) &
         bind(c, name="hipsolverZpotrsBatched_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -4790,17 +4383,13 @@ module hipfort_hipsolver
       integer(c_int),value :: batch_count
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverSpotrsBatched
-#ifdef USE_CUDA_NAMES
-    function hipsolverSpotrsBatched_(handle,uplo,n,nrhs,A,lda,B,ldb,work,lwork,devInfo, &
-        batch_count) &
-        bind(c, name="cusolverSpotrsBatched")
-#else
     function hipsolverSpotrsBatched_(handle,uplo,n,nrhs,A,lda,B,ldb,work,lwork,devInfo, &
         batch_count) &
         bind(c, name="hipsolverSpotrsBatched")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -4819,17 +4408,13 @@ module hipfort_hipsolver
       integer(c_int),value :: batch_count
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverDpotrsBatched
-#ifdef USE_CUDA_NAMES
-    function hipsolverDpotrsBatched_(handle,uplo,n,nrhs,A,lda,B,ldb,work,lwork,devInfo, &
-        batch_count) &
-        bind(c, name="cusolverDpotrsBatched")
-#else
     function hipsolverDpotrsBatched_(handle,uplo,n,nrhs,A,lda,B,ldb,work,lwork,devInfo, &
         batch_count) &
         bind(c, name="hipsolverDpotrsBatched")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -4848,17 +4433,13 @@ module hipfort_hipsolver
       integer(c_int),value :: batch_count
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverCpotrsBatched
-#ifdef USE_CUDA_NAMES
-    function hipsolverCpotrsBatched_(handle,uplo,n,nrhs,A,lda,B,ldb,work,lwork,devInfo, &
-        batch_count) &
-        bind(c, name="cusolverCpotrsBatched")
-#else
     function hipsolverCpotrsBatched_(handle,uplo,n,nrhs,A,lda,B,ldb,work,lwork,devInfo, &
         batch_count) &
         bind(c, name="hipsolverCpotrsBatched")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -4877,17 +4458,13 @@ module hipfort_hipsolver
       integer(c_int),value :: batch_count
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverZpotrsBatched
-#ifdef USE_CUDA_NAMES
-    function hipsolverZpotrsBatched_(handle,uplo,n,nrhs,A,lda,B,ldb,work,lwork,devInfo, &
-        batch_count) &
-        bind(c, name="cusolverZpotrsBatched")
-#else
     function hipsolverZpotrsBatched_(handle,uplo,n,nrhs,A,lda,B,ldb,work,lwork,devInfo, &
         batch_count) &
         bind(c, name="hipsolverZpotrsBatched")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -4906,15 +4483,12 @@ module hipfort_hipsolver
       integer(c_int),value :: batch_count
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverSsyevd_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverSsyevd_bufferSize_(handle,jobz,uplo,n,A,lda,D,lwork) &
-        bind(c, name="cusolverSsyevd_bufferSize")
-#else
     function hipsolverSsyevd_bufferSize_(handle,jobz,uplo,n,A,lda,D,lwork) &
         bind(c, name="hipsolverSsyevd_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -4936,15 +4510,12 @@ module hipfort_hipsolver
       hipsolverSsyevd_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverDsyevd_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverDsyevd_bufferSize_(handle,jobz,uplo,n,A,lda,D,lwork) &
-        bind(c, name="cusolverDsyevd_bufferSize")
-#else
     function hipsolverDsyevd_bufferSize_(handle,jobz,uplo,n,A,lda,D,lwork) &
         bind(c, name="hipsolverDsyevd_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -4966,15 +4537,12 @@ module hipfort_hipsolver
       hipsolverDsyevd_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverCheevd_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverCheevd_bufferSize_(handle,jobz,uplo,n,A,lda,D,lwork) &
-        bind(c, name="cusolverCheevd_bufferSize")
-#else
     function hipsolverCheevd_bufferSize_(handle,jobz,uplo,n,A,lda,D,lwork) &
         bind(c, name="hipsolverCheevd_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -4996,15 +4564,12 @@ module hipfort_hipsolver
       hipsolverCheevd_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverZheevd_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverZheevd_bufferSize_(handle,jobz,uplo,n,A,lda,D,lwork) &
-        bind(c, name="cusolverZheevd_bufferSize")
-#else
     function hipsolverZheevd_bufferSize_(handle,jobz,uplo,n,A,lda,D,lwork) &
         bind(c, name="hipsolverZheevd_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -5026,15 +4591,12 @@ module hipfort_hipsolver
       hipsolverZheevd_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverSsyevd
-#ifdef USE_CUDA_NAMES
-    function hipsolverSsyevd_(handle,jobz,uplo,n,A,lda,D,work,lwork,devInfo) &
-        bind(c, name="cusolverSsyevd")
-#else
     function hipsolverSsyevd_(handle,jobz,uplo,n,A,lda,D,work,lwork,devInfo) &
         bind(c, name="hipsolverSsyevd")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -5058,15 +4620,12 @@ module hipfort_hipsolver
       hipsolverSsyevd_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverDsyevd
-#ifdef USE_CUDA_NAMES
-    function hipsolverDsyevd_(handle,jobz,uplo,n,A,lda,D,work,lwork,devInfo) &
-        bind(c, name="cusolverDsyevd")
-#else
     function hipsolverDsyevd_(handle,jobz,uplo,n,A,lda,D,work,lwork,devInfo) &
         bind(c, name="hipsolverDsyevd")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -5090,15 +4649,12 @@ module hipfort_hipsolver
       hipsolverDsyevd_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverCheevd
-#ifdef USE_CUDA_NAMES
-    function hipsolverCheevd_(handle,jobz,uplo,n,A,lda,D,work,lwork,devInfo) &
-        bind(c, name="cusolverCheevd")
-#else
     function hipsolverCheevd_(handle,jobz,uplo,n,A,lda,D,work,lwork,devInfo) &
         bind(c, name="hipsolverCheevd")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -5122,15 +4678,12 @@ module hipfort_hipsolver
       hipsolverCheevd_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverZheevd
-#ifdef USE_CUDA_NAMES
-    function hipsolverZheevd_(handle,jobz,uplo,n,A,lda,D,work,lwork,devInfo) &
-        bind(c, name="cusolverZheevd")
-#else
     function hipsolverZheevd_(handle,jobz,uplo,n,A,lda,D,work,lwork,devInfo) &
         bind(c, name="hipsolverZheevd")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -5154,15 +4707,12 @@ module hipfort_hipsolver
       hipsolverZheevd_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverSsyevdx_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverSsyevdx_bufferSize_(handle,jobz,range,uplo,n,A,lda,vl,vu,il,iu,nev,W,lwork) &
-        bind(c, name="cusolverSsyevdx_bufferSize")
-#else
     function hipsolverSsyevdx_bufferSize_(handle,jobz,range,uplo,n,A,lda,vl,vu,il,iu,nev,W,lwork) &
         bind(c, name="hipsolverSsyevdx_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -5183,6 +4733,7 @@ module hipfort_hipsolver
       integer(c_int) :: lwork
     end function
   end interface
+#endif
 
   interface hipsolverDsyevdx_bufferSize
 #ifdef USE_CUDA_NAMES
@@ -5213,14 +4764,10 @@ module hipfort_hipsolver
     end function
   end interface
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverCheevdx_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverCheevdx_bufferSize_(handle,jobz,range,uplo,n,A,lda,vl,vu,il,iu,nev,W,lwork) &
-        bind(c, name="cusolverCheevdx_bufferSize")
-#else
     function hipsolverCheevdx_bufferSize_(handle,jobz,range,uplo,n,A,lda,vl,vu,il,iu,nev,W,lwork) &
         bind(c, name="hipsolverCheevdx_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -5241,15 +4788,12 @@ module hipfort_hipsolver
       integer(c_int) :: lwork
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverZheevdx_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverZheevdx_bufferSize_(handle,jobz,range,uplo,n,A,lda,vl,vu,il,iu,nev,W,lwork) &
-        bind(c, name="cusolverZheevdx_bufferSize")
-#else
     function hipsolverZheevdx_bufferSize_(handle,jobz,range,uplo,n,A,lda,vl,vu,il,iu,nev,W,lwork) &
         bind(c, name="hipsolverZheevdx_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -5270,17 +4814,13 @@ module hipfort_hipsolver
       integer(c_int) :: lwork
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverSsyevdx
-#ifdef USE_CUDA_NAMES
-    function hipsolverSsyevdx_(handle,jobz,range,uplo,n,A,lda,vl,vu,il,iu,nev,W,work,lwork, &
-        devInfo) &
-        bind(c, name="cusolverSsyevdx")
-#else
     function hipsolverSsyevdx_(handle,jobz,range,uplo,n,A,lda,vl,vu,il,iu,nev,W,work,lwork, &
         devInfo) &
         bind(c, name="hipsolverSsyevdx")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -5303,6 +4843,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: devInfo
     end function
   end interface
+#endif
 
   interface hipsolverDsyevdx
 #ifdef USE_CUDA_NAMES
@@ -5337,16 +4878,11 @@ module hipfort_hipsolver
     end function
   end interface
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverCheevdx
-#ifdef USE_CUDA_NAMES
-    function hipsolverCheevdx_(handle,jobz,range,uplo,n,A,lda,vl,vu,il,iu,nev,W,work,lwork, &
-        devInfo) &
-        bind(c, name="cusolverCheevdx")
-#else
     function hipsolverCheevdx_(handle,jobz,range,uplo,n,A,lda,vl,vu,il,iu,nev,W,work,lwork, &
         devInfo) &
         bind(c, name="hipsolverCheevdx")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -5369,17 +4905,13 @@ module hipfort_hipsolver
       integer(c_int) :: devInfo
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverZheevdx
-#ifdef USE_CUDA_NAMES
-    function hipsolverZheevdx_(handle,jobz,range,uplo,n,A,lda,vl,vu,il,iu,nev,W,work,lwork, &
-        devInfo) &
-        bind(c, name="cusolverZheevdx")
-#else
     function hipsolverZheevdx_(handle,jobz,range,uplo,n,A,lda,vl,vu,il,iu,nev,W,work,lwork, &
         devInfo) &
         bind(c, name="hipsolverZheevdx")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -5402,15 +4934,12 @@ module hipfort_hipsolver
       integer(c_int) :: devInfo
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverSsyevj_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverSsyevj_bufferSize_(handle,jobz,uplo,n,A,lda,W,lwork,params) &
-        bind(c, name="cusolverSsyevj_bufferSize")
-#else
     function hipsolverSsyevj_bufferSize_(handle,jobz,uplo,n,A,lda,W,lwork,params) &
         bind(c, name="hipsolverSsyevj_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -5426,15 +4955,12 @@ module hipfort_hipsolver
       type(c_ptr),value :: params
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverDsyevj_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverDsyevj_bufferSize_(handle,jobz,uplo,n,A,lda,W,lwork,params) &
-        bind(c, name="cusolverDsyevj_bufferSize")
-#else
     function hipsolverDsyevj_bufferSize_(handle,jobz,uplo,n,A,lda,W,lwork,params) &
         bind(c, name="hipsolverDsyevj_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -5450,15 +4976,12 @@ module hipfort_hipsolver
       type(c_ptr),value :: params
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverCheevj_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverCheevj_bufferSize_(handle,jobz,uplo,n,A,lda,W,lwork,params) &
-        bind(c, name="cusolverCheevj_bufferSize")
-#else
     function hipsolverCheevj_bufferSize_(handle,jobz,uplo,n,A,lda,W,lwork,params) &
         bind(c, name="hipsolverCheevj_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -5474,15 +4997,12 @@ module hipfort_hipsolver
       type(c_ptr),value :: params
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverZheevj_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverZheevj_bufferSize_(handle,jobz,uplo,n,A,lda,W,lwork,params) &
-        bind(c, name="cusolverZheevj_bufferSize")
-#else
     function hipsolverZheevj_bufferSize_(handle,jobz,uplo,n,A,lda,W,lwork,params) &
         bind(c, name="hipsolverZheevj_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -5498,15 +5018,12 @@ module hipfort_hipsolver
       type(c_ptr),value :: params
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverSsyevj
-#ifdef USE_CUDA_NAMES
-    function hipsolverSsyevj_(handle,jobz,uplo,n,A,lda,W,work,lwork,devInfo,params) &
-        bind(c, name="cusolverSsyevj")
-#else
     function hipsolverSsyevj_(handle,jobz,uplo,n,A,lda,W,work,lwork,devInfo,params) &
         bind(c, name="hipsolverSsyevj")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -5524,15 +5041,12 @@ module hipfort_hipsolver
       type(c_ptr),value :: params
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverDsyevj
-#ifdef USE_CUDA_NAMES
-    function hipsolverDsyevj_(handle,jobz,uplo,n,A,lda,W,work,lwork,devInfo,params) &
-        bind(c, name="cusolverDsyevj")
-#else
     function hipsolverDsyevj_(handle,jobz,uplo,n,A,lda,W,work,lwork,devInfo,params) &
         bind(c, name="hipsolverDsyevj")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -5550,15 +5064,12 @@ module hipfort_hipsolver
       type(c_ptr),value :: params
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverCheevj
-#ifdef USE_CUDA_NAMES
-    function hipsolverCheevj_(handle,jobz,uplo,n,A,lda,W,work,lwork,devInfo,params) &
-        bind(c, name="cusolverCheevj")
-#else
     function hipsolverCheevj_(handle,jobz,uplo,n,A,lda,W,work,lwork,devInfo,params) &
         bind(c, name="hipsolverCheevj")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -5576,15 +5087,12 @@ module hipfort_hipsolver
       type(c_ptr),value :: params
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverZheevj
-#ifdef USE_CUDA_NAMES
-    function hipsolverZheevj_(handle,jobz,uplo,n,A,lda,W,work,lwork,devInfo,params) &
-        bind(c, name="cusolverZheevj")
-#else
     function hipsolverZheevj_(handle,jobz,uplo,n,A,lda,W,work,lwork,devInfo,params) &
         bind(c, name="hipsolverZheevj")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -5602,17 +5110,13 @@ module hipfort_hipsolver
       type(c_ptr),value :: params
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverSsyevjBatched_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverSsyevjBatched_bufferSize_(handle,jobz,uplo,n,A,lda,W,lwork,params, &
-        batch_count) &
-        bind(c, name="cusolverSsyevjBatched_bufferSize")
-#else
     function hipsolverSsyevjBatched_bufferSize_(handle,jobz,uplo,n,A,lda,W,lwork,params, &
         batch_count) &
         bind(c, name="hipsolverSsyevjBatched_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -5629,17 +5133,13 @@ module hipfort_hipsolver
       integer(c_int),value :: batch_count
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverDsyevjBatched_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverDsyevjBatched_bufferSize_(handle,jobz,uplo,n,A,lda,W,lwork,params, &
-        batch_count) &
-        bind(c, name="cusolverDsyevjBatched_bufferSize")
-#else
     function hipsolverDsyevjBatched_bufferSize_(handle,jobz,uplo,n,A,lda,W,lwork,params, &
         batch_count) &
         bind(c, name="hipsolverDsyevjBatched_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -5656,17 +5156,13 @@ module hipfort_hipsolver
       integer(c_int),value :: batch_count
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverCheevjBatched_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverCheevjBatched_bufferSize_(handle,jobz,uplo,n,A,lda,W,lwork,params, &
-        batch_count) &
-        bind(c, name="cusolverCheevjBatched_bufferSize")
-#else
     function hipsolverCheevjBatched_bufferSize_(handle,jobz,uplo,n,A,lda,W,lwork,params, &
         batch_count) &
         bind(c, name="hipsolverCheevjBatched_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -5683,17 +5179,13 @@ module hipfort_hipsolver
       integer(c_int),value :: batch_count
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverZheevjBatched_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverZheevjBatched_bufferSize_(handle,jobz,uplo,n,A,lda,W,lwork,params, &
-        batch_count) &
-        bind(c, name="cusolverZheevjBatched_bufferSize")
-#else
     function hipsolverZheevjBatched_bufferSize_(handle,jobz,uplo,n,A,lda,W,lwork,params, &
         batch_count) &
         bind(c, name="hipsolverZheevjBatched_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -5710,17 +5202,13 @@ module hipfort_hipsolver
       integer(c_int),value :: batch_count
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverSsyevjBatched
-#ifdef USE_CUDA_NAMES
-    function hipsolverSsyevjBatched_(handle,jobz,uplo,n,A,lda,W,work,lwork,devInfo,params, &
-        batch_count) &
-        bind(c, name="cusolverSsyevjBatched")
-#else
     function hipsolverSsyevjBatched_(handle,jobz,uplo,n,A,lda,W,work,lwork,devInfo,params, &
         batch_count) &
         bind(c, name="hipsolverSsyevjBatched")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -5739,6 +5227,7 @@ module hipfort_hipsolver
       integer(c_int),value :: batch_count
     end function
   end interface
+#endif
 
   interface hipsolverDsyevjBatched
 #ifdef USE_CUDA_NAMES
@@ -5769,16 +5258,11 @@ module hipfort_hipsolver
     end function
   end interface
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverCheevjBatched
-#ifdef USE_CUDA_NAMES
-    function hipsolverCheevjBatched_(handle,jobz,uplo,n,A,lda,W,work,lwork,devInfo,params, &
-        batch_count) &
-        bind(c, name="cusolverCheevjBatched")
-#else
     function hipsolverCheevjBatched_(handle,jobz,uplo,n,A,lda,W,work,lwork,devInfo,params, &
         batch_count) &
         bind(c, name="hipsolverCheevjBatched")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -5797,17 +5281,13 @@ module hipfort_hipsolver
       integer(c_int),value :: batch_count
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverZheevjBatched
-#ifdef USE_CUDA_NAMES
-    function hipsolverZheevjBatched_(handle,jobz,uplo,n,A,lda,W,work,lwork,devInfo,params, &
-        batch_count) &
-        bind(c, name="cusolverZheevjBatched")
-#else
     function hipsolverZheevjBatched_(handle,jobz,uplo,n,A,lda,W,work,lwork,devInfo,params, &
         batch_count) &
         bind(c, name="hipsolverZheevjBatched")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -5826,15 +5306,12 @@ module hipfort_hipsolver
       integer(c_int),value :: batch_count
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverSsygvd_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverSsygvd_bufferSize_(handle,itype,jobz,uplo,n,A,lda,B,ldb,W,lwork) &
-        bind(c, name="cusolverSsygvd_bufferSize")
-#else
     function hipsolverSsygvd_bufferSize_(handle,itype,jobz,uplo,n,A,lda,B,ldb,W,lwork) &
         bind(c, name="hipsolverSsygvd_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -5859,15 +5336,12 @@ module hipfort_hipsolver
       hipsolverSsygvd_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverDsygvd_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverDsygvd_bufferSize_(handle,itype,jobz,uplo,n,A,lda,B,ldb,W,lwork) &
-        bind(c, name="cusolverDsygvd_bufferSize")
-#else
     function hipsolverDsygvd_bufferSize_(handle,itype,jobz,uplo,n,A,lda,B,ldb,W,lwork) &
         bind(c, name="hipsolverDsygvd_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -5892,15 +5366,12 @@ module hipfort_hipsolver
       hipsolverDsygvd_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverChegvd_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverChegvd_bufferSize_(handle,itype,jobz,uplo,n,A,lda,B,ldb,W,lwork) &
-        bind(c, name="cusolverChegvd_bufferSize")
-#else
     function hipsolverChegvd_bufferSize_(handle,itype,jobz,uplo,n,A,lda,B,ldb,W,lwork) &
         bind(c, name="hipsolverChegvd_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -5925,15 +5396,12 @@ module hipfort_hipsolver
       hipsolverChegvd_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverZhegvd_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverZhegvd_bufferSize_(handle,itype,jobz,uplo,n,A,lda,B,ldb,W,lwork) &
-        bind(c, name="cusolverZhegvd_bufferSize")
-#else
     function hipsolverZhegvd_bufferSize_(handle,itype,jobz,uplo,n,A,lda,B,ldb,W,lwork) &
         bind(c, name="hipsolverZhegvd_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -5958,15 +5426,12 @@ module hipfort_hipsolver
       hipsolverZhegvd_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverSsygvd
-#ifdef USE_CUDA_NAMES
-    function hipsolverSsygvd_(handle,itype,jobz,uplo,n,A,lda,B,ldb,W,work,lwork,devInfo) &
-        bind(c, name="cusolverSsygvd")
-#else
     function hipsolverSsygvd_(handle,itype,jobz,uplo,n,A,lda,B,ldb,W,work,lwork,devInfo) &
         bind(c, name="hipsolverSsygvd")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -5993,15 +5458,12 @@ module hipfort_hipsolver
       hipsolverSsygvd_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverDsygvd
-#ifdef USE_CUDA_NAMES
-    function hipsolverDsygvd_(handle,itype,jobz,uplo,n,A,lda,B,ldb,W,work,lwork,devInfo) &
-        bind(c, name="cusolverDsygvd")
-#else
     function hipsolverDsygvd_(handle,itype,jobz,uplo,n,A,lda,B,ldb,W,work,lwork,devInfo) &
         bind(c, name="hipsolverDsygvd")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -6028,15 +5490,12 @@ module hipfort_hipsolver
       hipsolverDsygvd_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverChegvd
-#ifdef USE_CUDA_NAMES
-    function hipsolverChegvd_(handle,itype,jobz,uplo,n,A,lda,B,ldb,W,work,lwork,devInfo) &
-        bind(c, name="cusolverChegvd")
-#else
     function hipsolverChegvd_(handle,itype,jobz,uplo,n,A,lda,B,ldb,W,work,lwork,devInfo) &
         bind(c, name="hipsolverChegvd")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -6063,15 +5522,12 @@ module hipfort_hipsolver
       hipsolverChegvd_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverZhegvd
-#ifdef USE_CUDA_NAMES
-    function hipsolverZhegvd_(handle,itype,jobz,uplo,n,A,lda,B,ldb,W,work,lwork,devInfo) &
-        bind(c, name="cusolverZhegvd")
-#else
     function hipsolverZhegvd_(handle,itype,jobz,uplo,n,A,lda,B,ldb,W,work,lwork,devInfo) &
         bind(c, name="hipsolverZhegvd")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -6098,17 +5554,13 @@ module hipfort_hipsolver
       hipsolverZhegvd_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverSsygvdx_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverSsygvdx_bufferSize_(handle,itype,jobz,range,uplo,n,A,lda,B,ldb,vl,vu,il,iu, &
-        nev,W,lwork) &
-        bind(c, name="cusolverSsygvdx_bufferSize")
-#else
     function hipsolverSsygvdx_bufferSize_(handle,itype,jobz,range,uplo,n,A,lda,B,ldb,vl,vu,il,iu, &
         nev,W,lwork) &
         bind(c, name="hipsolverSsygvdx_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -6132,17 +5584,13 @@ module hipfort_hipsolver
       integer(c_int) :: lwork
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverDsygvdx_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverDsygvdx_bufferSize_(handle,itype,jobz,range,uplo,n,A,lda,B,ldb,vl,vu,il,iu, &
-        nev,W,lwork) &
-        bind(c, name="cusolverDsygvdx_bufferSize")
-#else
     function hipsolverDsygvdx_bufferSize_(handle,itype,jobz,range,uplo,n,A,lda,B,ldb,vl,vu,il,iu, &
         nev,W,lwork) &
         bind(c, name="hipsolverDsygvdx_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -6166,17 +5614,13 @@ module hipfort_hipsolver
       integer(c_int) :: lwork
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverChegvdx_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverChegvdx_bufferSize_(handle,itype,jobz,range,uplo,n,A,lda,B,ldb,vl,vu,il,iu, &
-        nev,W,lwork) &
-        bind(c, name="cusolverChegvdx_bufferSize")
-#else
     function hipsolverChegvdx_bufferSize_(handle,itype,jobz,range,uplo,n,A,lda,B,ldb,vl,vu,il,iu, &
         nev,W,lwork) &
         bind(c, name="hipsolverChegvdx_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -6200,17 +5644,13 @@ module hipfort_hipsolver
       integer(c_int) :: lwork
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverZhegvdx_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverZhegvdx_bufferSize_(handle,itype,jobz,range,uplo,n,A,lda,B,ldb,vl,vu,il,iu, &
-        nev,W,lwork) &
-        bind(c, name="cusolverZhegvdx_bufferSize")
-#else
     function hipsolverZhegvdx_bufferSize_(handle,itype,jobz,range,uplo,n,A,lda,B,ldb,vl,vu,il,iu, &
         nev,W,lwork) &
         bind(c, name="hipsolverZhegvdx_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -6234,17 +5674,13 @@ module hipfort_hipsolver
       integer(c_int) :: lwork
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverSsygvdx
-#ifdef USE_CUDA_NAMES
-    function hipsolverSsygvdx_(handle,itype,jobz,range,uplo,n,A,lda,B,ldb,vl,vu,il,iu,nev,W,work, &
-        lwork,devInfo) &
-        bind(c, name="cusolverSsygvdx")
-#else
     function hipsolverSsygvdx_(handle,itype,jobz,range,uplo,n,A,lda,B,ldb,vl,vu,il,iu,nev,W,work, &
         lwork,devInfo) &
         bind(c, name="hipsolverSsygvdx")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -6270,17 +5706,13 @@ module hipfort_hipsolver
       integer(c_int) :: devInfo
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverDsygvdx
-#ifdef USE_CUDA_NAMES
-    function hipsolverDsygvdx_(handle,itype,jobz,range,uplo,n,A,lda,B,ldb,vl,vu,il,iu,nev,W,work, &
-        lwork,devInfo) &
-        bind(c, name="cusolverDsygvdx")
-#else
     function hipsolverDsygvdx_(handle,itype,jobz,range,uplo,n,A,lda,B,ldb,vl,vu,il,iu,nev,W,work, &
         lwork,devInfo) &
         bind(c, name="hipsolverDsygvdx")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -6306,17 +5738,13 @@ module hipfort_hipsolver
       integer(c_int) :: devInfo
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverChegvdx
-#ifdef USE_CUDA_NAMES
-    function hipsolverChegvdx_(handle,itype,jobz,range,uplo,n,A,lda,B,ldb,vl,vu,il,iu,nev,W,work, &
-        lwork,devInfo) &
-        bind(c, name="cusolverChegvdx")
-#else
     function hipsolverChegvdx_(handle,itype,jobz,range,uplo,n,A,lda,B,ldb,vl,vu,il,iu,nev,W,work, &
         lwork,devInfo) &
         bind(c, name="hipsolverChegvdx")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -6342,17 +5770,13 @@ module hipfort_hipsolver
       integer(c_int) :: devInfo
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverZhegvdx
-#ifdef USE_CUDA_NAMES
-    function hipsolverZhegvdx_(handle,itype,jobz,range,uplo,n,A,lda,B,ldb,vl,vu,il,iu,nev,W,work, &
-        lwork,devInfo) &
-        bind(c, name="cusolverZhegvdx")
-#else
     function hipsolverZhegvdx_(handle,itype,jobz,range,uplo,n,A,lda,B,ldb,vl,vu,il,iu,nev,W,work, &
         lwork,devInfo) &
         bind(c, name="hipsolverZhegvdx")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -6378,15 +5802,12 @@ module hipfort_hipsolver
       integer(c_int) :: devInfo
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverSsygvj_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverSsygvj_bufferSize_(handle,itype,jobz,uplo,n,A,lda,B,ldb,W,lwork,params) &
-        bind(c, name="cusolverSsygvj_bufferSize")
-#else
     function hipsolverSsygvj_bufferSize_(handle,itype,jobz,uplo,n,A,lda,B,ldb,W,lwork,params) &
         bind(c, name="hipsolverSsygvj_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -6405,15 +5826,12 @@ module hipfort_hipsolver
       type(c_ptr),value :: params
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverDsygvj_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverDsygvj_bufferSize_(handle,itype,jobz,uplo,n,A,lda,B,ldb,W,lwork,params) &
-        bind(c, name="cusolverDsygvj_bufferSize")
-#else
     function hipsolverDsygvj_bufferSize_(handle,itype,jobz,uplo,n,A,lda,B,ldb,W,lwork,params) &
         bind(c, name="hipsolverDsygvj_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -6432,15 +5850,12 @@ module hipfort_hipsolver
       type(c_ptr),value :: params
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverChegvj_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverChegvj_bufferSize_(handle,itype,jobz,uplo,n,A,lda,B,ldb,W,lwork,params) &
-        bind(c, name="cusolverChegvj_bufferSize")
-#else
     function hipsolverChegvj_bufferSize_(handle,itype,jobz,uplo,n,A,lda,B,ldb,W,lwork,params) &
         bind(c, name="hipsolverChegvj_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -6459,15 +5874,12 @@ module hipfort_hipsolver
       type(c_ptr),value :: params
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverZhegvj_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverZhegvj_bufferSize_(handle,itype,jobz,uplo,n,A,lda,B,ldb,W,lwork,params) &
-        bind(c, name="cusolverZhegvj_bufferSize")
-#else
     function hipsolverZhegvj_bufferSize_(handle,itype,jobz,uplo,n,A,lda,B,ldb,W,lwork,params) &
         bind(c, name="hipsolverZhegvj_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -6486,15 +5898,12 @@ module hipfort_hipsolver
       type(c_ptr),value :: params
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverSsygvj
-#ifdef USE_CUDA_NAMES
-    function hipsolverSsygvj_(handle,itype,jobz,uplo,n,A,lda,B,ldb,W,work,lwork,devInfo,params) &
-        bind(c, name="cusolverSsygvj")
-#else
     function hipsolverSsygvj_(handle,itype,jobz,uplo,n,A,lda,B,ldb,W,work,lwork,devInfo,params) &
         bind(c, name="hipsolverSsygvj")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -6515,15 +5924,12 @@ module hipfort_hipsolver
       type(c_ptr),value :: params
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverDsygvj
-#ifdef USE_CUDA_NAMES
-    function hipsolverDsygvj_(handle,itype,jobz,uplo,n,A,lda,B,ldb,W,work,lwork,devInfo,params) &
-        bind(c, name="cusolverDsygvj")
-#else
     function hipsolverDsygvj_(handle,itype,jobz,uplo,n,A,lda,B,ldb,W,work,lwork,devInfo,params) &
         bind(c, name="hipsolverDsygvj")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -6544,15 +5950,12 @@ module hipfort_hipsolver
       type(c_ptr),value :: params
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverChegvj
-#ifdef USE_CUDA_NAMES
-    function hipsolverChegvj_(handle,itype,jobz,uplo,n,A,lda,B,ldb,W,work,lwork,devInfo,params) &
-        bind(c, name="cusolverChegvj")
-#else
     function hipsolverChegvj_(handle,itype,jobz,uplo,n,A,lda,B,ldb,W,work,lwork,devInfo,params) &
         bind(c, name="hipsolverChegvj")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -6573,15 +5976,12 @@ module hipfort_hipsolver
       type(c_ptr),value :: params
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverZhegvj
-#ifdef USE_CUDA_NAMES
-    function hipsolverZhegvj_(handle,itype,jobz,uplo,n,A,lda,B,ldb,W,work,lwork,devInfo,params) &
-        bind(c, name="cusolverZhegvj")
-#else
     function hipsolverZhegvj_(handle,itype,jobz,uplo,n,A,lda,B,ldb,W,work,lwork,devInfo,params) &
         bind(c, name="hipsolverZhegvj")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -6602,15 +6002,12 @@ module hipfort_hipsolver
       type(c_ptr),value :: params
     end function
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverSsytrd_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverSsytrd_bufferSize_(handle,uplo,n,A,lda,D,E,tau,lwork) &
-        bind(c, name="cusolverSsytrd_bufferSize")
-#else
     function hipsolverSsytrd_bufferSize_(handle,uplo,n,A,lda,D,E,tau,lwork) &
         bind(c, name="hipsolverSsytrd_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -6633,15 +6030,12 @@ module hipfort_hipsolver
       hipsolverSsytrd_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverDsytrd_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverDsytrd_bufferSize_(handle,uplo,n,A,lda,D,E,tau,lwork) &
-        bind(c, name="cusolverDsytrd_bufferSize")
-#else
     function hipsolverDsytrd_bufferSize_(handle,uplo,n,A,lda,D,E,tau,lwork) &
         bind(c, name="hipsolverDsytrd_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -6664,15 +6058,12 @@ module hipfort_hipsolver
       hipsolverDsytrd_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverChetrd_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverChetrd_bufferSize_(handle,uplo,n,A,lda,D,E,tau,lwork) &
-        bind(c, name="cusolverChetrd_bufferSize")
-#else
     function hipsolverChetrd_bufferSize_(handle,uplo,n,A,lda,D,E,tau,lwork) &
         bind(c, name="hipsolverChetrd_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -6695,15 +6086,12 @@ module hipfort_hipsolver
       hipsolverChetrd_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverZhetrd_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverZhetrd_bufferSize_(handle,uplo,n,A,lda,D,E,tau,lwork) &
-        bind(c, name="cusolverZhetrd_bufferSize")
-#else
     function hipsolverZhetrd_bufferSize_(handle,uplo,n,A,lda,D,E,tau,lwork) &
         bind(c, name="hipsolverZhetrd_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -6726,15 +6114,12 @@ module hipfort_hipsolver
       hipsolverZhetrd_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverSsytrd
-#ifdef USE_CUDA_NAMES
-    function hipsolverSsytrd_(handle,uplo,n,A,lda,D,E,tau,work,lwork,devInfo) &
-        bind(c, name="cusolverSsytrd")
-#else
     function hipsolverSsytrd_(handle,uplo,n,A,lda,D,E,tau,work,lwork,devInfo) &
         bind(c, name="hipsolverSsytrd")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -6759,15 +6144,12 @@ module hipfort_hipsolver
       hipsolverSsytrd_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverDsytrd
-#ifdef USE_CUDA_NAMES
-    function hipsolverDsytrd_(handle,uplo,n,A,lda,D,E,tau,work,lwork,devInfo) &
-        bind(c, name="cusolverDsytrd")
-#else
     function hipsolverDsytrd_(handle,uplo,n,A,lda,D,E,tau,work,lwork,devInfo) &
         bind(c, name="hipsolverDsytrd")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -6792,15 +6174,12 @@ module hipfort_hipsolver
       hipsolverDsytrd_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverChetrd
-#ifdef USE_CUDA_NAMES
-    function hipsolverChetrd_(handle,uplo,n,A,lda,D,E,tau,work,lwork,devInfo) &
-        bind(c, name="cusolverChetrd")
-#else
     function hipsolverChetrd_(handle,uplo,n,A,lda,D,E,tau,work,lwork,devInfo) &
         bind(c, name="hipsolverChetrd")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -6825,15 +6204,12 @@ module hipfort_hipsolver
       hipsolverChetrd_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverZhetrd
-#ifdef USE_CUDA_NAMES
-    function hipsolverZhetrd_(handle,uplo,n,A,lda,D,E,tau,work,lwork,devInfo) &
-        bind(c, name="cusolverZhetrd")
-#else
     function hipsolverZhetrd_(handle,uplo,n,A,lda,D,E,tau,work,lwork,devInfo) &
         bind(c, name="hipsolverZhetrd")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -6858,15 +6234,12 @@ module hipfort_hipsolver
       hipsolverZhetrd_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverSsytrf_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverSsytrf_bufferSize_(handle,n,A,lda,lwork) &
-        bind(c, name="cusolverSsytrf_bufferSize")
-#else
     function hipsolverSsytrf_bufferSize_(handle,n,A,lda,lwork) &
         bind(c, name="hipsolverSsytrf_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -6885,15 +6258,12 @@ module hipfort_hipsolver
       hipsolverSsytrf_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverDsytrf_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverDsytrf_bufferSize_(handle,n,A,lda,lwork) &
-        bind(c, name="cusolverDsytrf_bufferSize")
-#else
     function hipsolverDsytrf_bufferSize_(handle,n,A,lda,lwork) &
         bind(c, name="hipsolverDsytrf_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -6912,15 +6282,12 @@ module hipfort_hipsolver
       hipsolverDsytrf_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverCsytrf_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverCsytrf_bufferSize_(handle,n,A,lda,lwork) &
-        bind(c, name="cusolverCsytrf_bufferSize")
-#else
     function hipsolverCsytrf_bufferSize_(handle,n,A,lda,lwork) &
         bind(c, name="hipsolverCsytrf_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -6939,15 +6306,12 @@ module hipfort_hipsolver
       hipsolverCsytrf_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverZsytrf_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsolverZsytrf_bufferSize_(handle,n,A,lda,lwork) &
-        bind(c, name="cusolverZsytrf_bufferSize")
-#else
     function hipsolverZsytrf_bufferSize_(handle,n,A,lda,lwork) &
         bind(c, name="hipsolverZsytrf_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -6966,15 +6330,12 @@ module hipfort_hipsolver
       hipsolverZsytrf_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverSsytrf
-#ifdef USE_CUDA_NAMES
-    function hipsolverSsytrf_(handle,uplo,n,A,lda,ipiv,work,lwork,devInfo) &
-        bind(c, name="cusolverSsytrf")
-#else
     function hipsolverSsytrf_(handle,uplo,n,A,lda,ipiv,work,lwork,devInfo) &
         bind(c, name="hipsolverSsytrf")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -6997,15 +6358,12 @@ module hipfort_hipsolver
       hipsolverSsytrf_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverDsytrf
-#ifdef USE_CUDA_NAMES
-    function hipsolverDsytrf_(handle,uplo,n,A,lda,ipiv,work,lwork,devInfo) &
-        bind(c, name="cusolverDsytrf")
-#else
     function hipsolverDsytrf_(handle,uplo,n,A,lda,ipiv,work,lwork,devInfo) &
         bind(c, name="hipsolverDsytrf")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -7028,15 +6386,12 @@ module hipfort_hipsolver
       hipsolverDsytrf_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverCsytrf
-#ifdef USE_CUDA_NAMES
-    function hipsolverCsytrf_(handle,uplo,n,A,lda,ipiv,work,lwork,devInfo) &
-        bind(c, name="cusolverCsytrf")
-#else
     function hipsolverCsytrf_(handle,uplo,n,A,lda,ipiv,work,lwork,devInfo) &
         bind(c, name="hipsolverCsytrf")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -7059,15 +6414,12 @@ module hipfort_hipsolver
       hipsolverCsytrf_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverZsytrf
-#ifdef USE_CUDA_NAMES
-    function hipsolverZsytrf_(handle,uplo,n,A,lda,ipiv,work,lwork,devInfo) &
-        bind(c, name="cusolverZsytrf")
-#else
     function hipsolverZsytrf_(handle,uplo,n,A,lda,ipiv,work,lwork,devInfo) &
         bind(c, name="hipsolverZsytrf")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -7090,6 +6442,7 @@ module hipfort_hipsolver
       hipsolverZsytrf_full_rank
 #endif
   end interface
+#endif
 
   !>  \brief An alias for `hipsolverCreate`.
   interface hipsolverDnCreate
@@ -13720,16 +13073,11 @@ module hipfort_hipsolver
     end function
   end interface
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverRfSetupDevice
-#ifdef USE_CUDA_NAMES
     function hipsolverRfSetupDevice_(n,nnzA,csrRowPtrA,csrColIndA,csrValA,nnzL,csrRowPtrL, &
         csrColIndL,csrValL,nnzU,csrRowPtrU,csrColIndU,csrValU,P,Q,handle) &
         bind(c, name="hipsolverRfSetupDevice")
-#else
-    function hipsolverRfSetupDevice_(n,nnzA,csrRowPtrA,csrColIndA,csrValA,nnzL,csrRowPtrL, &
-        csrColIndL,csrValL,nnzU,csrRowPtrU,csrColIndU,csrValU,P,Q,handle) &
-        bind(c, name="hipsolverRfSetupDevice")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -13752,17 +13100,13 @@ module hipfort_hipsolver
       type(c_ptr),value :: handle
     end function
   end interface
-
-  interface hipsolverRfSetupHost
-#ifdef USE_CUDA_NAMES
-    function hipsolverRfSetupHost_(n,nnzA,h_csrRowPtrA,h_csrColIndA,h_csrValA,nnzL,h_csrRowPtrL, &
-        h_csrColIndL,h_csrValL,nnzU,h_csrRowPtrU,h_csrColIndU,h_csrValU,h_P,h_Q,handle) &
-        bind(c, name="hipsolverRfSetupHost")
-#else
-    function hipsolverRfSetupHost_(n,nnzA,h_csrRowPtrA,h_csrColIndA,h_csrValA,nnzL,h_csrRowPtrL, &
-        h_csrColIndL,h_csrValL,nnzU,h_csrRowPtrU,h_csrColIndU,h_csrValU,h_P,h_Q,handle) &
-        bind(c, name="hipsolverRfSetupHost")
 #endif
+
+#ifndef USE_CUDA_NAMES
+  interface hipsolverRfSetupHost
+    function hipsolverRfSetupHost_(n,nnzA,h_csrRowPtrA,h_csrColIndA,h_csrValA,nnzL,h_csrRowPtrL, &
+        h_csrColIndL,h_csrValL,nnzU,h_csrRowPtrU,h_csrColIndU,h_csrValU,h_P,h_Q,handle) &
+        bind(c, name="hipsolverRfSetupHost")
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -13785,15 +13129,12 @@ module hipfort_hipsolver
       type(c_ptr),value :: handle
     end function
   end interface
-
-  interface hipsolverRfAccessBundledFactorsDevice
-#ifdef USE_CUDA_NAMES
-    function hipsolverRfAccessBundledFactorsDevice_(handle,nnzM,Mp,Mi,Mx) &
-        bind(c, name="hipsolverRfAccessBundledFactorsDevice")
-#else
-    function hipsolverRfAccessBundledFactorsDevice_(handle,nnzM,Mp,Mi,Mx) &
-        bind(c, name="hipsolverRfAccessBundledFactorsDevice")
 #endif
+
+#ifndef USE_CUDA_NAMES
+  interface hipsolverRfAccessBundledFactorsDevice
+    function hipsolverRfAccessBundledFactorsDevice_(handle,nnzM,Mp,Mi,Mx) &
+        bind(c, name="hipsolverRfAccessBundledFactorsDevice")
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -13805,6 +13146,7 @@ module hipfort_hipsolver
       type(c_ptr) :: Mx
     end function
   end interface
+#endif
 
   interface hipsolverRfAnalyze
 #ifdef USE_CUDA_NAMES
@@ -13820,14 +13162,10 @@ module hipfort_hipsolver
     end function
   end interface
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverRfExtractBundledFactorsHost
-#ifdef USE_CUDA_NAMES
     function hipsolverRfExtractBundledFactorsHost_(handle,h_nnzM,h_Mp,h_Mi,h_Mx) &
         bind(c, name="hipsolverRfExtractBundledFactorsHost")
-#else
-    function hipsolverRfExtractBundledFactorsHost_(handle,h_nnzM,h_Mp,h_Mi,h_Mx) &
-        bind(c, name="hipsolverRfExtractBundledFactorsHost")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -13839,17 +13177,13 @@ module hipfort_hipsolver
       type(c_ptr) :: h_Mx
     end function
   end interface
-
-  interface hipsolverRfExtractSplitFactorsHost
-#ifdef USE_CUDA_NAMES
-    function hipsolverRfExtractSplitFactorsHost_(handle,h_nnzL,h_Lp,h_Li,h_Lx,h_nnzU,h_Up,h_Ui, &
-        h_Ux) &
-        bind(c, name="hipsolverRfExtractSplitFactorsHost")
-#else
-    function hipsolverRfExtractSplitFactorsHost_(handle,h_nnzL,h_Lp,h_Li,h_Lx,h_nnzU,h_Up,h_Ui, &
-        h_Ux) &
-        bind(c, name="hipsolverRfExtractSplitFactorsHost")
 #endif
+
+#ifndef USE_CUDA_NAMES
+  interface hipsolverRfExtractSplitFactorsHost
+    function hipsolverRfExtractSplitFactorsHost_(handle,h_nnzL,h_Lp,h_Li,h_Lx,h_nnzU,h_Up,h_Ui, &
+        h_Ux) &
+        bind(c, name="hipsolverRfExtractSplitFactorsHost")
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -13865,13 +13199,11 @@ module hipfort_hipsolver
       type(c_ptr) :: h_Ux
     end function
   end interface
-
-  interface hipsolverRfGet_Algs
-#ifdef USE_CUDA_NAMES
-    function hipsolverRfGet_Algs_(handle,fact_alg,solve_alg) bind(c, name="cusolverRfGet_Algs")
-#else
-    function hipsolverRfGet_Algs_(handle,fact_alg,solve_alg) bind(c, name="hipsolverRfGet_Algs")
 #endif
+
+#ifndef USE_CUDA_NAMES
+  interface hipsolverRfGet_Algs
+    function hipsolverRfGet_Algs_(handle,fact_alg,solve_alg) bind(c, name="hipsolverRfGet_Algs")
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -13881,6 +13213,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: solve_alg
     end function
   end interface
+#endif
 
   interface hipsolverRfGetMatrixFormat
 #ifdef USE_CUDA_NAMES
@@ -13966,14 +13299,10 @@ module hipfort_hipsolver
     end function
   end interface
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverRfResetValues
-#ifdef USE_CUDA_NAMES
     function hipsolverRfResetValues_(n,nnzA,csrRowPtrA,csrColIndA,csrValA,P,Q,handle) &
         bind(c, name="hipsolverRfResetValues")
-#else
-    function hipsolverRfResetValues_(n,nnzA,csrRowPtrA,csrColIndA,csrValA,P,Q,handle) &
-        bind(c, name="hipsolverRfResetValues")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -13988,6 +13317,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: handle
     end function
   end interface
+#endif
 
   interface hipsolverRfSetAlgs
 #ifdef USE_CUDA_NAMES
@@ -14058,12 +13388,9 @@ module hipfort_hipsolver
     end function
   end interface
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverRfSolve
-#ifdef USE_CUDA_NAMES
     function hipsolverRfSolve_(handle,P,Q,nrhs,Temp,ldt,XF,ldxf) bind(c, name="hipsolverRfSolve")
-#else
-    function hipsolverRfSolve_(handle,P,Q,nrhs,Temp,ldt,XF,ldxf) bind(c, name="hipsolverRfSolve")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -14078,19 +13405,14 @@ module hipfort_hipsolver
       integer(c_int),value :: ldxf
     end function
   end interface
-
-  interface hipsolverRfBatchSetupHost
-#ifdef USE_CUDA_NAMES
-    function hipsolverRfBatchSetupHost_(batchSize,n,nnzA,h_csrRowPtrA,h_csrColIndA, &
-        h_csrValA_array,nnzL,h_csrRowPtrL,h_csrColIndL,h_csrValL,nnzU,h_csrRowPtrU,h_csrColIndU, &
-        h_csrValU,h_P,h_Q,handle) &
-        bind(c, name="hipsolverRfBatchSetupHost")
-#else
-    function hipsolverRfBatchSetupHost_(batchSize,n,nnzA,h_csrRowPtrA,h_csrColIndA, &
-        h_csrValA_array,nnzL,h_csrRowPtrL,h_csrColIndL,h_csrValL,nnzU,h_csrRowPtrU,h_csrColIndU, &
-        h_csrValU,h_P,h_Q,handle) &
-        bind(c, name="hipsolverRfBatchSetupHost")
 #endif
+
+#ifndef USE_CUDA_NAMES
+  interface hipsolverRfBatchSetupHost
+    function hipsolverRfBatchSetupHost_(batchSize,n,nnzA,h_csrRowPtrA,h_csrColIndA, &
+        h_csrValA_array,nnzL,h_csrRowPtrL,h_csrColIndL,h_csrValL,nnzU,h_csrRowPtrU,h_csrColIndU, &
+        h_csrValU,h_P,h_Q,handle) &
+        bind(c, name="hipsolverRfBatchSetupHost")
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -14114,6 +13436,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: handle
     end function
   end interface
+#endif
 
   interface hipsolverRfBatchAnalyze
 #ifdef USE_CUDA_NAMES
@@ -14143,16 +13466,11 @@ module hipfort_hipsolver
     end function
   end interface
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverRfBatchResetValues
-#ifdef USE_CUDA_NAMES
     function hipsolverRfBatchResetValues_(batchSize,n,nnzA,csrRowPtrA,csrColIndA,csrValA_array,P, &
         Q,handle) &
         bind(c, name="hipsolverRfBatchResetValues")
-#else
-    function hipsolverRfBatchResetValues_(batchSize,n,nnzA,csrRowPtrA,csrColIndA,csrValA_array,P, &
-        Q,handle) &
-        bind(c, name="hipsolverRfBatchResetValues")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -14168,15 +13486,12 @@ module hipfort_hipsolver
       type(c_ptr),value :: handle
     end function
   end interface
-
-  interface hipsolverRfBatchSolve
-#ifdef USE_CUDA_NAMES
-    function hipsolverRfBatchSolve_(handle,P,Q,nrhs,Temp,ldt,XF_array,ldxf) &
-        bind(c, name="hipsolverRfBatchSolve")
-#else
-    function hipsolverRfBatchSolve_(handle,P,Q,nrhs,Temp,ldt,XF_array,ldxf) &
-        bind(c, name="hipsolverRfBatchSolve")
 #endif
+
+#ifndef USE_CUDA_NAMES
+  interface hipsolverRfBatchSolve
+    function hipsolverRfBatchSolve_(handle,P,Q,nrhs,Temp,ldt,XF_array,ldxf) &
+        bind(c, name="hipsolverRfBatchSolve")
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -14191,6 +13506,7 @@ module hipfort_hipsolver
       integer(c_int),value :: ldxf
     end function
   end interface
+#endif
 
   interface hipsolverRfBatchZeroPivot
 #ifdef USE_CUDA_NAMES
@@ -14250,16 +13566,11 @@ module hipfort_hipsolver
     end function
   end interface
 
+#ifndef USE_CUDA_NAMES
   interface hipsolverSpScsrlsvchol
-#ifdef USE_CUDA_NAMES
     function hipsolverSpScsrlsvchol_(handle,n,nnzA,descrA,csrVal,csrRowPtr,csrColInd,b,tolerance, &
         reorder,x,singularity) &
         bind(c, name="hipsolverSpScsrlsvchol")
-#else
-    function hipsolverSpScsrlsvchol_(handle,n,nnzA,descrA,csrVal,csrRowPtr,csrColInd,b,tolerance, &
-        reorder,x,singularity) &
-        bind(c, name="hipsolverSpScsrlsvchol")
-#endif
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -14278,17 +13589,13 @@ module hipfort_hipsolver
       integer(c_int) :: singularity
     end function
   end interface
-
-  interface hipsolverSpDcsrlsvchol
-#ifdef USE_CUDA_NAMES
-    function hipsolverSpDcsrlsvchol_(handle,n,nnzA,descrA,csrVal,csrRowPtr,csrColInd,b,tolerance, &
-        reorder,x,singularity) &
-        bind(c, name="hipsolverSpDcsrlsvchol")
-#else
-    function hipsolverSpDcsrlsvchol_(handle,n,nnzA,descrA,csrVal,csrRowPtr,csrColInd,b,tolerance, &
-        reorder,x,singularity) &
-        bind(c, name="hipsolverSpDcsrlsvchol")
 #endif
+
+#ifndef USE_CUDA_NAMES
+  interface hipsolverSpDcsrlsvchol
+    function hipsolverSpDcsrlsvchol_(handle,n,nnzA,descrA,csrVal,csrRowPtr,csrColInd,b,tolerance, &
+        reorder,x,singularity) &
+        bind(c, name="hipsolverSpDcsrlsvchol")
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -14307,17 +13614,13 @@ module hipfort_hipsolver
       integer(c_int) :: singularity
     end function
   end interface
-
-  interface hipsolverSpScsrlsvcholHost
-#ifdef USE_CUDA_NAMES
-    function hipsolverSpScsrlsvcholHost_(handle,n,nnzA,descrA,csrVal,csrRowPtr,csrColInd,b, &
-        tolerance,reorder,x,singularity) &
-        bind(c, name="hipsolverSpScsrlsvcholHost")
-#else
-    function hipsolverSpScsrlsvcholHost_(handle,n,nnzA,descrA,csrVal,csrRowPtr,csrColInd,b, &
-        tolerance,reorder,x,singularity) &
-        bind(c, name="hipsolverSpScsrlsvcholHost")
 #endif
+
+#ifndef USE_CUDA_NAMES
+  interface hipsolverSpScsrlsvcholHost
+    function hipsolverSpScsrlsvcholHost_(handle,n,nnzA,descrA,csrVal,csrRowPtr,csrColInd,b, &
+        tolerance,reorder,x,singularity) &
+        bind(c, name="hipsolverSpScsrlsvcholHost")
       use iso_c_binding
       use hipfort_hipsolver_enums
       implicit none
@@ -14336,6 +13639,7 @@ module hipfort_hipsolver
       integer(c_int) :: singularity
     end function
   end interface
+#endif
 
   interface hipsolverSpDcsrlsvcholHost
 #ifdef USE_CUDA_NAMES

--- a/lib/hipfort/hipfort_hipsparse.F90
+++ b/lib/hipfort/hipfort_hipsparse.F90
@@ -151,12 +151,9 @@ module hipfort_hipsparse
   !>
   !>   \details
   !>   \p hipsparseGetGitRevision gets the hipSPARSE library git commit revision (SHA-1).
+#ifndef USE_CUDA_NAMES
   interface hipsparseGetGitRevision
-#ifdef USE_CUDA_NAMES
-    function hipsparseGetGitRevision_(handle,rev) bind(c, name="cusparseGetGitRevision")
-#else
     function hipsparseGetGitRevision_(handle,rev) bind(c, name="hipsparseGetGitRevision")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -165,6 +162,7 @@ module hipfort_hipsparse
       type(c_ptr),value :: rev
     end function
   end interface
+#endif
 
   !>  \ingroup aux_module
   !>   \brief Specify the user-defined HIP stream.
@@ -298,12 +296,9 @@ module hipfort_hipsparse
   !>   \details
   !>   \p hipsparseCopyMatDescr copies a matrix descriptor. Both source and destination
   !>   matrix descriptors must be initialized prior to calling \p hipsparseCopyMatDescr.
+#ifndef USE_CUDA_NAMES
   interface hipsparseCopyMatDescr
-#ifdef USE_CUDA_NAMES
-    function hipsparseCopyMatDescr_(dest,src) bind(c, name="cusparseCopyMatDescr")
-#else
     function hipsparseCopyMatDescr_(dest,src) bind(c, name="hipsparseCopyMatDescr")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -312,6 +307,7 @@ module hipfort_hipsparse
       type(c_ptr),value :: src
     end function
   end interface
+#endif
 
   !>  \ingroup aux_module
   !>   \brief Specify the matrix type of a matrix descriptor.
@@ -484,12 +480,9 @@ module hipfort_hipsparse
   !>   \details
   !>   \p hipsparseCreateHybMat creates a structure that holds the matrix in \p HYB
   !>   storage format. It should be destroyed at the end using hipsparseDestroyHybMat().
+#ifndef USE_CUDA_NAMES
   interface hipsparseCreateHybMat
-#ifdef USE_CUDA_NAMES
-    function hipsparseCreateHybMat_(hybA) bind(c, name="cusparseCreateHybMat")
-#else
     function hipsparseCreateHybMat_(hybA) bind(c, name="hipsparseCreateHybMat")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -497,18 +490,16 @@ module hipfort_hipsparse
       type(c_ptr) :: hybA
     end function
   end interface
+#endif
 
   !>  \ingroup aux_module
   !>   \brief Destroy a \p HYB matrix structure.
   !>
   !>   \details
   !>   \p hipsparseDestroyHybMat destroys a \p HYB structure.
+#ifndef USE_CUDA_NAMES
   interface hipsparseDestroyHybMat
-#ifdef USE_CUDA_NAMES
-    function hipsparseDestroyHybMat_(hybA) bind(c, name="cusparseDestroyHybMat")
-#else
     function hipsparseDestroyHybMat_(hybA) bind(c, name="hipsparseDestroyHybMat")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -516,6 +507,7 @@ module hipfort_hipsparse
       type(c_ptr),value :: hybA
     end function
   end interface
+#endif
 
   !>  \ingroup aux_module
   !>   \brief Create a bsrsv2 info structure.
@@ -684,12 +676,9 @@ module hipfort_hipsparse
   !>   \p hipsparseCreateCsrsv2Info creates a structure that holds the csrsv2 info data
   !>   that is gathered during the analysis routines. It should be destroyed
   !>   at the end using hipsparseDestroyCsrsv2Info().
+#ifndef USE_CUDA_NAMES
   interface hipsparseCreateCsrsv2Info
-#ifdef USE_CUDA_NAMES
-    function hipsparseCreateCsrsv2Info_(myInfo) bind(c, name="cusparseCreateCsrsv2Info")
-#else
     function hipsparseCreateCsrsv2Info_(myInfo) bind(c, name="hipsparseCreateCsrsv2Info")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -697,18 +686,16 @@ module hipfort_hipsparse
       type(c_ptr) :: myInfo
     end function
   end interface
+#endif
 
   !>  \ingroup aux_module
   !>   \brief Destroy a csrsv2 info structure.
   !>
   !>   \details
   !>   \p hipsparseDestroyCsrsv2Info destroys a csrsv2 info structure.
+#ifndef USE_CUDA_NAMES
   interface hipsparseDestroyCsrsv2Info
-#ifdef USE_CUDA_NAMES
-    function hipsparseDestroyCsrsv2Info_(myInfo) bind(c, name="cusparseDestroyCsrsv2Info")
-#else
     function hipsparseDestroyCsrsv2Info_(myInfo) bind(c, name="hipsparseDestroyCsrsv2Info")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -716,6 +703,7 @@ module hipfort_hipsparse
       type(c_ptr),value :: myInfo
     end function
   end interface
+#endif
 
   !>  \ingroup aux_module
   !>   \brief Create a csrsm2 info structure.
@@ -724,12 +712,9 @@ module hipfort_hipsparse
   !>   \p hipsparseCreateCsrsm2Info creates a structure that holds the csrsm2 info data
   !>   that is gathered during the analysis routines. It should be destroyed
   !>   at the end using hipsparseDestroyCsrsm2Info().
+#ifndef USE_CUDA_NAMES
   interface hipsparseCreateCsrsm2Info
-#ifdef USE_CUDA_NAMES
-    function hipsparseCreateCsrsm2Info_(myInfo) bind(c, name="cusparseCreateCsrsm2Info")
-#else
     function hipsparseCreateCsrsm2Info_(myInfo) bind(c, name="hipsparseCreateCsrsm2Info")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -737,18 +722,16 @@ module hipfort_hipsparse
       type(c_ptr) :: myInfo
     end function
   end interface
+#endif
 
   !>  \ingroup aux_module
   !>   \brief Destroy a csrsm2 info structure.
   !>
   !>   \details
   !>   \p hipsparseDestroyCsrsm2Info destroys a csrsm2 info structure.
+#ifndef USE_CUDA_NAMES
   interface hipsparseDestroyCsrsm2Info
-#ifdef USE_CUDA_NAMES
-    function hipsparseDestroyCsrsm2Info_(myInfo) bind(c, name="cusparseDestroyCsrsm2Info")
-#else
     function hipsparseDestroyCsrsm2Info_(myInfo) bind(c, name="hipsparseDestroyCsrsm2Info")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -756,6 +739,7 @@ module hipfort_hipsparse
       type(c_ptr),value :: myInfo
     end function
   end interface
+#endif
 
   !>  \ingroup aux_module
   !>   \brief Create a csrilu02 info structure.
@@ -924,12 +908,9 @@ module hipfort_hipsparse
   !>   \p hipsparseCreateCsrgemm2Info creates a structure that holds the csrgemm2 info data
   !>   that is gathered during the analysis routines. It should be destroyed
   !>   at the end using hipsparseDestroyCsrgemm2Info().
+#ifndef USE_CUDA_NAMES
   interface hipsparseCreateCsrgemm2Info
-#ifdef USE_CUDA_NAMES
-    function hipsparseCreateCsrgemm2Info_(myInfo) bind(c, name="cusparseCreateCsrgemm2Info")
-#else
     function hipsparseCreateCsrgemm2Info_(myInfo) bind(c, name="hipsparseCreateCsrgemm2Info")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -937,18 +918,16 @@ module hipfort_hipsparse
       type(c_ptr) :: myInfo
     end function
   end interface
+#endif
 
   !>  \ingroup aux_module
   !>   \brief Destroy a csrgemm2 info structure.
   !>
   !>   \details
   !>   \p hipsparseDestroyCsrgemm2Info destroys a csrgemm2 info structure.
+#ifndef USE_CUDA_NAMES
   interface hipsparseDestroyCsrgemm2Info
-#ifdef USE_CUDA_NAMES
-    function hipsparseDestroyCsrgemm2Info_(myInfo) bind(c, name="cusparseDestroyCsrgemm2Info")
-#else
     function hipsparseDestroyCsrgemm2Info_(myInfo) bind(c, name="hipsparseDestroyCsrgemm2Info")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -956,6 +935,7 @@ module hipfort_hipsparse
       type(c_ptr),value :: myInfo
     end function
   end interface
+#endif
 
   !>  \ingroup aux_module
   !>   \brief Create a prune info structure.
@@ -1051,12 +1031,9 @@ module hipfort_hipsparse
   !>   \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle is nullptr, \p nnz is negative,
   !>           \p alpha, \p xVal, \p xInd, or \p y is nullptr when \p nnz is greater than zero,
   !>           or \p idxBase is neither `HIPSPARSE_INDEX_BASE_ZERO` nor `HIPSPARSE_INDEX_BASE_ONE`.
+#ifndef USE_CUDA_NAMES
   interface hipsparseSaxpyi
-#ifdef USE_CUDA_NAMES
-    function hipsparseSaxpyi_(handle,nnz,alpha,xVal,xInd,y,idxBase) bind(c, name="cusparseSaxpyi")
-#else
     function hipsparseSaxpyi_(handle,nnz,alpha,xVal,xInd,y,idxBase) bind(c, name="hipsparseSaxpyi")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -1076,13 +1053,11 @@ module hipfort_hipsparse
       hipsparseSaxpyi_rank_1
 #endif
   end interface
-
-  interface hipsparseDaxpyi
-#ifdef USE_CUDA_NAMES
-    function hipsparseDaxpyi_(handle,nnz,alpha,xVal,xInd,y,idxBase) bind(c, name="cusparseDaxpyi")
-#else
-    function hipsparseDaxpyi_(handle,nnz,alpha,xVal,xInd,y,idxBase) bind(c, name="hipsparseDaxpyi")
 #endif
+
+#ifndef USE_CUDA_NAMES
+  interface hipsparseDaxpyi
+    function hipsparseDaxpyi_(handle,nnz,alpha,xVal,xInd,y,idxBase) bind(c, name="hipsparseDaxpyi")
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -1102,13 +1077,11 @@ module hipfort_hipsparse
       hipsparseDaxpyi_rank_1
 #endif
   end interface
-
-  interface hipsparseCaxpyi
-#ifdef USE_CUDA_NAMES
-    function hipsparseCaxpyi_(handle,nnz,alpha,xVal,xInd,y,idxBase) bind(c, name="cusparseCaxpyi")
-#else
-    function hipsparseCaxpyi_(handle,nnz,alpha,xVal,xInd,y,idxBase) bind(c, name="hipsparseCaxpyi")
 #endif
+
+#ifndef USE_CUDA_NAMES
+  interface hipsparseCaxpyi
+    function hipsparseCaxpyi_(handle,nnz,alpha,xVal,xInd,y,idxBase) bind(c, name="hipsparseCaxpyi")
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -1128,13 +1101,11 @@ module hipfort_hipsparse
       hipsparseCaxpyi_rank_1
 #endif
   end interface
-
-  interface hipsparseZaxpyi
-#ifdef USE_CUDA_NAMES
-    function hipsparseZaxpyi_(handle,nnz,alpha,xVal,xInd,y,idxBase) bind(c, name="cusparseZaxpyi")
-#else
-    function hipsparseZaxpyi_(handle,nnz,alpha,xVal,xInd,y,idxBase) bind(c, name="hipsparseZaxpyi")
 #endif
+
+#ifndef USE_CUDA_NAMES
+  interface hipsparseZaxpyi
+    function hipsparseZaxpyi_(handle,nnz,alpha,xVal,xInd,y,idxBase) bind(c, name="hipsparseZaxpyi")
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -1154,6 +1125,7 @@ module hipfort_hipsparse
       hipsparseZaxpyi_rank_1
 #endif
   end interface
+#endif
 
   !>  \ingroup level1_module
   !>   \brief Compute the dot product of a complex conjugate sparse vector with a dense
@@ -1211,14 +1183,10 @@ module hipfort_hipsparse
   !>   \retval HIPSPARSE_STATUS_ALLOC_FAILED the buffer for the dot product reduction
   !>           could not be allocated.
   !>   \retval HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
+#ifndef USE_CUDA_NAMES
   interface hipsparseCdotci
-#ifdef USE_CUDA_NAMES
-    function hipsparseCdotci_(handle,nnz,xVal,xInd,y,myResult,idxBase) &
-        bind(c, name="cusparseCdotci")
-#else
     function hipsparseCdotci_(handle,nnz,xVal,xInd,y,myResult,idxBase) &
         bind(c, name="hipsparseCdotci")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -1238,15 +1206,12 @@ module hipfort_hipsparse
       hipsparseCdotci_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseZdotci
-#ifdef USE_CUDA_NAMES
-    function hipsparseZdotci_(handle,nnz,xVal,xInd,y,myResult,idxBase) &
-        bind(c, name="cusparseZdotci")
-#else
     function hipsparseZdotci_(handle,nnz,xVal,xInd,y,myResult,idxBase) &
         bind(c, name="hipsparseZdotci")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -1266,6 +1231,7 @@ module hipfort_hipsparse
       hipsparseZdotci_rank_1
 #endif
   end interface
+#endif
 
   !>  \ingroup level1_module
   !>   \brief Compute the dot product of a sparse vector with a dense vector.
@@ -1322,12 +1288,9 @@ module hipfort_hipsparse
   !>   \retval HIPSPARSE_STATUS_ALLOC_FAILED the buffer for the dot product reduction
   !>           could not be allocated.
   !>   \retval HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
+#ifndef USE_CUDA_NAMES
   interface hipsparseSdoti
-#ifdef USE_CUDA_NAMES
-    function hipsparseSdoti_(handle,nnz,xVal,xInd,y,myResult,idxBase) bind(c, name="cusparseSdoti")
-#else
     function hipsparseSdoti_(handle,nnz,xVal,xInd,y,myResult,idxBase) bind(c, name="hipsparseSdoti")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -1347,13 +1310,11 @@ module hipfort_hipsparse
       hipsparseSdoti_rank_1
 #endif
   end interface
-
-  interface hipsparseDdoti
-#ifdef USE_CUDA_NAMES
-    function hipsparseDdoti_(handle,nnz,xVal,xInd,y,myResult,idxBase) bind(c, name="cusparseDdoti")
-#else
-    function hipsparseDdoti_(handle,nnz,xVal,xInd,y,myResult,idxBase) bind(c, name="hipsparseDdoti")
 #endif
+
+#ifndef USE_CUDA_NAMES
+  interface hipsparseDdoti
+    function hipsparseDdoti_(handle,nnz,xVal,xInd,y,myResult,idxBase) bind(c, name="hipsparseDdoti")
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -1373,13 +1334,11 @@ module hipfort_hipsparse
       hipsparseDdoti_rank_1
 #endif
   end interface
-
-  interface hipsparseCdoti
-#ifdef USE_CUDA_NAMES
-    function hipsparseCdoti_(handle,nnz,xVal,xInd,y,myResult,idxBase) bind(c, name="cusparseCdoti")
-#else
-    function hipsparseCdoti_(handle,nnz,xVal,xInd,y,myResult,idxBase) bind(c, name="hipsparseCdoti")
 #endif
+
+#ifndef USE_CUDA_NAMES
+  interface hipsparseCdoti
+    function hipsparseCdoti_(handle,nnz,xVal,xInd,y,myResult,idxBase) bind(c, name="hipsparseCdoti")
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -1399,13 +1358,11 @@ module hipfort_hipsparse
       hipsparseCdoti_rank_1
 #endif
   end interface
-
-  interface hipsparseZdoti
-#ifdef USE_CUDA_NAMES
-    function hipsparseZdoti_(handle,nnz,xVal,xInd,y,myResult,idxBase) bind(c, name="cusparseZdoti")
-#else
-    function hipsparseZdoti_(handle,nnz,xVal,xInd,y,myResult,idxBase) bind(c, name="hipsparseZdoti")
 #endif
+
+#ifndef USE_CUDA_NAMES
+  interface hipsparseZdoti
+    function hipsparseZdoti_(handle,nnz,xVal,xInd,y,myResult,idxBase) bind(c, name="hipsparseZdoti")
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -1425,6 +1382,7 @@ module hipfort_hipsparse
       hipsparseZdoti_rank_1
 #endif
   end interface
+#endif
 
   !>  \ingroup level1_module
   !>   \brief Gather elements from a dense vector and store them in a sparse vector.
@@ -1472,12 +1430,9 @@ module hipfort_hipsparse
   !>   \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle is nullptr, \p nnz is negative,
   !>           \p y, \p xVal, or \p xInd is nullptr when \p nnz is greater than zero, or \p idxBase
   !>           is neither `HIPSPARSE_INDEX_BASE_ZERO` nor `HIPSPARSE_INDEX_BASE_ONE`.
+#ifndef USE_CUDA_NAMES
   interface hipsparseSgthr
-#ifdef USE_CUDA_NAMES
-    function hipsparseSgthr_(handle,nnz,y,xVal,xInd,idxBase) bind(c, name="cusparseSgthr")
-#else
     function hipsparseSgthr_(handle,nnz,y,xVal,xInd,idxBase) bind(c, name="hipsparseSgthr")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -1496,13 +1451,11 @@ module hipfort_hipsparse
       hipsparseSgthr_rank_1
 #endif
   end interface
-
-  interface hipsparseDgthr
-#ifdef USE_CUDA_NAMES
-    function hipsparseDgthr_(handle,nnz,y,xVal,xInd,idxBase) bind(c, name="cusparseDgthr")
-#else
-    function hipsparseDgthr_(handle,nnz,y,xVal,xInd,idxBase) bind(c, name="hipsparseDgthr")
 #endif
+
+#ifndef USE_CUDA_NAMES
+  interface hipsparseDgthr
+    function hipsparseDgthr_(handle,nnz,y,xVal,xInd,idxBase) bind(c, name="hipsparseDgthr")
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -1521,13 +1474,11 @@ module hipfort_hipsparse
       hipsparseDgthr_rank_1
 #endif
   end interface
-
-  interface hipsparseCgthr
-#ifdef USE_CUDA_NAMES
-    function hipsparseCgthr_(handle,nnz,y,xVal,xInd,idxBase) bind(c, name="cusparseCgthr")
-#else
-    function hipsparseCgthr_(handle,nnz,y,xVal,xInd,idxBase) bind(c, name="hipsparseCgthr")
 #endif
+
+#ifndef USE_CUDA_NAMES
+  interface hipsparseCgthr
+    function hipsparseCgthr_(handle,nnz,y,xVal,xInd,idxBase) bind(c, name="hipsparseCgthr")
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -1546,13 +1497,11 @@ module hipfort_hipsparse
       hipsparseCgthr_rank_1
 #endif
   end interface
-
-  interface hipsparseZgthr
-#ifdef USE_CUDA_NAMES
-    function hipsparseZgthr_(handle,nnz,y,xVal,xInd,idxBase) bind(c, name="cusparseZgthr")
-#else
-    function hipsparseZgthr_(handle,nnz,y,xVal,xInd,idxBase) bind(c, name="hipsparseZgthr")
 #endif
+
+#ifndef USE_CUDA_NAMES
+  interface hipsparseZgthr
+    function hipsparseZgthr_(handle,nnz,y,xVal,xInd,idxBase) bind(c, name="hipsparseZgthr")
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -1571,6 +1520,7 @@ module hipfort_hipsparse
       hipsparseZgthr_rank_1
 #endif
   end interface
+#endif
 
   !>  \ingroup level1_module
   !>   \brief Gather and zero out elements from a dense vector and store them in a sparse
@@ -1622,12 +1572,9 @@ module hipfort_hipsparse
   !>   \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle is nullptr, \p nnz is negative,
   !>           \p y, \p xVal, or \p xInd is nullptr when \p nnz is greater than zero, or \p idxBase
   !>           is neither `HIPSPARSE_INDEX_BASE_ZERO` nor `HIPSPARSE_INDEX_BASE_ONE`.
+#ifndef USE_CUDA_NAMES
   interface hipsparseSgthrz
-#ifdef USE_CUDA_NAMES
-    function hipsparseSgthrz_(handle,nnz,y,xVal,xInd,idxBase) bind(c, name="cusparseSgthrz")
-#else
     function hipsparseSgthrz_(handle,nnz,y,xVal,xInd,idxBase) bind(c, name="hipsparseSgthrz")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -1646,13 +1593,11 @@ module hipfort_hipsparse
       hipsparseSgthrz_rank_1
 #endif
   end interface
-
-  interface hipsparseDgthrz
-#ifdef USE_CUDA_NAMES
-    function hipsparseDgthrz_(handle,nnz,y,xVal,xInd,idxBase) bind(c, name="cusparseDgthrz")
-#else
-    function hipsparseDgthrz_(handle,nnz,y,xVal,xInd,idxBase) bind(c, name="hipsparseDgthrz")
 #endif
+
+#ifndef USE_CUDA_NAMES
+  interface hipsparseDgthrz
+    function hipsparseDgthrz_(handle,nnz,y,xVal,xInd,idxBase) bind(c, name="hipsparseDgthrz")
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -1671,13 +1616,11 @@ module hipfort_hipsparse
       hipsparseDgthrz_rank_1
 #endif
   end interface
-
-  interface hipsparseCgthrz
-#ifdef USE_CUDA_NAMES
-    function hipsparseCgthrz_(handle,nnz,y,xVal,xInd,idxBase) bind(c, name="cusparseCgthrz")
-#else
-    function hipsparseCgthrz_(handle,nnz,y,xVal,xInd,idxBase) bind(c, name="hipsparseCgthrz")
 #endif
+
+#ifndef USE_CUDA_NAMES
+  interface hipsparseCgthrz
+    function hipsparseCgthrz_(handle,nnz,y,xVal,xInd,idxBase) bind(c, name="hipsparseCgthrz")
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -1696,13 +1639,11 @@ module hipfort_hipsparse
       hipsparseCgthrz_rank_1
 #endif
   end interface
-
-  interface hipsparseZgthrz
-#ifdef USE_CUDA_NAMES
-    function hipsparseZgthrz_(handle,nnz,y,xVal,xInd,idxBase) bind(c, name="cusparseZgthrz")
-#else
-    function hipsparseZgthrz_(handle,nnz,y,xVal,xInd,idxBase) bind(c, name="hipsparseZgthrz")
 #endif
+
+#ifndef USE_CUDA_NAMES
+  interface hipsparseZgthrz
+    function hipsparseZgthrz_(handle,nnz,y,xVal,xInd,idxBase) bind(c, name="hipsparseZgthrz")
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -1721,6 +1662,7 @@ module hipfort_hipsparse
       hipsparseZgthrz_rank_1
 #endif
   end interface
+#endif
 
   !>  \ingroup level1_module
   !>   \brief Apply the Givens rotation to a dense and a sparse vector.
@@ -1780,12 +1722,9 @@ module hipfort_hipsparse
   !>   negative,
   !>           \p xVal, \p xInd, or \p y is nullptr when \p nnz is greater than zero, or \p idxBase
   !>           is neither `HIPSPARSE_INDEX_BASE_ZERO` nor `HIPSPARSE_INDEX_BASE_ONE`.
+#ifndef USE_CUDA_NAMES
   interface hipsparseSroti
-#ifdef USE_CUDA_NAMES
-    function hipsparseSroti_(handle,nnz,xVal,xInd,y,c,s,idxBase) bind(c, name="cusparseSroti")
-#else
     function hipsparseSroti_(handle,nnz,xVal,xInd,y,c,s,idxBase) bind(c, name="hipsparseSroti")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -1806,13 +1745,11 @@ module hipfort_hipsparse
       hipsparseSroti_rank_1
 #endif
   end interface
-
-  interface hipsparseDroti
-#ifdef USE_CUDA_NAMES
-    function hipsparseDroti_(handle,nnz,xVal,xInd,y,c,s,idxBase) bind(c, name="cusparseDroti")
-#else
-    function hipsparseDroti_(handle,nnz,xVal,xInd,y,c,s,idxBase) bind(c, name="hipsparseDroti")
 #endif
+
+#ifndef USE_CUDA_NAMES
+  interface hipsparseDroti
+    function hipsparseDroti_(handle,nnz,xVal,xInd,y,c,s,idxBase) bind(c, name="hipsparseDroti")
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -1833,6 +1770,7 @@ module hipfort_hipsparse
       hipsparseDroti_rank_1
 #endif
   end interface
+#endif
 
   !>  \ingroup level1_module
   !>   \brief Scatter elements from a dense vector across a sparse vector.
@@ -1882,12 +1820,9 @@ module hipfort_hipsparse
   !>   \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle is nullptr, \p nnz is negative,
   !>           \p xVal, \p xInd, or \p y is nullptr when \p nnz is greater than zero, or \p idxBase
   !>           is neither `HIPSPARSE_INDEX_BASE_ZERO` nor `HIPSPARSE_INDEX_BASE_ONE`.
+#ifndef USE_CUDA_NAMES
   interface hipsparseSsctr
-#ifdef USE_CUDA_NAMES
-    function hipsparseSsctr_(handle,nnz,xVal,xInd,y,idxBase) bind(c, name="cusparseSsctr")
-#else
     function hipsparseSsctr_(handle,nnz,xVal,xInd,y,idxBase) bind(c, name="hipsparseSsctr")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -1906,13 +1841,11 @@ module hipfort_hipsparse
       hipsparseSsctr_rank_1
 #endif
   end interface
-
-  interface hipsparseDsctr
-#ifdef USE_CUDA_NAMES
-    function hipsparseDsctr_(handle,nnz,xVal,xInd,y,idxBase) bind(c, name="cusparseDsctr")
-#else
-    function hipsparseDsctr_(handle,nnz,xVal,xInd,y,idxBase) bind(c, name="hipsparseDsctr")
 #endif
+
+#ifndef USE_CUDA_NAMES
+  interface hipsparseDsctr
+    function hipsparseDsctr_(handle,nnz,xVal,xInd,y,idxBase) bind(c, name="hipsparseDsctr")
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -1931,13 +1864,11 @@ module hipfort_hipsparse
       hipsparseDsctr_rank_1
 #endif
   end interface
-
-  interface hipsparseCsctr
-#ifdef USE_CUDA_NAMES
-    function hipsparseCsctr_(handle,nnz,xVal,xInd,y,idxBase) bind(c, name="cusparseCsctr")
-#else
-    function hipsparseCsctr_(handle,nnz,xVal,xInd,y,idxBase) bind(c, name="hipsparseCsctr")
 #endif
+
+#ifndef USE_CUDA_NAMES
+  interface hipsparseCsctr
+    function hipsparseCsctr_(handle,nnz,xVal,xInd,y,idxBase) bind(c, name="hipsparseCsctr")
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -1956,13 +1887,11 @@ module hipfort_hipsparse
       hipsparseCsctr_rank_1
 #endif
   end interface
-
-  interface hipsparseZsctr
-#ifdef USE_CUDA_NAMES
-    function hipsparseZsctr_(handle,nnz,xVal,xInd,y,idxBase) bind(c, name="cusparseZsctr")
-#else
-    function hipsparseZsctr_(handle,nnz,xVal,xInd,y,idxBase) bind(c, name="hipsparseZsctr")
 #endif
+
+#ifndef USE_CUDA_NAMES
+  interface hipsparseZsctr
+    function hipsparseZsctr_(handle,nnz,xVal,xInd,y,idxBase) bind(c, name="hipsparseZsctr")
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -1981,6 +1910,7 @@ module hipfort_hipsparse
       hipsparseZsctr_rank_1
 #endif
   end interface
+#endif
 
   !>  \ingroup level2_module
   !>   \brief Sparse matrix vector multiplication using the BSR storage format.
@@ -2482,16 +2412,11 @@ module hipfort_hipsparse
   !>   \retval     HIPSPARSE_STATUS_NOT_SUPPORTED
   !>               \p transA == `HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE` or
   !>               `hipsparseMatrixType_t` != `HIPSPARSE_MATRIX_TYPE_GENERAL`.
+#ifndef USE_CUDA_NAMES
   interface hipsparseSbsrsv2_bufferSizeExt
-#ifdef USE_CUDA_NAMES
-    function hipsparseSbsrsv2_bufferSizeExt_(handle,dirA,transA,mb,nnzb,descrA,bsrSortedValA, &
-        bsrSortedRowPtrA,bsrSortedColIndA,blockDim,myInfo,pBufferSizeInBytes) &
-        bind(c, name="cusparseSbsrsv2_bufferSizeExt")
-#else
     function hipsparseSbsrsv2_bufferSizeExt_(handle,dirA,transA,mb,nnzb,descrA,bsrSortedValA, &
         bsrSortedRowPtrA,bsrSortedColIndA,blockDim,myInfo,pBufferSizeInBytes) &
         bind(c, name="hipsparseSbsrsv2_bufferSizeExt")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -2516,17 +2441,13 @@ module hipfort_hipsparse
       hipsparseSbsrsv2_bufferSizeExt_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseDbsrsv2_bufferSizeExt
-#ifdef USE_CUDA_NAMES
-    function hipsparseDbsrsv2_bufferSizeExt_(handle,dirA,transA,mb,nnzb,descrA,bsrSortedValA, &
-        bsrSortedRowPtrA,bsrSortedColIndA,blockDim,myInfo,pBufferSizeInBytes) &
-        bind(c, name="cusparseDbsrsv2_bufferSizeExt")
-#else
     function hipsparseDbsrsv2_bufferSizeExt_(handle,dirA,transA,mb,nnzb,descrA,bsrSortedValA, &
         bsrSortedRowPtrA,bsrSortedColIndA,blockDim,myInfo,pBufferSizeInBytes) &
         bind(c, name="hipsparseDbsrsv2_bufferSizeExt")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -2551,17 +2472,13 @@ module hipfort_hipsparse
       hipsparseDbsrsv2_bufferSizeExt_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseCbsrsv2_bufferSizeExt
-#ifdef USE_CUDA_NAMES
-    function hipsparseCbsrsv2_bufferSizeExt_(handle,dirA,transA,mb,nnzb,descrA,bsrSortedValA, &
-        bsrSortedRowPtrA,bsrSortedColIndA,blockDim,myInfo,pBufferSizeInBytes) &
-        bind(c, name="cusparseCbsrsv2_bufferSizeExt")
-#else
     function hipsparseCbsrsv2_bufferSizeExt_(handle,dirA,transA,mb,nnzb,descrA,bsrSortedValA, &
         bsrSortedRowPtrA,bsrSortedColIndA,blockDim,myInfo,pBufferSizeInBytes) &
         bind(c, name="hipsparseCbsrsv2_bufferSizeExt")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -2586,17 +2503,13 @@ module hipfort_hipsparse
       hipsparseCbsrsv2_bufferSizeExt_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseZbsrsv2_bufferSizeExt
-#ifdef USE_CUDA_NAMES
-    function hipsparseZbsrsv2_bufferSizeExt_(handle,dirA,transA,mb,nnzb,descrA,bsrSortedValA, &
-        bsrSortedRowPtrA,bsrSortedColIndA,blockDim,myInfo,pBufferSizeInBytes) &
-        bind(c, name="cusparseZbsrsv2_bufferSizeExt")
-#else
     function hipsparseZbsrsv2_bufferSizeExt_(handle,dirA,transA,mb,nnzb,descrA,bsrSortedValA, &
         bsrSortedRowPtrA,bsrSortedColIndA,blockDim,myInfo,pBufferSizeInBytes) &
         bind(c, name="hipsparseZbsrsv2_bufferSizeExt")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -2621,6 +2534,7 @@ module hipfort_hipsparse
       hipsparseZbsrsv2_bufferSizeExt_rank_1
 #endif
   end interface
+#endif
 
   !>  \ingroup level2_module
   !>   \details
@@ -3436,16 +3350,11 @@ module hipfort_hipsparse
   !>   \retval HIPSPARSE_STATUS_ARCH_MISMATCH the device is not supported.
   !>   \retval HIPSPARSE_STATUS_NOT_SUPPORTED `hipsparseMatrixType_t` is not
   !>           `HIPSPARSE_MATRIX_TYPE_GENERAL`.
+#ifndef USE_CUDA_NAMES
   interface hipsparseScsrmv
-#ifdef USE_CUDA_NAMES
-    function hipsparseScsrmv_(handle,transA,m,n,nnz,alpha,descrA,csrSortedValA,csrSortedRowPtrA, &
-        csrSortedColIndA,x,beta,y) &
-        bind(c, name="cusparseScsrmv")
-#else
     function hipsparseScsrmv_(handle,transA,m,n,nnz,alpha,descrA,csrSortedValA,csrSortedRowPtrA, &
         csrSortedColIndA,x,beta,y) &
         bind(c, name="hipsparseScsrmv")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -3471,17 +3380,13 @@ module hipfort_hipsparse
       hipsparseScsrmv_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseDcsrmv
-#ifdef USE_CUDA_NAMES
-    function hipsparseDcsrmv_(handle,transA,m,n,nnz,alpha,descrA,csrSortedValA,csrSortedRowPtrA, &
-        csrSortedColIndA,x,beta,y) &
-        bind(c, name="cusparseDcsrmv")
-#else
     function hipsparseDcsrmv_(handle,transA,m,n,nnz,alpha,descrA,csrSortedValA,csrSortedRowPtrA, &
         csrSortedColIndA,x,beta,y) &
         bind(c, name="hipsparseDcsrmv")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -3507,17 +3412,13 @@ module hipfort_hipsparse
       hipsparseDcsrmv_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseCcsrmv
-#ifdef USE_CUDA_NAMES
-    function hipsparseCcsrmv_(handle,transA,m,n,nnz,alpha,descrA,csrSortedValA,csrSortedRowPtrA, &
-        csrSortedColIndA,x,beta,y) &
-        bind(c, name="cusparseCcsrmv")
-#else
     function hipsparseCcsrmv_(handle,transA,m,n,nnz,alpha,descrA,csrSortedValA,csrSortedRowPtrA, &
         csrSortedColIndA,x,beta,y) &
         bind(c, name="hipsparseCcsrmv")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -3543,17 +3444,13 @@ module hipfort_hipsparse
       hipsparseCcsrmv_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseZcsrmv
-#ifdef USE_CUDA_NAMES
-    function hipsparseZcsrmv_(handle,transA,m,n,nnz,alpha,descrA,csrSortedValA,csrSortedRowPtrA, &
-        csrSortedColIndA,x,beta,y) &
-        bind(c, name="cusparseZcsrmv")
-#else
     function hipsparseZcsrmv_(handle,transA,m,n,nnz,alpha,descrA,csrSortedValA,csrSortedRowPtrA, &
         csrSortedColIndA,x,beta,y) &
         bind(c, name="hipsparseZcsrmv")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -3579,6 +3476,7 @@ module hipfort_hipsparse
       hipsparseZcsrmv_rank_1
 #endif
   end interface
+#endif
 
   !>  \ingroup level2_module
   !>   \details
@@ -3610,14 +3508,10 @@ module hipfort_hipsparse
   !>   \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p info, or \p position is nullptr.
   !>   \retval HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
   !>   \retval HIPSPARSE_STATUS_ZERO_PIVOT zero pivot has been found.
+#ifndef USE_CUDA_NAMES
   interface hipsparseXcsrsv2_zeroPivot
-#ifdef USE_CUDA_NAMES
-    function hipsparseXcsrsv2_zeroPivot_(handle,myInfo,position) &
-        bind(c, name="cusparseXcsrsv2_zeroPivot")
-#else
     function hipsparseXcsrsv2_zeroPivot_(handle,myInfo,position) &
         bind(c, name="hipsparseXcsrsv2_zeroPivot")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -3627,6 +3521,7 @@ module hipfort_hipsparse
       integer(c_int) :: position
     end function
   end interface
+#endif
 
   !>  \ingroup level2_module
   !>   \details
@@ -3668,16 +3563,11 @@ module hipfort_hipsparse
   !>   \retval     HIPSPARSE_STATUS_NOT_SUPPORTED
   !>               \p transA == `HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE` or
   !>               `hipsparseMatrixType_t` != `HIPSPARSE_MATRIX_TYPE_GENERAL`.
+#ifndef USE_CUDA_NAMES
   interface hipsparseScsrsv2_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsparseScsrsv2_bufferSize_(handle,transA,m,nnz,descrA,csrSortedValA, &
-        csrSortedRowPtrA,csrSortedColIndA,myInfo,pBufferSizeInBytes) &
-        bind(c, name="cusparseScsrsv2_bufferSize")
-#else
     function hipsparseScsrsv2_bufferSize_(handle,transA,m,nnz,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,pBufferSizeInBytes) &
         bind(c, name="hipsparseScsrsv2_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -3700,17 +3590,13 @@ module hipfort_hipsparse
       hipsparseScsrsv2_bufferSize_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseDcsrsv2_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsparseDcsrsv2_bufferSize_(handle,transA,m,nnz,descrA,csrSortedValA, &
-        csrSortedRowPtrA,csrSortedColIndA,myInfo,pBufferSizeInBytes) &
-        bind(c, name="cusparseDcsrsv2_bufferSize")
-#else
     function hipsparseDcsrsv2_bufferSize_(handle,transA,m,nnz,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,pBufferSizeInBytes) &
         bind(c, name="hipsparseDcsrsv2_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -3733,17 +3619,13 @@ module hipfort_hipsparse
       hipsparseDcsrsv2_bufferSize_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseCcsrsv2_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsparseCcsrsv2_bufferSize_(handle,transA,m,nnz,descrA,csrSortedValA, &
-        csrSortedRowPtrA,csrSortedColIndA,myInfo,pBufferSizeInBytes) &
-        bind(c, name="cusparseCcsrsv2_bufferSize")
-#else
     function hipsparseCcsrsv2_bufferSize_(handle,transA,m,nnz,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,pBufferSizeInBytes) &
         bind(c, name="hipsparseCcsrsv2_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -3766,17 +3648,13 @@ module hipfort_hipsparse
       hipsparseCcsrsv2_bufferSize_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseZcsrsv2_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsparseZcsrsv2_bufferSize_(handle,transA,m,nnz,descrA,csrSortedValA, &
-        csrSortedRowPtrA,csrSortedColIndA,myInfo,pBufferSizeInBytes) &
-        bind(c, name="cusparseZcsrsv2_bufferSize")
-#else
     function hipsparseZcsrsv2_bufferSize_(handle,transA,m,nnz,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,pBufferSizeInBytes) &
         bind(c, name="hipsparseZcsrsv2_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -3799,6 +3677,7 @@ module hipfort_hipsparse
       hipsparseZcsrsv2_bufferSize_rank_1
 #endif
   end interface
+#endif
 
   !>  \ingroup level2_module
   !>   \details
@@ -3840,16 +3719,11 @@ module hipfort_hipsparse
   !>   \retval     HIPSPARSE_STATUS_NOT_SUPPORTED
   !>               \p transA == `HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE` or
   !>               `hipsparseMatrixType_t` != `HIPSPARSE_MATRIX_TYPE_GENERAL`.
+#ifndef USE_CUDA_NAMES
   interface hipsparseScsrsv2_bufferSizeExt
-#ifdef USE_CUDA_NAMES
-    function hipsparseScsrsv2_bufferSizeExt_(handle,transA,m,nnz,descrA,csrSortedValA, &
-        csrSortedRowPtrA,csrSortedColIndA,myInfo,pBufferSizeInBytes) &
-        bind(c, name="cusparseScsrsv2_bufferSizeExt")
-#else
     function hipsparseScsrsv2_bufferSizeExt_(handle,transA,m,nnz,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,pBufferSizeInBytes) &
         bind(c, name="hipsparseScsrsv2_bufferSizeExt")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -3872,17 +3746,13 @@ module hipfort_hipsparse
       hipsparseScsrsv2_bufferSizeExt_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseDcsrsv2_bufferSizeExt
-#ifdef USE_CUDA_NAMES
-    function hipsparseDcsrsv2_bufferSizeExt_(handle,transA,m,nnz,descrA,csrSortedValA, &
-        csrSortedRowPtrA,csrSortedColIndA,myInfo,pBufferSizeInBytes) &
-        bind(c, name="cusparseDcsrsv2_bufferSizeExt")
-#else
     function hipsparseDcsrsv2_bufferSizeExt_(handle,transA,m,nnz,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,pBufferSizeInBytes) &
         bind(c, name="hipsparseDcsrsv2_bufferSizeExt")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -3905,17 +3775,13 @@ module hipfort_hipsparse
       hipsparseDcsrsv2_bufferSizeExt_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseCcsrsv2_bufferSizeExt
-#ifdef USE_CUDA_NAMES
-    function hipsparseCcsrsv2_bufferSizeExt_(handle,transA,m,nnz,descrA,csrSortedValA, &
-        csrSortedRowPtrA,csrSortedColIndA,myInfo,pBufferSizeInBytes) &
-        bind(c, name="cusparseCcsrsv2_bufferSizeExt")
-#else
     function hipsparseCcsrsv2_bufferSizeExt_(handle,transA,m,nnz,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,pBufferSizeInBytes) &
         bind(c, name="hipsparseCcsrsv2_bufferSizeExt")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -3938,17 +3804,13 @@ module hipfort_hipsparse
       hipsparseCcsrsv2_bufferSizeExt_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseZcsrsv2_bufferSizeExt
-#ifdef USE_CUDA_NAMES
-    function hipsparseZcsrsv2_bufferSizeExt_(handle,transA,m,nnz,descrA,csrSortedValA, &
-        csrSortedRowPtrA,csrSortedColIndA,myInfo,pBufferSizeInBytes) &
-        bind(c, name="cusparseZcsrsv2_bufferSizeExt")
-#else
     function hipsparseZcsrsv2_bufferSizeExt_(handle,transA,m,nnz,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,pBufferSizeInBytes) &
         bind(c, name="hipsparseZcsrsv2_bufferSizeExt")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -3971,6 +3833,7 @@ module hipfort_hipsparse
       hipsparseZcsrsv2_bufferSizeExt_rank_1
 #endif
   end interface
+#endif
 
   !>  \ingroup level2_module
   !>   \details
@@ -4018,16 +3881,11 @@ module hipfort_hipsparse
   !>   \retval     HIPSPARSE_STATUS_NOT_SUPPORTED
   !>               \p transA == `HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE` or
   !>               `hipsparseMatrixType_t` != `HIPSPARSE_MATRIX_TYPE_GENERAL`.
+#ifndef USE_CUDA_NAMES
   interface hipsparseScsrsv2_analysis
-#ifdef USE_CUDA_NAMES
-    function hipsparseScsrsv2_analysis_(handle,transA,m,nnz,descrA,csrSortedValA,csrSortedRowPtrA, &
-        csrSortedColIndA,myInfo,policy,pBuffer) &
-        bind(c, name="cusparseScsrsv2_analysis")
-#else
     function hipsparseScsrsv2_analysis_(handle,transA,m,nnz,descrA,csrSortedValA,csrSortedRowPtrA, &
         csrSortedColIndA,myInfo,policy,pBuffer) &
         bind(c, name="hipsparseScsrsv2_analysis")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -4051,17 +3909,13 @@ module hipfort_hipsparse
       hipsparseScsrsv2_analysis_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseDcsrsv2_analysis
-#ifdef USE_CUDA_NAMES
-    function hipsparseDcsrsv2_analysis_(handle,transA,m,nnz,descrA,csrSortedValA,csrSortedRowPtrA, &
-        csrSortedColIndA,myInfo,policy,pBuffer) &
-        bind(c, name="cusparseDcsrsv2_analysis")
-#else
     function hipsparseDcsrsv2_analysis_(handle,transA,m,nnz,descrA,csrSortedValA,csrSortedRowPtrA, &
         csrSortedColIndA,myInfo,policy,pBuffer) &
         bind(c, name="hipsparseDcsrsv2_analysis")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -4085,17 +3939,13 @@ module hipfort_hipsparse
       hipsparseDcsrsv2_analysis_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseCcsrsv2_analysis
-#ifdef USE_CUDA_NAMES
-    function hipsparseCcsrsv2_analysis_(handle,transA,m,nnz,descrA,csrSortedValA,csrSortedRowPtrA, &
-        csrSortedColIndA,myInfo,policy,pBuffer) &
-        bind(c, name="cusparseCcsrsv2_analysis")
-#else
     function hipsparseCcsrsv2_analysis_(handle,transA,m,nnz,descrA,csrSortedValA,csrSortedRowPtrA, &
         csrSortedColIndA,myInfo,policy,pBuffer) &
         bind(c, name="hipsparseCcsrsv2_analysis")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -4119,17 +3969,13 @@ module hipfort_hipsparse
       hipsparseCcsrsv2_analysis_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseZcsrsv2_analysis
-#ifdef USE_CUDA_NAMES
-    function hipsparseZcsrsv2_analysis_(handle,transA,m,nnz,descrA,csrSortedValA,csrSortedRowPtrA, &
-        csrSortedColIndA,myInfo,policy,pBuffer) &
-        bind(c, name="cusparseZcsrsv2_analysis")
-#else
     function hipsparseZcsrsv2_analysis_(handle,transA,m,nnz,descrA,csrSortedValA,csrSortedRowPtrA, &
         csrSortedColIndA,myInfo,policy,pBuffer) &
         bind(c, name="hipsparseZcsrsv2_analysis")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -4153,6 +3999,7 @@ module hipfort_hipsparse
       hipsparseZcsrsv2_analysis_rank_1
 #endif
   end interface
+#endif
 
   !>  \ingroup level2_module
   !>   \brief Sparse triangular solve using the CSR storage format
@@ -4270,16 +4117,11 @@ module hipfort_hipsparse
   !>   \retval     HIPSPARSE_STATUS_NOT_SUPPORTED
   !>               \p transA == `HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE` or
   !>               `hipsparseMatrixType_t` != `HIPSPARSE_MATRIX_TYPE_GENERAL`.
+#ifndef USE_CUDA_NAMES
   interface hipsparseScsrsv2_solve
-#ifdef USE_CUDA_NAMES
-    function hipsparseScsrsv2_solve_(handle,transA,m,nnz,alpha,descrA,csrSortedValA, &
-        csrSortedRowPtrA,csrSortedColIndA,myInfo,f,x,policy,pBuffer) &
-        bind(c, name="cusparseScsrsv2_solve")
-#else
     function hipsparseScsrsv2_solve_(handle,transA,m,nnz,alpha,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,f,x,policy,pBuffer) &
         bind(c, name="hipsparseScsrsv2_solve")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -4306,17 +4148,13 @@ module hipfort_hipsparse
       hipsparseScsrsv2_solve_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseDcsrsv2_solve
-#ifdef USE_CUDA_NAMES
-    function hipsparseDcsrsv2_solve_(handle,transA,m,nnz,alpha,descrA,csrSortedValA, &
-        csrSortedRowPtrA,csrSortedColIndA,myInfo,f,x,policy,pBuffer) &
-        bind(c, name="cusparseDcsrsv2_solve")
-#else
     function hipsparseDcsrsv2_solve_(handle,transA,m,nnz,alpha,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,f,x,policy,pBuffer) &
         bind(c, name="hipsparseDcsrsv2_solve")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -4343,17 +4181,13 @@ module hipfort_hipsparse
       hipsparseDcsrsv2_solve_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseCcsrsv2_solve
-#ifdef USE_CUDA_NAMES
-    function hipsparseCcsrsv2_solve_(handle,transA,m,nnz,alpha,descrA,csrSortedValA, &
-        csrSortedRowPtrA,csrSortedColIndA,myInfo,f,x,policy,pBuffer) &
-        bind(c, name="cusparseCcsrsv2_solve")
-#else
     function hipsparseCcsrsv2_solve_(handle,transA,m,nnz,alpha,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,f,x,policy,pBuffer) &
         bind(c, name="hipsparseCcsrsv2_solve")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -4380,17 +4214,13 @@ module hipfort_hipsparse
       hipsparseCcsrsv2_solve_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseZcsrsv2_solve
-#ifdef USE_CUDA_NAMES
-    function hipsparseZcsrsv2_solve_(handle,transA,m,nnz,alpha,descrA,csrSortedValA, &
-        csrSortedRowPtrA,csrSortedColIndA,myInfo,f,x,policy,pBuffer) &
-        bind(c, name="cusparseZcsrsv2_solve")
-#else
     function hipsparseZcsrsv2_solve_(handle,transA,m,nnz,alpha,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,f,x,policy,pBuffer) &
         bind(c, name="hipsparseZcsrsv2_solve")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -4417,6 +4247,7 @@ module hipfort_hipsparse
       hipsparseZcsrsv2_solve_rank_1
 #endif
   end interface
+#endif
 
   !>  \ingroup level2_module
   !>   \details
@@ -4801,14 +4632,10 @@ module hipfort_hipsparse
   !>   \retval HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
   !>   \retval HIPSPARSE_STATUS_NOT_SUPPORTED \p transA is not `HIPSPARSE_OPERATION_NON_TRANSPOSE`
   !>           or `hipsparseMatrixType_t` is not `HIPSPARSE_MATRIX_TYPE_GENERAL`.
+#ifndef USE_CUDA_NAMES
   interface hipsparseShybmv
-#ifdef USE_CUDA_NAMES
-    function hipsparseShybmv_(handle,transA,alpha,descrA,hybA,x,beta,y) &
-        bind(c, name="cusparseShybmv")
-#else
     function hipsparseShybmv_(handle,transA,alpha,descrA,hybA,x,beta,y) &
         bind(c, name="hipsparseShybmv")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -4829,15 +4656,12 @@ module hipfort_hipsparse
       hipsparseShybmv_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseDhybmv
-#ifdef USE_CUDA_NAMES
-    function hipsparseDhybmv_(handle,transA,alpha,descrA,hybA,x,beta,y) &
-        bind(c, name="cusparseDhybmv")
-#else
     function hipsparseDhybmv_(handle,transA,alpha,descrA,hybA,x,beta,y) &
         bind(c, name="hipsparseDhybmv")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -4858,15 +4682,12 @@ module hipfort_hipsparse
       hipsparseDhybmv_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseChybmv
-#ifdef USE_CUDA_NAMES
-    function hipsparseChybmv_(handle,transA,alpha,descrA,hybA,x,beta,y) &
-        bind(c, name="cusparseChybmv")
-#else
     function hipsparseChybmv_(handle,transA,alpha,descrA,hybA,x,beta,y) &
         bind(c, name="hipsparseChybmv")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -4887,15 +4708,12 @@ module hipfort_hipsparse
       hipsparseChybmv_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseZhybmv
-#ifdef USE_CUDA_NAMES
-    function hipsparseZhybmv_(handle,transA,alpha,descrA,hybA,x,beta,y) &
-        bind(c, name="cusparseZhybmv")
-#else
     function hipsparseZhybmv_(handle,transA,alpha,descrA,hybA,x,beta,y) &
         bind(c, name="hipsparseZhybmv")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -4916,6 +4734,7 @@ module hipfort_hipsparse
       hipsparseZhybmv_rank_1
 #endif
   end interface
+#endif
 
   !>  \ingroup level3_module
   !>   \brief Sparse matrix dense matrix multiplication using the BSR storage format.
@@ -6192,16 +6011,11 @@ module hipfort_hipsparse
   !>   \retval HIPSPARSE_STATUS_ARCH_MISMATCH the device is not supported.
   !>   \retval HIPSPARSE_STATUS_NOT_SUPPORTED `hipsparseMatrixType_t` is not
   !>           `HIPSPARSE_MATRIX_TYPE_GENERAL`.
+#ifndef USE_CUDA_NAMES
   interface hipsparseScsrmm
-#ifdef USE_CUDA_NAMES
-    function hipsparseScsrmm_(handle,transA,m,n,k,nnz,alpha,descrA,csrSortedValA,csrSortedRowPtrA, &
-        csrSortedColIndA,B,ldb,beta,C,ldc) &
-        bind(c, name="cusparseScsrmm")
-#else
     function hipsparseScsrmm_(handle,transA,m,n,k,nnz,alpha,descrA,csrSortedValA,csrSortedRowPtrA, &
         csrSortedColIndA,B,ldb,beta,C,ldc) &
         bind(c, name="hipsparseScsrmm")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -6231,17 +6045,13 @@ module hipfort_hipsparse
       hipsparseScsrmm_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseDcsrmm
-#ifdef USE_CUDA_NAMES
-    function hipsparseDcsrmm_(handle,transA,m,n,k,nnz,alpha,descrA,csrSortedValA,csrSortedRowPtrA, &
-        csrSortedColIndA,B,ldb,beta,C,ldc) &
-        bind(c, name="cusparseDcsrmm")
-#else
     function hipsparseDcsrmm_(handle,transA,m,n,k,nnz,alpha,descrA,csrSortedValA,csrSortedRowPtrA, &
         csrSortedColIndA,B,ldb,beta,C,ldc) &
         bind(c, name="hipsparseDcsrmm")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -6271,17 +6081,13 @@ module hipfort_hipsparse
       hipsparseDcsrmm_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseCcsrmm
-#ifdef USE_CUDA_NAMES
-    function hipsparseCcsrmm_(handle,transA,m,n,k,nnz,alpha,descrA,csrSortedValA,csrSortedRowPtrA, &
-        csrSortedColIndA,B,ldb,beta,C,ldc) &
-        bind(c, name="cusparseCcsrmm")
-#else
     function hipsparseCcsrmm_(handle,transA,m,n,k,nnz,alpha,descrA,csrSortedValA,csrSortedRowPtrA, &
         csrSortedColIndA,B,ldb,beta,C,ldc) &
         bind(c, name="hipsparseCcsrmm")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -6311,17 +6117,13 @@ module hipfort_hipsparse
       hipsparseCcsrmm_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseZcsrmm
-#ifdef USE_CUDA_NAMES
-    function hipsparseZcsrmm_(handle,transA,m,n,k,nnz,alpha,descrA,csrSortedValA,csrSortedRowPtrA, &
-        csrSortedColIndA,B,ldb,beta,C,ldc) &
-        bind(c, name="cusparseZcsrmm")
-#else
     function hipsparseZcsrmm_(handle,transA,m,n,k,nnz,alpha,descrA,csrSortedValA,csrSortedRowPtrA, &
         csrSortedColIndA,B,ldb,beta,C,ldc) &
         bind(c, name="hipsparseZcsrmm")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -6351,6 +6153,7 @@ module hipfort_hipsparse
       hipsparseZcsrmm_full_rank
 #endif
   end interface
+#endif
 
   !>  \ingroup level3_module
   !>   \brief Sparse matrix dense matrix multiplication using the CSR storage format.
@@ -6452,16 +6255,11 @@ module hipfort_hipsparse
   !>   \retval     HIPSPARSE_STATUS_ARCH_MISMATCH the device is not supported.
   !>   \retval     HIPSPARSE_STATUS_NOT_SUPPORTED
   !>               `hipsparseMatrixType_t` != `HIPSPARSE_MATRIX_TYPE_GENERAL`.
+#ifndef USE_CUDA_NAMES
   interface hipsparseScsrmm2
-#ifdef USE_CUDA_NAMES
-    function hipsparseScsrmm2_(handle,transA,transB,m,n,k,nnz,alpha,descrA,csrSortedValA, &
-        csrSortedRowPtrA,csrSortedColIndA,B,ldb,beta,C,ldc) &
-        bind(c, name="cusparseScsrmm2")
-#else
     function hipsparseScsrmm2_(handle,transA,transB,m,n,k,nnz,alpha,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,B,ldb,beta,C,ldc) &
         bind(c, name="hipsparseScsrmm2")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -6492,17 +6290,13 @@ module hipfort_hipsparse
       hipsparseScsrmm2_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseDcsrmm2
-#ifdef USE_CUDA_NAMES
-    function hipsparseDcsrmm2_(handle,transA,transB,m,n,k,nnz,alpha,descrA,csrSortedValA, &
-        csrSortedRowPtrA,csrSortedColIndA,B,ldb,beta,C,ldc) &
-        bind(c, name="cusparseDcsrmm2")
-#else
     function hipsparseDcsrmm2_(handle,transA,transB,m,n,k,nnz,alpha,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,B,ldb,beta,C,ldc) &
         bind(c, name="hipsparseDcsrmm2")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -6533,17 +6327,13 @@ module hipfort_hipsparse
       hipsparseDcsrmm2_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseCcsrmm2
-#ifdef USE_CUDA_NAMES
-    function hipsparseCcsrmm2_(handle,transA,transB,m,n,k,nnz,alpha,descrA,csrSortedValA, &
-        csrSortedRowPtrA,csrSortedColIndA,B,ldb,beta,C,ldc) &
-        bind(c, name="cusparseCcsrmm2")
-#else
     function hipsparseCcsrmm2_(handle,transA,transB,m,n,k,nnz,alpha,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,B,ldb,beta,C,ldc) &
         bind(c, name="hipsparseCcsrmm2")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -6574,17 +6364,13 @@ module hipfort_hipsparse
       hipsparseCcsrmm2_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseZcsrmm2
-#ifdef USE_CUDA_NAMES
-    function hipsparseZcsrmm2_(handle,transA,transB,m,n,k,nnz,alpha,descrA,csrSortedValA, &
-        csrSortedRowPtrA,csrSortedColIndA,B,ldb,beta,C,ldc) &
-        bind(c, name="cusparseZcsrmm2")
-#else
     function hipsparseZcsrmm2_(handle,transA,transB,m,n,k,nnz,alpha,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,B,ldb,beta,C,ldc) &
         bind(c, name="hipsparseZcsrmm2")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -6615,6 +6401,7 @@ module hipfort_hipsparse
       hipsparseZcsrmm2_full_rank
 #endif
   end interface
+#endif
 
   !>  \ingroup level3_module
   !>   \details
@@ -6646,14 +6433,10 @@ module hipfort_hipsparse
   !>   \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p info, or \p position is nullptr.
   !>   \retval HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
   !>   \retval HIPSPARSE_STATUS_ZERO_PIVOT zero pivot has been found.
+#ifndef USE_CUDA_NAMES
   interface hipsparseXcsrsm2_zeroPivot
-#ifdef USE_CUDA_NAMES
-    function hipsparseXcsrsm2_zeroPivot_(handle,myInfo,position) &
-        bind(c, name="cusparseXcsrsm2_zeroPivot")
-#else
     function hipsparseXcsrsm2_zeroPivot_(handle,myInfo,position) &
         bind(c, name="hipsparseXcsrsm2_zeroPivot")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -6663,6 +6446,7 @@ module hipfort_hipsparse
       integer(c_int) :: position
     end function
   end interface
+#endif
 
   !>  \ingroup level3_module
   !>   \details
@@ -6720,16 +6504,11 @@ module hipfort_hipsparse
   !>               \p transA == `HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE`,
   !>               \p transB == `HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE`, or
   !>               `hipsparseMatrixType_t` != `HIPSPARSE_MATRIX_TYPE_GENERAL`.
+#ifndef USE_CUDA_NAMES
   interface hipsparseScsrsm2_bufferSizeExt
-#ifdef USE_CUDA_NAMES
-    function hipsparseScsrsm2_bufferSizeExt_(handle,algo,transA,transB,m,nrhs,nnz,alpha,descrA, &
-        csrSortedValA,csrSortedRowPtrA,csrSortedColIndA,B,ldb,myInfo,policy,pBufferSizeInBytes) &
-        bind(c, name="cusparseScsrsm2_bufferSizeExt")
-#else
     function hipsparseScsrsm2_bufferSizeExt_(handle,algo,transA,transB,m,nrhs,nnz,alpha,descrA, &
         csrSortedValA,csrSortedRowPtrA,csrSortedColIndA,B,ldb,myInfo,policy,pBufferSizeInBytes) &
         bind(c, name="hipsparseScsrsm2_bufferSizeExt")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -6760,17 +6539,13 @@ module hipfort_hipsparse
       hipsparseScsrsm2_bufferSizeExt_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseDcsrsm2_bufferSizeExt
-#ifdef USE_CUDA_NAMES
-    function hipsparseDcsrsm2_bufferSizeExt_(handle,algo,transA,transB,m,nrhs,nnz,alpha,descrA, &
-        csrSortedValA,csrSortedRowPtrA,csrSortedColIndA,B,ldb,myInfo,policy,pBufferSizeInBytes) &
-        bind(c, name="cusparseDcsrsm2_bufferSizeExt")
-#else
     function hipsparseDcsrsm2_bufferSizeExt_(handle,algo,transA,transB,m,nrhs,nnz,alpha,descrA, &
         csrSortedValA,csrSortedRowPtrA,csrSortedColIndA,B,ldb,myInfo,policy,pBufferSizeInBytes) &
         bind(c, name="hipsparseDcsrsm2_bufferSizeExt")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -6801,17 +6576,13 @@ module hipfort_hipsparse
       hipsparseDcsrsm2_bufferSizeExt_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseCcsrsm2_bufferSizeExt
-#ifdef USE_CUDA_NAMES
-    function hipsparseCcsrsm2_bufferSizeExt_(handle,algo,transA,transB,m,nrhs,nnz,alpha,descrA, &
-        csrSortedValA,csrSortedRowPtrA,csrSortedColIndA,B,ldb,myInfo,policy,pBufferSizeInBytes) &
-        bind(c, name="cusparseCcsrsm2_bufferSizeExt")
-#else
     function hipsparseCcsrsm2_bufferSizeExt_(handle,algo,transA,transB,m,nrhs,nnz,alpha,descrA, &
         csrSortedValA,csrSortedRowPtrA,csrSortedColIndA,B,ldb,myInfo,policy,pBufferSizeInBytes) &
         bind(c, name="hipsparseCcsrsm2_bufferSizeExt")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -6842,17 +6613,13 @@ module hipfort_hipsparse
       hipsparseCcsrsm2_bufferSizeExt_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseZcsrsm2_bufferSizeExt
-#ifdef USE_CUDA_NAMES
-    function hipsparseZcsrsm2_bufferSizeExt_(handle,algo,transA,transB,m,nrhs,nnz,alpha,descrA, &
-        csrSortedValA,csrSortedRowPtrA,csrSortedColIndA,B,ldb,myInfo,policy,pBufferSizeInBytes) &
-        bind(c, name="cusparseZcsrsm2_bufferSizeExt")
-#else
     function hipsparseZcsrsm2_bufferSizeExt_(handle,algo,transA,transB,m,nrhs,nnz,alpha,descrA, &
         csrSortedValA,csrSortedRowPtrA,csrSortedColIndA,B,ldb,myInfo,policy,pBufferSizeInBytes) &
         bind(c, name="hipsparseZcsrsm2_bufferSizeExt")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -6883,6 +6650,7 @@ module hipfort_hipsparse
       hipsparseZcsrsm2_bufferSizeExt_full_rank
 #endif
   end interface
+#endif
 
   !>  \ingroup level3_module
   !>   \details
@@ -6944,16 +6712,11 @@ module hipfort_hipsparse
   !>               \p transA == `HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE`,
   !>               \p transB == `HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE`, or
   !>               `hipsparseMatrixType_t` != `HIPSPARSE_MATRIX_TYPE_GENERAL`.
+#ifndef USE_CUDA_NAMES
   interface hipsparseScsrsm2_analysis
-#ifdef USE_CUDA_NAMES
-    function hipsparseScsrsm2_analysis_(handle,algo,transA,transB,m,nrhs,nnz,alpha,descrA, &
-        csrSortedValA,csrSortedRowPtrA,csrSortedColIndA,B,ldb,myInfo,policy,pBuffer) &
-        bind(c, name="cusparseScsrsm2_analysis")
-#else
     function hipsparseScsrsm2_analysis_(handle,algo,transA,transB,m,nrhs,nnz,alpha,descrA, &
         csrSortedValA,csrSortedRowPtrA,csrSortedColIndA,B,ldb,myInfo,policy,pBuffer) &
         bind(c, name="hipsparseScsrsm2_analysis")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -6984,17 +6747,13 @@ module hipfort_hipsparse
       hipsparseScsrsm2_analysis_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseDcsrsm2_analysis
-#ifdef USE_CUDA_NAMES
-    function hipsparseDcsrsm2_analysis_(handle,algo,transA,transB,m,nrhs,nnz,alpha,descrA, &
-        csrSortedValA,csrSortedRowPtrA,csrSortedColIndA,B,ldb,myInfo,policy,pBuffer) &
-        bind(c, name="cusparseDcsrsm2_analysis")
-#else
     function hipsparseDcsrsm2_analysis_(handle,algo,transA,transB,m,nrhs,nnz,alpha,descrA, &
         csrSortedValA,csrSortedRowPtrA,csrSortedColIndA,B,ldb,myInfo,policy,pBuffer) &
         bind(c, name="hipsparseDcsrsm2_analysis")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -7025,17 +6784,13 @@ module hipfort_hipsparse
       hipsparseDcsrsm2_analysis_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseCcsrsm2_analysis
-#ifdef USE_CUDA_NAMES
-    function hipsparseCcsrsm2_analysis_(handle,algo,transA,transB,m,nrhs,nnz,alpha,descrA, &
-        csrSortedValA,csrSortedRowPtrA,csrSortedColIndA,B,ldb,myInfo,policy,pBuffer) &
-        bind(c, name="cusparseCcsrsm2_analysis")
-#else
     function hipsparseCcsrsm2_analysis_(handle,algo,transA,transB,m,nrhs,nnz,alpha,descrA, &
         csrSortedValA,csrSortedRowPtrA,csrSortedColIndA,B,ldb,myInfo,policy,pBuffer) &
         bind(c, name="hipsparseCcsrsm2_analysis")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -7066,17 +6821,13 @@ module hipfort_hipsparse
       hipsparseCcsrsm2_analysis_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseZcsrsm2_analysis
-#ifdef USE_CUDA_NAMES
-    function hipsparseZcsrsm2_analysis_(handle,algo,transA,transB,m,nrhs,nnz,alpha,descrA, &
-        csrSortedValA,csrSortedRowPtrA,csrSortedColIndA,B,ldb,myInfo,policy,pBuffer) &
-        bind(c, name="cusparseZcsrsm2_analysis")
-#else
     function hipsparseZcsrsm2_analysis_(handle,algo,transA,transB,m,nrhs,nnz,alpha,descrA, &
         csrSortedValA,csrSortedRowPtrA,csrSortedColIndA,B,ldb,myInfo,policy,pBuffer) &
         bind(c, name="hipsparseZcsrsm2_analysis")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -7107,6 +6858,7 @@ module hipfort_hipsparse
       hipsparseZcsrsm2_analysis_full_rank
 #endif
   end interface
+#endif
 
   !>  \ingroup level3_module
   !>   \brief Sparse triangular system solve using the CSR storage format
@@ -7316,16 +7068,11 @@ module hipfort_hipsparse
   !>               \p transA == `HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE`,
   !>               \p transB == `HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE`, or
   !>               `hipsparseMatrixType_t` != `HIPSPARSE_MATRIX_TYPE_GENERAL`.
+#ifndef USE_CUDA_NAMES
   interface hipsparseScsrsm2_solve
-#ifdef USE_CUDA_NAMES
-    function hipsparseScsrsm2_solve_(handle,algo,transA,transB,m,nrhs,nnz,alpha,descrA, &
-        csrSortedValA,csrSortedRowPtrA,csrSortedColIndA,B,ldb,myInfo,policy,pBuffer) &
-        bind(c, name="cusparseScsrsm2_solve")
-#else
     function hipsparseScsrsm2_solve_(handle,algo,transA,transB,m,nrhs,nnz,alpha,descrA, &
         csrSortedValA,csrSortedRowPtrA,csrSortedColIndA,B,ldb,myInfo,policy,pBuffer) &
         bind(c, name="hipsparseScsrsm2_solve")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -7356,17 +7103,13 @@ module hipfort_hipsparse
       hipsparseScsrsm2_solve_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseDcsrsm2_solve
-#ifdef USE_CUDA_NAMES
-    function hipsparseDcsrsm2_solve_(handle,algo,transA,transB,m,nrhs,nnz,alpha,descrA, &
-        csrSortedValA,csrSortedRowPtrA,csrSortedColIndA,B,ldb,myInfo,policy,pBuffer) &
-        bind(c, name="cusparseDcsrsm2_solve")
-#else
     function hipsparseDcsrsm2_solve_(handle,algo,transA,transB,m,nrhs,nnz,alpha,descrA, &
         csrSortedValA,csrSortedRowPtrA,csrSortedColIndA,B,ldb,myInfo,policy,pBuffer) &
         bind(c, name="hipsparseDcsrsm2_solve")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -7397,17 +7140,13 @@ module hipfort_hipsparse
       hipsparseDcsrsm2_solve_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseCcsrsm2_solve
-#ifdef USE_CUDA_NAMES
-    function hipsparseCcsrsm2_solve_(handle,algo,transA,transB,m,nrhs,nnz,alpha,descrA, &
-        csrSortedValA,csrSortedRowPtrA,csrSortedColIndA,B,ldb,myInfo,policy,pBuffer) &
-        bind(c, name="cusparseCcsrsm2_solve")
-#else
     function hipsparseCcsrsm2_solve_(handle,algo,transA,transB,m,nrhs,nnz,alpha,descrA, &
         csrSortedValA,csrSortedRowPtrA,csrSortedColIndA,B,ldb,myInfo,policy,pBuffer) &
         bind(c, name="hipsparseCcsrsm2_solve")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -7438,17 +7177,13 @@ module hipfort_hipsparse
       hipsparseCcsrsm2_solve_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseZcsrsm2_solve
-#ifdef USE_CUDA_NAMES
-    function hipsparseZcsrsm2_solve_(handle,algo,transA,transB,m,nrhs,nnz,alpha,descrA, &
-        csrSortedValA,csrSortedRowPtrA,csrSortedColIndA,B,ldb,myInfo,policy,pBuffer) &
-        bind(c, name="cusparseZcsrsm2_solve")
-#else
     function hipsparseZcsrsm2_solve_(handle,algo,transA,transB,m,nrhs,nnz,alpha,descrA, &
         csrSortedValA,csrSortedRowPtrA,csrSortedColIndA,B,ldb,myInfo,policy,pBuffer) &
         bind(c, name="hipsparseZcsrsm2_solve")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -7479,6 +7214,7 @@ module hipfort_hipsparse
       hipsparseZcsrsm2_solve_full_rank
 #endif
   end interface
+#endif
 
   !>  \ingroup level3_module
   !>   \brief Dense matrix sparse matrix multiplication using the CSC storage format.
@@ -7541,16 +7277,11 @@ module hipfort_hipsparse
   !>   \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p alpha or \p beta is nullptr,
   !>           \p m, \p n, \p k, or \p nnz is negative, \p lda or \p ldc is invalid, or
   !>           \p A, \p cscValB, \p cscColPtrB, \p cscRowIndB, or \p C is nullptr.
+#ifndef USE_CUDA_NAMES
   interface hipsparseSgemmi
-#ifdef USE_CUDA_NAMES
-    function hipsparseSgemmi_(handle,m,n,k,nnz,alpha,A,lda,cscValB,cscColPtrB,cscRowIndB,beta,C, &
-        ldc) &
-        bind(c, name="cusparseSgemmi")
-#else
     function hipsparseSgemmi_(handle,m,n,k,nnz,alpha,A,lda,cscValB,cscColPtrB,cscRowIndB,beta,C, &
         ldc) &
         bind(c, name="hipsparseSgemmi")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -7578,17 +7309,13 @@ module hipfort_hipsparse
       hipsparseSgemmi_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseDgemmi
-#ifdef USE_CUDA_NAMES
-    function hipsparseDgemmi_(handle,m,n,k,nnz,alpha,A,lda,cscValB,cscColPtrB,cscRowIndB,beta,C, &
-        ldc) &
-        bind(c, name="cusparseDgemmi")
-#else
     function hipsparseDgemmi_(handle,m,n,k,nnz,alpha,A,lda,cscValB,cscColPtrB,cscRowIndB,beta,C, &
         ldc) &
         bind(c, name="hipsparseDgemmi")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -7616,17 +7343,13 @@ module hipfort_hipsparse
       hipsparseDgemmi_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseCgemmi
-#ifdef USE_CUDA_NAMES
-    function hipsparseCgemmi_(handle,m,n,k,nnz,alpha,A,lda,cscValB,cscColPtrB,cscRowIndB,beta,C, &
-        ldc) &
-        bind(c, name="cusparseCgemmi")
-#else
     function hipsparseCgemmi_(handle,m,n,k,nnz,alpha,A,lda,cscValB,cscColPtrB,cscRowIndB,beta,C, &
         ldc) &
         bind(c, name="hipsparseCgemmi")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -7654,17 +7377,13 @@ module hipfort_hipsparse
       hipsparseCgemmi_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseZgemmi
-#ifdef USE_CUDA_NAMES
-    function hipsparseZgemmi_(handle,m,n,k,nnz,alpha,A,lda,cscValB,cscColPtrB,cscRowIndB,beta,C, &
-        ldc) &
-        bind(c, name="cusparseZgemmi")
-#else
     function hipsparseZgemmi_(handle,m,n,k,nnz,alpha,A,lda,cscValB,cscColPtrB,cscRowIndB,beta,C, &
         ldc) &
         bind(c, name="hipsparseZgemmi")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -7692,6 +7411,7 @@ module hipfort_hipsparse
       hipsparseZgemmi_full_rank
 #endif
   end interface
+#endif
 
   !>  \ingroup extra_module
   !>   \details
@@ -7767,16 +7487,11 @@ module hipfort_hipsparse
   !>           \p csrColIndB, \p csrRowPtrC, or \p nnzTotalDevHostPtr is nullptr.
   !>   \retval HIPSPARSE_STATUS_NOT_SUPPORTED `hipsparseMatrixType_t` is not
   !>           `HIPSPARSE_MATRIX_TYPE_GENERAL`.
+#ifndef USE_CUDA_NAMES
   interface hipsparseXcsrgeamNnz
-#ifdef USE_CUDA_NAMES
-    function hipsparseXcsrgeamNnz_(handle,m,n,descrA,nnzA,csrRowPtrA,csrColIndA,descrB,nnzB, &
-        csrRowPtrB,csrColIndB,descrC,csrRowPtrC,nnzTotalDevHostPtr) &
-        bind(c, name="cusparseXcsrgeamNnz")
-#else
     function hipsparseXcsrgeamNnz_(handle,m,n,descrA,nnzA,csrRowPtrA,csrColIndA,descrB,nnzB, &
         csrRowPtrB,csrColIndB,descrC,csrRowPtrC,nnzTotalDevHostPtr) &
         bind(c, name="hipsparseXcsrgeamNnz")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -7803,6 +7518,7 @@ module hipfort_hipsparse
       hipsparseXcsrgeamNnz_rank_1
 #endif
   end interface
+#endif
 
   !>  \ingroup extra_module
   !>   \brief Sparse matrix sparse matrix addition using the CSR storage format.
@@ -7890,16 +7606,11 @@ module hipfort_hipsparse
   !>           \p csrRowPtrC, or \p csrColIndC is invalid.
   !>   \retval HIPSPARSE_STATUS_NOT_SUPPORTED
   !>           `hipsparseMatrixType_t` != `HIPSPARSE_MATRIX_TYPE_GENERAL`.
+#ifndef USE_CUDA_NAMES
   interface hipsparseScsrgeam
-#ifdef USE_CUDA_NAMES
-    function hipsparseScsrgeam_(handle,m,n,alpha,descrA,nnzA,csrValA,csrRowPtrA,csrColIndA,beta, &
-        descrB,nnzB,csrValB,csrRowPtrB,csrColIndB,descrC,csrValC,csrRowPtrC,csrColIndC) &
-        bind(c, name="cusparseScsrgeam")
-#else
     function hipsparseScsrgeam_(handle,m,n,alpha,descrA,nnzA,csrValA,csrRowPtrA,csrColIndA,beta, &
         descrB,nnzB,csrValB,csrRowPtrB,csrColIndB,descrC,csrValC,csrRowPtrC,csrColIndC) &
         bind(c, name="hipsparseScsrgeam")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -7931,17 +7642,13 @@ module hipfort_hipsparse
       hipsparseScsrgeam_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseDcsrgeam
-#ifdef USE_CUDA_NAMES
-    function hipsparseDcsrgeam_(handle,m,n,alpha,descrA,nnzA,csrValA,csrRowPtrA,csrColIndA,beta, &
-        descrB,nnzB,csrValB,csrRowPtrB,csrColIndB,descrC,csrValC,csrRowPtrC,csrColIndC) &
-        bind(c, name="cusparseDcsrgeam")
-#else
     function hipsparseDcsrgeam_(handle,m,n,alpha,descrA,nnzA,csrValA,csrRowPtrA,csrColIndA,beta, &
         descrB,nnzB,csrValB,csrRowPtrB,csrColIndB,descrC,csrValC,csrRowPtrC,csrColIndC) &
         bind(c, name="hipsparseDcsrgeam")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -7973,17 +7680,13 @@ module hipfort_hipsparse
       hipsparseDcsrgeam_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseCcsrgeam
-#ifdef USE_CUDA_NAMES
-    function hipsparseCcsrgeam_(handle,m,n,alpha,descrA,nnzA,csrValA,csrRowPtrA,csrColIndA,beta, &
-        descrB,nnzB,csrValB,csrRowPtrB,csrColIndB,descrC,csrValC,csrRowPtrC,csrColIndC) &
-        bind(c, name="cusparseCcsrgeam")
-#else
     function hipsparseCcsrgeam_(handle,m,n,alpha,descrA,nnzA,csrValA,csrRowPtrA,csrColIndA,beta, &
         descrB,nnzB,csrValB,csrRowPtrB,csrColIndB,descrC,csrValC,csrRowPtrC,csrColIndC) &
         bind(c, name="hipsparseCcsrgeam")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -8015,17 +7718,13 @@ module hipfort_hipsparse
       hipsparseCcsrgeam_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseZcsrgeam
-#ifdef USE_CUDA_NAMES
-    function hipsparseZcsrgeam_(handle,m,n,alpha,descrA,nnzA,csrValA,csrRowPtrA,csrColIndA,beta, &
-        descrB,nnzB,csrValB,csrRowPtrB,csrColIndB,descrC,csrValC,csrRowPtrC,csrColIndC) &
-        bind(c, name="cusparseZcsrgeam")
-#else
     function hipsparseZcsrgeam_(handle,m,n,alpha,descrA,nnzA,csrValA,csrRowPtrA,csrColIndA,beta, &
         descrB,nnzB,csrValB,csrRowPtrB,csrColIndB,descrC,csrValC,csrRowPtrC,csrColIndC) &
         bind(c, name="hipsparseZcsrgeam")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -8057,6 +7756,7 @@ module hipfort_hipsparse
       hipsparseZcsrgeam_rank_1
 #endif
   end interface
+#endif
 
   !>  \ingroup extra_module
   !>   \details
@@ -8781,16 +8481,11 @@ module hipfort_hipsparse
   !>   \retval HIPSPARSE_STATUS_NOT_SUPPORTED \p transA is not `HIPSPARSE_OPERATION_NON_TRANSPOSE`,
   !>           \p transB is not `HIPSPARSE_OPERATION_NON_TRANSPOSE`, or
   !>           `hipsparseMatrixType_t` is not `HIPSPARSE_MATRIX_TYPE_GENERAL`.
+#ifndef USE_CUDA_NAMES
   interface hipsparseXcsrgemmNnz
-#ifdef USE_CUDA_NAMES
-    function hipsparseXcsrgemmNnz_(handle,transA,transB,m,n,k,descrA,nnzA,csrRowPtrA,csrColIndA, &
-        descrB,nnzB,csrRowPtrB,csrColIndB,descrC,csrRowPtrC,nnzTotalDevHostPtr) &
-        bind(c, name="cusparseXcsrgemmNnz")
-#else
     function hipsparseXcsrgemmNnz_(handle,transA,transB,m,n,k,descrA,nnzA,csrRowPtrA,csrColIndA, &
         descrB,nnzB,csrRowPtrB,csrColIndB,descrC,csrRowPtrC,nnzTotalDevHostPtr) &
         bind(c, name="hipsparseXcsrgemmNnz")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -8820,6 +8515,7 @@ module hipfort_hipsparse
       hipsparseXcsrgemmNnz_rank_1
 #endif
   end interface
+#endif
 
   !>  \ingroup extra_module
   !>   \brief Sparse matrix and sparse matrix multiplication using the CSR storage format.
@@ -8935,16 +8631,11 @@ module hipfort_hipsparse
   !>           \p transA != `HIPSPARSE_OPERATION_NON_TRANSPOSE`,
   !>           \p transB != `HIPSPARSE_OPERATION_NON_TRANSPOSE`, or
   !>           `hipsparseMatrixType_t` != `HIPSPARSE_MATRIX_TYPE_GENERAL`.
+#ifndef USE_CUDA_NAMES
   interface hipsparseScsrgemm
-#ifdef USE_CUDA_NAMES
-    function hipsparseScsrgemm_(handle,transA,transB,m,n,k,descrA,nnzA,csrValA,csrRowPtrA, &
-        csrColIndA,descrB,nnzB,csrValB,csrRowPtrB,csrColIndB,descrC,csrValC,csrRowPtrC,csrColIndC) &
-        bind(c, name="cusparseScsrgemm")
-#else
     function hipsparseScsrgemm_(handle,transA,transB,m,n,k,descrA,nnzA,csrValA,csrRowPtrA, &
         csrColIndA,descrB,nnzB,csrValB,csrRowPtrB,csrColIndB,descrC,csrValC,csrRowPtrC,csrColIndC) &
         bind(c, name="hipsparseScsrgemm")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -8977,17 +8668,13 @@ module hipfort_hipsparse
       hipsparseScsrgemm_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseDcsrgemm
-#ifdef USE_CUDA_NAMES
-    function hipsparseDcsrgemm_(handle,transA,transB,m,n,k,descrA,nnzA,csrValA,csrRowPtrA, &
-        csrColIndA,descrB,nnzB,csrValB,csrRowPtrB,csrColIndB,descrC,csrValC,csrRowPtrC,csrColIndC) &
-        bind(c, name="cusparseDcsrgemm")
-#else
     function hipsparseDcsrgemm_(handle,transA,transB,m,n,k,descrA,nnzA,csrValA,csrRowPtrA, &
         csrColIndA,descrB,nnzB,csrValB,csrRowPtrB,csrColIndB,descrC,csrValC,csrRowPtrC,csrColIndC) &
         bind(c, name="hipsparseDcsrgemm")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -9020,17 +8707,13 @@ module hipfort_hipsparse
       hipsparseDcsrgemm_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseCcsrgemm
-#ifdef USE_CUDA_NAMES
-    function hipsparseCcsrgemm_(handle,transA,transB,m,n,k,descrA,nnzA,csrValA,csrRowPtrA, &
-        csrColIndA,descrB,nnzB,csrValB,csrRowPtrB,csrColIndB,descrC,csrValC,csrRowPtrC,csrColIndC) &
-        bind(c, name="cusparseCcsrgemm")
-#else
     function hipsparseCcsrgemm_(handle,transA,transB,m,n,k,descrA,nnzA,csrValA,csrRowPtrA, &
         csrColIndA,descrB,nnzB,csrValB,csrRowPtrB,csrColIndB,descrC,csrValC,csrRowPtrC,csrColIndC) &
         bind(c, name="hipsparseCcsrgemm")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -9063,17 +8746,13 @@ module hipfort_hipsparse
       hipsparseCcsrgemm_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseZcsrgemm
-#ifdef USE_CUDA_NAMES
-    function hipsparseZcsrgemm_(handle,transA,transB,m,n,k,descrA,nnzA,csrValA,csrRowPtrA, &
-        csrColIndA,descrB,nnzB,csrValB,csrRowPtrB,csrColIndB,descrC,csrValC,csrRowPtrC,csrColIndC) &
-        bind(c, name="cusparseZcsrgemm")
-#else
     function hipsparseZcsrgemm_(handle,transA,transB,m,n,k,descrA,nnzA,csrValA,csrRowPtrA, &
         csrColIndA,descrB,nnzB,csrValB,csrRowPtrB,csrColIndB,descrC,csrValC,csrRowPtrC,csrColIndC) &
         bind(c, name="hipsparseZcsrgemm")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -9106,6 +8785,7 @@ module hipfort_hipsparse
       hipsparseZcsrgemm_rank_1
 #endif
   end interface
+#endif
 
   !>  \ingroup extra_module
   !>   \details
@@ -9189,18 +8869,12 @@ module hipfort_hipsparse
   !>           is invalid.
   !>   \retval HIPSPARSE_STATUS_NOT_SUPPORTED
   !>           `hipsparseMatrixType_t` != `HIPSPARSE_MATRIX_TYPE_GENERAL`.
+#ifndef USE_CUDA_NAMES
   interface hipsparseScsrgemm2_bufferSizeExt
-#ifdef USE_CUDA_NAMES
-    function hipsparseScsrgemm2_bufferSizeExt_(handle,m,n,k,alpha,descrA,nnzA,csrRowPtrA, &
-        csrColIndA,descrB,nnzB,csrRowPtrB,csrColIndB,beta,descrD,nnzD,csrRowPtrD,csrColIndD, &
-        myInfo,pBufferSizeInBytes) &
-        bind(c, name="cusparseScsrgemm2_bufferSizeExt")
-#else
     function hipsparseScsrgemm2_bufferSizeExt_(handle,m,n,k,alpha,descrA,nnzA,csrRowPtrA, &
         csrColIndA,descrB,nnzB,csrRowPtrB,csrColIndB,beta,descrD,nnzD,csrRowPtrD,csrColIndD, &
         myInfo,pBufferSizeInBytes) &
         bind(c, name="hipsparseScsrgemm2_bufferSizeExt")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -9233,19 +8907,14 @@ module hipfort_hipsparse
       hipsparseScsrgemm2_bufferSizeExt_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseDcsrgemm2_bufferSizeExt
-#ifdef USE_CUDA_NAMES
-    function hipsparseDcsrgemm2_bufferSizeExt_(handle,m,n,k,alpha,descrA,nnzA,csrRowPtrA, &
-        csrColIndA,descrB,nnzB,csrRowPtrB,csrColIndB,beta,descrD,nnzD,csrRowPtrD,csrColIndD, &
-        myInfo,pBufferSizeInBytes) &
-        bind(c, name="cusparseDcsrgemm2_bufferSizeExt")
-#else
     function hipsparseDcsrgemm2_bufferSizeExt_(handle,m,n,k,alpha,descrA,nnzA,csrRowPtrA, &
         csrColIndA,descrB,nnzB,csrRowPtrB,csrColIndB,beta,descrD,nnzD,csrRowPtrD,csrColIndD, &
         myInfo,pBufferSizeInBytes) &
         bind(c, name="hipsparseDcsrgemm2_bufferSizeExt")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -9278,19 +8947,14 @@ module hipfort_hipsparse
       hipsparseDcsrgemm2_bufferSizeExt_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseCcsrgemm2_bufferSizeExt
-#ifdef USE_CUDA_NAMES
-    function hipsparseCcsrgemm2_bufferSizeExt_(handle,m,n,k,alpha,descrA,nnzA,csrRowPtrA, &
-        csrColIndA,descrB,nnzB,csrRowPtrB,csrColIndB,beta,descrD,nnzD,csrRowPtrD,csrColIndD, &
-        myInfo,pBufferSizeInBytes) &
-        bind(c, name="cusparseCcsrgemm2_bufferSizeExt")
-#else
     function hipsparseCcsrgemm2_bufferSizeExt_(handle,m,n,k,alpha,descrA,nnzA,csrRowPtrA, &
         csrColIndA,descrB,nnzB,csrRowPtrB,csrColIndB,beta,descrD,nnzD,csrRowPtrD,csrColIndD, &
         myInfo,pBufferSizeInBytes) &
         bind(c, name="hipsparseCcsrgemm2_bufferSizeExt")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -9323,19 +8987,14 @@ module hipfort_hipsparse
       hipsparseCcsrgemm2_bufferSizeExt_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseZcsrgemm2_bufferSizeExt
-#ifdef USE_CUDA_NAMES
-    function hipsparseZcsrgemm2_bufferSizeExt_(handle,m,n,k,alpha,descrA,nnzA,csrRowPtrA, &
-        csrColIndA,descrB,nnzB,csrRowPtrB,csrColIndB,beta,descrD,nnzD,csrRowPtrD,csrColIndD, &
-        myInfo,pBufferSizeInBytes) &
-        bind(c, name="cusparseZcsrgemm2_bufferSizeExt")
-#else
     function hipsparseZcsrgemm2_bufferSizeExt_(handle,m,n,k,alpha,descrA,nnzA,csrRowPtrA, &
         csrColIndA,descrB,nnzB,csrRowPtrB,csrColIndB,beta,descrD,nnzD,csrRowPtrD,csrColIndD, &
         myInfo,pBufferSizeInBytes) &
         bind(c, name="hipsparseZcsrgemm2_bufferSizeExt")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -9368,6 +9027,7 @@ module hipfort_hipsparse
       hipsparseZcsrgemm2_bufferSizeExt_rank_1
 #endif
   end interface
+#endif
 
   !>  \ingroup extra_module
   !>   \details
@@ -9467,18 +9127,12 @@ module hipfort_hipsparse
   !>           allocated.
   !>   \retval HIPSPARSE_STATUS_NOT_SUPPORTED
   !>           `hipsparseMatrixType_t` != `HIPSPARSE_MATRIX_TYPE_GENERAL`.
+#ifndef USE_CUDA_NAMES
   interface hipsparseXcsrgemm2Nnz
-#ifdef USE_CUDA_NAMES
-    function hipsparseXcsrgemm2Nnz_(handle,m,n,k,descrA,nnzA,csrRowPtrA,csrColIndA,descrB,nnzB, &
-        csrRowPtrB,csrColIndB,descrD,nnzD,csrRowPtrD,csrColIndD,descrC,csrRowPtrC, &
-        nnzTotalDevHostPtr,myInfo,pBuffer) &
-        bind(c, name="cusparseXcsrgemm2Nnz")
-#else
     function hipsparseXcsrgemm2Nnz_(handle,m,n,k,descrA,nnzA,csrRowPtrA,csrColIndA,descrB,nnzB, &
         csrRowPtrB,csrColIndB,descrD,nnzD,csrRowPtrD,csrColIndD,descrC,csrRowPtrC, &
         nnzTotalDevHostPtr,myInfo,pBuffer) &
         bind(c, name="hipsparseXcsrgemm2Nnz")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -9512,6 +9166,7 @@ module hipfort_hipsparse
       hipsparseXcsrgemm2Nnz_rank_1
 #endif
   end interface
+#endif
 
   !>  \ingroup extra_module
   !>   \brief Sparse matrix and sparse matrix multiplication using CSR storage format
@@ -9631,18 +9286,12 @@ module hipfort_hipsparse
   !>           allocated.
   !>   \retval HIPSPARSE_STATUS_NOT_SUPPORTED
   !>           `hipsparseMatrixType_t` != `HIPSPARSE_MATRIX_TYPE_GENERAL`.
+#ifndef USE_CUDA_NAMES
   interface hipsparseScsrgemm2
-#ifdef USE_CUDA_NAMES
-    function hipsparseScsrgemm2_(handle,m,n,k,alpha,descrA,nnzA,csrValA,csrRowPtrA,csrColIndA, &
-        descrB,nnzB,csrValB,csrRowPtrB,csrColIndB,beta,descrD,nnzD,csrValD,csrRowPtrD,csrColIndD, &
-        descrC,csrValC,csrRowPtrC,csrColIndC,myInfo,pBuffer) &
-        bind(c, name="cusparseScsrgemm2")
-#else
     function hipsparseScsrgemm2_(handle,m,n,k,alpha,descrA,nnzA,csrValA,csrRowPtrA,csrColIndA, &
         descrB,nnzB,csrValB,csrRowPtrB,csrColIndB,beta,descrD,nnzD,csrValD,csrRowPtrD,csrColIndD, &
         descrC,csrValC,csrRowPtrC,csrColIndC,myInfo,pBuffer) &
         bind(c, name="hipsparseScsrgemm2")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -9682,19 +9331,14 @@ module hipfort_hipsparse
       hipsparseScsrgemm2_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseDcsrgemm2
-#ifdef USE_CUDA_NAMES
-    function hipsparseDcsrgemm2_(handle,m,n,k,alpha,descrA,nnzA,csrValA,csrRowPtrA,csrColIndA, &
-        descrB,nnzB,csrValB,csrRowPtrB,csrColIndB,beta,descrD,nnzD,csrValD,csrRowPtrD,csrColIndD, &
-        descrC,csrValC,csrRowPtrC,csrColIndC,myInfo,pBuffer) &
-        bind(c, name="cusparseDcsrgemm2")
-#else
     function hipsparseDcsrgemm2_(handle,m,n,k,alpha,descrA,nnzA,csrValA,csrRowPtrA,csrColIndA, &
         descrB,nnzB,csrValB,csrRowPtrB,csrColIndB,beta,descrD,nnzD,csrValD,csrRowPtrD,csrColIndD, &
         descrC,csrValC,csrRowPtrC,csrColIndC,myInfo,pBuffer) &
         bind(c, name="hipsparseDcsrgemm2")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -9734,19 +9378,14 @@ module hipfort_hipsparse
       hipsparseDcsrgemm2_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseCcsrgemm2
-#ifdef USE_CUDA_NAMES
-    function hipsparseCcsrgemm2_(handle,m,n,k,alpha,descrA,nnzA,csrValA,csrRowPtrA,csrColIndA, &
-        descrB,nnzB,csrValB,csrRowPtrB,csrColIndB,beta,descrD,nnzD,csrValD,csrRowPtrD,csrColIndD, &
-        descrC,csrValC,csrRowPtrC,csrColIndC,myInfo,pBuffer) &
-        bind(c, name="cusparseCcsrgemm2")
-#else
     function hipsparseCcsrgemm2_(handle,m,n,k,alpha,descrA,nnzA,csrValA,csrRowPtrA,csrColIndA, &
         descrB,nnzB,csrValB,csrRowPtrB,csrColIndB,beta,descrD,nnzD,csrValD,csrRowPtrD,csrColIndD, &
         descrC,csrValC,csrRowPtrC,csrColIndC,myInfo,pBuffer) &
         bind(c, name="hipsparseCcsrgemm2")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -9786,19 +9425,14 @@ module hipfort_hipsparse
       hipsparseCcsrgemm2_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseZcsrgemm2
-#ifdef USE_CUDA_NAMES
-    function hipsparseZcsrgemm2_(handle,m,n,k,alpha,descrA,nnzA,csrValA,csrRowPtrA,csrColIndA, &
-        descrB,nnzB,csrValB,csrRowPtrB,csrColIndB,beta,descrD,nnzD,csrValD,csrRowPtrD,csrColIndD, &
-        descrC,csrValC,csrRowPtrC,csrColIndC,myInfo,pBuffer) &
-        bind(c, name="cusparseZcsrgemm2")
-#else
     function hipsparseZcsrgemm2_(handle,m,n,k,alpha,descrA,nnzA,csrValA,csrRowPtrA,csrColIndA, &
         descrB,nnzB,csrValB,csrRowPtrB,csrColIndB,beta,descrD,nnzD,csrValD,csrRowPtrD,csrColIndD, &
         descrC,csrValC,csrRowPtrC,csrColIndC,myInfo,pBuffer) &
         bind(c, name="hipsparseZcsrgemm2")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -9838,6 +9472,7 @@ module hipfort_hipsparse
       hipsparseZcsrgemm2_rank_1
 #endif
   end interface
+#endif
 
   !>  \ingroup precond_module
   !>   \details
@@ -11487,16 +11122,11 @@ module hipfort_hipsparse
   !>   \retval     HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
   !>   \retval     HIPSPARSE_STATUS_NOT_SUPPORTED
   !>               `hipsparseMatrixType_t` != `HIPSPARSE_MATRIX_TYPE_GENERAL`.
+#ifndef USE_CUDA_NAMES
   interface hipsparseScsric02_bufferSizeExt
-#ifdef USE_CUDA_NAMES
-    function hipsparseScsric02_bufferSizeExt_(handle,m,nnz,descrA,csrSortedValA,csrSortedRowPtrA, &
-        csrSortedColIndA,myInfo,pBufferSizeInBytes) &
-        bind(c, name="cusparseScsric02_bufferSizeExt")
-#else
     function hipsparseScsric02_bufferSizeExt_(handle,m,nnz,descrA,csrSortedValA,csrSortedRowPtrA, &
         csrSortedColIndA,myInfo,pBufferSizeInBytes) &
         bind(c, name="hipsparseScsric02_bufferSizeExt")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -11518,17 +11148,13 @@ module hipfort_hipsparse
       hipsparseScsric02_bufferSizeExt_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseDcsric02_bufferSizeExt
-#ifdef USE_CUDA_NAMES
-    function hipsparseDcsric02_bufferSizeExt_(handle,m,nnz,descrA,csrSortedValA,csrSortedRowPtrA, &
-        csrSortedColIndA,myInfo,pBufferSizeInBytes) &
-        bind(c, name="cusparseDcsric02_bufferSizeExt")
-#else
     function hipsparseDcsric02_bufferSizeExt_(handle,m,nnz,descrA,csrSortedValA,csrSortedRowPtrA, &
         csrSortedColIndA,myInfo,pBufferSizeInBytes) &
         bind(c, name="hipsparseDcsric02_bufferSizeExt")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -11550,17 +11176,13 @@ module hipfort_hipsparse
       hipsparseDcsric02_bufferSizeExt_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseCcsric02_bufferSizeExt
-#ifdef USE_CUDA_NAMES
-    function hipsparseCcsric02_bufferSizeExt_(handle,m,nnz,descrA,csrSortedValA,csrSortedRowPtrA, &
-        csrSortedColIndA,myInfo,pBufferSizeInBytes) &
-        bind(c, name="cusparseCcsric02_bufferSizeExt")
-#else
     function hipsparseCcsric02_bufferSizeExt_(handle,m,nnz,descrA,csrSortedValA,csrSortedRowPtrA, &
         csrSortedColIndA,myInfo,pBufferSizeInBytes) &
         bind(c, name="hipsparseCcsric02_bufferSizeExt")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -11582,17 +11204,13 @@ module hipfort_hipsparse
       hipsparseCcsric02_bufferSizeExt_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseZcsric02_bufferSizeExt
-#ifdef USE_CUDA_NAMES
-    function hipsparseZcsric02_bufferSizeExt_(handle,m,nnz,descrA,csrSortedValA,csrSortedRowPtrA, &
-        csrSortedColIndA,myInfo,pBufferSizeInBytes) &
-        bind(c, name="cusparseZcsric02_bufferSizeExt")
-#else
     function hipsparseZcsric02_bufferSizeExt_(handle,m,nnz,descrA,csrSortedValA,csrSortedRowPtrA, &
         csrSortedColIndA,myInfo,pBufferSizeInBytes) &
         bind(c, name="hipsparseZcsric02_bufferSizeExt")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -11614,6 +11232,7 @@ module hipfort_hipsparse
       hipsparseZcsric02_bufferSizeExt_rank_1
 #endif
   end interface
+#endif
 
   !>  \ingroup precond_module
   !>   \details
@@ -12451,16 +12070,11 @@ module hipfort_hipsparse
   !>               pointer
   !>               is invalid.
   !>   \retval     HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
+#ifndef USE_CUDA_NAMES
   interface hipsparseScsrilu02_bufferSizeExt
-#ifdef USE_CUDA_NAMES
-    function hipsparseScsrilu02_bufferSizeExt_(handle,m,nnz,descrA,csrSortedValA,csrSortedRowPtrA, &
-        csrSortedColIndA,myInfo,pBufferSizeInBytes) &
-        bind(c, name="cusparseScsrilu02_bufferSizeExt")
-#else
     function hipsparseScsrilu02_bufferSizeExt_(handle,m,nnz,descrA,csrSortedValA,csrSortedRowPtrA, &
         csrSortedColIndA,myInfo,pBufferSizeInBytes) &
         bind(c, name="hipsparseScsrilu02_bufferSizeExt")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -12482,17 +12096,13 @@ module hipfort_hipsparse
       hipsparseScsrilu02_bufferSizeExt_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseDcsrilu02_bufferSizeExt
-#ifdef USE_CUDA_NAMES
-    function hipsparseDcsrilu02_bufferSizeExt_(handle,m,nnz,descrA,csrSortedValA,csrSortedRowPtrA, &
-        csrSortedColIndA,myInfo,pBufferSizeInBytes) &
-        bind(c, name="cusparseDcsrilu02_bufferSizeExt")
-#else
     function hipsparseDcsrilu02_bufferSizeExt_(handle,m,nnz,descrA,csrSortedValA,csrSortedRowPtrA, &
         csrSortedColIndA,myInfo,pBufferSizeInBytes) &
         bind(c, name="hipsparseDcsrilu02_bufferSizeExt")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -12514,17 +12124,13 @@ module hipfort_hipsparse
       hipsparseDcsrilu02_bufferSizeExt_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseCcsrilu02_bufferSizeExt
-#ifdef USE_CUDA_NAMES
-    function hipsparseCcsrilu02_bufferSizeExt_(handle,m,nnz,descrA,csrSortedValA,csrSortedRowPtrA, &
-        csrSortedColIndA,myInfo,pBufferSizeInBytes) &
-        bind(c, name="cusparseCcsrilu02_bufferSizeExt")
-#else
     function hipsparseCcsrilu02_bufferSizeExt_(handle,m,nnz,descrA,csrSortedValA,csrSortedRowPtrA, &
         csrSortedColIndA,myInfo,pBufferSizeInBytes) &
         bind(c, name="hipsparseCcsrilu02_bufferSizeExt")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -12546,17 +12152,13 @@ module hipfort_hipsparse
       hipsparseCcsrilu02_bufferSizeExt_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseZcsrilu02_bufferSizeExt
-#ifdef USE_CUDA_NAMES
-    function hipsparseZcsrilu02_bufferSizeExt_(handle,m,nnz,descrA,csrSortedValA,csrSortedRowPtrA, &
-        csrSortedColIndA,myInfo,pBufferSizeInBytes) &
-        bind(c, name="cusparseZcsrilu02_bufferSizeExt")
-#else
     function hipsparseZcsrilu02_bufferSizeExt_(handle,m,nnz,descrA,csrSortedValA,csrSortedRowPtrA, &
         csrSortedColIndA,myInfo,pBufferSizeInBytes) &
         bind(c, name="hipsparseZcsrilu02_bufferSizeExt")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -12578,6 +12180,7 @@ module hipfort_hipsparse
       hipsparseZcsrilu02_bufferSizeExt_rank_1
 #endif
   end interface
+#endif
 
   !>  \ingroup precond_module
   !>   \details
@@ -15477,14 +15080,10 @@ module hipfort_hipsparse
   !>   \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
   !>   \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descr, \p cscVal, \p cscColPtr,
   !>           \p cscRowInd, or \p A is nullptr, \p m or \p n is negative, or \p ld is invalid.
+#ifndef USE_CUDA_NAMES
   interface hipsparseScsc2dense
-#ifdef USE_CUDA_NAMES
-    function hipsparseScsc2dense_(handle,m,n,descr,cscVal,cscRowInd,cscColPtr,A,ld) &
-        bind(c, name="cusparseScsc2dense")
-#else
     function hipsparseScsc2dense_(handle,m,n,descr,cscVal,cscRowInd,cscColPtr,A,ld) &
         bind(c, name="hipsparseScsc2dense")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -15507,15 +15106,12 @@ module hipfort_hipsparse
       hipsparseScsc2dense_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseDcsc2dense
-#ifdef USE_CUDA_NAMES
-    function hipsparseDcsc2dense_(handle,m,n,descr,cscVal,cscRowInd,cscColPtr,A,ld) &
-        bind(c, name="cusparseDcsc2dense")
-#else
     function hipsparseDcsc2dense_(handle,m,n,descr,cscVal,cscRowInd,cscColPtr,A,ld) &
         bind(c, name="hipsparseDcsc2dense")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -15538,15 +15134,12 @@ module hipfort_hipsparse
       hipsparseDcsc2dense_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseCcsc2dense
-#ifdef USE_CUDA_NAMES
-    function hipsparseCcsc2dense_(handle,m,n,descr,cscVal,cscRowInd,cscColPtr,A,ld) &
-        bind(c, name="cusparseCcsc2dense")
-#else
     function hipsparseCcsc2dense_(handle,m,n,descr,cscVal,cscRowInd,cscColPtr,A,ld) &
         bind(c, name="hipsparseCcsc2dense")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -15569,15 +15162,12 @@ module hipfort_hipsparse
       hipsparseCcsc2dense_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseZcsc2dense
-#ifdef USE_CUDA_NAMES
-    function hipsparseZcsc2dense_(handle,m,n,descr,cscVal,cscRowInd,cscColPtr,A,ld) &
-        bind(c, name="cusparseZcsc2dense")
-#else
     function hipsparseZcsc2dense_(handle,m,n,descr,cscVal,cscRowInd,cscColPtr,A,ld) &
         bind(c, name="hipsparseZcsc2dense")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -15600,6 +15190,7 @@ module hipfort_hipsparse
       hipsparseZcsc2dense_full_rank
 #endif
   end interface
+#endif
 
   !>  \ingroup conv_module
   !>   \brief Sort a sparse CSC matrix.
@@ -16362,16 +15953,11 @@ module hipfort_hipsparse
   !>           `HIPSPARSE_INDEX_BASE_ZERO` nor `HIPSPARSE_INDEX_BASE_ONE`.
   !>   \retval HIPSPARSE_STATUS_ARCH_MISMATCH the device is not supported.
   !>   \retval HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
+#ifndef USE_CUDA_NAMES
   interface hipsparseScsr2csc
-#ifdef USE_CUDA_NAMES
-    function hipsparseScsr2csc_(handle,m,n,nnz,csrSortedVal,csrSortedRowPtr,csrSortedColInd, &
-        cscSortedVal,cscSortedRowInd,cscSortedColPtr,copyValues,idxBase) &
-        bind(c, name="cusparseScsr2csc")
-#else
     function hipsparseScsr2csc_(handle,m,n,nnz,csrSortedVal,csrSortedRowPtr,csrSortedColInd, &
         cscSortedVal,cscSortedRowInd,cscSortedColPtr,copyValues,idxBase) &
         bind(c, name="hipsparseScsr2csc")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -16396,17 +15982,13 @@ module hipfort_hipsparse
       hipsparseScsr2csc_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseDcsr2csc
-#ifdef USE_CUDA_NAMES
-    function hipsparseDcsr2csc_(handle,m,n,nnz,csrSortedVal,csrSortedRowPtr,csrSortedColInd, &
-        cscSortedVal,cscSortedRowInd,cscSortedColPtr,copyValues,idxBase) &
-        bind(c, name="cusparseDcsr2csc")
-#else
     function hipsparseDcsr2csc_(handle,m,n,nnz,csrSortedVal,csrSortedRowPtr,csrSortedColInd, &
         cscSortedVal,cscSortedRowInd,cscSortedColPtr,copyValues,idxBase) &
         bind(c, name="hipsparseDcsr2csc")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -16431,17 +16013,13 @@ module hipfort_hipsparse
       hipsparseDcsr2csc_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseCcsr2csc
-#ifdef USE_CUDA_NAMES
-    function hipsparseCcsr2csc_(handle,m,n,nnz,csrSortedVal,csrSortedRowPtr,csrSortedColInd, &
-        cscSortedVal,cscSortedRowInd,cscSortedColPtr,copyValues,idxBase) &
-        bind(c, name="cusparseCcsr2csc")
-#else
     function hipsparseCcsr2csc_(handle,m,n,nnz,csrSortedVal,csrSortedRowPtr,csrSortedColInd, &
         cscSortedVal,cscSortedRowInd,cscSortedColPtr,copyValues,idxBase) &
         bind(c, name="hipsparseCcsr2csc")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -16466,17 +16044,13 @@ module hipfort_hipsparse
       hipsparseCcsr2csc_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseZcsr2csc
-#ifdef USE_CUDA_NAMES
-    function hipsparseZcsr2csc_(handle,m,n,nnz,csrSortedVal,csrSortedRowPtr,csrSortedColInd, &
-        cscSortedVal,cscSortedRowInd,cscSortedColPtr,copyValues,idxBase) &
-        bind(c, name="cusparseZcsr2csc")
-#else
     function hipsparseZcsr2csc_(handle,m,n,nnz,csrSortedVal,csrSortedRowPtr,csrSortedColInd, &
         cscSortedVal,cscSortedRowInd,cscSortedColPtr,copyValues,idxBase) &
         bind(c, name="hipsparseZcsr2csc")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -16501,6 +16075,7 @@ module hipfort_hipsparse
       hipsparseZcsr2csc_rank_1
 #endif
   end interface
+#endif
 
   !>  \ingroup conv_module
   !>   \brief This function computes the size of the user-allocated temporary storage buffer used
@@ -17098,14 +16673,10 @@ module hipfort_hipsparse
   !>   \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
   !>   \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descr, \p csrVal, \p csrRowPtr,
   !>           \p csrColInd, or \p A is nullptr, \p m or \p n is negative, or \p ld is invalid.
+#ifndef USE_CUDA_NAMES
   interface hipsparseScsr2dense
-#ifdef USE_CUDA_NAMES
-    function hipsparseScsr2dense_(handle,m,n,descr,csrVal,csrRowPtr,csrColInd,A,ld) &
-        bind(c, name="cusparseScsr2dense")
-#else
     function hipsparseScsr2dense_(handle,m,n,descr,csrVal,csrRowPtr,csrColInd,A,ld) &
         bind(c, name="hipsparseScsr2dense")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -17128,15 +16699,12 @@ module hipfort_hipsparse
       hipsparseScsr2dense_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseDcsr2dense
-#ifdef USE_CUDA_NAMES
-    function hipsparseDcsr2dense_(handle,m,n,descr,csrVal,csrRowPtr,csrColInd,A,ld) &
-        bind(c, name="cusparseDcsr2dense")
-#else
     function hipsparseDcsr2dense_(handle,m,n,descr,csrVal,csrRowPtr,csrColInd,A,ld) &
         bind(c, name="hipsparseDcsr2dense")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -17159,15 +16727,12 @@ module hipfort_hipsparse
       hipsparseDcsr2dense_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseCcsr2dense
-#ifdef USE_CUDA_NAMES
-    function hipsparseCcsr2dense_(handle,m,n,descr,csrVal,csrRowPtr,csrColInd,A,ld) &
-        bind(c, name="cusparseCcsr2dense")
-#else
     function hipsparseCcsr2dense_(handle,m,n,descr,csrVal,csrRowPtr,csrColInd,A,ld) &
         bind(c, name="hipsparseCcsr2dense")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -17190,15 +16755,12 @@ module hipfort_hipsparse
       hipsparseCcsr2dense_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseZcsr2dense
-#ifdef USE_CUDA_NAMES
-    function hipsparseZcsr2dense_(handle,m,n,descr,csrVal,csrRowPtr,csrColInd,A,ld) &
-        bind(c, name="cusparseZcsr2dense")
-#else
     function hipsparseZcsr2dense_(handle,m,n,descr,csrVal,csrRowPtr,csrColInd,A,ld) &
         bind(c, name="hipsparseZcsr2dense")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -17221,6 +16783,7 @@ module hipfort_hipsparse
       hipsparseZcsr2dense_full_rank
 #endif
   end interface
+#endif
 
   !>  \ingroup conv_module
   !>   \brief Convert a sparse CSR matrix into a sparse GEBSR matrix.
@@ -17966,16 +17529,11 @@ module hipfort_hipsparse
   !>   \retval HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
   !>   \retval HIPSPARSE_STATUS_NOT_SUPPORTED `hipsparseMatrixType_t` !=
   !>   `HIPSPARSE_MATRIX_TYPE_GENERAL`.
+#ifndef USE_CUDA_NAMES
   interface hipsparseScsr2hyb
-#ifdef USE_CUDA_NAMES
-    function hipsparseScsr2hyb_(handle,m,n,descrA,csrSortedValA,csrSortedRowPtrA,csrSortedColIndA, &
-        hybA,userEllWidth,partitionType) &
-        bind(c, name="cusparseScsr2hyb")
-#else
     function hipsparseScsr2hyb_(handle,m,n,descrA,csrSortedValA,csrSortedRowPtrA,csrSortedColIndA, &
         hybA,userEllWidth,partitionType) &
         bind(c, name="hipsparseScsr2hyb")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -17998,17 +17556,13 @@ module hipfort_hipsparse
       hipsparseScsr2hyb_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseDcsr2hyb
-#ifdef USE_CUDA_NAMES
-    function hipsparseDcsr2hyb_(handle,m,n,descrA,csrSortedValA,csrSortedRowPtrA,csrSortedColIndA, &
-        hybA,userEllWidth,partitionType) &
-        bind(c, name="cusparseDcsr2hyb")
-#else
     function hipsparseDcsr2hyb_(handle,m,n,descrA,csrSortedValA,csrSortedRowPtrA,csrSortedColIndA, &
         hybA,userEllWidth,partitionType) &
         bind(c, name="hipsparseDcsr2hyb")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -18031,17 +17585,13 @@ module hipfort_hipsparse
       hipsparseDcsr2hyb_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseCcsr2hyb
-#ifdef USE_CUDA_NAMES
-    function hipsparseCcsr2hyb_(handle,m,n,descrA,csrSortedValA,csrSortedRowPtrA,csrSortedColIndA, &
-        hybA,userEllWidth,partitionType) &
-        bind(c, name="cusparseCcsr2hyb")
-#else
     function hipsparseCcsr2hyb_(handle,m,n,descrA,csrSortedValA,csrSortedRowPtrA,csrSortedColIndA, &
         hybA,userEllWidth,partitionType) &
         bind(c, name="hipsparseCcsr2hyb")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -18064,17 +17614,13 @@ module hipfort_hipsparse
       hipsparseCcsr2hyb_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseZcsr2hyb
-#ifdef USE_CUDA_NAMES
-    function hipsparseZcsr2hyb_(handle,m,n,descrA,csrSortedValA,csrSortedRowPtrA,csrSortedColIndA, &
-        hybA,userEllWidth,partitionType) &
-        bind(c, name="cusparseZcsr2hyb")
-#else
     function hipsparseZcsr2hyb_(handle,m,n,descrA,csrSortedValA,csrSortedRowPtrA,csrSortedColIndA, &
         hybA,userEllWidth,partitionType) &
         bind(c, name="hipsparseZcsr2hyb")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -18097,6 +17643,7 @@ module hipfort_hipsparse
       hipsparseZcsr2hyb_rank_1
 #endif
   end interface
+#endif
 
   !>  \ingroup conv_module
   !>   \brief Sort a sparse CSR matrix.
@@ -18580,14 +18127,10 @@ module hipfort_hipsparse
   !>   \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descr, \p A, \p nnzPerColumn, \p cscVal,
   !>           \p cscColPtr, or \p cscRowInd is nullptr, \p m or \p n is negative, or \p ld is
   !>           invalid.
+#ifndef USE_CUDA_NAMES
   interface hipsparseSdense2csc
-#ifdef USE_CUDA_NAMES
-    function hipsparseSdense2csc_(handle,m,n,descr,A,ld,nnzPerColumn,cscVal,cscRowInd,cscColPtr) &
-        bind(c, name="cusparseSdense2csc")
-#else
     function hipsparseSdense2csc_(handle,m,n,descr,A,ld,nnzPerColumn,cscVal,cscRowInd,cscColPtr) &
         bind(c, name="hipsparseSdense2csc")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -18611,15 +18154,12 @@ module hipfort_hipsparse
       hipsparseSdense2csc_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseDdense2csc
-#ifdef USE_CUDA_NAMES
-    function hipsparseDdense2csc_(handle,m,n,descr,A,ld,nnzPerColumn,cscVal,cscRowInd,cscColPtr) &
-        bind(c, name="cusparseDdense2csc")
-#else
     function hipsparseDdense2csc_(handle,m,n,descr,A,ld,nnzPerColumn,cscVal,cscRowInd,cscColPtr) &
         bind(c, name="hipsparseDdense2csc")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -18643,15 +18183,12 @@ module hipfort_hipsparse
       hipsparseDdense2csc_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseCdense2csc
-#ifdef USE_CUDA_NAMES
-    function hipsparseCdense2csc_(handle,m,n,descr,A,ld,nnzPerColumn,cscVal,cscRowInd,cscColPtr) &
-        bind(c, name="cusparseCdense2csc")
-#else
     function hipsparseCdense2csc_(handle,m,n,descr,A,ld,nnzPerColumn,cscVal,cscRowInd,cscColPtr) &
         bind(c, name="hipsparseCdense2csc")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -18675,15 +18212,12 @@ module hipfort_hipsparse
       hipsparseCdense2csc_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseZdense2csc
-#ifdef USE_CUDA_NAMES
-    function hipsparseZdense2csc_(handle,m,n,descr,A,ld,nnzPerColumn,cscVal,cscRowInd,cscColPtr) &
-        bind(c, name="cusparseZdense2csc")
-#else
     function hipsparseZdense2csc_(handle,m,n,descr,A,ld,nnzPerColumn,cscVal,cscRowInd,cscColPtr) &
         bind(c, name="hipsparseZdense2csc")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -18707,6 +18241,7 @@ module hipfort_hipsparse
       hipsparseZdense2csc_full_rank
 #endif
   end interface
+#endif
 
   !>  \ingroup conv_module
   !>   \brief
@@ -18778,14 +18313,10 @@ module hipfort_hipsparse
   !>   \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descr, \p A, \p nnzPerRow, \p csrVal,
   !>           \p csrRowPtr, or \p csrColInd is nullptr, \p m or \p n is negative, or \p ld is
   !>           invalid.
+#ifndef USE_CUDA_NAMES
   interface hipsparseSdense2csr
-#ifdef USE_CUDA_NAMES
-    function hipsparseSdense2csr_(handle,m,n,descr,A,ld,nnzPerRow,csrVal,csrRowPtr,csrColInd) &
-        bind(c, name="cusparseSdense2csr")
-#else
     function hipsparseSdense2csr_(handle,m,n,descr,A,ld,nnzPerRow,csrVal,csrRowPtr,csrColInd) &
         bind(c, name="hipsparseSdense2csr")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -18809,15 +18340,12 @@ module hipfort_hipsparse
       hipsparseSdense2csr_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseDdense2csr
-#ifdef USE_CUDA_NAMES
-    function hipsparseDdense2csr_(handle,m,n,descr,A,ld,nnzPerRow,csrVal,csrRowPtr,csrColInd) &
-        bind(c, name="cusparseDdense2csr")
-#else
     function hipsparseDdense2csr_(handle,m,n,descr,A,ld,nnzPerRow,csrVal,csrRowPtr,csrColInd) &
         bind(c, name="hipsparseDdense2csr")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -18841,15 +18369,12 @@ module hipfort_hipsparse
       hipsparseDdense2csr_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseCdense2csr
-#ifdef USE_CUDA_NAMES
-    function hipsparseCdense2csr_(handle,m,n,descr,A,ld,nnzPerRow,csrVal,csrRowPtr,csrColInd) &
-        bind(c, name="cusparseCdense2csr")
-#else
     function hipsparseCdense2csr_(handle,m,n,descr,A,ld,nnzPerRow,csrVal,csrRowPtr,csrColInd) &
         bind(c, name="hipsparseCdense2csr")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -18873,15 +18398,12 @@ module hipfort_hipsparse
       hipsparseCdense2csr_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseZdense2csr
-#ifdef USE_CUDA_NAMES
-    function hipsparseZdense2csr_(handle,m,n,descr,A,ld,nnzPerRow,csrVal,csrRowPtr,csrColInd) &
-        bind(c, name="cusparseZdense2csr")
-#else
     function hipsparseZdense2csr_(handle,m,n,descr,A,ld,nnzPerRow,csrVal,csrRowPtr,csrColInd) &
         bind(c, name="hipsparseZdense2csr")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -18905,6 +18427,7 @@ module hipfort_hipsparse
       hipsparseZdense2csr_full_rank
 #endif
   end interface
+#endif
 
   !>  \ingroup conv_module
   !>   \brief Convert a sparse GEBSR matrix into a sparse CSR matrix.
@@ -20229,16 +19752,11 @@ module hipfort_hipsparse
   !>   \retval HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
   !>   \retval HIPSPARSE_STATUS_NOT_SUPPORTED `hipsparseMatrixType_t` !=
   !>   `HIPSPARSE_MATRIX_TYPE_GENERAL`.
+#ifndef USE_CUDA_NAMES
   interface hipsparseShyb2csr
-#ifdef USE_CUDA_NAMES
-    function hipsparseShyb2csr_(handle,descrA,hybA,csrSortedValA,csrSortedRowPtrA, &
-        csrSortedColIndA) &
-        bind(c, name="cusparseShyb2csr")
-#else
     function hipsparseShyb2csr_(handle,descrA,hybA,csrSortedValA,csrSortedRowPtrA, &
         csrSortedColIndA) &
         bind(c, name="hipsparseShyb2csr")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -20257,17 +19775,13 @@ module hipfort_hipsparse
       hipsparseShyb2csr_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseDhyb2csr
-#ifdef USE_CUDA_NAMES
-    function hipsparseDhyb2csr_(handle,descrA,hybA,csrSortedValA,csrSortedRowPtrA, &
-        csrSortedColIndA) &
-        bind(c, name="cusparseDhyb2csr")
-#else
     function hipsparseDhyb2csr_(handle,descrA,hybA,csrSortedValA,csrSortedRowPtrA, &
         csrSortedColIndA) &
         bind(c, name="hipsparseDhyb2csr")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -20286,17 +19800,13 @@ module hipfort_hipsparse
       hipsparseDhyb2csr_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseChyb2csr
-#ifdef USE_CUDA_NAMES
-    function hipsparseChyb2csr_(handle,descrA,hybA,csrSortedValA,csrSortedRowPtrA, &
-        csrSortedColIndA) &
-        bind(c, name="cusparseChyb2csr")
-#else
     function hipsparseChyb2csr_(handle,descrA,hybA,csrSortedValA,csrSortedRowPtrA, &
         csrSortedColIndA) &
         bind(c, name="hipsparseChyb2csr")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -20315,17 +19825,13 @@ module hipfort_hipsparse
       hipsparseChyb2csr_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseZhyb2csr
-#ifdef USE_CUDA_NAMES
-    function hipsparseZhyb2csr_(handle,descrA,hybA,csrSortedValA,csrSortedRowPtrA, &
-        csrSortedColIndA) &
-        bind(c, name="cusparseZhyb2csr")
-#else
     function hipsparseZhyb2csr_(handle,descrA,hybA,csrSortedValA,csrSortedRowPtrA, &
         csrSortedColIndA) &
         bind(c, name="hipsparseZhyb2csr")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -20344,6 +19850,7 @@ module hipfort_hipsparse
       hipsparseZhyb2csr_rank_1
 #endif
   end interface
+#endif
 
   !>  \ingroup conv_module
   !>   \brief
@@ -20763,16 +20270,11 @@ module hipfort_hipsparse
   !>   \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
   !>   \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle or \p pBufferSizeInBytes pointer is invalid.
   !>   \retval     HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
+#ifndef USE_CUDA_NAMES
   interface hipsparseSpruneCsr2csr_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsparseSpruneCsr2csr_bufferSize_(handle,m,n,nnzA,descrA,csrValA,csrRowPtrA, &
-        csrColIndA,threshold,descrC,csrValC,csrRowPtrC,csrColIndC,pBufferSizeInBytes) &
-        bind(c, name="cusparseSpruneCsr2csr_bufferSize")
-#else
     function hipsparseSpruneCsr2csr_bufferSize_(handle,m,n,nnzA,descrA,csrValA,csrRowPtrA, &
         csrColIndA,threshold,descrC,csrValC,csrRowPtrC,csrColIndC,pBufferSizeInBytes) &
         bind(c, name="hipsparseSpruneCsr2csr_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -20799,17 +20301,13 @@ module hipfort_hipsparse
       hipsparseSpruneCsr2csr_bufferSize_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseDpruneCsr2csr_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsparseDpruneCsr2csr_bufferSize_(handle,m,n,nnzA,descrA,csrValA,csrRowPtrA, &
-        csrColIndA,threshold,descrC,csrValC,csrRowPtrC,csrColIndC,pBufferSizeInBytes) &
-        bind(c, name="cusparseDpruneCsr2csr_bufferSize")
-#else
     function hipsparseDpruneCsr2csr_bufferSize_(handle,m,n,nnzA,descrA,csrValA,csrRowPtrA, &
         csrColIndA,threshold,descrC,csrValC,csrRowPtrC,csrColIndC,pBufferSizeInBytes) &
         bind(c, name="hipsparseDpruneCsr2csr_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -20836,6 +20334,7 @@ module hipfort_hipsparse
       hipsparseDpruneCsr2csr_bufferSize_rank_1
 #endif
   end interface
+#endif
 
   !>  \ingroup conv_module
   !>   \brief Convert and prune sparse a CSR matrix into a sparse CSR matrix.
@@ -21279,18 +20778,12 @@ module hipfort_hipsparse
   !>   \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
   !>   \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle or \p pBufferSizeInBytes pointer is invalid.
   !>   \retval     HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
+#ifndef USE_CUDA_NAMES
   interface hipsparseSpruneCsr2csrByPercentage_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsparseSpruneCsr2csrByPercentage_bufferSize_(handle,m,n,nnzA,descrA,csrValA, &
-        csrRowPtrA,csrColIndA,percentage,descrC,csrValC,csrRowPtrC,csrColIndC,myInfo, &
-        pBufferSizeInBytes) &
-        bind(c, name="cusparseSpruneCsr2csrByPercentage_bufferSize")
-#else
     function hipsparseSpruneCsr2csrByPercentage_bufferSize_(handle,m,n,nnzA,descrA,csrValA, &
         csrRowPtrA,csrColIndA,percentage,descrC,csrValC,csrRowPtrC,csrColIndC,myInfo, &
         pBufferSizeInBytes) &
         bind(c, name="hipsparseSpruneCsr2csrByPercentage_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -21318,19 +20811,14 @@ module hipfort_hipsparse
       hipsparseSpruneCsr2csrByPercentage_bufferSize_rank_1
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseDpruneCsr2csrByPercentage_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsparseDpruneCsr2csrByPercentage_bufferSize_(handle,m,n,nnzA,descrA,csrValA, &
-        csrRowPtrA,csrColIndA,percentage,descrC,csrValC,csrRowPtrC,csrColIndC,myInfo, &
-        pBufferSizeInBytes) &
-        bind(c, name="cusparseDpruneCsr2csrByPercentage_bufferSize")
-#else
     function hipsparseDpruneCsr2csrByPercentage_bufferSize_(handle,m,n,nnzA,descrA,csrValA, &
         csrRowPtrA,csrColIndA,percentage,descrC,csrValC,csrRowPtrC,csrColIndC,myInfo, &
         pBufferSizeInBytes) &
         bind(c, name="hipsparseDpruneCsr2csrByPercentage_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -21358,6 +20846,7 @@ module hipfort_hipsparse
       hipsparseDpruneCsr2csrByPercentage_bufferSize_rank_1
 #endif
   end interface
+#endif
 
   !>  \ingroup conv_module
   !>   \brief Convert and prune by percentage a sparse CSR matrix into a sparse CSR matrix.
@@ -21831,16 +21320,11 @@ module hipfort_hipsparse
   !>   \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle or \p pBufferSizeInBytes is nullptr,
   !>           or \p m or \p n is negative.
   !>   \retval HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
+#ifndef USE_CUDA_NAMES
   interface hipsparseSpruneDense2csr_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsparseSpruneDense2csr_bufferSize_(handle,m,n,A,lda,threshold,descr,csrVal, &
-        csrRowPtr,csrColInd,pBufferSizeInBytes) &
-        bind(c, name="cusparseSpruneDense2csr_bufferSize")
-#else
     function hipsparseSpruneDense2csr_bufferSize_(handle,m,n,A,lda,threshold,descr,csrVal, &
         csrRowPtr,csrColInd,pBufferSizeInBytes) &
         bind(c, name="hipsparseSpruneDense2csr_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -21865,17 +21349,13 @@ module hipfort_hipsparse
       hipsparseSpruneDense2csr_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseDpruneDense2csr_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsparseDpruneDense2csr_bufferSize_(handle,m,n,A,lda,threshold,descr,csrVal, &
-        csrRowPtr,csrColInd,pBufferSizeInBytes) &
-        bind(c, name="cusparseDpruneDense2csr_bufferSize")
-#else
     function hipsparseDpruneDense2csr_bufferSize_(handle,m,n,A,lda,threshold,descr,csrVal, &
         csrRowPtr,csrColInd,pBufferSizeInBytes) &
         bind(c, name="hipsparseDpruneDense2csr_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -21900,6 +21380,7 @@ module hipfort_hipsparse
       hipsparseDpruneDense2csr_bufferSize_full_rank
 #endif
   end interface
+#endif
 
   interface hipsparseSpruneDense2csr_bufferSizeExt
 #ifdef USE_CUDA_NAMES
@@ -22376,16 +21857,11 @@ module hipfort_hipsparse
   !>   \retval HIPSPARSE_STATUS_INVALID_VALUE the \p handle or \p pBufferSizeInBytes pointer is
   !>   invalid.
   !>   \retval     HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
+#ifndef USE_CUDA_NAMES
   interface hipsparseSpruneDense2csrByPercentage_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsparseSpruneDense2csrByPercentage_bufferSize_(handle,m,n,A,lda,percentage,descr, &
-        csrVal,csrRowPtr,csrColInd,myInfo,pBufferSizeInBytes) &
-        bind(c, name="cusparseSpruneDense2csrByPercentage_bufferSize")
-#else
     function hipsparseSpruneDense2csrByPercentage_bufferSize_(handle,m,n,A,lda,percentage,descr, &
         csrVal,csrRowPtr,csrColInd,myInfo,pBufferSizeInBytes) &
         bind(c, name="hipsparseSpruneDense2csrByPercentage_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -22411,17 +21887,13 @@ module hipfort_hipsparse
       hipsparseSpruneDense2csrByPercentage_bufferSize_full_rank
 #endif
   end interface
+#endif
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseDpruneDense2csrByPercentage_bufferSize
-#ifdef USE_CUDA_NAMES
-    function hipsparseDpruneDense2csrByPercentage_bufferSize_(handle,m,n,A,lda,percentage,descr, &
-        csrVal,csrRowPtr,csrColInd,myInfo,pBufferSizeInBytes) &
-        bind(c, name="cusparseDpruneDense2csrByPercentage_bufferSize")
-#else
     function hipsparseDpruneDense2csrByPercentage_bufferSize_(handle,m,n,A,lda,percentage,descr, &
         csrVal,csrRowPtr,csrColInd,myInfo,pBufferSizeInBytes) &
         bind(c, name="hipsparseDpruneDense2csrByPercentage_bufferSize")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -22447,6 +21919,7 @@ module hipfort_hipsparse
       hipsparseDpruneDense2csrByPercentage_bufferSize_full_rank
 #endif
   end interface
+#endif
 
   !>  \ingroup conv_module
   !>   \brief
@@ -23301,16 +22774,11 @@ module hipfort_hipsparse
     end function
   end interface
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseCreateCooAoS
-#ifdef USE_CUDA_NAMES
-    function hipsparseCreateCooAoS_(spMatDescr,rows,cols,nnz,cooInd,cooValues,cooIdxType,idxBase, &
-        valueType) &
-        bind(c, name="cusparseCreateCooAoS")
-#else
     function hipsparseCreateCooAoS_(spMatDescr,rows,cols,nnz,cooInd,cooValues,cooIdxType,idxBase, &
         valueType) &
         bind(c, name="hipsparseCreateCooAoS")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       use hipfort_enums
@@ -23327,6 +22795,7 @@ module hipfort_hipsparse
       integer(kind(HIP_R_32F)),value :: valueType
     end function
   end interface
+#endif
 
   interface hipsparseCreateCsr
 #ifdef USE_CUDA_NAMES
@@ -23634,16 +23103,11 @@ module hipfort_hipsparse
     end function
   end interface
 
+#ifndef USE_CUDA_NAMES
   interface hipsparseCooAoSGet
-#ifdef USE_CUDA_NAMES
-    function hipsparseCooAoSGet_(spMatDescr,rows,cols,nnz,cooInd,cooValues,idxType,idxBase, &
-        valueType) &
-        bind(c, name="cusparseCooAoSGet")
-#else
     function hipsparseCooAoSGet_(spMatDescr,rows,cols,nnz,cooInd,cooValues,idxType,idxBase, &
         valueType) &
         bind(c, name="hipsparseCooAoSGet")
-#endif
       use iso_c_binding
       use hipfort_hipsparse_enums
       implicit none
@@ -23659,6 +23123,7 @@ module hipfort_hipsparse
       type(c_ptr),value :: valueType
     end function
   end interface
+#endif
 
   interface hipsparseCsrGet
 #ifdef USE_CUDA_NAMES


### PR DESCRIPTION
Investigating the README known issue *"hipSOLVER interfaces will only work for AMD GPUs"* (still true, verified) surfaced the same class of bug in several libraries: interfaces mapped under `USE_CUDA_NAMES` to `cu*` symbols that **do not exist** in the CUDA libraries. Referencing them breaks the NVIDIA link.

Validated every emitted `cu*` name against the real CUDA libraries (CUDA 13.3, cross-checked 13.2 / 12), via `check_cuda_symbols.sh --fix`. Names with no CUDA symbol are dropped from `src/<lib>/<lib>.txt`, so those interfaces are emitted under `#ifndef USE_CUDA_NAMES` (AMD-only, explicit) instead of binding a phantom symbol:

| lib | bogus mappings dropped | nature |
|---|---|---|
| hipBLAS | 715 (377 base + 338 `_64`) | batched/strided variants cuBLAS has no equivalent for |
| hipSOLVER | 229 | regular `hipsolver*` API — no native cuSOLVER equivalent (cuSOLVER is `cusolverDn*`) |
| hipSPARSE | 153 | legacy cuSPARSE API removed in CUDA 12 |
| HIP runtime | 118 | `cuda*` symbols absent in CUDA 13 |
| hipRAND | 2 | `curandGenerateChar/Short` — no cuRAND equivalent |

Kept mappings all verified to exist (e.g. the `hipsolverDn*` compat API → real `cusolverDn*`; `cublasDgemm` etc.). `hipFFT` was already clean (0). AMD build clean.

The hipSOLVER known-issue note is reworded to be precise (regular API = AMD-only; `hipsolverDn*` compat = NVIDIA too).