### PR TITLE
toolchains: note that intel.cmake needs icx/icpx too

### DIFF
--- a/cmake/toolchains/intel.cmake
+++ b/cmake/toolchains/intel.cmake
@@ -3,6 +3,12 @@
 # Uses the LLVM-based Intel compilers (ifx/icx/icpx). For the end-of-life
 # classic ifort compiler, see intel-classic.cmake.
 #
+# Requires the C/C++ Intel compilers (icx/icpx) in addition to the Fortran one
+# (ifx): this file sets all three, and hipfort enables C and CXX because
+# find_package(hip) requires them. Install the Intel oneAPI C/C++ component
+# alongside ifx (they are separate downloads), or edit the CMAKE_C_COMPILER /
+# CMAKE_CXX_COMPILER lines below to point at another available C/C++ compiler.
+#
 # Usage:
 #   source /opt/intel/oneapi/setvars.sh
 #   cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/intel.cmake


### PR DESCRIPTION
## Summary

`cmake/toolchains/intel.cmake` sets the Intel C/C++ compilers (`icx`/`icpx`) in addition to `ifx`. Because hipfort enables the C and CXX languages (`find_package(hip)` requires CXX), CMake configuration **fails** if only the Intel Fortran compiler is installed:

```
CMake Error at CMakeLists.txt:34 (PROJECT):
  The CMAKE_C_COMPILER:  icx    ... is not a full path and was not found
  The CMAKE_CXX_COMPILER: icpx  ... is not a full path and was not found
```

The Intel oneAPI Fortran (`ifx`) and C/C++ (`icx`/`icpx`) compilers are separate downloads, so a user may have only `ifx`. This adds a comment documenting that the C/C++ component must be installed alongside `ifx`, or that the `CMAKE_C_COMPILER`/`CMAKE_CXX_COMPILER` lines can be edited to point at another available C/C++ compiler.

Comment only — no behavior change.

Context: the other toolchains (`gnu`, `amdflang`, `nvhpc`) do not hit this because their C/C++ compilers ship together with the Fortran one. `ifx` itself builds hipfort fine when a C/C++ compiler is available (verified in #395).