### PR TITLE
Support the Intel Fortran compilers (ifx/ifort)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Added
 
+* hipfort now builds with the Intel Fortran compilers (`ifx`/`ifort`). On Intel,
+  the Fortran 2003 (`type(c_ptr)`) interfaces are used; the Fortran 2008 array
+  interfaces stay disabled there because their generic interfaces are rejected as
+  ambiguous by the Intel front end.
 * **hipFFTW support.** Added Fortran interfaces to the FFTW3-compatible hipFFTW
   library (new `hipfort_hipfftw` modules) and a `hipfort::hipfftw` CMake target.
 * Regenerated the library bindings against the current ROCm API, adding the new

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -22,6 +22,19 @@ file(GLOB HIPFORT_SRC_HIP_F90 "${CMAKE_CURRENT_SOURCE_DIR}/hipfort/*.f90")
 file(GLOB HIPFORT_SRC_HIP_F90_UPPER "${CMAKE_CURRENT_SOURCE_DIR}/hipfort/*.F90")
 set(HIPFORT_SRC_HIP ${HIPFORT_SRC_HIP_F90} ${HIPFORT_SRC_HIP_F90_UPPER})
 
+# The Fortran 2008 array interfaces (USE_FPOINTER_INTERFACES) rely on generic
+# interfaces that the Intel compilers (ifx/ifort) reject as ambiguous. Build the
+# Fortran 2003 (type(c_ptr)) interfaces there instead.
+set(HIPFORT_USE_FPOINTER_INTERFACES OFF)
+if(CMAKE_Fortran_COMPILER_SUPPORTS_F08 AND NOT CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
+  set(HIPFORT_USE_FPOINTER_INTERFACES ON)
+elseif(CMAKE_Fortran_COMPILER_SUPPORTS_F08)
+  message(STATUS "Intel Fortran (${CMAKE_Fortran_COMPILER_ID}) detected: building the "
+                 "Fortran 2003 (type(c_ptr)) interfaces; the Fortran 2008 array "
+                 "interfaces are disabled to avoid a generic-interface ambiguity "
+                 "rejected by ifx/ifort.")
+endif()
+
 set(HIPFORT_ARCH "amdgcn")
     # amdgcn
     set(HIPFORT_LIB      "hipfort-${HIPFORT_ARCH}")
@@ -33,9 +46,9 @@ set(HIPFORT_ARCH "amdgcn")
       PUBLIC
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/hipfort/amdgcn>
     )
-    IF(CMAKE_Fortran_COMPILER_SUPPORTS_F08)
+    IF(HIPFORT_USE_FPOINTER_INTERFACES)
     	target_compile_definitions(${HIPFORT_LIB} PRIVATE USE_FPOINTER_INTERFACES)
-    ENDIF(CMAKE_Fortran_COMPILER_SUPPORTS_F08)
+    ENDIF(HIPFORT_USE_FPOINTER_INTERFACES)
     target_compile_definitions(${HIPFORT_LIB} PRIVATE _HIPFORT_ARCH='${HIPFORT_ARCH}')
     # Install Target hipfort-amdgcn
     # CMAKE_INSTALL_LIBDIR/INCLUDEDIR already carry the toolchain-specific
@@ -61,9 +74,9 @@ set(HIPFORT_ARCH "nvptx")
     ADD_LIBRARY(${HIPFORT_LIB} STATIC 
          ${HIPFORT_SRC_HIP} 
          )
-    IF(CMAKE_Fortran_COMPILER_SUPPORTS_F08)
+    IF(HIPFORT_USE_FPOINTER_INTERFACES)
     	target_compile_definitions(${HIPFORT_LIB} PRIVATE USE_FPOINTER_INTERFACES)
-    ENDIF(CMAKE_Fortran_COMPILER_SUPPORTS_F08)
+    ENDIF(HIPFORT_USE_FPOINTER_INTERFACES)
     target_compile_definitions(${HIPFORT_LIB} PRIVATE USE_CUDA_NAMES)
     target_compile_definitions(${HIPFORT_LIB} PRIVATE _HIPFORT_ARCH='${HIPFORT_ARCH}')
     # Install Target hipfort-nvptx

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,7 +13,22 @@ endif()
 # cmake-based test infrastructure
 
 if(BUILD_TESTING)
+  # The Intel compilers (ifx/ifort) do not recognize the .f03/.f08 source
+  # extensions and skip such files ("no action performed"). Force Fortran
+  # compilation by inserting -Tf immediately before the source in the compile
+  # rule (set_source_files_properties(LANGUAGE Fortran) alone is not enough).
+  if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
+    string(REPLACE "<SOURCE>" "-Tf <SOURCE>"
+           CMAKE_Fortran_COMPILE_OBJECT "${CMAKE_Fortran_COMPILE_OBJECT}")
+  endif()
+
   function(hipfort_add_test lib func dir)
+    # The Fortran 2008 array interfaces are disabled on the Intel compilers
+    # (see USE_FPOINTER_INTERFACES in lib/CMakeLists.txt), so the f2008 tests
+    # cannot be built there; skip them.
+    if(dir STREQUAL "f2008" AND CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
+      return()
+    endif()
     # f2003 tests use .f03, f2008 tests use .f08 to match the target standard.
     if(dir STREQUAL "f2008")
       set(ext "f08")
@@ -361,6 +376,11 @@ if(BUILD_TESTING)
   if(CMAKE_HIP_COMPILER)
     enable_language(HIP)
     foreach(std IN ITEMS f2003 f2008)
+      # The f2008 interfaces are disabled on the Intel compilers, so skip the
+      # f2008 vecadd test there (see USE_FPOINTER_INTERFACES in lib/CMakeLists.txt).
+      if(std STREQUAL "f2008" AND CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
+        continue()
+      endif()
       # f2003 tests use .f03, f2008 tests use .f08 to match the target standard.
       if(std STREQUAL "f2008")
         set(ext "f08")


### PR DESCRIPTION
## Summary

Make hipfort (and its test suite) build with the Intel Fortran compilers (`ifx`, and classic `ifort`).

### Library: Fortran 2003 interfaces on Intel

The Fortran 2008 array interfaces (`USE_FPOINTER_INTERFACES`) add many typed specifics to generic interfaces such as `hipMemcpy`. The Intel front end applies stricter generic-disambiguation rules than GNU/LLVM Flang and rejects some as *not distinguishable* (`error #5286: Ambiguous generic interface HIPMEMCPY`), aborting the build. gfortran and amdflang accept the same code.

Since the typed variants are all guarded by `USE_FPOINTER_INTERFACES` (the raw `type(c_ptr)` bindings are always present), we simply do not enable that definition on Intel. hipfort then exposes the Fortran 2003 (`type(c_ptr)`) interfaces there; the raw bindings the library calls internally remain available. GNU/LLVM Flang/NVHPC/Cray keep the full Fortran 2008 interfaces.

### Tests: build with Intel

- The Intel front end does not recognize the `.f03`/`.f08` extensions and silently skips such files (`warning #10145: no action performed`), so linking fails. The test compile rule now inserts `-Tf` before the source on Intel to force Fortran compilation (`set_source_files_properties(LANGUAGE Fortran)` alone is not enough for ifx).
- The f2008 tests (and the f2008 vecadd) are skipped on Intel, since the f2008 interfaces are disabled there.

## Verification (real build against ROCm 7.2.3, ifx 2026.1)

- `libhipfort-amdgcn.a` builds with ifx (f2003 interfaces).
- The **full f2003 test suite — 125 executables**, including the Fortran + HIP `vecadd` — **compiles and links** with ifx; the f2008 targets are correctly skipped.
- Tests were **not executed**: the environment has no GPU (`/dev/kfd`, `/dev/dri` absent), so the HIP runtime cannot run — execution needs CI with a GPU.
- Classic `ifort` could not be run directly (removed from oneAPI 2025+; only `ifx` ships in 2026.1), but the same gating applies to it.

## Trade-off

On Intel, the Fortran 2008 convenience interfaces (array overloads of `hipMalloc`/`hipMemcpy`, etc.) are unavailable. Restoring them would require making the generated generic interfaces distinguishable under Intel's rules — a code-generator change, out of scope here.

Relates to #123.