### PR TITLE
Expose hipStreamGetDevice device output by reference

### DIFF
--- a/lib/hipfort/hipfort.F90
+++ b/lib/hipfort/hipfort.F90
@@ -1658,7 +1658,7 @@ module hipfort
       implicit none
       integer(kind(hipSuccess)) :: hipStreamGetDevice_
       type(c_ptr),value :: stream
-      type(c_ptr),value :: device
+      integer(c_int) :: device
     end function
   end interface
 


### PR DESCRIPTION
Small consistency follow-up. `hipStreamGetDevice(stream, device)` returned its `device` output as `type(c_ptr), value`, forcing callers to use `C_LOC`. `hipDevice_t` is an `int`, and the analogous `hipGetDevice` already returns its device ordinal by reference, so `device` now takes a plain `integer(c_int)`:

```fortran
integer(c_int) :: dev
istat = hipStreamGetDevice(stream, dev)
```

Done via `src/hip/hip.argkinds`. The `stream` handle stays `type(c_ptr), value`. Builds clean.