### PR TITLE
[documentation] how to build a hipfort application with CMake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@
 * Added example CMake toolchain files in `cmake/toolchains/`, for amdflang, GNU,
   Intel `ifx`/`ifort`, Cray, and NVHPC. Select one with `-DCMAKE_TOOLCHAIN_FILE`
   to build hipfort with a different Fortran compiler or backend.
+* Documented how to build hipfort applications with CMake, in the *Using hipFORT*
+  how-to guide. It covers `find_package(hipfort)`, the exported `hipfort::*` targets,
+  and the multiple-Fortran-toolchain install layout.
 
 ### Changed
 

--- a/docs/how-to/using-hipfort.rst
+++ b/docs/how-to/using-hipfort.rst
@@ -64,6 +64,44 @@ should build with them too. Please open an issue at https://github.com/ROCm/hipf
    If you plan to use the `f2008` interfaces, GFortran version 7.5.0 or newer is recommended.
    Problems can occur with older versions.
 
+Building your application with CMake
+-----------------------------------
+
+hipFORT installs CMake package files, so you can locate it with ``find_package``
+and link against its exported ``hipfort::*`` targets. Each target pulls in the
+right Fortran module (``.mod``) search path, the hipFORT library, and the
+underlying ROCm library it wraps.
+
+.. code-block:: cmake
+
+   find_package(hipfort REQUIRED COMPONENTS hip rocblas hipblas)
+
+   add_executable(my_app main.f08)
+   target_link_libraries(my_app PRIVATE hipfort::rocblas hipfort::hipblas hipfort::hip)
+
+List the libraries your code uses as ``COMPONENTS`` (for example ``hip``,
+``rocblas``, ``hipblas``, ``rocsparse``, ``hipsparse``, ``rocfft``, ``hipfft``,
+``rocrand``, ``hiprand``, ``rocsolver``, ``hipsolver``) and link the matching
+``hipfort::<component>`` targets. ``hipfort::hip`` is always required. If hipFORT
+is not in a default location, point CMake at it with ``-Dhipfort_ROOT=/path/to/hipfort``
+(or ``CMAKE_PREFIX_PATH``).
+
+Multiple Fortran toolchains
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Fortran ``.mod`` files are compiler-specific, so a hipFORT build works only with
+the compiler that produced it. To let several toolchains coexist, hipFORT installs
+its modules and libraries into compiler-specific subdirectories
+(``include/fortran/<compiler>`` and ``lib/fortran/<compiler>``). This is enabled by
+the ``HIPFORT_MULTITOOLCHAIN_LAYOUT`` CMake option (``ON`` by default). The exported
+``hipfort::*`` targets resolve these paths automatically, so your application picks
+the right modules and library by using the hipFORT installation that was built with
+the same Fortran compiler.
+
+To build hipFORT itself with a specific compiler or backend, use one of the example
+toolchain files in ``cmake/toolchains/`` (amdflang, GNU, Intel ``ifx``/``ifort``,
+Cray, and NVHPC) via ``-DCMAKE_TOOLCHAIN_FILE=...``.
+
 Examples
 --------
 


### PR DESCRIPTION
Addresses #133. Adds a *Building your application with CMake* section to `docs/how-to/using-hipfort.rst`, the how-to page that the issue flagged as empty.

It documents:
* `find_package(hipfort REQUIRED COMPONENTS ...)` and linking the exported `hipfort::*` targets;
* how to list the libraries as components and point CMake at a non-default install (`hipfort_ROOT` / `CMAKE_PREFIX_PATH`);
* the multiple-Fortran-toolchain story that was the core pain in #133: `.mod` files are compiler-specific, so hipFORT installs into `include/fortran/<compiler>` and `lib/fortran/<compiler>` (`HIPFORT_MULTITOOLCHAIN_LAYOUT`, ON by default) and the `hipfort::*` targets resolve those paths automatically;
* the `cmake/toolchains/` files for building hipFORT with a specific compiler/backend.