### PR TITLE
Normalize @param docstrings (attach the '-' separator on the multi-line format)

### DIFF
--- a/lib/hipfort/hipfort_hipblas.F90
+++ b/lib/hipfort/hipfort_hipblas.F90
@@ -224,21 +224,15 @@ module hipfort_hipblas
   end interface
 
   !>  \brief Copy vector from host to device.
-  !>     @param[in]
-  !>     n           [int]
+  !>     @param[in] n - [int]
   !>                 number of elements in the vector.
-  !>     @param[in]
-  !>     elemSize    [int]
+  !>     @param[in] elemSize - [int]
   !>                 Size of both vectors in bytes.
-  !>     @param[in]
-  !>     x           pointer to vector on the host.
-  !>     @param[in]
-  !>     incx        [int]
+  !>     @param[in] x - pointer to vector on the host.
+  !>     @param[in] incx - [int]
   !>                 specifies the increment for the elements of the vector.
-  !>     @param[out]
-  !>     y           pointer to vector on the device.
-  !>     @param[in]
-  !>     incy        [int]
+  !>     @param[out] y - pointer to vector on the device.
+  !>     @param[in] incy - [int]
   !>                 specifies the increment for the elements of the vector.
   interface hipblasSetVector
 #ifdef USE_CUDA_NAMES
@@ -260,21 +254,15 @@ module hipfort_hipblas
   end interface
 
   !>  \brief Copy vector from device to host.
-  !>     @param[in]
-  !>     n           [int]
+  !>     @param[in] n - [int]
   !>                 number of elements in the vector.
-  !>     @param[in]
-  !>     elemSize    [int]
+  !>     @param[in] elemSize - [int]
   !>                 Size of both vectors in bytes.
-  !>     @param[in]
-  !>     x           pointer to vector on the device.
-  !>     @param[in]
-  !>     incx        [int]
+  !>     @param[in] x - pointer to vector on the device.
+  !>     @param[in] incx - [int]
   !>                 specifies the increment for the elements of the vector.
-  !>     @param[out]
-  !>     y           pointer to vector on the host.
-  !>     @param[in]
-  !>     incy        [int]
+  !>     @param[out] y - pointer to vector on the host.
+  !>     @param[in] incy - [int]
   !>                 specifies the increment for the elements of the vector.
   interface hipblasGetVector
 #ifdef USE_CUDA_NAMES
@@ -296,24 +284,17 @@ module hipfort_hipblas
   end interface
 
   !>  \brief Copy matrix from host to device.
-  !>     @param[in]
-  !>     rows        [int]
+  !>     @param[in] rows - [int]
   !>                 number of rows in the matrix.
-  !>     @param[in]
-  !>     cols        [int]
+  !>     @param[in] cols - [int]
   !>                 number of columns in the matrix.
-  !>     @param[in]
-  !>     elemSize   [int]
+  !>     @param[in] elemSize - [int]
   !>                 number of bytes per element in the matrix.
-  !>     @param[in]
-  !>     AP          pointer to matrix on the host.
-  !>     @param[in]
-  !>     lda         [int]
+  !>     @param[in] AP - pointer to matrix on the host.
+  !>     @param[in] lda - [int]
   !>                 specifies the leading dimension of A. lda >= rows.
-  !>     @param[out]
-  !>     BP           pointer to matrix on the GPU.
-  !>     @param[in]
-  !>     ldb         [int]
+  !>     @param[out] BP - pointer to matrix on the GPU.
+  !>     @param[in] ldb - [int]
   !>                 specifies the leading dimension of B. ldb >= rows.
   interface hipblasSetMatrix
 #ifdef USE_CUDA_NAMES
@@ -336,24 +317,17 @@ module hipfort_hipblas
   end interface
 
   !>  \brief Copy matrix from device to host.
-  !>     @param[in]
-  !>     rows        [int]
+  !>     @param[in] rows - [int]
   !>                 number of rows in the matrix.
-  !>     @param[in]
-  !>     cols        [int]
+  !>     @param[in] cols - [int]
   !>                 number of columns in the matrix.
-  !>     @param[in]
-  !>     elemSize   [int]
+  !>     @param[in] elemSize - [int]
   !>                 number of bytes per element in the matrix.
-  !>     @param[in]
-  !>     AP          pointer to matrix on the GPU.
-  !>     @param[in]
-  !>     lda         [int]
+  !>     @param[in] AP - pointer to matrix on the GPU.
+  !>     @param[in] lda - [int]
   !>                 specifies the leading dimension of A. lda >= rows.
-  !>     @param[out]
-  !>     BP          pointer to matrix on the host.
-  !>     @param[in]
-  !>     ldb         [int]
+  !>     @param[out] BP - pointer to matrix on the host.
+  !>     @param[in] ldb - [int]
   !>                 specifies the leading dimension of B. ldb >= rows.
   interface hipblasGetMatrix
 #ifdef USE_CUDA_NAMES
@@ -381,24 +355,17 @@ module hipfort_hipblas
   !>     asynchronously.
   !>     Memory on the host must be allocated with ``hipHostMalloc`` or the transfer will be
   !>     synchronous.
-  !>     @param[in]
-  !>     n           [int]
+  !>     @param[in] n - [int]
   !>                 number of elements in the vector.
-  !>     @param[in]
-  !>     elemSize   [int]
+  !>     @param[in] elemSize - [int]
   !>                 number of bytes per element in the matrix.
-  !>     @param[in]
-  !>     x           pointer to vector on the host.
-  !>     @param[in]
-  !>     incx        [int]
+  !>     @param[in] x - pointer to vector on the host.
+  !>     @param[in] incx - [int]
   !>                 specifies the increment for the elements of the vector.
-  !>     @param[out]
-  !>     y           pointer to vector on the device.
-  !>     @param[in]
-  !>     incy        [int]
+  !>     @param[out] y - pointer to vector on the device.
+  !>     @param[in] incy - [int]
   !>                 specifies the increment for the elements of the vector.
-  !>     @param[in]
-  !>     stream      specifies the stream into which this transfer request is queued.
+  !>     @param[in] stream - specifies the stream into which this transfer request is queued.
   interface hipblasSetVectorAsync
 #ifdef USE_CUDA_NAMES
     function hipblasSetVectorAsync_(n,elemSize,x,incx,y,incy,stream) &
@@ -427,24 +394,17 @@ module hipfort_hipblas
   !>     asynchronously.
   !>     Memory on the host must be allocated with ``hipHostMalloc`` or the transfer will be
   !>     synchronous.
-  !>     @param[in]
-  !>     n           [int]
+  !>     @param[in] n - [int]
   !>                 number of elements in the vector.
-  !>     @param[in]
-  !>     elemSize   [int]
+  !>     @param[in] elemSize - [int]
   !>                 number of bytes per element in the matrix.
-  !>     @param[in]
-  !>     x           pointer to vector on the device.
-  !>     @param[in]
-  !>     incx        [int]
+  !>     @param[in] x - pointer to vector on the device.
+  !>     @param[in] incx - [int]
   !>                 specifies the increment for the elements of the vector.
-  !>     @param[out]
-  !>     y           pointer to vector on the host.
-  !>     @param[in]
-  !>     incy        [int]
+  !>     @param[out] y - pointer to vector on the host.
+  !>     @param[in] incy - [int]
   !>                 specifies the increment for the elements of the vector.
-  !>     @param[in]
-  !>     stream      specifies the stream into which this transfer request is queued.
+  !>     @param[in] stream - specifies the stream into which this transfer request is queued.
   interface hipblasGetVectorAsync
 #ifdef USE_CUDA_NAMES
     function hipblasGetVectorAsync_(n,elemSize,x,incx,y,incy,stream) &
@@ -473,27 +433,19 @@ module hipfort_hipblas
   !>     asynchronously.
   !>     Memory on the host must be allocated with ``hipHostMalloc`` or the transfer will be
   !>     synchronous.
-  !>     @param[in]
-  !>     rows        [int]
+  !>     @param[in] rows - [int]
   !>                 number of rows in matrices.
-  !>     @param[in]
-  !>     cols        [int]
+  !>     @param[in] cols - [int]
   !>                 number of columns in matrices.
-  !>     @param[in]
-  !>     elemSize   [int]
+  !>     @param[in] elemSize - [int]
   !>                 number of bytes per element in the matrix.
-  !>     @param[in]
-  !>     AP           pointer to matrix on the host.
-  !>     @param[in]
-  !>     lda         [int]
+  !>     @param[in] AP - pointer to matrix on the host.
+  !>     @param[in] lda - [int]
   !>                 specifies the leading dimension of A. lda >= rows.
-  !>     @param[out]
-  !>     BP           pointer to matrix on the GPU.
-  !>     @param[in]
-  !>     ldb         [int]
+  !>     @param[out] BP - pointer to matrix on the GPU.
+  !>     @param[in] ldb - [int]
   !>                 specifies the leading dimension of B. ldb >= rows.
-  !>     @param[in]
-  !>     stream      specifies the stream into which this transfer request is queued.
+  !>     @param[in] stream - specifies the stream into which this transfer request is queued.
   interface hipblasSetMatrixAsync
 #ifdef USE_CUDA_NAMES
     function hipblasSetMatrixAsync_(rows,cols,elemSize,AP,lda,BP,ldb,stream) &
@@ -523,27 +475,19 @@ module hipfort_hipblas
   !>     asynchronously.
   !>     Memory on the host must be allocated with ``hipHostMalloc`` or the transfer will be
   !>     synchronous.
-  !>     @param[in]
-  !>     rows        [int]
+  !>     @param[in] rows - [int]
   !>                 number of rows in matrices.
-  !>     @param[in]
-  !>     cols        [int]
+  !>     @param[in] cols - [int]
   !>                 number of columns in matrices.
-  !>     @param[in]
-  !>     elemSize   [int]
+  !>     @param[in] elemSize - [int]
   !>                 number of bytes per element in the matrix.
-  !>     @param[in]
-  !>     AP          pointer to matrix on the GPU.
-  !>     @param[in]
-  !>     lda         [int]
+  !>     @param[in] AP - pointer to matrix on the GPU.
+  !>     @param[in] lda - [int]
   !>                 specifies the leading dimension of A. lda >= rows.
-  !>     @param[out]
-  !>     BP           pointer to matrix on the host.
-  !>     @param[in]
-  !>     ldb         [int]
+  !>     @param[out] BP - pointer to matrix on the host.
+  !>     @param[in] ldb - [int]
   !>                 specifies the leading dimension of B. ldb >= rows.
-  !>     @param[in]
-  !>     stream      specifies the stream into which this transfer request is queued.
+  !>     @param[in] stream - specifies the stream into which this transfer request is queued.
   interface hipblasGetMatrixAsync
 #ifdef USE_CUDA_NAMES
     function hipblasGetMatrixAsync_(rows,cols,elemSize,AP,lda,BP,ldb,stream) &
@@ -686,19 +630,14 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : ``s``, ``d``, ``c``, and ``z``.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of elements in x.
-  !>     @param[in]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device pointer storing vector x.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of y.
-  !>     @param[inout]
-  !>     result
+  !>     @param[inout] myResult
   !>               device pointer or host pointer to store the amax index.
   !>               Return value is 0.0 if n, incx<=0.
   interface hipblasIsamax
@@ -878,22 +817,16 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               number of elements in each vector x_i.
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each x_i. incx must be > 0.
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>               number of instances in the batch. Must be > 0.
-  !>     @param[out]
-  !>     result
+  !>     @param[out] myResult
   !>               device or host array of pointers of batchCount size for results.
   !>               Return value is 0 if n, incx<=0.
 #ifndef USE_CUDA_NAMES
@@ -1049,25 +982,18 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               number of elements in each vector x_i.
-  !>     @param[in]
-  !>     x         device pointer to the first vector x_1.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device pointer to the first vector x_1.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each x_i. incx must be > 0.
-  !>     @param[in]
-  !>     stridex   [hipblasStride]
+  !>     @param[in] stridex - [hipblasStride]
   !>               specifies the pointer increment between one x_i and the next x_(i + 1).
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>               number of instances in the batch.
-  !>     @param[out]
-  !>     result
+  !>     @param[out] myResult
   !>               device or host pointer for storing contiguous batchCount results.
   !>               Return value is 0 if n <= 0, incx<=0.
 #ifndef USE_CUDA_NAMES
@@ -1255,19 +1181,14 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : ``s``, ``d``, ``c``, and ``z``.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of elements in x.
-  !>     @param[in]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device pointer storing vector x.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of y.
-  !>     @param[inout]
-  !>     result
+  !>     @param[inout] myResult
   !>               device pointer or host pointer to store the amin index.
   !>               Return value is 0.0 if n, incx<=0.
   interface hipblasIsamin
@@ -1447,22 +1368,16 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               number of elements in each vector x_i.
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each x_i. incx must be > 0.
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>               number of instances in the batch. Must be > 0.
-  !>     @param[out]
-  !>     result
+  !>     @param[out] myResult
   !>               device or host pointers to array of batchCount size for results.
   !>               Return value is 0 if n, incx<=0.
 #ifndef USE_CUDA_NAMES
@@ -1618,25 +1533,18 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               number of elements in each vector x_i.
-  !>     @param[in]
-  !>     x         device pointer to the first vector x_1.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device pointer to the first vector x_1.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each x_i. incx must be > 0.
-  !>     @param[in]
-  !>     stridex   [hipblasStride]
+  !>     @param[in] stridex - [hipblasStride]
   !>               specifies the pointer increment between one x_i and the next x_(i + 1).
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>               number of instances in the batch.
-  !>     @param[out]
-  !>     result
+  !>     @param[out] myResult
   !>               device or host pointer to array for storing contiguous batchCount results.
   !>               Return value is 0 if n <= 0, incx<=0.
 #ifndef USE_CUDA_NAMES
@@ -1825,19 +1733,14 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : ``s``, ``d``, ``c``, and ``z``.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of elements in x and y.
-  !>     @param[in]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device pointer storing vector x.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of x. incx must be > 0.
-  !>     @param[inout]
-  !>     result
+  !>     @param[inout] myResult
   !>               device pointer or host pointer to store the asum product.
   !>               Return value is 0.0 if n <= 0.
   interface hipblasSasum
@@ -2020,22 +1923,16 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               number of elements in each vector x_i.
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each x_i. incx must be > 0.
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>               number of instances in the batch.
-  !>     @param[out]
-  !>     result
+  !>     @param[out] myResult
   !>               device array or host array of batchCount size for results.
   !>               Return value is 0.0 if n, incx<=0.
 #ifndef USE_CUDA_NAMES
@@ -2194,28 +2091,21 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               number of elements in each vector x_i.
-  !>     @param[in]
-  !>     x         device pointer to the first vector x_1.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device pointer to the first vector x_1.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each x_i. incx must be > 0.
-  !>     @param[in]
-  !>     stridex   [hipblasStride]
+  !>     @param[in] stridex - [hipblasStride]
   !>               stride from the start of one vector (x_i) to the next one (x_i+1).
   !>               There are no restrictions placed on stride_x. However, the user should
   !>               take care to ensure that stride_x is of an appropriate size. For a typical
   !>               case, this means stride_x >= n * incx.
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>               number of instances in the batch.
-  !>     @param[out]
-  !>     result
+  !>     @param[out] myResult
   !>               device pointer or host pointer to array for storing contiguous batchCount
   !>               results.
   !>               Return value is 0.0 if n, incx<=0.
@@ -2406,23 +2296,16 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``h``, ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : ``s``, ``d``, ``c``, and ``z``.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of elements in x and y.
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer to specify the scalar alpha.
-  !>     @param[in]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] alpha - device pointer or host pointer to specify the scalar alpha.
+  !>     @param[in] x - device pointer storing vector x.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of x.
-  !>     @param[out]
-  !>     y         device pointer storing vector y.
-  !>     @param[inout]
-  !>     incy      [int]
+  !>     @param[out] y - device pointer storing vector y.
+  !>     @param[inout] incy - [int]
   !>               specifies the increment for the elements of y.
 #ifndef USE_CUDA_NAMES
   interface hipblasHaxpy
@@ -2652,27 +2535,19 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``h``, ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of elements in x and y.
-  !>     @param[in]
-  !>     alpha     specifies the scalar alpha.
-  !>     @param[in]
-  !>     x         pointer storing vector x on the GPU.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] alpha - specifies the scalar alpha.
+  !>     @param[in] x - pointer storing vector x on the GPU.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of x.
-  !>     @param[out]
-  !>     y         pointer storing vector y on the GPU.
-  !>     @param[inout]
-  !>     incy      [int]
+  !>     @param[out] y - pointer storing vector y on the GPU.
+  !>     @param[inout] incy - [int]
   !>               specifies the increment for the elements of y.
   !>
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>               number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasHaxpyBatched
@@ -2883,32 +2758,22 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``h``, ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     n         [int]
-  !>     @param[in]
-  !>     alpha     specifies the scalar alpha.
-  !>     @param[in]
-  !>     x         pointer storing vector x on the GPU.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] n - [int]
+  !>     @param[in] alpha - specifies the scalar alpha.
+  !>     @param[in] x - pointer storing vector x on the GPU.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of x.
-  !>     @param[in]
-  !>     stridex   [hipblasStride]
+  !>     @param[in] stridex - [hipblasStride]
   !>               specifies the increment between vectors of x.
-  !>     @param[out]
-  !>     y         pointer storing vector y on the GPU.
-  !>     @param[inout]
-  !>     incy      [int]
+  !>     @param[out] y - pointer storing vector y on the GPU.
+  !>     @param[inout] incy - [int]
   !>               specifies the increment for the elements of y.
-  !>     @param[in]
-  !>     stridey   [hipblasStride]
+  !>     @param[in] stridey - [hipblasStride]
   !>               specifies the increment between vectors of y.
   !>
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>               number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasHaxpyStridedBatched
@@ -3169,21 +3034,15 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : ``s``, ``d``, ``c``, and ``z``.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of elements in x to be copied to y.
-  !>     @param[in]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device pointer storing vector x.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of x.
-  !>     @param[out]
-  !>     y         device pointer storing vector y.
-  !>     @param[in]
-  !>     incy      [int]
+  !>     @param[out] y - device pointer storing vector y.
+  !>     @param[in] incy - [int]
   !>               specifies the increment for the elements of y.
   interface hipblasScopy
 #ifdef USE_CUDA_NAMES
@@ -3375,24 +3234,17 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of elements in each x_i to be copied to y_i.
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each vector x_i.
-  !>     @param[out]
-  !>     y         device array of device pointers storing each vector y_i.
-  !>     @param[in]
-  !>     incy      [int]
+  !>     @param[out] y - device array of device pointers storing each vector y_i.
+  !>     @param[in] incy - [int]
   !>               specifies the increment for the elements of each vector y_i.
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasScopyBatched
@@ -3560,36 +3412,27 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of elements in each x_i to be copied to y_i.
-  !>     @param[in]
-  !>     x         device pointer to the first vector (x_1) in the batch.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device pointer to the first vector (x_1) in the batch.
+  !>     @param[in] incx - [int]
   !>               specifies the increments for the elements of vectors x_i.
-  !>     @param[in]
-  !>     stridex     [hipblasStride]
+  !>     @param[in] stridex - [hipblasStride]
   !>                 stride from the start of one vector (x_i) to the next one (x_i+1).
   !>                 There are no restrictions placed on stridex. However, the user should
   !>                 ensure that stridex is of an appropriate size. For a typical
   !>                 case, this means stridex >= n * incx.
-  !>     @param[out]
-  !>     y         device pointer to the first vector (y_1) in the batch.
-  !>     @param[in]
-  !>     incy      [int]
+  !>     @param[out] y - device pointer to the first vector (y_1) in the batch.
+  !>     @param[in] incy - [int]
   !>               specifies the increment for the elements of vectors y_i.
-  !>     @param[in]
-  !>     stridey     [hipblasStride]
+  !>     @param[in] stridey - [hipblasStride]
   !>                 stride from the start of one vector (y_i) to the next one (y_i+1).
   !>                 There are no restrictions placed on stridey. However, the user should
   !>                 ensure that stridey is of an appropriate size. For a typical
   !>                 case this means stridey >= n * incy. stridey should be non zero.
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasScopyStridedBatched
@@ -3798,24 +3641,17 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``h``, ``bf``, ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : ``s``, ``d``, ``c``, and ``z``.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of elements in x and y.
-  !>     @param[in]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device pointer storing vector x.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of y.
-  !>     @param[in]
-  !>     y         device pointer storing vector y.
-  !>     @param[in]
-  !>     incy      [int]
+  !>     @param[in] y - device pointer storing vector y.
+  !>     @param[in] incy - [int]
   !>               specifies the increment for the elements of y.
-  !>     @param[inout]
-  !>     result
+  !>     @param[inout] myResult
   !>               device pointer or host pointer to store the dot product.
   !>               Return value is 0.0 if n <= 0.
 #ifndef USE_CUDA_NAMES
@@ -4184,27 +4020,19 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``h``, ``bf``, ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of elements in each x_i and y_i.
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     y         device array of device pointers storing each vector y_i.
-  !>     @param[in]
-  !>     incy      [int]
+  !>     @param[in] y - device array of device pointers storing each vector y_i.
+  !>     @param[in] incy - [int]
   !>               specifies the increment for the elements of each y_i.
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
-  !>     @param[inout]
-  !>     result
+  !>     @param[inout] myResult
   !>               device array or host array of batchCount size to store the dot products of each
   !>               batch.
   !>               Returns 0.0 for each element if n <= 0.
@@ -4547,33 +4375,23 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``h``, ``bf``, ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of elements in each x_i and y_i.
-  !>     @param[in]
-  !>     x         device pointer to the first vector (x_1) in the batch.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device pointer to the first vector (x_1) in the batch.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     stridex     [hipblasStride]
+  !>     @param[in] stridex - [hipblasStride]
   !>                 stride from the start of one vector (x_i) to the next one (x_i+1).
-  !>     @param[in]
-  !>     y         device pointer to the first vector (y_1) in the batch.
-  !>     @param[in]
-  !>     incy      [int]
+  !>     @param[in] y - device pointer to the first vector (y_1) in the batch.
+  !>     @param[in] incy - [int]
   !>               specifies the increment for the elements of each y_i.
-  !>     @param[in]
-  !>     stridey     [hipblasStride]
+  !>     @param[in] stridey - [hipblasStride]
   !>                 stride from the start of one vector (y_i) to the next one (y_i+1).
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
-  !>     @param[inout]
-  !>     result
+  !>     @param[inout] myResult
   !>               device array or host array of batchCount size to store the dot products of each
   !>               batch.
   !>               Returns 0.0 for each element if n <= 0.
@@ -4992,19 +4810,14 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, ``z``, ``sc``, and ``dz``.
   !>     - Supported precisions in cuBLAS  : ``s``, ``d``, ``sc``, and ``dz``.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of elements in x.
-  !>     @param[in]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device pointer storing vector x.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of y.
-  !>     @param[inout]
-  !>     result
+  !>     @param[inout] myResult
   !>               device pointer or host pointer to store the nrm2 product.
   !>               Return value is 0.0 if n, incx<=0.
   interface hipblasSnrm2
@@ -5187,22 +5000,16 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, ``z``, ``sc``, and ``dz``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               number of elements in each x_i.
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each x_i. incx must be > 0.
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>               number of instances in the batch.
-  !>     @param[out]
-  !>     result
+  !>     @param[out] myResult
   !>               device pointer or host pointer to array of batchCount size for nrm2 results.
   !>               Return value is 0.0 for each element if n <= 0, incx<=0.
 #ifndef USE_CUDA_NAMES
@@ -5361,28 +5168,21 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, ``z``, ``sc``, and ``dz``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               number of elements in each x_i.
-  !>     @param[in]
-  !>     x         device pointer to the first vector x_1.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device pointer to the first vector x_1.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each x_i. incx must be > 0.
-  !>     @param[in]
-  !>     stridex   [hipblasStride]
+  !>     @param[in] stridex - [hipblasStride]
   !>               stride from the start of one vector (x_i) to the next one (x_i+1).
   !>               There are no restrictions placed on stridex. However, the user should
   !>               ensure that stridex is of an appropriate size. For a typical
   !>               case, this means stridex >= n * incx.
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>               number of instances in the batch.
-  !>     @param[out]
-  !>     result
+  !>     @param[out] myResult
   !>               device pointer or host pointer to array for storing contiguous batchCount
   !>               results.
   !>               Return value is 0.0 for each element if n <= 0, incx<=0.
@@ -5573,27 +5373,20 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, ``z``, ``sc``, and ``dz``.
   !>     - Supported precisions in cuBLAS  : ``s``, ``d``, ``c``, ``z``, ``cs``, and ``zd``.
   !>
-  !>     @param[in]
-  !>     handle  [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>             handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     n       [int]
+  !>     @param[in] n - [int]
   !>             number of elements in the x and y vectors.
-  !>     @param[inout]
-  !>     x       device pointer storing vector x.
-  !>     @param[in]
-  !>     incx    [int]
+  !>     @param[inout] x - device pointer storing vector x.
+  !>     @param[in] incx - [int]
   !>             specifies the increment between elements of x.
-  !>     @param[inout]
-  !>     y       device pointer storing vector y.
-  !>     @param[in]
-  !>     incy    [int]
+  !>     @param[inout] y - device pointer storing vector y.
+  !>     @param[in] incy - [int]
   !>             specifies the increment between elements of y.
-  !>     @param[in]
-  !>     c device pointer or host pointer storing the scalar cosine component of the rotation
-  !>     matrix.
-  !>     @param[in]
-  !>     s device pointer or host pointer storing the scalar sine component of the rotation matrix.
+  !>     @param[in] c - device pointer or host pointer storing the scalar cosine component of the
+  !>     rotation matrix.
+  !>     @param[in] s - device pointer or host pointer storing the scalar sine component of the
+  !>     rotation matrix.
   interface hipblasSrot
 #ifdef USE_CUDA_NAMES
     function hipblasSrot_(handle,n,x,incx,y,incy,c,s) bind(c, name="cublasSrot_v2")
@@ -5894,28 +5687,21 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``sc``, and ``dz``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle  [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>             handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     n       [int]
+  !>     @param[in] n - [int]
   !>             number of elements in each x_i and y_i vectors.
-  !>     @param[inout]
-  !>     x       device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx    [int]
+  !>     @param[inout] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [int]
   !>             specifies the increment between elements of each x_i.
-  !>     @param[inout]
-  !>     y       device array of device pointers storing each vector y_i.
-  !>     @param[in]
-  !>     incy    [int]
+  !>     @param[inout] y - device array of device pointers storing each vector y_i.
+  !>     @param[in] incy - [int]
   !>             specifies the increment between elements of each y_i.
-  !>     @param[in]
-  !>     c device pointer or host pointer to the scalar cosine component of the rotation matrix.
-  !>     @param[in]
-  !>     s       device pointer or host pointer to the scalar sine component of the rotation matrix.
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] c - device pointer or host pointer to the scalar cosine component of the
+  !>     rotation matrix.
+  !>     @param[in] s - device pointer or host pointer to the scalar sine component of the rotation
+  !>     matrix.
+  !>     @param[in] batchCount - [int]
   !>                 the number of x and y arrays, that is, the number of batches.
 #ifndef USE_CUDA_NAMES
   interface hipblasSrotBatched
@@ -6181,34 +5967,25 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``sc``, and ``dz``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle  [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>             handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     n       [int]
+  !>     @param[in] n - [int]
   !>             number of elements in each x_i and y_i vectors.
-  !>     @param[inout]
-  !>     x       device pointer to the first vector x_1.
-  !>     @param[in]
-  !>     incx    [int]
+  !>     @param[inout] x - device pointer to the first vector x_1.
+  !>     @param[in] incx - [int]
   !>             specifies the increment between elements of each x_i.
-  !>     @param[in]
-  !>     stridex [hipblasStride]
+  !>     @param[in] stridex - [hipblasStride]
   !>              specifies the increment from the beginning of x_i to the beginning of x_(i+1).
-  !>     @param[inout]
-  !>     y       device pointer to the first vector y_1.
-  !>     @param[in]
-  !>     incy    [int]
+  !>     @param[inout] y - device pointer to the first vector y_1.
+  !>     @param[in] incy - [int]
   !>             specifies the increment between elements of each y_i.
-  !>     @param[in]
-  !>     stridey  [hipblasStride]
+  !>     @param[in] stridey - [hipblasStride]
   !>              specifies the increment from the beginning of y_i to the beginning of y_(i+1).
-  !>     @param[in]
-  !>     c device pointer or host pointer to the scalar cosine component of the rotation matrix.
-  !>     @param[in]
-  !>     s       device pointer or host pointer to the scalar sine component of the rotation matrix.
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] c - device pointer or host pointer to the scalar cosine component of the
+  !>     rotation matrix.
+  !>     @param[in] s - device pointer or host pointer to the scalar sine component of the rotation
+  !>     matrix.
+  !>     @param[in] batchCount - [int]
   !>             the number of x and y arrays, that is, the number of batches.
 #ifndef USE_CUDA_NAMES
   interface hipblasSrotStridedBatched
@@ -6536,17 +6313,16 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : ``s``, ``d``, ``c``, and ``z``.
   !>
-  !>     @param[in]
-  !>     handle  [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>             handle to the hipBLAS library context queue.
-  !>     @param[inout]
-  !>     a       device pointer or host pointer to the input vector element, overwritten with r.
-  !>     @param[inout]
-  !>     b       device pointer or host pointer to the input vector element, overwritten with z.
-  !>     @param[inout]
-  !>     c       device pointer or host pointer to the cosine element of the Givens rotation.
-  !>     @param[inout]
-  !>     s       device pointer or host pointer to the sine element of the Givens rotation.
+  !>     @param[inout] a - device pointer or host pointer to the input vector element, overwritten
+  !>     with r.
+  !>     @param[inout] b - device pointer or host pointer to the input vector element, overwritten
+  !>     with z.
+  !>     @param[inout] c - device pointer or host pointer to the cosine element of the Givens
+  !>     rotation.
+  !>     @param[inout] s - device pointer or host pointer to the sine element of the Givens
+  !>     rotation.
   interface hipblasSrotg
 #ifdef USE_CUDA_NAMES
     function hipblasSrotg_(handle,a,b,c,s) bind(c, name="cublasSrotg_v2")
@@ -6698,23 +6474,17 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle  [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>             handle to the hipBLAS library context queue.
-  !>     @param[inout]
-  !>     a device array of device pointers storing each single input vector element a_i, overwritten
-  !>     with r_i.
-  !>     @param[inout]
-  !>     b device array of device pointers storing each single input vector element b_i, overwritten
-  !>     with z_i.
-  !>     @param[inout]
-  !>     c device array of device pointers storing each cosine element of the Givens rotation for
-  !>     the batch.
-  !>     @param[inout]
-  !>     s device array of device pointers storing each sine element of the Givens rotation for the
-  !>     batch.
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[inout] a - device array of device pointers storing each single input vector element
+  !>     a_i, overwritten with r_i.
+  !>     @param[inout] b - device array of device pointers storing each single input vector element
+  !>     b_i, overwritten with z_i.
+  !>     @param[inout] c - device array of device pointers storing each cosine element of the Givens
+  !>     rotation for the batch.
+  !>     @param[inout] s - device array of device pointers storing each sine element of the Givens
+  !>     rotation for the batch.
+  !>     @param[in] batchCount - [int]
   !>                 number of batches (length of arrays a, b, c, and s).
 #ifndef USE_CUDA_NAMES
   interface hipblasSrotgBatched
@@ -6871,35 +6641,25 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle  [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>             handle to the hipBLAS library context queue.
-  !>     @param[inout]
-  !>     a device strided_batched pointer or host strided_batched pointer to the first single input
-  !>     vector element a_1, overwritten with r.
-  !>     @param[in]
-  !>     stridea [hipblasStride]
+  !>     @param[inout] a - device strided_batched pointer or host strided_batched pointer to the
+  !>     first single input vector element a_1, overwritten with r.
+  !>     @param[in] stridea - [hipblasStride]
   !>              distance between elements of a in batch (distance between a_i and a_(i + 1)).
-  !>     @param[inout]
-  !>     b device strided_batched pointer or host strided_batched pointer to the first single input
-  !>     vector element b_1, overwritten with z.
-  !>     @param[in]
-  !>     strideb [hipblasStride]
+  !>     @param[inout] b - device strided_batched pointer or host strided_batched pointer to the
+  !>     first single input vector element b_1, overwritten with z.
+  !>     @param[in] strideb - [hipblasStride]
   !>              distance between elements of b in batch (distance between b_i and b_(i + 1)).
-  !>     @param[inout]
-  !>     c device strided_batched pointer or host strided_batched pointer to the first cosine
-  !>     element of the Givens rotations c_1.
-  !>     @param[in]
-  !>     stridec [hipblasStride]
+  !>     @param[inout] c - device strided_batched pointer or host strided_batched pointer to the
+  !>     first cosine element of the Givens rotations c_1.
+  !>     @param[in] stridec - [hipblasStride]
   !>              distance between elements of c in batch (distance between c_i and c_(i + 1)).
-  !>     @param[inout]
-  !>     s device strided_batched pointer or host strided_batched pointer to the sine element of the
-  !>     Givens rotations s_1.
-  !>     @param[in]
-  !>     strides [hipblasStride]
+  !>     @param[inout] s - device strided_batched pointer or host strided_batched pointer to the
+  !>     sine element of the Givens rotations s_1.
+  !>     @param[in] strides - [hipblasStride]
   !>              distance between elements of s in batch (distance between s_i and s_(i + 1)).
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of batches (length of arrays a, b, c, and s).
 #ifndef USE_CUDA_NAMES
   interface hipblasSrotgStridedBatched
@@ -7094,24 +6854,17 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s`` and ``d``.
   !>     - Supported precisions in cuBLAS  : ``s`` and ``d``.
   !>
-  !>     @param[in]
-  !>     handle  [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>             handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     n       [int]
+  !>     @param[in] n - [int]
   !>             number of elements in the x and y vectors.
-  !>     @param[inout]
-  !>     x       device pointer storing vector x.
-  !>     @param[in]
-  !>     incx    [int]
+  !>     @param[inout] x - device pointer storing vector x.
+  !>     @param[in] incx - [int]
   !>             specifies the increment between elements of x.
-  !>     @param[inout]
-  !>     y       device pointer storing vector y.
-  !>     @param[in]
-  !>     incy    [int]
+  !>     @param[inout] y - device pointer storing vector y.
+  !>     @param[in] incy - [int]
   !>             specifies the increment between elements of y.
-  !>     @param[in]
-  !>     param   device vector or host vector of five elements defining the rotation.
+  !>     @param[in] param - device vector or host vector of five elements defining the rotation.
   !>             param can be stored in either the host or device memory. The location is specified
   !>             by calling hipblasSetPointerMode.
   !>             - param[0] = flag
@@ -7225,24 +6978,17 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s`` and ``d``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle  [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>             handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     n       [int]
+  !>     @param[in] n - [int]
   !>             number of elements in the x and y vectors.
-  !>     @param[inout]
-  !>     x       device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx    [int]
+  !>     @param[inout] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [int]
   !>             specifies the increment between elements of each x_i.
-  !>     @param[inout]
-  !>     y       device array of device pointers storing each vector y_1.
-  !>     @param[in]
-  !>     incy    [int]
+  !>     @param[inout] y - device array of device pointers storing each vector y_1.
+  !>     @param[in] incy - [int]
   !>             specifies the increment between elements of each y_i.
-  !>     @param[in]
-  !>     param   device array of device vectors of five elements defining the rotation.
+  !>     @param[in] param - device array of device vectors of five elements defining the rotation.
   !>             param can ONLY be stored on the device for the batched version of this function.
   !>             - param[0] = flag
   !>             - param[1] = H11
@@ -7254,8 +7000,7 @@ module hipfort_hipblas
   !>             - flag =  0 => H = ( 1.0 H12 H21 1.0 )
   !>             - flag =  1 => H = ( H11 1.0 -1.0 H22 )
   !>             - flag = -2 => H = ( 1.0 0.0 0.0 1.0 )
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 the number of x and y arrays, that is, the number of batches.
 #ifndef USE_CUDA_NAMES
   interface hipblasSrotmBatched
@@ -7347,31 +7092,22 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s`` and ``d``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle  [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>             handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     n       [int]
+  !>     @param[in] n - [int]
   !>             number of elements in the x and y vectors.
-  !>     @param[inout]
-  !>     x       device pointer pointing to first strided batched vector x_1.
-  !>     @param[in]
-  !>     incx    [int]
+  !>     @param[inout] x - device pointer pointing to first strided batched vector x_1.
+  !>     @param[in] incx - [int]
   !>             specifies the increment between elements of each x_i.
-  !>     @param[in]
-  !>     stridex [hipblasStride]
+  !>     @param[in] stridex - [hipblasStride]
   !>              specifies the increment between the beginning of x_i and x_(i + 1).
-  !>     @param[inout]
-  !>     y       device pointer pointing to the first strided batched vector y_1.
-  !>     @param[in]
-  !>     incy    [int]
+  !>     @param[inout] y - device pointer pointing to the first strided batched vector y_1.
+  !>     @param[in] incy - [int]
   !>             specifies the increment between elements of each y_i.
-  !>     @param[in]
-  !>     stridey  [hipblasStride]
+  !>     @param[in] stridey - [hipblasStride]
   !>              specifies the increment between the beginning of y_i and y_(i + 1).
-  !>     @param[in]
-  !>     param device pointer pointing to first array of five elements defining the rotation
-  !>     (param_1).
+  !>     @param[in] param - device pointer pointing to first array of five elements defining the
+  !>     rotation (param_1).
   !>             param can ONLY be stored on the device for the strided_batched version of this
   !>             function.
   !>             - param[0] = flag
@@ -7384,11 +7120,9 @@ module hipfort_hipblas
   !>             - flag =  0 => H = ( 1.0 H12 H21 1.0 )
   !>             - flag =  1 => H = ( H11 1.0 -1.0 H22 )
   !>             - flag = -2 => H = ( 1.0 0.0 0.0 1.0 )
-  !>     @param[in]
-  !>     strideParam [hipblasStride]
+  !>     @param[in] strideParam - [hipblasStride]
   !>                  specifies the increment between the beginning of param_i and param_(i + 1).
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 the number of x and y arrays, that is, the number of batches.
 #ifndef USE_CUDA_NAMES
   interface hipblasSrotmStridedBatched
@@ -7513,19 +7247,13 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s`` and ``d``.
   !>     - Supported precisions in cuBLAS  : ``s`` and ``d``.
   !>
-  !>     @param[in]
-  !>     handle  [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>             handle to the hipBLAS library context queue.
-  !>     @param[inout]
-  !>     d1      device pointer or host pointer to input scalar that is overwritten.
-  !>     @param[inout]
-  !>     d2      device pointer or host pointer to input scalar that is overwritten.
-  !>     @param[inout]
-  !>     x1      device pointer or host pointer to input scalar that is overwritten.
-  !>     @param[in]
-  !>     y1      device pointer or host pointer to input scalar.
-  !>     @param[out]
-  !>     param   device vector or host vector of five elements defining the rotation.
+  !>     @param[inout] d1 - device pointer or host pointer to input scalar that is overwritten.
+  !>     @param[inout] d2 - device pointer or host pointer to input scalar that is overwritten.
+  !>     @param[inout] x1 - device pointer or host pointer to input scalar that is overwritten.
+  !>     @param[in] y1 - device pointer or host pointer to input scalar.
+  !>     @param[out] param - device vector or host vector of five elements defining the rotation.
   !>             param can be stored in either host or device memory. The location is specified by
   !>             calling hipblasSetPointerMode.
   !>             - param[0] = flag
@@ -7625,20 +7353,17 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s`` and ``d``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle  [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>             handle to the hipBLAS library context queue.
-  !>     @param[inout]
-  !>     d1      device batched array or host batched array of input scalars that is overwritten.
-  !>     @param[inout]
-  !>     d2      device batched array or host batched array of input scalars that is overwritten.
-  !>     @param[inout]
-  !>     x1      device batched array or host batched array of input scalars that is overwritten.
-  !>     @param[in]
-  !>     y1      device batched array or host batched array of input scalars.
-  !>     @param[out]
-  !>     param device batched array or host batched array of vectors of five elements defining the
-  !>     rotation.
+  !>     @param[inout] d1 - device batched array or host batched array of input scalars that is
+  !>     overwritten.
+  !>     @param[inout] d2 - device batched array or host batched array of input scalars that is
+  !>     overwritten.
+  !>     @param[inout] x1 - device batched array or host batched array of input scalars that is
+  !>     overwritten.
+  !>     @param[in] y1 - device batched array or host batched array of input scalars.
+  !>     @param[out] param - device batched array or host batched array of vectors of five elements
+  !>     defining the rotation.
   !>             param can be stored in either host or device memory. The location is specified by
   !>             calling hipblasSetPointerMode.
   !>             - param[0] = flag
@@ -7651,8 +7376,7 @@ module hipfort_hipblas
   !>             - flag =  0 => H = ( 1.0 H12 H21 1.0 )
   !>             - flag =  1 => H = ( H11 1.0 -1.0 H22 )
   !>             - flag = -2 => H = ( 1.0 0.0 0.0 1.0 )
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 the number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasSrotmgBatched
@@ -7745,35 +7469,26 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s`` and ``d``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle  [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>             handle to the hipBLAS library context queue.
-  !>     @param[inout]
-  !>     d1 device strided_batched array or host strided_batched array of input scalars that is
-  !>     overwritten.
-  !>     @param[in]
-  !>     strided1 [hipblasStride]
+  !>     @param[inout] d1 - device strided_batched array or host strided_batched array of input
+  !>     scalars that is overwritten.
+  !>     @param[in] strided1 - [hipblasStride]
   !>               specifies the increment between the beginning of d1_i and d1_(i+1).
-  !>     @param[inout]
-  !>     d2 device strided_batched array or host strided_batched array of input scalars that is
-  !>     overwritten.
-  !>     @param[in]
-  !>     strided2 [hipblasStride]
+  !>     @param[inout] d2 - device strided_batched array or host strided_batched array of input
+  !>     scalars that is overwritten.
+  !>     @param[in] strided2 - [hipblasStride]
   !>               specifies the increment between the beginning of d2_i and d2_(i+1).
-  !>     @param[inout]
-  !>     x1 device strided_batched array or host strided_batched array of input scalars that is
-  !>     overwritten.
-  !>     @param[in]
-  !>     stridex1 [hipblasStride]
+  !>     @param[inout] x1 - device strided_batched array or host strided_batched array of input
+  !>     scalars that is overwritten.
+  !>     @param[in] stridex1 - [hipblasStride]
   !>               specifies the increment between the beginning of x1_i and x1_(i+1).
-  !>     @param[in]
-  !>     y1      device strided_batched array or host strided_batched array of input scalars.
-  !>     @param[in]
-  !>     stridey1 [hipblasStride]
+  !>     @param[in] y1 - device strided_batched array or host strided_batched array of input
+  !>     scalars.
+  !>     @param[in] stridey1 - [hipblasStride]
   !>               specifies the increment between the beginning of y1_i and y1_(i+1).
-  !>     @param[out]
-  !>     param device stridedBatched array or host stridedBatched array of vectors of five elements
-  !>     defining the rotation.
+  !>     @param[out] param - device stridedBatched array or host stridedBatched array of vectors of
+  !>     five elements defining the rotation.
   !>             param can be stored in either host or device memory. The location is specified by
   !>             calling hipblasSetPointerMode.
   !>             - param[0] = flag
@@ -7786,11 +7501,9 @@ module hipfort_hipblas
   !>             - flag =  0 => H = ( 1.0 H12 H21 1.0 )
   !>             - flag =  1 => H = ( H11 1.0 -1.0 H22 )
   !>             - flag = -2 => H = ( 1.0 0.0 0.0 1.0 )
-  !>     @param[in]
-  !>     strideParam [hipblasStride]
+  !>     @param[in] strideParam - [hipblasStride]
   !>                  specifies the increment between the beginning of param_i and param_(i + 1).
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 the number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasSrotmgStridedBatched
@@ -7902,18 +7615,13 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, ``z``, ``cs``, and ``zd``.
   !>     - Supported precisions in cuBLAS  : ``s``, ``d``, ``c``, ``z``, ``cs``, and ``zd``.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of elements in x.
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer for the scalar alpha.
-  !>     @param[inout]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] alpha - device pointer or host pointer for the scalar alpha.
+  !>     @param[inout] x - device pointer storing vector x.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of x.
   interface hipblasSscal
 #ifdef USE_CUDA_NAMES
@@ -8179,21 +7887,15 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, ``z``, ``cs``, and ``zd``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle      [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>                 handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     n           [int]
+  !>     @param[in] n - [int]
   !>                 the number of elements in each x_i.
-  !>     @param[in]
-  !>     alpha       host pointer or device pointer for the scalar alpha.
-  !>     @param[inout]
-  !>     x           device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx        [int]
+  !>     @param[in] alpha - host pointer or device pointer for the scalar alpha.
+  !>     @param[inout] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [int]
   !>                 specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 specifies the number of batches in x.
 #ifndef USE_CUDA_NAMES
   interface hipblasSscalBatched
@@ -8423,27 +8125,20 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, ``z``, ``cs``, and ``zd``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>      @param[in]
-  !>     handle      [hipblasHandle_t]
+  !>      @param[in] handle - [hipblasHandle_t]
   !>                 handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     n           [int]
+  !>     @param[in] n - [int]
   !>                 the number of elements in each x_i.
-  !>     @param[in]
-  !>     alpha       host pointer or device pointer for the scalar alpha.
-  !>     @param[inout]
-  !>     x           device pointer to the first vector (x_1) in the batch.
-  !>     @param[in]
-  !>     incx        [int]
+  !>     @param[in] alpha - host pointer or device pointer for the scalar alpha.
+  !>     @param[inout] x - device pointer to the first vector (x_1) in the batch.
+  !>     @param[in] incx - [int]
   !>                 specifies the increment for the elements of x.
-  !>     @param[in]
-  !>     stridex     [hipblasStride]
+  !>     @param[in] stridex - [hipblasStride]
   !>                 stride from the start of one vector (x_i) to the next one (x_i+1).
   !>                 There are no restrictions placed on stride_x. However, the user should
   !>                 ensure that stride_x is of an appropriate size. For a typical
   !>                 case, this means stride_x >= n * incx.
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 specifies the number of batches in x.
 #ifndef USE_CUDA_NAMES
   interface hipblasSscalStridedBatched
@@ -8719,21 +8414,15 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : ``s``, ``d``, ``c``, and ``z``.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of elements in x and y.
-  !>     @param[inout]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[inout] x - device pointer storing vector x.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of x.
-  !>     @param[inout]
-  !>     y         device pointer storing vector y.
-  !>     @param[in]
-  !>     incy      [int]
+  !>     @param[inout] y - device pointer storing vector y.
+  !>     @param[in] incy - [int]
   !>               specifies the increment for the elements of y.
   interface hipblasSswap
 #ifdef USE_CUDA_NAMES
@@ -8922,24 +8611,17 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of elements in each x_i and y_i.
-  !>     @param[inout]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[inout] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[inout]
-  !>     y         device array of device pointers storing each vector y_i.
-  !>     @param[in]
-  !>     incy      [int]
+  !>     @param[inout] y - device array of device pointers storing each vector y_i.
+  !>     @param[in] incy - [int]
   !>               specifies the increment for the elements of each y_i.
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasSswapBatched
@@ -9104,36 +8786,27 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of elements in each x_i and y_i.
-  !>     @param[inout]
-  !>     x         device pointer to the first vector x_1.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[inout] x - device pointer to the first vector x_1.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of x.
-  !>     @param[in]
-  !>     stridex   [hipblasStride]
+  !>     @param[in] stridex - [hipblasStride]
   !>               stride from the start of one vector (x_i) to the next one (x_i+1).
   !>               There are no restrictions placed on stridex. However, the user should
   !>               ensure that stridex is of an appropriate size. For a typical
   !>               case, this means stridex >= n * incx.
-  !>     @param[inout]
-  !>     y         device pointer to the first vector y_1.
-  !>     @param[in]
-  !>     incy      [int]
+  !>     @param[inout] y - device pointer to the first vector y_1.
+  !>     @param[in] incy - [int]
   !>               specifies the increment for the elements of y.
-  !>     @param[in]
-  !>     stridey   [hipblasStride]
+  !>     @param[in] stridey - [hipblasStride]
   !>               stride from the start of one vector (y_i) to the next one (y_i+1).
   !>               There are no restrictions placed on stridey. However, the user should
   !>               ensure that stridey is of an appropriate size. For a typical
   !>               case, this means stridey >= n * incy. stridey should be non zero.
-  !>      @param[in]
-  !>      batchCount [int]
+  !>      @param[in] batchCount - [int]
   !>                  number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasSswapStridedBatched
@@ -9342,28 +9015,20 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : ``s``, ``d``, ``c``, and ``z``.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     trans     [hipblasOperation_t]
+  !>     @param[in] trans - [hipblasOperation_t]
   !>               indicates whether matrix A is tranposed (conjugated) or not.
-  !>     @param[in]
-  !>     m         [int]
+  !>     @param[in] m - [int]
   !>               number of rows of matrix A.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               number of columns of matrix A.
-  !>     @param[in]
-  !>     kl        [int]
+  !>     @param[in] kl - [int]
   !>               number of sub-diagonals of A.
-  !>     @param[in]
-  !>     ku        [int]
+  !>     @param[in] ku - [int]
   !>               number of super-diagonals of A.
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>         AP    device pointer storing banded matrix A.
+  !>     @param[in] alpha - device pointer or host pointer to scalar alpha.
+  !>     @param[in] AP - device pointer storing banded matrix A.
   !>               The leading (kl + ku + 1) by n part of the matrix contains the coefficients
   !>               of the banded matrix. The leading diagonal resides in row (ku + 1) with
   !>               the first super-diagonal above on the RHS of row ku. The first sub-diagonal
@@ -9379,20 +9044,14 @@ module hipfort_hipblas
   !>                 0 0 0 0 5 4 1    ->     0 0 0 0 0 0 0
   !>               Note that empty elements that don't correspond to data will not
   !>               be referenced.
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of A. Must be >= (kl + ku + 1).
-  !>     @param[in]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device pointer storing vector x.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of x.
-  !>     @param[in]
-  !>     beta      device pointer or host pointer to scalar beta.
-  !>     @param[inout]
-  !>     y         device pointer storing vector y.
-  !>     @param[in]
-  !>     incy      [int]
+  !>     @param[in] beta - device pointer or host pointer to scalar beta.
+  !>     @param[inout] y - device pointer storing vector y.
+  !>     @param[in] incy - [int]
   !>               specifies the increment for the elements of y.
   interface hipblasSgbmv
 #ifdef USE_CUDA_NAMES
@@ -9671,28 +9330,20 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     trans     [hipblasOperation_t]
+  !>     @param[in] trans - [hipblasOperation_t]
   !>               indicates whether matrix A is tranposed (conjugated) or not.
-  !>     @param[in]
-  !>     m         [int]
+  !>     @param[in] m - [int]
   !>               number of rows of each matrix A_i.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               number of columns of each matrix A_i.
-  !>     @param[in]
-  !>     kl        [int]
+  !>     @param[in] kl - [int]
   !>               number of sub-diagonals of each A_i.
-  !>     @param[in]
-  !>     ku        [int]
+  !>     @param[in] ku - [int]
   !>               number of super-diagonals of each A_i.
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>         AP    device array of device pointers storing each banded matrix A_i.
+  !>     @param[in] alpha - device pointer or host pointer to scalar alpha.
+  !>     @param[in] AP - device array of device pointers storing each banded matrix A_i.
   !>               The leading (kl + ku + 1) by n part of the matrix contains the coefficients
   !>               of the banded matrix. The leading diagonal resides in row (ku + 1) with
   !>               the first super-diagonal above on the RHS of row ku. The first sub-diagonal
@@ -9708,23 +9359,16 @@ module hipfort_hipblas
   !>                 0 0 0 0 5 4 1    ->    0 0 0 0 0 0 0
   !>               Note that empty elements that don't correspond to data will not
   !>               be referenced.
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of each A_i. Must be >= (kl + ku + 1).
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     beta      device pointer or host pointer to scalar beta.
-  !>     @param[inout]
-  !>     y         device array of device pointers storing each vector y_i.
-  !>     @param[in]
-  !>     incy      [int]
+  !>     @param[in] beta - device pointer or host pointer to scalar beta.
+  !>     @param[inout] y - device array of device pointers storing each vector y_i.
+  !>     @param[in] incy - [int]
   !>               specifies the increment for the elements of each y_i.
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 specifies the number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasSgbmvBatched
@@ -9967,28 +9611,20 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     trans     [hipblasOperation_t]
+  !>     @param[in] trans - [hipblasOperation_t]
   !>               indicates whether matrix A is tranposed (conjugated) or not.
-  !>     @param[in]
-  !>     m         [int]
+  !>     @param[in] m - [int]
   !>               number of rows of matrix A.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               number of columns of matrix A.
-  !>     @param[in]
-  !>     kl        [int]
+  !>     @param[in] kl - [int]
   !>               number of sub-diagonals of A.
-  !>     @param[in]
-  !>     ku        [int]
+  !>     @param[in] ku - [int]
   !>               number of super-diagonals of A.
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>         AP    device pointer to first banded matrix (A_1).
+  !>     @param[in] alpha - device pointer or host pointer to scalar alpha.
+  !>     @param[in] AP - device pointer to first banded matrix (A_1).
   !>               The leading (kl + ku + 1) by n part of the matrix contains the coefficients
   !>               of the banded matrix. The leading diagonal resides in row (ku + 1) with
   !>               the first super-diagonal above on the RHS of row ku. The first sub-diagonal
@@ -10004,32 +9640,22 @@ module hipfort_hipblas
   !>                 0 0 0 0 5 4 1    ->   0 0 0 0 0 0 0
   !>               Note that empty elements that don't correspond to data will not
   !>               be referenced.
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of A. Must be >= (kl + ku + 1).
-  !>     @param[in]
-  !>     strideA  [hipblasStride]
+  !>     @param[in] strideA - [hipblasStride]
   !>               stride from the start of one matrix (A_i) to the next one (A_i+1).
-  !>     @param[in]
-  !>     x         device pointer to first vector (x_1).
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device pointer to first vector (x_1).
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of x.
-  !>     @param[in]
-  !>     stridex  [hipblasStride]
+  !>     @param[in] stridex - [hipblasStride]
   !>               stride from the start of one vector (x_i) to the next one (x_i+1).
-  !>     @param[in]
-  !>     beta      device pointer or host pointer to scalar beta.
-  !>     @param[inout]
-  !>     y         device pointer to first vector (y_1).
-  !>     @param[in]
-  !>     incy      [int]
+  !>     @param[in] beta - device pointer or host pointer to scalar beta.
+  !>     @param[inout] y - device pointer to first vector (y_1).
+  !>     @param[in] incy - [int]
   !>               specifies the increment for the elements of y.
-  !>     @param[in]
-  !>     stridey  [hipblasStride]
+  !>     @param[in] stridey - [hipblasStride]
   !>               stride from the start of one vector (y_i) to the next one (x_i+1).
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 specifies the number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasSgbmvStridedBatched
@@ -10322,36 +9948,24 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : ``s``, ``d``, ``c``, and ``z``.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     trans     [hipblasOperation_t]
+  !>     @param[in] trans - [hipblasOperation_t]
   !>               indicates whether matrix A is tranposed (conjugated) or not.
-  !>     @param[in]
-  !>     m         [int]
+  !>     @param[in] m - [int]
   !>               number of rows of matrix A.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               number of columns of matrix A.
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     AP        device pointer storing matrix A.
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[in] alpha - device pointer or host pointer to scalar alpha.
+  !>     @param[in] AP - device pointer storing matrix A.
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of A.
-  !>     @param[in]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device pointer storing vector x.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of x.
-  !>     @param[in]
-  !>     beta      device pointer or host pointer to scalar beta.
-  !>     @param[inout]
-  !>     y         device pointer storing vector y.
-  !>     @param[in]
-  !>     incy      [int]
+  !>     @param[in] beta - device pointer or host pointer to scalar beta.
+  !>     @param[inout] y - device pointer storing vector y.
+  !>     @param[in] incy - [int]
   !>               specifies the increment for the elements of y.
   interface hipblasSgemv
 #ifdef USE_CUDA_NAMES
@@ -10613,39 +10227,26 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle      [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>                 handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     trans       [hipblasOperation_t]
+  !>     @param[in] trans - [hipblasOperation_t]
   !>                 indicates whether matrices A_i are tranposed (conjugated) or not.
-  !>     @param[in]
-  !>     m           [int]
+  !>     @param[in] m - [int]
   !>                 number of rows of each matrix A_i.
-  !>     @param[in]
-  !>     n           [int]
+  !>     @param[in] n - [int]
   !>                 number of columns of each matrix A_i.
-  !>     @param[in]
-  !>     alpha       device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     AP         device array of device pointers storing each matrix A_i.
-  !>     @param[in]
-  !>     lda         [int]
+  !>     @param[in] alpha - device pointer or host pointer to scalar alpha.
+  !>     @param[in] AP - device array of device pointers storing each matrix A_i.
+  !>     @param[in] lda - [int]
   !>                 specifies the leading dimension of each matrix A_i.
-  !>     @param[in]
-  !>     x           device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx        [int]
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [int]
   !>                 specifies the increment for the elements of each vector x_i.
-  !>     @param[in]
-  !>     beta        device pointer or host pointer to scalar beta.
-  !>     @param[inout]
-  !>     y           device array of device pointers storing each vector y_i.
-  !>     @param[in]
-  !>     incy        [int]
+  !>     @param[in] beta - device pointer or host pointer to scalar beta.
+  !>     @param[inout] y - device array of device pointers storing each vector y_i.
+  !>     @param[in] incy - [int]
   !>                 specifies the increment for the elements of each vector y_i.
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
   interface hipblasSgemvBatched
 #ifdef USE_CUDA_NAMES
@@ -10887,55 +10488,39 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle      [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>                 handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     transA      [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>                 indicates whether matrices A_i are tranposed (conjugated) or not.
-  !>     @param[in]
-  !>     m           [int]
+  !>     @param[in] m - [int]
   !>                 number of rows of matrices A_i.
-  !>     @param[in]
-  !>     n           [int]
+  !>     @param[in] n - [int]
   !>                 number of columns of matrices A_i.
-  !>     @param[in]
-  !>     alpha       device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     AP          device pointer to the first matrix (A_1) in the batch.
-  !>     @param[in]
-  !>     lda         [int]
+  !>     @param[in] alpha - device pointer or host pointer to scalar alpha.
+  !>     @param[in] AP - device pointer to the first matrix (A_1) in the batch.
+  !>     @param[in] lda - [int]
   !>                 specifies the leading dimension of matrices A_i.
-  !>     @param[in]
-  !>     strideA     [hipblasStride]
+  !>     @param[in] strideA - [hipblasStride]
   !>                 stride from the start of one matrix (A_i) to the next one (A_i+1).
-  !>     @param[in]
-  !>     x           device pointer to the first vector (x_1) in the batch.
-  !>     @param[in]
-  !>     incx        [int]
+  !>     @param[in] x - device pointer to the first vector (x_1) in the batch.
+  !>     @param[in] incx - [int]
   !>                 specifies the increment for the elements of vectors x_i.
-  !>     @param[in]
-  !>     stridex     [hipblasStride]
+  !>     @param[in] stridex - [hipblasStride]
   !>                 stride from the start of one vector (x_i) to the next one (x_i+1).
   !>                 There are no restrictions placed on stridex. However, the user should
   !>                 ensure that stridex is of an appropriate size. When trans equals HIPBLAS_OP_N,
   !>                 this typically means stridex >= n * incx. Otherwise, stridex >= m * incx.
-  !>     @param[in]
-  !>     beta        device pointer or host pointer to scalar beta.
-  !>     @param[inout]
-  !>     y           device pointer to the first vector (y_1) in the batch.
-  !>     @param[in]
-  !>     incy        [int]
+  !>     @param[in] beta - device pointer or host pointer to scalar beta.
+  !>     @param[inout] y - device pointer to the first vector (y_1) in the batch.
+  !>     @param[in] incy - [int]
   !>                 specifies the increment for the elements of vectors y_i.
-  !>     @param[in]
-  !>     stridey     [hipblasStride]
+  !>     @param[in] stridey - [hipblasStride]
   !>                 stride from the start of one vector (y_i) to the next one (y_i+1).
   !>                 There are no restrictions placed on stridey. However, the user should
   !>                 ensure that stridey is of an appropriate size. When trans equals HIPBLAS_OP_N,
   !>                 this typically means stridey >= m * incy. Otherwise, stridey >= n * incy.
   !>                 stridey should be non zero.
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
   interface hipblasSgemvStridedBatched
 #ifdef USE_CUDA_NAMES
@@ -11243,32 +10828,22 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : ``s``, ``d``, ``c``, and ``z``.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     m         [int]
+  !>     @param[in] m - [int]
   !>               the number of rows of the matrix A.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of columns of the matrix A.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device pointer storing vector x.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of x.
-  !>     @param[in]
-  !>     y         device pointer storing vector y.
-  !>     @param[in]
-  !>     incy      [int]
+  !>     @param[in] y - device pointer storing vector y.
+  !>     @param[in] incy - [int]
   !>               specifies the increment for the elements of y.
-  !>     @param[inout]
-  !>     AP         device pointer storing matrix A.
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[inout] AP - device pointer storing matrix A.
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of A.
   interface hipblasSger
 #ifdef USE_CUDA_NAMES
@@ -11608,35 +11183,24 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     m         [int]
+  !>     @param[in] m - [int]
   !>               the number of rows of each matrix A_i.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of columns of each matrix A_i.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each vector x_i.
-  !>     @param[in]
-  !>     y         device array of device pointers storing each vector y_i.
-  !>     @param[in]
-  !>     incy      [int]
+  !>     @param[in] y - device array of device pointers storing each vector y_i.
+  !>     @param[in] incy - [int]
   !>               specifies the increment for the elements of each vector y_i.
-  !>     @param[inout]
-  !>     AP        device array of device pointers storing each matrix A_i.
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[inout] AP - device array of device pointers storing each matrix A_i.
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of each A_i.
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasSgerBatched
@@ -11930,50 +11494,36 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     m         [int]
+  !>     @param[in] m - [int]
   !>               the number of rows of each matrix A_i.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of columns of each matrix A_i.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     x         device pointer to the first vector (x_1) in the batch.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device pointer to the first vector (x_1) in the batch.
+  !>     @param[in] incx - [int]
   !>               specifies the increments for the elements of each vector x_i.
-  !>     @param[in]
-  !>     stridex   [hipblasStride]
+  !>     @param[in] stridex - [hipblasStride]
   !>               stride from the start of one vector (x_i) to the next one (x_i+1).
   !>               There are no restrictions placed on stridex. However, the user should
   !>               ensure that stridex is of an appropriate size. For a typical
   !>               case, this means stridex >= m * incx.
-  !>     @param[inout]
-  !>     y         device pointer to the first vector (y_1) in the batch.
-  !>     @param[in]
-  !>     incy      [int]
+  !>     @param[inout] y - device pointer to the first vector (y_1) in the batch.
+  !>     @param[in] incy - [int]
   !>               specifies the increment for the elements of each vector y_i.
-  !>     @param[in]
-  !>     stridey   [hipblasStride]
+  !>     @param[in] stridey - [hipblasStride]
   !>               stride from the start of one vector (y_i) to the next one (y_i+1).
   !>               There are no restrictions placed on stridey. However, the user should
   !>               ensure that stridey is of an appropriate size. For a typical
   !>               case, this means stridey >= n * incy.
-  !>     @param[inout]
-  !>     AP        device pointer to the first matrix (A_1) in the batch.
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[inout] AP - device pointer to the first matrix (A_1) in the batch.
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of each A_i.
-  !>     @param[in]
-  !>     strideA     [hipblasStride]
+  !>     @param[in] strideA - [hipblasStride]
   !>                 stride from the start of one matrix (A_i) to the next one (A_i+1)
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasSgerStridedBatched
@@ -12355,23 +11905,17 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``c`` and ``z``.
   !>     - Supported precisions in cuBLAS  : ``c`` and ``z``.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>               - HIPBLAS_FILL_MODE_UPPER: The upper triangular part of A is being supplied.
   !>               - HIPBLAS_FILL_MODE_LOWER: The lower triangular part of A is being supplied.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the order of the matrix A.
-  !>     @param[in]
-  !>     k         [int]
+  !>     @param[in] k - [int]
   !>               the number of super-diagonals of the matrix A. Must be >= 0.
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     AP        device pointer storing matrix A. Of dimension (lda, n).
+  !>     @param[in] alpha - device pointer or host pointer to scalar alpha.
+  !>     @param[in] AP - device pointer storing matrix A. Of dimension (lda, n).
   !>               - if uplo == HIPBLAS_FILL_MODE_UPPER:
   !>                 The leading (k + 1) by n part of A must contain the upper
   !>                 triangular band part of the Hermitian matrix, with the leading
@@ -12398,20 +11942,14 @@ module hipfort_hipblas
   !>                     ->                                (0, 0) (0, 0) (7, 7) (4, 0)
   !>               - As a Hermitian matrix, the imaginary part of the main diagonal
   !>               of A will not be referenced and is assumed to be == 0.
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of A. Must be >= k + 1.
-  !>     @param[in]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device pointer storing vector x.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of x.
-  !>     @param[in]
-  !>     beta      device pointer or host pointer to scalar beta.
-  !>     @param[inout]
-  !>     y         device pointer storing vector y.
-  !>     @param[in]
-  !>     incy      [int]
+  !>     @param[in] beta - device pointer or host pointer to scalar beta.
+  !>     @param[inout] y - device pointer storing vector y.
+  !>     @param[in] incy - [int]
   !>               specifies the increment for the elements of y.
   interface hipblasChbmv
 #ifdef USE_CUDA_NAMES
@@ -12550,25 +12088,20 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``c`` and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>               - HIPBLAS_FILL_MODE_UPPER: The upper triangular part of each A_i is being
   !>               supplied.
   !>               - HIPBLAS_FILL_MODE_LOWER: The lower triangular part of each A_i is being
   !>               supplied.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the order of each matrix A_i.
-  !>     @param[in]
-  !>     k         [int]
+  !>     @param[in] k - [int]
   !>               the number of super-diagonals of each matrix A_i. Must be >= 0.
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     AP        device array of device pointers storing each matrix_i A of dimension (lda, n).
+  !>     @param[in] alpha - device pointer or host pointer to scalar alpha.
+  !>     @param[in] AP - device array of device pointers storing each matrix_i A of dimension (lda,
+  !>     n).
   !>               - if uplo == HIPBLAS_FILL_MODE_UPPER:
   !>                 The leading (k + 1) by n part of each A_i must contain the upper
   !>                 triangular band part of the Hermitian matrix, with the leading
@@ -12595,23 +12128,16 @@ module hipfort_hipblas
   !>                     ->                                (0, 0) (0, 0) (7, 7) (4, 0)
   !>               - As a Hermitian matrix, the imaginary part of the main diagonal
   !>               of each A_i will not be referenced and is assumed to be == 0.
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of each A_i. Must be >= max(1, n).
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     beta      device pointer or host pointer to scalar beta.
-  !>     @param[inout]
-  !>     y         device array of device pointers storing each vector y_i.
-  !>     @param[in]
-  !>     incy      [int]
+  !>     @param[in] beta - device pointer or host pointer to scalar beta.
+  !>     @param[inout] y - device array of device pointers storing each vector y_i.
+  !>     @param[in] incy - [int]
   !>               specifies the increment for the elements of y.
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasChbmvBatched
@@ -12728,25 +12254,20 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``c`` and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>               - HIPBLAS_FILL_MODE_UPPER: The upper triangular part of each A_i is being
   !>               supplied.
   !>               - HIPBLAS_FILL_MODE_LOWER: The lower triangular part of each A_i is being
   !>               supplied.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the order of each matrix A_i.
-  !>     @param[in]
-  !>     k         [int]
+  !>     @param[in] k - [int]
   !>               the number of super-diagonals of each matrix A_i. Must be >= 0.
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     AP        device array pointing to the first matrix A_1. Each A_i is of dimension (lda, n).
+  !>     @param[in] alpha - device pointer or host pointer to scalar alpha.
+  !>     @param[in] AP - device array pointing to the first matrix A_1. Each A_i is of dimension
+  !>     (lda, n).
   !>               - if uplo == HIPBLAS_FILL_MODE_UPPER:
   !>                 The leading (k + 1) by n part of each A_i must contain the upper
   !>                 triangular band part of the Hermitian matrix, with the leading
@@ -12773,32 +12294,22 @@ module hipfort_hipblas
   !>                     ->                              (0, 0) (0, 0) (7, 7) (4, 0)
   !>               - As a Hermitian matrix, the imaginary part of the main diagonal
   !>               of each A_i will not be referenced and is assumed to be == 0.
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of each A_i. Must be >= max(1, n).
-  !>     @param[in]
-  !>     strideA  [hipblasStride]
+  !>     @param[in] strideA - [hipblasStride]
   !>               stride from the start of one matrix (A_i) to the next one (A_i+1).
-  !>     @param[in]
-  !>     x         device array pointing to the first vector y_1.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device array pointing to the first vector y_1.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     stridex  [hipblasStride]
+  !>     @param[in] stridex - [hipblasStride]
   !>               stride from the start of one vector (x_i) to the next one (x_i+1).
-  !>     @param[in]
-  !>     beta      device pointer or host pointer to scalar beta.
-  !>     @param[inout]
-  !>     y         device array pointing to the first vector y_1.
-  !>     @param[in]
-  !>     incy      [int]
+  !>     @param[in] beta - device pointer or host pointer to scalar beta.
+  !>     @param[inout] y - device array pointing to the first vector y_1.
+  !>     @param[in] incy - [int]
   !>               specifies the increment for the elements of y.
-  !>     @param[in]
-  !>     stridey  [hipblasStride]
+  !>     @param[in] stridey - [hipblasStride]
   !>               stride from the start of one vector (y_i) to the next one (y_i+1).
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasChbmvStridedBatched
@@ -12944,22 +12455,17 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``c`` and ``z``.
   !>     - Supported precisions in cuBLAS  : ``c`` and ``z``.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>               - HIPBLAS_FILL_MODE_UPPER: the upper triangular part of the Hermitian matrix A is
   !>               supplied.
   !>               - HIPBLAS_FILL_MODE_LOWER: the lower triangular part of the Hermitian matrix A is
   !>               supplied.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the order of the matrix A.
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     AP        device pointer storing matrix A. Of dimension (lda, n).
+  !>     @param[in] alpha - device pointer or host pointer to scalar alpha.
+  !>     @param[in] AP - device pointer storing matrix A. Of dimension (lda, n).
   !>               - if uplo == HIPBLAS_FILL_MODE_UPPER:
   !>                 The upper triangular part of A must contain
   !>                 the upper triangular part of a Hermitian matrix. The lower
@@ -12970,20 +12476,14 @@ module hipfort_hipblas
   !>                 triangular part of A will not be referenced.
   !>               - As a Hermitian matrix, the imaginary part of the main diagonal
   !>               of A will not be referenced and is assumed to be == 0.
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of A. Must be >= max(1, n).
-  !>     @param[in]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device pointer storing vector x.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of x.
-  !>     @param[in]
-  !>     beta      device pointer or host pointer to scalar beta.
-  !>     @param[inout]
-  !>     y         device pointer storing vector y.
-  !>     @param[in]
-  !>     incy      [int]
+  !>     @param[in] beta - device pointer or host pointer to scalar beta.
+  !>     @param[inout] y - device pointer storing vector y.
+  !>     @param[in] incy - [int]
   !>               specifies the increment for the elements of y.
   interface hipblasChemv
 #ifdef USE_CUDA_NAMES
@@ -13117,22 +12617,18 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``c`` and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>               - HIPBLAS_FILL_MODE_UPPER: the upper triangular part of the Hermitian matrix A is
   !>               supplied.
   !>               - HIPBLAS_FILL_MODE_LOWER: the lower triangular part of the Hermitian matrix A is
   !>               supplied.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the order of each matrix A_i.
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     AP        device array of device pointers storing each matrix A_i of dimension (lda, n).
+  !>     @param[in] alpha - device pointer or host pointer to scalar alpha.
+  !>     @param[in] AP - device array of device pointers storing each matrix A_i of dimension (lda,
+  !>     n).
   !>               - if uplo == HIPBLAS_FILL_MODE_UPPER:
   !>                 The upper triangular part of each A_i must contain
   !>                 the upper triangular part of a Hermitian matrix. The lower
@@ -13143,23 +12639,16 @@ module hipfort_hipblas
   !>                 triangular part of each A_i will not be referenced.
   !>               - As a Hermitian matrix, the imaginary part of the main diagonal
   !>               of each A_i will not be referenced and is assumed to be == 0.
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of each A_i. Must be >= max(1, n).
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     beta      device pointer or host pointer to scalar beta.
-  !>     @param[inout]
-  !>     y         device array of device pointers storing each vector y_i.
-  !>     @param[in]
-  !>     incy      [int]
+  !>     @param[in] beta - device pointer or host pointer to scalar beta.
+  !>     @param[inout] y - device array of device pointers storing each vector y_i.
+  !>     @param[in] incy - [int]
   !>               specifies the increment for the elements of y.
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasChemvBatched
@@ -13271,22 +12760,18 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``c`` and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>               - HIPBLAS_FILL_MODE_UPPER: the upper triangular part of the Hermitian matrix A is
   !>               supplied.
   !>               - HIPBLAS_FILL_MODE_LOWER: the lower triangular part of the Hermitian matrix A is
   !>               supplied.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the order of each matrix A_i.
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     AP        device array of device pointers storing each matrix A_i of dimension (lda, n).
+  !>     @param[in] alpha - device pointer or host pointer to scalar alpha.
+  !>     @param[in] AP - device array of device pointers storing each matrix A_i of dimension (lda,
+  !>     n).
   !>               - if uplo == HIPBLAS_FILL_MODE_UPPER:
   !>                 The upper triangular part of each A_i must contain
   !>                 the upper triangular part of a Hermitian matrix. The lower
@@ -13297,33 +12782,23 @@ module hipfort_hipblas
   !>                 triangular part of each A_i will not be referenced.
   !>               - As a Hermitian matrix, the imaginary part of the main diagonal
   !>               of each A_i will not be referenced and is assumed to be == 0.
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of each A_i. Must be >= max(1, n).
-  !>     @param[in]
-  !>     strideA    [hipblasStride]
+  !>     @param[in] strideA - [hipblasStride]
   !>                 stride from the start of one (A_i) to the next (A_i+1).
   !>
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     stridex  [hipblasStride]
+  !>     @param[in] stridex - [hipblasStride]
   !>               stride from the start of one vector (x_i) to the next one (x_i+1).
-  !>     @param[in]
-  !>     beta      device pointer or host pointer to scalar beta.
-  !>     @param[inout]
-  !>     y         device array of device pointers storing each vector y_i.
-  !>     @param[in]
-  !>     incy      [int]
+  !>     @param[in] beta - device pointer or host pointer to scalar beta.
+  !>     @param[inout] y - device array of device pointers storing each vector y_i.
+  !>     @param[in] incy - [int]
   !>               specifies the increment for the elements of y.
-  !>     @param[in]
-  !>     stridey  [hipblasStride]
+  !>     @param[in] stridey - [hipblasStride]
   !>               stride from the start of one vector (y_i) to the next one (y_i+1).
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasChemvStridedBatched
@@ -13464,28 +12939,21 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``c`` and ``z``.
   !>     - Supported precisions in cuBLAS  : ``c`` and ``z``.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>               specifies either upper (HIPBLAS_FILL_MODE_UPPER) or lower
   !>               (HIPBLAS_FILL_MODE_LOWER):
   !>               - HIPBLAS_FILL_MODE_UPPER: The upper triangular part of A is supplied in A.
   !>               - HIPBLAS_FILL_MODE_LOWER: The lower triangular part of A is supplied in A.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of rows and columns of matrix A. Must be at least 0.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device pointer storing vector x.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of x.
-  !>     @param[inout]
-  !>     AP        device pointer storing the specified triangular portion of
+  !>     @param[inout] AP - device pointer storing the specified triangular portion of
   !>               the Hermitian matrix A. Of size (lda * n).
   !>               - if uplo == HIPBLAS_FILL_MODE_UPPER:
   !>                 The upper triangular portion of the Hermitian matrix A is supplied. The lower
@@ -13496,8 +12964,7 @@ module hipfort_hipblas
   !>               - Note that the imaginary parts of the diagonal elements are not accessed and are
   !>               assumed
   !>                 to be 0.
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of A. Must be at least max(1, n).
   interface hipblasCher
 #ifdef USE_CUDA_NAMES
@@ -13610,30 +13077,24 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``c`` and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>               specifies either upper (HIPBLAS_FILL_MODE_UPPER) or lower
   !>               (HIPBLAS_FILL_MODE_LOWER):
   !>               - HIPBLAS_FILL_MODE_UPPER: The upper triangular part of each A_i is supplied in
   !>               A.
   !>               - HIPBLAS_FILL_MODE_LOWER: The lower triangular part of each A_i is supplied in
   !>               A.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of rows and columns of each matrix A_i. Must be at least 0.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[inout]
-  !>     AP        device array of device pointers storing the specified triangular portion of
+  !>     @param[inout] AP - device array of device pointers storing the specified triangular portion
+  !>     of
   !>               each Hermitian matrix A_i of at least size ((n * (n + 1)) / 2). Array is of at
   !>               least size batchCount.
   !>               - if uplo == HIPBLAS_FILL_MODE_UPPER:
@@ -13647,11 +13108,9 @@ module hipfort_hipblas
   !>               - Note that the imaginary parts of the diagonal elements are not accessed and are
   !>               assumed
   !>                 to be 0.
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of each A_i. Must be at least max(1, n).
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasCherBatched
@@ -13750,33 +13209,26 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``c`` and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>               specifies either upper (HIPBLAS_FILL_MODE_UPPER) or lower
   !>               (HIPBLAS_FILL_MODE_LOWER):
   !>               - HIPBLAS_FILL_MODE_UPPER: The upper triangular part of each A_i is supplied in
   !>               A.
   !>               - HIPBLAS_FILL_MODE_LOWER: The lower triangular part of each A_i is supplied in
   !>               A.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of rows and columns of each matrix A_i. Must be at least 0.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     x         device pointer pointing to the first vector (x_1).
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device pointer pointing to the first vector (x_1).
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     stridex  [hipblasStride]
+  !>     @param[in] stridex - [hipblasStride]
   !>               stride from the start of one vector (x_i) to the next one (x_i+1).
-  !>     @param[inout]
-  !>     AP        device array of device pointers storing the specified triangular portion of
+  !>     @param[inout] AP - device array of device pointers storing the specified triangular portion
+  !>     of
   !>               each Hermitian matrix A_i. Points to the first matrix (A_1).
   !>               - if uplo == HIPBLAS_FILL_MODE_UPPER:
   !>                 The upper triangular portion of each Hermitian matrix A_i is supplied. The
@@ -13789,14 +13241,11 @@ module hipfort_hipblas
   !>               - Note that the imaginary parts of the diagonal elements are not accessed and are
   !>               assumed
   !>                 to be 0.
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of each A_i.
-  !>     @param[in]
-  !>     strideA    [hipblasStride]
+  !>     @param[in] strideA - [hipblasStride]
   !>                 stride from the start of one (A_i) to the next (A_i+1).
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasCherStridedBatched
@@ -13921,33 +13370,24 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``c`` and ``z``.
   !>     - Supported precisions in cuBLAS  : ``c`` and ``z``.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>               specifies either upper (HIPBLAS_FILL_MODE_UPPER) or lower
   !>               (HIPBLAS_FILL_MODE_LOWER):
   !>               - HIPBLAS_FILL_MODE_UPPER: The upper triangular part of A is supplied.
   !>               - HIPBLAS_FILL_MODE_LOWER: The lower triangular part of A is supplied.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of rows and columns of matrix A. Must be at least 0.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device pointer storing vector x.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of x.
-  !>     @param[in]
-  !>     y         device pointer storing vector y.
-  !>     @param[in]
-  !>     incy      [int]
+  !>     @param[in] y - device pointer storing vector y.
+  !>     @param[in] incy - [int]
   !>               specifies the increment for the elements of y.
-  !>     @param[inout]
-  !>     AP        device pointer storing the specified triangular portion of
+  !>     @param[inout] AP - device pointer storing the specified triangular portion of
   !>               the Hermitian matrix A. Of size (lda, n).
   !>               - if uplo == HIPBLAS_FILL_MODE_UPPER:
   !>                 The upper triangular portion of the Hermitian matrix A is supplied. The lower
@@ -13960,8 +13400,7 @@ module hipfort_hipblas
   !>               - Note that the imaginary parts of the diagonal elements are not accessed and are
   !>               assumed
   !>                 to be 0.
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of A. Must be at least max(lda, 1).
   interface hipblasCher2
 #ifdef USE_CUDA_NAMES
@@ -14086,33 +13525,25 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``c`` and ``z``.
   !>     - Supported precisions in cuBLAS  : No support
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>               specifies either upper (HIPBLAS_FILL_MODE_UPPER) or lower
   !>               (HIPBLAS_FILL_MODE_LOWER):
   !>               - HIPBLAS_FILL_MODE_UPPER: The upper triangular part of each A_i is supplied.
   !>               - HIPBLAS_FILL_MODE_LOWER: The lower triangular part of each A_i is supplied.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of rows and columns of each matrix A_i. Must be at least 0.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of x.
-  !>     @param[in]
-  !>     y         device array of device pointers storing each vector y_i.
-  !>     @param[in]
-  !>     incy      [int]
+  !>     @param[in] y - device array of device pointers storing each vector y_i.
+  !>     @param[in] incy - [int]
   !>               specifies the increment for the elements of each y_i.
-  !>     @param[inout]
-  !>     AP        device array of device pointers storing the specified triangular portion of
+  !>     @param[inout] AP - device array of device pointers storing the specified triangular portion
+  !>     of
   !>               each Hermitian matrix A_i of size (lda, n).
   !>               - if uplo == HIPBLAS_FILL_MODE_UPPER:
   !>                 The upper triangular portion of each Hermitian matrix A_i is supplied. The
@@ -14125,11 +13556,9 @@ module hipfort_hipblas
   !>               - Note that the imaginary parts of the diagonal elements are not accessed and are
   !>               assumed
   !>                 to be 0.
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of each A_i. Must be at least max(lda, 1).
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasCher2Batched
@@ -14236,42 +13665,31 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``c`` and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>               specifies either upper (HIPBLAS_FILL_MODE_UPPER) or lower
   !>               (HIPBLAS_FILL_MODE_LOWER):
   !>               - HIPBLAS_FILL_MODE_UPPER: The upper triangular part of each A_i is supplied.
   !>               - HIPBLAS_FILL_MODE_LOWER: The lower triangular part of each A_i is supplied.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of rows and columns of each matrix A_i. Must be at least 0.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     x         device pointer pointing to the first vector x_1.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device pointer pointing to the first vector x_1.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     stridex  [hipblasStride]
+  !>     @param[in] stridex - [hipblasStride]
   !>               specifies the stride between the beginning of one vector (x_i) and the next
   !>               (x_i+1).
-  !>     @param[in]
-  !>     y         device pointer pointing to the first vector y_i.
-  !>     @param[in]
-  !>     incy      [int]
+  !>     @param[in] y - device pointer pointing to the first vector y_i.
+  !>     @param[in] incy - [int]
   !>               specifies the increment for the elements of each y_i.
-  !>     @param[in]
-  !>     stridey  [hipblasStride]
+  !>     @param[in] stridey - [hipblasStride]
   !>               specifies the stride between the beginning of one vector (y_i) and the next
   !>               (y_i+1).
-  !>     @param[inout]
-  !>     AP device pointer pointing to the first matrix (A_1). Stores the specified triangular
-  !>     portion of
+  !>     @param[inout] AP - device pointer pointing to the first matrix (A_1). Stores the specified
+  !>     triangular portion of
   !>               each Hermitian matrix A_i.
   !>               - if uplo == HIPBLAS_FILL_MODE_UPPER:
   !>                 The upper triangular portion of each Hermitian matrix A_i is supplied. The
@@ -14284,15 +13702,12 @@ module hipfort_hipblas
   !>               - Note that the imaginary part of the diagonal elements are not accessed and are
   !>               assumed
   !>                 to be 0.
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of each A_i. Must be at least max(lda, 1).
-  !>     @param[in]
-  !>     strideA  [hipblasStride]
+  !>     @param[in] strideA - [hipblasStride]
   !>               specifies the stride between the beginning of one matrix (A_i) and the next
   !>               (A_i+1).
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasCher2StridedBatched
@@ -14430,22 +13845,18 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``c`` and ``z``.
   !>     - Supported precisions in cuBLAS  : ``c`` and ``z``.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>               - HIPBLAS_FILL_MODE_UPPER: the upper triangular part of the Hermitian matrix A is
   !>               supplied in AP.
   !>               - HIPBLAS_FILL_MODE_LOWER: the lower triangular part of the Hermitian matrix A is
   !>               supplied in AP.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the order of the matrix A. Must be >= 0.
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     AP        device pointer storing the packed version of the specified triangular portion of
+  !>     @param[in] alpha - device pointer or host pointer to scalar alpha.
+  !>     @param[in] AP - device pointer storing the packed version of the specified triangular
+  !>     portion of
   !>               the Hermitian matrix A. Of at least size ((n * (n + 1)) / 2).
   !>               - if uplo == HIPBLAS_FILL_MODE_UPPER:
   !>                 The upper triangular portion of the Hermitian matrix A is supplied.
@@ -14474,17 +13885,12 @@ module hipfort_hipblas
   !>               - Note that the imaginary parts of the diagonal elements are not accessed and are
   !>               assumed
   !>               to be 0.
-  !>     @param[in]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device pointer storing vector x.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of x.
-  !>     @param[in]
-  !>     beta      device pointer or host pointer to scalar beta.
-  !>     @param[inout]
-  !>     y         device pointer storing vector y.
-  !>     @param[in]
-  !>     incy      [int]
+  !>     @param[in] beta - device pointer or host pointer to scalar beta.
+  !>     @param[inout] y - device pointer storing vector y.
+  !>     @param[in] incy - [int]
   !>               specifies the increment for the elements of y.
   interface hipblasChpmv
 #ifdef USE_CUDA_NAMES
@@ -14609,22 +14015,18 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``c`` and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>               - HIPBLAS_FILL_MODE_UPPER: the upper triangular part of each Hermitian matrix A_i
   !>               is supplied in AP.
   !>               - HIPBLAS_FILL_MODE_LOWER: the lower triangular part of each Hermitian matrix A_i
   !>               is supplied in AP.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the order of each matrix A_i.
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     AP device pointer of device pointers storing the packed version of the specified triangular
+  !>     @param[in] alpha - device pointer or host pointer to scalar alpha.
+  !>     @param[in] AP - device pointer of device pointers storing the packed version of the
+  !>     specified triangular
   !>             portion of each Hermitian matrix A_i. Each A_i is of at least size ((n * (n + 1)) /
   !>             2).
   !>             - if uplo == HIPBLAS_FILL_MODE_UPPER:
@@ -14654,20 +14056,14 @@ module hipfort_hipblas
   !>             - Note that the imaginary parts of the diagonal elements are not accessed and are
   !>             assumed
   !>               to be 0.
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     beta      device pointer or host pointer to scalar beta.
-  !>     @param[inout]
-  !>     y         device array of device pointers storing each vector y_i.
-  !>     @param[in]
-  !>     incy      [int]
+  !>     @param[in] beta - device pointer or host pointer to scalar beta.
+  !>     @param[inout] y - device array of device pointers storing each vector y_i.
+  !>     @param[in] incy - [int]
   !>               specifies the increment for the elements of y.
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasChpmvBatched
@@ -14776,22 +14172,18 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``c`` and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>               - HIPBLAS_FILL_MODE_UPPER: the upper triangular part of each Hermitian matrix A_i
   !>               is supplied in AP.
   !>               - HIPBLAS_FILL_MODE_LOWER: the lower triangular part of each Hermitian matrix A_i
   !>               is supplied in AP.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the order of each matrix A_i.
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     AP device pointer pointing to the beginning of the first matrix (AP_1). Stores the packed
+  !>     @param[in] alpha - device pointer or host pointer to scalar alpha.
+  !>     @param[in] AP - device pointer pointing to the beginning of the first matrix (AP_1). Stores
+  !>     the packed
   !>               version of the specified triangular portion of each Hermitian matrix AP_i of size
   !>               ((n * (n + 1)) / 2).
   !>               - if uplo == HIPBLAS_FILL_MODE_UPPER:
@@ -14821,29 +14213,20 @@ module hipfort_hipblas
   !>               - Note that the imaginary parts of the diagonal elements are not accessed and are
   !>               assumed
   !>                 to be 0.
-  !>     @param[in]
-  !>     strideA  [hipblasStride]
+  !>     @param[in] strideA - [hipblasStride]
   !>               stride from the start of one matrix (AP_i) to the next one (AP_i+1).
-  !>     @param[in]
-  !>     x         device array pointing to the beginning of the first vector (x_1).
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device array pointing to the beginning of the first vector (x_1).
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     stridex  [hipblasStride]
+  !>     @param[in] stridex - [hipblasStride]
   !>               stride from the start of one vector (x_i) to the next one (x_i+1).
-  !>     @param[in]
-  !>     beta      device pointer or host pointer to scalar beta.
-  !>     @param[inout]
-  !>     y         device array pointing to the beginning of the first vector (y_1).
-  !>     @param[in]
-  !>     incy      [int]
+  !>     @param[in] beta - device pointer or host pointer to scalar beta.
+  !>     @param[inout] y - device array pointing to the beginning of the first vector (y_1).
+  !>     @param[in] incy - [int]
   !>               specifies the increment for the elements of y.
-  !>     @param[in]
-  !>     stridey  [hipblasStride]
+  !>     @param[in] stridey - [hipblasStride]
   !>               stride from the start of one vector (y_i) to the next one (y_i+1).
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasChpmvStridedBatched
@@ -14978,28 +14361,22 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``c`` and ``z``.
   !>     - Supported precisions in cuBLAS  : ``c`` and ``z``.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>               specifies either upper (HIPBLAS_FILL_MODE_UPPER) or lower
   !>               (HIPBLAS_FILL_MODE_LOWER):
   !>               - HIPBLAS_FILL_MODE_UPPER: The upper triangular part of A is supplied in AP.
   !>               - HIPBLAS_FILL_MODE_LOWER: The lower triangular part of A is supplied in AP.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of rows and columns of matrix A. Must be at least 0.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device pointer storing vector x.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of x.
-  !>     @param[inout]
-  !>     AP        device pointer storing the packed version of the specified triangular portion of
+  !>     @param[inout] AP - device pointer storing the packed version of the specified triangular
+  !>     portion of
   !>               the Hermitian matrix A. Of at least size ((n * (n + 1)) / 2).
   !>               - if uplo == HIPBLAS_FILL_MODE_UPPER:
   !>                 The upper triangular portion of the Hermitian matrix A is supplied.
@@ -15134,31 +14511,24 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``c`` and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>               specifies either upper (HIPBLAS_FILL_MODE_UPPER) or lower
   !>               (HIPBLAS_FILL_MODE_LOWER):
   !>               - HIPBLAS_FILL_MODE_UPPER: The upper triangular part of each A_i is supplied in
   !>               AP.
   !>               - HIPBLAS_FILL_MODE_LOWER: The lower triangular part of each A_i is supplied in
   !>               AP.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of rows and columns of each matrix A_i. Must be at least 0.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[inout]
-  !>     AP device array of device pointers storing the packed version of the specified triangular
-  !>     portion of
+  !>     @param[inout] AP - device array of device pointers storing the packed version of the
+  !>     specified triangular portion of
   !>               each Hermitian matrix A_i of at least size ((n * (n + 1)) / 2). Array is of at
   !>               least size batchCount.
   !>               - if uplo == HIPBLAS_FILL_MODE_UPPER:
@@ -15188,8 +14558,7 @@ module hipfort_hipblas
   !>               - Note that the imaginary part of the diagonal elements are not accessed and are
   !>               assumed
   !>               to be 0.
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasChprBatched
@@ -15285,34 +14654,26 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``c`` and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>               specifies either upper (HIPBLAS_FILL_MODE_UPPER) or lower
   !>               (HIPBLAS_FILL_MODE_LOWER):
   !>               - HIPBLAS_FILL_MODE_UPPER: The upper triangular part of each A_i is supplied in
   !>               AP.
   !>               - HIPBLAS_FILL_MODE_LOWER: The lower triangular part of each A_i is supplied in
   !>               AP.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of rows and columns of each matrix A_i. Must be at least 0.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     x         device pointer pointing to the first vector (x_1).
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device pointer pointing to the first vector (x_1).
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     stridex  [hipblasStride]
+  !>     @param[in] stridex - [hipblasStride]
   !>               stride from the start of one vector (x_i) to the next one (x_i+1).
-  !>     @param[inout]
-  !>     AP device array of device pointers storing the packed version of the specified triangular
-  !>     portion of
+  !>     @param[inout] AP - device array of device pointers storing the packed version of the
+  !>     specified triangular portion of
   !>               each Hermitian matrix A_i. Points to the first matrix (A_1).
   !>               - if uplo == HIPBLAS_FILL_MODE_UPPER:
   !>                 The upper triangular portion of each Hermitian matrix A_i is supplied.
@@ -15341,11 +14702,9 @@ module hipfort_hipblas
   !>               - Note that the imaginary parts of the diagonal elements are not accessed and are
   !>               assumed
   !>                 to be 0.
-  !>     @param[in]
-  !>     strideA   [hipblasStride]
+  !>     @param[in] strideA - [hipblasStride]
   !>                 stride from the start of one (A_i) to the next (A_i+1).
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasChprStridedBatched
@@ -15462,33 +14821,25 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``c`` and ``z``.
   !>     - Supported precisions in cuBLAS  : ``c`` and ``z``.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>               specifies either upper (HIPBLAS_FILL_MODE_UPPER) or lower
   !>               (HIPBLAS_FILL_MODE_LOWER):
   !>               - HIPBLAS_FILL_MODE_UPPER: The upper triangular part of A is supplied in AP.
   !>               - HIPBLAS_FILL_MODE_LOWER: The lower triangular part of A is supplied in AP.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of rows and columns of matrix A. Must be at least 0.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device pointer storing vector x.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of x.
-  !>     @param[in]
-  !>     y         device pointer storing vector y.
-  !>     @param[in]
-  !>     incy      [int]
+  !>     @param[in] y - device pointer storing vector y.
+  !>     @param[in] incy - [int]
   !>               specifies the increment for the elements of y.
-  !>     @param[inout]
-  !>     AP        device pointer storing the packed version of the specified triangular portion of
+  !>     @param[inout] AP - device pointer storing the packed version of the specified triangular
+  !>     portion of
   !>               the Hermitian matrix A. Of at least size ((n * (n + 1)) / 2).
   !>               - if uplo == HIPBLAS_FILL_MODE_UPPER:
   !>                 The upper triangular portion of the Hermitian matrix A is supplied.
@@ -15633,36 +14984,27 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``c`` and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>               specifies either upper (HIPBLAS_FILL_MODE_UPPER) or lower
   !>               (HIPBLAS_FILL_MODE_LOWER):
   !>               - HIPBLAS_FILL_MODE_UPPER: The upper triangular part of each A_i is supplied in
   !>               AP.
   !>               - HIPBLAS_FILL_MODE_LOWER: The lower triangular part of each A_i is supplied in
   !>               AP.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of rows and columns of each matrix A_i. Must be at least 0.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     y         device array of device pointers storing each vector y_i.
-  !>     @param[in]
-  !>     incy      [int]
+  !>     @param[in] y - device array of device pointers storing each vector y_i.
+  !>     @param[in] incy - [int]
   !>               specifies the increment for the elements of each y_i.
-  !>     @param[inout]
-  !>     AP device array of device pointers storing the packed version of the specified triangular
-  !>     portion of
+  !>     @param[inout] AP - device array of device pointers storing the packed version of the
+  !>     specified triangular portion of
   !>               each Hermitian matrix A_i of at least size ((n * (n + 1)) / 2). Array is of at
   !>               least size batchCount.
   !>               - if uplo == HIPBLAS_FILL_MODE_UPPER:
@@ -15692,8 +15034,7 @@ module hipfort_hipblas
   !>               - Note that the imaginary parts of the diagonal elements are not accessed and are
   !>               assumed
   !>                 to be 0.
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasChpr2Batched
@@ -15797,42 +15138,31 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``c`` and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>               specifies either upper (HIPBLAS_FILL_MODE_UPPER) or lower
   !>               (HIPBLAS_FILL_MODE_LOWER):
   !>               - HIPBLAS_FILL_MODE_UPPER: The upper triangular part of each A_i is supplied in
   !>               AP.
   !>               - HIPBLAS_FILL_MODE_LOWER: The lower triangular part of each A_i is supplied in
   !>               AP.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of rows and columns of each matrix A_i. Must be at least 0.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     x         device pointer pointing to the first vector (x_1).
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device pointer pointing to the first vector (x_1).
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     stridex  [hipblasStride]
+  !>     @param[in] stridex - [hipblasStride]
   !>               stride from the start of one vector (x_i) to the next one (x_i+1).
-  !>     @param[in]
-  !>     y         device pointer pointing to the first vector (y_1).
-  !>     @param[in]
-  !>     incy      [int]
+  !>     @param[in] y - device pointer pointing to the first vector (y_1).
+  !>     @param[in] incy - [int]
   !>               specifies the increment for the elements of each y_i.
-  !>     @param[in]
-  !>     stridey  [hipblasStride]
+  !>     @param[in] stridey - [hipblasStride]
   !>               stride from the start of one vector (y_i) to the next one (y_i+1).
-  !>     @param[inout]
-  !>     AP device array of device pointers storing the packed version of the specified triangular
-  !>     portion of
+  !>     @param[inout] AP - device array of device pointers storing the packed version of the
+  !>     specified triangular portion of
   !>               each Hermitian matrix A_i. Points to the first matrix (A_1).
   !>               - if uplo == HIPBLAS_FILL_MODE_UPPER:
   !>                 The upper triangular portion of each Hermitian matrix A_i is supplied.
@@ -15861,11 +15191,9 @@ module hipfort_hipblas
   !>               - Note that the imaginary part of the diagonal elements are not accessed and are
   !>               assumed
   !>                 to be 0.
-  !>     @param[in]
-  !>     strideA    [hipblasStride]
+  !>     @param[in] strideA - [hipblasStride]
   !>                 stride from the start of one (A_i) to the next (A_i+1).
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasChpr2StridedBatched
@@ -15996,39 +15324,27 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s`` and ``d``.
   !>     - Supported precisions in cuBLAS  : ``s`` and ``d``.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>               specifies either upper (HIPBLAS_FILL_MODE_UPPER) or lower
   !>               (HIPBLAS_FILL_MODE_LOWER):
   !>               - If HIPBLAS_FILL_MODE_UPPER, the lower part of A is not referenced.
   !>               - If HIPBLAS_FILL_MODE_LOWER, the upper part of A is not referenced.
-  !>     @param[in]
-  !>     n         [int]
-  !>     @param[in]
-  !>     k         [int]
+  !>     @param[in] n - [int]
+  !>     @param[in] k - [int]
   !>               specifies the number of sub- and super-diagonals.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               specifies the scalar alpha.
-  !>     @param[in]
-  !>     AP         pointer storing matrix A on the GPU.
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[in] AP - pointer storing matrix A on the GPU.
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of matrix A.
-  !>     @param[in]
-  !>     x         pointer storing vector x on the GPU.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - pointer storing vector x on the GPU.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of x.
-  !>     @param[in]
-  !>     beta      specifies the scalar beta.
-  !>     @param[out]
-  !>     y         pointer storing vector y on the GPU.
-  !>     @param[in]
-  !>     incy      [int]
+  !>     @param[in] beta - specifies the scalar beta.
+  !>     @param[out] y - pointer storing vector y on the GPU.
+  !>     @param[in] incy - [int]
   !>               specifies the increment for the elements of y.
   interface hipblasSsbmv
 #ifdef USE_CUDA_NAMES
@@ -16167,43 +15483,30 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s`` and ``d``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>               specifies either upper (HIPBLAS_FILL_MODE_UPPER) or lower
   !>               (HIPBLAS_FILL_MODE_LOWER):
   !>               - If HIPBLAS_FILL_MODE_UPPER, the lower part of A is not referenced.
   !>               - If HIPBLAS_FILL_MODE_LOWER, the upper part of A is not referenced.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               number of rows and columns of each matrix A_i.
-  !>     @param[in]
-  !>     k         [int]
+  !>     @param[in] k - [int]
   !>               specifies the number of sub- and super-diagonals.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     AP         device array of device pointers storing each matrix A_i.
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[in] AP - device array of device pointers storing each matrix A_i.
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of each matrix A_i.
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each vector x_i.
-  !>     @param[in]
-  !>     beta      device pointer or host pointer to scalar beta.
-  !>     @param[out]
-  !>     y         device array of device pointers storing each vector y_i.
-  !>     @param[in]
-  !>     incy      [int]
+  !>     @param[in] beta - device pointer or host pointer to scalar beta.
+  !>     @param[out] y - device array of device pointers storing each vector y_i.
+  !>     @param[in] incy - [int]
   !>               specifies the increment for the elements of each vector y_i.
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasSsbmvBatched
@@ -16320,58 +15623,42 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s`` and ``d``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>               specifies either upper (HIPBLAS_FILL_MODE_UPPER) or lower
   !>               (HIPBLAS_FILL_MODE_LOWER):
   !>               - If HIPBLAS_FILL_MODE_UPPER, the lower part of A is not referenced.
   !>               - If HIPBLAS_FILL_MODE_LOWER, the upper part of A is not referenced.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               number of rows and columns of each matrix A_i.
-  !>     @param[in]
-  !>     k         [int]
+  !>     @param[in] k - [int]
   !>               specifies the number of sub- and super-diagonals.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     AP        device pointer to the first matrix A_1 on the GPU.
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[in] AP - device pointer to the first matrix A_1 on the GPU.
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of each matrix A_i.
-  !>     @param[in]
-  !>     strideA     [hipblasStride]
+  !>     @param[in] strideA - [hipblasStride]
   !>                 stride from the start of one matrix (A_i) to the next one (A_i+1).
-  !>     @param[in]
-  !>     x         device pointer to the first vector x_1 on the GPU.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device pointer to the first vector x_1 on the GPU.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each vector x_i.
-  !>     @param[in]
-  !>     stridex     [hipblasStride]
+  !>     @param[in] stridex - [hipblasStride]
   !>                 stride from the start of one vector (x_i) to the next one (x_i+1).
   !>                 There are no restrictions placed on stridex. However, the user should
   !>                 ensure that stridex is of an appropriate size.
   !>                 This typically means stridex >= n * incx. stridex should be non zero.
-  !>     @param[in]
-  !>     beta      device pointer or host pointer to scalar beta.
-  !>     @param[out]
-  !>     y         device pointer to the first vector y_1 on the GPU.
-  !>     @param[in]
-  !>     incy      [int]
+  !>     @param[in] beta - device pointer or host pointer to scalar beta.
+  !>     @param[out] y - device pointer to the first vector y_1 on the GPU.
+  !>     @param[in] incy - [int]
   !>               specifies the increment for the elements of each vector y_i.
-  !>     @param[in]
-  !>     stridey     [hipblasStride]
+  !>     @param[in] stridey - [hipblasStride]
   !>                 stride from the start of one vector (y_i) to the next one (y_i+1).
   !>                 There are no restrictions placed on stridey. However, the user should
   !>                 ensure that stridey is of an appropriate size.
   !>                 This typically means stridey >= n * incy. stridey should be non zero.
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasSsbmvStridedBatched
@@ -16516,33 +15803,23 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s`` and ``d``.
   !>     - Supported precisions in cuBLAS  : ``s`` and ``d``.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>               specifies either upper (HIPBLAS_FILL_MODE_UPPER) or lower
   !>               (HIPBLAS_FILL_MODE_LOWER):
   !>               - If HIPBLAS_FILL_MODE_UPPER, the lower part of A is not referenced.
   !>               - If HIPBLAS_FILL_MODE_LOWER, the upper part of A is not referenced.
-  !>     @param[in]
-  !>     n         [int]
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] n - [int]
+  !>     @param[in] alpha
   !>               specifies the scalar alpha.
-  !>     @param[in]
-  !>     AP         pointer storing matrix A on the GPU.
-  !>     @param[in]
-  !>     x         pointer storing vector x on the GPU.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] AP - pointer storing matrix A on the GPU.
+  !>     @param[in] x - pointer storing vector x on the GPU.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of x.
-  !>     @param[in]
-  !>     beta      specifies the scalar beta.
-  !>     @param[out]
-  !>     y         pointer storing vector y on the GPU.
-  !>     @param[in]
-  !>     incy      [int]
+  !>     @param[in] beta - specifies the scalar beta.
+  !>     @param[out] y - pointer storing vector y on the GPU.
+  !>     @param[in] incy - [int]
   !>               specifies the increment for the elements of y.
   interface hipblasSspmv
 #ifdef USE_CUDA_NAMES
@@ -16667,37 +15944,26 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s`` and ``d``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>               specifies either upper (HIPBLAS_FILL_MODE_UPPER) or lower
   !>               (HIPBLAS_FILL_MODE_LOWER):
   !>               - If HIPBLAS_FILL_MODE_UPPER, the lower part of A is not referenced.
   !>               - If HIPBLAS_FILL_MODE_LOWER, the upper part of A is not referenced.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               number of rows and columns of each matrix A_i.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     AP         device array of device pointers storing each matrix A_i.
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] AP - device array of device pointers storing each matrix A_i.
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each vector x_i.
-  !>     @param[in]
-  !>     beta      device pointer or host pointer to scalar beta.
-  !>     @param[out]
-  !>     y         device array of device pointers storing each vector y_i.
-  !>     @param[in]
-  !>     incy      [int]
+  !>     @param[in] beta - device pointer or host pointer to scalar beta.
+  !>     @param[out] y - device array of device pointers storing each vector y_i.
+  !>     @param[in] incy - [int]
   !>               specifies the increment for the elements of each vector y_i.
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasSspmvBatched
@@ -16806,52 +16072,38 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s`` and ``d``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>               specifies either upper (HIPBLAS_FILL_MODE_UPPER) or lower
   !>               (HIPBLAS_FILL_MODE_LOWER):
   !>               - If HIPBLAS_FILL_MODE_UPPER, the lower part of A is not referenced.
   !>               - If HIPBLAS_FILL_MODE_LOWER, the upper part of A is not referenced.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               number of rows and columns of each matrix A_i.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     AP        Device pointer to the first matrix A_1 on the GPU.
-  !>     @param[in]
-  !>     strideA    [hipblasStride]
+  !>     @param[in] AP - Device pointer to the first matrix A_1 on the GPU.
+  !>     @param[in] strideA - [hipblasStride]
   !>                 stride from the start of one matrix (A_i) to the next one (A_i+1).
-  !>     @param[in]
-  !>     x         Device pointer to the first vector x_1 on the GPU.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - Device pointer to the first vector x_1 on the GPU.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each vector x_i.
-  !>     @param[in]
-  !>     stridex     [hipblasStride]
+  !>     @param[in] stridex - [hipblasStride]
   !>                 stride from the start of one vector (x_i) to the next one (x_i+1).
   !>                 There are no restrictions placed on stridex. However, the user should
   !>                 take care to ensure that stridex is of an appropriate size.
   !>                 This typically means stridex >= n * incx. stridex should be non zero.
-  !>     @param[in]
-  !>     beta      device pointer or host pointer to scalar beta.
-  !>     @param[out]
-  !>     y         Device pointer to the first vector y_1 on the GPU.
-  !>     @param[in]
-  !>     incy      [int]
+  !>     @param[in] beta - device pointer or host pointer to scalar beta.
+  !>     @param[out] y - Device pointer to the first vector y_1 on the GPU.
+  !>     @param[in] incy - [int]
   !>               specifies the increment for the elements of each vector y_i.
-  !>     @param[in]
-  !>     stridey     [hipblasStride]
+  !>     @param[in] stridey - [hipblasStride]
   !>                 stride from the start of one vector (y_i) to the next one (y_i+1).
   !>                 There are no restrictions placed on stridey. However, the user should
   !>                 take care to ensure that stridey is of an appropriate size.
   !>                 This typically means stridey >= n * incy. stridey should be non zero.
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasSspmvStridedBatched
@@ -16986,28 +16238,22 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : ``s``, ``d``, ``c``, and ``z``.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>               specifies either upper (HIPBLAS_FILL_MODE_UPPER) or lower
   !>               (HIPBLAS_FILL_MODE_LOWER):
   !>               - HIPBLAS_FILL_MODE_UPPER: The upper triangular part of A is supplied in AP.
   !>               - HIPBLAS_FILL_MODE_LOWER: The lower triangular part of A is supplied in AP.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of rows and columns of matrix A. Must be at least 0.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device pointer storing vector x.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of x.
-  !>     @param[inout]
-  !>     AP        device pointer storing the packed version of the specified triangular portion of
+  !>     @param[inout] AP - device pointer storing the packed version of the specified triangular
+  !>     portion of
   !>               the symmetric matrix A. Of at least size ((n * (n + 1)) / 2).
   !>               - if uplo == HIPBLAS_FILL_MODE_UPPER:
   !>                 The upper triangular portion of the symmetric matrix A is supplied.
@@ -17225,31 +16471,24 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>               specifies either upper (HIPBLAS_FILL_MODE_UPPER) or lower
   !>               (HIPBLAS_FILL_MODE_LOWER):
   !>               - HIPBLAS_FILL_MODE_UPPER: The upper triangular part of each A_i is supplied in
   !>               AP.
   !>               - HIPBLAS_FILL_MODE_LOWER: The lower triangular part of each A_i is supplied in
   !>               AP.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of rows and columns of each matrix A_i. Must be at least 0.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[inout]
-  !>     AP device array of device pointers storing the packed version of the specified triangular
-  !>     portion of
+  !>     @param[inout] AP - device array of device pointers storing the packed version of the
+  !>     specified triangular portion of
   !>               each symmetric matrix A_i of at least size ((n * (n + 1)) / 2). Array is of at
   !>               least size batchCount.
   !>               - if uplo == HIPBLAS_FILL_MODE_UPPER:
@@ -17278,8 +16517,7 @@ module hipfort_hipblas
   !>                         2 5 6 7    -> [1, 2, 3, 4, 5, 6, 7, 8, 9, 0]
   !>                         3 6 8 9
   !>                         4 7 9 0
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasSsprBatched
@@ -17455,33 +16693,26 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>               specifies either upper (HIPBLAS_FILL_MODE_UPPER) or lower
   !>               (HIPBLAS_FILL_MODE_LOWER):
   !>               - HIPBLAS_FILL_MODE_UPPER: The upper triangular part of each A_i is supplied in
   !>               AP.
   !>               - HIPBLAS_FILL_MODE_LOWER: The lower triangular part of each A_i is supplied in
   !>               AP.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of rows and columns of each matrix A_i. Must be at least 0.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     x         device pointer pointing to the first vector (x_1).
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device pointer pointing to the first vector (x_1).
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     stridex  [hipblasStride]
+  !>     @param[in] stridex - [hipblasStride]
   !>               stride from the start of one vector (x_i) to the next one (x_i+1).
-  !>     @param[inout]
-  !>     AP        device pointer storing the packed version of the specified triangular portion of
+  !>     @param[inout] AP - device pointer storing the packed version of the specified triangular
+  !>     portion of
   !>               each symmetric matrix A_i. Points to the first A_1.
   !>               - if uplo == HIPBLAS_FILL_MODE_UPPER:
   !>                 The upper triangular portion of each symmetric matrix A_i is supplied.
@@ -17509,11 +16740,9 @@ module hipfort_hipblas
   !>                         2 5 6 7    -> [1, 2, 3, 4, 5, 6, 7, 8, 9, 0]
   !>                         3 6 8 9
   !>                         4 7 9 0
-  !>     @param[in]
-  !>     strideA    [hipblasStride]
+  !>     @param[in] strideA - [hipblasStride]
   !>                 stride from the start of one (A_i) to the next (A_i+1).
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasSsprStridedBatched
@@ -17732,33 +16961,25 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s`` and ``d``.
   !>     - Supported precisions in cuBLAS  : ``s`` and ``d``.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>               specifies either upper (HIPBLAS_FILL_MODE_UPPER) or lower
   !>               (HIPBLAS_FILL_MODE_LOWER):
   !>               - HIPBLAS_FILL_MODE_UPPER: The upper triangular part of A is supplied in AP.
   !>               - HIPBLAS_FILL_MODE_LOWER: The lower triangular part of A is supplied in AP.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of rows and columns of matrix A. Must be at least 0.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device pointer storing vector x.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of x.
-  !>     @param[in]
-  !>     y         device pointer storing vector y.
-  !>     @param[in]
-  !>     incy      [int]
+  !>     @param[in] y - device pointer storing vector y.
+  !>     @param[in] incy - [int]
   !>               specifies the increment for the elements of y.
-  !>     @param[inout]
-  !>     AP        device pointer storing the packed version of the specified triangular portion of
+  !>     @param[inout] AP - device pointer storing the packed version of the specified triangular
+  !>     portion of
   !>               the symmetric matrix A. Of at least size ((n * (n + 1)) / 2).
   !>               - if uplo == HIPBLAS_FILL_MODE_UPPER:
   !>                 The upper triangular portion of the symmetric matrix A is supplied.
@@ -17902,36 +17123,27 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s`` and ``d``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>               specifies either upper (HIPBLAS_FILL_MODE_UPPER) or lower
   !>               (HIPBLAS_FILL_MODE_LOWER):
   !>               - HIPBLAS_FILL_MODE_UPPER: The upper triangular part of each A_i is supplied in
   !>               AP.
   !>               - HIPBLAS_FILL_MODE_LOWER: The lower triangular part of each A_i is supplied in
   !>               AP.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of rows and columns of each matrix A_i. Must be at least 0.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     y         device array of device pointers storing each vector y_i.
-  !>     @param[in]
-  !>     incy      [int]
+  !>     @param[in] y - device array of device pointers storing each vector y_i.
+  !>     @param[in] incy - [int]
   !>               specifies the increment for the elements of each y_i.
-  !>     @param[inout]
-  !>     AP device array of device pointers storing the packed version of the specified triangular
-  !>     portion of
+  !>     @param[inout] AP - device array of device pointers storing the packed version of the
+  !>     specified triangular portion of
   !>               each symmetric matrix A_i of at least size ((n * (n + 1)) / 2). Array is of at
   !>               least size batchCount.
   !>               - if uplo == HIPBLAS_FILL_MODE_UPPER:
@@ -17960,8 +17172,7 @@ module hipfort_hipblas
   !>                         2 5 6 7    -> [1, 2, 3, 4, 5, 6, 7, 8, 9, 0]
   !>                         3 6 8 9
   !>                         4 7 9 0
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasSspr2Batched
@@ -18065,41 +17276,31 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s`` and ``d``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>               specifies either upper (HIPBLAS_FILL_MODE_UPPER) or lower
   !>               (HIPBLAS_FILL_MODE_LOWER):
   !>               - HIPBLAS_FILL_MODE_UPPER: The upper triangular part of each A_i is supplied in
   !>               AP.
   !>               - HIPBLAS_FILL_MODE_LOWER: The lower triangular part of each A_i is supplied in
   !>               AP.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of rows and columns of each matrix A_i. Must be at least 0.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     x         device pointer pointing to the first vector (x_1).
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device pointer pointing to the first vector (x_1).
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     stridex  [hipblasStride]
+  !>     @param[in] stridex - [hipblasStride]
   !>               stride from the start of one vector (x_i) to the next one (x_i+1).
-  !>     @param[in]
-  !>     y         device pointer pointing to the first vector (y_1).
-  !>     @param[in]
-  !>     incy      [int]
+  !>     @param[in] y - device pointer pointing to the first vector (y_1).
+  !>     @param[in] incy - [int]
   !>               specifies the increment for the elements of each y_i.
-  !>     @param[in]
-  !>     stridey  [hipblasStride]
+  !>     @param[in] stridey - [hipblasStride]
   !>               stride from the start of one vector (y_i) to the next one (y_i+1).
-  !>     @param[inout]
-  !>     AP        device pointer storing the packed version of the specified triangular portion of
+  !>     @param[inout] AP - device pointer storing the packed version of the specified triangular
+  !>     portion of
   !>               each symmetric matrix A_i. Points to the first A_1.
   !>               - if uplo == HIPBLAS_FILL_MODE_UPPER:
   !>                 The upper triangular portion of each symmetric matrix A_i is supplied.
@@ -18127,11 +17328,9 @@ module hipfort_hipblas
   !>                         2 5 6 7    -> [1, 2, 3, 4, 5, 6, 7, 8, 9, 0]
   !>                         3 6 8 9
   !>                         4 7 9 0
-  !>     @param[in]
-  !>     strideA   [hipblasStride]
+  !>     @param[in] strideA - [hipblasStride]
   !>                 stride from the start of one (A_i) to the next (A_i+1).
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasSspr2StridedBatched
@@ -18262,36 +17461,25 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : ``s``, ``d``, ``c``, and ``z``.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>               specifies either upper (HIPBLAS_FILL_MODE_UPPER) or lower
   !>               (HIPBLAS_FILL_MODE_LOWER):
   !>               - If HIPBLAS_FILL_MODE_UPPER, the lower part of A is not referenced.
   !>               - If HIPBLAS_FILL_MODE_LOWER, the upper part of A is not referenced.
-  !>     @param[in]
-  !>     n         [int]
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] n - [int]
+  !>     @param[in] alpha
   !>               specifies the scalar alpha.
-  !>     @param[in]
-  !>     AP         pointer storing matrix A on the GPU.
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[in] AP - pointer storing matrix A on the GPU.
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of A.
-  !>     @param[in]
-  !>     x         pointer storing vector x on the GPU.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - pointer storing vector x on the GPU.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of x.
-  !>     @param[in]
-  !>     beta      specifies the scalar beta.
-  !>     @param[out]
-  !>     y         pointer storing vector y on the GPU.
-  !>     @param[in]
-  !>     incy      [int]
+  !>     @param[in] beta - specifies the scalar beta.
+  !>     @param[out] y - pointer storing vector y on the GPU.
+  !>     @param[in] incy - [int]
   !>               specifies the increment for the elements of y.
   interface hipblasSsymv
 #ifdef USE_CUDA_NAMES
@@ -18545,40 +17733,28 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>               specifies either upper (HIPBLAS_FILL_MODE_UPPER) or lower
   !>               (HIPBLAS_FILL_MODE_LOWER):
   !>               - If HIPBLAS_FILL_MODE_UPPER, the lower part of A is not referenced.
   !>               - If HIPBLAS_FILL_MODE_LOWER, the upper part of A is not referenced.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               number of rows and columns of each matrix A_i.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     AP        device array of device pointers storing each matrix A_i.
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[in] AP - device array of device pointers storing each matrix A_i.
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of each matrix A_i.
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each vector x_i.
-  !>     @param[in]
-  !>     beta      device pointer or host pointer to scalar beta.
-  !>     @param[out]
-  !>     y         device array of device pointers storing each vector y_i.
-  !>     @param[in]
-  !>     incy      [int]
+  !>     @param[in] beta - device pointer or host pointer to scalar beta.
+  !>     @param[out] y - device array of device pointers storing each vector y_i.
+  !>     @param[in] incy - [int]
   !>               specifies the increment for the elements of each vector y_i.
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasSsymvBatched
@@ -18788,55 +17964,40 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>               specifies either upper (HIPBLAS_FILL_MODE_UPPER) or lower
   !>               (HIPBLAS_FILL_MODE_LOWER):
   !>               - If HIPBLAS_FILL_MODE_UPPER, the lower part of A is not referenced.
   !>               - If HIPBLAS_FILL_MODE_LOWER, the upper part of A is not referenced.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               number of rows and columns of each matrix A_i.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     AP         Device pointer to the first matrix A_1 on the GPU.
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[in] AP - Device pointer to the first matrix A_1 on the GPU.
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of each matrix A_i.
-  !>     @param[in]
-  !>     strideA     [hipblasStride]
+  !>     @param[in] strideA - [hipblasStride]
   !>                 stride from the start of one matrix (A_i) to the next one (A_i+1).
-  !>     @param[in]
-  !>     x         Device pointer to the first vector x_1 on the GPU.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - Device pointer to the first vector x_1 on the GPU.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each vector x_i.
-  !>     @param[in]
-  !>     stridex     [hipblasStride]
+  !>     @param[in] stridex - [hipblasStride]
   !>                 stride from the start of one vector (x_i) to the next one (x_i+1).
   !>                 There are no restrictions placed on stridex. However, the user should
   !>                 take care to ensure that stridex is of an appropriate size.
   !>                 This typically means stridex >= n * incx. stridex should be non zero.
-  !>     @param[in]
-  !>     beta      device pointer or host pointer to scalar beta.
-  !>     @param[out]
-  !>     y         Device pointer to the first vector y_1 on the GPU.
-  !>     @param[in]
-  !>     incy      [int]
+  !>     @param[in] beta - device pointer or host pointer to scalar beta.
+  !>     @param[out] y - Device pointer to the first vector y_1 on the GPU.
+  !>     @param[in] incy - [int]
   !>               specifies the increment for the elements of each vector y_i.
-  !>     @param[in]
-  !>     stridey     [hipblasStride]
+  !>     @param[in] stridey - [hipblasStride]
   !>                 stride from the start of one vector (y_i) to the next one (y_i+1).
   !>                 There are no restrictions placed on stridey. However, the user should
   !>                 take care to ensure that stridey is of an appropriate size.
   !>                 This typically means stridey >= n * incy. stridey should be non zero.
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasSsymvStridedBatched
@@ -19103,31 +18264,23 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : ``s``, ``d``, ``c``, and ``z``.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>               specifies either upper (HIPBLAS_FILL_MODE_UPPER) or lower
   !>               (HIPBLAS_FILL_MODE_LOWER):
   !>               - If HIPBLAS_FILL_MODE_UPPER, the lower part of A is not referenced.
   !>               - If HIPBLAS_FILL_MODE_LOWER, the upper part of A is not referenced.
   !>
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of rows and columns of matrix A.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device pointer storing vector x.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of x.
-  !>     @param[inout]
-  !>     AP         device pointer storing matrix A.
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[inout] AP - device pointer storing matrix A.
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of A.
   interface hipblasSsyr
 #ifdef USE_CUDA_NAMES
@@ -19338,33 +18491,24 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>               specifies either upper (HIPBLAS_FILL_MODE_UPPER) or lower
   !>               (HIPBLAS_FILL_MODE_LOWER):
   !>               - If HIPBLAS_FILL_MODE_UPPER, the lower part of A is not referenced.
   !>               - If HIPBLAS_FILL_MODE_LOWER, the upper part of A is not referenced.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of rows and columns of matrix A.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[inout]
-  !>     AP         device array of device pointers storing each matrix A_i.
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[inout] AP - device array of device pointers storing each matrix A_i.
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of each A_i.
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasSsyrBatched
@@ -19548,39 +18692,28 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>               specifies either upper (HIPBLAS_FILL_MODE_UPPER) or lower
   !>               (HIPBLAS_FILL_MODE_LOWER):
   !>               - If HIPBLAS_FILL_MODE_UPPER, the lower part of A is not referenced.
   !>               - If HIPBLAS_FILL_MODE_LOWER, the upper part of A is not referenced.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of rows and columns of each matrix A.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     x         device pointer to the first vector x_1.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device pointer to the first vector x_1.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     stridex   [hipblasStride]
+  !>     @param[in] stridex - [hipblasStride]
   !>               specifies the pointer increment between vectors (x_i) and (x_i+1).
-  !>     @param[inout]
-  !>     AP         device pointer to the first matrix A_1.
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[inout] AP - device pointer to the first matrix A_1.
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of each A_i.
-  !>     @param[in]
-  !>     strideA   [hipblasStride]
+  !>     @param[in] strideA - [hipblasStride]
   !>               stride from the start of one matrix (A_i) to the next one (A_i+1).
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>               number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasSsyrStridedBatched
@@ -19815,36 +18948,26 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>               specifies either upper (HIPBLAS_FILL_MODE_UPPER) or lower
   !>               (HIPBLAS_FILL_MODE_LOWER):
   !>               - If HIPBLAS_FILL_MODE_UPPER, the lower part of A is not referenced.
   !>               - If HIPBLAS_FILL_MODE_LOWER, the upper part of A is not referenced.
   !>
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of rows and columns of matrix A.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device pointer storing vector x.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of x.
-  !>     @param[in]
-  !>     y         device pointer storing vector y.
-  !>     @param[in]
-  !>     incy      [int]
+  !>     @param[in] y - device pointer storing vector y.
+  !>     @param[in] incy - [int]
   !>               specifies the increment for the elements of y.
-  !>     @param[inout]
-  !>     AP         device pointer storing matrix A.
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[inout] AP - device pointer storing matrix A.
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of A.
   interface hipblasSsyr2
 #ifdef USE_CUDA_NAMES
@@ -20079,38 +19202,27 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>               specifies either upper (HIPBLAS_FILL_MODE_UPPER) or lower
   !>               (HIPBLAS_FILL_MODE_LOWER):
   !>               - If HIPBLAS_FILL_MODE_UPPER, the lower part of A is not referenced.
   !>               - If HIPBLAS_FILL_MODE_LOWER, the upper part of A is not referenced.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of rows and columns of matrix A.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     y         device array of device pointers storing each vector y_i.
-  !>     @param[in]
-  !>     incy      [int]
+  !>     @param[in] y - device array of device pointers storing each vector y_i.
+  !>     @param[in] incy - [int]
   !>               specifies the increment for the elements of each y_i.
-  !>     @param[inout]
-  !>     AP         device array of device pointers storing each matrix A_i.
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[inout] AP - device array of device pointers storing each matrix A_i.
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of each A_i.
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasSsyr2Batched
@@ -20309,47 +19421,33 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>               specifies either upper (HIPBLAS_FILL_MODE_UPPER) or lower
   !>               (HIPBLAS_FILL_MODE_LOWER):
   !>               - If HIPBLAS_FILL_MODE_UPPER, the lower part of A is not referenced.
   !>               - If HIPBLAS_FILL_MODE_LOWER, the upper part of A is not referenced.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of rows and columns of each matrix A.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     x         device pointer to the first vector x_1.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device pointer to the first vector x_1.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     stridex   [hipblasStride]
+  !>     @param[in] stridex - [hipblasStride]
   !>               specifies the pointer increment between vectors (x_i) and (x_i+1).
-  !>     @param[in]
-  !>     y         device pointer to the first vector y_1.
-  !>     @param[in]
-  !>     incy      [int]
+  !>     @param[in] y - device pointer to the first vector y_1.
+  !>     @param[in] incy - [int]
   !>               specifies the increment for the elements of each y_i.
-  !>     @param[in]
-  !>     stridey   [hipblasStride]
+  !>     @param[in] stridey - [hipblasStride]
   !>               specifies the pointer increment between vectors (y_i) and (y_i+1).
-  !>     @param[inout]
-  !>     AP         device pointer to the first matrix A_1.
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[inout] AP - device pointer to the first matrix A_1.
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of each A_i.
-  !>     @param[in]
-  !>     strideA   [hipblasStride]
+  !>     @param[in] strideA - [hipblasStride]
   !>               stride from the start of one matrix (A_i) to the next one (A_i+1).
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>               number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasSsyr2StridedBatched
@@ -20610,33 +19708,26 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : ``s``, ``d``, ``c``, and ``z``.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>               - HIPBLAS_FILL_MODE_UPPER: A is an upper banded triangular matrix.
   !>               - HIPBLAS_FILL_MODE_LOWER: A is a lower banded triangular matrix.
-  !>     @param[in]
-  !>     transA     [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>               indicates whether matrix A is tranposed (conjugated) or not.
-  !>     @param[in]
-  !>     diag      [hipblasDiagType_t]
+  !>     @param[in] diag - [hipblasDiagType_t]
   !>               - HIPBLAS_DIAG_UNIT: The main diagonal of A is assumed to consist of only
   !>                                      1's and is not referenced.
   !>               - HIPBLAS_DIAG_NON_UNIT: No assumptions are made of A's main diagonal.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of rows and columns of the matrix represented by A.
-  !>     @param[in]
-  !>     k         [int]
+  !>     @param[in] k - [int]
   !>               - if uplo == HIPBLAS_FILL_MODE_UPPER, k specifies the number of super-diagonals
   !>                 of the matrix A.
   !>               - if uplo == HIPBLAS_FILL_MODE_LOWER, k specifies the number of sub-diagonals
   !>                 of the matrix A.
   !>               - k must satisfy k > 0 && k < lda.
-  !>     @param[in]
-  !>     AP         device pointer storing banded triangular matrix A.
+  !>     @param[in] AP - device pointer storing banded triangular matrix A.
   !>                - if uplo == HIPBLAS_FILL_MODE_UPPER:
   !>                 The matrix represented is an upper banded triangular matrix
   !>                 with the main diagonal and k super-diagonals. Everything
@@ -20663,13 +19754,10 @@ module hipfort_hipblas
   !>                       9 7 3 0 0     ->      9 8 7 0 0
   !>                       0 8 8 4 0     ->      0 0 0 0 0
   !>                       0 0 7 9 5     ->      0 0 0 0 0
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of A. lda must satisfy lda > k.
-  !>     @param[inout]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[inout] x - device pointer storing vector x.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of x.
   interface hipblasStbmv
 #ifdef USE_CUDA_NAMES
@@ -20907,33 +19995,26 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>               - HIPBLAS_FILL_MODE_UPPER: each A_i is an upper banded triangular matrix.
   !>               - HIPBLAS_FILL_MODE_LOWER: each A_i is a  lower banded triangular matrix.
-  !>     @param[in]
-  !>     transA     [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>               indicates whether each matrix A_i is tranposed (conjugated) or not.
-  !>     @param[in]
-  !>     diag      [hipblasDiagType_t]
+  !>     @param[in] diag - [hipblasDiagType_t]
   !>               - HIPBLAS_DIAG_UNIT: The main diagonal of each A_i is assumed to consist of only
   !>                                      1's and is not referenced.
   !>               - HIPBLAS_DIAG_NON_UNIT: No assumptions are made of each A_i's main diagonal.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of rows and columns of the matrix represented by each A_i.
-  !>     @param[in]
-  !>     k         [int]
+  !>     @param[in] k - [int]
   !>               - if uplo == HIPBLAS_FILL_MODE_UPPER, k specifies the number of super-diagonals
   !>               of each matrix A_i.
   !>               - if uplo == HIPBLAS_FILL_MODE_LOWER, k specifies the number of sub-diagonals
   !>               of each matrix A_i.
   !>               - k must satisfy k > 0 && k < lda.
-  !>     @param[in]
-  !>     AP         device array of device pointers storing each banded triangular matrix A_i.
+  !>     @param[in] AP - device array of device pointers storing each banded triangular matrix A_i.
   !>                - if uplo == HIPBLAS_FILL_MODE_UPPER:
   !>                 The matrix represented is an upper banded triangular matrix
   !>                 with the main diagonal and k super-diagonals. Everything
@@ -20960,16 +20041,12 @@ module hipfort_hipblas
   !>                       9 7 3 0 0        ->      9 8 7 0 0
   !>                       0 8 8 4 0        ->      0 0 0 0 0
   !>                       0 0 7 9 5        ->      0 0 0 0 0
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of each A_i. lda must satisfy lda > k.
-  !>     @param[inout]
-  !>     x         device array of device pointer storing each vector x_i.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[inout] x - device array of device pointer storing each vector x_i.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasStbmvBatched
@@ -21171,34 +20248,27 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>               - HIPBLAS_FILL_MODE_UPPER: each A_i is an upper banded triangular matrix.
   !>               - HIPBLAS_FILL_MODE_LOWER: each A_i is a lower banded triangular matrix.
-  !>     @param[in]
-  !>     transA     [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>               indicates whether each matrix A_i is tranposed (conjugated) or not.
-  !>     @param[in]
-  !>     diag      [hipblasDiagType_t]
+  !>     @param[in] diag - [hipblasDiagType_t]
   !>               - HIPBLAS_DIAG_UNIT: The main diagonal of each A_i is assumed to consist of only
   !>                                      1's and is not referenced.
   !>               - HIPBLAS_DIAG_NON_UNIT: No assumptions are made of each A_i's main diagonal.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of rows and columns of the matrix represented by each A_i.
-  !>     @param[in]
-  !>     k         [int]
+  !>     @param[in] k - [int]
   !>               - if uplo == HIPBLAS_FILL_MODE_UPPER, k specifies the number of super-diagonals
   !>               of each matrix A_i.
   !>               - if uplo == HIPBLAS_FILL_MODE_LOWER, k specifies the number of sub-diagonals
   !>               of each matrix A_i.
   !>               - k must satisfy k > 0 && k < lda.
-  !>     @param[in]
-  !>     AP device array to the first matrix A_i of the batch. Stores each banded triangular matrix
-  !>     A_i.
+  !>     @param[in] AP - device array to the first matrix A_i of the batch. Stores each banded
+  !>     triangular matrix A_i.
   !>               - if uplo == HIPBLAS_FILL_MODE_UPPER:
   !>                 The matrix represented is an upper banded triangular matrix
   !>                 with the main diagonal and k super-diagonals. Everything
@@ -21225,22 +20295,16 @@ module hipfort_hipblas
   !>                       9 7 3 0 0     ->         9 8 7 0 0
   !>                       0 8 8 4 0     ->         0 0 0 0 0
   !>                       0 0 7 9 5     ->         0 0 0 0 0
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of each A_i. lda must satisfy lda > k.
-  !>     @param[in]
-  !>     strideA  [hipblasStride]
+  !>     @param[in] strideA - [hipblasStride]
   !>               stride from the start of one A_i matrix to the next A_(i + 1).
-  !>     @param[inout]
-  !>     x         device array to the first vector x_i of the batch.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[inout] x - device array to the first vector x_i of the batch.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     stridex  [hipblasStride]
+  !>     @param[in] stridex - [hipblasStride]
   !>               stride from the start of one x_i matrix to the next x_(i + 1).
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasStbmvStridedBatched
@@ -21490,52 +20554,43 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : ``s``, ``d``, ``c``, and ``z``.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>             - HIPBLAS_FILL_MODE_UPPER:  A is an upper triangular matrix.
   !>             - HIPBLAS_FILL_MODE_LOWER:  A is a lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA     [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>                - HIPBLAS_OP_N: Solves A*x = b
   !>                - HIPBLAS_OP_T: Solves A**T*x = b
   !>                - HIPBLAS_OP_C: Solves A**H*x = b
   !>
-  !>     @param[in]
-  !>     diag    [hipblasDiagType_t]
+  !>     @param[in] diag - [hipblasDiagType_t]
   !>             - HIPBLAS_DIAG_UNIT: A is assumed to be unit triangular (that is, the diagonal
   !>             elements
   !>                                        of A are not used in computations).
   !>             - HIPBLAS_DIAG_NON_UNIT: A is not assumed to be unit triangular.
   !>
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               n specifies the number of rows of b. n >= 0.
-  !>     @param[in]
-  !>     k         [int]
+  !>     @param[in] k - [int]
   !>               - if(uplo == HIPBLAS_FILL_MODE_UPPER),
   !>                 k specifies the number of super-diagonals of A.
   !>               - if(uplo == HIPBLAS_FILL_MODE_LOWER),
   !>                 k specifies the number of sub-diagonals of A.
   !>               - k >= 0.
   !>
-  !>     @param[in]
-  !>     AP         device pointer storing the matrix A in banded format.
+  !>     @param[in] AP - device pointer storing the matrix A in banded format.
   !>
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of A.
   !>               lda >= (k + 1).
   !>
-  !>     @param[inout]
-  !>     x         device pointer storing input vector b. Overwritten by the output vector x.
+  !>     @param[inout] x - device pointer storing input vector b. Overwritten by the output vector
+  !>     x.
   !>
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of x.
   interface hipblasStbsv
 #ifdef USE_CUDA_NAMES
@@ -21772,56 +20827,45 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>             - HIPBLAS_FILL_MODE_UPPER:  A_i is an upper triangular matrix.
   !>             - HIPBLAS_FILL_MODE_LOWER:  A_i is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA     [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>                - HIPBLAS_OP_N: Solves A_i*x_i = b_i
   !>                - HIPBLAS_OP_T: Solves A_i**T*x_i = b_i
   !>                - HIPBLAS_OP_C: Solves A_i**H*x_i = b_i
   !>
-  !>     @param[in]
-  !>     diag    [hipblasDiagType_t]
+  !>     @param[in] diag - [hipblasDiagType_t]
   !>             - HIPBLAS_DIAG_UNIT: each A_i is assumed to be unit triangular (that is, the
   !>             diagonal elements
   !>                                        of each A_i are not used in computations).
   !>             - HIPBLAS_DIAG_NON_UNIT: each A_i is not assumed to be unit triangular.
   !>
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               n specifies the number of rows of each b_i. n >= 0.
-  !>     @param[in]
-  !>     k         [int]
+  !>     @param[in] k - [int]
   !>               - if(uplo == HIPBLAS_FILL_MODE_UPPER),
   !>                 k specifies the number of super-diagonals of each A_i.
   !>               - if(uplo == HIPBLAS_FILL_MODE_LOWER),
   !>                 k specifies the number of sub-diagonals of each A_i.
   !>               - k >= 0.
   !>
-  !>     @param[in]
-  !>     AP         device vector of device pointers storing each matrix A_i in banded format.
+  !>     @param[in] AP - device vector of device pointers storing each matrix A_i in banded format.
   !>
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of each A_i.
   !>               lda >= (k + 1).
   !>
-  !>     @param[inout]
-  !>     x device vector of device pointers storing each input vector b_i. Overwritten by each
-  !>     output
+  !>     @param[inout] x - device vector of device pointers storing each input vector b_i.
+  !>     Overwritten by each output
   !>               vector x_i.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasStbsvBatched
@@ -22022,62 +21066,50 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>             - HIPBLAS_FILL_MODE_UPPER:  A_i is an upper triangular matrix.
   !>             - HIPBLAS_FILL_MODE_LOWER:  A_i is a lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA     [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>                - HIPBLAS_OP_N: Solves A_i*x_i = b_i
   !>                - HIPBLAS_OP_T: Solves A_i**T*x_i = b_i
   !>                - HIPBLAS_OP_C: Solves A_i**H*x_i = b_i
   !>
-  !>     @param[in]
-  !>     diag    [hipblasDiagType_t]
+  !>     @param[in] diag - [hipblasDiagType_t]
   !>             - HIPBLAS_DIAG_UNIT: each A_i is assumed to be unit triangular (that is, the
   !>             diagonal elements
   !>                                        of each A_i are not used in computations).
   !>             - HIPBLAS_DIAG_NON_UNIT: each A_i is not assumed to be unit triangular.
   !>
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               n specifies the number of rows of each b_i. n >= 0.
-  !>     @param[in]
-  !>     k         [int]
+  !>     @param[in] k - [int]
   !>               - if(uplo == HIPBLAS_FILL_MODE_UPPER),
   !>                 k specifies the number of super-diagonals of each A_i.
   !>               - if(uplo == HIPBLAS_FILL_MODE_LOWER),
   !>                 k specifies the number of sub-diagonals of each A_i.
   !>               - k >= 0.
   !>
-  !>     @param[in]
-  !>     AP         device pointer pointing to the first banded matrix A_1.
+  !>     @param[in] AP - device pointer pointing to the first banded matrix A_1.
   !>
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of each A_i.
   !>               lda >= (k + 1).
-  !>     @param[in]
-  !>     strideA  [hipblasStride]
+  !>     @param[in] strideA - [hipblasStride]
   !>               specifies the distance between the start of one matrix (A_i) and the next
   !>               (A_i+1).
   !>
-  !>     @param[inout]
-  !>     x device pointer pointing to the first input vector b_1. Overwritten by output vectors x.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[inout] x - device pointer pointing to the first input vector b_1. Overwritten by
+  !>     output vectors x.
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     stridex  [hipblasStride]
+  !>     @param[in] stridex - [hipblasStride]
   !>               specifies the distance between the start of one vector (x_i) and the next
   !>               (x_i+1).
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasStbsvStridedBatched
@@ -22330,29 +21362,23 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : ``s``, ``d``, ``c``, and ``z``.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>             - HIPBLAS_FILL_MODE_UPPER:  A is an upper triangular matrix.
   !>             - HIPBLAS_FILL_MODE_LOWER:  A is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA     [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>
-  !>     @param[in]
-  !>     diag    [hipblasDiagType_t]
+  !>     @param[in] diag - [hipblasDiagType_t]
   !>             - HIPBLAS_DIAG_UNIT:     A is assumed to be unit triangular.
   !>             - HIPBLAS_DIAG_NON_UNIT:  A is not assumed to be unit triangular.
   !>
-  !>     @param[in]
-  !>     n       [int]
+  !>     @param[in] n - [int]
   !>             n specifies the number of rows of A. n >= 0.
   !>
-  !>     @param[in]
-  !>     AP       device pointer storing matrix A,
+  !>     @param[in] AP - device pointer storing matrix A,
   !>             of dimension at least ( n * ( n + 1 ) / 2 ).
   !>           - Before entry with uplo = HIPBLAS_FILL_MODE_UPPER, the array A
   !>           must contain the upper triangular matrix packed sequentially,
@@ -22365,11 +21391,9 @@ module hipfort_hipblas
   !>           - Note that when DIAG = HIPBLAS_DIAG_UNIT, the diagonal elements of A are
   !>           not referenced, but are assumed to be unity.
   !>
-  !>     @param[in]
-  !>     x       device pointer storing vector x.
+  !>     @param[in] x - device pointer storing vector x.
   !>
-  !>     @param[in]
-  !>     incx    [int]
+  !>     @param[in] incx - [int]
   !>             specifies the increment for the elements of x. incx must not be zero.
   interface hipblasStpmv
 #ifdef USE_CUDA_NAMES
@@ -22578,40 +21602,31 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>             - HIPBLAS_FILL_MODE_UPPER:  A_i is an upper triangular matrix.
   !>             - HIPBLAS_FILL_MODE_LOWER:  A_i is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA     [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>
-  !>     @param[in]
-  !>     diag    [hipblasDiagType_t]
+  !>     @param[in] diag - [hipblasDiagType_t]
   !>             - HIPBLAS_DIAG_UNIT:     A_i is assumed to be unit triangular.
   !>             - HIPBLAS_DIAG_NON_UNIT:  A_i is not assumed to be unit triangular.
   !>
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               n specifies the number of rows of matrices A_i. n >= 0.
   !>
-  !>     @param[in]
-  !>     AP         device pointer storing pointer of matrices A_i
+  !>     @param[in] AP - device pointer storing pointer of matrices A_i
   !>               of dimension ( lda, n ).
   !>
-  !>     @param[in]
-  !>     x         device pointer storing vectors x_i.
+  !>     @param[in] x - device pointer storing vectors x_i.
   !>
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of vectors x_i.
   !>
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>               The number of batched matrices/vectors.
 #ifndef USE_CUDA_NAMES
   interface hipblasStpmvBatched
@@ -22798,48 +21813,37 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>             - HIPBLAS_FILL_MODE_UPPER:  A_i is an upper triangular matrix.
   !>             - HIPBLAS_FILL_MODE_LOWER:  A_i is a lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA     [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>
-  !>     @param[in]
-  !>     diag    [hipblasDiagType_t]
+  !>     @param[in] diag - [hipblasDiagType_t]
   !>             - HIPBLAS_DIAG_UNIT:     A_i is assumed to be unit triangular.
   !>             - HIPBLAS_DIAG_NON_UNIT:  A_i is not assumed to be unit triangular.
   !>
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               n specifies the number of rows of matrices A_i. n >= 0.
   !>
-  !>     @param[in]
-  !>     AP         device pointer of the matrix A_0
+  !>     @param[in] AP - device pointer of the matrix A_0
   !>               of dimension ( lda, n ).
   !>
-  !>     @param[in]
-  !>     strideA  [hipblasStride]
+  !>     @param[in] strideA - [hipblasStride]
   !>               stride from the start of one A_i matrix to the next A_{i + 1}.
   !>
-  !>     @param[in]
-  !>     x         device pointer storing the vector x_0.
+  !>     @param[in] x - device pointer storing the vector x_0.
   !>
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of one vector x.
   !>
-  !>     @param[in]
-  !>     stridex  [hipblasStride]
+  !>     @param[in] stridex - [hipblasStride]
   !>               stride from the start of one x_i vector to the next x_{i + 1}.
   !>
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>               The number of batched matrices/vectors.
 #ifndef USE_CUDA_NAMES
   interface hipblasStpmvStridedBatched
@@ -23072,41 +22076,33 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : ``s``, ``d``, ``c``, and ``z``.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>             - HIPBLAS_FILL_MODE_UPPER:  A is an upper triangular matrix.
   !>             - HIPBLAS_FILL_MODE_LOWER:  A is a lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA  [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>             - HIPBLAS_OP_N: Solves A*x = b
   !>             - HIPBLAS_OP_T: Solves A**T*x = b
   !>             - HIPBLAS_OP_C: Solves A**H*x = b
   !>
-  !>     @param[in]
-  !>     diag    [hipblasDiagType_t]
+  !>     @param[in] diag - [hipblasDiagType_t]
   !>             - HIPBLAS_DIAG_UNIT: A is assumed to be unit triangular (that is, the diagonal
   !>             elements
   !>                                        of A are not used in computations).
   !>             - HIPBLAS_DIAG_NON_UNIT: A is not assumed to be unit triangular.
   !>
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               n specifies the number of rows of b. n >= 0.
   !>
-  !>     @param[in]
-  !>     AP        device pointer storing the packed version of matrix A
+  !>     @param[in] AP - device pointer storing the packed version of matrix A
   !>               of dimension >= (n * (n + 1) / 2).
   !>
-  !>     @param[inout]
-  !>     x         device pointer storing vector b on input, overwritten by x on output.
+  !>     @param[inout] x - device pointer storing vector b on input, overwritten by x on output.
   !>
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of x.
   interface hipblasStpsv
 #ifdef USE_CUDA_NAMES
@@ -23316,45 +22312,37 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>             - HIPBLAS_FILL_MODE_UPPER:  each A_i is an upper triangular matrix.
   !>             - HIPBLAS_FILL_MODE_LOWER:  each A_i is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA  [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>             - HIPBLAS_OP_N: Solves A*x = b
   !>             - HIPBLAS_OP_T: Solves A**T*x = b
   !>             - HIPBLAS_OP_C: Solves A**H*x = b
   !>
-  !>     @param[in]
-  !>     diag    [hipblasDiagType_t]
+  !>     @param[in] diag - [hipblasDiagType_t]
   !>             - HIPBLAS_DIAG_UNIT: each A_i is assumed to be unit triangular (that is, the
   !>             diagonal elements
   !>                                        of each A_i are not used in computations).
   !>             - HIPBLAS_DIAG_NON_UNIT: each A_i is not assumed to be unit triangular.
   !>
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               n specifies the number of rows of each b_i. n >= 0.
   !>
-  !>     @param[in]
-  !>     AP        device array of device pointers storing the packed versions of each matrix A_i
+  !>     @param[in] AP - device array of device pointers storing the packed versions of each matrix
+  !>     A_i
   !>               of dimension >= (n * (n + 1) / 2).
   !>
-  !>     @param[inout]
-  !>     x device array of device pointers storing each input vector b_i, overwritten by x_i on
-  !>     output.
+  !>     @param[inout] x - device array of device pointers storing each input vector b_i,
+  !>     overwritten by x_i on output.
   !>
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 specifies the number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasStpsvBatched
@@ -23540,51 +22528,41 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>             - HIPBLAS_FILL_MODE_UPPER:  each A_i is an upper triangular matrix.
   !>             - HIPBLAS_FILL_MODE_LOWER:  each A_i is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA  [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>             - HIPBLAS_OP_N: Solves A*x = b
   !>             - HIPBLAS_OP_T: Solves A**T*x = b
   !>             - HIPBLAS_OP_C: Solves A**H*x = b
   !>
-  !>     @param[in]
-  !>     diag    [hipblasDiagType_t]
+  !>     @param[in] diag - [hipblasDiagType_t]
   !>             - HIPBLAS_DIAG_UNIT: each A_i is assumed to be unit triangular (that is, the
   !>             diagonal elements
   !>                                        of each A_i are not used in computations).
   !>             - HIPBLAS_DIAG_NON_UNIT: each A_i is not assumed to be unit triangular.
   !>
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               n specifies the number of rows of each b_i. n >= 0.
   !>
-  !>     @param[in]
-  !>     AP        device pointer pointing to the first packed matrix A_1
+  !>     @param[in] AP - device pointer pointing to the first packed matrix A_1
   !>               of dimension >= (n * (n + 1) / 2).
   !>
-  !>     @param[in]
-  !>     strideA  [hipblasStride]
+  !>     @param[in] strideA - [hipblasStride]
   !>               stride from the beginning of one packed matrix (AP_i) to the next (AP_i+1).
   !>
-  !>     @param[inout]
-  !>     x device pointer pointing to the first input vector b_1. Overwritten by each x_i on output.
+  !>     @param[inout] x - device pointer pointing to the first input vector b_1. Overwritten by
+  !>     each x_i on output.
   !>
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     stridex  [hipblasStride]
+  !>     @param[in] stridex - [hipblasStride]
   !>               stride from the beginning of one vector (x_i) to the next (x_i+1).
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 specifies the number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasStpsvStridedBatched
@@ -23817,41 +22795,32 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : ``s``, ``d``, ``c``, and ``z``.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>             - HIPBLAS_FILL_MODE_UPPER:  A is an upper triangular matrix.
   !>             - HIPBLAS_FILL_MODE_LOWER:  A is a lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA     [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>
-  !>     @param[in]
-  !>     diag    [hipblasDiagType_t]
+  !>     @param[in] diag - [hipblasDiagType_t]
   !>             - HIPBLAS_DIAG_UNIT:     A is assumed to be unit triangular.
   !>             - HIPBLAS_DIAG_NON_UNIT:  A is not assumed to be unit triangular.
   !>
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               n specifies the number of rows of A. n >= 0.
   !>
-  !>     @param[in]
-  !>     AP        device pointer storing matrix A,
+  !>     @param[in] AP - device pointer storing matrix A,
   !>               of dimension ( lda, n ).
   !>
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of A.
   !>               lda = max( 1, n ).
   !>
-  !>     @param[in]
-  !>     x         device pointer storing vector x.
+  !>     @param[in] x - device pointer storing vector x.
   !>
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of x.
   interface hipblasStrmv
 #ifdef USE_CUDA_NAMES
@@ -24080,45 +23049,35 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>             - HIPBLAS_FILL_MODE_UPPER:  A_i is an upper triangular matrix.
   !>             - HIPBLAS_FILL_MODE_LOWER:  A_i is a lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA     [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>
-  !>     @param[in]
-  !>     diag    [hipblasDiagType_t]
+  !>     @param[in] diag - [hipblasDiagType_t]
   !>             - HIPBLAS_DIAG_UNIT:     A_i is assumed to be unit triangular.
   !>             - HIPBLAS_DIAG_NON_UNIT:  A_i is not assumed to be unit triangular.
   !>
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               n specifies the number of rows of matrices A_i. n >= 0.
   !>
-  !>     @param[in]
-  !>     AP        device pointer storing pointer of matrices A_i,
+  !>     @param[in] AP - device pointer storing pointer of matrices A_i,
   !>               of dimension ( lda, n ).
   !>
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of A_i.
   !>               lda >= max( 1, n ).
   !>
-  !>     @param[in]
-  !>     x         device pointer storing vectors x_i.
+  !>     @param[in] x - device pointer storing vectors x_i.
   !>
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of vectors x_i.
   !>
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>               The number of batched matrices/vectors.
 #ifndef USE_CUDA_NAMES
   interface hipblasStrmvBatched
@@ -24313,53 +23272,41 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>             - HIPBLAS_FILL_MODE_UPPER:  A_i is an upper triangular matrix.
   !>             - HIPBLAS_FILL_MODE_LOWER:  A_i is a lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA     [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>
-  !>     @param[in]
-  !>     diag    [hipblasDiagType_t]
+  !>     @param[in] diag - [hipblasDiagType_t]
   !>             - HIPBLAS_DIAG_UNIT:     A_i is assumed to be unit triangular.
   !>             - HIPBLAS_DIAG_NON_UNIT:  A_i is not assumed to be unit triangular.
   !>
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               n specifies the number of rows of matrices A_i. n >= 0.
   !>
-  !>     @param[in]
-  !>     AP        device pointer of the matrix A_0,
+  !>     @param[in] AP - device pointer of the matrix A_0,
   !>               of dimension ( lda, n ).
   !>
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of A_i.
   !>               lda >= max( 1, n ).
   !>
-  !>     @param[in]
-  !>     strideA  [hipblasStride]
+  !>     @param[in] strideA - [hipblasStride]
   !>               stride from the start of one A_i matrix to the next A_{i + 1}.
   !>
-  !>     @param[in]
-  !>     x         device pointer storing the vector x_0.
+  !>     @param[in] x - device pointer storing the vector x_0.
   !>
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of one vector x.
   !>
-  !>     @param[in]
-  !>     stridex  [hipblasStride]
+  !>     @param[in] stridex - [hipblasStride]
   !>               stride from the start of one x_i vector to the next x_{i + 1}.
   !>
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>               The number of batched matrices/vectors.
 #ifndef USE_CUDA_NAMES
   interface hipblasStrmvStridedBatched
@@ -24603,41 +23550,32 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : ``s``, ``d``, ``c``, and ``z``.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>             - HIPBLAS_FILL_MODE_UPPER:  A is an upper triangular matrix.
   !>             - HIPBLAS_FILL_MODE_LOWER:  A is a lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA     [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>
-  !>     @param[in]
-  !>     diag    [hipblasDiagType_t]
+  !>     @param[in] diag - [hipblasDiagType_t]
   !>             - HIPBLAS_DIAG_UNIT:     A is assumed to be unit triangular.
   !>             - HIPBLAS_DIAG_NON_UNIT:  A is not assumed to be unit triangular.
   !>
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               n specifies the number of rows of b. n >= 0.
   !>
-  !>     @param[in]
-  !>     AP        device pointer storing matrix A,
+  !>     @param[in] AP - device pointer storing matrix A,
   !>               of dimension ( lda, n ).
   !>
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of A.
   !>               lda = max( 1, n ).
   !>
-  !>     @param[in]
-  !>     x         device pointer storing vector x.
+  !>     @param[in] x - device pointer storing vector x.
   !>
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of x.
   interface hipblasStrsv
 #ifdef USE_CUDA_NAMES
@@ -24867,44 +23805,34 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>             - HIPBLAS_FILL_MODE_UPPER:  A is an upper triangular matrix.
   !>             - HIPBLAS_FILL_MODE_LOWER:  A is a lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA     [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>
-  !>     @param[in]
-  !>     diag    [hipblasDiagType_t]
+  !>     @param[in] diag - [hipblasDiagType_t]
   !>             - HIPBLAS_DIAG_UNIT:     A is assumed to be unit triangular.
   !>             - HIPBLAS_DIAG_NON_UNIT:  A is not assumed to be unit triangular.
   !>
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               n specifies the number of rows of b. n >= 0.
   !>
-  !>     @param[in]
-  !>     AP         device array of device pointers storing each matrix A_i.
+  !>     @param[in] AP - device array of device pointers storing each matrix A_i.
   !>
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of each A_i.
   !>               lda = max(1, n).
   !>
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i.
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
   !>
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of x.
   !>
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch
 #ifndef USE_CUDA_NAMES
   interface hipblasStrsvBatched
@@ -25098,52 +24026,41 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>             - HIPBLAS_FILL_MODE_UPPER:  A is an upper triangular matrix.
   !>             - HIPBLAS_FILL_MODE_LOWER:  A is a lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA     [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>
-  !>     @param[in]
-  !>     diag    [hipblasDiagType_t]
+  !>     @param[in] diag - [hipblasDiagType_t]
   !>             - HIPBLAS_DIAG_UNIT:     A is assumed to be unit triangular.
   !>             - HIPBLAS_DIAG_NON_UNIT:  A is not assumed to be unit triangular.
   !>
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               n specifies the number of rows of each b_i. n >= 0.
   !>
-  !>     @param[in]
-  !>     AP         device pointer to the first matrix (A_1) in the batch, of dimension ( lda, n ).
+  !>     @param[in] AP - device pointer to the first matrix (A_1) in the batch, of dimension ( lda,
+  !>     n ).
   !>
-  !>     @param[in]
-  !>     strideA  [hipblasStride]
+  !>     @param[in] strideA - [hipblasStride]
   !>               stride from the start of one A_i matrix to the next A_(i + 1).
   !>
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of each A_i.
   !>               lda = max( 1, n ).
   !>
-  !>     @param[in, out]
-  !>     x         device pointer to the first vector (x_1) in the batch.
+  !>     @param[in, out] x - device pointer to the first vector (x_1) in the batch.
   !>
-  !>     @param[in]
-  !>     stridex [hipblasStride]
+  !>     @param[in] stridex - [hipblasStride]
   !>              stride from the start of one x_i vector to the next x_(i + 1).
   !>
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each x_i.
   !>
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasStrsvStridedBatched
@@ -25393,42 +24310,28 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``h``, ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : ``h``, ``s``, ``d``, ``c``, and ``z``.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     transA    [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>               specifies the form of op( A ).
-  !>     @param[in]
-  !>     transB    [hipblasOperation_t]
+  !>     @param[in] transB - [hipblasOperation_t]
   !>               specifies the form of op( B ).
-  !>     @param[in]
-  !>     m         [int]
+  !>     @param[in] m - [int]
   !>               number or rows of matrices op( A ) and C.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               number of columns of matrices op( B ) and C.
-  !>     @param[in]
-  !>     k         [int]
+  !>     @param[in] k - [int]
   !>               number of columns of matrix op( A ) and number of rows of matrix op( B ).
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer specifying the scalar alpha.
-  !>     @param[in]
-  !>     AP         device pointer storing matrix A.
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[in] alpha - device pointer or host pointer specifying the scalar alpha.
+  !>     @param[in] AP - device pointer storing matrix A.
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of A.
-  !>     @param[in]
-  !>     BP         device pointer storing matrix B.
-  !>     @param[in]
-  !>     ldb       [int]
+  !>     @param[in] BP - device pointer storing matrix B.
+  !>     @param[in] ldb - [int]
   !>               specifies the leading dimension of B.
-  !>     @param[in]
-  !>     beta      device pointer or host pointer specifying the scalar beta.
-  !>     @param[in, out]
-  !>     CP         device pointer storing matrix C on the GPU.
-  !>     @param[in]
-  !>     ldc       [int]
+  !>     @param[in] beta - device pointer or host pointer specifying the scalar beta.
+  !>     @param[in, out] CP - device pointer storing matrix C on the GPU.
+  !>     @param[in] ldc - [int]
   !>               specifies the leading dimension of C.
   interface hipblasHgemm
 #ifdef USE_CUDA_NAMES
@@ -25770,45 +24673,30 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``h``, ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : ``h``, ``s``, ``d``, ``c``, and ``z``.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     transA    [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>               specifies the form of op( A ).
-  !>     @param[in]
-  !>     transB    [hipblasOperation_t]
+  !>     @param[in] transB - [hipblasOperation_t]
   !>               specifies the form of op( B ).
-  !>     @param[in]
-  !>     m         [int]
+  !>     @param[in] m - [int]
   !>               matrix dimension m.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               matrix dimension n.
-  !>     @param[in]
-  !>     k         [int]
+  !>     @param[in] k - [int]
   !>               matrix dimension k.
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer specifying the scalar alpha.
-  !>     @param[in]
-  !>     AP         device array of device pointers storing each matrix A_i.
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[in] alpha - device pointer or host pointer specifying the scalar alpha.
+  !>     @param[in] AP - device array of device pointers storing each matrix A_i.
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of each A_i.
-  !>     @param[in]
-  !>     BP         device array of device pointers storing each matrix B_i.
-  !>     @param[in]
-  !>     ldb       [int]
+  !>     @param[in] BP - device array of device pointers storing each matrix B_i.
+  !>     @param[in] ldb - [int]
   !>               specifies the leading dimension of each B_i.
-  !>     @param[in]
-  !>     beta      device pointer or host pointer specifying the scalar beta.
-  !>     @param[in, out]
-  !>     CP         device array of device pointers storing each matrix C_i.
-  !>     @param[in]
-  !>     ldc       [int]
+  !>     @param[in] beta - device pointer or host pointer specifying the scalar beta.
+  !>     @param[in, out] CP - device array of device pointers storing each matrix C_i.
+  !>     @param[in] ldc - [int]
   !>               specifies the leading dimension of each C_i.
-  !>     @param[in]
-  !>     batchCount
+  !>     @param[in] batchCount
   !>               [int]
   !>               number of gemm operations in the batch.
   interface hipblasHgemmBatched
@@ -26154,54 +25042,36 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``h``, ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : ``h``, ``s``, ``d``, ``c``, and ``z``.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     transA    [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>               specifies the form of op( A ).
-  !>     @param[in]
-  !>     transB    [hipblasOperation_t]
+  !>     @param[in] transB - [hipblasOperation_t]
   !>               specifies the form of op( B ).
-  !>     @param[in]
-  !>     m         [int]
+  !>     @param[in] m - [int]
   !>               matrix dimension m.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               matrix dimension n.
-  !>     @param[in]
-  !>     k         [int]
+  !>     @param[in] k - [int]
   !>               matrix dimension k.
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer specifying the scalar alpha.
-  !>     @param[in]
-  !>     AP         device pointer pointing to the first matrix A_1.
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[in] alpha - device pointer or host pointer specifying the scalar alpha.
+  !>     @param[in] AP - device pointer pointing to the first matrix A_1.
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of each A_i.
-  !>     @param[in]
-  !>     strideA  [hipblasStride]
+  !>     @param[in] strideA - [hipblasStride]
   !>               stride from the start of one A_i matrix to the next A_(i + 1).
-  !>     @param[in]
-  !>     BP         device pointer pointing to the first matrix B_1.
-  !>     @param[in]
-  !>     ldb       [int]
+  !>     @param[in] BP - device pointer pointing to the first matrix B_1.
+  !>     @param[in] ldb - [int]
   !>               specifies the leading dimension of each B_i.
-  !>     @param[in]
-  !>     strideB  [hipblasStride]
+  !>     @param[in] strideB - [hipblasStride]
   !>               stride from the start of one B_i matrix to the next B_(i + 1).
-  !>     @param[in]
-  !>     beta      device pointer or host pointer specifying the scalar beta.
-  !>     @param[in, out]
-  !>     CP         device pointer pointing to the first matrix C_1.
-  !>     @param[in]
-  !>     ldc       [int]
+  !>     @param[in] beta - device pointer or host pointer specifying the scalar beta.
+  !>     @param[in, out] CP - device pointer pointing to the first matrix C_1.
+  !>     @param[in] ldc - [int]
   !>               specifies the leading dimension of each C_i.
-  !>     @param[in]
-  !>     strideC  [hipblasStride]
+  !>     @param[in] strideC - [hipblasStride]
   !>               stride from the start of one C_i matrix to the next C_(i + 1).
-  !>     @param[in]
-  !>     batchCount
+  !>     @param[in] batchCount
   !>               [int]
   !>               number of gemm operatons in the batch.
   interface hipblasHgemmStridedBatched
@@ -26600,57 +25470,46 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``c`` and ``z``.
   !>     - Supported precisions in cuBLAS  : ``c`` and ``z``.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>             - HIPBLAS_FILL_MODE_UPPER:  C is an upper triangular matrix.
   !>             - HIPBLAS_FILL_MODE_LOWER:  C is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA  [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>             - HIPBLAS_OP_C:  op(A) = A^H
   !>             - HIPBLAS_ON_N:  op(A) = A
   !>
-  !>     @param[in]
-  !>     n       [int]
+  !>     @param[in] n - [int]
   !>             n specifies the number of rows and columns of C. n >= 0.
   !>
-  !>     @param[in]
-  !>     k       [int]
+  !>     @param[in] k - [int]
   !>             k specifies the number of columns of op(A). k >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             alpha specifies the scalar alpha. When alpha is
   !>             zero, then A is not referenced and A does not need to be set before
   !>             entry.
   !>
-  !>     @param[in]
-  !>     AP       pointer storing matrix A on the GPU.
+  !>     @param[in] AP - pointer storing matrix A on the GPU.
   !>              Matrix dimension is ( lda, k ) when transA = HIPBLAS_OP_N. Otherwise, (lda, n).
   !>              Only the upper/lower triangular part is accessed.
   !>
-  !>     @param[in]
-  !>     lda     [int]
+  !>     @param[in] lda - [int]
   !>             lda specifies the first dimension of A.
   !>             If transA = HIPBLAS_OP_N,  lda >= max( 1, n ).
   !>             Otherwise, lda >= max( 1, k ).
   !>
-  !>     @param[in]
-  !>     beta
+  !>     @param[in] beta
   !>             beta specifies the scalar beta. When beta is
   !>             zero, then C does not need to be set before entry.
   !>
-  !>     @param[in]
-  !>     CP       pointer storing matrix C on the GPU.
+  !>     @param[in] CP - pointer storing matrix C on the GPU.
   !>             The imaginary component of the diagonal elements are not used but are set to zero,
   !>             except for quick return.
   !>
-  !>     @param[in]
-  !>     ldc    [int]
+  !>     @param[in] ldc - [int]
   !>            ldc specifies the first dimension of C. ldc >= max( 1, n ).
   interface hipblasCherk
 #ifdef USE_CUDA_NAMES
@@ -26788,59 +25647,48 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``c`` and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>             - HIPBLAS_FILL_MODE_UPPER:  C_i is an upper triangular matrix.
   !>             - HIPBLAS_FILL_MODE_LOWER:  C_i is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA  [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>             - HIPBLAS_OP_C: op(A) = A^H
   !>             - HIPBLAS_OP_N: op(A) = A
   !>
-  !>     @param[in]
-  !>     n       [int]
+  !>     @param[in] n - [int]
   !>             n specifies the number of rows and columns of C_i. n >= 0.
   !>
-  !>     @param[in]
-  !>     k       [int]
+  !>     @param[in] k - [int]
   !>             k specifies the number of columns of op(A). k >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             alpha specifies the scalar alpha. When alpha is
   !>             zero, then A is not referenced and A does not need to be set before
   !>             entry.
   !>
-  !>     @param[in]
-  !>     AP       device array of device pointers storing each matrix_i A of dimension (lda, k)
+  !>     @param[in] AP - device array of device pointers storing each matrix_i A of dimension (lda,
+  !>     k)
   !>              when transA is HIPBLAS_OP_N. Otherwise, of dimension (lda, n).
   !>
-  !>     @param[in]
-  !>     lda     [int]
+  !>     @param[in] lda - [int]
   !>             lda specifies the first dimension of A_i.
   !>             If transA = HIPBLAS_OP_N,  lda >= max( 1, n ).
   !>             Otherwise, lda >= max( 1, k ).
   !>
-  !>     @param[in]
-  !>     beta
+  !>     @param[in] beta
   !>             beta specifies the scalar beta. When beta is
   !>             zero, then C does not need to be set before entry.
   !>
-  !>     @param[in]
-  !>     CP      device array of device pointers storing each matrix C_i on the GPU.
+  !>     @param[in] CP - device array of device pointers storing each matrix C_i on the GPU.
   !>             The imaginary components of the diagonal elements are not used but are set to zero,
   !>             except for quick return.
   !>
-  !>     @param[in]
-  !>     ldc    [int]
+  !>     @param[in] ldc - [int]
   !>            ldc specifies the first dimension of C. ldc >= max( 1, n ).
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasCherkBatched
@@ -26956,68 +25804,54 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``c`` and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>             - HIPBLAS_FILL_MODE_UPPER:  C_i is an upper triangular matrix.
   !>             - HIPBLAS_FILL_MODE_LOWER:  C_i is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA  [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>             - HIPBLAS_OP_C: op(A) = A^H
   !>             - HIPBLAS_OP_N: op(A) = A
   !>
-  !>     @param[in]
-  !>     n       [int]
+  !>     @param[in] n - [int]
   !>             n specifies the number of rows and columns of C_i. n >= 0.
   !>
-  !>     @param[in]
-  !>     k       [int]
+  !>     @param[in] k - [int]
   !>             k specifies the number of columns of op(A). k >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             alpha specifies the scalar alpha. When alpha is
   !>             zero, then A is not referenced and A does not need to be set before
   !>             entry.
   !>
-  !>     @param[in]
-  !>     AP      Device pointer to the first matrix A_1 on the GPU of dimension (lda, k)
+  !>     @param[in] AP - Device pointer to the first matrix A_1 on the GPU of dimension (lda, k)
   !>             when transA is HIPBLAS_OP_N. Otherwise, of dimension (lda, n).
   !>
-  !>     @param[in]
-  !>     lda     [int]
+  !>     @param[in] lda - [int]
   !>             lda specifies the first dimension of A_i.
   !>             If transA = HIPBLAS_OP_N,  lda >= max( 1, n ).
   !>             Otherwise, lda >= max( 1, k ).
   !>
-  !>     @param[in]
-  !>     strideA  [hipblasStride]
+  !>     @param[in] strideA - [hipblasStride]
   !>               stride from the start of one matrix (A_i) to the next one (A_i+1).
   !>
-  !>     @param[in]
-  !>     beta
+  !>     @param[in] beta
   !>             beta specifies the scalar beta. When beta is
   !>             zero, then C does not need to be set before entry.
   !>
-  !>     @param[in]
-  !>     CP      Device pointer to the first matrix C_1 on the GPU.
+  !>     @param[in] CP - Device pointer to the first matrix C_1 on the GPU.
   !>             The imaginary components of the diagonal elements are not used but are set to zero,
   !>             except for quick return.
   !>
-  !>     @param[in]
-  !>     ldc    [int]
+  !>     @param[in] ldc - [int]
   !>            ldc specifies the first dimension of C. ldc >= max( 1, n ).
   !>
-  !>     @param[inout]
-  !>     strideC  [hipblasStride]
+  !>     @param[inout] strideC - [hipblasStride]
   !>               stride from the start of one matrix (C_i) to the next one (C_i+1).
   !>
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasCherkStridedBatched
@@ -27162,66 +25996,53 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``c`` and ``z``.
   !>     - Supported precisions in cuBLAS  : ``c`` and ``z``.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>             - HIPBLAS_FILL_MODE_UPPER:  C is an upper triangular matrix.
   !>             - HIPBLAS_FILL_MODE_LOWER:  C is a lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA  [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>             - HIPBLAS_OP_C:  op( A ) = A^H, op( B ) = B^H
   !>             - HIPBLAS_OP_N:  op( A ) = A, op( B ) = B
   !>
-  !>     @param[in]
-  !>     n       [int]
+  !>     @param[in] n - [int]
   !>             n specifies the number of rows and columns of C. n >= 0.
   !>
-  !>     @param[in]
-  !>     k       [int]
+  !>     @param[in] k - [int]
   !>             k specifies the number of columns of op(A). k >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             alpha specifies the scalar alpha. When alpha is
   !>             zero, then A is not referenced and does not need to be set before
   !>             entry.
   !>
-  !>     @param[in]
-  !>     AP      pointer storing matrix A on the GPU.
+  !>     @param[in] AP - pointer storing matrix A on the GPU.
   !>             Matrix dimension is ( lda, k ) when trans = HIPBLAS_OP_N. Otherwise, (lda, n).
   !>             Only the upper/lower triangular part is accessed.
   !>
-  !>     @param[in]
-  !>     lda     [int]
+  !>     @param[in] lda - [int]
   !>             lda specifies the first dimension of A.
   !>             if trans = HIPBLAS_OP_N,  lda >= max( 1, n ).
   !>             Otherwise, lda >= max( 1, k ).
-  !>     @param[in]
-  !>     BP      pointer storing matrix B on the GPU.
+  !>     @param[in] BP - pointer storing matrix B on the GPU.
   !>             Matrix dimension is ( ldb, k ) when trans = HIPBLAS_OP_N. Otherwise, (ldb, n).
   !>             Only the upper/lower triangular part is accessed.
   !>
-  !>     @param[in]
-  !>     ldb     [int]
+  !>     @param[in] ldb - [int]
   !>             ldb specifies the first dimension of B.
   !>             If trans = HIPBLAS_OP_N,  ldb >= max( 1, n ).
   !>             Otherwise, ldb >= max( 1, k ).
-  !>     @param[in]
-  !>     beta
+  !>     @param[in] beta
   !>             beta specifies the scalar beta. When beta is
   !>             zero, then C does not need to be set before entry.
   !>
-  !>     @param[in]
-  !>     CP       pointer storing matrix C on the GPU.
+  !>     @param[in] CP - pointer storing matrix C on the GPU.
   !>             The imaginary components of the diagonal elements are not used but are set to zero,
   !>             except for quick return.
   !>
-  !>     @param[in]
-  !>     ldc    [int]
+  !>     @param[in] ldc - [int]
   !>            ldc specifies the first dimension of C. ldc >= max( 1, n ).
   interface hipblasCherkx
 #ifdef USE_CUDA_NAMES
@@ -27371,70 +26192,58 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``c`` and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>             - HIPBLAS_FILL_MODE_UPPER:  C_i is an upper triangular matrix.
   !>             - HIPBLAS_FILL_MODE_LOWER:  C_i is a lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA  [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>             - HIPBLAS_OP_C: op(A) = A^H
   !>             - HIPBLAS_OP_N: op(A) = A
   !>
-  !>     @param[in]
-  !>     n       [int]
+  !>     @param[in] n - [int]
   !>             n specifies the number of rows and columns of C_i. n >= 0.
   !>
-  !>     @param[in]
-  !>     k       [int]
+  !>     @param[in] k - [int]
   !>             k specifies the number of columns of op(A). k >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             alpha specifies the scalar alpha. When alpha is
   !>             zero, then A is not referenced and does not need to be set before
   !>             entry.
   !>
-  !>     @param[in]
-  !>     AP      device array of device pointers storing each matrix_i A of dimension (lda, k)
+  !>     @param[in] AP - device array of device pointers storing each matrix_i A of dimension (lda,
+  !>     k)
   !>             when trans is HIPBLAS_OP_N. Otherwise, of dimension (lda, n).
   !>
-  !>     @param[in]
-  !>     lda     [int]
+  !>     @param[in] lda - [int]
   !>             lda specifies the first dimension of A_i.
   !>             If trans = HIPBLAS_OP_N,  lda >= max( 1, n ).
   !>             Otherwise, lda >= max( 1, k ).
   !>
-  !>     @param[in]
-  !>     BP      device array of device pointers storing each matrix_i B of dimension (ldb, k)
+  !>     @param[in] BP - device array of device pointers storing each matrix_i B of dimension (ldb,
+  !>     k)
   !>             when trans is HIPBLAS_OP_N. Otherwise, of dimension (ldb, n).
   !>
-  !>     @param[in]
-  !>     ldb     [int]
+  !>     @param[in] ldb - [int]
   !>             ldb specifies the first dimension of B_i.
   !>             If trans = HIPBLAS_OP_N,  ldb >= max( 1, n ).
   !>             Otherwise, ldb >= max( 1, k ).
   !>
-  !>     @param[in]
-  !>     beta
+  !>     @param[in] beta
   !>             beta specifies the scalar beta. When beta is
   !>             zero, then C does not need to be set before entry.
   !>
-  !>     @param[in]
-  !>     CP      device array of device pointers storing each matrix C_i on the GPU.
+  !>     @param[in] CP - device array of device pointers storing each matrix C_i on the GPU.
   !>             The imaginary components of the diagonal elements are not used but are set to zero,
   !>             except for quick return.
   !>
-  !>     @param[in]
-  !>     ldc    [int]
+  !>     @param[in] ldc - [int]
   !>            ldc specifies the first dimension of C. ldc >= max( 1, n ).
   !>
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasCherkxBatched
@@ -27566,82 +26375,65 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``c`` and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>             - HIPBLAS_FILL_MODE_UPPER:  C_i is an upper triangular matrix.
   !>             - HIPBLAS_FILL_MODE_LOWER:  C_i is a lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA  [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>             - HIPBLAS_OP_C: op( A_i ) = A_i^H, op( B_i ) = B_i^H
   !>             - HIPBLAS_OP_N: op( A_i ) = A_i, op( B_i ) = B_i
   !>
-  !>     @param[in]
-  !>     n       [int]
+  !>     @param[in] n - [int]
   !>             n specifies the number of rows and columns of C_i. n >= 0.
   !>
-  !>     @param[in]
-  !>     k       [int]
+  !>     @param[in] k - [int]
   !>             k specifies the number of columns of op(A). k >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             alpha specifies the scalar alpha. When alpha is
   !>             zero, then A is not referenced and does not need to be set before
   !>             entry.
   !>
-  !>     @param[in]
-  !>     AP       Device pointer to the first matrix A_1 on the GPU of dimension (lda, k)
+  !>     @param[in] AP - Device pointer to the first matrix A_1 on the GPU of dimension (lda, k)
   !>             when trans is HIPBLAS_OP_N. Otherwise, of dimension (lda, n).
   !>
-  !>     @param[in]
-  !>     lda     [int]
+  !>     @param[in] lda - [int]
   !>             lda specifies the first dimension of A_i.
   !>             If trans = HIPBLAS_OP_N,  lda >= max( 1, n ).
   !>             Otherwise, lda >= max( 1, k ).
   !>
-  !>     @param[in]
-  !>     strideA  [hipblasStride]
+  !>     @param[in] strideA - [hipblasStride]
   !>               stride from the start of one matrix (A_i) to the next one (A_i+1).
   !>
-  !>     @param[in]
-  !>     BP      Device pointer to the first matrix B_1 on the GPU of dimension (ldb, k)
+  !>     @param[in] BP - Device pointer to the first matrix B_1 on the GPU of dimension (ldb, k)
   !>             when trans is HIPBLAS_OP_N. Otherwise, of dimension (ldb, n).
   !>
-  !>     @param[in]
-  !>     ldb     [int]
+  !>     @param[in] ldb - [int]
   !>             ldb specifies the first dimension of B_i.
   !>             If trans = HIPBLAS_OP_N,  ldb >= max( 1, n ).
   !>             Otherwise, ldb >= max( 1, k ).
   !>
-  !>     @param[in]
-  !>     strideB  [hipblasStride]
+  !>     @param[in] strideB - [hipblasStride]
   !>               stride from the start of one matrix (B_i) to the next one (B_i+1).
   !>
-  !>     @param[in]
-  !>     beta
+  !>     @param[in] beta
   !>             beta specifies the scalar beta. When beta is
   !>             zero, then C does not need to be set before entry.
   !>
-  !>     @param[in]
-  !>     CP      Device pointer to the first matrix C_1 on the GPU.
+  !>     @param[in] CP - Device pointer to the first matrix C_1 on the GPU.
   !>             The imaginary components of the diagonal elements are not used but are set to zero,
   !>             except for quick return.
   !>
-  !>     @param[in]
-  !>     ldc    [int]
+  !>     @param[in] ldc - [int]
   !>            ldc specifies the first dimension of C. ldc >= max( 1, n ).
   !>
-  !>     @param[inout]
-  !>     strideC  [hipblasStride]
+  !>     @param[inout] strideC - [hipblasStride]
   !>               stride from the start of one matrix (C_i) to the next one (C_i+1).
   !>
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasCherkxStridedBatched
@@ -27796,66 +26588,53 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``c`` and ``z``.
   !>     - Supported precisions in cuBLAS  : ``c`` and ``z``.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>             - HIPBLAS_FILL_MODE_UPPER:  C is an upper triangular matrix.
   !>             - HIPBLAS_FILL_MODE_LOWER:  C is a lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA  [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>             - HIPBLAS_OP_C:  op( A ) = A^H, op( B ) = B^H
   !>             - HIPBLAS_OP_N:  op( A ) = A, op( B ) = B
   !>
-  !>     @param[in]
-  !>     n       [int]
+  !>     @param[in] n - [int]
   !>             n specifies the number of rows and columns of C. n >= 0.
   !>
-  !>     @param[in]
-  !>     k       [int]
+  !>     @param[in] k - [int]
   !>             k specifies the number of columns of op(A). k >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             alpha specifies the scalar alpha. When alpha is
   !>             zero, then A is not referenced and does not need to be set before
   !>             entry.
   !>
-  !>     @param[in]
-  !>     AP       pointer storing matrix A on the GPU.
+  !>     @param[in] AP - pointer storing matrix A on the GPU.
   !>             Matrix dimension is ( lda, k ) when trans = HIPBLAS_OP_N. Otherwise, (lda, n).
   !>             Only the upper/lower triangular part is accessed.
   !>
-  !>     @param[in]
-  !>     lda     [int]
+  !>     @param[in] lda - [int]
   !>             lda specifies the first dimension of A.
   !>             If trans = HIPBLAS_OP_N,  lda >= max( 1, n ).
   !>             Otherwise, lda >= max( 1, k ).
-  !>     @param[in]
-  !>     BP      pointer storing matrix B on the GPU.
+  !>     @param[in] BP - pointer storing matrix B on the GPU.
   !>             Matrix dimension is ( ldb, k ) when trans = HIPBLAS_OP_N. Otherwise, (ldb, n).
   !>             Only the upper/lower triangular part is accessed.
   !>
-  !>     @param[in]
-  !>     ldb     [int]
+  !>     @param[in] ldb - [int]
   !>             ldb specifies the first dimension of B.
   !>             If trans = HIPBLAS_OP_N,  ldb >= max( 1, n ).
   !>             Otherwise, ldb >= max( 1, k ).
-  !>     @param[in]
-  !>     beta
+  !>     @param[in] beta
   !>             beta specifies the scalar beta. When beta is
   !>             zero, then C does not need to be set before entry.
   !>
-  !>     @param[in]
-  !>     CP      pointer storing matrix C on the GPU.
+  !>     @param[in] CP - pointer storing matrix C on the GPU.
   !>             The imaginary components of the diagonal elements are not used but are set to zero,
   !>             except for quick return.
   !>
-  !>     @param[in]
-  !>     ldc    [int]
+  !>     @param[in] ldc - [int]
   !>            ldc specifies the first dimension of C. ldc >= max( 1, n ).
   interface hipblasCher2k
 #ifdef USE_CUDA_NAMES
@@ -28003,67 +26782,55 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``c`` and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>             - HIPBLAS_FILL_MODE_UPPER:  C_i is an upper triangular matrix.
   !>             - HIPBLAS_FILL_MODE_LOWER:  C_i is a lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA  [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>             - HIPBLAS_OP_C: op(A) = A^H
   !>             - HIPBLAS_OP_N: op(A) = A
   !>
-  !>     @param[in]
-  !>     n       [int]
+  !>     @param[in] n - [int]
   !>             n specifies the number of rows and columns of C_i. n >= 0.
   !>
-  !>     @param[in]
-  !>     k       [int]
+  !>     @param[in] k - [int]
   !>             k specifies the number of columns of op(A). k >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             alpha specifies the scalar alpha. When alpha is
   !>             zero, then A is not referenced and does not need to be set before
   !>             entry.
   !>
-  !>     @param[in]
-  !>     AP      device array of device pointers storing each matrix_i A of dimension (lda, k)
+  !>     @param[in] AP - device array of device pointers storing each matrix_i A of dimension (lda,
+  !>     k)
   !>             when trans is HIPBLAS_OP_N. Otherwise, of dimension (lda, n).
   !>
-  !>     @param[in]
-  !>     lda     [int]
+  !>     @param[in] lda - [int]
   !>             lda specifies the first dimension of A_i.
   !>             If trans = HIPBLAS_OP_N,  lda >= max( 1, n ).
   !>             Otherwise, lda >= max( 1, k ).
-  !>     @param[in]
-  !>     BP      device array of device pointers storing each matrix_i B of dimension (ldb, k)
+  !>     @param[in] BP - device array of device pointers storing each matrix_i B of dimension (ldb,
+  !>     k)
   !>             when trans is HIPBLAS_OP_N. Otherwise, of dimension (ldb, n).
   !>
-  !>     @param[in]
-  !>     ldb     [int]
+  !>     @param[in] ldb - [int]
   !>             ldb specifies the first dimension of B_i.
   !>             If trans = HIPBLAS_OP_N,  ldb >= max( 1, n ).
   !>             Otherwise, ldb >= max( 1, k ).
-  !>     @param[in]
-  !>     beta
+  !>     @param[in] beta
   !>             beta specifies the scalar beta. When beta is
   !>             zero, then C does not need to be set before entry.
   !>
-  !>     @param[in]
-  !>     CP      device array of device pointers storing each matrix C_i on the GPU.
+  !>     @param[in] CP - device array of device pointers storing each matrix C_i on the GPU.
   !>             The imaginary components of the diagonal elements are not used but are set to zero,
   !>             except for quick return.
   !>
-  !>     @param[in]
-  !>     ldc    [int]
+  !>     @param[in] ldc - [int]
   !>            ldc specifies the first dimension of C. ldc >= max( 1, n ).
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasCher2kBatched
@@ -28193,82 +26960,65 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``c`` and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>             - HIPBLAS_FILL_MODE_UPPER:  C_i is an upper triangular matrix.
   !>             - HIPBLAS_FILL_MODE_LOWER:  C_i is a lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA  [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>             - HIPBLAS_OP_C: op( A_i ) = A_i^H, op( B_i ) = B_i^H
   !>             - HIPBLAS_OP_N: op( A_i ) = A_i, op( B_i ) = B_i
   !>
-  !>     @param[in]
-  !>     n       [int]
+  !>     @param[in] n - [int]
   !>             n specifies the number of rows and columns of C_i. n >= 0.
   !>
-  !>     @param[in]
-  !>     k       [int]
+  !>     @param[in] k - [int]
   !>             k specifies the number of columns of op(A). k >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             alpha specifies the scalar alpha. When alpha is
   !>             zero, then A is not referenced and does not need to be set before
   !>             entry.
   !>
-  !>     @param[in]
-  !>     AP      Device pointer to the first matrix A_1 on the GPU of dimension (lda, k)
+  !>     @param[in] AP - Device pointer to the first matrix A_1 on the GPU of dimension (lda, k)
   !>             when trans is HIPBLAS_OP_N. Otherwise, of dimension (lda, n).
   !>
-  !>     @param[in]
-  !>     lda     [int]
+  !>     @param[in] lda - [int]
   !>             lda specifies the first dimension of A_i.
   !>             if trans = HIPBLAS_OP_N,  lda >= max( 1, n ).
   !>             Otherwise, lda >= max( 1, k ).
   !>
-  !>     @param[in]
-  !>     strideA  [hipblasStride]
+  !>     @param[in] strideA - [hipblasStride]
   !>               stride from the start of one matrix (A_i) to the next one (A_i+1).
   !>
-  !>     @param[in]
-  !>     BP      Device pointer to the first matrix B_1 on the GPU of dimension (ldb, k)
+  !>     @param[in] BP - Device pointer to the first matrix B_1 on the GPU of dimension (ldb, k)
   !>             when trans is HIPBLAS_OP_N. Otherwise, of dimension (ldb, n).
   !>
-  !>     @param[in]
-  !>     ldb     [int]
+  !>     @param[in] ldb - [int]
   !>             ldb specifies the first dimension of B_i.
   !>             If trans = HIPBLAS_OP_N,  ldb >= max( 1, n ).
   !>             Otherwise, ldb >= max( 1, k ).
   !>
-  !>     @param[in]
-  !>     strideB  [hipblasStride]
+  !>     @param[in] strideB - [hipblasStride]
   !>               stride from the start of one matrix (B_i) to the next one (B_i+1).
   !>
-  !>     @param[in]
-  !>     beta
+  !>     @param[in] beta
   !>             beta specifies the scalar beta. When beta is
   !>             zero, then C does not need to be set before entry.
   !>
-  !>     @param[in]
-  !>     CP      Device pointer to the first matrix C_1 on the GPU.
+  !>     @param[in] CP - Device pointer to the first matrix C_1 on the GPU.
   !>             The imaginary components of the diagonal elements are not used but are set to zero,
   !>             except for quick return.
   !>
-  !>     @param[in]
-  !>     ldc    [int]
+  !>     @param[in] ldc - [int]
   !>            ldc specifies the first dimension of C. ldc >= max( 1, n ).
   !>
-  !>     @param[inout]
-  !>     strideC  [hipblasStride]
+  !>     @param[inout] strideC - [hipblasStride]
   !>               stride from the start of one matrix (C_i) to the next one (C_i+1).
   !>
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasCher2kStridedBatched
@@ -28419,64 +27169,51 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : ``s``, ``d``, ``c``, and ``z``.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     side  [hipblasSideMode_t]
+  !>     @param[in] side - [hipblasSideMode_t]
   !>             - HIPBLAS_SIDE_LEFT:      C := alpha*A*B + beta*C
   !>             - HIPBLAS_SIDE_RIGHT:     C := alpha*B*A + beta*C
   !>
-  !>     @param[in]
-  !>     uplo    [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>             - HIPBLAS_FILL_MODE_UPPER:  A is an upper triangular matrix.
   !>             - HIPBLAS_FILL_MODE_LOWER:  A is a lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     m       [int]
+  !>     @param[in] m - [int]
   !>             m specifies the number of rows of B and C. m >= 0.
   !>
-  !>     @param[in]
-  !>     n       [int]
+  !>     @param[in] n - [int]
   !>             n specifies the number of columns of B and C. n >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             alpha specifies the scalar alpha. When alpha is
   !>             zero, then A and B are not referenced.
   !>
-  !>     @param[in]
-  !>     AP      pointer storing matrix A on the GPU.
+  !>     @param[in] AP - pointer storing matrix A on the GPU.
   !>             A is m by m if side == HIPBLAS_SIDE_LEFT.
   !>             A is n by n if side == HIPBLAS_SIDE_RIGHT.
   !>             Only the upper/lower triangular part is accessed.
   !>
-  !>     @param[in]
-  !>     lda     [int]
+  !>     @param[in] lda - [int]
   !>             lda specifies the first dimension of A.
   !>             If side = HIPBLAS_SIDE_LEFT,  lda >= max( 1, m ).
   !>             Otherwise, lda >= max( 1, n ).
   !>
-  !>     @param[in]
-  !>     BP      pointer storing matrix B on the GPU.
+  !>     @param[in] BP - pointer storing matrix B on the GPU.
   !>             Matrix dimension is m by n.
   !>
-  !>     @param[in]
-  !>     ldb     [int]
+  !>     @param[in] ldb - [int]
   !>             ldb specifies the first dimension of B. ldb >= max( 1, m ).
   !>
-  !>     @param[in]
-  !>     beta
+  !>     @param[in] beta
   !>             beta specifies the scalar beta. When beta is
   !>             zero, then C does not need to be set before entry.
   !>
-  !>     @param[in]
-  !>     CP      pointer storing matrix C on the GPU.
+  !>     @param[in] CP - pointer storing matrix C on the GPU.
   !>             Matrix dimension is m by n.
   !>
-  !>     @param[in]
-  !>     ldc    [int]
+  !>     @param[in] ldc - [int]
   !>            ldc specifies the first dimension of C. ldc >= max( 1, m ).
   interface hipblasSsymm
 #ifdef USE_CUDA_NAMES
@@ -28746,68 +27483,54 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     side  [hipblasSideMode_t]
+  !>     @param[in] side - [hipblasSideMode_t]
   !>             - HIPBLAS_SIDE_LEFT:      C_i := alpha*A_i*B_i + beta*C_i
   !>             - HIPBLAS_SIDE_RIGHT:     C_i := alpha*B_i*A_i + beta*C_i
   !>
-  !>     @param[in]
-  !>     uplo    [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>             - HIPBLAS_FILL_MODE_UPPER:  A_i is an upper triangular matrix.
   !>             - HIPBLAS_FILL_MODE_LOWER:  A_i is a lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     m       [int]
+  !>     @param[in] m - [int]
   !>             m specifies the number of rows of B_i and C_i. m >= 0.
   !>
-  !>     @param[in]
-  !>     n       [int]
+  !>     @param[in] n - [int]
   !>             n specifies the number of columns of B_i and C_i. n >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             alpha specifies the scalar alpha. When alpha is
   !>             zero, then A_i and B_i are not referenced.
   !>
-  !>     @param[in]
-  !>     AP      device array of device pointers storing each matrix A_i on the GPU.
+  !>     @param[in] AP - device array of device pointers storing each matrix A_i on the GPU.
   !>             A_i is m by m if side == HIPBLAS_SIDE_LEFT.
   !>             A_i is n by n if side == HIPBLAS_SIDE_RIGHT.
   !>             Only the upper/lower triangular part is accessed.
   !>
-  !>     @param[in]
-  !>     lda     [int]
+  !>     @param[in] lda - [int]
   !>             lda specifies the first dimension of A_i.
   !>             If side = HIPBLAS_SIDE_LEFT,  lda >= max( 1, m ).
   !>             Otherwise, lda >= max( 1, n ).
   !>
-  !>     @param[in]
-  !>     BP      device array of device pointers storing each matrix B_i on the GPU.
+  !>     @param[in] BP - device array of device pointers storing each matrix B_i on the GPU.
   !>             Matrix dimension is m by n.
   !>
-  !>     @param[in]
-  !>     ldb     [int]
+  !>     @param[in] ldb - [int]
   !>             ldb specifies the first dimension of B_i. ldb >= max( 1, m ).
   !>
-  !>     @param[in]
-  !>     beta
+  !>     @param[in] beta
   !>             beta specifies the scalar beta. When beta is
   !>             zero, then C_i does not need to be set before entry.
   !>
-  !>     @param[in]
-  !>     CP      device array of device pointers storing each matrix C_i on the GPU.
+  !>     @param[in] CP - device array of device pointers storing each matrix C_i on the GPU.
   !>             Matrix dimension is m by n.
   !>
-  !>     @param[in]
-  !>     ldc    [int]
+  !>     @param[in] ldc - [int]
   !>            ldc specifies the first dimension of C_i. ldc >= max( 1, m ).
   !>
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasSsymmBatched
@@ -29037,77 +27760,60 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     side  [hipblasSideMode_t]
+  !>     @param[in] side - [hipblasSideMode_t]
   !>             - HIPBLAS_SIDE_LEFT:      C_i := alpha*A_i*B_i + beta*C_i
   !>             - HIPBLAS_SIDE_RIGHT:     C_i := alpha*B_i*A_i + beta*C_i
   !>
-  !>     @param[in]
-  !>     uplo    [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>             - HIPBLAS_FILL_MODE_UPPER:  A_i is an upper triangular matrix.
   !>             - HIPBLAS_FILL_MODE_LOWER:  A_i is a lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     m       [int]
+  !>     @param[in] m - [int]
   !>             m specifies the number of rows of B_i and C_i. m >= 0.
   !>
-  !>     @param[in]
-  !>     n       [int]
+  !>     @param[in] n - [int]
   !>             n specifies the number of columns of B_i and C_i. n >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             alpha specifies the scalar alpha. When alpha is
   !>             zero, then A_i and B_i are not referenced.
   !>
-  !>     @param[in]
-  !>     AP       device pointer to first matrix A_1.
+  !>     @param[in] AP - device pointer to first matrix A_1.
   !>             A_i is m by m if side == HIPBLAS_SIDE_LEFT.
   !>             A_i is n by n if side == HIPBLAS_SIDE_RIGHT.
   !>             Only the upper/lower triangular part is accessed.
   !>
-  !>     @param[in]
-  !>     lda     [int]
+  !>     @param[in] lda - [int]
   !>             lda specifies the first dimension of A_i.
   !>             If side = HIPBLAS_SIDE_LEFT,  lda >= max( 1, m ).
   !>             Otherwise, lda >= max( 1, n ).
   !>
-  !>     @param[in]
-  !>     strideA  [hipblasStride]
+  !>     @param[in] strideA - [hipblasStride]
   !>               stride from the start of one matrix (A_i) to the next one (A_i+1).
   !>
-  !>     @param[in]
-  !>     BP       device pointer to first matrix B_1 of dimension (ldb, n) on the GPU.
+  !>     @param[in] BP - device pointer to first matrix B_1 of dimension (ldb, n) on the GPU.
   !>
-  !>     @param[in]
-  !>     ldb     [int]
+  !>     @param[in] ldb - [int]
   !>             ldb specifies the first dimension of B_i. ldb >= max( 1, m ).
   !>
-  !>     @param[in]
-  !>     strideB  [hipblasStride]
+  !>     @param[in] strideB - [hipblasStride]
   !>               stride from the start of one matrix (B_i) to the next one (B_i+1).
-  !>     @param[in]
-  !>     beta
+  !>     @param[in] beta
   !>             beta specifies the scalar beta. When beta is
   !>             zero, then C does not need to be set before entry.
   !>
-  !>     @param[in]
-  !>     CP        device pointer to first matrix C_1 of dimension (ldc, n) on the GPU.
+  !>     @param[in] CP - device pointer to first matrix C_1 of dimension (ldc, n) on the GPU.
   !>
-  !>     @param[in]
-  !>     ldc    [int]
+  !>     @param[in] ldc - [int]
   !>            ldc specifies the first dimension of C. ldc >= max( 1, m ).
   !>
-  !>     @param[inout]
-  !>     strideC  [hipblasStride]
+  !>     @param[inout] strideC - [hipblasStride]
   !>               stride from the start of one matrix (C_i) to the next one (C_i+1).
   !>
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasSsymmStridedBatched
@@ -29395,58 +28101,47 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : ``s``, ``d``, ``c``, and ``z``.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>             - HIPBLAS_FILL_MODE_UPPER:  C is an upper triangular matrix.
   !>             - HIPBLAS_FILL_MODE_LOWER:  C is a lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA  [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>             - HIPBLAS_OP_T: op(A) = A^T
   !>             - HIPBLAS_OP_N: op(A) = A
   !>             - HIPBLAS_OP_C: op(A) = A^T
   !>             - HIPBLAS_OP_C is not supported for complex types. See cherk
   !>             and zherk.
   !>
-  !>     @param[in]
-  !>     n       [int]
+  !>     @param[in] n - [int]
   !>             n specifies the number of rows and columns of C. n >= 0.
   !>
-  !>     @param[in]
-  !>     k       [int]
+  !>     @param[in] k - [int]
   !>             k specifies the number of columns of op(A). k >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             alpha specifies the scalar alpha. When alpha is
   !>             zero, then A is not referenced and A does not need to be set before
   !>             entry.
   !>
-  !>     @param[in]
-  !>     AP      pointer storing matrix A on the GPU.
+  !>     @param[in] AP - pointer storing matrix A on the GPU.
   !>             Matrix dimension is ( lda, k ) when transA = HIPBLAS_OP_N. Otherwise, (lda, n).
   !>             Only the upper/lower triangular part is accessed.
   !>
-  !>     @param[in]
-  !>     lda     [int]
+  !>     @param[in] lda - [int]
   !>             lda specifies the first dimension of A.
   !>             If transA = HIPBLAS_OP_N,  lda >= max( 1, n ).
   !>             Otherwise, lda >= max( 1, k ).
   !>
-  !>     @param[in]
-  !>     beta
+  !>     @param[in] beta
   !>             beta specifies the scalar beta. When beta is
   !>             zero, then C does not need to be set before entry.
   !>
-  !>     @param[in]
-  !>     CP       pointer storing matrix C on the GPU.
+  !>     @param[in] CP - pointer storing matrix C on the GPU.
   !>
-  !>     @param[in]
-  !>     ldc    [int]
+  !>     @param[in] ldc - [int]
   !>            ldc specifies the first dimension of C. ldc >= max( 1, n ).
   interface hipblasSsyrk
 #ifdef USE_CUDA_NAMES
@@ -29702,60 +28397,49 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>             - HIPBLAS_FILL_MODE_UPPER:  C_i is an upper triangular matrix.
   !>             - HIPBLAS_FILL_MODE_LOWER:  C_i is a lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA  [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>             - HIPBLAS_OP_T: op(A) = A^T
   !>             - HIPBLAS_OP_N: op(A) = A
   !>             - HIPBLAS_OP_C: op(A) = A^T
   !>             - HIPBLAS_OP_C is not supported for complex types. See cherk
   !>             and zherk.
   !>
-  !>     @param[in]
-  !>     n       [int]
+  !>     @param[in] n - [int]
   !>             n specifies the number of rows and columns of C_i. n >= 0.
   !>
-  !>     @param[in]
-  !>     k       [int]
+  !>     @param[in] k - [int]
   !>             k specifies the number of columns of op(A). k >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             alpha specifies the scalar alpha. When alpha is
   !>             zero, then A is not referenced and does not need to be set before
   !>             entry.
   !>
-  !>     @param[in]
-  !>     AP      device array of device pointers storing each matrix_i A of dimension (lda, k)
+  !>     @param[in] AP - device array of device pointers storing each matrix_i A of dimension (lda,
+  !>     k)
   !>             when transA is HIPBLAS_OP_N. Otherwise, of dimension (lda, n).
   !>
-  !>     @param[in]
-  !>     lda     [int]
+  !>     @param[in] lda - [int]
   !>             lda specifies the first dimension of A_i.
   !>             If transA = HIPBLAS_OP_N, lda >= max( 1, n ).
   !>             Otherwise, lda >= max( 1, k ).
   !>
-  !>     @param[in]
-  !>     beta
+  !>     @param[in] beta
   !>             beta specifies the scalar beta. When beta is
   !>             zero, then C does not need to be set before entry.
   !>
-  !>     @param[in]
-  !>     CP       device array of device pointers storing each matrix C_i on the GPU.
+  !>     @param[in] CP - device array of device pointers storing each matrix C_i on the GPU.
   !>
-  !>     @param[in]
-  !>     ldc    [int]
+  !>     @param[in] ldc - [int]
   !>            ldc specifies the first dimension of C. ldc >= max( 1, n ).
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasSsyrkBatched
@@ -29967,69 +28651,55 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>             - HIPBLAS_FILL_MODE_UPPER:  C_i is an upper triangular matrix.
   !>             - HIPBLAS_FILL_MODE_LOWER:  C_i is a lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA  [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>             - HIPBLAS_OP_T: op(A) = A^T
   !>             - HIPBLAS_OP_N: op(A) = A
   !>             - HIPBLAS_OP_C: op(A) = A^T
   !>             - HIPBLAS_OP_C is not supported for complex types. See cherk
   !>             and zherk.
   !>
-  !>     @param[in]
-  !>     n       [int]
+  !>     @param[in] n - [int]
   !>             n specifies the number of rows and columns of C_i. n >= 0.
   !>
-  !>     @param[in]
-  !>     k       [int]
+  !>     @param[in] k - [int]
   !>             k specifies the number of columns of op(A). k >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             alpha specifies the scalar alpha. When alpha is
   !>             zero, then A is not referenced and does not need to be set before
   !>             entry.
   !>
-  !>     @param[in]
-  !>     AP      Device pointer to the first matrix A_1 on the GPU of dimension (lda, k)
+  !>     @param[in] AP - Device pointer to the first matrix A_1 on the GPU of dimension (lda, k)
   !>             when transA is HIPBLAS_OP_N. Otherwise, of dimension (lda, n).
   !>
-  !>     @param[in]
-  !>     lda     [int]
+  !>     @param[in] lda - [int]
   !>             lda specifies the first dimension of A_i.
   !>             If transA = HIPBLAS_OP_N,  lda >= max( 1, n ).
   !>             Otherwise, lda >= max( 1, k ).
   !>
-  !>     @param[in]
-  !>     strideA  [hipblasStride]
+  !>     @param[in] strideA - [hipblasStride]
   !>               stride from the start of one matrix (A_i) to the next one (A_i+1).
   !>
-  !>     @param[in]
-  !>     beta
+  !>     @param[in] beta
   !>             beta specifies the scalar beta. When beta is
   !>             zero, then C does not need to be set before entry.
   !>
-  !>     @param[in]
-  !>     CP       Device pointer to the first matrix C_1 on the GPU.
+  !>     @param[in] CP - Device pointer to the first matrix C_1 on the GPU.
   !>
-  !>     @param[in]
-  !>     ldc    [int]
+  !>     @param[in] ldc - [int]
   !>            ldc specifies the first dimension of C. ldc >= max( 1, n ).
   !>
-  !>     @param[inout]
-  !>     strideC  [hipblasStride]
+  !>     @param[inout] strideC - [hipblasStride]
   !>               stride from the start of one matrix (C_i) to the next one (C_i+1).
   !>
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasSsyrkStridedBatched
@@ -30294,64 +28964,51 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : ``s``, ``d``, ``c``, and ``z``.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>             - HIPBLAS_FILL_MODE_UPPER:  C is an upper triangular matrix.
   !>             - HIPBLAS_FILL_MODE_LOWER:  C is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA  [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>             - HIPBLAS_OP_T:      op( A ) = A^T, op( B ) = B^T
   !>             - HIPBLAS_OP_N:           op( A ) = A, op( B ) = B
   !>
-  !>     @param[in]
-  !>     n       [int]
+  !>     @param[in] n - [int]
   !>             n specifies the number of rows and columns of C. n >= 0.
   !>
-  !>     @param[in]
-  !>     k       [int]
+  !>     @param[in] k - [int]
   !>             k specifies the number of columns of op(A) and op(B). k >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             alpha specifies the scalar alpha. When alpha is
   !>             zero, then A is not referenced and does not need to be set before
   !>             entry.
   !>
-  !>     @param[in]
-  !>     AP      Pointer storing matrix A on the GPU.
+  !>     @param[in] AP - Pointer storing matrix A on the GPU.
   !>             Matrix dimension is ( lda, k ) when trans = HIPBLAS_OP_N. Otherwise, (lda, n).
   !>             Only the upper/lower triangular part is accessed.
   !>
-  !>     @param[in]
-  !>     lda     [int]
+  !>     @param[in] lda - [int]
   !>             lda specifies the first dimension of A.
   !>             If trans = HIPBLAS_OP_N,  lda >= max( 1, n ).
   !>             Otherwise, lda >= max( 1, k ).
-  !>     @param[in]
-  !>     BP      pointer storing matrix B on the GPU.
+  !>     @param[in] BP - pointer storing matrix B on the GPU.
   !>             Matrix dimension is ( ldb, k ) when trans = HIPBLAS_OP_N. Otherwise, (ldb, n).
   !>             Only the upper/lower triangular part is accessed.
   !>
-  !>     @param[in]
-  !>     ldb     [int]
+  !>     @param[in] ldb - [int]
   !>             ldb specifies the first dimension of B.
   !>             If trans = HIPBLAS_OP_N,  ldb >= max( 1, n ).
   !>             Otherwise, ldb >= max( 1, k ).
-  !>     @param[in]
-  !>     beta
+  !>     @param[in] beta
   !>             beta specifies the scalar beta. When beta is
   !>             zero, then C does not need to be set before entry.
   !>
-  !>     @param[in]
-  !>     CP       pointer storing matrix C on the GPU.
+  !>     @param[in] CP - pointer storing matrix C on the GPU.
   !>
-  !>     @param[in]
-  !>     ldc    [int]
+  !>     @param[in] ldc - [int]
   !>            ldc specifies the first dimension of C. ldc >= max( 1, n ).
   interface hipblasSsyr2k
 #ifdef USE_CUDA_NAMES
@@ -30625,64 +29282,52 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>             - HIPBLAS_FILL_MODE_UPPER:  C_i is an upper triangular matrix.
   !>             - HIPBLAS_FILL_MODE_LOWER:  C_i is a lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA  [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>             - HIPBLAS_OP_T:      op( A_i ) = A_i^T, op( B_i ) = B_i^T
   !>             - HIPBLAS_OP_N:           op( A_i ) = A_i, op( B_i ) = B_i
   !>
-  !>     @param[in]
-  !>     n       [int]
+  !>     @param[in] n - [int]
   !>             n specifies the number of rows and columns of C_i. n >= 0.
   !>
-  !>     @param[in]
-  !>     k       [int]
+  !>     @param[in] k - [int]
   !>             k specifies the number of columns of op(A). k >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             alpha specifies the scalar alpha. When alpha is
   !>             zero, then A is not referenced and does not need to be set before
   !>             entry.
   !>
-  !>     @param[in]
-  !>     AP      device array of device pointers storing each matrix_i A of dimension (lda, k)
+  !>     @param[in] AP - device array of device pointers storing each matrix_i A of dimension (lda,
+  !>     k)
   !>             when trans is HIPBLAS_OP_N. Otherwise, of dimension (lda, n).
   !>
-  !>     @param[in]
-  !>     lda     [int]
+  !>     @param[in] lda - [int]
   !>             lda specifies the first dimension of A_i.
   !>             If trans = HIPBLAS_OP_N,  lda >= max( 1, n ).
   !>             Otherwise, lda >= max( 1, k ).
-  !>     @param[in]
-  !>     BP      device array of device pointers storing each matrix_i B of dimension (ldb, k)
+  !>     @param[in] BP - device array of device pointers storing each matrix_i B of dimension (ldb,
+  !>     k)
   !>             when trans is HIPBLAS_OP_N. Otherwise, of dimension (ldb, n).
-  !>     @param[in]
-  !>     ldb     [int]
+  !>     @param[in] ldb - [int]
   !>             ldb specifies the first dimension of B.
   !>             If trans = HIPBLAS_OP_N,  ldb >= max( 1, n ).
   !>             Otherwise, ldb >= max( 1, k ).
-  !>     @param[in]
-  !>     beta
+  !>     @param[in] beta
   !>             beta specifies the scalar beta. When beta is
   !>             zero, then C does not need to be set before entry.
   !>
-  !>     @param[in]
-  !>     CP      device array of device pointers storing each matrix C_i on the GPU.
+  !>     @param[in] CP - device array of device pointers storing each matrix C_i on the GPU.
   !>
-  !>     @param[in]
-  !>     ldc    [int]
+  !>     @param[in] ldc - [int]
   !>            ldc specifies the first dimension of C. ldc >= max( 1, n ).
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasSsyr2kBatched
@@ -30920,80 +29565,63 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>             - HIPBLAS_FILL_MODE_UPPER:  C_i is an upper triangular matrix.
   !>             - HIPBLAS_FILL_MODE_LOWER:  C_i is a lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA  [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>             - HIPBLAS_OP_T:      op( A_i ) = A_i^T, op( B_i ) = B_i^T
   !>             - HIPBLAS_OP_N:           op( A_i ) = A_i, op( B_i ) = B_i
   !>
-  !>     @param[in]
-  !>     n       [int]
+  !>     @param[in] n - [int]
   !>             n specifies the number of rows and columns of C_i. n >= 0.
   !>
-  !>     @param[in]
-  !>     k       [int]
+  !>     @param[in] k - [int]
   !>             k specifies the number of columns of op(A). k >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             alpha specifies the scalar alpha. When alpha is
   !>             zero, then A is not referenced and does not need to be set before
   !>             entry.
   !>
-  !>     @param[in]
-  !>     AP      Device pointer to the first matrix A_1 on the GPU of dimension (lda, k)
+  !>     @param[in] AP - Device pointer to the first matrix A_1 on the GPU of dimension (lda, k)
   !>             when trans is HIPBLAS_OP_N. Otherwise, of dimension (lda, n).
   !>
-  !>     @param[in]
-  !>     lda     [int]
+  !>     @param[in] lda - [int]
   !>             lda specifies the first dimension of A_i.
   !>             If trans = HIPBLAS_OP_N,  lda >= max( 1, n ).
   !>             Otherwise, lda >= max( 1, k ).
   !>
-  !>     @param[in]
-  !>     strideA  [hipblasStride]
+  !>     @param[in] strideA - [hipblasStride]
   !>               stride from the start of one matrix (A_i) to the next one (A_i+1).
   !>
-  !>     @param[in]
-  !>     BP      Device pointer to the first matrix B_1 on the GPU of dimension (ldb, k)
+  !>     @param[in] BP - Device pointer to the first matrix B_1 on the GPU of dimension (ldb, k)
   !>             when trans is HIPBLAS_OP_N. Otherwise, of dimension (ldb, n).
   !>
-  !>     @param[in]
-  !>     ldb     [int]
+  !>     @param[in] ldb - [int]
   !>             ldb specifies the first dimension of B_i.
   !>             If trans = HIPBLAS_OP_N,  ldb >= max( 1, n ).
   !>             Otherwise, ldb >= max( 1, k ).
   !>
-  !>     @param[in]
-  !>     strideB  [hipblasStride]
+  !>     @param[in] strideB - [hipblasStride]
   !>               stride from the start of one matrix (B_i) to the next one (B_i+1).
   !>
-  !>     @param[in]
-  !>     beta
+  !>     @param[in] beta
   !>             beta specifies the scalar beta. When beta is
   !>             zero, then C does not need to be set before entry.
   !>
-  !>     @param[in]
-  !>     CP       Device pointer to the first matrix C_1 on the GPU.
+  !>     @param[in] CP - Device pointer to the first matrix C_1 on the GPU.
   !>
-  !>     @param[in]
-  !>     ldc    [int]
+  !>     @param[in] ldc - [int]
   !>            ldc specifies the first dimension of C. ldc >= max( 1, n ).
   !>
-  !>     @param[inout]
-  !>     strideC  [hipblasStride]
+  !>     @param[inout] strideC - [hipblasStride]
   !>               stride from the start of one matrix (C_i) to the next one (C_i+1).
   !>
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasSsyr2kStridedBatched
@@ -31284,66 +29912,53 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : ``s``, ``d``, ``c``, and ``z``.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>             - HIPBLAS_FILL_MODE_UPPER:  C is an upper triangular matrix.
   !>             - HIPBLAS_FILL_MODE_LOWER:  C is a lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA  [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>             - HIPBLAS_OP_T:      op( A ) = A^T, op( B ) = B^T
   !>             - HIPBLAS_OP_N:           op( A ) = A, op( B ) = B
   !>
-  !>     @param[in]
-  !>     n       [int]
+  !>     @param[in] n - [int]
   !>             n specifies the number of rows and columns of C. n >= 0.
   !>
-  !>     @param[in]
-  !>     k       [int]
+  !>     @param[in] k - [int]
   !>             k specifies the number of columns of op(A) and op(B). k >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             alpha specifies the scalar alpha. When alpha is
   !>             zero, then A is not referenced and does not need to be set before
   !>             entry.
   !>
-  !>     @param[in]
-  !>     AP      pointer storing matrix A on the GPU.
+  !>     @param[in] AP - pointer storing matrix A on the GPU.
   !>             Matrix dimension is ( lda, k ) when trans = HIPBLAS_OP_N. Otherwise, (lda, n).
   !>             Only the upper/lower triangular part is accessed.
   !>
-  !>     @param[in]
-  !>     lda     [int]
+  !>     @param[in] lda - [int]
   !>             lda specifies the first dimension of A.
   !>             If trans = HIPBLAS_OP_N,  lda >= max( 1, n ).
   !>             Otherwise, lda >= max( 1, k ).
   !>
-  !>     @param[in]
-  !>     BP      pointer storing matrix B on the GPU.
+  !>     @param[in] BP - pointer storing matrix B on the GPU.
   !>             Matrix dimension is ( ldb, k ) when trans = HIPBLAS_OP_N. Otherwise, (ldb, n).
   !>             Only the upper/lower triangular part is accessed.
   !>
-  !>     @param[in]
-  !>     ldb     [int]
+  !>     @param[in] ldb - [int]
   !>             ldb specifies the first dimension of B.
   !>             if trans = HIPBLAS_OP_N,  ldb >= max( 1, n ).
   !>             Otherwise, ldb >= max( 1, k ).
   !>
-  !>     @param[in]
-  !>     beta
+  !>     @param[in] beta
   !>             beta specifies the scalar beta. When beta is
   !>             zero, then C does not need to be set before entry.
   !>
-  !>     @param[in]
-  !>     CP       pointer storing matrix C on the GPU.
+  !>     @param[in] CP - pointer storing matrix C on the GPU.
   !>
-  !>     @param[in]
-  !>     ldc    [int]
+  !>     @param[in] ldc - [int]
   !>            ldc specifies the first dimension of C. ldc >= max( 1, n ).
   interface hipblasSsyrkx
 #ifdef USE_CUDA_NAMES
@@ -31619,68 +30234,56 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>             - HIPBLAS_FILL_MODE_UPPER:  C_i is an upper triangular matrix.
   !>             - HIPBLAS_FILL_MODE_LOWER:  C_i is a lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA  [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>             - HIPBLAS_OP_T:      op( A_i ) = A_i^T, op( B_i ) = B_i^T
   !>             - HIPBLAS_OP_N:           op( A_i ) = A_i, op( B_i ) = B_i
   !>
-  !>     @param[in]
-  !>     n       [int]
+  !>     @param[in] n - [int]
   !>             n specifies the number of rows and columns of C_i. n >= 0.
   !>
-  !>     @param[in]
-  !>     k       [int]
+  !>     @param[in] k - [int]
   !>             k specifies the number of columns of op(A). k >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             alpha specifies the scalar alpha. When alpha is
   !>             zero, then A is not referenced and A does not need to be set before
   !>             entry.
   !>
-  !>     @param[in]
-  !>     AP      device array of device pointers storing each matrix_i A of dimension (lda, k)
+  !>     @param[in] AP - device array of device pointers storing each matrix_i A of dimension (lda,
+  !>     k)
   !>             when trans is HIPBLAS_OP_N. Otherwise, of dimension (lda, n).
   !>
-  !>     @param[in]
-  !>     lda     [int]
+  !>     @param[in] lda - [int]
   !>             lda specifies the first dimension of A_i.
   !>             If trans = HIPBLAS_OP_N,  lda >= max( 1, n ).
   !>             Otherwise, lda >= max( 1, k ).
   !>
-  !>     @param[in]
-  !>     BP      device array of device pointers storing each matrix_i B of dimension (ldb, k)
+  !>     @param[in] BP - device array of device pointers storing each matrix_i B of dimension (ldb,
+  !>     k)
   !>             when trans is HIPBLAS_OP_N. Otherwise, of dimension (ldb, n).
   !>
-  !>     @param[in]
-  !>     ldb     [int]
+  !>     @param[in] ldb - [int]
   !>             ldb specifies the first dimension of B.
   !>             If trans = HIPBLAS_OP_N,  ldb >= max( 1, n ).
   !>             Otherwise, ldb >= max( 1, k ).
   !>
-  !>     @param[in]
-  !>     beta
+  !>     @param[in] beta
   !>             beta specifies the scalar beta. When beta is
   !>             zero, then C does not need to be set before entry.
   !>
-  !>     @param[in]
-  !>     CP       device array of device pointers storing each matrix C_i on the GPU.
+  !>     @param[in] CP - device array of device pointers storing each matrix C_i on the GPU.
   !>
-  !>     @param[in]
-  !>     ldc    [int]
+  !>     @param[in] ldc - [int]
   !>            ldc specifies the first dimension of C. ldc >= max( 1, n ).
   !>
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>             number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasSsyrkxBatched
@@ -31920,80 +30523,63 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>             - HIPBLAS_FILL_MODE_UPPER:  C_i is an upper triangular matrix
   !>             - HIPBLAS_FILL_MODE_LOWER:  C_i is a  lower triangular matrix
   !>
-  !>     @param[in]
-  !>     transA  [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>             - HIPBLAS_OP_T:      op( A_i ) = A_i^T, op( B_i ) = B_i^T
   !>             - HIPBLAS_OP_N:           op( A_i ) = A_i, op( B_i ) = B_i
   !>
-  !>     @param[in]
-  !>     n       [int]
+  !>     @param[in] n - [int]
   !>             n specifies the number of rows and columns of C_i. n >= 0.
   !>
-  !>     @param[in]
-  !>     k       [int]
+  !>     @param[in] k - [int]
   !>             k specifies the number of columns of op(A). k >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             alpha specifies the scalar alpha. When alpha is
   !>             zero, then A is not referenced and does not need to be set before
   !>             entry.
   !>
-  !>     @param[in]
-  !>     AP      Device pointer to the first matrix A_1 on the GPU of dimension (lda, k)
+  !>     @param[in] AP - Device pointer to the first matrix A_1 on the GPU of dimension (lda, k)
   !>             when trans is HIPBLAS_OP_N. Otherwise, of dimension (lda, n).
   !>
-  !>     @param[in]
-  !>     lda     [int]
+  !>     @param[in] lda - [int]
   !>             lda specifies the first dimension of A_i.
   !>             If trans = HIPBLAS_OP_N,  lda >= max( 1, n ).
   !>             Otherwise, lda >= max( 1, k ).
   !>
-  !>     @param[in]
-  !>     strideA  [hipblasStride]
+  !>     @param[in] strideA - [hipblasStride]
   !>               stride from the start of one matrix (A_i) to the next one (A_i+1).
   !>
-  !>     @param[in]
-  !>     BP       Device pointer to the first matrix B_1 on the GPU of dimension (ldb, k)
+  !>     @param[in] BP - Device pointer to the first matrix B_1 on the GPU of dimension (ldb, k)
   !>             when trans is HIPBLAS_OP_N. Otherwise, of dimension (ldb, n).
   !>
-  !>     @param[in]
-  !>     ldb     [int]
+  !>     @param[in] ldb - [int]
   !>             ldb specifies the first dimension of B_i.
   !>             If trans = HIPBLAS_OP_N,  ldb >= max( 1, n ).
   !>             Otherwise, ldb >= max( 1, k ).
   !>
-  !>     @param[in]
-  !>     strideB  [hipblasStride]
+  !>     @param[in] strideB - [hipblasStride]
   !>               stride from the start of one matrix (B_i) to the next one (B_i+1).
   !>
-  !>     @param[in]
-  !>     beta
+  !>     @param[in] beta
   !>             beta specifies the scalar beta. When beta is
   !>             zero, then C does not need to be set before entry.
   !>
-  !>     @param[in]
-  !>     CP       Device pointer to the first matrix C_1 on the GPU.
+  !>     @param[in] CP - Device pointer to the first matrix C_1 on the GPU.
   !>
-  !>     @param[in]
-  !>     ldc    [int]
+  !>     @param[in] ldc - [int]
   !>            ldc specifies the first dimension of C. ldc >= max( 1, n ).
   !>
-  !>     @param[inout]
-  !>     strideC  [hipblasStride]
+  !>     @param[inout] strideC - [hipblasStride]
   !>               stride from the start of one matrix (C_i) to the next one (C_i+1).
   !>
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasSsyrkxStridedBatched
@@ -32283,39 +30869,26 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : ``s``, ``d``, ``c``, and ``z``.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     transA    [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>               specifies the form of op( A ).
-  !>     @param[in]
-  !>     transB    [hipblasOperation_t]
+  !>     @param[in] transB - [hipblasOperation_t]
   !>               specifies the form of op( B ).
-  !>     @param[in]
-  !>     m         [int]
+  !>     @param[in] m - [int]
   !>               matrix dimension m.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               matrix dimension n.
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer specifying the scalar alpha.
-  !>     @param[in]
-  !>     AP         device pointer storing matrix A.
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[in] alpha - device pointer or host pointer specifying the scalar alpha.
+  !>     @param[in] AP - device pointer storing matrix A.
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of A.
-  !>     @param[in]
-  !>     beta      device pointer or host pointer specifying the scalar beta.
-  !>     @param[in]
-  !>     BP         device pointer storing matrix B.
-  !>     @param[in]
-  !>     ldb       [int]
+  !>     @param[in] beta - device pointer or host pointer specifying the scalar beta.
+  !>     @param[in] BP - device pointer storing matrix B.
+  !>     @param[in] ldb - [int]
   !>               specifies the leading dimension of B.
-  !>     @param[in, out]
-  !>     CP         device pointer storing matrix C.
-  !>     @param[in]
-  !>     ldc       [int]
+  !>     @param[in, out] CP - device pointer storing matrix C.
+  !>     @param[in] ldc - [int]
   !>               specifies the leading dimension of C.
   interface hipblasSgeam
 #ifdef USE_CUDA_NAMES
@@ -32586,50 +31159,36 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     transA    [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>               specifies the form of op( A ).
-  !>     @param[in]
-  !>     transB    [hipblasOperation_t]
+  !>     @param[in] transB - [hipblasOperation_t]
   !>               specifies the form of op( B ).
-  !>     @param[in]
-  !>     m         [int]
+  !>     @param[in] m - [int]
   !>               matrix dimension m.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               matrix dimension n.
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer specifying the scalar alpha.
-  !>     @param[in]
-  !>     AP        device array of device pointers storing each matrix A_i on the GPU.
+  !>     @param[in] alpha - device pointer or host pointer specifying the scalar alpha.
+  !>     @param[in] AP - device array of device pointers storing each matrix A_i on the GPU.
   !>               Each A_i is of dimension ( lda, k ), where k is m
   !>               when  transA == HIPBLAS_OP_N and
   !>               is  n  when  transA == HIPBLAS_OP_T.
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of A.
-  !>     @param[in]
-  !>     beta      device pointer or host pointer specifying the scalar beta.
-  !>     @param[in]
-  !>     BP         device array of device pointers storing each matrix B_i on the GPU.
+  !>     @param[in] beta - device pointer or host pointer specifying the scalar beta.
+  !>     @param[in] BP - device array of device pointers storing each matrix B_i on the GPU.
   !>               Each B_i is of dimension ( ldb, k ), where k is m
   !>               when  transB == HIPBLAS_OP_N and
   !>               is  n  when  transB == HIPBLAS_OP_T.
-  !>     @param[in]
-  !>     ldb       [int]
+  !>     @param[in] ldb - [int]
   !>               specifies the leading dimension of B.
-  !>     @param[in, out]
-  !>     CP         device array of device pointers storing each matrix C_i on the GPU.
+  !>     @param[in, out] CP - device array of device pointers storing each matrix C_i on the GPU.
   !>               Each C_i is of dimension ( ldc, n ).
-  !>     @param[in]
-  !>     ldc       [int]
+  !>     @param[in] ldc - [int]
   !>               specifies the leading dimension of C.
   !>
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances i in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasSgeamBatched
@@ -32865,74 +31424,57 @@ module hipfort_hipblas
   !>     - Supported precisions in cuBLAS  : No support.
   !>
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     transA    [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>               specifies the form of op( A ).
   !>
-  !>     @param[in]
-  !>     transB    [hipblasOperation_t]
+  !>     @param[in] transB - [hipblasOperation_t]
   !>               specifies the form of op( B ).
   !>
-  !>     @param[in]
-  !>     m         [int]
+  !>     @param[in] m - [int]
   !>               matrix dimension m.
   !>
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               matrix dimension n.
   !>
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer specifying the scalar alpha.
+  !>     @param[in] alpha - device pointer or host pointer specifying the scalar alpha.
   !>
-  !>     @param[in]
-  !>     AP        device pointer to the first matrix A_0 on the GPU.
+  !>     @param[in] AP - device pointer to the first matrix A_0 on the GPU.
   !>               Each A_i is of dimension ( lda, k ), where k is m
   !>               when  transA == HIPBLAS_OP_N and
   !>               is  n  when  transA == HIPBLAS_OP_T.
   !>
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of A.
   !>
-  !>     @param[in]
-  !>     strideA  [hipblasStride]
+  !>     @param[in] strideA - [hipblasStride]
   !>               stride from the start of one matrix (A_i) to the next one (A_i+1).
   !>
-  !>     @param[in]
-  !>     beta      device pointer or host pointer specifying the scalar beta.
+  !>     @param[in] beta - device pointer or host pointer specifying the scalar beta.
   !>
-  !>     @param[in]
-  !>     BP        pointer to the first matrix B_0 on the GPU.
+  !>     @param[in] BP - pointer to the first matrix B_0 on the GPU.
   !>               Each B_i is of dimension ( ldb, k ), where k is m
   !>               when  transB == HIPBLAS_OP_N and
   !>               is  n  when  transB == HIPBLAS_OP_T.
   !>
-  !>     @param[in]
-  !>     ldb       [int]
+  !>     @param[in] ldb - [int]
   !>               specifies the leading dimension of B.
   !>
-  !>     @param[in]
-  !>     strideB  [hipblasStride]
+  !>     @param[in] strideB - [hipblasStride]
   !>               stride from the start of one matrix (B_i) to the next one (B_i+1).
   !>
-  !>     @param[in, out]
-  !>     CP         pointer to the first matrix C_0 on the GPU.
+  !>     @param[in, out] CP - pointer to the first matrix C_0 on the GPU.
   !>               Each C_i is of dimension ( ldc, n ).
   !>
-  !>     @param[in]
-  !>     ldc       [int]
+  !>     @param[in] ldc - [int]
   !>               specifies the leading dimension of C.
   !>
-  !>     @param[in]
-  !>     strideC  [hipblasStride]
+  !>     @param[in] strideC - [hipblasStride]
   !>               stride from the start of one matrix (C_i) to the next one (C_i+1).
   !>
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances i in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasSgeamStridedBatched
@@ -33217,65 +31759,52 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``c`` and ``z``.
   !>     - Supported precisions in cuBLAS  : ``c`` and ``z``.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     side  [hipblasSideMode_t]
+  !>     @param[in] side - [hipblasSideMode_t]
   !>             - HIPBLAS_SIDE_LEFT:      C := alpha*A*B + beta*C
   !>             - HIPBLAS_SIDE_RIGHT:     C := alpha*B*A + beta*C
   !>
-  !>     @param[in]
-  !>     uplo    [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>             - HIPBLAS_FILL_MODE_UPPER:  A is an upper triangular matrix.
   !>             - HIPBLAS_FILL_MODE_LOWER:  A is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     n       [int]
+  !>     @param[in] n - [int]
   !>             n specifies the number of rows of B and C. n >= 0.
   !>
-  !>     @param[in]
-  !>     k       [int]
+  !>     @param[in] k - [int]
   !>             n specifies the number of columns of B and C. k >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             alpha specifies the scalar alpha. When alpha is
   !>             zero, then A and B are not referenced.
   !>
-  !>     @param[in]
-  !>     AP      pointer storing matrix A on the GPU.
+  !>     @param[in] AP - pointer storing matrix A on the GPU.
   !>             - A is m by m if side == HIPBLAS_SIDE_LEFT.
   !>             - A is n by n if side == HIPBLAS_SIDE_RIGHT.
   !>             - Only the upper/lower triangular part is accessed.
   !>             - The imaginary component of the diagonal elements is not used.
   !>
-  !>     @param[in]
-  !>     lda     [int]
+  !>     @param[in] lda - [int]
   !>             lda specifies the first dimension of A.
   !>             If side = HIPBLAS_SIDE_LEFT,  lda >= max( 1, m ).
   !>             Otherwise, lda >= max( 1, n ).
   !>
-  !>     @param[in]
-  !>     BP      pointer storing matrix B on the GPU.
+  !>     @param[in] BP - pointer storing matrix B on the GPU.
   !>             Matrix dimension is m by n.
   !>
-  !>     @param[in]
-  !>     ldb     [int]
+  !>     @param[in] ldb - [int]
   !>             ldb specifies the first dimension of B. ldb >= max( 1, m ).
   !>
-  !>     @param[in]
-  !>     beta
+  !>     @param[in] beta
   !>             beta specifies the scalar beta. When beta is
   !>             zero, then C does not need to be set before entry.
   !>
-  !>     @param[in]
-  !>     CP      pointer storing matrix C on the GPU.
+  !>     @param[in] CP - pointer storing matrix C on the GPU.
   !>             Matrix dimension is m by n.
   !>
-  !>     @param[in]
-  !>     ldc    [int]
+  !>     @param[in] ldc - [int]
   !>            ldc specifies the first dimension of C. ldc >= max( 1, m ).
   interface hipblasChemm
 #ifdef USE_CUDA_NAMES
@@ -33419,69 +31948,55 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``c`` and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     side  [hipblasSideMode_t]
+  !>     @param[in] side - [hipblasSideMode_t]
   !>             - HIPBLAS_SIDE_LEFT:      C_i := alpha*A_i*B_i + beta*C_i
   !>             - HIPBLAS_SIDE_RIGHT:     C_i := alpha*B_i*A_i + beta*C_i
   !>
-  !>     @param[in]
-  !>     uplo    [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>             - HIPBLAS_FILL_MODE_UPPER:  A_i is an upper triangular matrix.
   !>             - HIPBLAS_FILL_MODE_LOWER:  A_i is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     n       [int]
+  !>     @param[in] n - [int]
   !>             n specifies the number of rows of B_i and C_i. n >= 0.
   !>
-  !>     @param[in]
-  !>     k       [int]
+  !>     @param[in] k - [int]
   !>             k specifies the number of columns of B_i and C_i. k >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             alpha specifies the scalar alpha. When alpha is
   !>             zero, then A_i and B_i are not referenced.
   !>
-  !>     @param[in]
-  !>     AP      device array of device pointers storing each matrix A_i on the GPU.
+  !>     @param[in] AP - device array of device pointers storing each matrix A_i on the GPU.
   !>             - A_i is m by m if side == HIPBLAS_SIDE_LEFT.
   !>             - A_i is n by n if side == HIPBLAS_SIDE_RIGHT.
   !>             - Only the upper/lower triangular part is accessed.
   !>             - The imaginary component of the diagonal elements is not used.
   !>
-  !>     @param[in]
-  !>     lda     [int]
+  !>     @param[in] lda - [int]
   !>             lda specifies the first dimension of A_i.
   !>             If side = HIPBLAS_SIDE_LEFT,  lda >= max( 1, m ).
   !>             Otherwise, lda >= max( 1, n ).
   !>
-  !>     @param[in]
-  !>     BP      device array of device pointers storing each matrix B_i on the GPU.
+  !>     @param[in] BP - device array of device pointers storing each matrix B_i on the GPU.
   !>             Matrix dimension is m by n.
   !>
-  !>     @param[in]
-  !>     ldb     [int]
+  !>     @param[in] ldb - [int]
   !>             ldb specifies the first dimension of B_i. ldb >= max( 1, m ).
   !>
-  !>     @param[in]
-  !>     beta
+  !>     @param[in] beta
   !>             beta specifies the scalar beta. When beta is
   !>             zero, then C_i need not be set before entry.
   !>
-  !>     @param[in]
-  !>     CP      device array of device pointers storing each matrix C_i on the GPU.
+  !>     @param[in] CP - device array of device pointers storing each matrix C_i on the GPU.
   !>             Matrix dimension is m by n.
   !>
-  !>     @param[in]
-  !>     ldc    [int]
+  !>     @param[in] ldc - [int]
   !>            ldc specifies the first dimension of C_i. ldc >= max( 1, m ).
   !>
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasChemmBatched
@@ -33605,81 +32120,64 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``c`` and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     side  [hipblasSideMode_t]
+  !>     @param[in] side - [hipblasSideMode_t]
   !>             - HIPBLAS_SIDE_LEFT:      C_i := alpha*A_i*B_i + beta*C_i
   !>             - HIPBLAS_SIDE_RIGHT:     C_i := alpha*B_i*A_i + beta*C_i
   !>
-  !>     @param[in]
-  !>     uplo    [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>             - HIPBLAS_FILL_MODE_UPPER:  A_i is an upper triangular matrix.
   !>             - HIPBLAS_FILL_MODE_LOWER:  A_i is a lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     n       [int]
+  !>     @param[in] n - [int]
   !>             n specifies the number of rows of B_i and C_i. n >= 0.
   !>
-  !>     @param[in]
-  !>     k       [int]
+  !>     @param[in] k - [int]
   !>             k specifies the number of columns of B_i and C_i. k >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             alpha specifies the scalar alpha. When alpha is
   !>             zero, then A_i and B_i are not referenced.
   !>
-  !>     @param[in]
-  !>     AP      device pointer to first matrix A_1
+  !>     @param[in] AP - device pointer to first matrix A_1
   !>             - A_i is m by m if side == HIPBLAS_SIDE_LEFT.
   !>             - A_i is n by n if side == HIPBLAS_SIDE_RIGHT.
   !>             - Only the upper/lower triangular part is accessed.
   !>             - The imaginary component of the diagonal elements is not used.
   !>
-  !>     @param[in]
-  !>     lda     [int]
+  !>     @param[in] lda - [int]
   !>             lda specifies the first dimension of A_i.
   !>             If side = HIPBLAS_SIDE_LEFT,  lda >= max( 1, m ).
   !>             Otherwise, lda >= max( 1, n ).
   !>
-  !>     @param[in]
-  !>     strideA  [hipblasStride]
+  !>     @param[in] strideA - [hipblasStride]
   !>               stride from the start of one matrix (A_i) to the next one (A_i+1).
   !>
-  !>     @param[in]
-  !>     BP       device pointer to first matrix B_1 of dimension (ldb, n) on the GPU.
+  !>     @param[in] BP - device pointer to first matrix B_1 of dimension (ldb, n) on the GPU.
   !>
-  !>     @param[in]
-  !>     ldb     [int]
+  !>     @param[in] ldb - [int]
   !>             ldb specifies the first dimension of B_i.
   !>             If side = HIPBLAS_OP_N,  ldb >= max( 1, m ).
   !>             Otherwise, ldb >= max( 1, n ).
   !>
-  !>     @param[in]
-  !>     strideB  [hipblasStride]
+  !>     @param[in] strideB - [hipblasStride]
   !>               stride from the start of one matrix (B_i) to the next one (B_i+1).
   !>
-  !>     @param[in]
-  !>     beta
+  !>     @param[in] beta
   !>             beta specifies the scalar beta. When beta is
   !>             zero, then C does not need to be set before entry.
   !>
-  !>     @param[in]
-  !>     CP        device pointer to first matrix C_1 of dimension (ldc, n) on the GPU.
+  !>     @param[in] CP - device pointer to first matrix C_1 of dimension (ldc, n) on the GPU.
   !>
-  !>     @param[in]
-  !>     ldc    [int]
+  !>     @param[in] ldc - [int]
   !>            ldc specifies the first dimension of C. ldc >= max( 1, m ).
   !>
-  !>     @param[inout]
-  !>     strideC  [hipblasStride]
+  !>     @param[inout] strideC - [hipblasStride]
   !>               stride from the start of one matrix (C_i) to the next one (C_i+1).
   !>
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasChemmStridedBatched
@@ -33835,51 +32333,42 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : ``s``, ``d``, ``c``, and ``z``.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     side    [hipblasSideMode_t]
+  !>     @param[in] side - [hipblasSideMode_t]
   !>             Specifies whether op(A) multiplies B from the left or right as follows:
   !>             - HIPBLAS_SIDE_LEFT:       C := alpha*op( A )*B.
   !>             - HIPBLAS_SIDE_RIGHT:      C := alpha*B*op( A ).
   !>
-  !>     @param[in]
-  !>     uplo    [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>             Specifies whether the matrix A is an upper or lower triangular matrix as follows:
   !>             - HIPBLAS_FILL_MODE_UPPER:  A is an upper triangular matrix.
   !>             - HIPBLAS_FILL_MODE_LOWER:  A is a lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA  [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>             Specifies the form of op(A) to be used in the matrix multiplication as follows:
   !>             - HIPBLAS_OP_N: op(A) = A.
   !>             - HIPBLAS_OP_T: op(A) = A^T.
   !>             - HIPBLAS_OP_C: op(A) = A^H.
   !>
-  !>     @param[in]
-  !>     diag    [hipblasDiagType_t]
+  !>     @param[in] diag - [hipblasDiagType_t]
   !>             Specifies whether or not A is unit triangular as follows:
   !>             - HIPBLAS_DIAG_UNIT:      A is assumed to be unit triangular.
   !>             - HIPBLAS_DIAG_NON_UNIT:  A is not assumed to be unit triangular.
   !>
-  !>     @param[in]
-  !>     m       [int]
+  !>     @param[in] m - [int]
   !>             m specifies the number of rows of B and C. m >= 0.
   !>
-  !>     @param[in]
-  !>     n       [int]
+  !>     @param[in] n - [int]
   !>             n specifies the number of columns of B and C. n >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             alpha specifies the scalar alpha. When alpha is
   !>             zero, then A is not referenced and B does not need to be set before
   !>             entry.
   !>
-  !>     @param[in]
-  !>     A       Device pointer to matrix A on the GPU.
+  !>     @param[in] A - Device pointer to matrix A on the GPU.
   !>             A has dimension ( lda, k ), where k is m
   !>             when  side == HIPBLAS_SIDE_LEFT  and
   !>             is  n  when  side == HIPBLAS_SIDE_RIGHT.
@@ -33894,25 +32383,20 @@ module hipfort_hipblas
   !>             Note that when  diag == HIPBLAS_DIAG_UNIT,  the diagonal elements of
   !>             A  are not referenced either,  but are assumed to be  unity.
   !>
-  !>     @param[in]
-  !>     lda     [int]
+  !>     @param[in] lda - [int]
   !>             lda specifies the first dimension of A.
   !>             - If side == HIPBLAS_SIDE_LEFT,  lda >= max( 1, m ).
   !>             - If side == HIPBLAS_SIDE_RIGHT, lda >= max( 1, n ).
   !>
-  !>     @param[inout]
-  !>     B       Device pointer to the matrix B of dimension (ldb, n) on the GPU.
+  !>     @param[inout] B - Device pointer to the matrix B of dimension (ldb, n) on the GPU.
   !>
-  !>     @param[in]
-  !>     ldb    [int]
+  !>     @param[in] ldb - [int]
   !>            ldb specifies the first dimension of B. ldb >= max( 1, m ).
   !>
-  !>     @param[in]
-  !>     C      Device pointer to the matrix C of dimension (ldc, n) on the GPU.
+  !>     @param[in] C - Device pointer to the matrix C of dimension (ldc, n) on the GPU.
   !>            Users can pass in the same matrix B to parameter C to achieve
   !>            in-place functionality for trmm.
-  !>     @param[in]
-  !>     ldc    [int]
+  !>     @param[in] ldc - [int]
   !>            ldc specifies the first dimension of C. ldc >= max( 1, m ).
   interface hipblasStrmm
 #ifdef USE_CUDA_NAMES
@@ -34196,51 +32680,42 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     side    [hipblasSideMode_t]
+  !>     @param[in] side - [hipblasSideMode_t]
   !>             Specifies whether op(A_i) multiplies B_i from the left or right as follows:
   !>             - HIPBLAS_SIDE_LEFT:       B_i := alpha*op( A_i )*B_i.
   !>             - HIPBLAS_SIDE_RIGHT:      B_i := alpha*B_i*op( A_i ).
   !>
-  !>     @param[in]
-  !>     uplo    [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>             Specifies whether the matrix A is an upper or lower triangular matrix as follows:
   !>             - HIPBLAS_FILL_MODE_UPPER:  A is an upper triangular matrix.
   !>             - HIPBLAS_FILL_MODE_LOWER:  A is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA  [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>             Specifies the form of op(A_i) to be used in the matrix multiplication as follows:
   !>             - HIPBLAS_OP_N:  op(A_i) = A_i.
   !>             - HIPBLAS_OP_T:  op(A_i) = A_i^T.
   !>             - HIPBLAS_OP_C:  op(A_i) = A_i^H.
   !>
-  !>     @param[in]
-  !>     diag    [hipblasDiagType_t]
+  !>     @param[in] diag - [hipblasDiagType_t]
   !>             Specifies whether or not A_i is unit triangular as follows:
   !>             - HIPBLAS_DIAG_UNIT:      A_i is assumed to be unit triangular.
   !>             - HIPBLAS_DIAG_NON_UNIT:  A_i is not assumed to be unit triangular.
   !>
-  !>     @param[in]
-  !>     m       [int]
+  !>     @param[in] m - [int]
   !>             m specifies the number of rows of B_i and C_i. m >= 0.
   !>
-  !>     @param[in]
-  !>     n       [int]
+  !>     @param[in] n - [int]
   !>             n specifies the number of columns of B_i and C_i. n >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             alpha specifies the scalar alpha. When alpha is
   !>             zero, then A_i is not referenced and B_i does not need to be set before
   !>             entry.
   !>
-  !>     @param[in]
-  !>     A       Device array of device pointers storing each matrix A_i on the GPU.
+  !>     @param[in] A - Device array of device pointers storing each matrix A_i on the GPU.
   !>             Each A_i is of dimension ( lda, k ), where k is m
   !>             when  side == HIPBLAS_SIDE_LEFT  and
   !>             is  n  when  side == HIPBLAS_SIDE_RIGHT.
@@ -34255,30 +32730,24 @@ module hipfort_hipblas
   !>             - Note that when  diag == HIPBLAS_DIAG_UNIT,  the diagonal elements of
   !>             A_i  are not referenced either,  but are assumed to be  unity.
   !>
-  !>     @param[in]
-  !>     lda     [int]
+  !>     @param[in] lda - [int]
   !>             lda specifies the first dimension of A.
   !>             - If side == HIPBLAS_SIDE_LEFT,  lda >= max( 1, m ).
   !>             - If side == HIPBLAS_SIDE_RIGHT, lda >= max( 1, n ).
   !>
-  !>     @param[inout]
-  !>     B       device array of device pointers storing each matrix B_i of
+  !>     @param[inout] B - device array of device pointers storing each matrix B_i of
   !>             dimension (ldb, n) on the GPU.
   !>
-  !>     @param[in]
-  !>     ldb    [int]
+  !>     @param[in] ldb - [int]
   !>            ldb specifies the first dimension of B_i. ldb >= max( 1, m ).
   !>
-  !>     @param[in]
-  !>     C      device array of device pointers storing each matrix C_i of
+  !>     @param[in] C - device array of device pointers storing each matrix C_i of
   !>            dimension (ldc, n) on the GPU. Users can pass in the same
   !>            matrices B to parameter C to achieve in-place functionality of trmmBatched.
   !>
-  !>     @param[in]
-  !>     ldc    ldc specifies the first dimension of C_i. ldc >= max( 1, m ).
+  !>     @param[in] ldc - ldc specifies the first dimension of C_i. ldc >= max( 1, m ).
   !>
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances i in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasStrmmBatched
@@ -34527,51 +32996,42 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     side    [hipblasSideMode_t]
+  !>     @param[in] side - [hipblasSideMode_t]
   !>             Specifies whether op(A_i) multiplies B_i from the left or right as follows:
   !>             - HIPBLAS_SIDE_LEFT:       C_i := alpha*op( A_i )*B_i.
   !>             - HIPBLAS_SIDE_RIGHT:      C_i := alpha*B_i*op( A_i ).
   !>
-  !>     @param[in]
-  !>     uplo    [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>             Specifies whether the matrix A is an upper or lower triangular matrix as follows:
   !>             - HIPBLAS_FILL_MODE_UPPER:  A is an upper triangular matrix.
   !>             - HIPBLAS_FILL_MODE_LOWER:  A is a lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA  [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>             Specifies the form of op(A_i) to be used in the matrix multiplication as follows:
   !>             - HIPBLAS_OP_N:  op(A_i) = A_i.
   !>             - HIPBLAS_OP_T:  op(A_i) = A_i^T.
   !>             - HIPBLAS_OP_C:  op(A_i) = A_i^H.
   !>
-  !>     @param[in]
-  !>     diag    [hipblasDiagType_t]
+  !>     @param[in] diag - [hipblasDiagType_t]
   !>             Specifies whether or not A_i is unit triangular as follows:
   !>             - HIPBLAS_DIAG_UNIT:      A_i is assumed to be unit triangular.
   !>             - HIPBLAS_DIAG_NON_UNIT:  A_i is not assumed to be unit triangular.
   !>
-  !>     @param[in]
-  !>     m       [int]
+  !>     @param[in] m - [int]
   !>             m specifies the number of rows of B_i and C_i. m >= 0.
   !>
-  !>     @param[in]
-  !>     n       [int]
+  !>     @param[in] n - [int]
   !>             n specifies the number of columns of B_i and C_i. n >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             alpha specifies the scalar alpha. When alpha is
   !>             zero, then A_i is not referenced and B_i does not need to be set before
   !>             entry.
   !>
-  !>     @param[in]
-  !>     A       Device pointer to the first matrix A_0 on the GPU.
+  !>     @param[in] A - Device pointer to the first matrix A_0 on the GPU.
   !>             Each A_i is of dimension ( lda, k ), where k is m
   !>             when side == HIPBLAS_SIDE_LEFT and
   !>             is n when side == HIPBLAS_SIDE_RIGHT.
@@ -34586,42 +33046,33 @@ module hipfort_hipblas
   !>             - Note that when diag == HIPBLAS_DIAG_UNIT, the diagonal elements of
   !>             A_i are not referenced either, but are assumed to be unity.
   !>
-  !>     @param[in]
-  !>     lda     [int]
+  !>     @param[in] lda - [int]
   !>             lda specifies the first dimension of A.
   !>             - if side == HIPBLAS_SIDE_LEFT,  lda >= max( 1, m ).
   !>             - if side == HIPBLAS_SIDE_RIGHT, lda >= max( 1, n ).
   !>
-  !>     @param[in]
-  !>     strideA  [hipblasStride]
+  !>     @param[in] strideA - [hipblasStride]
   !>               stride from the start of one matrix (A_i) to the next one (A_i+1).
   !>
-  !>     @param[inout]
-  !>     B      Device pointer to the first matrix B_0 on the GPU. Each B_i is of
+  !>     @param[inout] B - Device pointer to the first matrix B_0 on the GPU. Each B_i is of
   !>            dimension ( ldb, n ).
   !>
-  !>     @param[in]
-  !>     ldb    [int]
+  !>     @param[in] ldb - [int]
   !>            ldb specifies the first dimension of B_i. ldb >= max( 1, m ).
   !>
-  !>     @param[in]
-  !>     strideB  [hipblasStride]
+  !>     @param[in] strideB - [hipblasStride]
   !>               stride from the start of one matrix (B_i) to the next one (B_i+1).
   !>
-  !>     @param[in]
-  !>     C      Device pointer to the first matrix C_0 on the GPU. Each C_i is of
+  !>     @param[in] C - Device pointer to the first matrix C_0 on the GPU. Each C_i is of
   !>            dimension ( ldc, n ).
   !>
-  !>     @param[in]
-  !>     ldc    [int]
+  !>     @param[in] ldc - [int]
   !>            ldc specifies the first dimension of C_i. ldc >= max( 1, m ).
   !>
-  !>     @param[in]
-  !>     strideC [hipblasStride]
+  !>     @param[in] strideC - [hipblasStride]
   !>             stride from the start of one matrix (C_i) to the next one (C_i+1).
   !>
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances i in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasStrmmStridedBatched
@@ -34925,63 +33376,51 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : ``s``, ``d``, ``c``, and ``z``.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     side    [hipblasSideMode_t]
+  !>     @param[in] side - [hipblasSideMode_t]
   !>             - HIPBLAS_SIDE_LEFT:       op(A)*X = alpha*B.
   !>             - HIPBLAS_SIDE_RIGHT:      X*op(A) = alpha*B.
   !>
-  !>     @param[in]
-  !>     uplo    [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>             - HIPBLAS_FILL_MODE_UPPER:  A is an upper triangular matrix.
   !>             - HIPBLAS_FILL_MODE_LOWER:  A is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA  [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>             - HIPBLAS_OP_N: op(A) = A.
   !>             - HIPBLAS_OP_T: op(A) = A^T.
   !>             - HIPBLAS_OP_C: op(A) = A^H.
   !>
-  !>     @param[in]
-  !>     diag    [hipblasDiagType_t]
+  !>     @param[in] diag - [hipblasDiagType_t]
   !>             - HIPBLAS_DIAG_UNIT:     A is assumed to be unit triangular.
   !>             - HIPBLAS_DIAG_NON_UNIT:  A is not assumed to be unit triangular.
   !>
-  !>     @param[in]
-  !>     m       [int]
+  !>     @param[in] m - [int]
   !>             m specifies the number of rows of B. m >= 0.
   !>
-  !>     @param[in]
-  !>     n       [int]
+  !>     @param[in] n - [int]
   !>             n specifies the number of columns of B. n >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             device pointer or host pointer specifying the scalar alpha. When alpha is
   !>             &zero, then A is not referenced and B does not need to be set before
   !>             entry.
   !>
-  !>     @param[in]
-  !>     AP      device pointer storing matrix A.
+  !>     @param[in] AP - device pointer storing matrix A.
   !>             Of dimension ( lda, k ), where k is m
   !>             when  HIPBLAS_SIDE_LEFT  and
   !>             is  n  when  HIPBLAS_SIDE_RIGHT.
   !>             Only the upper/lower triangular part is accessed.
   !>
-  !>     @param[in]
-  !>     lda     [int]
+  !>     @param[in] lda - [int]
   !>             lda specifies the first dimension of A.
   !>             - If side = HIPBLAS_SIDE_LEFT,  lda >= max( 1, m ).
   !>             - If side = HIPBLAS_SIDE_RIGHT, lda >= max( 1, n ).
   !>
-  !>     @param[in,out]
-  !>     BP       device pointer storing matrix B.
+  !>     @param[in,out] BP - device pointer storing matrix B.
   !>
-  !>     @param[in]
-  !>     ldb    [int]
+  !>     @param[in] ldb - [int]
   !>            ldb specifies the first dimension of B. ldb >= max( 1, m ).
   interface hipblasStrsm
 #ifdef USE_CUDA_NAMES
@@ -35252,54 +33691,41 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : ``s``, ``d``, ``c``, and ``z``.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     side    [hipblasSideMode_t]
+  !>     @param[in] side - [hipblasSideMode_t]
   !>             - HIPBLAS_SIDE_LEFT:       op(A)*X = alpha*B.
   !>             - HIPBLAS_SIDE_RIGHT:      X*op(A) = alpha*B.
-  !>     @param[in]
-  !>     uplo    [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>             - HIPBLAS_FILL_MODE_UPPER:  each A_i is an upper triangular matrix.
   !>             - HIPBLAS_FILL_MODE_LOWER:  each A_i is a lower triangular matrix.
-  !>     @param[in]
-  !>     transA  [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>             - HIPBLAS_OP_N: op(A) = A.
   !>             - HIPBLAS_OP_T: op(A) = A^T.
   !>             - HIPBLAS_OP_C: op(A) = A^H.
-  !>     @param[in]
-  !>     diag    [hipblasDiagType_t]
+  !>     @param[in] diag - [hipblasDiagType_t]
   !>             - HIPBLAS_DIAG_UNIT:     each A_i is assumed to be unit triangular.
   !>             - HIPBLAS_DIAG_NON_UNIT:  each A_i is not assumed to be unit triangular.
-  !>     @param[in]
-  !>     m       [int]
+  !>     @param[in] m - [int]
   !>             m specifies the number of rows of each B_i. m >= 0.
-  !>     @param[in]
-  !>     n       [int]
+  !>     @param[in] n - [int]
   !>             n specifies the number of columns of each B_i. n >= 0.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             device pointer or host pointer specifying the scalar alpha. When alpha is
   !>             &zero, then A is not referenced and B does not need to be set before
   !>             entry.
-  !>     @param[in]
-  !>     AP      device array of device pointers storing each matrix A_i on the GPU.
+  !>     @param[in] AP - device array of device pointers storing each matrix A_i on the GPU.
   !>             Matricies are of dimension ( lda, k ), where k is m
   !>             when  HIPBLAS_SIDE_LEFT  and is  n  when  HIPBLAS_SIDE_RIGHT.
   !>             Only the upper/lower triangular part is accessed.
-  !>     @param[in]
-  !>     lda     [int]
+  !>     @param[in] lda - [int]
   !>             lda specifies the first dimension of each A_i.
   !>             - If side = HIPBLAS_SIDE_LEFT,  lda >= max( 1, m ).
   !>             - If side = HIPBLAS_SIDE_RIGHT, lda >= max( 1, n ).
-  !>     @param[in,out]
-  !>     BP       device array of device pointers storing each matrix B_i on the GPU.
-  !>     @param[in]
-  !>     ldb    [int]
+  !>     @param[in,out] BP - device array of device pointers storing each matrix B_i on the GPU.
+  !>     @param[in] ldb - [int]
   !>            ldb specifies the first dimension of each B_i. ldb >= max( 1, m ).
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of trsm operatons in the batch.
   interface hipblasStrsmBatched
 #ifdef USE_CUDA_NAMES
@@ -35558,61 +33984,46 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     side    [hipblasSideMode_t]
+  !>     @param[in] side - [hipblasSideMode_t]
   !>             - HIPBLAS_SIDE_LEFT:       op(A)*X = alpha*B.
   !>             - HIPBLAS_SIDE_RIGHT:      X*op(A) = alpha*B.
-  !>     @param[in]
-  !>     uplo    [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>             - HIPBLAS_FILL_MODE_UPPER:  each A_i is an upper triangular matrix.
   !>             - HIPBLAS_FILL_MODE_LOWER:  each A_i is a  lower triangular matrix.
-  !>     @param[in]
-  !>     transA  [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>             - HIPBLAS_OP_N: op(A) = A.
   !>             - HIPBLAS_OP_T: op(A) = A^T.
   !>             - HIPBLAS_OP_C: op(A) = A^H.
-  !>     @param[in]
-  !>     diag    [hipblasDiagType_t]
+  !>     @param[in] diag - [hipblasDiagType_t]
   !>             - HIPBLAS_DIAG_UNIT:     each A_i is assumed to be unit triangular.
   !>             - HIPBLAS_DIAG_NON_UNIT:  each A_i is not assumed to be unit triangular.
-  !>     @param[in]
-  !>     m       [int]
+  !>     @param[in] m - [int]
   !>             m specifies the number of rows of each B_i. m >= 0.
-  !>     @param[in]
-  !>     n       [int]
+  !>     @param[in] n - [int]
   !>             n specifies the number of columns of each B_i. n >= 0.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             device pointer or host pointer specifying the scalar alpha. When alpha is
   !>             &zero, then A is not referenced and B does not need to be set before
   !>             entry.
-  !>     @param[in]
-  !>     AP      device pointer pointing to the first matrix A_1.
+  !>     @param[in] AP - device pointer pointing to the first matrix A_1.
   !>             Of dimension ( lda, k ), where k is m
   !>             when  HIPBLAS_SIDE_LEFT  and
   !>             is  n  when  HIPBLAS_SIDE_RIGHT.
   !>             Only the upper/lower triangular part is accessed.
-  !>     @param[in]
-  !>     lda     [int]
+  !>     @param[in] lda - [int]
   !>             lda specifies the first dimension of each A_i.
   !>             - If side = HIPBLAS_SIDE_LEFT,  lda >= max( 1, m ).
   !>             - If side = HIPBLAS_SIDE_RIGHT, lda >= max( 1, n ).
-  !>     @param[in]
-  !>     strideA [hipblasStride]
+  !>     @param[in] strideA - [hipblasStride]
   !>              stride from the start of one A_i matrix to the next A_(i + 1).
-  !>     @param[in,out]
-  !>     BP       device pointer pointing to the first matrix B_1.
-  !>     @param[in]
-  !>     ldb    [int]
+  !>     @param[in,out] BP - device pointer pointing to the first matrix B_1.
+  !>     @param[in] ldb - [int]
   !>            ldb specifies the first dimension of each B_i. ldb >= max( 1, m ).
-  !>     @param[in]
-  !>     strideB [hipblasStride]
+  !>     @param[in] strideB - [hipblasStride]
   !>              stride from the start of one B_i matrix to the next B_(i + 1).
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of trsm operatons in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasStrsmStridedBatched
@@ -35878,31 +34289,23 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>               specifies either upper (HIPBLAS_FILL_MODE_UPPER) or lower
   !>               (HIPBLAS_FILL_MODE_LOWER):
   !>               - If HIPBLAS_FILL_MODE_UPPER, the lower part of A is not referenced.
   !>               - If HIPBLAS_FILL_MODE_LOWER, the upper part of A is not referenced.
-  !>     @param[in]
-  !>     diag      [hipblasDiagType_t]
+  !>     @param[in] diag - [hipblasDiagType_t]
   !>               - 'HIPBLAS_DIAG_NON_UNIT', A is non-unit triangular.
   !>               - 'HIPBLAS_DIAG_UNIT', A is unit triangular.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               size of matrix A and invA.
-  !>     @param[in]
-  !>     AP         device pointer storing matrix A.
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[in] AP - device pointer storing matrix A.
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of A.
-  !>     @param[out]
-  !>     invA      device pointer storing matrix invA.
-  !>     @param[in]
-  !>     ldinvA    [int]
+  !>     @param[out] invA - device pointer storing matrix invA.
+  !>     @param[in] ldinvA - [int]
   !>               specifies the leading dimension of invA.
 #ifndef USE_CUDA_NAMES
   interface hipblasStrtri
@@ -36018,26 +34421,19 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>               specifies either upper (HIPBLAS_FILL_MODE_UPPER) or lower
   !>               (HIPBLAS_FILL_MODE_LOWER):
-  !>     @param[in]
-  !>     diag      [hipblasDiagType_t]
+  !>     @param[in] diag - [hipblasDiagType_t]
   !>               - 'HIPBLAS_DIAG_NON_UNIT', A is non-unit triangular.
   !>               - 'HIPBLAS_DIAG_UNIT', A is unit triangular.
-  !>     @param[in]
-  !>     n         [int]
-  !>     @param[in]
-  !>     AP         device array of device pointers storing each matrix A_i.
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[in] n - [int]
+  !>     @param[in] AP - device array of device pointers storing each matrix A_i.
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of each A_i.
-  !>     @param[out]
-  !>     invA      device array of device pointers storing the inverse of each matrix A_i.
+  !>     @param[out] invA - device array of device pointers storing the inverse of each matrix A_i.
   !>               Partial inplace operation is supported, see below.
   !>               - If UPLO = 'U', the leading N-by-N upper triangular part of the invA will store
   !>               the inverse of the upper triangular matrix, and the strictly lower
@@ -36045,11 +34441,9 @@ module hipfort_hipblas
   !>               - If UPLO = 'L', the leading N-by-N lower triangular part of the invA will store
   !>               the inverse of the lower triangular matrix, and the strictly upper
   !>               triangular part of invA is cleared.
-  !>     @param[in]
-  !>     ldinvA    [int]
+  !>     @param[in] ldinvA - [int]
   !>               specifies the leading dimension of each invA_i.
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>               numbers of matrices in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasStrtriBatched
@@ -36146,29 +34540,21 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>               specifies either upper (HIPBLAS_FILL_MODE_UPPER) or lower
   !>               (HIPBLAS_FILL_MODE_LOWER):
-  !>     @param[in]
-  !>     diag      [hipblasDiagType_t]
+  !>     @param[in] diag - [hipblasDiagType_t]
   !>               - 'HIPBLAS_DIAG_NON_UNIT', A is non-unit triangular.
   !>               - 'HIPBLAS_DIAG_UNIT', A is unit triangular.
-  !>     @param[in]
-  !>     n         [int]
-  !>     @param[in]
-  !>     AP         device pointer pointing to address of first matrix A_1.
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[in] n - [int]
+  !>     @param[in] AP - device pointer pointing to address of first matrix A_1.
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of each A.
-  !>     @param[in]
-  !>     strideA  [hipblasStride]
+  !>     @param[in] strideA - [hipblasStride]
   !>              "batch stride a": stride from the start of one A_i matrix to the next A_(i + 1).
-  !>     @param[out]
-  !>     invA      device pointer storing the inverses of each matrix A_i.
+  !>     @param[out] invA - device pointer storing the inverses of each matrix A_i.
   !>               Partial inplace operation is supported, see below.
   !>               - If UPLO = 'U', the leading N-by-N upper triangular part of the invA will store
   !>               the inverse of the upper triangular matrix, and the strictly lower
@@ -36176,15 +34562,12 @@ module hipfort_hipblas
   !>               - If UPLO = 'L', the leading N-by-N lower triangular part of the invA will store
   !>               the inverse of the lower triangular matrix, and the strictly upper
   !>               triangular part of invA is cleared.
-  !>     @param[in]
-  !>     ldinvA    [int]
+  !>     @param[in] ldinvA - [int]
   !>               specifies the leading dimension of each invA_i.
-  !>     @param[in]
-  !>     stride_invA  [hipblasStride]
+  !>     @param[in] stride_invA - [hipblasStride]
   !>                  "batch stride invA": stride from the start of one invA_i matrix to the next
   !>                  invA_(i + 1).
-  !>     @param[in]
-  !>     batchCount  [int]
+  !>     @param[in] batchCount - [int]
   !>                  numbers of matrices in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasStrtriStridedBatched
@@ -36327,32 +34710,22 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : ``s``, ``d``, ``c``, and ``z``.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     side      [hipblasSideMode_t]
+  !>     @param[in] side - [hipblasSideMode_t]
   !>               specifies the side of diag(x).
-  !>     @param[in]
-  !>     m         [int]
+  !>     @param[in] m - [int]
   !>               matrix dimension m.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               matrix dimension n.
-  !>     @param[in]
-  !>     AP         device pointer storing matrix A.
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[in] AP - device pointer storing matrix A.
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of A.
-  !>     @param[in]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] x - device pointer storing vector x.
+  !>     @param[in] incx - [int]
   !>               specifies the increment between values of x
-  !>     @param[in, out]
-  !>     CP         device pointer storing matrix C.
-  !>     @param[in]
-  !>     ldc       [int]
+  !>     @param[in, out] CP - device pointer storing matrix C.
+  !>     @param[in] ldc - [int]
   !>               specifies the leading dimension of C.
   interface hipblasSdgmm
 #ifdef USE_CUDA_NAMES
@@ -36583,39 +34956,28 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     side      [hipblasSideMode_t]
+  !>     @param[in] side - [hipblasSideMode_t]
   !>               specifies the side of diag(x).
-  !>     @param[in]
-  !>     m         [int]
+  !>     @param[in] m - [int]
   !>               matrix dimension m.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               matrix dimension n.
-  !>     @param[in]
-  !>     AP         device array of device pointers storing each matrix A_i on the GPU.
+  !>     @param[in] AP - device array of device pointers storing each matrix A_i on the GPU.
   !>               Each A_i is of dimension ( lda, n ).
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of A_i.
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i on the GPU.
+  !>     @param[in] x - device array of device pointers storing each vector x_i on the GPU.
   !>               Each x_i is of dimension n if side == HIPBLAS_SIDE_RIGHT and dimension
   !>               m if side == HIPBLAS_SIDE_LEFT.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] incx - [int]
   !>               specifies the increment between values of x_i.
-  !>     @param[in, out]
-  !>     CP         device array of device pointers storing each matrix C_i on the GPU.
+  !>     @param[in, out] CP - device array of device pointers storing each matrix C_i on the GPU.
   !>               Each C_i is of dimension ( ldc, n ).
-  !>     @param[in]
-  !>     ldc       [int]
+  !>     @param[in] ldc - [int]
   !>               specifies the leading dimension of C_i.
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasSdgmmBatched
@@ -36818,48 +35180,34 @@ module hipfort_hipblas
   !>     - Supported precisions in rocBLAS : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS  : No support.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     side      [hipblasSideMode_t]
+  !>     @param[in] side - [hipblasSideMode_t]
   !>               specifies the side of diag(x).
-  !>     @param[in]
-  !>     m         [int]
+  !>     @param[in] m - [int]
   !>               matrix dimension m.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               matrix dimension n.
-  !>     @param[in]
-  !>     AP         device pointer to the first matrix A_0 on the GPU.
+  !>     @param[in] AP - device pointer to the first matrix A_0 on the GPU.
   !>               Each A_i is of dimension ( lda, n ).
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of A.
-  !>     @param[in]
-  !>     strideA  [hipblasStride]
+  !>     @param[in] strideA - [hipblasStride]
   !>               stride from the start of one matrix (A_i) to the next one (A_i+1).
-  !>     @param[in]
-  !>     x         pointer to the first vector x_0 on the GPU.
+  !>     @param[in] x - pointer to the first vector x_0 on the GPU.
   !>               Each x_i is of dimension n if side == HIPBLAS_SIDE_RIGHT and dimension
   !>               m if side == HIPBLAS_SIDE_LEFT.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] incx - [int]
   !>               specifies the increment between values of x.
-  !>     @param[in]
-  !>     stridex  [hipblasStride]
+  !>     @param[in] stridex - [hipblasStride]
   !>               stride from the start of one vector(x_i) to the next one (x_i+1).
-  !>     @param[in, out]
-  !>     CP         device pointer to the first matrix C_0 on the GPU.
+  !>     @param[in, out] CP - device pointer to the first matrix C_0 on the GPU.
   !>               Each C_i is of dimension ( ldc, n ).
-  !>     @param[in]
-  !>     ldc       [int]
+  !>     @param[in] ldc - [int]
   !>               specifies the leading dimension of C.
-  !>     @param[in]
-  !>     strideC  [hipblasStride]
+  !>     @param[in] strideC - [hipblasStride]
   !>               stride from the start of one matrix (C_i) to the next one (C_i+1).
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances i in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasSdgmmStridedBatched
@@ -37130,29 +35478,23 @@ module hipfort_hipblas
   !>     - Supported precisions in rocSOLVER : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS    : ``s``, ``d``, ``c``, and ``z``.
   !>
-  !>     @param[in]
-  !>     handle    hipblasHandle_t.
-  !>     @param[in]
-  !>     n         int. n >= 0.
+  !>     @param[in] handle - hipblasHandle_t.
+  !>     @param[in] n - int. n >= 0.
   !>               The number of columns and rows of the matrix A.
-  !>     @param[inout]
-  !>     A         pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>               - On entry, the n-by-n matrix A to be factored.
   !>               - On exit, the factors L and U from the factorization.
   !>               - The unit diagonal elements of L are not stored.
-  !>     @param[in]
-  !>     lda       int. lda >= n.
+  !>     @param[in] lda - int. lda >= n.
   !>               Specifies the leading dimension of A.
-  !>     @param[out]
-  !>     ipiv      pointer to int. Array on the GPU of dimension n.
+  !>     @param[out] ipiv - pointer to int. Array on the GPU of dimension n.
   !>               The vector of pivot indices. Elements of ipiv are 1-based indices.
   !>               For 1 <= i <= n, row i of the
   !>               matrix was interchanged with row ipiv[i].
   !>               Matrix P of the factorization can be derived from ipiv.
   !>               This factorization can be done without pivoting if ipiv is passed
   !>               in as a nullptr.
-  !>     @param[out]
-  !>     info      pointer to a int on the GPU.
+  !>     @param[out] myInfo - pointer to a int on the GPU.
   !>               - If info = 0, successful exit.
   !>               - If info = j > 0, U is singular. U[j,j] is the first zero pivot.
 #ifndef USE_CUDA_NAMES
@@ -37277,21 +35619,17 @@ module hipfort_hipblas
   !>     - Supported precisions in rocSOLVER : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS    : ``s``, ``d``, ``c``, and ``z``.
   !>
-  !>     @param[in]
-  !>     handle    hipblasHandle_t.
-  !>     @param[in]
-  !>     n         int. n >= 0.
+  !>     @param[in] handle - hipblasHandle_t.
+  !>     @param[in] n - int. n >= 0.
   !>               The number of columns and rows of all matrices A_i in the batch.
-  !>     @param[inout]
-  !>     A array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>               - On entry, the n-by-n matrices A_i to be factored.
   !>               - On exit, the factors L_i and U_i from the factorizations.
   !>               - The unit diagonal elements of L_i are not stored.
-  !>     @param[in]
-  !>     lda       int. lda >= n.
+  !>     @param[in] lda - int. lda >= n.
   !>               Specifies the leading dimension of matrices A_i.
-  !>     @param[out]
-  !>     ipiv      pointer to int. Array on the GPU.
+  !>     @param[out] ipiv - pointer to int. Array on the GPU.
   !>               Contains the vectors of pivot indices ipiv_i (corresponding to A_i).
   !>               Dimension of ipiv_i is n.
   !>               Elements of ipiv_i are 1-based indices.
@@ -37300,12 +35638,10 @@ module hipfort_hipblas
   !>               Matrix P_i of the factorization can be derived from ipiv_i.
   !>               This factorization can be done without pivoting if ipiv is passed
   !>               in as a nullptr.
-  !>     @param[out]
-  !>     info      pointer to int. Array of batchCount integers on the GPU.
+  !>     @param[out] myInfo - pointer to int. Array of batchCount integers on the GPU.
   !>               - If info[i] = 0, successful exit for factorization of A_i.
   !>               - If info[i] = j > 0, U_i is singular. U_i[j,j] is the first zero pivot.
-  !>     @param[in]
-  !>     batchCount int. batchCount >= 0.
+  !>     @param[in] batchCount - int. batchCount >= 0.
   !>                 Number of matrices in the batch.
   interface hipblasSgetrfBatched
 #ifdef USE_CUDA_NAMES
@@ -37421,26 +35757,22 @@ module hipfort_hipblas
   !>     - Supported precisions in rocSOLVER : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS    : ``s``, ``d``, ``c``, and ``z``.
   !>
-  !>     @param[in]
-  !>     handle    hipblasHandle_t.
-  !>     @param[in]
-  !>     n         int. n >= 0.
+  !>     @param[in] handle - hipblasHandle_t.
+  !>     @param[in] n - int. n >= 0.
   !>               The number of columns and rows of all matrices A_i in the batch.
-  !>     @param[inout]
-  !>     A         pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>               - On entry, the n-by-n matrices A_i to be factored.
   !>               - On exit, the factors L_i and U_i from the factorization.
   !>               - The unit diagonal elements of L_i are not stored.
-  !>     @param[in]
-  !>     lda       int. lda >= n.
+  !>     @param[in] lda - int. lda >= n.
   !>               Specifies the leading dimension of matrices A_i.
-  !>     @param[in]
-  !>     strideA   hipblasStride.
+  !>     @param[in] strideA - hipblasStride.
   !>               Stride from the start of one matrix A_i to the next one A_(i+1).
   !>               There is no restriction for the value of strideA. Normal use case is strideA >=
   !>               lda*n.
-  !>     @param[out]
-  !>     ipiv      pointer to int. Array on the GPU (the size depends on the value of strideP).
+  !>     @param[out] ipiv - pointer to int. Array on the GPU (the size depends on the value of
+  !>     strideP).
   !>               Contains the vectors of pivots indices ipiv_i (corresponding to A_i).
   !>               Dimension of ipiv_i is n.
   !>               Elements of ipiv_i are 1-based indices.
@@ -37449,17 +35781,14 @@ module hipfort_hipblas
   !>               Matrix P_i of the factorization can be derived from ipiv_i.
   !>               The factorization here can be done without pivoting if ipiv is passed
   !>               in as a nullptr.
-  !>     @param[in]
-  !>     strideP   hipblasStride.
+  !>     @param[in] strideP - hipblasStride.
   !>               Stride from the start of one vector ipiv_i to the next one ipiv_(i+1).
   !>               There is no restriction for the value of strideP. Normal use case is strideP >=
   !>               n.
-  !>     @param[out]
-  !>     info      pointer to int. Array of batchCount integers on the GPU.
+  !>     @param[out] myInfo - pointer to int. Array of batchCount integers on the GPU.
   !>               - If info[i] = 0, successful exit for factorization of A_i.
   !>               - If info[i] = j > 0, U_i is singular. U_i[j,j] is the first zero pivot.
-  !>     @param[in]
-  !>     batchCount int. batchCount >= 0.
+  !>     @param[in] batchCount - int. batchCount >= 0.
   !>                 Number of matrices in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasSgetrfStridedBatched
@@ -37595,37 +35924,27 @@ module hipfort_hipblas
   !>     - Supported precisions in cuBLAS    : ``s``, ``d``, ``c``, and ``z``.
   !>
   !>
-  !>     @param[in]
-  !>     handle      hipblasHandle_t.
-  !>     @param[in]
-  !>     trans       hipblasOperation_t.
+  !>     @param[in] handle - hipblasHandle_t.
+  !>     @param[in] trans - hipblasOperation_t.
   !>                 Specifies the form of the system of equations.
-  !>     @param[in]
-  !>     n           int. n >= 0.
+  !>     @param[in] n - int. n >= 0.
   !>                 The order of the system, that is, the number of columns and rows of A.
-  !>     @param[in]
-  !>     nrhs        int. nrhs >= 0.
+  !>     @param[in] nrhs - int. nrhs >= 0.
   !>                 The number of right hand sides, that is, the number of columns
   !>                 of the matrix B.
-  !>     @param[in]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[in] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 The factors L and U of the factorization A = P*L*U returned by `hipblasSgetrf`
   !>                 "getrf".
-  !>     @param[in]
-  !>     lda         int. lda >= n.
+  !>     @param[in] lda - int. lda >= n.
   !>                 The leading dimension of A.
-  !>     @param[in]
-  !>     ipiv        pointer to int. Array on the GPU of dimension n.
+  !>     @param[in] ipiv - pointer to int. Array on the GPU of dimension n.
   !>                 The pivot indices returned by `hipblasSgetrf` "getrf".
-  !>     @param[in,out]
-  !>     B           pointer to type. Array on the GPU of dimension ldb*nrhs.
+  !>     @param[in,out] B - pointer to type. Array on the GPU of dimension ldb*nrhs.
   !>                 - On entry, the right hand side matrix B.
   !>                 - On exit, the solution matrix X.
-  !>     @param[in]
-  !>     ldb         int. ldb >= n.
+  !>     @param[in] ldb - int. ldb >= n.
   !>                 The leading dimension of B.
-  !>     @param[out]
-  !>     info      pointer to a int on the host.
+  !>     @param[out] myInfo - pointer to a int on the host.
   !>               - If info = 0, successful exit.
   !>               - If info = j < 0, the argument at position -j is invalid.
 #ifndef USE_CUDA_NAMES
@@ -37767,44 +36086,34 @@ module hipfort_hipblas
   !>     - Supported precisions in rocSOLVER : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS    : ``s``, ``d``, ``c``, and ``z``.
   !>
-  !>     @param[in]
-  !>     handle      hipblasHandle_t.
-  !>     @param[in]
-  !>     trans       hipblasOperation_t.
+  !>     @param[in] handle - hipblasHandle_t.
+  !>     @param[in] trans - hipblasOperation_t.
   !>                 Specifies the form of the system of equations of each instance in the batch.
-  !>     @param[in]
-  !>     n           int. n >= 0.
+  !>     @param[in] n - int. n >= 0.
   !>                 The order of the system, that is, the number of columns and rows of all A_i
   !>                 matrices.
-  !>     @param[in]
-  !>     nrhs        int. nrhs >= 0.
+  !>     @param[in] nrhs - int. nrhs >= 0.
   !>                 The number of right hand sides, that is, the number of columns
   !>                 of all the matrices B_i.
-  !>     @param[in]
-  !>     A Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[in] A - Array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 The factors L_i and U_i of the factorization A_i = P_i*L_i*U_i returned by
   !>                 `hipblasSgetrfBatched` "getrfBatched".
-  !>     @param[in]
-  !>     lda         int. lda >= n.
+  !>     @param[in] lda - int. lda >= n.
   !>                 The leading dimension of matrices A_i.
-  !>     @param[in]
-  !>     ipiv        pointer to int. Array on the GPU.
+  !>     @param[in] ipiv - pointer to int. Array on the GPU.
   !>                 Contains the vectors ipiv_i of pivot indices returned by `hipblasSgetrfBatched`
   !>                 "getrfBatched".
-  !>     @param[in,out]
-  !>     B Array of pointers to type. Each pointer points to an array on the GPU of dimension
-  !>     ldb*nrhs.
+  !>     @param[in,out] B - Array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension ldb*nrhs.
   !>                 - On entry, the right hand side matrices B_i.
   !>                 - On exit, the solution matrix X_i of each system in the batch.
-  !>     @param[in]
-  !>     ldb         int. ldb >= n.
+  !>     @param[in] ldb - int. ldb >= n.
   !>                 The leading dimension of matrices B_i.
-  !>     @param[out]
-  !>     info      pointer to a int on the host.
+  !>     @param[out] myInfo - pointer to a int on the host.
   !>               - If info = 0, successful exit.
   !>               - If info = j < 0, the argument at position -j is invalid.
-  !>     @param[in]
-  !>     batchCount int. batchCount >= 0.
+  !>     @param[in] batchCount - int. batchCount >= 0.
   !>                 Number of instances (systems) in the batch.
   interface hipblasSgetrsBatched
 #ifdef USE_CUDA_NAMES
@@ -37933,58 +36242,47 @@ module hipfort_hipblas
   !>     - Supported precisions in rocSOLVER : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS    : No support.
   !>
-  !>     @param[in]
-  !>     handle      hipblasHandle_t.
-  !>     @param[in]
-  !>     trans       hipblasOperation_t.
+  !>     @param[in] handle - hipblasHandle_t.
+  !>     @param[in] trans - hipblasOperation_t.
   !>                 Specifies the form of the system of equations of each instance in the batch.
-  !>     @param[in]
-  !>     n           int. n >= 0.
+  !>     @param[in] n - int. n >= 0.
   !>                 The order of the system, that is, the number of columns and rows of all A_i
   !>                 matrices.
-  !>     @param[in]
-  !>     nrhs        int. nrhs >= 0.
+  !>     @param[in] nrhs - int. nrhs >= 0.
   !>                 The number of right hand sides, that is, the number of columns
   !>                 of all the matrices B_i.
-  !>     @param[in]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[in] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 The factors L_i and U_i of the factorization A_i = P_i*L_i*U_i returned by
   !>                 `hipblasSgetrfStridedBatched` "getrfStridedBatched".
-  !>     @param[in]
-  !>     lda         int. lda >= n.
+  !>     @param[in] lda - int. lda >= n.
   !>                 The leading dimension of matrices A_i.
-  !>     @param[in]
-  !>     strideA     hipblasStride.
+  !>     @param[in] strideA - hipblasStride.
   !>                 Stride from the start of one matrix A_i to the next one A_(i+1).
   !>                 There is no restriction for the value of strideA. Normal use case is strideA >=
   !>                 lda*n.
-  !>     @param[in]
-  !>     ipiv        pointer to int. Array on the GPU (the size depends on the value of strideP).
+  !>     @param[in] ipiv - pointer to int. Array on the GPU (the size depends on the value of
+  !>     strideP).
   !>                 Contains the vectors ipiv_i of pivot indices returned by
   !>                 `hipblasSgetrfStridedBatched` "getrfStridedBatched".
-  !>     @param[in]
-  !>     strideP     hipblasStride.
+  !>     @param[in] strideP - hipblasStride.
   !>                 Stride from the start of one vector ipiv_i to the next one ipiv_(i+1).
   !>                 There is no restriction for the value of strideP. Normal use case is strideP >=
   !>                 n.
-  !>     @param[in,out]
-  !>     B           pointer to type. Array on the GPU (size depends on the value of strideB).
+  !>     @param[in,out] B - pointer to type. Array on the GPU (size depends on the value of
+  !>     strideB).
   !>                 - On entry, the right hand side matrices B_i.
   !>                 - On exit, the solution matrix X_i of each system in the batch.
-  !>     @param[in]
-  !>     ldb         int. ldb >= n.
+  !>     @param[in] ldb - int. ldb >= n.
   !>                 The leading dimension of matrices B_i.
-  !>     @param[in]
-  !>     strideB     hipblasStride.
+  !>     @param[in] strideB - hipblasStride.
   !>                 Stride from the start of one matrix B_i to the next one B_(i+1).
   !>                 There is no restriction for the value of strideB. Normal use case is strideB >=
   !>                 ldb*nrhs.
-  !>     @param[out]
-  !>     info      pointer to a int on the host.
+  !>     @param[out] myInfo - pointer to a int on the host.
   !>               - If info = 0, successful exit.
   !>               - If info = j < 0, the argument at position -j is invalid.
-  !>     @param[in]
-  !>     batchCount int. batchCount >= 0.
+  !>     @param[in] batchCount - int. batchCount >= 0.
   !>                 Number of instances (systems) in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasSgetrsStridedBatched
@@ -38140,35 +36438,29 @@ module hipfort_hipblas
   !>     - Supported precisions in rocSOLVER : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS    : ``s``, ``d``, ``c``, and ``z``.
   !>
-  !>     @param[in]
-  !>     handle    hipblasHandle_t.
-  !>     @param[in]
-  !>     n         int. n >= 0.
+  !>     @param[in] handle - hipblasHandle_t.
+  !>     @param[in] n - int. n >= 0.
   !>               The number of rows and columns of all matrices A_i in the batch.
-  !>     @param[in]
-  !>     A array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[in] A - array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>               The factors L_i and U_i of the factorization A_i = P_i*L_i*U_i returned by
   !>               `hipblasSgetrfBatched` "getrfBatched".
-  !>     @param[in]
-  !>     lda       int. lda >= n.
+  !>     @param[in] lda - int. lda >= n.
   !>               Specifies the leading dimension of matrices A_i.
-  !>     @param[in]
-  !>     ipiv      pointer to int. Array on the GPU (the size depends on the value of strideP).
+  !>     @param[in] ipiv - pointer to int. Array on the GPU (the size depends on the value of
+  !>     strideP).
   !>               The pivot indices returned by `hipblasSgetrfBatched` "getrfBatched".
   !>               ipiv can be passed in as a nullptr. This will assume that getrfBatched was called
   !>               without partial pivoting.
-  !>     @param[out]
-  !>     C array of pointers to type. Each pointer points to an array on the GPU of dimension ldc*n.
+  !>     @param[out] C - array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension ldc*n.
   !>               If info[i] = 0, the inverse of matrices A_i. Otherwise, undefined.
-  !>     @param[in]
-  !>     ldc       int. ldc >= n.
+  !>     @param[in] ldc - int. ldc >= n.
   !>               Specifies the leading dimension of C_i.
-  !>     @param[out]
-  !>     info      pointer to int. Array of batchCount integers on the GPU.
+  !>     @param[out] myInfo - pointer to int. Array of batchCount integers on the GPU.
   !>               - If info[i] = 0, successful exit for inversion of A_i.
   !>               - If info[i] = j > 0, U_i is singular. U_i[j,j] is the first zero pivot.
-  !>     @param[in]
-  !>     batchCount int. batchCount >= 0.
+  !>     @param[in] batchCount - int. batchCount >= 0.
   !>                 Number of matrices in the batch.
   interface hipblasSgetriBatched
 #ifdef USE_CUDA_NAMES
@@ -38300,44 +36592,33 @@ module hipfort_hipblas
   !>     - Supported precisions in rocSOLVER : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS    : No support.
   !>
-  !>     @param[in]
-  !>     handle      hipblasHandle_t.
-  !>     @param[in]
-  !>     trans       hipblasOperation_t.
+  !>     @param[in] handle - hipblasHandle_t.
+  !>     @param[in] trans - hipblasOperation_t.
   !>                 Specifies the form of the system of equations.
-  !>     @param[in]
-  !>     m           int. m >= 0.
+  !>     @param[in] m - int. m >= 0.
   !>                 The number of rows of matrix A.
-  !>     @param[in]
-  !>     n           int. n >= 0.
+  !>     @param[in] n - int. n >= 0.
   !>                 The number of columns of matrix A.
-  !>     @param[in]
-  !>     nrhs        int. nrhs >= 0.
+  !>     @param[in] nrhs - int. nrhs >= 0.
   !>                 The number of columns of matrices B and X,
   !>                 that is, the columns on the right hand side.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 - On entry, the matrix A.
   !>                 - On exit, the QR (or LQ) factorization of A as returned by "GEQRF" (or
   !>                 "GELQF").
-  !>     @param[in]
-  !>     lda         int. lda >= m.
+  !>     @param[in] lda - int. lda >= m.
   !>                 Specifies the leading dimension of matrix A.
-  !>     @param[inout]
-  !>     B           pointer to type. Array on the GPU of dimension ldb*nrhs.
+  !>     @param[inout] B - pointer to type. Array on the GPU of dimension ldb*nrhs.
   !>                 - On entry, the matrix B.
   !>                 - On exit, when info = 0, B is overwritten by the solution vectors (and the
   !>                 residuals in
   !>                 the overdetermined cases) stored as columns.
-  !>     @param[in]
-  !>     ldb         int. ldb >= max(m,n).
+  !>     @param[in] ldb - int. ldb >= max(m,n).
   !>                 Specifies the leading dimension of matrix B.
-  !>     @param[out]
-  !>     info        pointer to an int on the host.
+  !>     @param[out] myInfo - pointer to an int on the host.
   !>                 - If info = 0, successful exit.
   !>                 - If info = j < 0, the argument at position -j is invalid.
-  !>     @param[out]
-  !>     deviceInfo  pointer to int on the GPU.
+  !>     @param[out] deviceInfo - pointer to int on the GPU.
   !>                 - If info = 0, successful exit.
   !>                 - If info = i > 0, the solution could not be computed because input matrix A is
   !>                 rank deficient; the i-th diagonal element of its triangular factor is zero.
@@ -38471,52 +36752,41 @@ module hipfort_hipblas
   !>     Note that the cuBLAS backend supports only the non-transpose operation and only solves
   !>     over-determined systems (``m >= n``).
   !>
-  !>     @param[in]
-  !>     handle      hipblasHandle_t.
-  !>     @param[in]
-  !>     trans       hipblasOperation_t.
+  !>     @param[in] handle - hipblasHandle_t.
+  !>     @param[in] trans - hipblasOperation_t.
   !>                 Specifies the form of the system of equations.
-  !>     @param[in]
-  !>     m           int. m >= 0.
+  !>     @param[in] m - int. m >= 0.
   !>                 The number of rows of all matrices A_j in the batch.
-  !>     @param[in]
-  !>     n           int. n >= 0.
+  !>     @param[in] n - int. n >= 0.
   !>                 The number of columns of all matrices A_j in the batch.
-  !>     @param[in]
-  !>     nrhs        int. nrhs >= 0.
+  !>     @param[in] nrhs - int. nrhs >= 0.
   !>                 The number of columns of all matrices B_j and X_j in the batch,
   !>                 that is, the columns on the right hand side.
-  !>     @param[inout]
-  !>     A array of pointer to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - array of pointer to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 - On entry, the matrices A_j.
   !>                 - On exit, the QR (or LQ) factorizations of A_j as returned by "GEQRF_BATCHED"
   !>                 (or "GELQF_BATCHED").
-  !>     @param[in]
-  !>     lda         int. lda >= m.
+  !>     @param[in] lda - int. lda >= m.
   !>                 Specifies the leading dimension of matrices A_j.
-  !>     @param[inout]
-  !>     B array of pointer to type. Each pointer points to an array on the GPU of dimension
-  !>     ldb*nrhs.
+  !>     @param[inout] B - array of pointer to type. Each pointer points to an array on the GPU of
+  !>     dimension ldb*nrhs.
   !>                 - On entry, the matrices B_j.
   !>                 - On exit, when info[j] = 0, B_j is overwritten by the solution vectors (and
   !>                 the residuals in
   !>                 the overdetermined cases) stored as columns.
-  !>     @param[in]
-  !>     ldb         int. ldb >= max(m,n).
+  !>     @param[in] ldb - int. ldb >= max(m,n).
   !>                 Specifies the leading dimension of matrices B_j.
-  !>     @param[out]
-  !>     info        pointer to an int on the host.
+  !>     @param[out] myInfo - pointer to an int on the host.
   !>                 If info = 0, successful exit.
   !>                 If info = j < 0, the argument at position -j is invalid.
-  !>     @param[out]
-  !>     deviceInfo  pointer to int. Array of batchCount integers on the GPU.
+  !>     @param[out] deviceInfo - pointer to int. Array of batchCount integers on the GPU.
   !>                 - If deviceInfo[j] = 0, successful exit for solution of A_j.
   !>                 - If deviceInfo[j] = i > 0, the solution of A_j could not be computed because
   !>                 input
   !>                 matrix A_j is rank deficient; the i-th diagonal element of its triangular
   !>                 factor is zero.
-  !>     @param[in]
-  !>     batchCount  int. batchCount >= 0.
+  !>     @param[in] batchCount - int. batchCount >= 0.
   !>                 Number of matrices in the batch.
   interface hipblasSgelsBatched
 #ifdef USE_CUDA_NAMES
@@ -38661,62 +36931,50 @@ module hipfort_hipblas
   !>     - Supported precisions in rocSOLVER : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS    : No support.
   !>
-  !>     @param[in]
-  !>     handle      hipblasHandle_t.
-  !>     @param[in]
-  !>     trans       hipblasOperation_t.
+  !>     @param[in] handle - hipblasHandle_t.
+  !>     @param[in] trans - hipblasOperation_t.
   !>                 Specifies the form of the system of equations.
-  !>     @param[in]
-  !>     m           int. m >= 0.
+  !>     @param[in] m - int. m >= 0.
   !>                 The number of rows of all matrices A_j in the batch.
-  !>     @param[in]
-  !>     n           int. n >= 0.
+  !>     @param[in] n - int. n >= 0.
   !>                 The number of columns of all matrices A_j in the batch.
-  !>     @param[in]
-  !>     nrhs        int. nrhs >= 0.
+  !>     @param[in] nrhs - int. nrhs >= 0.
   !>                 The number of columns of all matrices B_j and X_j in the batch,
   !>                 that is, the columns on the right hand side.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 - On entry, the matrices A_j.
   !>                 - On exit, the QR (or LQ) factorizations of A_j as returned by
   !>                 "GEQRF_STRIDED_BATCHED"
   !>                 (or "GELQF_STRIDED_BATCHED").
-  !>     @param[in]
-  !>     lda         int. lda >= m.
+  !>     @param[in] lda - int. lda >= m.
   !>                 Specifies the leading dimension of matrices A_j.
-  !>     @param[in]
-  !>     strideA     hipblasStride.
+  !>     @param[in] strideA - hipblasStride.
   !>                 Stride from the start of one matrix A_j to the next one A_(j+1).
   !>                 There is no restriction for the value of strideA. Normal use case is strideA >=
   !>                 lda*n.
-  !>     @param[inout]
-  !>     B           pointer to type. Array on the GPU (the size depends on the value of strideB).
+  !>     @param[inout] B - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideB).
   !>                 - On entry, the matrices B_j.
   !>                 - On exit, when info[j] = 0, each B_j is overwritten by the solution vectors
   !>                 (and the residuals in
   !>                 the overdetermined cases) stored as columns.
-  !>     @param[in]
-  !>     ldb         int. ldb >= max(m,n).
+  !>     @param[in] ldb - int. ldb >= max(m,n).
   !>                 Specifies the leading dimension of matrices B_j.
-  !>     @param[in]
-  !>     strideB     hipblasStride.
+  !>     @param[in] strideB - hipblasStride.
   !>                 Stride from the start of one matrix B_j to the next one B_(j+1).
   !>                 There is no restriction for the value of strideB. Normal use case is strideB >=
   !>                 ldb*nrhs.
-  !>     @param[out]
-  !>     info        pointer to an int on the host.
+  !>     @param[out] myInfo - pointer to an int on the host.
   !>                 - If info = 0, successful exit.
   !>                 - If info = j < 0, the argument at position -j is invalid.
-  !>     @param[out]
-  !>     deviceInfo  pointer to int. Array of batchCount integers on the GPU.
+  !>     @param[out] deviceInfo - pointer to int. Array of batchCount integers on the GPU.
   !>                 - If deviceInfo[j] = 0, successful exit for solution of A_j.
   !>                 - If deviceInfo[j] = i > 0, the solution of A_j could not be computed because
   !>                 input
   !>                 matrix A_j is rank deficient; the i-th diagonal element of its triangular
   !>                 factor is zero.
-  !>     @param[in]
-  !>     batchCount  int. batchCount >= 0.
+  !>     @param[in] batchCount - int. batchCount >= 0.
   !>                 Number of matrices in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasSgelsStridedBatched
@@ -38859,28 +37117,21 @@ module hipfort_hipblas
   !>     - Supported precisions in rocSOLVER : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS    : ``s``, ``d``, ``c``, and ``z``.
   !>
-  !>     @param[in]
-  !>     handle    hipblasHandle_t.
-  !>     @param[in]
-  !>     m         int. m >= 0.
+  !>     @param[in] handle - hipblasHandle_t.
+  !>     @param[in] m - int. m >= 0.
   !>               The number of rows of the matrix A.
-  !>     @param[in]
-  !>     n         int. n >= 0.
+  !>     @param[in] n - int. n >= 0.
   !>               The number of columns of the matrix A.
-  !>     @param[inout]
-  !>     A         pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>               - On entry, the m-by-n matrix to be factored.
   !>               - On exit, the elements on and above the diagonal contain the
   !>               factor R. The elements below the diagonal are the last m - i elements
   !>               of Householder vector v_i.
-  !>     @param[in]
-  !>     lda       int. lda >= m.
+  !>     @param[in] lda - int. lda >= m.
   !>               Specifies the leading dimension of A.
-  !>     @param[out]
-  !>     ipiv      pointer to type. Array on the GPU of dimension min(m,n).
+  !>     @param[out] ipiv - pointer to type. Array on the GPU of dimension min(m,n).
   !>               The Householder scalars.
-  !>     @param[out]
-  !>     info      pointer to a int on the host.
+  !>     @param[out] myInfo - pointer to a int on the host.
   !>               - If info = 0, successful exit.
   !>               - If info = j < 0, the argument at position -j is invalid.
 #ifndef USE_CUDA_NAMES
@@ -39018,33 +37269,26 @@ module hipfort_hipblas
   !>     - Supported precisions in rocSOLVER : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS    : ``s``, ``d``, ``c``, and ``z``.
   !>
-  !>     @param[in]
-  !>     handle    hipblasHandle_t.
-  !>     @param[in]
-  !>     m         int. m >= 0.
+  !>     @param[in] handle - hipblasHandle_t.
+  !>     @param[in] m - int. m >= 0.
   !>               The number of rows of all the matrices A_i in the batch.
-  !>     @param[in]
-  !>     n         int. n >= 0.
+  !>     @param[in] n - int. n >= 0.
   !>               The number of columns of all the matrices A_i in the batch.
-  !>     @param[inout]
-  !>     A Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - Array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>               - On entry, the m-by-n matrices A_i to be factored.
   !>               - On exit, the elements on and above the diagonal contain the
   !>               factor R_i. The elements below the diagonal are the last m - j elements
   !>               of Householder vector v_(i_j).
-  !>     @param[in]
-  !>     lda       int. lda >= m.
+  !>     @param[in] lda - int. lda >= m.
   !>               Specifies the leading dimension of matrices A_i.
-  !>     @param[out]
-  !>     ipiv      array of pointers to type. Each pointer points to an array on the GPU
+  !>     @param[out] ipiv - array of pointers to type. Each pointer points to an array on the GPU
   !>               of dimension min(m, n).
   !>               Contains the vectors ipiv_i of corresponding Householder scalars.
-  !>     @param[out]
-  !>     info      pointer to a int on the host.
+  !>     @param[out] myInfo - pointer to a int on the host.
   !>               - If info = 0, successful exit.
   !>               - If info = j < 0, the argument at position -j is invalid.
-  !>     @param[in]
-  !>     batchCount  int. batchCount >= 0.
+  !>     @param[in] batchCount - int. batchCount >= 0.
   !>                  Number of matrices in the batch.
   interface hipblasSgeqrfBatched
 #ifdef USE_CUDA_NAMES
@@ -39173,42 +37417,34 @@ module hipfort_hipblas
   !>     - Supported precisions in rocSOLVER : ``s``, ``d``, ``c``, and ``z``.
   !>     - Supported precisions in cuBLAS    : No support.
   !>
-  !>     @param[in]
-  !>     handle    hipblasHandle_t.
-  !>     @param[in]
-  !>     m         int. m >= 0.
+  !>     @param[in] handle - hipblasHandle_t.
+  !>     @param[in] m - int. m >= 0.
   !>               The number of rows of all the matrices A_i in the batch.
-  !>     @param[in]
-  !>     n         int. n >= 0.
+  !>     @param[in] n - int. n >= 0.
   !>               The number of columns of all the matrices A_i in the batch.
-  !>     @param[inout]
-  !>     A         pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>               - On entry, the m-by-n matrices A_i to be factored.
   !>               - On exit, the elements on and above the diagonal contain the
   !>               factor R_i. The elements below the diagonal are the last m - j elements
   !>               of Householder vector v_(i_j).
-  !>     @param[in]
-  !>     lda       int. lda >= m.
+  !>     @param[in] lda - int. lda >= m.
   !>               Specifies the leading dimension of matrices A_i.
-  !>     @param[in]
-  !>     strideA   hipblasStride.
+  !>     @param[in] strideA - hipblasStride.
   !>               Stride from the start of one matrix A_i to the next one A_(i+1).
   !>               There is no restriction for the value of strideA. Normal use case is strideA >=
   !>               lda*n.
-  !>     @param[out]
-  !>     ipiv      pointer to type. Array on the GPU (the size depends on the value of strideP).
+  !>     @param[out] ipiv - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideP).
   !>               Contains the vectors ipiv_i of corresponding Householder scalars.
-  !>     @param[in]
-  !>     strideP   hipblasStride.
+  !>     @param[in] strideP - hipblasStride.
   !>               Stride from the start of one vector ipiv_i to the next one ipiv_(i+1).
   !>               There is no restriction for the value
   !>               of strideP. Normal use is strideP >= min(m,n).
-  !>     @param[out]
-  !>     info      pointer to a int on the host.
+  !>     @param[out] myInfo - pointer to a int on the host.
   !>               - If info = 0, successful exit.
   !>               - If info = j < 0, the argument at position -j is invalid.
-  !>     @param[in]
-  !>     batchCount  int. batchCount >= 0.
+  !>     @param[in] batchCount - int. batchCount >= 0.
   !>                  Number of matrices in the batch.
 #ifndef USE_CUDA_NAMES
   interface hipblasSgeqrfStridedBatched
@@ -39367,68 +37603,49 @@ module hipfort_hipblas
   !>     control gemm algorithms with the
   !>     rocBLAS backend. When using a cuBLAS backend, this parameter is ignored.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     transA    [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>               specifies the form of op( A ).
-  !>     @param[in]
-  !>     transB    [hipblasOperation_t]
+  !>     @param[in] transB - [hipblasOperation_t]
   !>               specifies the form of op( B ).
-  !>     @param[in]
-  !>     m         [int]
+  !>     @param[in] m - [int]
   !>               matrix dimension m.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               matrix dimension n.
-  !>     @param[in]
-  !>     k         [int]
+  !>     @param[in] k - [int]
   !>               matrix dimension k.
-  !>     @param[in]
-  !>     alpha     [const void *]
+  !>     @param[in] alpha - [const void *]
   !>               device pointer or host pointer specifying the scalar alpha. Same datatype as
   !>               computeType.
-  !>     @param[in]
-  !>     A         [void *]
+  !>     @param[in] A - [void *]
   !>               device pointer storing matrix A.
-  !>     @param[in]
-  !>     aType
+  !>     @param[in] aType
   !>     [hipDataType]
   !>               specifies the datatype of matrix A.
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of A.
-  !>     @param[in]
-  !>     B         [void *]
+  !>     @param[in] B - [void *]
   !>               device pointer storing matrix B.
-  !>     @param[in]
-  !>     bType
+  !>     @param[in] bType
   !>     [hipDataType]
   !>               specifies the datatype of matrix B.
-  !>     @param[in]
-  !>     ldb       [int]
+  !>     @param[in] ldb - [int]
   !>               specifies the leading dimension of B.
-  !>     @param[in]
-  !>     beta      [const void *]
+  !>     @param[in] beta - [const void *]
   !>               device pointer or host pointer specifying the scalar beta. Same datatype as
   !>               computeType.
-  !>     @param[in]
-  !>     C         [void *]
+  !>     @param[in] C - [void *]
   !>               device pointer storing matrix C.
-  !>     @param[in]
-  !>     cType
+  !>     @param[in] cType
   !>     [hipDataType]
   !>               specifies the datatype of matrix C.
-  !>     @param[in]
-  !>     ldc       [int]
+  !>     @param[in] ldc - [int]
   !>               specifies the leading dimension of C.
-  !>     @param[in]
-  !>     computeType
+  !>     @param[in] computeType
   !>     [hipblasComputeType_t]
   !>               specifies the datatype of computation.
-  !>     @param[in]
-  !>     algo      [hipblasGemmAlgo_t]
+  !>     @param[in] algo - [hipblasGemmAlgo_t]
   !>               enumerant specifying the algorithm type.
   interface hipblasGemmEx
 #ifdef USE_CUDA_NAMES
@@ -39601,72 +37818,52 @@ module hipfort_hipblas
   !>     control gemm algorithms with the
   !>     rocBLAS backend. When using a cuBLAS backend, this parameter is ignored.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     transA    [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>               specifies the form of op( A ).
-  !>     @param[in]
-  !>     transB    [hipblasOperation_t]
+  !>     @param[in] transB - [hipblasOperation_t]
   !>               specifies the form of op( B ).
-  !>     @param[in]
-  !>     m         [int]
+  !>     @param[in] m - [int]
   !>               matrix dimension m.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               matrix dimension n.
-  !>     @param[in]
-  !>     k         [int]
+  !>     @param[in] k - [int]
   !>               matrix dimension k.
-  !>     @param[in]
-  !>     alpha     [const void *]
+  !>     @param[in] alpha - [const void *]
   !>               device pointer or host pointer specifying the scalar alpha. Same datatype as
   !>               computeType.
-  !>     @param[in]
-  !>     A         [void *]
+  !>     @param[in] A - [void *]
   !>               device pointer storing array of pointers to each matrix A_i.
-  !>     @param[in]
-  !>     aType
+  !>     @param[in] aType
   !>     [hipDataType]
   !>               specifies the datatype of each matrix A_i.
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of each A_i.
-  !>     @param[in]
-  !>     B         [void *]
+  !>     @param[in] B - [void *]
   !>               device pointer storing array of pointers to each matrix B_i.
-  !>     @param[in]
-  !>     bType
+  !>     @param[in] bType
   !>     [hipDataType]
   !>               specifies the datatype of each matrix B_i.
-  !>     @param[in]
-  !>     ldb       [int]
+  !>     @param[in] ldb - [int]
   !>               specifies the leading dimension of each B_i.
-  !>     @param[in]
-  !>     beta      [const void *]
+  !>     @param[in] beta - [const void *]
   !>               device pointer or host pointer specifying the scalar beta. Same datatype as
   !>               computeType.
-  !>     @param[in]
-  !>     C         [void *]
+  !>     @param[in] C - [void *]
   !>               device array of device pointers to each matrix C_i.
-  !>     @param[in]
-  !>     cType
+  !>     @param[in] cType
   !>     [hipDataType]
   !>               specifies the datatype of each matrix C_i.
-  !>     @param[in]
-  !>     ldc       [int]
+  !>     @param[in] ldc - [int]
   !>               specifies the leading dimension of each C_i.
-  !>     @param[in]
-  !>     batchCount
+  !>     @param[in] batchCount
   !>               [int]
   !>               number of gemm operations in the batch.
-  !>     @param[in]
-  !>     computeType
+  !>     @param[in] computeType
   !>     [hipblasComputeType_t]
   !>               specifies the datatype of computation.
-  !>     @param[in]
-  !>     algo      [hipblasGemmAlgo_t]
+  !>     @param[in] algo - [hipblasGemmAlgo_t]
   !>               enumerant specifying the algorithm type.
   interface hipblasGemmBatchedEx
 #ifdef USE_CUDA_NAMES
@@ -39845,81 +38042,58 @@ module hipfort_hipblas
   !>     control gemm algorithms with the
   !>     rocBLAS backend. When using a cuBLAS backend, this parameter is ignored.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     transA    [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>               specifies the form of op( A ).
-  !>     @param[in]
-  !>     transB    [hipblasOperation_t]
+  !>     @param[in] transB - [hipblasOperation_t]
   !>               specifies the form of op( B ).
-  !>     @param[in]
-  !>     m         [int]
+  !>     @param[in] m - [int]
   !>               matrix dimension m.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               matrix dimension n.
-  !>     @param[in]
-  !>     k         [int]
+  !>     @param[in] k - [int]
   !>               matrix dimension k.
-  !>     @param[in]
-  !>     alpha     [const void *]
+  !>     @param[in] alpha - [const void *]
   !>               device pointer or host pointer specifying the scalar alpha. Same datatype as
   !>               computeType.
-  !>     @param[in]
-  !>     A         [void *]
+  !>     @param[in] A - [void *]
   !>               device pointer pointing to first matrix A_1.
-  !>     @param[in]
-  !>     aType
+  !>     @param[in] aType
   !>     [hipDataType]
   !>               specifies the datatype of each matrix A_i.
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of each A_i.
-  !>     @param[in]
-  !>     strideA  [hipblasStride]
+  !>     @param[in] strideA - [hipblasStride]
   !>               specifies stride from start of one A_i matrix to the next A_(i + 1).
-  !>     @param[in]
-  !>     B         [void *]
+  !>     @param[in] B - [void *]
   !>               device pointer pointing to first matrix B_1.
-  !>     @param[in]
-  !>     bType
+  !>     @param[in] bType
   !>     [hipDataType]
   !>               specifies the datatype of each matrix B_i.
-  !>     @param[in]
-  !>     ldb       [int]
+  !>     @param[in] ldb - [int]
   !>               specifies the leading dimension of each B_i.
-  !>     @param[in]
-  !>     strideB  [hipblasStride]
+  !>     @param[in] strideB - [hipblasStride]
   !>               specifies stride from start of one B_i matrix to the next B_(i + 1).
-  !>     @param[in]
-  !>     beta      [const void *]
+  !>     @param[in] beta - [const void *]
   !>               device pointer or host pointer specifying the scalar beta. Same datatype as
   !>               computeType.
-  !>     @param[in]
-  !>     C         [void *]
+  !>     @param[in] C - [void *]
   !>               device pointer pointing to first matrix C_1.
-  !>     @param[in]
-  !>     cType
+  !>     @param[in] cType
   !>     [hipDataType]
   !>               specifies the datatype of each matrix C_i.
-  !>     @param[in]
-  !>     ldc       [int]
+  !>     @param[in] ldc - [int]
   !>               specifies the leading dimension of each C_i.
-  !>     @param[in]
-  !>     strideC  [hipblasStride]
+  !>     @param[in] strideC - [hipblasStride]
   !>               specifies stride from start of one C_i matrix to the next C_(i + 1).
-  !>     @param[in]
-  !>     batchCount
+  !>     @param[in] batchCount
   !>               [int]
   !>               number of gemm operations in the batch.
-  !>     @param[in]
-  !>     computeType
+  !>     @param[in] computeType
   !>     [hipblasComputeType_t]
   !>               specifies the datatype of computation.
-  !>     @param[in]
-  !>     algo      [hipblasGemmAlgo_t]
+  !>     @param[in] algo - [hipblasGemmAlgo_t]
   !>               enumerant specifying the algorithm type.
   interface hipblasGemmStridedBatchedEx
 #ifdef USE_CUDA_NAMES
@@ -40097,53 +38271,39 @@ module hipfort_hipblas
   !>
   !>     - Supported types are determined by the backend. See the rocBLAS or cuBLAS documentation.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>               Specifies whether the matrix C is an upper or lower triangular matrix as follows:
   !>               - HIPBLAS_FILL_MODE_UPPER:  C is an upper triangular matrix.
   !>               - HIPBLAS_FILL_MODE_LOWER:  C is a  lower triangular matrix.
-  !>     @param[in]
-  !>     transA    [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>               specifies the form of op( A ).
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               matrix dimension n.
-  !>     @param[in]
-  !>     k         [int]
+  !>     @param[in] k - [int]
   !>               matrix dimension k.
-  !>     @param[in]
-  !>     alpha     [const void *]
+  !>     @param[in] alpha - [const void *]
   !>               device pointer or host pointer specifying the scalar alpha. Same datatype as
   !>               computeType.
-  !>     @param[in]
-  !>     A         [void *]
+  !>     @param[in] A - [void *]
   !>               device pointer storing matrix A.
-  !>     @param[in]
-  !>     aType
+  !>     @param[in] aType
   !>     [hipDataType]
   !>               specifies the datatype of matrix A.
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of A.
-  !>     @param[in]
-  !>     beta      [const void *]
+  !>     @param[in] beta - [const void *]
   !>               device pointer or host pointer specifying the scalar beta. Same datatype as
   !>               computeType.
-  !>     @param[in]
-  !>     C         [void *]
+  !>     @param[in] C - [void *]
   !>               device pointer storing matrix C.
-  !>     @param[in]
-  !>     cType
+  !>     @param[in] cType
   !>     [hipDataType]
   !>               specifies the datatype of matrix C.
-  !>     @param[in]
-  !>     ldc       [int]
+  !>     @param[in] ldc - [int]
   !>               specifies the leading dimension of C.
-  !>     @param[in]
-  !>     computeType
+  !>     @param[in] computeType
   !>     [hipDataType]
   !>               specifies the datatype of the computation.
 #ifndef USE_CUDA_NAMES
@@ -40217,85 +38377,70 @@ module hipfort_hipblas
   !>       - ``ldinvA`` = 128
   !>       - ``batchCount`` = 1
   !>
-  !>     @param[in]
-  !>     handle  [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>             handle to the hipBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     side    [hipblasSideMode_t]
+  !>     @param[in] side - [hipblasSideMode_t]
   !>             - HIPBLAS_SIDE_LEFT:       op(A)*X = alpha*B.
   !>             - HIPBLAS_SIDE_RIGHT:      X*op(A) = alpha*B.
   !>
-  !>     @param[in]
-  !>     uplo    [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>             - HIPBLAS_FILL_MODE_UPPER:  A is an upper triangular matrix.
   !>             - HIPBLAS_FILL_MODE_LOWER:  A is a lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA  [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>             - HIPBLAS_OP_N: op(A) = A.
   !>             - HIPBLAS_OP_T: op(A) = A^T.
   !>             - HIPBLAS_ON_C: op(A) = A^H.
   !>
-  !>     @param[in]
-  !>     diag    [hipblasDiagType_t]
+  !>     @param[in] diag - [hipblasDiagType_t]
   !>             - HIPBLAS_DIAG_UNIT:     A is assumed to be unit triangular.
   !>             - HIPBLAS_DIAG_NON_UNIT:  A is not assumed to be unit triangular.
   !>
-  !>     @param[in]
-  !>     m       [int]
+  !>     @param[in] m - [int]
   !>             m specifies the number of rows of B. m >= 0.
   !>
-  !>     @param[in]
-  !>     n       [int]
+  !>     @param[in] n - [int]
   !>             n specifies the number of columns of B. n >= 0.
   !>
-  !>     @param[in]
-  !>     alpha   [void *]
+  !>     @param[in] alpha - [void *]
   !>             device pointer or host pointer specifying the scalar alpha. When alpha is
   !>             &zero, then A is not referenced, and B does not need to be set before
   !>             entry.
   !>
-  !>     @param[in]
-  !>     A       [void *]
+  !>     @param[in] A - [void *]
   !>             device pointer storing matrix A.
   !>             Of dimension ( lda, k ), where k is m
   !>             when HIPBLAS_SIDE_LEFT and
   !>             is n when HIPBLAS_SIDE_RIGHT.
   !>             Only the upper/lower triangular part is accessed.
   !>
-  !>     @param[in]
-  !>     lda     [int]
+  !>     @param[in] lda - [int]
   !>             lda specifies the first dimension of A.
   !>             - If side = HIPBLAS_SIDE_LEFT,  lda >= max( 1, m ).
   !>             - If side = HIPBLAS_SIDE_RIGHT, lda >= max( 1, n ).
   !>
-  !>     @param[in, out]
-  !>     B       [void *]
+  !>     @param[in, out] B - [void *]
   !>             device pointer storing matrix B.
   !>             B is of dimension ( ldb, n ).
   !>             Before entry, the leading m by n part of the array B must
   !>             contain the right-hand side matrix B, and on exit is
   !>             overwritten by the solution matrix X.
   !>
-  !>     @param[in]
-  !>     ldb    [int]
+  !>     @param[in] ldb - [int]
   !>            ldb specifies the first dimension of B. ldb >= max( 1, m ).
   !>
-  !>     @param[in]
-  !>     invA    [void *]
+  !>     @param[in] invA - [void *]
   !>             device pointer storing the inverse diagonal blocks of A.
   !>             invA is of dimension ( ld_invA, k ), where k is m
   !>             when HIPBLAS_SIDE_LEFT and
   !>             is n when HIPBLAS_SIDE_RIGHT.
   !>             ld_invA must be equal to 128.
   !>
-  !>     @param[in]
-  !>     invAsize [int]
+  !>     @param[in] invAsize - [int]
   !>             invAsize specifies the number of elements of device memory in invA.
   !>
-  !>     @param[in]
-  !>     computeType
+  !>     @param[in] computeType
   !>     [hipDataType]
   !>             specifies the datatype of computation.
 #ifndef USE_CUDA_NAMES
@@ -40344,53 +38489,39 @@ module hipfort_hipblas
   !>
   !>     - Supported types are determined by the backend. See the rocBLAS or cuBLAS documentation.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>               Specifies whether the matrix C is an upper or lower triangular matrix as follows:
   !>               - HIPBLAS_FILL_MODE_UPPER:  C is an upper triangular matrix.
   !>               - HIPBLAS_FILL_MODE_LOWER:  C is a  lower triangular matrix.
-  !>     @param[in]
-  !>     transA    [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>               specifies the form of op( A ).
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               matrix dimension n.
-  !>     @param[in]
-  !>     k         [int]
+  !>     @param[in] k - [int]
   !>               matrix dimension k.
-  !>     @param[in]
-  !>     alpha     [const void *]
+  !>     @param[in] alpha - [const void *]
   !>               device pointer or host pointer specifying the scalar alpha. Same datatype as
   !>               computeType.
-  !>     @param[in]
-  !>     A         [void *]
+  !>     @param[in] A - [void *]
   !>               device pointer storing matrix A.
-  !>     @param[in]
-  !>     aType
+  !>     @param[in] aType
   !>     [hipDataType]
   !>               specifies the datatype of matrix A.
-  !>     @param[in]
-  !>     lda       [int]
+  !>     @param[in] lda - [int]
   !>               specifies the leading dimension of A.
-  !>     @param[in]
-  !>     beta      [const void *]
+  !>     @param[in] beta - [const void *]
   !>               device pointer or host pointer specifying the scalar beta. Same datatype as
   !>               computeType.
-  !>     @param[in]
-  !>     C         [void *]
+  !>     @param[in] C - [void *]
   !>               device pointer storing matrix C.
-  !>     @param[in]
-  !>     cType
+  !>     @param[in] cType
   !>     [hipDataType]
   !>               specifies the datatype of matrix C.
-  !>     @param[in]
-  !>     ldc       [int]
+  !>     @param[in] ldc - [int]
   !>               specifies the leading dimension of C.
-  !>     @param[in]
-  !>     computeType
+  !>     @param[in] computeType
   !>     [hipDataType]
   !>               specifies the datatype of the computation.
 #ifndef USE_CUDA_NAMES
@@ -40467,89 +38598,73 @@ module hipfort_hipblas
   !>       - ``ldinvA`` = 128
   !>       - ``batchCount`` = 1
   !>
-  !>     @param[in]
-  !>     handle  [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>             handle to the hipBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     side    [hipblasSideMode_t]
+  !>     @param[in] side - [hipblasSideMode_t]
   !>             - HIPBLAS_SIDE_LEFT:       op(A)*X = alpha*B.
   !>             - HIPBLAS_SIDE_RIGHT:      X*op(A) = alpha*B.
   !>
-  !>     @param[in]
-  !>     uplo    [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>             - HIPBLAS_FILL_MODE_UPPER:  each A_i is an upper triangular matrix.
   !>             - HIPBLAS_FILL_MODE_LOWER:  each A_i is a lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA  [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>             - HIPBLAS_OP_N: op(A) = A.
   !>             - HIPBLAS_OP_T: op(A) = A^T.
   !>             - HIPBLAS_OP_C: op(A) = A^H.
   !>
-  !>     @param[in]
-  !>     diag    [hipblasDiagType_t]
+  !>     @param[in] diag - [hipblasDiagType_t]
   !>             - HIPBLAS_DIAG_UNIT:     each A_i is assumed to be unit triangular.
   !>             - HIPBLAS_DIAG_NON_UNIT:  each A_i is not assumed to be unit triangular.
   !>
-  !>     @param[in]
-  !>     m       [int]
+  !>     @param[in] m - [int]
   !>             m specifies the number of rows of each B_i. m >= 0.
   !>
-  !>     @param[in]
-  !>     n       [int]
+  !>     @param[in] n - [int]
   !>             n specifies the number of columns of each B_i. n >= 0.
   !>
-  !>     @param[in]
-  !>     alpha   [void *]
+  !>     @param[in] alpha - [void *]
   !>             device pointer or host pointer alpha specifying the scalar alpha. When alpha is
   !>             &zero, then A is not referenced, and B does not need to be set before
   !>             entry.
   !>
-  !>     @param[in]
-  !>     A       [void *]
+  !>     @param[in] A - [void *]
   !>             device array of device pointers storing each matrix A_i.
   !>             Each A_i is of dimension ( lda, k ), where k is m
   !>             when HIPBLAS_SIDE_LEFT and
   !>             is n when HIPBLAS_SIDE_RIGHT.
   !>             Only the upper/lower triangular part is accessed.
   !>
-  !>     @param[in]
-  !>     lda     [int]
+  !>     @param[in] lda - [int]
   !>             lda specifies the first dimension of each A_i.
   !>             - If side = HIPBLAS_SIDE_LEFT,  lda >= max( 1, m ).
   !>             - If side = HIPBLAS_SIDE_RIGHT, lda >= max( 1, n ).
   !>
-  !>     @param[in, out]
-  !>     B       [void *]
+  !>     @param[in, out] B - [void *]
   !>             device array of device pointers storing each matrix B_i.
   !>             Each B_i is of dimension ( ldb, n ).
   !>             Before entry, the leading m by n part of the array B_i must
   !>             contain the right-hand side matrix B_i, and on exit is
   !>             overwritten by the solution matrix X_i.
   !>
-  !>     @param[in]
-  !>     ldb    [int]
+  !>     @param[in] ldb - [int]
   !>            ldb specifies the first dimension of each B_i. ldb >= max( 1, m ).
   !>
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>             specifies how many batches.
   !>
-  !>     @param[in]
-  !>     invA    [void *]
+  !>     @param[in] invA - [void *]
   !>             device array of device pointers storing the inverse diagonal blocks of each A_i.
   !>             Each invA_i is of dimension ( ld_invA, k ), where k is m
   !>             when HIPBLAS_SIDE_LEFT and
   !>             is n when HIPBLAS_SIDE_RIGHT.
   !>             ld_invA must be equal to 128.
   !>
-  !>     @param[in]
-  !>     invAsize [int]
+  !>     @param[in] invAsize - [int]
   !>             invAsize specifies the number of elements of device memory in each invA_i.
   !>
-  !>     @param[in]
-  !>     computeType
+  !>     @param[in] computeType
   !>     [hipDataType]
   !>             specifies the datatype of computation.
 #ifndef USE_CUDA_NAMES
@@ -40629,85 +38744,69 @@ module hipfort_hipblas
   !>       - ``ldinvA`` = 128
   !>       - ``batchCount`` = 1
   !>
-  !>     @param[in]
-  !>     handle  [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>             handle to the hipBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     side    [hipblasSideMode_t]
+  !>     @param[in] side - [hipblasSideMode_t]
   !>             - HIPBLAS_SIDE_LEFT:       op(A)*X = alpha*B.
   !>             - HIPBLAS_SIDE_RIGHT:      X*op(A) = alpha*B.
   !>
-  !>     @param[in]
-  !>     uplo    [hipblasFillMode_t]
+  !>     @param[in] uplo - [hipblasFillMode_t]
   !>             - HIPBLAS_FILL_MODE_UPPER:  each A_i is an upper triangular matrix.
   !>             - HIPBLAS_FILL_MODE_LOWER:  each A_i is a lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA  [hipblasOperation_t]
+  !>     @param[in] transA - [hipblasOperation_t]
   !>             - HIPBLAS_OP_N: op(A) = A.
   !>             - HIPBLAS_OP_T: op(A) = A^T.
   !>             - HIPBLAS_OP_C: op(A) = A^H.
   !>
-  !>     @param[in]
-  !>     diag    [hipblasDiagType_t]
+  !>     @param[in] diag - [hipblasDiagType_t]
   !>             - HIPBLAS_DIAG_UNIT:     each A_i is assumed to be unit triangular.
   !>             - HIPBLAS_DIAG_NON_UNIT:  each A_i is not assumed to be unit triangular.
   !>
-  !>     @param[in]
-  !>     m       [int]
+  !>     @param[in] m - [int]
   !>             m specifies the number of rows of each B_i. m >= 0.
   !>
-  !>     @param[in]
-  !>     n       [int]
+  !>     @param[in] n - [int]
   !>             n specifies the number of columns of each B_i. n >= 0.
   !>
-  !>     @param[in]
-  !>     alpha   [void *]
+  !>     @param[in] alpha - [void *]
   !>             device pointer or host pointer specifying the scalar alpha. When alpha is
   !>             &zero, then A is not referenced, and B does not need to be set before
   !>             entry.
   !>
-  !>     @param[in]
-  !>     A       [void *]
+  !>     @param[in] A - [void *]
   !>             device pointer storing matrix A.
   !>             Of dimension ( lda, k ), where k is m
   !>             when HIPBLAS_SIDE_LEFT and
   !>             is n when HIPBLAS_SIDE_RIGHT.
   !>             Only the upper/lower triangular part is accessed.
   !>
-  !>     @param[in]
-  !>     lda     [int]
+  !>     @param[in] lda - [int]
   !>             lda specifies the first dimension of A.
   !>             - If side = HIPBLAS_SIDE_LEFT,  lda >= max( 1, m ).
   !>             - If side = HIPBLAS_SIDE_RIGHT, lda >= max( 1, n ).
   !>
-  !>     @param[in]
-  !>     strideA [hipblasStride]
+  !>     @param[in] strideA - [hipblasStride]
   !>             The stride between each A matrix.
   !>
-  !>     @param[in, out]
-  !>     B       [void *]
+  !>     @param[in, out] B - [void *]
   !>             device pointer pointing to first matrix B_i.
   !>             Each B_i is of dimension ( ldb, n ).
   !>             Before entry, the leading m by n part of each array B_i must
   !>             contain the right-hand side of matrix B_i, and on exit is
   !>             overwritten by the solution matrix X_i.
   !>
-  !>     @param[in]
-  !>     ldb    [int]
+  !>     @param[in] ldb - [int]
   !>            ldb specifies the first dimension of each B_i. ldb >= max( 1, m ).
   !>
-  !>     @param[in]
-  !>     strideB [hipblasStride]
+  !>     @param[in] strideB - [hipblasStride]
   !>             The stride between each B_i matrix.
   !>
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>             specifies how many batches.
   !>
-  !>     @param[in]
-  !>     invA    [void *]
+  !>     @param[in] invA - [void *]
   !>             device pointer storing the inverse diagonal blocks of each A_i.
   !>             invA points to the first invA_1.
   !>             Each invA_i is of dimension ( ld_invA, k ), where k is m
@@ -40715,16 +38814,13 @@ module hipfort_hipblas
   !>             is n when HIPBLAS_SIDE_RIGHT.
   !>             ld_invA must be equal to 128.
   !>
-  !>     @param[in]
-  !>     invAsize [int]
+  !>     @param[in] invAsize - [int]
   !>             invAsize specifies the number of elements of device memory in each invA_i.
   !>
-  !>     @param[in]
-  !>     strideInvA [hipblasStride]
+  !>     @param[in] strideInvA - [hipblasStride]
   !>             The stride between each invA matrix.
   !>
-  !>     @param[in]
-  !>     computeType
+  !>     @param[in] computeType
   !>     [hipDataType]
   !>             specifies the datatype of computation.
 #ifndef USE_CUDA_NAMES
@@ -40770,38 +38866,27 @@ module hipfort_hipblas
   !>
   !>     The supported types are determined by the backend. See the rocBLAS or cuBLAS documentation.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of elements in x and y.
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer to specify the scalar alpha.
-  !>     @param[in]
-  !>     alphaType
+  !>     @param[in] alpha - device pointer or host pointer to specify the scalar alpha.
+  !>     @param[in] alphaType
   !>     [hipDataType]
   !>               specifies the datatype of alpha.
-  !>     @param[in]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     xType
+  !>     @param[in] x - device pointer storing vector x.
+  !>     @param[in] xType
   !>     [hipDataType]
   !>               specifies the datatype of vector x.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of x.
-  !>     @param[inout]
-  !>     y         device pointer storing vector y.
-  !>     @param[in]
-  !>     yType
+  !>     @param[inout] y - device pointer storing vector y.
+  !>     @param[in] yType
   !>     [hipDataType]
   !>               specifies the datatype of vector y.
-  !>     @param[in]
-  !>     incy      [int]
+  !>     @param[in] incy - [int]
   !>               specifies the increment for the elements of y.
-  !>     @param[in]
-  !>     executionType
+  !>     @param[in] executionType
   !>     [hipDataType]
   !>               specifies the datatype of computation.
   interface hipblasAxpyEx
@@ -40869,41 +38954,29 @@ module hipfort_hipblas
   !>
   !>     The supported types are determined by the backend. See the rocBLAS or cuBLAS documentation.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of elements in each x_i and y_i.
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer to specify the scalar alpha.
-  !>     @param[in]
-  !>     alphaType
+  !>     @param[in] alpha - device pointer or host pointer to specify the scalar alpha.
+  !>     @param[in] alphaType
   !>     [hipDataType]
   !>               specifies the datatype of alpha.
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     xType
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] xType
   !>     [hipDataType]
   !>               specifies the datatype of each vector x_i.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[inout]
-  !>     y         device array of device pointers storing each vector y_i.
-  !>     @param[in]
-  !>     yType
+  !>     @param[inout] y - device array of device pointers storing each vector y_i.
+  !>     @param[in] yType
   !>     [hipDataType]
   !>               specifies the datatype of each vector y_i.
-  !>     @param[in]
-  !>     incy      [int]
+  !>     @param[in] incy - [int]
   !>               specifies the increment for the elements of each y_i.
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>               number of instances in the batch.
-  !>     @param[in]
-  !>     executionType
+  !>     @param[in] executionType
   !>     [hipDataType]
   !>               specifies the datatype of computation.
 #ifndef USE_CUDA_NAMES
@@ -40969,53 +39042,39 @@ module hipfort_hipblas
   !>
   !>     The supported types are determined by the backend. See the rocBLAS or cuBLAS documentation.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of elements in each x_i and y_i.
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer to specify the scalar alpha.
-  !>     @param[in]
-  !>     alphaType
+  !>     @param[in] alpha - device pointer or host pointer to specify the scalar alpha.
+  !>     @param[in] alphaType
   !>     [hipDataType]
   !>               specifies the datatype of alpha.
-  !>     @param[in]
-  !>     x         device pointer to the first vector x_1.
-  !>     @param[in]
-  !>     xType
+  !>     @param[in] x - device pointer to the first vector x_1.
+  !>     @param[in] xType
   !>     [hipDataType]
   !>               specifies the datatype of each vector x_i.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     stridex   [hipblasStride]
+  !>     @param[in] stridex - [hipblasStride]
   !>               stride from the start of one vector (x_i) to the next one (x_i+1).
   !>               There are no restrictions placed on stridex. However, the user should
   !>               ensure that stridex is of an appropriate size. For a typical
   !>               case, this means stridex >= n * incx.
-  !>     @param[inout]
-  !>     y         device pointer to the first vector y_1.
-  !>     @param[in]
-  !>     yType
+  !>     @param[inout] y - device pointer to the first vector y_1.
+  !>     @param[in] yType
   !>     [hipDataType]
   !>               specifies the datatype of each vector y_i.
-  !>     @param[in]
-  !>     incy      [int]
+  !>     @param[in] incy - [int]
   !>               specifies the increment for the elements of each y_i.
-  !>     @param[in]
-  !>     stridey   [hipblasStride]
+  !>     @param[in] stridey - [hipblasStride]
   !>               stride from the start of one vector (y_i) to the next one (y_i+1).
   !>               There are no restrictions placed on stridey. However, the user should
   !>               ensure that stridey is of appropriate size. For a typical
   !>               case, this means stridey >= n * incy.
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>               number of instances in the batch.
-  !>     @param[in]
-  !>     executionType
+  !>     @param[in] executionType
   !>     [hipDataType]
   !>               specifies the datatype of computation.
 #ifndef USE_CUDA_NAMES
@@ -41088,40 +39147,29 @@ module hipfort_hipblas
   !>
   !>     The supported types are determined by the backend. See the rocBLAS or cuBLAS documentation.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of elements in x and y.
-  !>     @param[in]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     xType
+  !>     @param[in] x - device pointer storing vector x.
+  !>     @param[in] xType
   !>     [hipDataType]
   !>               specifies the datatype of vector x.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of y.
-  !>     @param[in]
-  !>     y         device pointer storing vector y.
-  !>     @param[in]
-  !>     yType
+  !>     @param[in] y - device pointer storing vector y.
+  !>     @param[in] yType
   !>     [hipDataType]
   !>               specifies the datatype of vector y.
-  !>     @param[in]
-  !>     incy      [int]
+  !>     @param[in] incy - [int]
   !>               specifies the increment for the elements of y.
-  !>     @param[inout]
-  !>     result
+  !>     @param[inout] myResult
   !>               device pointer or host pointer to store the dot product.
   !>               Return value is 0.0 if n <= 0.
-  !>     @param[in]
-  !>     resultType
+  !>     @param[in] resultType
   !>     [hipDataType]
   !>               specifies the datatype of the result.
-  !>     @param[in]
-  !>     executionType
+  !>     @param[in] executionType
   !>     [hipDataType]
   !>               specifies the datatype of computation.
   interface hipblasDotEx
@@ -41253,44 +39301,32 @@ module hipfort_hipblas
   !>
   !>     The supported types are determined by the backend. See the rocBLAS or cuBLAS documentation.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of elements in each x_i and y_i.
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     xType
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] xType
   !>     [hipDataType]
   !>               specifies the datatype of each vector x_i.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     y         device array of device pointers storing each vector y_i.
-  !>     @param[in]
-  !>     yType
+  !>     @param[in] y - device array of device pointers storing each vector y_i.
+  !>     @param[in] yType
   !>     [hipDataType]
   !>               specifies the datatype of each vector y_i.
-  !>     @param[in]
-  !>     incy      [int]
+  !>     @param[in] incy - [int]
   !>               specifies the increment for the elements of each y_i.
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>               number of instances in the batch.
-  !>     @param[inout]
-  !>     result
+  !>     @param[inout] myResult
   !>               device array or host array of batchCount size to store the dot products of each
   !>               batch.
   !>               Returns 0.0 for each element if n <= 0.
-  !>     @param[in]
-  !>     resultType
+  !>     @param[in] resultType
   !>     [hipDataType]
   !>               specifies the datatype of the result.
-  !>     @param[in]
-  !>     executionType
+  !>     @param[in] executionType
   !>     [hipDataType]
   !>               specifies the datatype of computation.
 #ifndef USE_CUDA_NAMES
@@ -41415,50 +39451,36 @@ module hipfort_hipblas
   !>
   !>     The supported types are determined by the backend. See rocBLAS/cuBLAS documentation.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of elements in each x_i and y_i.
-  !>     @param[in]
-  !>     x         device pointer to the first vector (x_1) in the batch.
-  !>     @param[in]
-  !>     xType
+  !>     @param[in] x - device pointer to the first vector (x_1) in the batch.
+  !>     @param[in] xType
   !>     [hipDataType]
   !>               specifies the datatype of each vector x_i.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     stridex   [hipblasStride]
+  !>     @param[in] stridex - [hipblasStride]
   !>               stride from the start of one vector (x_i) to the next one (x_i+1).
-  !>     @param[in]
-  !>     y         device pointer to the first vector (y_1) in the batch.
-  !>     @param[in]
-  !>     yType
+  !>     @param[in] y - device pointer to the first vector (y_1) in the batch.
+  !>     @param[in] yType
   !>     [hipDataType]
   !>               specifies the datatype of each vector y_i.
-  !>     @param[in]
-  !>     incy      [int]
+  !>     @param[in] incy - [int]
   !>               specifies the increment for the elements of each y_i.
-  !>     @param[in]
-  !>     stridey   [hipblasStride]
+  !>     @param[in] stridey - [hipblasStride]
   !>               stride from the start of one vector (y_i) to the next one (y_i+1).
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>               number of instances in the batch.
-  !>     @param[inout]
-  !>     result
+  !>     @param[inout] myResult
   !>               device array or host array of batchCount size to store the dot products of each
   !>               batch.
   !>               Returns 0.0 for each element if n <= 0.
-  !>     @param[in]
-  !>     resultType
+  !>     @param[in] resultType
   !>     [hipDataType]
   !>               specifies the datatype of the result.
-  !>     @param[in]
-  !>     executionType
+  !>     @param[in] executionType
   !>     [hipDataType]
   !>               specifies the datatype of computation.
 #ifndef USE_CUDA_NAMES
@@ -41583,31 +39605,23 @@ module hipfort_hipblas
   !>
   !>     The supported types are determined by the backend. See the rocBLAS or cuBLAS documentation.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of elements in x.
-  !>     @param[in]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     xType
+  !>     @param[in] x - device pointer storing vector x.
+  !>     @param[in] xType
   !>     [hipDataType]
   !>               specifies the datatype of the vector x.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of y.
-  !>     @param[inout]
-  !>     result
+  !>     @param[inout] myResult
   !>               device pointer or host pointer to store the nrm2 product.
   !>               The return value is 0.0 if n, incx<=0.
-  !>     @param[in]
-  !>     resultType
+  !>     @param[in] resultType
   !>     [hipDataType]
   !>               specifies the datatype of the result.
-  !>     @param[in]
-  !>     executionType
+  !>     @param[in] executionType
   !>     [hipDataType]
   !>               specifies the datatype of computation.
   interface hipblasNrm2Ex
@@ -41669,34 +39683,25 @@ module hipfort_hipblas
   !>
   !>     The supported types are determined by the backend. See the rocBLAS or cuBLAS documentation.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               number of elements in each x_i.
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     xType
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] xType
   !>     [hipDataType]
   !>               specifies the datatype of each vector x_i.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each x_i. incx must be > 0.
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>               number of instances in the batch.
-  !>     @param[out]
-  !>     result
+  !>     @param[out] myResult
   !>               device pointer or host pointer to array of batchCount size for nrm2 results.
   !>               Returns 0.0 for each element if n <= 0, incx<=0.
-  !>     @param[in]
-  !>     resultType
+  !>     @param[in] resultType
   !>     [hipDataType]
   !>               specifies the datatype of the result.
-  !>     @param[in]
-  !>     executionType
+  !>     @param[in] executionType
   !>     [hipDataType]
   !>               specifies the datatype of computation.
 #ifndef USE_CUDA_NAMES
@@ -41756,41 +39761,31 @@ module hipfort_hipblas
   !>
   !>     The supported types are determined by the backend. See the rocBLAS or cuBLAS documentation.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               number of elements in each x_i.
-  !>     @param[in]
-  !>     x         device pointer to the first vector x_1.
-  !>     @param[in]
-  !>     xType
+  !>     @param[in] x - device pointer to the first vector x_1.
+  !>     @param[in] xType
   !>     [hipDataType]
   !>               specifies the datatype of each vector x_i.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each x_i. incx must be > 0.
-  !>     @param[in]
-  !>     stridex   [hipblasStride]
+  !>     @param[in] stridex - [hipblasStride]
   !>               stride from the start of one vector (x_i) and the next one (x_i+1).
   !>               There are no restrictions placed on stridex. However, the user should
   !>               ensure that stridex is of an appropriate size. For a typical
   !>               case, this means stridex >= n * incx.
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>               number of instances in the batch.
-  !>     @param[out]
-  !>     result
+  !>     @param[out] myResult
   !>               device pointer or host pointer to array for storing contiguous batchCount
   !>               results.
   !>               Returns 0.0 for each element if n <= 0, incx<=0.
-  !>     @param[in]
-  !>     resultType
+  !>     @param[in] resultType
   !>     [hipDataType]
   !>               specifies the datatype of the result.
-  !>     @param[in]
-  !>     executionType
+  !>     @param[in] executionType
   !>     [hipDataType]
   !>               specifies the datatype of computation.
 #ifndef USE_CUDA_NAMES
@@ -41861,40 +39856,30 @@ module hipfort_hipblas
   !>
   !>     The supported types are determined by the backend. See the rocBLAS or cuBLAS documentation.
   !>
-  !>     @param[in]
-  !>     handle  [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>             handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     n       [int]
+  !>     @param[in] n - [int]
   !>             number of elements in the x and y vectors.
-  !>     @param[inout]
-  !>     x       device pointer storing vector x.
-  !>     @param[in]
-  !>     xType
+  !>     @param[inout] x - device pointer storing vector x.
+  !>     @param[in] xType
   !>     [hipDataType]
   !>             specifies the datatype of vector x.
-  !>     @param[in]
-  !>     incx    [int]
+  !>     @param[in] incx - [int]
   !>             specifies the increment between elements of x.
-  !>     @param[inout]
-  !>     y       device pointer storing vector y.
-  !>     @param[in]
-  !>     yType
+  !>     @param[inout] y - device pointer storing vector y.
+  !>     @param[in] yType
   !>     [hipDataType]
   !>             specifies the datatype of vector y.
-  !>     @param[in]
-  !>     incy    [int]
+  !>     @param[in] incy - [int]
   !>             specifies the increment between elements of y.
-  !>     @param[in]
-  !>     c device pointer or host pointer storing scalar cosine component of the rotation matrix.
-  !>     @param[in]
-  !>     s device pointer or host pointer storing scalar sine component of the rotation matrix.
-  !>     @param[in]
-  !>     csType
+  !>     @param[in] c - device pointer or host pointer storing scalar cosine component of the
+  !>     rotation matrix.
+  !>     @param[in] s - device pointer or host pointer storing scalar sine component of the rotation
+  !>     matrix.
+  !>     @param[in] csType
   !>     [hipDataType]
   !>             specifies the datatype of c and s.
-  !>     @param[in]
-  !>     executionType
+  !>     @param[in] executionType
   !>     [hipDataType]
   !>             specifies the datatype of computation.
   interface hipblasRotEx
@@ -41974,43 +39959,32 @@ module hipfort_hipblas
   !>
   !>     The supported types are determined by the backend. See the rocBLAS or cuBLAS documentation.
   !>
-  !>     @param[in]
-  !>     handle  [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>             handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     n       [int]
+  !>     @param[in] n - [int]
   !>             number of elements in each x_i and y_i vectors.
-  !>     @param[inout]
-  !>     x       device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     xType
+  !>     @param[inout] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] xType
   !>     [hipDataType]
   !>             specifies the datatype of each vector x_i.
-  !>     @param[in]
-  !>     incx    [int]
+  !>     @param[in] incx - [int]
   !>             specifies the increment between elements of each x_i.
-  !>     @param[inout]
-  !>     y       device array of device pointers storing each vector y_i.
-  !>     @param[in]
-  !>     yType
+  !>     @param[inout] y - device array of device pointers storing each vector y_i.
+  !>     @param[in] yType
   !>     [hipDataType]
   !>             specifies the datatype of each vector y_i.
-  !>     @param[in]
-  !>     incy    [int]
+  !>     @param[in] incy - [int]
   !>             specifies the increment between elements of each y_i.
-  !>     @param[in]
-  !>     c       device pointer or host pointer to scalar cosine component of the rotation matrix.
-  !>     @param[in]
-  !>     s       device pointer or host pointer to scalar sine component of the rotation matrix.
-  !>     @param[in]
-  !>     csType
+  !>     @param[in] c - device pointer or host pointer to scalar cosine component of the rotation
+  !>     matrix.
+  !>     @param[in] s - device pointer or host pointer to scalar sine component of the rotation
+  !>     matrix.
+  !>     @param[in] csType
   !>     [hipDataType]
   !>             specifies the datatype of c and s.
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>             the number of x and y arrays, that is, the number of batches.
-  !>     @param[in]
-  !>     executionType
+  !>     @param[in] executionType
   !>     [hipDataType]
   !>             specifies the datatype of computation.
 #ifndef USE_CUDA_NAMES
@@ -42088,49 +40062,36 @@ module hipfort_hipblas
   !>
   !>     The supported types are determined by the backend. See the rocBLAS or cuBLAS documentation.
   !>
-  !>     @param[in]
-  !>     handle  [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>             handle to the hipblas library context queue.
-  !>     @param[in]
-  !>     n       [int]
+  !>     @param[in] n - [int]
   !>             number of elements in each x_i and y_i vectors.
-  !>     @param[inout]
-  !>     x       device pointer to the first vector x_1.
-  !>     @param[in]
-  !>     xType
+  !>     @param[inout] x - device pointer to the first vector x_1.
+  !>     @param[in] xType
   !>     [hipDataType]
   !>             specifies the datatype of each vector x_i.
-  !>     @param[in]
-  !>     incx    [int]
+  !>     @param[in] incx - [int]
   !>             specifies the increment between elements of each x_i.
-  !>     @param[in]
-  !>     stridex [hipblasStride]
+  !>     @param[in] stridex - [hipblasStride]
   !>             specifies the increment from the beginning of x_i to the beginning of x_(i+1).
-  !>     @param[inout]
-  !>     y       device pointer to the first vector y_1.
-  !>     @param[in]
-  !>     yType
+  !>     @param[inout] y - device pointer to the first vector y_1.
+  !>     @param[in] yType
   !>     [hipDataType]
   !>             specifies the datatype of each vector y_i.
-  !>     @param[in]
-  !>     incy    [int]
+  !>     @param[in] incy - [int]
   !>             specifies the increment between elements of each y_i.
-  !>     @param[in]
-  !>     stridey [hipblasStride]
+  !>     @param[in] stridey - [hipblasStride]
   !>             specifies the increment from the beginning of y_i to the beginning of y_(i+1).
-  !>     @param[in]
-  !>     c       device pointer or host pointer to scalar cosine component of the rotation matrix.
-  !>     @param[in]
-  !>     s       device pointer or host pointer to scalar sine component of the rotation matrix.
-  !>     @param[in]
-  !>     csType
+  !>     @param[in] c - device pointer or host pointer to scalar cosine component of the rotation
+  !>     matrix.
+  !>     @param[in] s - device pointer or host pointer to scalar sine component of the rotation
+  !>     matrix.
+  !>     @param[in] csType
   !>     [hipDataType]
   !>             specifies the datatype of c and s.
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>             the number of x and y arrays, that is, the number of batches.
-  !>     @param[in]
-  !>     executionType
+  !>     @param[in] executionType
   !>     [hipDataType]
   !>             specifies the datatype of computation.
 #ifndef USE_CUDA_NAMES
@@ -42200,29 +40161,21 @@ module hipfort_hipblas
   !>
   !>     The supported types are determined by the backend. See the rocBLAS or cuBLAS documentation.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of elements in x.
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer for the scalar alpha.
-  !>     @param[in]
-  !>     alphaType
+  !>     @param[in] alpha - device pointer or host pointer for the scalar alpha.
+  !>     @param[in] alphaType
   !>     [hipDataType]
   !>                specifies the datatype of alpha.
-  !>     @param[inout]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     xType
+  !>     @param[inout] x - device pointer storing vector x.
+  !>     @param[in] xType
   !>     [hipDataType]
   !>            specifies the datatype of vector x.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of x.
-  !>     @param[in]
-  !>     executionType
+  !>     @param[in] executionType
   !>     [hipDataType]
   !>                    specifies the datatype of computation.
   interface hipblasScalEx
@@ -42283,32 +40236,23 @@ module hipfort_hipblas
   !>
   !>     The supported types are determined by the backend. See the rocBLAS or cuBLAS documentation.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of elements in x.
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer for the scalar alpha.
-  !>     @param[in]
-  !>     alphaType
+  !>     @param[in] alpha - device pointer or host pointer for the scalar alpha.
+  !>     @param[in] alphaType
   !>     [hipDataType]
   !>                specifies the datatype of alpha.
-  !>     @param[inout]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     xType
+  !>     @param[inout] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] xType
   !>     [hipDataType]
   !>            specifies the datatype of each vector x_i.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
-  !>     @param[in]
-  !>     executionType
+  !>     @param[in] executionType
   !>     [hipDataType]
   !>                    specifies the datatype of computation.
 #ifndef USE_CUDA_NAMES
@@ -42367,38 +40311,28 @@ module hipfort_hipblas
   !>
   !>     The supported types are determined by the backend. See the rocBLAS or cuBLAS documentation.
   !>
-  !>     @param[in]
-  !>     handle    [hipblasHandle_t]
+  !>     @param[in] handle - [hipblasHandle_t]
   !>               handle to the hipBLAS library context queue.
-  !>     @param[in]
-  !>     n         [int]
+  !>     @param[in] n - [int]
   !>               the number of elements in x.
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer for the scalar alpha.
-  !>     @param[in]
-  !>     alphaType
+  !>     @param[in] alpha - device pointer or host pointer for the scalar alpha.
+  !>     @param[in] alphaType
   !>     [hipDataType]
   !>                specifies the datatype of alpha.
-  !>     @param[inout]
-  !>     x         device pointer to the first vector x_1.
-  !>     @param[in]
-  !>     xType
+  !>     @param[inout] x - device pointer to the first vector x_1.
+  !>     @param[in] xType
   !>     [hipDataType]
   !>            specifies the datatype of each vector x_i.
-  !>     @param[in]
-  !>     incx      [int]
+  !>     @param[in] incx - [int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     stridex   [hipblasStride]
+  !>     @param[in] stridex - [hipblasStride]
   !>               stride from the start of one vector (x_i) to the next one (x_i+1).
   !>               There are no restrictions placed on stridex. However, the user should
   !>               take care to ensure that stridex is of an appropriate size. For a typical
   !>               case, this means stridex >= n * incx.
-  !>     @param[in]
-  !>     batchCount [int]
+  !>     @param[in] batchCount - [int]
   !>                 number of instances in the batch.
-  !>     @param[in]
-  !>     executionType
+  !>     @param[in] executionType
   !>     [hipDataType]
   !>                    specifies the datatype of computation.
 #ifndef USE_CUDA_NAMES
@@ -42454,8 +40388,7 @@ module hipfort_hipblas
   !>     \details
   !>     Returns a string representing the ``hipblasStatus_t`` value.
   !>
-  !>     @param[in]
-  !>     status  [hipblasStatus_t]
+  !>     @param[in] status - [hipblasStatus_t]
   !>             hipBLAS status to convert to string.
 #ifndef USE_CUDA_NAMES
   interface hipblasStatusToString

--- a/lib/hipfort/hipfort_hipsparse.F90
+++ b/lib/hipfort/hipfort_hipsparse.F90
@@ -1008,22 +1008,15 @@ module hipfort_hipsparse
   !>   This function is deprecated when using the CUDA backend (CUDA 11.0+) and will be
   !>   removed in CUDA 12.0. This deprecation does not apply to the ROCm backend.
   !>
-  !>   @param[in]
-  !>   handle      handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of vector \f$x\f$. Must be non-negative.
-  !>   @param[in]
-  !>   alpha       scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   xVal        array of \p nnz elements containing the values of \f$x\f$.
-  !>   @param[in]
-  !>   xInd        array of \p nnz elements containing the indices of the non-zero
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] nnz - number of non-zero entries of vector \f$x\f$. Must be non-negative.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] xVal - array of \p nnz elements containing the values of \f$x\f$.
+  !>   @param[in] xInd - array of \p nnz elements containing the indices of the non-zero
   !>               values of \f$x\f$.
-  !>   @param[inout]
-  !>   y           array of values in dense format. Must be pre-allocated with sufficient
+  !>   @param[inout] y - array of values in dense format. Must be pre-allocated with sufficient
   !>               size to accommodate all indices specified in \p xInd.
-  !>   @param[in]
-  !>   idxBase     index base. `HIPSPARSE_INDEX_BASE_ZERO` for zero-based indexing or
+  !>   @param[in] idxBase - index base. `HIPSPARSE_INDEX_BASE_ZERO` for zero-based indexing or
   !>               `HIPSPARSE_INDEX_BASE_ONE` for one-based indexing.
   !>
   !>   \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
@@ -1157,22 +1150,15 @@ module hipfort_hipsparse
   !>   This function is deprecated when using the CUDA backend (CUDA 10.0+) and will be
   !>   removed in CUDA 11.0. This deprecation does not apply to the ROCm backend.
   !>
-  !>   @param[in]
-  !>   handle      handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of vector \f$x\f$. Must be non-negative.
-  !>   @param[in]
-  !>   xVal        array of \p nnz values containing the elements of \f$x\f$.
-  !>   @param[in]
-  !>   xInd        array of \p nnz elements containing the indices of the non-zero
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] nnz - number of non-zero entries of vector \f$x\f$. Must be non-negative.
+  !>   @param[in] xVal - array of \p nnz values containing the elements of \f$x\f$.
+  !>   @param[in] xInd - array of \p nnz elements containing the indices of the non-zero
   !>               values of \f$x\f$.
-  !>   @param[in]
-  !>   y           array of values in dense format. Must be pre-allocated with sufficient
+  !>   @param[in] y - array of values in dense format. Must be pre-allocated with sufficient
   !>               size to accommodate all indices specified in \p xInd.
-  !>   @param[out]
-  !>   result      pointer to the result, which can be host or device memory.
-  !>   @param[in]
-  !>   idxBase     index base. `HIPSPARSE_INDEX_BASE_ZERO` for zero-based indexing or
+  !>   @param[out] myResult - pointer to the result, which can be host or device memory.
+  !>   @param[in] idxBase - index base. `HIPSPARSE_INDEX_BASE_ZERO` for zero-based indexing or
   !>               `HIPSPARSE_INDEX_BASE_ONE` for one-based indexing.
   !>
   !>   \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
@@ -1262,22 +1248,15 @@ module hipfort_hipsparse
   !>   This function is deprecated when using the CUDA backend (CUDA 10.0+) and will be
   !>   removed in CUDA 11.0. This deprecation does not apply to the ROCm backend.
   !>
-  !>   @param[in]
-  !>   handle      handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of vector \f$x\f$. Must be non-negative.
-  !>   @param[in]
-  !>   xVal        array of \p nnz values containing the elements of \f$x\f$.
-  !>   @param[in]
-  !>   xInd        array of \p nnz elements containing the indices of the non-zero
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] nnz - number of non-zero entries of vector \f$x\f$. Must be non-negative.
+  !>   @param[in] xVal - array of \p nnz values containing the elements of \f$x\f$.
+  !>   @param[in] xInd - array of \p nnz elements containing the indices of the non-zero
   !>               values of \f$x\f$.
-  !>   @param[in]
-  !>   y           array of values in dense format. Must be pre-allocated with sufficient
+  !>   @param[in] y - array of values in dense format. Must be pre-allocated with sufficient
   !>               size to accommodate all indices specified in \p xInd.
-  !>   @param[out]
-  !>   result      pointer to the result, which can be host or device memory.
-  !>   @param[in]
-  !>   idxBase     index base. `HIPSPARSE_INDEX_BASE_ZERO` for zero-based indexing or
+  !>   @param[out] myResult - pointer to the result, which can be host or device memory.
+  !>   @param[in] idxBase - index base. `HIPSPARSE_INDEX_BASE_ZERO` for zero-based indexing or
   !>               `HIPSPARSE_INDEX_BASE_ONE` for one-based indexing.
   !>
   !>   \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
@@ -1409,20 +1388,14 @@ module hipfort_hipsparse
   !>   This function is deprecated when using the CUDA backend (CUDA 11.0+) and will be
   !>   removed in CUDA 12.0. This deprecation does not apply to the ROCm backend.
   !>
-  !>   @param[in]
-  !>   handle      handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of \f$x\f$. Must be non-negative.
-  !>   @param[in]
-  !>   y           array of values in dense format. Must be pre-allocated with sufficient
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] nnz - number of non-zero entries of \f$x\f$. Must be non-negative.
+  !>   @param[in] y - array of values in dense format. Must be pre-allocated with sufficient
   !>               size to accommodate all indices specified in \p xInd.
-  !>   @param[out]
-  !>   xVal        array of \p nnz elements that will contain the gathered values of \f$x\f$.
-  !>   @param[in]
-  !>   xInd        array of \p nnz elements containing the indices of the non-zero
+  !>   @param[out] xVal - array of \p nnz elements that will contain the gathered values of \f$x\f$.
+  !>   @param[in] xInd - array of \p nnz elements containing the indices of the non-zero
   !>               values of \f$x\f$.
-  !>   @param[in]
-  !>   idxBase     index base. `HIPSPARSE_INDEX_BASE_ZERO` for zero-based indexing or
+  !>   @param[in] idxBase - index base. `HIPSPARSE_INDEX_BASE_ZERO` for zero-based indexing or
   !>               `HIPSPARSE_INDEX_BASE_ONE` for one-based indexing.
   !>
   !>   \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
@@ -1550,21 +1523,15 @@ module hipfort_hipsparse
   !>   This function is deprecated when using the CUDA backend (CUDA 11.0+) and will be
   !>   removed in CUDA 12.0. This deprecation does not apply to the ROCm backend.
   !>
-  !>   @param[in]
-  !>   handle      handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of \f$x\f$. Must be non-negative.
-  !>   @param[inout]
-  !>   y           array of values in dense format. Must be pre-allocated with sufficient
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] nnz - number of non-zero entries of \f$x\f$. Must be non-negative.
+  !>   @param[inout] y - array of values in dense format. Must be pre-allocated with sufficient
   !>               size to accommodate all indices specified in \p xInd. Gathered elements
   !>               are set to zero.
-  !>   @param[out]
-  !>   xVal        array of \p nnz elements that will contain the gathered values of \f$x\f$.
-  !>   @param[in]
-  !>   xInd        array of \p nnz elements containing the indices of the non-zero
+  !>   @param[out] xVal - array of \p nnz elements that will contain the gathered values of \f$x\f$.
+  !>   @param[in] xInd - array of \p nnz elements containing the indices of the non-zero
   !>               values of \f$x\f$.
-  !>   @param[in]
-  !>   idxBase     index base. `HIPSPARSE_INDEX_BASE_ZERO` for zero-based indexing or
+  !>   @param[in] idxBase - index base. `HIPSPARSE_INDEX_BASE_ZERO` for zero-based indexing or
   !>               `HIPSPARSE_INDEX_BASE_ONE` for one-based indexing.
   !>
   !>   \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
@@ -1696,24 +1663,16 @@ module hipfort_hipsparse
   !>   This function is deprecated when using the CUDA backend (CUDA 11.0+) and will be
   !>   removed in CUDA 12.0. This deprecation does not apply to the ROCm backend.
   !>
-  !>   @param[in]
-  !>   handle      handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of \f$x\f$. Must be non-negative.
-  !>   @param[inout]
-  !>   xVal        array of \p nnz elements containing the non-zero values of \f$x\f$.
-  !>   @param[in]
-  !>   xInd        array of \p nnz elements containing the indices of the non-zero
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] nnz - number of non-zero entries of \f$x\f$. Must be non-negative.
+  !>   @param[inout] xVal - array of \p nnz elements containing the non-zero values of \f$x\f$.
+  !>   @param[in] xInd - array of \p nnz elements containing the indices of the non-zero
   !>               values of \f$x\f$.
-  !>   @param[inout]
-  !>   y           array of values in dense format. Must be pre-allocated with sufficient
+  !>   @param[inout] y - array of values in dense format. Must be pre-allocated with sufficient
   !>               size to accommodate all indices specified in \p xInd.
-  !>   @param[in]
-  !>   c           pointer to the cosine element of \f$G\f$, which can be on host or device.
-  !>   @param[in]
-  !>   s           pointer to the sine element of \f$G\f$, which can be on host or device.
-  !>   @param[in]
-  !>   idxBase     index base. `HIPSPARSE_INDEX_BASE_ZERO` for zero-based indexing or
+  !>   @param[in] c - pointer to the cosine element of \f$G\f$, which can be on host or device.
+  !>   @param[in] s - pointer to the sine element of \f$G\f$, which can be on host or device.
+  !>   @param[in] idxBase - index base. `HIPSPARSE_INDEX_BASE_ZERO` for zero-based indexing or
   !>               `HIPSPARSE_INDEX_BASE_ONE` for one-based indexing.
   !>
   !>   \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
@@ -1799,20 +1758,14 @@ module hipfort_hipsparse
   !>   This function is deprecated when using the CUDA backend (CUDA 11.0+) and will be
   !>   removed in CUDA 12.0. This deprecation does not apply to the ROCm backend.
   !>
-  !>   @param[in]
-  !>   handle      handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of \f$x\f$. Must be non-negative.
-  !>   @param[in]
-  !>   xVal        array of \p nnz elements containing the non-zero values of \f$x\f$.
-  !>   @param[in]
-  !>   xInd        array of \p nnz elements containing the indices of the non-zero
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] nnz - number of non-zero entries of \f$x\f$. Must be non-negative.
+  !>   @param[in] xVal - array of \p nnz elements containing the non-zero values of \f$x\f$.
+  !>   @param[in] xInd - array of \p nnz elements containing the indices of the non-zero
   !>               values of \f$x\f$.
-  !>   @param[inout]
-  !>   y           array of values in dense format. Must be pre-allocated with sufficient
+  !>   @param[inout] y - array of values in dense format. Must be pre-allocated with sufficient
   !>               size to accommodate all indices specified in \p xInd.
-  !>   @param[in]
-  !>   idxBase     index base. `HIPSPARSE_INDEX_BASE_ZERO` for zero-based indexing or
+  !>   @param[in] idxBase - index base. `HIPSPARSE_INDEX_BASE_ZERO` for zero-based indexing or
   !>               `HIPSPARSE_INDEX_BASE_ONE` for one-based indexing.
   !>
   !>   \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
@@ -1940,40 +1893,27 @@ module hipfort_hipsparse
   !>   \note
   !>   Currently, only \p transA == `HIPSPARSE_OPERATION_NON_TRANSPOSE` is supported.
   !>
-  !>   @param[in]
-  !>   handle          handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   dirA            matrix storage of BSR blocks.
-  !>   @param[in]
-  !>   transA          matrix operation type.
-  !>   @param[in]
-  !>   mb              number of block rows of the sparse BSR matrix. Must be non-negative.
-  !>   @param[in]
-  !>   nb              number of block columns of the sparse BSR matrix. Must be non-negative.
-  !>   @param[in]
-  !>   nnzb            number of non-zero blocks of the sparse BSR matrix. Must be non-negative.
-  !>   @param[in]
-  !>   alpha           scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   descrA          descriptor of the sparse BSR matrix. Currently, only
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] dirA - matrix storage of BSR blocks.
+  !>   @param[in] transA - matrix operation type.
+  !>   @param[in] mb - number of block rows of the sparse BSR matrix. Must be non-negative.
+  !>   @param[in] nb - number of block columns of the sparse BSR matrix. Must be non-negative.
+  !>   @param[in] nnzb - number of non-zero blocks of the sparse BSR matrix. Must be non-negative.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] descrA - descriptor of the sparse BSR matrix. Currently, only
   !>                   `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[in]
-  !>   bsrSortedValA   array of \p nnzb blocks of the sparse BSR matrix.
-  !>   @param[in]
-  !>   bsrSortedRowPtrA array of \p mb+1 elements that point to the start of every block row of
+  !>   @param[in] bsrSortedValA - array of \p nnzb blocks of the sparse BSR matrix.
+  !>   @param[in] bsrSortedRowPtrA - array of \p mb+1 elements that point to the start of every
+  !>   block row of
   !>                   the sparse BSR matrix.
-  !>   @param[in]
-  !>   bsrSortedColIndA array of \p nnzb elements containing the block column indices of the sparse
+  !>   @param[in] bsrSortedColIndA - array of \p nnzb elements containing the block column indices
+  !>   of the sparse
   !>                   BSR matrix.
-  !>   @param[in]
-  !>   blockDim        block dimension of the sparse BSR matrix. Must be positive.
-  !>   @param[in]
-  !>   x               array of \p nb*blockDim elements (\f$op(A) = A\f$) or \p mb*blockDim
+  !>   @param[in] blockDim - block dimension of the sparse BSR matrix. Must be positive.
+  !>   @param[in] x - array of \p nb*blockDim elements (\f$op(A) = A\f$) or \p mb*blockDim
   !>                   elements (\f$op(A) = A^T\f$ or \f$op(A) = A^H\f$).
-  !>   @param[in]
-  !>   beta            scalar \f$\beta\f$.
-  !>   @param[inout]
-  !>   y               array of \p mb*blockDim elements (\f$op(A) = A\f$) or \p nb*blockDim
+  !>   @param[in] beta - scalar \f$\beta\f$.
+  !>   @param[inout] y - array of \p mb*blockDim elements (\f$op(A) = A\f$) or \p nb*blockDim
   !>                   elements (\f$op(A) = A^T\f$ or \f$op(A) = A^H\f$).
   !>
   !>   \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
@@ -2154,12 +2094,9 @@ module hipfort_hipsparse
   !>   This function is deprecated when using the CUDA backend (CUDA 12.0+) and will be
   !>   removed in CUDA 13.0. This deprecation does not apply to the ROCm backend.
   !>
-  !>   @param[in]
-  !>   handle      handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   info        structure that holds the information collected during the analysis step.
-  !>   @param[inout]
-  !>   position    pointer to zero pivot \f$j\f$, can be in host or device memory.
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[inout] position - pointer to zero pivot \f$j\f$, can be in host or device memory.
   !>
   !>   \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
   !>   \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
@@ -2191,32 +2128,22 @@ module hipfort_hipsparse
   !>   `hipsparseSbsrsv2_solve` "hipsparseXbsrsv2_solve()". The temporary storage buffer must
   !>   be allocated by the user.
   !>
-  !>   @param[in]
-  !>   handle      handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   dirA        matrix storage of BSR blocks.
-  !>   @param[in]
-  !>   transA      matrix operation type.
-  !>   @param[in]
-  !>   mb          number of block rows of the sparse BSR matrix.
-  !>   @param[in]
-  !>   nnzb        number of non-zero blocks of the sparse BSR matrix.
-  !>   @param[in]
-  !>   descrA      descriptor of the sparse BSR matrix.
-  !>   @param[in]
-  !>   bsrSortedValA array of \p nnzb blocks of the sparse BSR matrix.
-  !>   @param[in]
-  !>   bsrSortedRowPtrA array of \p mb+1 elements that point to the start of every block row of
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] dirA - matrix storage of BSR blocks.
+  !>   @param[in] transA - matrix operation type.
+  !>   @param[in] mb - number of block rows of the sparse BSR matrix.
+  !>   @param[in] nnzb - number of non-zero blocks of the sparse BSR matrix.
+  !>   @param[in] descrA - descriptor of the sparse BSR matrix.
+  !>   @param[in] bsrSortedValA - array of \p nnzb blocks of the sparse BSR matrix.
+  !>   @param[in] bsrSortedRowPtrA - array of \p mb+1 elements that point to the start of every
+  !>   block row of
   !>               the sparse BSR matrix.
-  !>   @param[in]
-  !>   bsrSortedColIndA array of \p nnz containing the block column indices of the sparse
+  !>   @param[in] bsrSortedColIndA - array of \p nnz containing the block column indices of the
+  !>   sparse
   !>               BSR matrix.
-  !>   @param[in]
-  !>   blockDim    block dimension of the sparse BSR matrix.
-  !>   @param[out]
-  !>   info        structure that holds the information collected during the analysis step.
-  !>   @param[out]
-  !>   pBufferSizeInBytes number of bytes of the temporary storage buffer required by
+  !>   @param[in] blockDim - block dimension of the sparse BSR matrix.
+  !>   @param[out] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[out] pBufferSizeInBytes - number of bytes of the temporary storage buffer required by
   !>               `hipsparseSbsrsv2_analysis` "hipsparseXbsrsv2_analysis()" and
   !>               `hipsparseSbsrsv2_solve` "hipsparseXbsrsv2_solve()".
   !>
@@ -2375,32 +2302,22 @@ module hipfort_hipsparse
   !>   `hipsparseSbsrsv2_solve` "hipsparseXbsrsv2_solve()". The temporary storage buffer must be
   !>   allocated by the user.
   !>
-  !>   @param[in]
-  !>   handle      handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   dirA        matrix storage of BSR blocks.
-  !>   @param[in]
-  !>   transA      matrix operation type.
-  !>   @param[in]
-  !>   mb          number of block rows of the sparse BSR matrix.
-  !>   @param[in]
-  !>   nnzb        number of non-zero blocks of the sparse BSR matrix.
-  !>   @param[in]
-  !>   descrA      descriptor of the sparse BSR matrix.
-  !>   @param[in]
-  !>   bsrSortedValA array of \p nnzb blocks of the sparse BSR matrix.
-  !>   @param[in]
-  !>   bsrSortedRowPtrA array of \p mb+1 elements that point to the start of every block row of
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] dirA - matrix storage of BSR blocks.
+  !>   @param[in] transA - matrix operation type.
+  !>   @param[in] mb - number of block rows of the sparse BSR matrix.
+  !>   @param[in] nnzb - number of non-zero blocks of the sparse BSR matrix.
+  !>   @param[in] descrA - descriptor of the sparse BSR matrix.
+  !>   @param[in] bsrSortedValA - array of \p nnzb blocks of the sparse BSR matrix.
+  !>   @param[in] bsrSortedRowPtrA - array of \p mb+1 elements that point to the start of every
+  !>   block row of
   !>               the sparse BSR matrix.
-  !>   @param[in]
-  !>   bsrSortedColIndA array of \p nnz containing the block column indices of the sparse
+  !>   @param[in] bsrSortedColIndA - array of \p nnz containing the block column indices of the
+  !>   sparse
   !>               BSR matrix.
-  !>   @param[in]
-  !>   blockDim    block dimension of the sparse BSR matrix.
-  !>   @param[out]
-  !>   info        structure that holds the information collected during the analysis step.
-  !>   @param[out]
-  !>   pBufferSizeInBytes number of bytes of the temporary storage buffer required by
+  !>   @param[in] blockDim - block dimension of the sparse BSR matrix.
+  !>   @param[out] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[out] pBufferSizeInBytes - number of bytes of the temporary storage buffer required by
   !>               `hipsparseSbsrsv2_analysis` "hipsparseXbsrsv2_analysis()" and
   !>               `hipsparseSbsrsv2_solve` "hipsparseXbsrsv2_solve()".
   !>
@@ -2549,36 +2466,25 @@ module hipfort_hipsparse
   !>   This function is non-blocking and executed asynchronously with respect to the host.
   !>   It can return before the actual computation has finished.
   !>
-  !>   @param[in]
-  !>   handle      handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   dirA        matrix storage of BSR blocks.
-  !>   @param[in]
-  !>   transA      matrix operation type.
-  !>   @param[in]
-  !>   mb          number of block rows of the sparse BSR matrix.
-  !>   @param[in]
-  !>   nnzb        number of non-zero blocks of the sparse BSR matrix.
-  !>   @param[in]
-  !>   descrA      descriptor of the sparse BSR matrix.
-  !>   @param[in]
-  !>   bsrSortedValA array of \p nnzb blocks of the sparse BSR matrix.
-  !>   @param[in]
-  !>   bsrSortedRowPtrA array of \p mb+1 elements that point to the start of every block row of
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] dirA - matrix storage of BSR blocks.
+  !>   @param[in] transA - matrix operation type.
+  !>   @param[in] mb - number of block rows of the sparse BSR matrix.
+  !>   @param[in] nnzb - number of non-zero blocks of the sparse BSR matrix.
+  !>   @param[in] descrA - descriptor of the sparse BSR matrix.
+  !>   @param[in] bsrSortedValA - array of \p nnzb blocks of the sparse BSR matrix.
+  !>   @param[in] bsrSortedRowPtrA - array of \p mb+1 elements that point to the start of every
+  !>   block row of
   !>               the sparse BSR matrix.
-  !>   @param[in]
-  !>   bsrSortedColIndA array of \p nnz containing the block column indices of the sparse
+  !>   @param[in] bsrSortedColIndA - array of \p nnz containing the block column indices of the
+  !>   sparse
   !>               BSR matrix.
-  !>   @param[in]
-  !>   blockDim    block dimension of the sparse BSR matrix.
-  !>   @param[out]
-  !>   info        structure that holds the information collected during
+  !>   @param[in] blockDim - block dimension of the sparse BSR matrix.
+  !>   @param[out] myInfo - structure that holds the information collected during
   !>               the analysis step.
-  !>   @param[in]
-  !>   policy      `HIPSPARSE_SOLVE_POLICY_NO_LEVEL` or
+  !>   @param[in] policy - `HIPSPARSE_SOLVE_POLICY_NO_LEVEL` or
   !>               `HIPSPARSE_SOLVE_POLICY_USE_LEVEL`.
-  !>   @param[in]
-  !>   pBuffer     temporary storage buffer allocated by the user.
+  !>   @param[in] pBuffer - temporary storage buffer allocated by the user.
   !>
   !>   \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
   !>   \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p mb, \p nnzb, \p blockDim,
@@ -2805,41 +2711,27 @@ module hipfort_hipsparse
   !>   Currently, only \p transA == `HIPSPARSE_OPERATION_NON_TRANSPOSE` and
   !>   \p transA == `HIPSPARSE_OPERATION_TRANSPOSE` is supported.
   !>
-  !>   @param[in]
-  !>   handle      handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   dirA        matrix storage of BSR blocks.
-  !>   @param[in]
-  !>   transA      matrix operation type.
-  !>   @param[in]
-  !>   mb          number of block rows of the sparse BSR matrix.
-  !>   @param[in]
-  !>   nnzb        number of non-zero blocks of the sparse BSR matrix.
-  !>   @param[in]
-  !>   alpha       scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   descrA      descriptor of the sparse BSR matrix.
-  !>   @param[in]
-  !>   bsrSortedValA array of \p nnzb blocks of the sparse BSR matrix.
-  !>   @param[in]
-  !>   bsrSortedRowPtrA array of \p mb+1 elements that point to the start of every block row of
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] dirA - matrix storage of BSR blocks.
+  !>   @param[in] transA - matrix operation type.
+  !>   @param[in] mb - number of block rows of the sparse BSR matrix.
+  !>   @param[in] nnzb - number of non-zero blocks of the sparse BSR matrix.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] descrA - descriptor of the sparse BSR matrix.
+  !>   @param[in] bsrSortedValA - array of \p nnzb blocks of the sparse BSR matrix.
+  !>   @param[in] bsrSortedRowPtrA - array of \p mb+1 elements that point to the start of every
+  !>   block row of
   !>               the sparse BSR matrix.
-  !>   @param[in]
-  !>   bsrSortedColIndA array of \p nnz containing the block column indices of the sparse
+  !>   @param[in] bsrSortedColIndA - array of \p nnz containing the block column indices of the
+  !>   sparse
   !>               BSR matrix.
-  !>   @param[in]
-  !>   blockDim    block dimension of the sparse BSR matrix.
-  !>   @param[in]
-  !>   info        structure that holds the information collected during the analysis step.
-  !>   @param[in]
-  !>   f           array of \p m elements, holding the right-hand side.
-  !>   @param[out]
-  !>   x           array of \p m elements, holding the solution.
-  !>   @param[in]
-  !>   policy      `HIPSPARSE_SOLVE_POLICY_NO_LEVEL` or
+  !>   @param[in] blockDim - block dimension of the sparse BSR matrix.
+  !>   @param[in] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[in] f - array of \p m elements, holding the right-hand side.
+  !>   @param[out] x - array of \p m elements, holding the solution.
+  !>   @param[in] policy - `HIPSPARSE_SOLVE_POLICY_NO_LEVEL` or
   !>               `HIPSPARSE_SOLVE_POLICY_USE_LEVEL`.
-  !>   @param[in]
-  !>   pBuffer     temporary storage buffer allocated by the user.
+  !>   @param[in] pBuffer - temporary storage buffer allocated by the user.
   !>
   !>   \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
   !>   \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p mb, \p nnzb, \p blockDim,
@@ -3047,48 +2939,33 @@ module hipfort_hipsparse
   !>   This function is deprecated when using the CUDA backend (CUDA 12.0+) and will be
   !>   removed in CUDA 13.0. This deprecation does not apply to the ROCm backend.
   !>
-  !>   @param[in]
-  !>   handle      handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   dir         matrix storage of BSR blocks.
-  !>   @param[in]
-  !>   trans       matrix operation type.
-  !>   @param[in]
-  !>   sizeOfMask  number of updated block rows of the array \p y. Must be non-negative and
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] dir - matrix storage of BSR blocks.
+  !>   @param[in] trans - matrix operation type.
+  !>   @param[in] sizeOfMask - number of updated block rows of the array \p y. Must be non-negative
+  !>   and
   !>               not greater than \p mb.
-  !>   @param[in]
-  !>   mb          number of block rows of the sparse BSR matrix. Must be non-negative.
-  !>   @param[in]
-  !>   nb          number of block columns of the sparse BSR matrix. Must be non-negative.
-  !>   @param[in]
-  !>   nnzb        number of non-zero blocks of the sparse BSR matrix. Must be non-negative.
-  !>   @param[in]
-  !>   alpha       scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   descr       descriptor of the sparse BSR matrix. Currently, only
+  !>   @param[in] mb - number of block rows of the sparse BSR matrix. Must be non-negative.
+  !>   @param[in] nb - number of block columns of the sparse BSR matrix. Must be non-negative.
+  !>   @param[in] nnzb - number of non-zero blocks of the sparse BSR matrix. Must be non-negative.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] descr - descriptor of the sparse BSR matrix. Currently, only
   !>               `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[in]
-  !>   bsrVal      array of \p nnzb blocks of the sparse BSR matrix.
-  !>   @param[in]
-  !>   bsrMaskPtr  array of \p sizeOfMask elements that give the indices of the updated block rows.
-  !>   @param[in]
-  !>   bsrRowPtr   array of \p mb elements that point to the start of every block row of
+  !>   @param[in] bsrVal - array of \p nnzb blocks of the sparse BSR matrix.
+  !>   @param[in] bsrMaskPtr - array of \p sizeOfMask elements that give the indices of the updated
+  !>   block rows.
+  !>   @param[in] bsrRowPtr - array of \p mb elements that point to the start of every block row of
   !>               the sparse BSR matrix.
-  !>   @param[in]
-  !>   bsrEndPtr   array of \p mb elements that point to the end of every block row of
+  !>   @param[in] bsrEndPtr - array of \p mb elements that point to the end of every block row of
   !>               the sparse BSR matrix.
-  !>   @param[in]
-  !>   bsrColInd   array of \p nnzb elements containing the block column indices of the sparse
+  !>   @param[in] bsrColInd - array of \p nnzb elements containing the block column indices of the
+  !>   sparse
   !>               BSR matrix.
-  !>   @param[in]
-  !>   blockDim    block dimension of the sparse BSR matrix. Must be greater than 1.
-  !>   @param[in]
-  !>   x           array of \p nb*blockDim elements (\f$op(A) = A\f$) or \p mb*blockDim
+  !>   @param[in] blockDim - block dimension of the sparse BSR matrix. Must be greater than 1.
+  !>   @param[in] x - array of \p nb*blockDim elements (\f$op(A) = A\f$) or \p mb*blockDim
   !>               elements (\f$op(A) = A^T\f$ or \f$op(A) = A^H\f$).
-  !>   @param[in]
-  !>   beta        scalar \f$\beta\f$.
-  !>   @param[inout]
-  !>   y           array of \p mb*blockDim elements (\f$op(A) = A\f$) or \p nb*blockDim
+  !>   @param[in] beta - scalar \f$\beta\f$.
+  !>   @param[inout] y - array of \p mb*blockDim elements (\f$op(A) = A\f$) or \p nb*blockDim
   !>               elements (\f$op(A) = A^T\f$ or \f$op(A) = A^H\f$).
   !>
   !>   \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
@@ -3310,36 +3187,24 @@ module hipfort_hipsparse
   !>   This function is deprecated when using the CUDA backend (CUDA 10.0+) and will be
   !>   removed in CUDA 11.0. This deprecation does not apply to the ROCm backend.
   !>
-  !>   @param[in]
-  !>   handle              handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   transA              matrix operation type.
-  !>   @param[in]
-  !>   m                   number of rows of the sparse CSR matrix. Must be non-negative.
-  !>   @param[in]
-  !>   n                   number of columns of the sparse CSR matrix. Must be non-negative.
-  !>   @param[in]
-  !>   nnz number of non-zero entries of the sparse CSR matrix. Must be non-negative.
-  !>   @param[in]
-  !>   alpha               scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   descrA              descriptor of the sparse CSR matrix. Currently, only
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] transA - matrix operation type.
+  !>   @param[in] m - number of rows of the sparse CSR matrix. Must be non-negative.
+  !>   @param[in] n - number of columns of the sparse CSR matrix. Must be non-negative.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix. Must be non-negative.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] descrA - descriptor of the sparse CSR matrix. Currently, only
   !>                       `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[in]
-  !>   csrSortedValA       array of \p nnz elements of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csrSortedRowPtrA    array of \p m+1 elements that point to the start
+  !>   @param[in] csrSortedValA - array of \p nnz elements of the sparse CSR matrix.
+  !>   @param[in] csrSortedRowPtrA - array of \p m+1 elements that point to the start
   !>                       of every row of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csrSortedColIndA    array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] csrSortedColIndA - array of \p nnz elements containing the column indices of the
+  !>   sparse
   !>                       CSR matrix.
-  !>   @param[in]
-  !>   x                   array of \p n elements (\f$op(A) == A\f$) or \p m elements
+  !>   @param[in] x - array of \p n elements (\f$op(A) == A\f$) or \p m elements
   !>                       (\f$op(A) == A^T\f$ or \f$op(A) == A^H\f$).
-  !>   @param[in]
-  !>   beta                scalar \f$\beta\f$.
-  !>   @param[inout]
-  !>   y                   array of \p m elements (\f$op(A) == A\f$) or \p n elements
+  !>   @param[in] beta - scalar \f$\beta\f$.
+  !>   @param[inout] y - array of \p m elements (\f$op(A) == A\f$) or \p n elements
   !>                       (\f$op(A) == A^T\f$ or \f$op(A) == A^H\f$).
   !>
   !>   \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
@@ -3496,12 +3361,10 @@ module hipfort_hipsparse
   !>   This function is deprecated when using the CUDA backend (CUDA 11.0+) and will be
   !>   removed in CUDA 12.0. This deprecation does not apply to the ROCm backend.
   !>
-  !>   @param[in]
-  !>   handle      handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   info        structure that holds the information collected during the analysis step.
-  !>   @param[inout]
-  !>   position    pointer to zero pivot \f$j\f$, which can be in host or device memory.
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[inout] position - pointer to zero pivot \f$j\f$, which can be in host or device
+  !>   memory.
   !>
   !>   \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
   !>   \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
@@ -3530,28 +3393,20 @@ module hipfort_hipsparse
   !>   `hipsparseScsrsv2_solve` "hipsparseXcsrsv2_solve()". The temporary storage buffer must
   !>   be allocated by the user.
   !>
-  !>   @param[in]
-  !>   handle           handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   transA           matrix operation type.
-  !>   @param[in]
-  !>   m                number of rows of the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnz              number of non-zero entries of the sparse CSR matrix.
-  !>   @param[in]
-  !>   descrA           descriptor of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csrSortedValA    array of \p nnz elements of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csrSortedRowPtrA array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] transA - matrix operation type.
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix.
+  !>   @param[in] descrA - descriptor of the sparse CSR matrix.
+  !>   @param[in] csrSortedValA - array of \p nnz elements of the sparse CSR matrix.
+  !>   @param[in] csrSortedRowPtrA - array of \p m+1 elements that point to the start of every row
+  !>   of the
   !>                    sparse CSR matrix.
-  !>   @param[in]
-  !>   csrSortedColIndA array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] csrSortedColIndA - array of \p nnz elements containing the column indices of the
+  !>   sparse
   !>                    CSR matrix.
-  !>   @param[out]
-  !>   info             structure that holds the information collected during the analysis step.
-  !>   @param[out]
-  !>   pBufferSizeInBytes number of bytes of the temporary storage buffer required by
+  !>   @param[out] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[out] pBufferSizeInBytes - number of bytes of the temporary storage buffer required by
   !>                      `hipsparseScsrsv2_analysis` "hipsparseXcsrsv2_analysis()" and
   !>                      `hipsparseScsrsv2_solve` "hipsparseXcsrsv2_solve()".
   !>
@@ -3686,28 +3541,20 @@ module hipfort_hipsparse
   !>   `hipsparseScsrsv2_solve` "`hipsparseScsrsv2_solve()`". The temporary storage buffer must be
   !>   allocated by the user.
   !>
-  !>   @param[in]
-  !>   handle           handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   transA           matrix operation type.
-  !>   @param[in]
-  !>   m                number of rows of the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnz              number of non-zero entries of the sparse CSR matrix.
-  !>   @param[in]
-  !>   descrA           descriptor of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csrSortedValA    array of \p nnz elements of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csrSortedRowPtrA array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] transA - matrix operation type.
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix.
+  !>   @param[in] descrA - descriptor of the sparse CSR matrix.
+  !>   @param[in] csrSortedValA - array of \p nnz elements of the sparse CSR matrix.
+  !>   @param[in] csrSortedRowPtrA - array of \p m+1 elements that point to the start of every row
+  !>   of the
   !>                    sparse CSR matrix.
-  !>   @param[in]
-  !>   csrSortedColIndA array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] csrSortedColIndA - array of \p nnz elements containing the column indices of the
+  !>   sparse
   !>                    CSR matrix.
-  !>   @param[out]
-  !>   info             structure that holds the information collected during the analysis step.
-  !>   @param[out]
-  !>   pBufferSizeInBytes number of bytes of the temporary storage buffer required by
+  !>   @param[out] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[out] pBufferSizeInBytes - number of bytes of the temporary storage buffer required by
   !>                      `hipsparseScsrsv2_analysis` "hipsparseXcsrsv2_analysis()" and
   !>                      `hipsparseScsrsv2_solve` "hipsparseXcsrsv2_solve()".
   !>
@@ -3846,32 +3693,23 @@ module hipfort_hipsparse
   !>   This function is non-blocking and executed asynchronously with respect to the host.
   !>   It can return before the actual computation has finished.
   !>
-  !>   @param[in]
-  !>   handle           handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   transA           matrix operation type.
-  !>   @param[in]
-  !>   m                number of rows of the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnz              number of non-zero entries of the sparse CSR matrix.
-  !>   @param[in]
-  !>   descrA           descriptor of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csrSortedValA    array of \p nnz elements of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csrSortedRowPtrA array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] transA - matrix operation type.
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix.
+  !>   @param[in] descrA - descriptor of the sparse CSR matrix.
+  !>   @param[in] csrSortedValA - array of \p nnz elements of the sparse CSR matrix.
+  !>   @param[in] csrSortedRowPtrA - array of \p m+1 elements that point to the start of every row
+  !>   of the
   !>                    sparse CSR matrix.
-  !>   @param[in]
-  !>   csrSortedColIndA array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] csrSortedColIndA - array of \p nnz elements containing the column indices of the
+  !>   sparse
   !>                    CSR matrix.
-  !>   @param[out]
-  !>   info             structure that holds the information collected during
+  !>   @param[out] myInfo - structure that holds the information collected during
   !>                    the analysis step.
-  !>   @param[in]
-  !>   policy      `HIPSPARSE_SOLVE_POLICY_NO_LEVEL` or
+  !>   @param[in] policy - `HIPSPARSE_SOLVE_POLICY_NO_LEVEL` or
   !>               `HIPSPARSE_SOLVE_POLICY_USE_LEVEL`.
-  !>   @param[in]
-  !>   pBuffer     temporary storage buffer allocated by the user.
+  !>   @param[in] pBuffer - temporary storage buffer allocated by the user.
   !>
   !>   \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
   !>   \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p m, \p nnz, \p descr,
@@ -4076,37 +3914,24 @@ module hipfort_hipsparse
   !>   Currently, only \p transA == `HIPSPARSE_OPERATION_NON_TRANSPOSE` and
   !>   \p transA == `HIPSPARSE_OPERATION_TRANSPOSE` is supported.
   !>
-  !>   @param[in]
-  !>   handle      handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   transA      matrix operation type.
-  !>   @param[in]
-  !>   m           number of rows of the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of the sparse CSR matrix.
-  !>   @param[in]
-  !>   alpha       scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   descrA      descriptor of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csrSortedValA array of \p nnz elements of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csrSortedRowPtrA array of \p m+1 elements that point to the start
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] transA - matrix operation type.
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] descrA - descriptor of the sparse CSR matrix.
+  !>   @param[in] csrSortedValA - array of \p nnz elements of the sparse CSR matrix.
+  !>   @param[in] csrSortedRowPtrA - array of \p m+1 elements that point to the start
   !>               of every row of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csrSortedColIndA array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] csrSortedColIndA - array of \p nnz elements containing the column indices of the
+  !>   sparse
   !>               CSR matrix.
-  !>   @param[in]
-  !>   info        structure that holds the information collected during the analysis step.
-  !>   @param[in]
-  !>   f           array of \p m elements, holding the right-hand side.
-  !>   @param[out]
-  !>   x           array of \p m elements, holding the solution.
-  !>   @param[in]
-  !>   policy      `HIPSPARSE_SOLVE_POLICY_NO_LEVEL` or
+  !>   @param[in] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[in] f - array of \p m elements, holding the right-hand side.
+  !>   @param[out] x - array of \p m elements, holding the solution.
+  !>   @param[in] policy - `HIPSPARSE_SOLVE_POLICY_NO_LEVEL` or
   !>               `HIPSPARSE_SOLVE_POLICY_USE_LEVEL`.
-  !>   @param[in]
-  !>   pBuffer     temporary storage buffer allocated by the user.
+  !>   @param[in] pBuffer - temporary storage buffer allocated by the user.
   !>
   !>   \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
   !>   \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p m, \p nnz, \p descrA,
@@ -4255,18 +4080,12 @@ module hipfort_hipsparse
   !>   required by `hipsparseSgemvi` "hipsparseXgemvi()". The temporary storage buffer must
   !>   be allocated by the user.
   !>
-  !>   @param[in]
-  !>   handle      handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   transA      matrix operation type.
-  !>   @param[in]
-  !>   m           number of rows of the dense matrix.
-  !>   @param[in]
-  !>   n           number of columns of the dense matrix.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries in the sparse vector.
-  !>   @param[out]
-  !>   pBufferSizeInBytes temporary storage buffer size.
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] transA - matrix operation type.
+  !>   @param[in] m - number of rows of the dense matrix.
+  !>   @param[in] n - number of columns of the dense matrix.
+  !>   @param[in] nnz - number of non-zero entries in the sparse vector.
+  !>   @param[out] pBufferSizeInBytes - temporary storage buffer size.
   !>
   !>   \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
   !>   \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p m, \p n, \p nnz, or
@@ -4391,35 +4210,21 @@ module hipfort_hipsparse
   !>   \note
   !>   Currently, only \p transA == `HIPSPARSE_OPERATION_NON_TRANSPOSE` is supported.
   !>
-  !>   @param[in]
-  !>   handle      handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   transA      matrix operation type.
-  !>   @param[in]
-  !>   m           number of rows of the dense matrix.
-  !>   @param[in]
-  !>   n           number of columns of the dense matrix.
-  !>   @param[in]
-  !>   alpha       scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   A           pointer to the dense matrix.
-  !>   @param[in]
-  !>   lda         leading dimension of the dense matrix.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries in the sparse vector.
-  !>   @param[in]
-  !>   x           array of \p nnz elements containing the values of the sparse vector.
-  !>   @param[in]
-  !>   xInd        array of \p nnz elements containing the indices of the sparse vector.
-  !>   @param[in]
-  !>   beta        scalar \f$\beta\f$.
-  !>   @param[inout]
-  !>   y           array of \p m elements (\f$op(A) == A\f$) or \p n elements
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] transA - matrix operation type.
+  !>   @param[in] m - number of rows of the dense matrix.
+  !>   @param[in] n - number of columns of the dense matrix.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] A - pointer to the dense matrix.
+  !>   @param[in] lda - leading dimension of the dense matrix.
+  !>   @param[in] nnz - number of non-zero entries in the sparse vector.
+  !>   @param[in] x - array of \p nnz elements containing the values of the sparse vector.
+  !>   @param[in] xInd - array of \p nnz elements containing the indices of the sparse vector.
+  !>   @param[in] beta - scalar \f$\beta\f$.
+  !>   @param[inout] y - array of \p m elements (\f$op(A) == A\f$) or \p n elements
   !>               (\f$op(A) == A^T\f$ or \f$op(A) == A^H\f$).
-  !>   @param[in]
-  !>   idxBase     `HIPSPARSE_INDEX_BASE_ZERO` or `HIPSPARSE_INDEX_BASE_ONE`.
-  !>   @param[in]
-  !>   pBuffer     temporary storage buffer.
+  !>   @param[in] idxBase - `HIPSPARSE_INDEX_BASE_ZERO` or `HIPSPARSE_INDEX_BASE_ONE`.
+  !>   @param[in] pBuffer - temporary storage buffer.
   !>
   !>   \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
   !>   \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p m, \p n, \p lda, \p nnz, \p alpha,
@@ -4602,24 +4407,16 @@ module hipfort_hipsparse
   !>   This function is deprecated when using the CUDA backend (CUDA 10.0+) and will be
   !>   removed in CUDA 11.0. This deprecation does not apply to the ROCm backend.
   !>
-  !>   @param[in]
-  !>   handle      handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   transA      matrix operation type.
-  !>   @param[in]
-  !>   alpha       scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   descrA      descriptor of the sparse HYB matrix. Currently, only
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] transA - matrix operation type.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] descrA - descriptor of the sparse HYB matrix. Currently, only
   !>               `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[in]
-  !>   hybA        matrix in HYB storage format.
-  !>   @param[in]
-  !>   x           array of \p n elements (\f$op(A) == A\f$) or \p m elements
+  !>   @param[in] hybA - matrix in HYB storage format.
+  !>   @param[in] x - array of \p n elements (\f$op(A) == A\f$) or \p m elements
   !>               (\f$op(A) == A^T\f$ or \f$op(A) == A^H\f$).
-  !>   @param[in]
-  !>   beta        scalar \f$\beta\f$.
-  !>   @param[inout]
-  !>   y           array of \p m elements (\f$op(A) == A\f$) or \p n elements
+  !>   @param[in] beta - scalar \f$\beta\f$.
+  !>   @param[inout] y - array of \p m elements (\f$op(A) == A\f$) or \p n elements
   !>               (\f$op(A) == A^T\f$ or \f$op(A) == A^H\f$).
   !>
   !>   \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
@@ -4774,55 +4571,42 @@ module hipfort_hipsparse
   !>   \note
   !>   Currently, only \p transA == `HIPSPARSE_OPERATION_NON_TRANSPOSE` is supported.
   !>
-  !>   @param[in]
-  !>   handle      handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   dirA the storage format of the blocks. Can be `HIPSPARSE_DIRECTION_ROW` or
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] dirA - the storage format of the blocks. Can be `HIPSPARSE_DIRECTION_ROW` or
   !>   `HIPSPARSE_DIRECTION_COLUMN`.
-  !>   @param[in]
-  !>   transA matrix \f$A\f$ operation type. Currently, only `HIPSPARSE_OPERATION_NON_TRANSPOSE` is
-  !>   supported.
-  !>   @param[in]
-  !>   transB matrix \f$B\f$ operation type. Currently, only `HIPSPARSE_OPERATION_NON_TRANSPOSE` and
-  !>   `HIPSPARSE_OPERATION_TRANSPOSE`
+  !>   @param[in] transA - matrix \f$A\f$ operation type. Currently, only
+  !>   `HIPSPARSE_OPERATION_NON_TRANSPOSE` is supported.
+  !>   @param[in] transB - matrix \f$B\f$ operation type. Currently, only
+  !>   `HIPSPARSE_OPERATION_NON_TRANSPOSE` and `HIPSPARSE_OPERATION_TRANSPOSE`
   !>               are supported.
-  !>   @param[in]
-  !>   mb          number of block rows of the sparse BSR matrix \f$A\f$. Must be non-negative.
-  !>   @param[in]
-  !>   n number of columns of the dense matrix \f$op(B)\f$ and \f$C\f$. Must be non-negative.
-  !>   @param[in]
-  !>   kb          number of block columns of the sparse BSR matrix \f$A\f$. Must be non-negative.
-  !>   @param[in]
-  !>   nnzb        number of non-zero blocks of the sparse BSR matrix \f$A\f$. Must be non-negative.
-  !>   @param[in]
-  !>   alpha       scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   descrA      descriptor of the sparse BSR matrix \f$A\f$. Currently, only
+  !>   @param[in] mb - number of block rows of the sparse BSR matrix \f$A\f$. Must be non-negative.
+  !>   @param[in] n - number of columns of the dense matrix \f$op(B)\f$ and \f$C\f$. Must be
+  !>   non-negative.
+  !>   @param[in] kb - number of block columns of the sparse BSR matrix \f$A\f$. Must be
+  !>   non-negative.
+  !>   @param[in] nnzb - number of non-zero blocks of the sparse BSR matrix \f$A\f$. Must be
+  !>   non-negative.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] descrA - descriptor of the sparse BSR matrix \f$A\f$. Currently, only
   !>               `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[in]
-  !>   bsrValA     array of \p nnzb*blockDim*blockDim elements of the sparse BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   bsrRowPtrA  array of \p mb+1 elements that point to the start of every block row of the
+  !>   @param[in] bsrValA - array of \p nnzb*blockDim*blockDim elements of the sparse BSR matrix
+  !>   \f$A\f$.
+  !>   @param[in] bsrRowPtrA - array of \p mb+1 elements that point to the start of every block row
+  !>   of the
   !>               sparse BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   bsrColIndA  array of \p nnzb elements containing the block column indices of the sparse
+  !>   @param[in] bsrColIndA - array of \p nnzb elements containing the block column indices of the
+  !>   sparse
   !>               BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   blockDim    size of the blocks in the sparse BSR matrix. Must be positive.
-  !>   @param[in]
-  !>   B           array of dimension \p ldb*n (\f$op(B) == B\f$),
+  !>   @param[in] blockDim - size of the blocks in the sparse BSR matrix. Must be positive.
+  !>   @param[in] B - array of dimension \p ldb*n (\f$op(B) == B\f$),
   !>               \p ldb*k otherwise.
-  !>   @param[in]
-  !>   ldb leading dimension of \f$B\f$, must be at least \f$\max{(1, k)}\f$ (\f$ op(B) == B\f$)
-  !>   where \p k=blockDim*kb,
+  !>   @param[in] ldb - leading dimension of \f$B\f$, must be at least \f$\max{(1, k)}\f$ (\f$ op(B)
+  !>   == B\f$) where \p k=blockDim*kb,
   !>               \f$\max{(1, n)}\f$ otherwise.
-  !>   @param[in]
-  !>   beta        scalar \f$\beta\f$.
-  !>   @param[inout]
-  !>   C           array of dimension \p ldc*n.
-  !>   @param[in]
-  !>   ldc leading dimension of \f$C\f$, must be at least \f$\max{(1, m)}\f$ (\f$ op(A) == A\f$)
-  !>   where \p m=blockDim*mb,
+  !>   @param[in] beta - scalar \f$\beta\f$.
+  !>   @param[inout] C - array of dimension \p ldc*n.
+  !>   @param[in] ldc - leading dimension of \f$C\f$, must be at least \f$\max{(1, m)}\f$ (\f$ op(A)
+  !>   == A\f$) where \p m=blockDim*mb,
   !>               \f$\max{(1, k)}\f$ where \p k=blockDim*kb otherwise.
   !>
   !>   \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
@@ -5027,12 +4811,10 @@ module hipfort_hipsparse
   !>   This function is deprecated when using the CUDA backend (CUDA 12.0+) and will be
   !>   removed in CUDA 13.0. This deprecation does not apply to the ROCm backend.
   !>
-  !>   @param[in]
-  !>   handle      handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   info        structure that holds the information collected during the analysis step.
-  !>   @param[inout]
-  !>   position    pointer to zero pivot \f$j\f$, which can be in host or device memory.
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[inout] position - pointer to zero pivot \f$j\f$, which can be in host or device
+  !>   memory.
   !>
   !>   \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
   !>   \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
@@ -5064,36 +4846,24 @@ module hipfort_hipsparse
   !>   `hipsparseSbsrsm2_solve` "hipsparseXbsrsm2_solve()". The temporary storage buffer must
   !>   be allocated by the user.
   !>
-  !>   @param[in]
-  !>   handle      handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   dirA        matrix storage of BSR blocks.
-  !>   @param[in]
-  !>   transA      matrix \f$A\f$ operation type.
-  !>   @param[in]
-  !>   transX      matrix \f$X\f$ operation type.
-  !>   @param[in]
-  !>   mb          number of block rows of the sparse BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   nrhs        number of columns of the dense matrix \f$op(X)\f$.
-  !>   @param[in]
-  !>   nnzb        number of non-zero blocks of the sparse BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   descrA      descriptor of the sparse BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   bsrSortedValA array of \p nnzb blocks of the sparse BSR matrix.
-  !>   @param[in]
-  !>   bsrSortedRowPtrA array of \p mb+1 elements that point to the start of every block row of
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] dirA - matrix storage of BSR blocks.
+  !>   @param[in] transA - matrix \f$A\f$ operation type.
+  !>   @param[in] transX - matrix \f$X\f$ operation type.
+  !>   @param[in] mb - number of block rows of the sparse BSR matrix \f$A\f$.
+  !>   @param[in] nrhs - number of columns of the dense matrix \f$op(X)\f$.
+  !>   @param[in] nnzb - number of non-zero blocks of the sparse BSR matrix \f$A\f$.
+  !>   @param[in] descrA - descriptor of the sparse BSR matrix \f$A\f$.
+  !>   @param[in] bsrSortedValA - array of \p nnzb blocks of the sparse BSR matrix.
+  !>   @param[in] bsrSortedRowPtrA - array of \p mb+1 elements that point to the start of every
+  !>   block row of
   !>               the sparse BSR matrix.
-  !>   @param[in]
-  !>   bsrSortedColIndA array of \p nnzb containing the block column indices of the sparse
+  !>   @param[in] bsrSortedColIndA - array of \p nnzb containing the block column indices of the
+  !>   sparse
   !>               BSR matrix.
-  !>   @param[in]
-  !>   blockDim    block dimension of the sparse BSR matrix.
-  !>   @param[in]
-  !>   info        structure that holds the information collected during the analysis step.
-  !>   @param[out]
-  !>   pBufferSizeInBytes number of bytes of the temporary storage buffer required by
+  !>   @param[in] blockDim - block dimension of the sparse BSR matrix.
+  !>   @param[in] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[out] pBufferSizeInBytes - number of bytes of the temporary storage buffer required by
   !>               `hipsparseSbsrsm2_analysis` "hipsparseXbsrsm2_analysis()" and
   !>               `hipsparseSbsrsm2_solve` "hipsparseXbsrsm2_solve()".
   !>
@@ -5270,39 +5040,26 @@ module hipfort_hipsparse
   !>   This function is non-blocking and executed asynchronously with respect to the host.
   !>   It can return before the actual computation has finished.
   !>
-  !>   @param[in]
-  !>   handle      handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   dirA        matrix storage of BSR blocks.
-  !>   @param[in]
-  !>   transA      matrix \f$A\f$ operation type.
-  !>   @param[in]
-  !>   transX      matrix \f$X\f$ operation type.
-  !>   @param[in]
-  !>   mb          number of block rows of the sparse BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   nrhs        number of columns of the dense matrix \f$op(X)\f$.
-  !>   @param[in]
-  !>   nnzb        number of non-zero blocks of the sparse BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   descrA      descriptor of the sparse BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   bsrSortedValA array of \p nnzb blocks of the sparse BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   bsrSortedRowPtrA array of \p mb+1 elements that point to the start of every block row of
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] dirA - matrix storage of BSR blocks.
+  !>   @param[in] transA - matrix \f$A\f$ operation type.
+  !>   @param[in] transX - matrix \f$X\f$ operation type.
+  !>   @param[in] mb - number of block rows of the sparse BSR matrix \f$A\f$.
+  !>   @param[in] nrhs - number of columns of the dense matrix \f$op(X)\f$.
+  !>   @param[in] nnzb - number of non-zero blocks of the sparse BSR matrix \f$A\f$.
+  !>   @param[in] descrA - descriptor of the sparse BSR matrix \f$A\f$.
+  !>   @param[in] bsrSortedValA - array of \p nnzb blocks of the sparse BSR matrix \f$A\f$.
+  !>   @param[in] bsrSortedRowPtrA - array of \p mb+1 elements that point to the start of every
+  !>   block row of
   !>               the sparse BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   bsrSortedColIndA array of \p nnzb containing the block column indices of the sparse
+  !>   @param[in] bsrSortedColIndA - array of \p nnzb containing the block column indices of the
+  !>   sparse
   !>               BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   blockDim    block dimension of the sparse BSR matrix \f$A\f$.
-  !>   @param[out]
-  !>   info        structure that holds the information collected during the analysis step.
-  !>   @param[in]
-  !>   policy      `HIPSPARSE_SOLVE_POLICY_NO_LEVEL` or
+  !>   @param[in] blockDim - block dimension of the sparse BSR matrix \f$A\f$.
+  !>   @param[out] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[in] policy - `HIPSPARSE_SOLVE_POLICY_NO_LEVEL` or
   !>               `HIPSPARSE_SOLVE_POLICY_USE_LEVEL`.
-  !>   @param[in]
-  !>   pBuffer     temporary storage buffer allocated by the user.
+  !>   @param[in] pBuffer - temporary storage buffer allocated by the user.
   !>
   !>   \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
   !>   \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p mb, \p nrhs, \p nnzb,
@@ -5682,48 +5439,30 @@ module hipfort_hipsparse
   !>   Currently, only \p transA != `HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE` and
   !>   \p transX != `HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE` is supported.
   !>
-  !>   @param[in]
-  !>   handle           handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   dirA             matrix storage of BSR blocks.
-  !>   @param[in]
-  !>   transA           matrix \f$A\f$ operation type.
-  !>   @param[in]
-  !>   transX           matrix \f$X\f$ operation type.
-  !>   @param[in]
-  !>   mb               number of block rows of the sparse BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   nrhs             number of columns of the dense matrix \f$op(X)\f$.
-  !>   @param[in]
-  !>   nnzb             number of non-zero blocks of the sparse BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   alpha            scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   descrA           descriptor of the sparse BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   bsrSortedValA    array of \p nnzb blocks of the sparse BSR matrix.
-  !>   @param[in]
-  !>   bsrSortedRowPtrA array of \p mb+1 elements that point to the start of every block row of
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] dirA - matrix storage of BSR blocks.
+  !>   @param[in] transA - matrix \f$A\f$ operation type.
+  !>   @param[in] transX - matrix \f$X\f$ operation type.
+  !>   @param[in] mb - number of block rows of the sparse BSR matrix \f$A\f$.
+  !>   @param[in] nrhs - number of columns of the dense matrix \f$op(X)\f$.
+  !>   @param[in] nnzb - number of non-zero blocks of the sparse BSR matrix \f$A\f$.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] descrA - descriptor of the sparse BSR matrix \f$A\f$.
+  !>   @param[in] bsrSortedValA - array of \p nnzb blocks of the sparse BSR matrix.
+  !>   @param[in] bsrSortedRowPtrA - array of \p mb+1 elements that point to the start of every
+  !>   block row of
   !>                    the sparse BSR matrix.
-  !>   @param[in]
-  !>   bsrSortedColIndA array of \p nnzb containing the block column indices of the sparse
+  !>   @param[in] bsrSortedColIndA - array of \p nnzb containing the block column indices of the
+  !>   sparse
   !>                    BSR matrix.
-  !>   @param[in]
-  !>   blockDim         block dimension of the sparse BSR matrix.
-  !>   @param[in]
-  !>   info             structure that holds the information collected during the analysis step.
-  !>   @param[in]
-  !>   B                rhs matrix B with leading dimension \p ldb.
-  !>   @param[in]
-  !>   ldb              leading dimension of rhs matrix \f$B\f$.
-  !>   @param[out]
-  !>   X                solution matrix X with leading dimension \p ldx.
-  !>   @param[in]
-  !>   ldx              leading dimension of solution matrix \f$X\f$.
-  !>   @param[in]
-  !>   policy           `HIPSPARSE_SOLVE_POLICY_NO_LEVEL` or `HIPSPARSE_SOLVE_POLICY_USE_LEVEL`.
-  !>   @param[in]
-  !>   pBuffer          temporary storage buffer allocated by the user.
+  !>   @param[in] blockDim - block dimension of the sparse BSR matrix.
+  !>   @param[in] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[in] B - rhs matrix B with leading dimension \p ldb.
+  !>   @param[in] ldb - leading dimension of rhs matrix \f$B\f$.
+  !>   @param[out] X - solution matrix X with leading dimension \p ldx.
+  !>   @param[in] ldx - leading dimension of solution matrix \f$X\f$.
+  !>   @param[in] policy - `HIPSPARSE_SOLVE_POLICY_NO_LEVEL` or `HIPSPARSE_SOLVE_POLICY_USE_LEVEL`.
+  !>   @param[in] pBuffer - temporary storage buffer allocated by the user.
   !>
   !>   \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
   !>   \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p mb, \p nrhs, \p nnzb, \p blockDim,
@@ -5964,43 +5703,31 @@ module hipfort_hipsparse
   !>   This function is deprecated when using the CUDA backend (CUDA 10.0+) and will be
   !>   removed in CUDA 11.0. This deprecation does not apply to the ROCm backend.
   !>
-  !>   @param[in]
-  !>   handle              handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   transA              matrix \f$A\f$ operation type.
-  !>   @param[in]
-  !>   m                   number of rows of the sparse CSR matrix \f$A\f$. Must be non-negative.
-  !>   @param[in]
-  !>   n number of columns of the dense matrix \f$op(B)\f$ and \f$C\f$. Must be non-negative.
-  !>   @param[in]
-  !>   k                   number of columns of the sparse CSR matrix \f$A\f$. Must be non-negative.
-  !>   @param[in]
-  !>   nnz number of non-zero entries of the sparse CSR matrix \f$A\f$. Must be non-negative.
-  !>   @param[in]
-  !>   alpha               scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   descrA              descriptor of the sparse CSR matrix \f$A\f$. Currently, only
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] transA - matrix \f$A\f$ operation type.
+  !>   @param[in] m - number of rows of the sparse CSR matrix \f$A\f$. Must be non-negative.
+  !>   @param[in] n - number of columns of the dense matrix \f$op(B)\f$ and \f$C\f$. Must be
+  !>   non-negative.
+  !>   @param[in] k - number of columns of the sparse CSR matrix \f$A\f$. Must be non-negative.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix \f$A\f$. Must be
+  !>   non-negative.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] descrA - descriptor of the sparse CSR matrix \f$A\f$. Currently, only
   !>                       `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[in]
-  !>   csrSortedValA       array of \p nnz elements of the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csrSortedRowPtrA    array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] csrSortedValA - array of \p nnz elements of the sparse CSR matrix \f$A\f$.
+  !>   @param[in] csrSortedRowPtrA - array of \p m+1 elements that point to the start of every row
+  !>   of the
   !>                       sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csrSortedColIndA    array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] csrSortedColIndA - array of \p nnz elements containing the column indices of the
+  !>   sparse
   !>                       CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   B                   array of dimension \p ldb*n (\f$op(B) == B\f$),
+  !>   @param[in] B - array of dimension \p ldb*n (\f$op(B) == B\f$),
   !>                       \p ldb*k otherwise.
-  !>   @param[in]
-  !>   ldb                 leading dimension of \f$B\f$, must be at least \f$\max{(1, k)}\f$
+  !>   @param[in] ldb - leading dimension of \f$B\f$, must be at least \f$\max{(1, k)}\f$
   !>                       (\f$op(B) == B\f$), \f$\max{(1, n)}\f$ otherwise.
-  !>   @param[in]
-  !>   beta                scalar \f$\beta\f$.
-  !>   @param[inout]
-  !>   C                   array of dimension \p ldc*n.
-  !>   @param[in]
-  !>   ldc                 leading dimension of \f$C\f$, must be at least \f$\max{(1, m)}\f$
+  !>   @param[in] beta - scalar \f$\beta\f$.
+  !>   @param[inout] C - array of dimension \p ldc*n.
+  !>   @param[in] ldc - leading dimension of \f$C\f$, must be at least \f$\max{(1, m)}\f$
   !>                       (\f$op(A) == A\f$), \f$\max{(1, k)}\f$ otherwise.
   !>
   !>   \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
@@ -6207,45 +5934,30 @@ module hipfort_hipsparse
   !>   This function is non-blocking and executed asynchronously with respect to the host.
   !>   It can return before the actual computation has finished.
   !>
-  !>   @param[in]
-  !>   handle      handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   transA      matrix \f$A\f$ operation type.
-  !>   @param[in]
-  !>   transB      matrix \f$B\f$ operation type.
-  !>   @param[in]
-  !>   m           number of rows of the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   n           number of columns of the dense matrix \f$op(B)\f$ and \f$C\f$.
-  !>   @param[in]
-  !>   k           number of columns of the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   alpha       scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   descrA      descriptor of the sparse CSR matrix \f$A\f$. Currently, only
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] transA - matrix \f$A\f$ operation type.
+  !>   @param[in] transB - matrix \f$B\f$ operation type.
+  !>   @param[in] m - number of rows of the sparse CSR matrix \f$A\f$.
+  !>   @param[in] n - number of columns of the dense matrix \f$op(B)\f$ and \f$C\f$.
+  !>   @param[in] k - number of columns of the sparse CSR matrix \f$A\f$.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix \f$A\f$.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] descrA - descriptor of the sparse CSR matrix \f$A\f$. Currently, only
   !>               `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[in]
-  !>   csrSortedValA array of \p nnz elements of the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csrSortedRowPtrA array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] csrSortedValA - array of \p nnz elements of the sparse CSR matrix \f$A\f$.
+  !>   @param[in] csrSortedRowPtrA - array of \p m+1 elements that point to the start of every row
+  !>   of the
   !>               sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csrSortedColIndA array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] csrSortedColIndA - array of \p nnz elements containing the column indices of the
+  !>   sparse
   !>               CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   B           array of dimension \p ldb*n (\f$op(B) == B\f$),
+  !>   @param[in] B - array of dimension \p ldb*n (\f$op(B) == B\f$),
   !>               \p ldb*k otherwise.
-  !>   @param[in]
-  !>   ldb         leading dimension of \f$B\f$. Must be at least \f$\max{(1, k)}\f$
+  !>   @param[in] ldb - leading dimension of \f$B\f$. Must be at least \f$\max{(1, k)}\f$
   !>               (\f$op(B) == B\f$), \f$\max{(1, n)}\f$ otherwise.
-  !>   @param[in]
-  !>   beta        scalar \f$\beta\f$.
-  !>   @param[inout]
-  !>   C           array of dimension \p ldc*n.
-  !>   @param[in]
-  !>   ldc         leading dimension of \f$C\f$. Must be at least \f$\max{(1, m)}\f$
+  !>   @param[in] beta - scalar \f$\beta\f$.
+  !>   @param[inout] C - array of dimension \p ldc*n.
+  !>   @param[in] ldc - leading dimension of \f$C\f$. Must be at least \f$\max{(1, m)}\f$
   !>               (\f$op(A) == A\f$), \f$\max{(1, k)}\f$ otherwise.
   !>
   !>   \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
@@ -6421,12 +6133,10 @@ module hipfort_hipsparse
   !>   This function is deprecated when using the CUDA backend (CUDA 11.0+) and will be
   !>   removed in CUDA 12.0. This deprecation does not apply to the ROCm backend.
   !>
-  !>   @param[in]
-  !>   handle      handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   info        structure that holds the information collected during the analysis step.
-  !>   @param[inout]
-  !>   position    pointer to zero pivot \f$j\f$, which can be in host or device memory.
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[inout] position - pointer to zero pivot \f$j\f$, which can be in host or device
+  !>   memory.
   !>
   !>   \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
   !>   \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
@@ -6455,43 +6165,28 @@ module hipfort_hipsparse
   !>   and `hipsparseScsrsm2_solve` "hipsparseXcsrsm2_solve()". The temporary storage buffer
   !>   must be allocated by the user.
   !>
-  !>   @param[in]
-  !>   handle           handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   algo             algorithm to use.
-  !>   @param[in]
-  !>   transA           matrix \f$A\f$ operation type.
-  !>   @param[in]
-  !>   transB           matrix \f$B\f$ operation type.
-  !>   @param[in]
-  !>   m                number of rows of the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   nrhs             number of columns of the dense matrix \f$op(B)\f$.
-  !>   @param[in]
-  !>   nnz              number of non-zero entries of the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   alpha            scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   descrA           descriptor of the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csrSortedValA    array of \p nnz elements of the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csrSortedRowPtrA array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] algo - algorithm to use.
+  !>   @param[in] transA - matrix \f$A\f$ operation type.
+  !>   @param[in] transB - matrix \f$B\f$ operation type.
+  !>   @param[in] m - number of rows of the sparse CSR matrix \f$A\f$.
+  !>   @param[in] nrhs - number of columns of the dense matrix \f$op(B)\f$.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix \f$A\f$.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] descrA - descriptor of the sparse CSR matrix \f$A\f$.
+  !>   @param[in] csrSortedValA - array of \p nnz elements of the sparse CSR matrix \f$A\f$.
+  !>   @param[in] csrSortedRowPtrA - array of \p m+1 elements that point to the start of every row
+  !>   of the
   !>                    sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csrSortedColIndA array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] csrSortedColIndA - array of \p nnz elements containing the column indices of the
+  !>   sparse
   !>                    CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   B                array of \p m \f$\times\f$ \p nrhs elements of the rhs matrix \f$B\f$.
-  !>   @param[in]
-  !>   ldb              leading dimension of rhs matrix \f$B\f$.
-  !>   @param[in]
-  !>   info             structure that holds the information collected during the analysis step.
-  !>   @param[in]
-  !>   policy      `HIPSPARSE_SOLVE_POLICY_NO_LEVEL` or
+  !>   @param[in] B - array of \p m \f$\times\f$ \p nrhs elements of the rhs matrix \f$B\f$.
+  !>   @param[in] ldb - leading dimension of rhs matrix \f$B\f$.
+  !>   @param[in] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[in] policy - `HIPSPARSE_SOLVE_POLICY_NO_LEVEL` or
   !>               `HIPSPARSE_SOLVE_POLICY_USE_LEVEL`.
-  !>   @param[out]
-  !>   pBufferSizeInBytes number of bytes of the temporary storage buffer required by
+  !>   @param[out] pBufferSizeInBytes - number of bytes of the temporary storage buffer required by
   !>                      `hipsparseScsrsm2_analysis` "hipsparseXcsrsm2_analysis()" and
   !>                      `hipsparseScsrsm2_solve` "hipsparseXcsrsm2_solve()".
   !>
@@ -6665,43 +6360,28 @@ module hipfort_hipsparse
   !>   This function is non-blocking and executed asynchronously with respect to the host.
   !>   It can return before the actual computation has finished.
   !>
-  !>   @param[in]
-  !>   handle      handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   algo        algorithm to use.
-  !>   @param[in]
-  !>   transA      matrix \f$A\f$ operation type.
-  !>   @param[in]
-  !>   transB      matrix \f$B\f$ operation type.
-  !>   @param[in]
-  !>   m           number of rows of the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   nrhs        number of columns of the dense matrix \f$op(B)\f$.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   alpha       scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   descrA      descriptor of the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csrSortedValA array of \p nnz elements of the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csrSortedRowPtrA array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] algo - algorithm to use.
+  !>   @param[in] transA - matrix \f$A\f$ operation type.
+  !>   @param[in] transB - matrix \f$B\f$ operation type.
+  !>   @param[in] m - number of rows of the sparse CSR matrix \f$A\f$.
+  !>   @param[in] nrhs - number of columns of the dense matrix \f$op(B)\f$.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix \f$A\f$.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] descrA - descriptor of the sparse CSR matrix \f$A\f$.
+  !>   @param[in] csrSortedValA - array of \p nnz elements of the sparse CSR matrix \f$A\f$.
+  !>   @param[in] csrSortedRowPtrA - array of \p m+1 elements that point to the start of every row
+  !>   of the
   !>               sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csrSortedColIndA array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] csrSortedColIndA - array of \p nnz elements containing the column indices of the
+  !>   sparse
   !>               CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   B           array of \p m \f$\times\f$ \p nrhs elements of the rhs matrix \f$B\f$.
-  !>   @param[in]
-  !>   ldb         leading dimension of rhs matrix \f$B\f$.
-  !>   @param[out]
-  !>   info        structure that holds the information collected during the analysis step.
-  !>   @param[in]
-  !>   policy      `HIPSPARSE_SOLVE_POLICY_NO_LEVEL` or
+  !>   @param[in] B - array of \p m \f$\times\f$ \p nrhs elements of the rhs matrix \f$B\f$.
+  !>   @param[in] ldb - leading dimension of rhs matrix \f$B\f$.
+  !>   @param[out] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[in] policy - `HIPSPARSE_SOLVE_POLICY_NO_LEVEL` or
   !>               `HIPSPARSE_SOLVE_POLICY_USE_LEVEL`.
-  !>   @param[in]
-  !>   pBuffer     temporary storage buffer allocated by the user.
+  !>   @param[in] pBuffer - temporary storage buffer allocated by the user.
   !>
   !>   \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
   !>   \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p m, \p nrhs, \p nnz, \p alpha,
@@ -7021,43 +6701,28 @@ module hipfort_hipsparse
   !>   Currently, only \p transA != `HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE` and
   !>   \p transB != `HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE` is supported.
   !>
-  !>   @param[in]
-  !>   handle      handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   algo        algorithm to use.
-  !>   @param[in]
-  !>   transA      matrix \f$A\f$ operation type.
-  !>   @param[in]
-  !>   transB      matrix \f$B\f$ operation type.
-  !>   @param[in]
-  !>   m           number of rows of the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   nrhs        number of columns of the dense matrix \f$op(B)\f$.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   alpha       scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   descrA      descriptor of the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csrSortedValA array of \p nnz elements of the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csrSortedRowPtrA array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] algo - algorithm to use.
+  !>   @param[in] transA - matrix \f$A\f$ operation type.
+  !>   @param[in] transB - matrix \f$B\f$ operation type.
+  !>   @param[in] m - number of rows of the sparse CSR matrix \f$A\f$.
+  !>   @param[in] nrhs - number of columns of the dense matrix \f$op(B)\f$.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix \f$A\f$.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] descrA - descriptor of the sparse CSR matrix \f$A\f$.
+  !>   @param[in] csrSortedValA - array of \p nnz elements of the sparse CSR matrix \f$A\f$.
+  !>   @param[in] csrSortedRowPtrA - array of \p m+1 elements that point to the start of every row
+  !>   of the
   !>               sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csrSortedColIndA array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] csrSortedColIndA - array of \p nnz elements containing the column indices of the
+  !>   sparse
   !>               CSR matrix \f$A\f$.
-  !>   @param[inout]
-  !>   B           array of \p m \f$\times\f$ \p nrhs elements of the rhs matrix \f$B\f$.
-  !>   @param[in]
-  !>   ldb         leading dimension of rhs matrix \f$B\f$.
-  !>   @param[in]
-  !>   info        structure that holds the information collected during the analysis step.
-  !>   @param[in]
-  !>   policy      `HIPSPARSE_SOLVE_POLICY_NO_LEVEL` or
+  !>   @param[inout] B - array of \p m \f$\times\f$ \p nrhs elements of the rhs matrix \f$B\f$.
+  !>   @param[in] ldb - leading dimension of rhs matrix \f$B\f$.
+  !>   @param[in] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[in] policy - `HIPSPARSE_SOLVE_POLICY_NO_LEVEL` or
   !>               `HIPSPARSE_SOLVE_POLICY_USE_LEVEL`.
-  !>   @param[in]
-  !>   pBuffer     temporary storage buffer allocated by the user.
+  !>   @param[in] pBuffer - temporary storage buffer allocated by the user.
   !>
   !>   \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
   !>   \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p m, \p nrhs, \p nnz, \p alpha,
@@ -7238,39 +6903,29 @@ module hipfort_hipsparse
   !>   This function is deprecated when using the CUDA backend (CUDA 11.0+) and will be
   !>   removed in CUDA 12.0. This deprecation does not apply to the ROCm backend.
   !>
-  !>   @param[in]
-  !>   handle      handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m           number of rows of the dense matrix \f$A\f$. Must be non-negative.
-  !>   @param[in]
-  !>   n number of columns of the sparse CSC matrix \f$op(B)\f$ and \f$C\f$. Must be non-negative.
-  !>   @param[in]
-  !>   k           number of columns of the dense matrix \f$A\f$. Must be non-negative.
-  !>   @param[in]
-  !>   nnz number of non-zero entries of the sparse CSC matrix \f$B\f$. Must be non-negative.
-  !>   @param[in]
-  !>   alpha       scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   A           array of dimension \f$lda \times k\f$ (\f$op(A) == A\f$) or
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - number of rows of the dense matrix \f$A\f$. Must be non-negative.
+  !>   @param[in] n - number of columns of the sparse CSC matrix \f$op(B)\f$ and \f$C\f$. Must be
+  !>   non-negative.
+  !>   @param[in] k - number of columns of the dense matrix \f$A\f$. Must be non-negative.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSC matrix \f$B\f$. Must be
+  !>   non-negative.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] A - array of dimension \f$lda \times k\f$ (\f$op(A) == A\f$) or
   !>               \f$lda \times m\f$ (\f$op(A) == A^T\f$ or \f$op(A) == A^H\f$).
-  !>   @param[in]
-  !>   lda         leading dimension of \f$A\f$, must be at least \f$m\f$
+  !>   @param[in] lda - leading dimension of \f$A\f$, must be at least \f$m\f$
   !>               (\f$op(A) == A\f$) or \f$k\f$ (\f$op(A) == A^T\f$ or
   !>               \f$op(A) == A^H\f$).
-  !>   @param[in]
-  !>   cscValB     array of \p nnz elements of the sparse CSC matrix \f$B\f$.
-  !>   @param[in]
-  !>   cscColPtrB  array of \p n+1 elements that point to the start of every column of the
+  !>   @param[in] cscValB - array of \p nnz elements of the sparse CSC matrix \f$B\f$.
+  !>   @param[in] cscColPtrB - array of \p n+1 elements that point to the start of every column of
+  !>   the
   !>               sparse CSC matrix \f$B\f$.
-  !>   @param[in]
-  !>   cscRowIndB  array of \p nnz elements containing the column indices of the sparse CSC
+  !>   @param[in] cscRowIndB - array of \p nnz elements containing the column indices of the sparse
+  !>   CSC
   !>               matrix \f$B\f$.
-  !>   @param[in]
-  !>   beta        scalar \f$\beta\f$.
-  !>   @param[inout]
-  !>   C           array of dimension \f$ldc \times n\f$ that holds the values of \f$C\f$.
-  !>   @param[in]
-  !>   ldc         leading dimension of \f$C\f$, must be at least \f$m\f$.
+  !>   @param[in] beta - scalar \f$\beta\f$.
+  !>   @param[inout] C - array of dimension \f$ldc \times n\f$ that holds the values of \f$C\f$.
+  !>   @param[in] ldc - leading dimension of \f$C\f$, must be at least \f$m\f$.
   !>
   !>   \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
   !>   \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
@@ -7438,44 +7093,32 @@ module hipfort_hipsparse
   !>   \deprecated
   !>   This function is deprecated and will be removed in a future release.
   !>
-  !>   @param[in]
-  !>   handle          handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m number of rows of the sparse CSR matrices \f$A\f$, \f$B\f$, and \f$C\f$. Must be
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse CSR matrices \f$A\f$, \f$B\f$, and \f$C\f$. Must
+  !>   be non-negative.
+  !>   @param[in] n - number of columns of the sparse CSR matrices \f$A\f$, \f$B\f$, and \f$C\f$.
+  !>   Must be non-negative.
+  !>   @param[in] descrA - descriptor of the sparse CSR matrix \f$A\f$. Currently, only
+  !>                   `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
+  !>   @param[in] nnzA - number of non-zero entries of the sparse CSR matrix \f$A\f$. Must be
   !>   non-negative.
-  !>   @param[in]
-  !>   n number of columns of the sparse CSR matrices \f$A\f$, \f$B\f$, and \f$C\f$. Must be
+  !>   @param[in] csrRowPtrA - array of \p m+1 elements that point to the start of every row of the
+  !>                   sparse CSR matrix \f$A\f$.
+  !>   @param[in] csrColIndA - array of \p nnzA elements containing the column indices of the
+  !>                   sparse CSR matrix \f$A\f$.
+  !>   @param[in] descrB - descriptor of the sparse CSR matrix \f$B\f$. Currently, only
+  !>                   `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
+  !>   @param[in] nnzB - number of non-zero entries of the sparse CSR matrix \f$B\f$. Must be
   !>   non-negative.
-  !>   @param[in]
-  !>   descrA          descriptor of the sparse CSR matrix \f$A\f$. Currently, only
-  !>                   `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[in]
-  !>   nnzA number of non-zero entries of the sparse CSR matrix \f$A\f$. Must be non-negative.
-  !>   @param[in]
-  !>   csrRowPtrA      array of \p m+1 elements that point to the start of every row of the
-  !>                   sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csrColIndA      array of \p nnzA elements containing the column indices of the
-  !>                   sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   descrB          descriptor of the sparse CSR matrix \f$B\f$. Currently, only
-  !>                   `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[in]
-  !>   nnzB number of non-zero entries of the sparse CSR matrix \f$B\f$. Must be non-negative.
-  !>   @param[in]
-  !>   csrRowPtrB      array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] csrRowPtrB - array of \p m+1 elements that point to the start of every row of the
   !>                   sparse CSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   csrColIndB      array of \p nnzB elements containing the column indices of the
+  !>   @param[in] csrColIndB - array of \p nnzB elements containing the column indices of the
   !>                   sparse CSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   descrC          descriptor of the sparse CSR matrix \f$C\f$. Currently, only
+  !>   @param[in] descrC - descriptor of the sparse CSR matrix \f$C\f$. Currently, only
   !>                   `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[out]
-  !>   csrRowPtrC      array of \p m+1 elements that point to the start of every row of the
+  !>   @param[out] csrRowPtrC - array of \p m+1 elements that point to the start of every row of the
   !>                   sparse CSR matrix \f$C\f$.
-  !>   @param[out]
-  !>   nnzTotalDevHostPtr pointer to the number of non-zero entries of the sparse CSR
+  !>   @param[out] nnzTotalDevHostPtr - pointer to the number of non-zero entries of the sparse CSR
   !>                      matrix \f$C\f$. \p nnzTotalDevHostPtr can be a host or device pointer.
   !>
   !>   \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
@@ -7551,52 +7194,33 @@ module hipfort_hipsparse
   !>   \deprecated
   !>   This function is deprecated and will be removed in a future release.
   !>
-  !>   @param[in]
-  !>   handle          handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m               number of rows of the sparse CSR matrices \f$A\f$, \f$B\f$, and \f$C\f$.
-  !>   @param[in]
-  !>   n               number of columns of the sparse CSR matrices \f$A\f$, \f$B\f$, and \f$C\f$.
-  !>   @param[in]
-  !>   alpha           scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   descrA          descriptor of the sparse CSR matrix \f$A\f$. Currently, only
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse CSR matrices \f$A\f$, \f$B\f$, and \f$C\f$.
+  !>   @param[in] n - number of columns of the sparse CSR matrices \f$A\f$, \f$B\f$, and \f$C\f$.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] descrA - descriptor of the sparse CSR matrix \f$A\f$. Currently, only
   !>                   `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[in]
-  !>   nnzA            number of non-zero entries of the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csrValA         array of \p nnzA elements of the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csrRowPtrA      array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] nnzA - number of non-zero entries of the sparse CSR matrix \f$A\f$.
+  !>   @param[in] csrValA - array of \p nnzA elements of the sparse CSR matrix \f$A\f$.
+  !>   @param[in] csrRowPtrA - array of \p m+1 elements that point to the start of every row of the
   !>                   sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csrColIndA      array of \p nnzA elements containing the column indices of the
+  !>   @param[in] csrColIndA - array of \p nnzA elements containing the column indices of the
   !>                   sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   beta            scalar \f$\beta\f$.
-  !>   @param[in]
-  !>   descrB          descriptor of the sparse CSR matrix \f$B\f$. Currently, only
+  !>   @param[in] beta - scalar \f$\beta\f$.
+  !>   @param[in] descrB - descriptor of the sparse CSR matrix \f$B\f$. Currently, only
   !>                   `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[in]
-  !>   nnzB            number of non-zero entries of the sparse CSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   csrValB         array of \p nnzB elements of the sparse CSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   csrRowPtrB      array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] nnzB - number of non-zero entries of the sparse CSR matrix \f$B\f$.
+  !>   @param[in] csrValB - array of \p nnzB elements of the sparse CSR matrix \f$B\f$.
+  !>   @param[in] csrRowPtrB - array of \p m+1 elements that point to the start of every row of the
   !>                   sparse CSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   csrColIndB      array of \p nnzB elements containing the column indices of the
+  !>   @param[in] csrColIndB - array of \p nnzB elements containing the column indices of the
   !>                   sparse CSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   descrC          descriptor of the sparse CSR matrix \f$C\f$. Currently, only
+  !>   @param[in] descrC - descriptor of the sparse CSR matrix \f$C\f$. Currently, only
   !>                   `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[out]
-  !>   csrValC         array of elements of the sparse CSR matrix \f$C\f$.
-  !>   @param[in]
-  !>   csrRowPtrC      array of \p m+1 elements that point to the start of every row of the
+  !>   @param[out] csrValC - array of elements of the sparse CSR matrix \f$C\f$.
+  !>   @param[in] csrRowPtrC - array of \p m+1 elements that point to the start of every row of the
   !>                   sparse CSR matrix \f$C\f$.
-  !>   @param[out]
-  !>   csrColIndC      array of elements containing the column indices of the
+  !>   @param[out] csrColIndC - array of elements containing the column indices of the
   !>                   sparse CSR matrix \f$C\f$.
   !>
   !>   \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
@@ -7767,55 +7391,38 @@ module hipfort_hipsparse
   !>   \note
   !>   Currently, only `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
   !>
-  !>   @param[in]
-  !>   handle             handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m                  number of rows of the sparse CSR matrices \f$A\f$, \f$B\f$, and \f$C\f$.
-  !>   @param[in]
-  !>   n number of columns of the sparse CSR matrices \f$A\f$, \f$B\f$, and \f$C\f$.
-  !>   @param[in]
-  !>   alpha              scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   descrA             descriptor of the sparse CSR matrix \f$A\f$. Currently, only
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse CSR matrices \f$A\f$, \f$B\f$, and \f$C\f$.
+  !>   @param[in] n - number of columns of the sparse CSR matrices \f$A\f$, \f$B\f$, and \f$C\f$.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] descrA - descriptor of the sparse CSR matrix \f$A\f$. Currently, only
   !>                      `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[in]
-  !>   nnzA               number of non-zero entries of the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csrSortedValA      array of \p nnzA elements of the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csrSortedRowPtrA   array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] nnzA - number of non-zero entries of the sparse CSR matrix \f$A\f$.
+  !>   @param[in] csrSortedValA - array of \p nnzA elements of the sparse CSR matrix \f$A\f$.
+  !>   @param[in] csrSortedRowPtrA - array of \p m+1 elements that point to the start of every row
+  !>   of the
   !>                      sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csrSortedColIndA   array of \p nnzA elements containing the column indices of the
+  !>   @param[in] csrSortedColIndA - array of \p nnzA elements containing the column indices of the
   !>                      sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   beta               scalar \f$\beta\f$.
-  !>   @param[in]
-  !>   descrB             descriptor of the sparse CSR matrix \f$B\f$. Currently, only
+  !>   @param[in] beta - scalar \f$\beta\f$.
+  !>   @param[in] descrB - descriptor of the sparse CSR matrix \f$B\f$. Currently, only
   !>                      `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[in]
-  !>   nnzB               number of non-zero entries of the sparse CSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   csrSortedValB      array of \p nnzB elements of the sparse CSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   csrSortedRowPtrB   array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] nnzB - number of non-zero entries of the sparse CSR matrix \f$B\f$.
+  !>   @param[in] csrSortedValB - array of \p nnzB elements of the sparse CSR matrix \f$B\f$.
+  !>   @param[in] csrSortedRowPtrB - array of \p m+1 elements that point to the start of every row
+  !>   of the
   !>                      sparse CSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   csrSortedColIndB   array of \p nnzB elements containing the column indices of the
+  !>   @param[in] csrSortedColIndB - array of \p nnzB elements containing the column indices of the
   !>                      sparse CSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   descrC             descriptor of the sparse CSR matrix \f$C\f$. Currently, only
+  !>   @param[in] descrC - descriptor of the sparse CSR matrix \f$C\f$. Currently, only
   !>                      `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[out]
-  !>   csrSortedValC      array of elements of the sparse CSR matrix \f$C\f$.
-  !>   @param[in]
-  !>   csrSortedRowPtrC   array of \p m+1 elements that point to the start of every row of the
+  !>   @param[out] csrSortedValC - array of elements of the sparse CSR matrix \f$C\f$.
+  !>   @param[in] csrSortedRowPtrC - array of \p m+1 elements that point to the start of every row
+  !>   of the
   !>                      sparse CSR matrix \f$C\f$.
-  !>   @param[out]
-  !>   csrSortedColIndC   array of elements containing the column indices of the
+  !>   @param[out] csrSortedColIndC - array of elements containing the column indices of the
   !>                      sparse CSR matrix \f$C\f$.
-  !>   @param[out]
-  !>   pBufferSizeInBytes number of bytes of the temporary storage buffer required by
+  !>   @param[out] pBufferSizeInBytes - number of bytes of the temporary storage buffer required by
   !>                      `hipsparseXcsrgeam2Nnz()` and `hipsparseScsrgeam2` "hipsparseXcsrgeam2()".
   !>
   !>   \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
@@ -8034,45 +7641,33 @@ module hipfort_hipsparse
   !>   \note
   !>   Currently, only `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
   !>
-  !>   @param[in]
-  !>   handle             handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m                  number of rows of the sparse CSR matrices \f$A\f$, \f$B\f$, and \f$C\f$.
-  !>   @param[in]
-  !>   n number of columns of the sparse CSR matrices \f$A\f$, \f$B\f$, and \f$C\f$.
-  !>   @param[in]
-  !>   descrA             descriptor of the sparse CSR matrix \f$A\f$. Currently, only
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse CSR matrices \f$A\f$, \f$B\f$, and \f$C\f$.
+  !>   @param[in] n - number of columns of the sparse CSR matrices \f$A\f$, \f$B\f$, and \f$C\f$.
+  !>   @param[in] descrA - descriptor of the sparse CSR matrix \f$A\f$. Currently, only
   !>                      `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[in]
-  !>   nnzA               number of non-zero entries of the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csrSortedRowPtrA   array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] nnzA - number of non-zero entries of the sparse CSR matrix \f$A\f$.
+  !>   @param[in] csrSortedRowPtrA - array of \p m+1 elements that point to the start of every row
+  !>   of the
   !>                      sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csrSortedColIndA   array of \p nnzA elements containing the column indices of the
+  !>   @param[in] csrSortedColIndA - array of \p nnzA elements containing the column indices of the
   !>                      sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   descrB             descriptor of the sparse CSR matrix \f$B\f$. Currently, only
+  !>   @param[in] descrB - descriptor of the sparse CSR matrix \f$B\f$. Currently, only
   !>                      `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[in]
-  !>   nnzB               number of non-zero entries of the sparse CSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   csrSortedRowPtrB   array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] nnzB - number of non-zero entries of the sparse CSR matrix \f$B\f$.
+  !>   @param[in] csrSortedRowPtrB - array of \p m+1 elements that point to the start of every row
+  !>   of the
   !>                      sparse CSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   csrSortedColIndB   array of \p nnzB elements containing the column indices of the
+  !>   @param[in] csrSortedColIndB - array of \p nnzB elements containing the column indices of the
   !>                      sparse CSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   descrC             descriptor of the sparse CSR matrix \f$C\f$. Currently, only
+  !>   @param[in] descrC - descriptor of the sparse CSR matrix \f$C\f$. Currently, only
   !>                      `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[in]
-  !>   csrSortedRowPtrC   array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] csrSortedRowPtrC - array of \p m+1 elements that point to the start of every row
+  !>   of the
   !>                      sparse CSR matrix \f$C\f$.
-  !>   @param[out]
-  !>   nnzTotalDevHostPtr pointer to the number of non-zero entries of the sparse CSR
+  !>   @param[out] nnzTotalDevHostPtr - pointer to the number of non-zero entries of the sparse CSR
   !>                      matrix \f$C\f$. \p nnzTotalDevHostPtr can be a host or device pointer.
-  !>   @param[in]
-  !>   workspace          temporary storage buffer allocated by the user.
+  !>   @param[in] workspace - temporary storage buffer allocated by the user.
   !>
   !>   \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
   !>   \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p m, \p n, \p nnzA, \p nnzB,
@@ -8154,55 +7749,38 @@ module hipfort_hipsparse
   !>   \note This function is non-blocking and executed asynchronously with respect to the
   !>         host. It can return before the actual computation has finished.
   !>
-  !>   @param[in]
-  !>   handle           handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m                number of rows of the sparse CSR matrices \f$A\f$, \f$B\f$, and \f$C\f$.
-  !>   @param[in]
-  !>   n                number of columns of the sparse CSR matrices \f$A\f$, \f$B\f$, and \f$C\f$.
-  !>   @param[in]
-  !>   alpha            scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   descrA           descriptor of the sparse CSR matrix \f$A\f$. Currently, only
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse CSR matrices \f$A\f$, \f$B\f$, and \f$C\f$.
+  !>   @param[in] n - number of columns of the sparse CSR matrices \f$A\f$, \f$B\f$, and \f$C\f$.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] descrA - descriptor of the sparse CSR matrix \f$A\f$. Currently, only
   !>                    `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[in]
-  !>   nnzA             number of non-zero entries of the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csrSortedValA    array of \p nnzA elements of the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csrSortedRowPtrA array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] nnzA - number of non-zero entries of the sparse CSR matrix \f$A\f$.
+  !>   @param[in] csrSortedValA - array of \p nnzA elements of the sparse CSR matrix \f$A\f$.
+  !>   @param[in] csrSortedRowPtrA - array of \p m+1 elements that point to the start of every row
+  !>   of the
   !>                    sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csrSortedColIndA array of \p nnzA elements containing the column indices of the
+  !>   @param[in] csrSortedColIndA - array of \p nnzA elements containing the column indices of the
   !>                    sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   beta             scalar \f$\beta\f$.
-  !>   @param[in]
-  !>   descrB           descriptor of the sparse CSR matrix \f$B\f$. Currently, only
+  !>   @param[in] beta - scalar \f$\beta\f$.
+  !>   @param[in] descrB - descriptor of the sparse CSR matrix \f$B\f$. Currently, only
   !>                    `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[in]
-  !>   nnzB             number of non-zero entries of the sparse CSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   csrSortedValB    array of \p nnzB elements of the sparse CSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   csrSortedRowPtrB array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] nnzB - number of non-zero entries of the sparse CSR matrix \f$B\f$.
+  !>   @param[in] csrSortedValB - array of \p nnzB elements of the sparse CSR matrix \f$B\f$.
+  !>   @param[in] csrSortedRowPtrB - array of \p m+1 elements that point to the start of every row
+  !>   of the
   !>                    sparse CSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   csrSortedColIndB array of \p nnzB elements containing the column indices of the
+  !>   @param[in] csrSortedColIndB - array of \p nnzB elements containing the column indices of the
   !>                    sparse CSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   descrC           descriptor of the sparse CSR matrix \f$C\f$. Currently, only
+  !>   @param[in] descrC - descriptor of the sparse CSR matrix \f$C\f$. Currently, only
   !>                    `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[out]
-  !>   csrSortedValC    array of elements of the sparse CSR matrix \f$C\f$.
-  !>   @param[in]
-  !>   csrSortedRowPtrC array of \p m+1 elements that point to the start of every row of the
+  !>   @param[out] csrSortedValC - array of elements of the sparse CSR matrix \f$C\f$.
+  !>   @param[in] csrSortedRowPtrC - array of \p m+1 elements that point to the start of every row
+  !>   of the
   !>                    sparse CSR matrix \f$C\f$.
-  !>   @param[out]
-  !>   csrSortedColIndC array of elements containing the column indices of the
+  !>   @param[out] csrSortedColIndC - array of elements containing the column indices of the
   !>                    sparse CSR matrix \f$C\f$.
-  !>   @param[in]
-  !>   pBuffer          temporary storage buffer allocated by the user.
+  !>   @param[in] pBuffer - temporary storage buffer allocated by the user.
   !>
   !>   \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
   !>   \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p m, \p n, \p nnzA, \p nnzB,
@@ -8424,52 +8002,39 @@ module hipfort_hipsparse
   !>   This function is deprecated when using the CUDA backend (CUDA 10.0+) and will be
   !>   removed in CUDA 11.0. This deprecation does not apply to the ROCm backend.
   !>
-  !>   @param[in]
-  !>   handle          handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   transA          matrix \f$A\f$ operation type.
-  !>   @param[in]
-  !>   transB          matrix \f$B\f$ operation type.
-  !>   @param[in]
-  !>   m number of rows of the sparse CSR matrix \f$op(A)\f$ and \f$C\f$. Must be non-negative.
-  !>   @param[in]
-  !>   n               number of columns of the sparse CSR matrix \f$op(B)\f$ and
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] transA - matrix \f$A\f$ operation type.
+  !>   @param[in] transB - matrix \f$B\f$ operation type.
+  !>   @param[in] m - number of rows of the sparse CSR matrix \f$op(A)\f$ and \f$C\f$. Must be
+  !>   non-negative.
+  !>   @param[in] n - number of columns of the sparse CSR matrix \f$op(B)\f$ and
   !>                   \f$C\f$. Must be non-negative.
-  !>   @param[in]
-  !>   k               number of columns of the sparse CSR matrix \f$op(A)\f$ and number of
+  !>   @param[in] k - number of columns of the sparse CSR matrix \f$op(A)\f$ and number of
   !>                   rows of the sparse CSR matrix \f$op(B)\f$. Must be non-negative.
-  !>   @param[in]
-  !>   descrA          descriptor of the sparse CSR matrix \f$A\f$. Currently, only
+  !>   @param[in] descrA - descriptor of the sparse CSR matrix \f$A\f$. Currently, only
   !>                   `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[in]
-  !>   nnzA number of non-zero entries of the sparse CSR matrix \f$A\f$. Must be non-negative.
-  !>   @param[in]
-  !>   csrRowPtrA      array of \p m+1 elements (\f$op(A) == A\f$, \p k+1 otherwise)
+  !>   @param[in] nnzA - number of non-zero entries of the sparse CSR matrix \f$A\f$. Must be
+  !>   non-negative.
+  !>   @param[in] csrRowPtrA - array of \p m+1 elements (\f$op(A) == A\f$, \p k+1 otherwise)
   !>                   that point to the start of every row of the sparse CSR matrix
   !>                   \f$op(A)\f$.
-  !>   @param[in]
-  !>   csrColIndA      array of \p nnzA elements containing the column indices of the
+  !>   @param[in] csrColIndA - array of \p nnzA elements containing the column indices of the
   !>                   sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   descrB          descriptor of the sparse CSR matrix \f$B\f$. Currently, only
+  !>   @param[in] descrB - descriptor of the sparse CSR matrix \f$B\f$. Currently, only
   !>                   `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[in]
-  !>   nnzB number of non-zero entries of the sparse CSR matrix \f$B\f$. Must be non-negative.
-  !>   @param[in]
-  !>   csrRowPtrB      array of \p k+1 elements (\f$op(B) == B\f$, \p m+1 otherwise)
+  !>   @param[in] nnzB - number of non-zero entries of the sparse CSR matrix \f$B\f$. Must be
+  !>   non-negative.
+  !>   @param[in] csrRowPtrB - array of \p k+1 elements (\f$op(B) == B\f$, \p m+1 otherwise)
   !>                   that point to the start of every row of the sparse CSR matrix
   !>                   \f$op(B)\f$.
-  !>   @param[in]
-  !>   csrColIndB      array of \p nnzB elements containing the column indices of the
+  !>   @param[in] csrColIndB - array of \p nnzB elements containing the column indices of the
   !>                   sparse CSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   descrC          descriptor of the sparse CSR matrix \f$C\f$. Currently, only
+  !>   @param[in] descrC - descriptor of the sparse CSR matrix \f$C\f$. Currently, only
   !>                   `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[in]
-  !>   csrRowPtrC      array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] csrRowPtrC - array of \p m+1 elements that point to the start of every row of the
   !>                   sparse CSR matrix \f$C\f$.
-  !>   @param[inout]
-  !>   nnzTotalDevHostPtr pointer to the number of non-zero entries of the sparse CSR
+  !>   @param[inout] nnzTotalDevHostPtr - pointer to the number of non-zero entries of the sparse
+  !>   CSR
   !>                      matrix \f$C\f$. \p nnzTotalDevHostPtr can be a host or device pointer.
   !>
   !>   \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
@@ -8566,58 +8131,38 @@ module hipfort_hipsparse
   !>   \note For matrix products with more than 4096 non-zero entries per
   !>   row, an additional temporary storage buffer is allocated by the algorithm.
   !>
-  !>   @param[in]
-  !>   handle          handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   transA          matrix \f$A\f$ operation type.
-  !>   @param[in]
-  !>   transB          matrix \f$B\f$ operation type.
-  !>   @param[in]
-  !>   m               number of rows of the sparse CSR matrix \f$op(A)\f$ and \f$C\f$.
-  !>   @param[in]
-  !>   n               number of columns of the sparse CSR matrix \f$op(B)\f$ and
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] transA - matrix \f$A\f$ operation type.
+  !>   @param[in] transB - matrix \f$B\f$ operation type.
+  !>   @param[in] m - number of rows of the sparse CSR matrix \f$op(A)\f$ and \f$C\f$.
+  !>   @param[in] n - number of columns of the sparse CSR matrix \f$op(B)\f$ and
   !>                   \f$C\f$.
-  !>   @param[in]
-  !>   k               number of columns of the sparse CSR matrix \f$op(A)\f$ and number of
+  !>   @param[in] k - number of columns of the sparse CSR matrix \f$op(A)\f$ and number of
   !>                   rows of the sparse CSR matrix \f$op(B)\f$.
-  !>   @param[in]
-  !>   descrA          descriptor of the sparse CSR matrix \f$A\f$. Currently, only
+  !>   @param[in] descrA - descriptor of the sparse CSR matrix \f$A\f$. Currently, only
   !>                   `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[in]
-  !>   nnzA            number of non-zero entries of the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csrValA         array of \p nnzA elements of the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csrRowPtrA      array of \p m+1 elements (\f$op(A) == A\f$, \p k+1 otherwise)
+  !>   @param[in] nnzA - number of non-zero entries of the sparse CSR matrix \f$A\f$.
+  !>   @param[in] csrValA - array of \p nnzA elements of the sparse CSR matrix \f$A\f$.
+  !>   @param[in] csrRowPtrA - array of \p m+1 elements (\f$op(A) == A\f$, \p k+1 otherwise)
   !>                   that point to the start of every row of the sparse CSR matrix
   !>                   \f$op(A)\f$.
-  !>   @param[in]
-  !>   csrColIndA      array of \p nnzA elements containing the column indices of the
+  !>   @param[in] csrColIndA - array of \p nnzA elements containing the column indices of the
   !>                   sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   descrB          descriptor of the sparse CSR matrix \f$B\f$. Currently, only
+  !>   @param[in] descrB - descriptor of the sparse CSR matrix \f$B\f$. Currently, only
   !>                   `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[in]
-  !>   nnzB            number of non-zero entries of the sparse CSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   csrValB         array of \p nnzB elements of the sparse CSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   csrRowPtrB      array of \p k+1 elements (\f$op(B) == B\f$, \p m+1 otherwise)
+  !>   @param[in] nnzB - number of non-zero entries of the sparse CSR matrix \f$B\f$.
+  !>   @param[in] csrValB - array of \p nnzB elements of the sparse CSR matrix \f$B\f$.
+  !>   @param[in] csrRowPtrB - array of \p k+1 elements (\f$op(B) == B\f$, \p m+1 otherwise)
   !>                   that point to the start of every row of the sparse CSR matrix
   !>                   \f$op(B)\f$.
-  !>   @param[in]
-  !>   csrColIndB      array of \p nnzB elements containing the column indices of the
+  !>   @param[in] csrColIndB - array of \p nnzB elements containing the column indices of the
   !>                   sparse CSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   descrC          descriptor of the sparse CSR matrix \f$C\f$. Currently, only
+  !>   @param[in] descrC - descriptor of the sparse CSR matrix \f$C\f$. Currently, only
   !>                   `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[out]
-  !>   csrValC         array of \p nnzC elements of the sparse CSR matrix \f$C\f$.
-  !>   @param[in]
-  !>   csrRowPtrC      array of \p m+1 elements that point to the start of every row of the
+  !>   @param[out] csrValC - array of \p nnzC elements of the sparse CSR matrix \f$C\f$.
+  !>   @param[in] csrRowPtrC - array of \p m+1 elements that point to the start of every row of the
   !>                   sparse CSR matrix \f$C\f$.
-  !>   @param[out]
-  !>   csrColIndC      array of \p nnzC elements containing the column indices of the
+  !>   @param[out] csrColIndC - array of \p nnzC elements containing the column indices of the
   !>                   sparse CSR matrix \f$C\f$.
   !>
   !>   \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
@@ -8804,59 +8349,39 @@ module hipfort_hipsparse
   !>   \note
   !>   Currently, only `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
   !>
-  !>   @param[in]
-  !>   handle          handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m               number of rows of the sparse CSR matrix \f$op(A)\f$ and \f$C\f$.
-  !>   @param[in]
-  !>   n               number of columns of the sparse CSR matrix \f$op(B)\f$ and
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse CSR matrix \f$op(A)\f$ and \f$C\f$.
+  !>   @param[in] n - number of columns of the sparse CSR matrix \f$op(B)\f$ and
   !>                   \f$C\f$.
-  !>   @param[in]
-  !>   k               number of columns of the sparse CSR matrix \f$op(A)\f$ and number of
+  !>   @param[in] k - number of columns of the sparse CSR matrix \f$op(A)\f$ and number of
   !>                   rows of the sparse CSR matrix \f$op(B)\f$.
-  !>   @param[in]
-  !>   alpha           scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   descrA          descriptor of the sparse CSR matrix \f$A\f$. Currently, only
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] descrA - descriptor of the sparse CSR matrix \f$A\f$. Currently, only
   !>                   `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[in]
-  !>   nnzA            number of non-zero entries of the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csrRowPtrA      array of \p m+1 elements (\f$op(A) == A\f$, \p k+1 otherwise)
+  !>   @param[in] nnzA - number of non-zero entries of the sparse CSR matrix \f$A\f$.
+  !>   @param[in] csrRowPtrA - array of \p m+1 elements (\f$op(A) == A\f$, \p k+1 otherwise)
   !>                   that point to the start of every row of the sparse CSR matrix
   !>                   \f$op(A)\f$.
-  !>   @param[in]
-  !>   csrColIndA      array of \p nnzA elements containing the column indices of the
+  !>   @param[in] csrColIndA - array of \p nnzA elements containing the column indices of the
   !>                   sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   descrB          descriptor of the sparse CSR matrix \f$B\f$. Currently, only
+  !>   @param[in] descrB - descriptor of the sparse CSR matrix \f$B\f$. Currently, only
   !>                   `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[in]
-  !>   nnzB            number of non-zero entries of the sparse CSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   csrRowPtrB      array of \p k+1 elements (\f$op(B) == B\f$, \p m+1 otherwise)
+  !>   @param[in] nnzB - number of non-zero entries of the sparse CSR matrix \f$B\f$.
+  !>   @param[in] csrRowPtrB - array of \p k+1 elements (\f$op(B) == B\f$, \p m+1 otherwise)
   !>                   that point to the start of every row of the sparse CSR matrix
   !>                   \f$op(B)\f$.
-  !>   @param[in]
-  !>   csrColIndB      array of \p nnzB elements containing the column indices of the
+  !>   @param[in] csrColIndB - array of \p nnzB elements containing the column indices of the
   !>                   sparse CSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   beta            scalar \f$\beta\f$.
-  !>   @param[in]
-  !>   descrD          descriptor of the sparse CSR matrix \f$D\f$. Currently, only
+  !>   @param[in] beta - scalar \f$\beta\f$.
+  !>   @param[in] descrD - descriptor of the sparse CSR matrix \f$D\f$. Currently, only
   !>                   `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[in]
-  !>   nnzD            number of non-zero entries of the sparse CSR matrix \f$D\f$.
-  !>   @param[in]
-  !>   csrRowPtrD      array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] nnzD - number of non-zero entries of the sparse CSR matrix \f$D\f$.
+  !>   @param[in] csrRowPtrD - array of \p m+1 elements that point to the start of every row of the
   !>                   sparse CSR matrix \f$D\f$.
-  !>   @param[in]
-  !>   csrColIndD      array of \p nnzD elements containing the column indices of the sparse
+  !>   @param[in] csrColIndD - array of \p nnzD elements containing the column indices of the sparse
   !>                   CSR matrix \f$D\f$.
-  !>   @param[inout]
-  !>   info            structure that holds meta data for the sparse CSR matrix \f$C\f$.
-  !>   @param[out]
-  !>   pBufferSizeInBytes number of bytes of the temporary storage buffer required by
+  !>   @param[inout] myInfo - structure that holds meta data for the sparse CSR matrix \f$C\f$.
+  !>   @param[out] pBufferSizeInBytes - number of bytes of the temporary storage buffer required by
   !>                      `hipsparseXcsrgemm2Nnz()`, `hipsparseScsrgemm2()`, hipsparseDcsrgemm2(),
   !>                      hipsparseCcsrgemm2(), and hipsparseZcsrgemm2().
   !>
@@ -9055,64 +8580,43 @@ module hipfort_hipsparse
   !>   \note
   !>   Currently, only `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
   !>
-  !>   @param[in]
-  !>   handle          handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m               number of rows of the sparse CSR matrix \f$op(A)\f$ and \f$C\f$.
-  !>   @param[in]
-  !>   n               number of columns of the sparse CSR matrix \f$op(B)\f$ and
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse CSR matrix \f$op(A)\f$ and \f$C\f$.
+  !>   @param[in] n - number of columns of the sparse CSR matrix \f$op(B)\f$ and
   !>                   \f$C\f$.
-  !>   @param[in]
-  !>   k               number of columns of the sparse CSR matrix \f$op(A)\f$ and number of
+  !>   @param[in] k - number of columns of the sparse CSR matrix \f$op(A)\f$ and number of
   !>                   rows of the sparse CSR matrix \f$op(B)\f$.
-  !>   @param[in]
-  !>   descrA          descriptor of the sparse CSR matrix \f$A\f$. Currently, only
+  !>   @param[in] descrA - descriptor of the sparse CSR matrix \f$A\f$. Currently, only
   !>                   `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[in]
-  !>   nnzA            number of non-zero entries of the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csrRowPtrA      array of \p m+1 elements (\f$op(A) == A\f$, \p k+1 otherwise)
+  !>   @param[in] nnzA - number of non-zero entries of the sparse CSR matrix \f$A\f$.
+  !>   @param[in] csrRowPtrA - array of \p m+1 elements (\f$op(A) == A\f$, \p k+1 otherwise)
   !>                   that point to the start of every row of the sparse CSR matrix
   !>                   \f$op(A)\f$.
-  !>   @param[in]
-  !>   csrColIndA      array of \p nnzA elements containing the column indices of the
+  !>   @param[in] csrColIndA - array of \p nnzA elements containing the column indices of the
   !>                   sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   descrB          descriptor of the sparse CSR matrix \f$B\f$. Currently, only
+  !>   @param[in] descrB - descriptor of the sparse CSR matrix \f$B\f$. Currently, only
   !>                   `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[in]
-  !>   nnzB            number of non-zero entries of the sparse CSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   csrRowPtrB      array of \p k+1 elements (\f$op(B) == B\f$, \p m+1 otherwise)
+  !>   @param[in] nnzB - number of non-zero entries of the sparse CSR matrix \f$B\f$.
+  !>   @param[in] csrRowPtrB - array of \p k+1 elements (\f$op(B) == B\f$, \p m+1 otherwise)
   !>                   that point to the start of every row of the sparse CSR matrix
   !>                   \f$op(B)\f$.
-  !>   @param[in]
-  !>   csrColIndB      array of \p nnzB elements containing the column indices of the
+  !>   @param[in] csrColIndB - array of \p nnzB elements containing the column indices of the
   !>                   sparse CSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   descrD          descriptor of the sparse CSR matrix \f$D\f$. Currently, only
+  !>   @param[in] descrD - descriptor of the sparse CSR matrix \f$D\f$. Currently, only
   !>                   `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[in]
-  !>   nnzD            number of non-zero entries of the sparse CSR matrix \f$D\f$.
-  !>   @param[in]
-  !>   csrRowPtrD      array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] nnzD - number of non-zero entries of the sparse CSR matrix \f$D\f$.
+  !>   @param[in] csrRowPtrD - array of \p m+1 elements that point to the start of every row of the
   !>                   sparse CSR matrix \f$D\f$.
-  !>   @param[in]
-  !>   csrColIndD      array of \p nnzD elements containing the column indices of the sparse
+  !>   @param[in] csrColIndD - array of \p nnzD elements containing the column indices of the sparse
   !>                   CSR matrix \f$D\f$.
-  !>   @param[in]
-  !>   descrC          descriptor of the sparse CSR matrix \f$C\f$. Currently, only
+  !>   @param[in] descrC - descriptor of the sparse CSR matrix \f$C\f$. Currently, only
   !>                   `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[out]
-  !>   csrRowPtrC      array of \p m+1 elements that point to the start of every row of the
+  !>   @param[out] csrRowPtrC - array of \p m+1 elements that point to the start of every row of the
   !>                   sparse CSR matrix \f$C\f$.
-  !>   @param[out]
-  !>   nnzTotalDevHostPtr pointer to the number of non-zero entries of the sparse CSR
+  !>   @param[out] nnzTotalDevHostPtr - pointer to the number of non-zero entries of the sparse CSR
   !>                      matrix \f$C\f$.
-  !>   @param[in]
-  !>   info            structure that holds meta data for the sparse CSR matrix \f$C\f$.
-  !>   @param[in]
-  !>   pBuffer         temporary storage buffer allocated by the user. The size is returned
+  !>   @param[in] myInfo - structure that holds meta data for the sparse CSR matrix \f$C\f$.
+  !>   @param[in] pBuffer - temporary storage buffer allocated by the user. The size is returned
   !>                   by `hipsparseScsrgemm2_bufferSizeExt()`, hipsparseDcsrgemm2_bufferSizeExt(),
   !>                   hipsparseZcsrgemm2_bufferSizeExt(), or hipsparseZcsrgemm2_bufferSizeExt().
   !>
@@ -9203,76 +8707,49 @@ module hipfort_hipsparse
   !>   \note For matrix products with more than 4096 non-zero entries per
   !>   row, an additional temporary storage buffer is allocated by the algorithm.
   !>
-  !>   @param[in]
-  !>   handle          handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m               number of rows of the sparse CSR matrix \f$op(A)\f$ and \f$C\f$.
-  !>   @param[in]
-  !>   n               number of columns of the sparse CSR matrix \f$op(B)\f$ and
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse CSR matrix \f$op(A)\f$ and \f$C\f$.
+  !>   @param[in] n - number of columns of the sparse CSR matrix \f$op(B)\f$ and
   !>                   \f$C\f$.
-  !>   @param[in]
-  !>   k               number of columns of the sparse CSR matrix \f$op(A)\f$ and number of
+  !>   @param[in] k - number of columns of the sparse CSR matrix \f$op(A)\f$ and number of
   !>                   rows of the sparse CSR matrix \f$op(B)\f$.
-  !>   @param[in]
-  !>   alpha           scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   descrA          descriptor of the sparse CSR matrix \f$A\f$. Currently, only
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] descrA - descriptor of the sparse CSR matrix \f$A\f$. Currently, only
   !>                   `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[in]
-  !>   nnzA            number of non-zero entries of the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csrValA         array of \p nnzA elements of the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csrRowPtrA      array of \p m+1 elements (\f$op(A) == A\f$, \p k+1 otherwise)
+  !>   @param[in] nnzA - number of non-zero entries of the sparse CSR matrix \f$A\f$.
+  !>   @param[in] csrValA - array of \p nnzA elements of the sparse CSR matrix \f$A\f$.
+  !>   @param[in] csrRowPtrA - array of \p m+1 elements (\f$op(A) == A\f$, \p k+1 otherwise)
   !>                   that point to the start of every row of the sparse CSR matrix
   !>                   \f$op(A)\f$.
-  !>   @param[in]
-  !>   csrColIndA      array of \p nnzA elements containing the column indices of the
+  !>   @param[in] csrColIndA - array of \p nnzA elements containing the column indices of the
   !>                   sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   descrB          descriptor of the sparse CSR matrix \f$B\f$. Currently, only
+  !>   @param[in] descrB - descriptor of the sparse CSR matrix \f$B\f$. Currently, only
   !>                   `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[in]
-  !>   nnzB            number of non-zero entries of the sparse CSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   csrValB         array of \p nnzB elements of the sparse CSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   csrRowPtrB      array of \p k+1 elements (\f$op(B) == B\f$, \p m+1 otherwise)
+  !>   @param[in] nnzB - number of non-zero entries of the sparse CSR matrix \f$B\f$.
+  !>   @param[in] csrValB - array of \p nnzB elements of the sparse CSR matrix \f$B\f$.
+  !>   @param[in] csrRowPtrB - array of \p k+1 elements (\f$op(B) == B\f$, \p m+1 otherwise)
   !>                   that point to the start of every row of the sparse CSR matrix
   !>                   \f$op(B)\f$.
-  !>   @param[in]
-  !>   csrColIndB      array of \p nnzB elements containing the column indices of the
+  !>   @param[in] csrColIndB - array of \p nnzB elements containing the column indices of the
   !>                   sparse CSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   beta            scalar \f$\beta\f$.
-  !>   @param[in]
-  !>   descrD          descriptor of the sparse CSR matrix \f$D\f$. Currently, only
+  !>   @param[in] beta - scalar \f$\beta\f$.
+  !>   @param[in] descrD - descriptor of the sparse CSR matrix \f$D\f$. Currently, only
   !>                   `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[in]
-  !>   nnzD            number of non-zero entries of the sparse CSR matrix \f$D\f$.
-  !>   @param[in]
-  !>   csrValD         array of \p nnzD elements of the sparse CSR matrix \f$D\f$.
-  !>   @param[in]
-  !>   csrRowPtrD      array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] nnzD - number of non-zero entries of the sparse CSR matrix \f$D\f$.
+  !>   @param[in] csrValD - array of \p nnzD elements of the sparse CSR matrix \f$D\f$.
+  !>   @param[in] csrRowPtrD - array of \p m+1 elements that point to the start of every row of the
   !>                   sparse CSR matrix \f$D\f$.
-  !>   @param[in]
-  !>   csrColIndD      array of \p nnzD elements containing the column indices of the
+  !>   @param[in] csrColIndD - array of \p nnzD elements containing the column indices of the
   !>                   sparse CSR matrix \f$D\f$.
-  !>   @param[in]
-  !>   descrC          descriptor of the sparse CSR matrix \f$C\f$. Currently, only
+  !>   @param[in] descrC - descriptor of the sparse CSR matrix \f$C\f$. Currently, only
   !>                   `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[out]
-  !>   csrValC         array of \p nnzC elements of the sparse CSR matrix \f$C\f$.
-  !>   @param[in]
-  !>   csrRowPtrC      array of \p m+1 elements that point to the start of every row of the
+  !>   @param[out] csrValC - array of \p nnzC elements of the sparse CSR matrix \f$C\f$.
+  !>   @param[in] csrRowPtrC - array of \p m+1 elements that point to the start of every row of the
   !>                   sparse CSR matrix \f$C\f$.
-  !>   @param[out]
-  !>   csrColIndC      array of \p nnzC elements containing the column indices of the
+  !>   @param[out] csrColIndC - array of \p nnzC elements containing the column indices of the
   !>                   sparse CSR matrix \f$C\f$.
-  !>   @param[in]
-  !>   info            structure that holds meta data for the sparse CSR matrix \f$C\f$.
-  !>   @param[in]
-  !>   pBuffer         temporary storage buffer allocated by the user. The size is returned
+  !>   @param[in] myInfo - structure that holds meta data for the sparse CSR matrix \f$C\f$.
+  !>   @param[in] pBuffer - temporary storage buffer allocated by the user. The size is returned
   !>                   by `hipsparseScsrgemm2_bufferSizeExt()`, hipsparseDcsrgemm2_bufferSizeExt(),
   !>                   hipsparseCcsrgemm2_bufferSizeExt(), or hipsparseZcsrgemm2_bufferSizeExt().
   !>
@@ -9497,12 +8974,10 @@ module hipfort_hipsparse
   !>   This function is deprecated when using the CUDA backend (CUDA 12.0+) and will be
   !>   removed in CUDA 13.0. This deprecation does not apply to the ROCm backend.
   !>
-  !>   @param[in]
-  !>   handle      handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   info        structure that holds the information collected during the analysis step.
-  !>   @param[inout]
-  !>   position    pointer to zero pivot \f$j\f$, which can be in host or device memory.
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[inout] position - pointer to zero pivot \f$j\f$, which can be in host or device
+  !>   memory.
   !>
   !>   \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
   !>   \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
@@ -9534,33 +9009,25 @@ module hipfort_hipsparse
   !>   and `hipsparseSbsric02` "hipsparseXbsric02()". The temporary storage buffer must be
   !>   allocated by the user.
   !>
-  !>   @param[in]
-  !>   handle             handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   dirA direction that specifies whether to count non-zero elements by `HIPSPARSE_DIRECTION_ROW`
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] dirA - direction that specifies whether to count non-zero elements by
+  !>   `HIPSPARSE_DIRECTION_ROW`
   !>                      or by `HIPSPARSE_DIRECTION_COLUMN`.
-  !>   @param[in]
-  !>   mb                 number of block rows in the sparse BSR matrix. Must be non-negative.
-  !>   @param[in]
-  !>   nnzb number of non-zero block entries of the sparse BSR matrix. Must be non-negative.
-  !>   @param[in]
-  !>   descrA             descriptor of the sparse BSR matrix.
-  !>   @param[in]
-  !>   bsrValA array of length \p nnzb*blockDim*blockDim containing the values of the sparse BSR
-  !>   matrix.
-  !>   @param[in]
-  !>   bsrRowPtrA array of \p mb+1 elements that point to the start of every block row of the
+  !>   @param[in] mb - number of block rows in the sparse BSR matrix. Must be non-negative.
+  !>   @param[in] nnzb - number of non-zero block entries of the sparse BSR matrix. Must be
+  !>   non-negative.
+  !>   @param[in] descrA - descriptor of the sparse BSR matrix.
+  !>   @param[in] bsrValA - array of length \p nnzb*blockDim*blockDim containing the values of the
+  !>   sparse BSR matrix.
+  !>   @param[in] bsrRowPtrA - array of \p mb+1 elements that point to the start of every block row
+  !>   of the
   !>                      sparse BSR matrix.
-  !>   @param[in]
-  !>   bsrColIndA array of \p nnzb elements containing the block column indices of the sparse BSR
-  !>   matrix.
-  !>   @param[in]
-  !>   blockDim the block dimension of the BSR matrix. Must be positive, which is between 1 and m
-  !>   where \p m=mb*blockDim.
-  !>   @param[out]
-  !>   info               structure that holds the information collected during the analysis step.
-  !>   @param[out]
-  !>   pBufferSizeInBytes number of bytes of the temporary storage buffer required by
+  !>   @param[in] bsrColIndA - array of \p nnzb elements containing the block column indices of the
+  !>   sparse BSR matrix.
+  !>   @param[in] blockDim - the block dimension of the BSR matrix. Must be positive, which is
+  !>   between 1 and m where \p m=mb*blockDim.
+  !>   @param[out] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[out] pBufferSizeInBytes - number of bytes of the temporary storage buffer required by
   !>                      `hipsparseSbsric02_analysis()`, hipsparseDbsric02_analysis(),
   !>                      hipsparseCbsric02_analysis(), hipsparseZbsric02_analysis(),
   !>                      `hipsparseSbsric02()`, hipsparseDbsric02(), hipsparseCbsric02(),
@@ -9724,36 +9191,25 @@ module hipfort_hipsparse
   !>   This function is non-blocking and executed asynchronously with respect to the host.
   !>   It can return before the actual computation has finished.
   !>
-  !>   @param[in]
-  !>   handle      handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   dirA direction that specifies whether to count non-zero elements by `HIPSPARSE_DIRECTION_ROW`
-  !>   or by
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] dirA - direction that specifies whether to count non-zero elements by
+  !>   `HIPSPARSE_DIRECTION_ROW` or by
   !>               `HIPSPARSE_DIRECTION_COLUMN`.
-  !>   @param[in]
-  !>   mb          number of block rows in the sparse BSR matrix.
-  !>   @param[in]
-  !>   nnzb        number of non-zero block entries of the sparse BSR matrix.
-  !>   @param[in]
-  !>   descrA      descriptor of the sparse BSR matrix.
-  !>   @param[in]
-  !>   bsrValA array of length \p nnzb*blockDim*blockDim containing the values of the sparse BSR
-  !>   matrix.
-  !>   @param[in]
-  !>   bsrRowPtrA  array of \p mb+1 elements that point to the start of every block row of the
+  !>   @param[in] mb - number of block rows in the sparse BSR matrix.
+  !>   @param[in] nnzb - number of non-zero block entries of the sparse BSR matrix.
+  !>   @param[in] descrA - descriptor of the sparse BSR matrix.
+  !>   @param[in] bsrValA - array of length \p nnzb*blockDim*blockDim containing the values of the
+  !>   sparse BSR matrix.
+  !>   @param[in] bsrRowPtrA - array of \p mb+1 elements that point to the start of every block row
+  !>   of the
   !>               sparse BSR matrix.
-  !>   @param[in]
-  !>   bsrColIndA array of \p nnzb elements containing the block column indices of the sparse BSR
-  !>   matrix.
-  !>   @param[in]
-  !>   blockDim the block dimension of the BSR matrix, which is between 1 and m where \p
-  !>   m=mb*blockDim.
-  !>   @param[out]
-  !>   info        structure that holds the information collected during the analysis step.
-  !>   @param[in]
-  !>   policy      `HIPSPARSE_SOLVE_POLICY_NO_LEVEL` or `HIPSPARSE_SOLVE_POLICY_USE_LEVEL`.
-  !>   @param[in]
-  !>   pBuffer     temporary storage buffer allocated by the user.
+  !>   @param[in] bsrColIndA - array of \p nnzb elements containing the block column indices of the
+  !>   sparse BSR matrix.
+  !>   @param[in] blockDim - the block dimension of the BSR matrix, which is between 1 and m where
+  !>   \p m=mb*blockDim.
+  !>   @param[out] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[in] policy - `HIPSPARSE_SOLVE_POLICY_NO_LEVEL` or `HIPSPARSE_SOLVE_POLICY_USE_LEVEL`.
+  !>   @param[in] pBuffer - temporary storage buffer allocated by the user.
   !>
   !>   \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
   !>   \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p mb, \p nnzb, \p blockDim, \p descrA,
@@ -9944,36 +9400,25 @@ module hipfort_hipsparse
   !>   This function is non-blocking and executed asynchronously with respect to the host.
   !>   It can return before the actual computation has finished.
   !>
-  !>   @param[in]
-  !>   handle      handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   dirA direction that specifies whether to count non-zero elements by `HIPSPARSE_DIRECTION_ROW`
-  !>   or by
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] dirA - direction that specifies whether to count non-zero elements by
+  !>   `HIPSPARSE_DIRECTION_ROW` or by
   !>               `HIPSPARSE_DIRECTION_COLUMN`.
-  !>   @param[in]
-  !>   mb          number of block rows in the sparse BSR matrix.
-  !>   @param[in]
-  !>   nnzb        number of non-zero block entries of the sparse BSR matrix.
-  !>   @param[in]
-  !>   descrA      descriptor of the sparse BSR matrix.
-  !>   @param[inout]
-  !>   bsrValA array of length \p nnzb*blockDim*blockDim containing the values of the sparse BSR
-  !>   matrix.
-  !>   @param[in]
-  !>   bsrRowPtrA  array of \p mb+1 elements that point to the start of every block row of the
+  !>   @param[in] mb - number of block rows in the sparse BSR matrix.
+  !>   @param[in] nnzb - number of non-zero block entries of the sparse BSR matrix.
+  !>   @param[in] descrA - descriptor of the sparse BSR matrix.
+  !>   @param[inout] bsrValA - array of length \p nnzb*blockDim*blockDim containing the values of
+  !>   the sparse BSR matrix.
+  !>   @param[in] bsrRowPtrA - array of \p mb+1 elements that point to the start of every block row
+  !>   of the
   !>               sparse BSR matrix.
-  !>   @param[in]
-  !>   bsrColIndA array of \p nnzb elements containing the block column indices of the sparse BSR
-  !>   matrix.
-  !>   @param[in]
-  !>   blockDim the block dimension of the BSR matrix, which is between 1 and m where \p
-  !>   m=mb*blockDim.
-  !>   @param[in]
-  !>   info        structure that holds the information collected during the analysis step.
-  !>   @param[in]
-  !>   policy      `HIPSPARSE_SOLVE_POLICY_NO_LEVEL` or `HIPSPARSE_SOLVE_POLICY_USE_LEVEL`.
-  !>   @param[in]
-  !>   pBuffer     temporary storage buffer allocated by the user.
+  !>   @param[in] bsrColIndA - array of \p nnzb elements containing the block column indices of the
+  !>   sparse BSR matrix.
+  !>   @param[in] blockDim - the block dimension of the BSR matrix, which is between 1 and m where
+  !>   \p m=mb*blockDim.
+  !>   @param[in] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[in] policy - `HIPSPARSE_SOLVE_POLICY_NO_LEVEL` or `HIPSPARSE_SOLVE_POLICY_USE_LEVEL`.
+  !>   @param[in] pBuffer - temporary storage buffer allocated by the user.
   !>
   !>   \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
   !>   \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p mb, \p nnzb, \p blockDim, \p descrA,
@@ -10145,12 +9590,10 @@ module hipfort_hipsparse
   !>   This function is deprecated when using the CUDA backend (CUDA 12.0+) and will be
   !>   removed in CUDA 13.0. This deprecation does not apply to the ROCm backend.
   !>
-  !>   @param[in]
-  !>   handle      handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   info        structure that holds the information collected during the analysis step.
-  !>   @param[inout]
-  !>   position    pointer to zero pivot \f$j\f$, which can be in host or device memory.
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[inout] position - pointer to zero pivot \f$j\f$, which can be in host or device
+  !>   memory.
   !>
   !>   \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
   !>   \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
@@ -10191,16 +9634,11 @@ module hipfort_hipsparse
   !>   This function is deprecated when using the CUDA backend (CUDA 12.0+) and will be
   !>   removed in CUDA 13.0. This deprecation does not apply to the ROCm backend.
   !>
-  !>   @param[in]
-  !>   handle        handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   info          structure that holds the information collected during the analysis step.
-  !>   @param[in]
-  !>   enable_boost  enable/disable numeric boost.
-  !>   @param[in]
-  !>   tol           tolerance to determine whether a numerical value is replaced or not.
-  !>   @param[in]
-  !>   boost_val     boost value to replace a numerical value.
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[in] enable_boost - enable/disable numeric boost.
+  !>   @param[in] tol - tolerance to determine whether a numerical value is replaced or not.
+  !>   @param[in] boost_val - boost value to replace a numerical value.
   !>
   !>   \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
   !>   \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
@@ -10294,33 +9732,24 @@ module hipfort_hipsparse
   !>   and `hipsparseSbsrilu02` "hipsparseXbsrilu02()". The temporary storage buffer must be
   !>   allocated by the user.
   !>
-  !>   @param[in]
-  !>   handle             handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   dirA direction that specifies whether to count non-zero elements by `HIPSPARSE_DIRECTION_ROW`
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] dirA - direction that specifies whether to count non-zero elements by
+  !>   `HIPSPARSE_DIRECTION_ROW`
   !>                      or by `HIPSPARSE_DIRECTION_COLUMN`.
-  !>   @param[in]
-  !>   mb                 number of block rows in the sparse BSR matrix.
-  !>   @param[in]
-  !>   nnzb               number of non-zero block entries of the sparse BSR matrix.
-  !>   @param[in]
-  !>   descrA             descriptor of the sparse BSR matrix.
-  !>   @param[in]
-  !>   bsrSortedValA array of length \p nnzb*blockDim*blockDim containing the values of the sparse
-  !>   BSR matrix.
-  !>   @param[in]
-  !>   bsrSortedRowPtrA array of \p mb+1 elements that point to the start of every block row of the
+  !>   @param[in] mb - number of block rows in the sparse BSR matrix.
+  !>   @param[in] nnzb - number of non-zero block entries of the sparse BSR matrix.
+  !>   @param[in] descrA - descriptor of the sparse BSR matrix.
+  !>   @param[in] bsrSortedValA - array of length \p nnzb*blockDim*blockDim containing the values of
+  !>   the sparse BSR matrix.
+  !>   @param[in] bsrSortedRowPtrA - array of \p mb+1 elements that point to the start of every
+  !>   block row of the
   !>                      sparse BSR matrix.
-  !>   @param[in]
-  !>   bsrSortedColIndA array of \p nnzb elements containing the block column indices of the sparse
-  !>   BSR matrix.
-  !>   @param[in]
-  !>   blockDim the block dimension of the BSR matrix, which is between 1 and m where \p
-  !>   m=mb*blockDim.
-  !>   @param[out]
-  !>   info               structure that holds the information collected during the analysis step.
-  !>   @param[out]
-  !>   pBufferSizeInBytes number of bytes of the temporary storage buffer required by
+  !>   @param[in] bsrSortedColIndA - array of \p nnzb elements containing the block column indices
+  !>   of the sparse BSR matrix.
+  !>   @param[in] blockDim - the block dimension of the BSR matrix, which is between 1 and m where
+  !>   \p m=mb*blockDim.
+  !>   @param[out] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[out] pBufferSizeInBytes - number of bytes of the temporary storage buffer required by
   !>                      `hipsparseSbsrilu02_analysis()`, hipsparseDbsrilu02_analysis(),
   !>                      hipsparseCbsrilu02_analysis(), hipsparseZbsrilu02_analysis(),
   !>                      `hipsparseSbsrilu02()`, hipsparseDbsrilu02(), hipsparseCbsrilu02(),
@@ -10482,35 +9911,24 @@ module hipfort_hipsparse
   !>   This function is non-blocking and executed asynchronously with respect to the host.
   !>   It can return before the actual computation has finished.
   !>
-  !>   @param[in]
-  !>   handle           handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   dirA             direction that specified whether to count non-zero elements by
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] dirA - direction that specified whether to count non-zero elements by
   !>                    `HIPSPARSE_DIRECTION_ROW` or by `HIPSPARSE_DIRECTION_COLUMN`.
-  !>   @param[in]
-  !>   mb               number of block rows in the sparse BSR matrix.
-  !>   @param[in]
-  !>   nnzb             number of non-zero block entries of the sparse BSR matrix.
-  !>   @param[in]
-  !>   descrA           descriptor of the sparse BSR matrix.
-  !>   @param[in]
-  !>   bsrSortedValA array of length \p nnzb*blockDim*blockDim containing the values of the sparse
-  !>   BSR matrix.
-  !>   @param[in]
-  !>   bsrSortedRowPtrA array of \p mb+1 elements that point to the start of every block row of the
+  !>   @param[in] mb - number of block rows in the sparse BSR matrix.
+  !>   @param[in] nnzb - number of non-zero block entries of the sparse BSR matrix.
+  !>   @param[in] descrA - descriptor of the sparse BSR matrix.
+  !>   @param[in] bsrSortedValA - array of length \p nnzb*blockDim*blockDim containing the values of
+  !>   the sparse BSR matrix.
+  !>   @param[in] bsrSortedRowPtrA - array of \p mb+1 elements that point to the start of every
+  !>   block row of the
   !>                    sparse BSR matrix.
-  !>   @param[in]
-  !>   bsrSortedColIndA array of \p nnzb elements containing the block column indices of the sparse
-  !>   BSR matrix.
-  !>   @param[in]
-  !>   blockDim the block dimension of the BSR matrix, which is between 1 and m where \p
-  !>   m=mb*blockDim.
-  !>   @param[out]
-  !>   info             structure that holds the information collected during the analysis step.
-  !>   @param[in]
-  !>   policy           `HIPSPARSE_SOLVE_POLICY_NO_LEVEL` or `HIPSPARSE_SOLVE_POLICY_USE_LEVEL`.
-  !>   @param[in]
-  !>   pBuffer          temporary storage buffer allocated by the user.
+  !>   @param[in] bsrSortedColIndA - array of \p nnzb elements containing the block column indices
+  !>   of the sparse BSR matrix.
+  !>   @param[in] blockDim - the block dimension of the BSR matrix, which is between 1 and m where
+  !>   \p m=mb*blockDim.
+  !>   @param[out] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[in] policy - `HIPSPARSE_SOLVE_POLICY_NO_LEVEL` or `HIPSPARSE_SOLVE_POLICY_USE_LEVEL`.
+  !>   @param[in] pBuffer - temporary storage buffer allocated by the user.
   !>
   !>   \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
   !>   \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p mb, \p nnzb, \p blockDim, \p descrA,
@@ -10692,35 +10110,24 @@ module hipfort_hipsparse
   !>   This function is non-blocking and executed asynchronously with respect to the host.
   !>   It can return before the actual computation has finished.
   !>
-  !>   @param[in]
-  !>   handle             handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   dirA               direction that specified whether to count non-zero elements by
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] dirA - direction that specified whether to count non-zero elements by
   !>                      `HIPSPARSE_DIRECTION_ROW` or by `HIPSPARSE_DIRECTION_COLUMN`.
-  !>   @param[in]
-  !>   mb                 number of block rows in the sparse BSR matrix.
-  !>   @param[in]
-  !>   nnzb               number of non-zero block entries of the sparse BSR matrix.
-  !>   @param[in]
-  !>   descrA             descriptor of the sparse BSR matrix.
-  !>   @param[inout]
-  !>   bsrSortedValA_valM array of length \p nnzb*blockDim*blockDim containing the values of the
-  !>   sparse BSR matrix.
-  !>   @param[in]
-  !>   bsrSortedRowPtrA array of \p mb+1 elements that point to the start of every block row of the
+  !>   @param[in] mb - number of block rows in the sparse BSR matrix.
+  !>   @param[in] nnzb - number of non-zero block entries of the sparse BSR matrix.
+  !>   @param[in] descrA - descriptor of the sparse BSR matrix.
+  !>   @param[inout] bsrSortedValA_valM - array of length \p nnzb*blockDim*blockDim containing the
+  !>   values of the sparse BSR matrix.
+  !>   @param[in] bsrSortedRowPtrA - array of \p mb+1 elements that point to the start of every
+  !>   block row of the
   !>                      sparse BSR matrix.
-  !>   @param[in]
-  !>   bsrSortedColIndA array of \p nnzb elements containing the block column indices of the sparse
-  !>   BSR matrix.
-  !>   @param[in]
-  !>   blockDim the block dimension of the BSR matrix, which is between 1 and m where \p
-  !>   m=mb*blockDim.
-  !>   @param[in]
-  !>   info               structure that holds the information collected during the analysis step.
-  !>   @param[in]
-  !>   policy             `HIPSPARSE_SOLVE_POLICY_NO_LEVEL` or `HIPSPARSE_SOLVE_POLICY_USE_LEVEL`.
-  !>   @param[in]
-  !>   pBuffer            temporary storage buffer allocated by the user.
+  !>   @param[in] bsrSortedColIndA - array of \p nnzb elements containing the block column indices
+  !>   of the sparse BSR matrix.
+  !>   @param[in] blockDim - the block dimension of the BSR matrix, which is between 1 and m where
+  !>   \p m=mb*blockDim.
+  !>   @param[in] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[in] policy - `HIPSPARSE_SOLVE_POLICY_NO_LEVEL` or `HIPSPARSE_SOLVE_POLICY_USE_LEVEL`.
+  !>   @param[in] pBuffer - temporary storage buffer allocated by the user.
   !>
   !>   \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
   !>   \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p mb, \p nnzb, \p blockDim, \p descrA,
@@ -10888,12 +10295,10 @@ module hipfort_hipsparse
   !>   This function is deprecated when using the CUDA backend (CUDA 12.0+) and will be
   !>   removed in CUDA 13.0. This deprecation does not apply to the ROCm backend.
   !>
-  !>   @param[in]
-  !>   handle      handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   info        structure that holds the information collected during the analysis step.
-  !>   @param[inout]
-  !>   position    pointer to zero pivot \f$j\f$, which can be in host or device memory.
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[inout] position - pointer to zero pivot \f$j\f$, which can be in host or device
+  !>   memory.
   !>
   !>   \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
   !>   \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
@@ -10925,26 +10330,19 @@ module hipfort_hipsparse
   !>   `hipsparseScsric02` "hipsparseXcsric02()". The temporary storage buffer must be allocated
   !>   by the user.
   !>
-  !>   @param[in]
-  !>   handle             handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m                  number of rows of the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnz                number of non-zero entries of the sparse CSR matrix.
-  !>   @param[in]
-  !>   descrA             descriptor of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csrSortedValA      array of \p nnz elements of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csrSortedRowPtrA   array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix.
+  !>   @param[in] descrA - descriptor of the sparse CSR matrix.
+  !>   @param[in] csrSortedValA - array of \p nnz elements of the sparse CSR matrix.
+  !>   @param[in] csrSortedRowPtrA - array of \p m+1 elements that point to the start of every row
+  !>   of the
   !>                      sparse CSR matrix.
-  !>   @param[in]
-  !>   csrSortedColIndA   array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] csrSortedColIndA - array of \p nnz elements containing the column indices of the
+  !>   sparse
   !>                      CSR matrix.
-  !>   @param[out]
-  !>   info               structure that holds the information collected during the analysis step.
-  !>   @param[out]
-  !>   pBufferSizeInBytes number of bytes of the temporary storage buffer required by
+  !>   @param[out] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[out] pBufferSizeInBytes - number of bytes of the temporary storage buffer required by
   !>                      `hipsparseScsric02_analysis` "hipsparseXcsric02_analysis()" and
   !>                      `hipsparseScsric02` "hipsparseXcsric02()".
   !>
@@ -11091,26 +10489,19 @@ module hipfort_hipsparse
   !>   and `hipsparseScsric02` "hipsparseXcsric02()". The temporary storage buffer must be
   !>   allocated by the user.
   !>
-  !>   @param[in]
-  !>   handle             handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m                  number of rows of the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnz                number of non-zero entries of the sparse CSR matrix.
-  !>   @param[in]
-  !>   descrA             descriptor of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csrSortedValA      array of \p nnz elements of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csrSortedRowPtrA   array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix.
+  !>   @param[in] descrA - descriptor of the sparse CSR matrix.
+  !>   @param[in] csrSortedValA - array of \p nnz elements of the sparse CSR matrix.
+  !>   @param[in] csrSortedRowPtrA - array of \p m+1 elements that point to the start of every row
+  !>   of the
   !>                      sparse CSR matrix.
-  !>   @param[in]
-  !>   csrSortedColIndA   array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] csrSortedColIndA - array of \p nnz elements containing the column indices of the
+  !>   sparse
   !>                      CSR matrix.
-  !>   @param[out]
-  !>   info               structure that holds the information collected during the analysis step.
-  !>   @param[out]
-  !>   pBufferSizeInBytes number of bytes of the temporary storage buffer required by
+  !>   @param[out] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[out] pBufferSizeInBytes - number of bytes of the temporary storage buffer required by
   !>                      `hipsparseScsric02_analysis` "hipsparseXcsric02_analysis()" and
   !>                      `hipsparseScsric02` "hipsparseXcsric02()".
   !>
@@ -11246,29 +10637,21 @@ module hipfort_hipsparse
   !>   This function is non-blocking and executed asynchronously with respect to the host.
   !>   It can return before the actual computation has finished.
   !>
-  !>   @param[in]
-  !>   handle           handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m                number of rows of the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnz              number of non-zero entries of the sparse CSR matrix.
-  !>   @param[in]
-  !>   descrA           descriptor of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csrSortedValA    array of \p nnz elements of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csrSortedRowPtrA array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix.
+  !>   @param[in] descrA - descriptor of the sparse CSR matrix.
+  !>   @param[in] csrSortedValA - array of \p nnz elements of the sparse CSR matrix.
+  !>   @param[in] csrSortedRowPtrA - array of \p m+1 elements that point to the start of every row
+  !>   of the
   !>                    sparse CSR matrix.
-  !>   @param[in]
-  !>   csrSortedColIndA array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] csrSortedColIndA - array of \p nnz elements containing the column indices of the
+  !>   sparse
   !>                    CSR matrix.
-  !>   @param[out]
-  !>   info             structure that holds the information collected during
+  !>   @param[out] myInfo - structure that holds the information collected during
   !>                    the analysis step.
-  !>   @param[in]
-  !>   policy           `HIPSPARSE_SOLVE_POLICY_NO_LEVEL` or `HIPSPARSE_SOLVE_POLICY_USE_LEVEL`.
-  !>   @param[in]
-  !>   pBuffer          temporary storage buffer allocated by the user.
+  !>   @param[in] policy - `HIPSPARSE_SOLVE_POLICY_NO_LEVEL` or `HIPSPARSE_SOLVE_POLICY_USE_LEVEL`.
+  !>   @param[in] pBuffer - temporary storage buffer allocated by the user.
   !>
   !>   \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
   !>   \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p m, \p nnz, \p descrA, \p csrSortedValA,
@@ -11546,28 +10929,19 @@ module hipfort_hipsparse
   !>   This function is non-blocking and executed asynchronously with respect to the host.
   !>   It can return before the actual computation has finished.
   !>
-  !>   @param[in]
-  !>   handle             handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m                  number of rows of the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnz                number of non-zero entries of the sparse CSR matrix.
-  !>   @param[in]
-  !>   descrA             descriptor of the sparse CSR matrix.
-  !>   @param[inout]
-  !>   csrSortedValA_valM array of \p nnz elements of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csrSortedRowPtrA   array of \p m+1 elements that point to the start
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix.
+  !>   @param[in] descrA - descriptor of the sparse CSR matrix.
+  !>   @param[inout] csrSortedValA_valM - array of \p nnz elements of the sparse CSR matrix.
+  !>   @param[in] csrSortedRowPtrA - array of \p m+1 elements that point to the start
   !>                      of every row of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csrSortedColIndA   array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] csrSortedColIndA - array of \p nnz elements containing the column indices of the
+  !>   sparse
   !>                      CSR matrix.
-  !>   @param[in]
-  !>   info               structure that holds the information collected during the analysis step.
-  !>   @param[in]
-  !>   policy             `HIPSPARSE_SOLVE_POLICY_NO_LEVEL` or `HIPSPARSE_SOLVE_POLICY_USE_LEVEL`.
-  !>   @param[in]
-  !>   pBuffer            temporary storage buffer allocated by the user.
+  !>   @param[in] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[in] policy - `HIPSPARSE_SOLVE_POLICY_NO_LEVEL` or `HIPSPARSE_SOLVE_POLICY_USE_LEVEL`.
+  !>   @param[in] pBuffer - temporary storage buffer allocated by the user.
   !>
   !>   \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
   !>   \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p m, \p nnz, \p descrA, \p
@@ -11728,12 +11102,10 @@ module hipfort_hipsparse
   !>   This function is deprecated when using the CUDA backend (CUDA 12.0+) and will be
   !>   removed in CUDA 13.0. This deprecation does not apply to the ROCm backend.
   !>
-  !>   @param[in]
-  !>   handle      handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   info        structure that holds the information collected during the analysis step.
-  !>   @param[inout]
-  !>   position    pointer to zero pivot \f$j\f$, which can be in host or device memory.
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[inout] position - pointer to zero pivot \f$j\f$, which can be in host or device
+  !>   memory.
   !>
   !>   \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
   !>   \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
@@ -11774,16 +11146,11 @@ module hipfort_hipsparse
   !>   This function is deprecated when using the CUDA backend (CUDA 12.0+) and will be
   !>   removed in CUDA 13.0. This deprecation does not apply to the ROCm backend.
   !>
-  !>   @param[in]
-  !>   handle          handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   info            structure that holds the information collected during the analysis step.
-  !>   @param[in]
-  !>   enable_boost    enable/disable numeric boost.
-  !>   @param[in]
-  !>   tol             tolerance to determine whether a numerical value is replaced or not.
-  !>   @param[in]
-  !>   boost_val       boost value to replace a numerical value.
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[in] enable_boost - enable/disable numeric boost.
+  !>   @param[in] tol - tolerance to determine whether a numerical value is replaced or not.
+  !>   @param[in] boost_val - boost value to replace a numerical value.
   !>
   !>   \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
   !>   \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
@@ -11877,26 +11244,19 @@ module hipfort_hipsparse
   !>   and `hipsparseScsrilu02` "hipsparseXcsrilu02()". The temporary storage buffer
   !>   must be allocated by the user.
   !>
-  !>   @param[in]
-  !>   handle             handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m                  number of rows of the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnz                number of non-zero entries of the sparse CSR matrix.
-  !>   @param[in]
-  !>   descrA             descriptor of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csrSortedValA      array of \p nnz elements of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csrSortedRowPtrA   array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix.
+  !>   @param[in] descrA - descriptor of the sparse CSR matrix.
+  !>   @param[in] csrSortedValA - array of \p nnz elements of the sparse CSR matrix.
+  !>   @param[in] csrSortedRowPtrA - array of \p m+1 elements that point to the start of every row
+  !>   of the
   !>                      sparse CSR matrix.
-  !>   @param[in]
-  !>   csrSortedColIndA   array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] csrSortedColIndA - array of \p nnz elements containing the column indices of the
+  !>   sparse
   !>                      CSR matrix.
-  !>   @param[out]
-  !>   info               structure that holds the information collected during the analysis step.
-  !>   @param[out]
-  !>   pBufferSizeInBytes number of bytes of the temporary storage buffer required by
+  !>   @param[out] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[out] pBufferSizeInBytes - number of bytes of the temporary storage buffer required by
   !>                      `hipsparseScsrilu02_analysis` "hipsparseXcsrilu02_analysis()" and
   !>                      `hipsparseScsrilu02` "hipsparseXcsrilu02()".
   !>
@@ -12041,26 +11401,19 @@ module hipfort_hipsparse
   !>   and `hipsparseScsrilu02` "hipsparseXcsrilu02()". The temporary storage buffer
   !>   must be allocated by the user.
   !>
-  !>   @param[in]
-  !>   handle             handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m                  number of rows of the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnz                number of non-zero entries of the sparse CSR matrix.
-  !>   @param[in]
-  !>   descrA             descriptor of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csrSortedValA      array of \p nnz elements of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csrSortedRowPtrA   array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix.
+  !>   @param[in] descrA - descriptor of the sparse CSR matrix.
+  !>   @param[in] csrSortedValA - array of \p nnz elements of the sparse CSR matrix.
+  !>   @param[in] csrSortedRowPtrA - array of \p m+1 elements that point to the start of every row
+  !>   of the
   !>                      sparse CSR matrix.
-  !>   @param[in]
-  !>   csrSortedColIndA   array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] csrSortedColIndA - array of \p nnz elements containing the column indices of the
+  !>   sparse
   !>                      CSR matrix.
-  !>   @param[out]
-  !>   info               structure that holds the information collected during the analysis step.
-  !>   @param[out]
-  !>   pBufferSizeInBytes number of bytes of the temporary storage buffer required by
+  !>   @param[out] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[out] pBufferSizeInBytes - number of bytes of the temporary storage buffer required by
   !>                      `hipsparseScsrilu02_analysis` "hipsparseXcsrilu02_analysis()" and
   !>                      `hipsparseScsrilu02` "hipsparseXcsrilu02()".
   !>
@@ -12195,29 +11548,21 @@ module hipfort_hipsparse
   !>   This function is non-blocking and executed asynchronously with respect to the host.
   !>   It can return before the actual computation has finished.
   !>
-  !>   @param[in]
-  !>   handle           handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m                number of rows of the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnz              number of non-zero entries of the sparse CSR matrix.
-  !>   @param[in]
-  !>   descrA           descriptor of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csrSortedValA    array of \p nnz elements of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csrSortedRowPtrA array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix.
+  !>   @param[in] descrA - descriptor of the sparse CSR matrix.
+  !>   @param[in] csrSortedValA - array of \p nnz elements of the sparse CSR matrix.
+  !>   @param[in] csrSortedRowPtrA - array of \p m+1 elements that point to the start of every row
+  !>   of the
   !>                    sparse CSR matrix.
-  !>   @param[in]
-  !>   csrSortedColIndA array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] csrSortedColIndA - array of \p nnz elements containing the column indices of the
+  !>   sparse
   !>                    CSR matrix.
-  !>   @param[out]
-  !>   info             structure that holds the information collected during
+  !>   @param[out] myInfo - structure that holds the information collected during
   !>                    the analysis step.
-  !>   @param[in]
-  !>   policy           `HIPSPARSE_SOLVE_POLICY_NO_LEVEL` or `HIPSPARSE_SOLVE_POLICY_USE_LEVEL`.
-  !>   @param[in]
-  !>   pBuffer          temporary storage buffer allocated by the user.
+  !>   @param[in] policy - `HIPSPARSE_SOLVE_POLICY_NO_LEVEL` or `HIPSPARSE_SOLVE_POLICY_USE_LEVEL`.
+  !>   @param[in] pBuffer - temporary storage buffer allocated by the user.
   !>
   !>   \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
   !>   \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p m, \p nnz, \p descrA, \p csrSortedValA,
@@ -12478,28 +11823,19 @@ module hipfort_hipsparse
   !>   This function is non-blocking and executed asynchronously with respect to the host.
   !>   It can return before the actual computation has finished.
   !>
-  !>   @param[in]
-  !>   handle             handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m                  number of rows of the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnz                number of non-zero entries of the sparse CSR matrix.
-  !>   @param[in]
-  !>   descrA             descriptor of the sparse CSR matrix.
-  !>   @param[inout]
-  !>   csrSortedValA_valM array of \p nnz elements of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csrSortedRowPtrA   array of \p m+1 elements that point to the start
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix.
+  !>   @param[in] descrA - descriptor of the sparse CSR matrix.
+  !>   @param[inout] csrSortedValA_valM - array of \p nnz elements of the sparse CSR matrix.
+  !>   @param[in] csrSortedRowPtrA - array of \p m+1 elements that point to the start
   !>                      of every row of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csrSortedColIndA   array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] csrSortedColIndA - array of \p nnz elements containing the column indices of the
+  !>   sparse
   !>                      CSR matrix.
-  !>   @param[in]
-  !>   info               structure that holds the information collected during the analysis step.
-  !>   @param[in]
-  !>   policy             `HIPSPARSE_SOLVE_POLICY_NO_LEVEL` or `HIPSPARSE_SOLVE_POLICY_USE_LEVEL`.
-  !>   @param[in]
-  !>   pBuffer            temporary storage buffer allocated by the user.
+  !>   @param[in] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[in] policy - `HIPSPARSE_SOLVE_POLICY_NO_LEVEL` or `HIPSPARSE_SOLVE_POLICY_USE_LEVEL`.
+  !>   @param[in] pBuffer - temporary storage buffer allocated by the user.
   !>
   !>   \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
   !>   \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p m, \p nnz, \p descrA, \p
@@ -12646,30 +11982,20 @@ module hipfort_hipsparse
   !>   "hipsparseXgpsvInterleavedBatch()".
   !>   The temporary storage buffer must be allocated by the user.
   !>
-  !>   @param[in]
-  !>   handle             handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   algo               algorithm to solve the linear system.
-  !>   @param[in]
-  !>   m                  size of the pentadiagonal linear system.
-  !>   @param[in]
-  !>   ds lower diagonal (distance 2) of the pentadiagonal system. The first two entries
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] algo - algorithm to solve the linear system.
+  !>   @param[in] m - size of the pentadiagonal linear system.
+  !>   @param[in] ds - lower diagonal (distance 2) of the pentadiagonal system. The first two
+  !>   entries
   !>                      must be zero.
-  !>   @param[in]
-  !>   dl                 lower diagonal of the pentadiagonal system. The first entry must be zero.
-  !>   @param[in]
-  !>   d                  main diagonal of the pentadiagonal system.
-  !>   @param[in]
-  !>   du                 upper diagonal of the pentadiagonal system. The last entry must be zero.
-  !>   @param[in]
-  !>   dw upper diagonal (distance 2) of the pentadiagonal system. The last two entries
+  !>   @param[in] dl - lower diagonal of the pentadiagonal system. The first entry must be zero.
+  !>   @param[in] d - main diagonal of the pentadiagonal system.
+  !>   @param[in] du - upper diagonal of the pentadiagonal system. The last entry must be zero.
+  !>   @param[in] dw - upper diagonal (distance 2) of the pentadiagonal system. The last two entries
   !>                      must be zero.
-  !>   @param[in]
-  !>   x                  Dense array of right-hand sides with dimension \p batchCount by \p m.
-  !>   @param[in]
-  !>   batchCount         The number of systems to solve.
-  !>   @param[out]
-  !>   pBufferSizeInBytes Number of bytes of the temporary storage buffer required.
+  !>   @param[in] x - Dense array of right-hand sides with dimension \p batchCount by \p m.
+  !>   @param[in] batchCount - The number of systems to solve.
+  !>   @param[out] pBufferSizeInBytes - Number of bytes of the temporary storage buffer required.
   !>
   !>   \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
   !>   \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p m, \p alg, \p batchCount, \p ds, \p dl,
@@ -12890,30 +12216,21 @@ module hipfort_hipsparse
   !>   This function is non-blocking and executed asynchronously with respect to the host.
   !>   It can return before the actual computation has finished.
   !>
-  !>   @param[in]
-  !>   handle      handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   algo        algorithm to solve the linear system.
-  !>   @param[in]
-  !>   m           size of the pentadiagonal linear system.
-  !>   @param[inout]
-  !>   ds          lower diagonal (distance 2) of the pentadiagonal system. The first two entries
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] algo - algorithm to solve the linear system.
+  !>   @param[in] m - size of the pentadiagonal linear system.
+  !>   @param[inout] ds - lower diagonal (distance 2) of the pentadiagonal system. The first two
+  !>   entries
   !>               must be zero.
-  !>   @param[inout]
-  !>   dl          lower diagonal of the pentadiagonal system. The first entry must be zero.
-  !>   @param[inout]
-  !>   d           main diagonal of the pentadiagonal system.
-  !>   @param[inout]
-  !>   du          upper diagonal of the pentadiagonal system. The last entry must be zero.
-  !>   @param[inout]
-  !>   dw          upper diagonal (distance 2) of the pentadiagonal system. The last two entries
+  !>   @param[inout] dl - lower diagonal of the pentadiagonal system. The first entry must be zero.
+  !>   @param[inout] d - main diagonal of the pentadiagonal system.
+  !>   @param[inout] du - upper diagonal of the pentadiagonal system. The last entry must be zero.
+  !>   @param[inout] dw - upper diagonal (distance 2) of the pentadiagonal system. The last two
+  !>   entries
   !>               must be zero.
-  !>   @param[inout]
-  !>   x           Dense array of right-hand-sides with dimension \p batchCount by \p m.
-  !>   @param[in]
-  !>   batchCount  The number of systems to solve.
-  !>   @param[in]
-  !>   pBuffer     Temporary storage buffer allocated by the user.
+  !>   @param[inout] x - Dense array of right-hand-sides with dimension \p batchCount by \p m.
+  !>   @param[in] batchCount - The number of systems to solve.
+  !>   @param[in] pBuffer - Temporary storage buffer allocated by the user.
   !>
   !>   \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
   !>   \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p m, \p alg, \p batchCount, \p ds,
@@ -13060,24 +12377,15 @@ module hipfort_hipsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle             handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m                  size of the tridiagonal linear system. Must be at least 2.
-  !>   @param[in]
-  !>   n                  number of columns in the dense matrix B. Must be non-negative.
-  !>   @param[in]
-  !>   dl                 lower diagonal of the tridiagonal system. The first entry must be zero.
-  !>   @param[in]
-  !>   d                  main diagonal of the tridiagonal system.
-  !>   @param[in]
-  !>   du                 upper diagonal of the tridiagonal system. The last entry must be zero.
-  !>   @param[in]
-  !>   B                  dense matrix of size ( \p ldb, \p n ).
-  !>   @param[in]
-  !>   ldb                leading dimension of B. Must satisfy \p ldb >= max(1, m).
-  !>   @param[out]
-  !>   pBufferSizeInBytes number of bytes of the temporary storage buffer required by
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - size of the tridiagonal linear system. Must be at least 2.
+  !>   @param[in] n - number of columns in the dense matrix B. Must be non-negative.
+  !>   @param[in] dl - lower diagonal of the tridiagonal system. The first entry must be zero.
+  !>   @param[in] d - main diagonal of the tridiagonal system.
+  !>   @param[in] du - upper diagonal of the tridiagonal system. The last entry must be zero.
+  !>   @param[in] B - dense matrix of size ( \p ldb, \p n ).
+  !>   @param[in] ldb - leading dimension of B. Must satisfy \p ldb >= max(1, m).
+  !>   @param[out] pBufferSizeInBytes - number of bytes of the temporary storage buffer required by
   !>                      `hipsparseSgtsv2` "hipsparseXgtsv2()".
   !>
   !>   \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
@@ -13242,24 +12550,15 @@ module hipfort_hipsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m           size of the tridiagonal linear system (must be >= 2).
-  !>   @param[in]
-  !>   n           number of columns in the dense matrix B.
-  !>   @param[in]
-  !>   dl          lower diagonal of the tridiagonal system. The first entry must be zero.
-  !>   @param[in]
-  !>   d           main diagonal of the tridiagonal system.
-  !>   @param[in]
-  !>   du          upper diagonal of the tridiagonal system. The last entry must be zero.
-  !>   @param[inout]
-  !>   B           Dense matrix of size ( \p ldb, \p n ).
-  !>   @param[in]
-  !>   ldb         Leading dimension of B. Must satisfy \p ldb >= max(1, m).
-  !>   @param[in]
-  !>   pBuffer     temporary storage buffer allocated by the user.
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - size of the tridiagonal linear system (must be >= 2).
+  !>   @param[in] n - number of columns in the dense matrix B.
+  !>   @param[in] dl - lower diagonal of the tridiagonal system. The first entry must be zero.
+  !>   @param[in] d - main diagonal of the tridiagonal system.
+  !>   @param[in] du - upper diagonal of the tridiagonal system. The last entry must be zero.
+  !>   @param[inout] B - Dense matrix of size ( \p ldb, \p n ).
+  !>   @param[in] ldb - Leading dimension of B. Must satisfy \p ldb >= max(1, m).
+  !>   @param[in] pBuffer - temporary storage buffer allocated by the user.
   !>
   !>   \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
   !>   \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p m, \p n, \p ldb, \p dl, \p d,
@@ -13388,29 +12687,21 @@ module hipfort_hipsparse
   !>   "hipsparseXgtsvInterleavedBatch()".
   !>   The temporary storage buffer must be allocated by the user.
   !>
-  !>   @param[in]
-  !>   handle             handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   algo Algorithm to use when solving tridiagonal systems. Options are Thomas ( \p algo=0 ),
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] algo - Algorithm to use when solving tridiagonal systems. Options are Thomas ( \p
+  !>   algo=0 ),
   !>                      LU ( \p algo=1 ), or QR ( \p algo=2 ). The Thomas algorithm is the fastest
   !>                      but is not
   !>                      stable, while LU and QR are slower but are stable.
-  !>   @param[in]
-  !>   m                  size of the tridiagonal linear system.
-  !>   @param[in]
-  !>   dl lower diagonal of the tridiagonal system. The first element of the lower diagonal must be
-  !>   zero.
-  !>   @param[in]
-  !>   d                  main diagonal of the tridiagonal system.
-  !>   @param[in]
-  !>   du upper diagonal of the tridiagonal system. The last element of the upper diagonal must be
-  !>   zero.
-  !>   @param[inout]
-  !>   x                  Dense array of right-hand sides with dimension \p batchCount by \p m.
-  !>   @param[in]
-  !>   batchCount         The number of systems to solve.
-  !>   @param[out]
-  !>   pBufferSizeInBytes number of bytes of the temporary storage buffer required by
+  !>   @param[in] m - size of the tridiagonal linear system.
+  !>   @param[in] dl - lower diagonal of the tridiagonal system. The first element of the lower
+  !>   diagonal must be zero.
+  !>   @param[in] d - main diagonal of the tridiagonal system.
+  !>   @param[in] du - upper diagonal of the tridiagonal system. The last element of the upper
+  !>   diagonal must be zero.
+  !>   @param[inout] x - Dense array of right-hand sides with dimension \p batchCount by \p m.
+  !>   @param[in] batchCount - The number of systems to solve.
+  !>   @param[out] pBufferSizeInBytes - number of bytes of the temporary storage buffer required by
   !>                      `hipsparseSgtsvInterleavedBatch` "`hipsparseSgtsvInterleavedBatch()`".
   !>
   !>   \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
@@ -13597,29 +12888,21 @@ module hipfort_hipsparse
   !>   This function is non-blocking and executed asynchronously with respect to the host.
   !>   It can return before the actual computation has finished.
   !>
-  !>   @param[in]
-  !>   handle      handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   algo Algorithm to use when solving tridiagonal systems. Options are Thomas ( \p algo=0 ),
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] algo - Algorithm to use when solving tridiagonal systems. Options are Thomas ( \p
+  !>   algo=0 ),
   !>               LU ( \p algo=1 ), or QR ( \p algo=2 ). The Thomas algorithm is the fastest but is
   !>               not
   !>               stable, while LU and QR are slower but are stable.
-  !>   @param[in]
-  !>   m           size of the tridiagonal linear system.
-  !>   @param[inout]
-  !>   dl lower diagonal of the tridiagonal system. The first element of the lower diagonal must be
-  !>   zero.
-  !>   @param[inout]
-  !>   d           main diagonal of the tridiagonal system.
-  !>   @param[inout]
-  !>   du upper diagonal of the tridiagonal system. The last element of the upper diagonal must be
-  !>   zero.
-  !>   @param[inout]
-  !>   x           Dense array of right-hand sides with dimension \p batchCount by \p m.
-  !>   @param[in]
-  !>   batchCount  The number of systems to solve.
-  !>   @param[in]
-  !>   pBuffer     temporary storage buffer allocated by the user.
+  !>   @param[in] m - size of the tridiagonal linear system.
+  !>   @param[inout] dl - lower diagonal of the tridiagonal system. The first element of the lower
+  !>   diagonal must be zero.
+  !>   @param[inout] d - main diagonal of the tridiagonal system.
+  !>   @param[inout] du - upper diagonal of the tridiagonal system. The last element of the upper
+  !>   diagonal must be zero.
+  !>   @param[inout] x - Dense array of right-hand sides with dimension \p batchCount by \p m.
+  !>   @param[in] batchCount - The number of systems to solve.
+  !>   @param[in] pBuffer - temporary storage buffer allocated by the user.
   !>
   !>   \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
   !>   \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p m, \p batchCount, \p dl, \p d,
@@ -13727,24 +13010,15 @@ module hipfort_hipsparse
   !>   buffer in bytes that is required by `hipsparseSgtsv2_nopivot` "hipsparseXgtsv2_nopivot()".
   !>   The temporary storage buffer must be allocated by the user.
   !>
-  !>   @param[in]
-  !>   handle             handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m                  size of the tridiagonal linear system. Must be >= 2.
-  !>   @param[in]
-  !>   n                  number of columns in the dense matrix B. Must be non-negative.
-  !>   @param[in]
-  !>   dl                 lower diagonal of the tridiagonal system. The first entry must be zero.
-  !>   @param[in]
-  !>   d                  main diagonal of the tridiagonal system.
-  !>   @param[in]
-  !>   du                 upper diagonal of the tridiagonal system. The last entry must be zero.
-  !>   @param[in]
-  !>   B                  Dense matrix of size ( \p ldb, \p n ).
-  !>   @param[in]
-  !>   ldb                Leading dimension of B. Must satisfy \p ldb >= max(1, m).
-  !>   @param[out]
-  !>   pBufferSizeInBytes number of bytes of the temporary storage buffer required by
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - size of the tridiagonal linear system. Must be >= 2.
+  !>   @param[in] n - number of columns in the dense matrix B. Must be non-negative.
+  !>   @param[in] dl - lower diagonal of the tridiagonal system. The first entry must be zero.
+  !>   @param[in] d - main diagonal of the tridiagonal system.
+  !>   @param[in] du - upper diagonal of the tridiagonal system. The last entry must be zero.
+  !>   @param[in] B - Dense matrix of size ( \p ldb, \p n ).
+  !>   @param[in] ldb - Leading dimension of B. Must satisfy \p ldb >= max(1, m).
+  !>   @param[out] pBufferSizeInBytes - number of bytes of the temporary storage buffer required by
   !>                      `hipsparseSgtsv2_nopivot` "hipsparseXgtsv2_nopivot()".
   !>
   !>   \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
@@ -13909,24 +13183,15 @@ module hipfort_hipsparse
   !>   This function is non-blocking and executed asynchronously with respect to the host.
   !>   It can return before the actual computation has finished.
   !>
-  !>   @param[in]
-  !>   handle      handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m           size of the tridiagonal linear system (must be >= 2).
-  !>   @param[in]
-  !>   n           number of columns in the dense matrix B.
-  !>   @param[in]
-  !>   dl          lower diagonal of the tridiagonal system. The first entry must be zero.
-  !>   @param[in]
-  !>   d           main diagonal of the tridiagonal system.
-  !>   @param[in]
-  !>   du          upper diagonal of the tridiagonal system. The last entry must be zero.
-  !>   @param[inout]
-  !>   B           Dense matrix of size ( \p ldb, \p n ).
-  !>   @param[in]
-  !>   ldb         Leading dimension of B. Must satisfy \p ldb >= max(1, m).
-  !>   @param[in]
-  !>   pBuffer     temporary storage buffer allocated by the user.
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - size of the tridiagonal linear system (must be >= 2).
+  !>   @param[in] n - number of columns in the dense matrix B.
+  !>   @param[in] dl - lower diagonal of the tridiagonal system. The first entry must be zero.
+  !>   @param[in] d - main diagonal of the tridiagonal system.
+  !>   @param[in] du - upper diagonal of the tridiagonal system. The last entry must be zero.
+  !>   @param[inout] B - Dense matrix of size ( \p ldb, \p n ).
+  !>   @param[in] ldb - Leading dimension of B. Must satisfy \p ldb >= max(1, m).
+  !>   @param[in] pBuffer - temporary storage buffer allocated by the user.
   !>
   !>   \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
   !>   \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p m, \p n, \p ldb, \p dl, \p d,
@@ -14063,28 +13328,23 @@ module hipfort_hipsparse
   !>   "hipsparseXgtsv2StridedBatch()".
   !>   The temporary storage buffer must be allocated by the user.
   !>
-  !>   @param[in]
-  !>   handle             handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m                  size of the tridiagonal linear system.
-  !>   @param[in]
-  !>   dl lower diagonal of the tridiagonal system where the ith system lower diagonal starts at
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - size of the tridiagonal linear system.
+  !>   @param[in] dl - lower diagonal of the tridiagonal system where the ith system lower diagonal
+  !>   starts at
   !>                      \p dl+batchStride*i.
-  !>   @param[in]
-  !>   d main diagonal of the tridiagonal system where the ith system diagonal starts at
+  !>   @param[in] d - main diagonal of the tridiagonal system where the ith system diagonal starts
+  !>   at
   !>                      \p d+batchStride*i.
-  !>   @param[in]
-  !>   du upper diagonal of the tridiagonal system where the ith system upper diagonal starts at
+  !>   @param[in] du - upper diagonal of the tridiagonal system where the ith system upper diagonal
+  !>   starts at
   !>                      \p du+batchStride*i.
-  !>   @param[inout]
-  !>   x Dense array of right-hand sides where the ith right-hand side starts at \p x+batchStride*i.
-  !>   @param[in]
-  !>   batchCount         The number of systems to solve.
-  !>   @param[in]
-  !>   batchStride The number of elements that separate each system, which must satisfy \p
-  !>   batchStride >= m.
-  !>   @param[out]
-  !>   pBufferSizeInBytes number of bytes of the temporary storage buffer required by
+  !>   @param[inout] x - Dense array of right-hand sides where the ith right-hand side starts at \p
+  !>   x+batchStride*i.
+  !>   @param[in] batchCount - The number of systems to solve.
+  !>   @param[in] batchStride - The number of elements that separate each system, which must satisfy
+  !>   \p batchStride >= m.
+  !>   @param[out] pBufferSizeInBytes - number of bytes of the temporary storage buffer required by
   !>                      `hipsparseSgtsv2StridedBatch` "hipsparseXgtsv2StridedBatch()".
   !>
   !>   \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
@@ -14287,25 +13547,17 @@ module hipfort_hipsparse
   !>   This function is non-blocking and executed asynchronously with respect to the host.
   !>   It can return before the actual computation has finished.
   !>
-  !>   @param[in]
-  !>   handle      handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m           size of the tridiagonal linear system (must be >= 2).
-  !>   @param[in]
-  !>   dl          lower diagonal of the tridiagonal system. The first entry must be zero.
-  !>   @param[in]
-  !>   d           main diagonal of the tridiagonal system.
-  !>   @param[in]
-  !>   du          upper diagonal of the tridiagonal system. The last entry must be zero.
-  !>   @param[inout]
-  !>   x Dense array of right-hand sides where the ith right-hand side starts at \p x+batchStride*i.
-  !>   @param[in]
-  !>   batchCount  The number of systems to solve.
-  !>   @param[in]
-  !>   batchStride The number of elements that separate each system, which must satisfy \p
-  !>   batchStride >= m.
-  !>   @param[in]
-  !>   pBuffer     temporary storage buffer allocated by the user.
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - size of the tridiagonal linear system (must be >= 2).
+  !>   @param[in] dl - lower diagonal of the tridiagonal system. The first entry must be zero.
+  !>   @param[in] d - main diagonal of the tridiagonal system.
+  !>   @param[in] du - upper diagonal of the tridiagonal system. The last entry must be zero.
+  !>   @param[inout] x - Dense array of right-hand sides where the ith right-hand side starts at \p
+  !>   x+batchStride*i.
+  !>   @param[in] batchCount - The number of systems to solve.
+  !>   @param[in] batchStride - The number of elements that separate each system, which must satisfy
+  !>   \p batchStride >= m.
+  !>   @param[in] pBuffer - temporary storage buffer allocated by the user.
   !>
   !>   \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
   !>   \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p m, \p batchCount, \p batchStride, \p dl,
@@ -14482,41 +13734,30 @@ module hipfort_hipsparse
   !>   This function is non-blocking and executed asynchronously with respect to the host.
   !>   It can return before the actual computation has finished.
   !>
-  !>   @param[in]
-  !>   handle      handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   dirA the storage format of the blocks, `HIPSPARSE_DIRECTION_ROW` or
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] dirA - the storage format of the blocks, `HIPSPARSE_DIRECTION_ROW` or
   !>   `HIPSPARSE_DIRECTION_COLUMN`.
-  !>   @param[in]
-  !>   mb          number of block rows in the sparse BSR matrix, which must be non-negative.
-  !>   @param[in]
-  !>   nb          number of block columns in the sparse BSR matrix, which must be non-negative.
-  !>   @param[in]
-  !>   descrA      descriptor of the sparse BSR matrix. Currently, only
+  !>   @param[in] mb - number of block rows in the sparse BSR matrix, which must be non-negative.
+  !>   @param[in] nb - number of block columns in the sparse BSR matrix, which must be non-negative.
+  !>   @param[in] descrA - descriptor of the sparse BSR matrix. Currently, only
   !>               `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[in]
-  !>   bsrValA array of \p nnzb*blockDim*blockDim containing the values of the sparse BSR matrix.
-  !>   @param[in]
-  !>   bsrRowPtrA  array of \p mb+1 elements that point to the start of every block row of the
+  !>   @param[in] bsrValA - array of \p nnzb*blockDim*blockDim containing the values of the sparse
+  !>   BSR matrix.
+  !>   @param[in] bsrRowPtrA - array of \p mb+1 elements that point to the start of every block row
+  !>   of the
   !>               sparse BSR matrix.
-  !>   @param[in]
-  !>   bsrColIndA array of \p nnzb elements containing the block column indices of the sparse BSR
-  !>   matrix.
-  !>   @param[in]
-  !>   blockDim    size of the blocks in the sparse BSR matrix. Must be positive.
-  !>   @param[in]
-  !>   descrC      descriptor of the sparse CSR matrix. Currently, only
+  !>   @param[in] bsrColIndA - array of \p nnzb elements containing the block column indices of the
+  !>   sparse BSR matrix.
+  !>   @param[in] blockDim - size of the blocks in the sparse BSR matrix. Must be positive.
+  !>   @param[in] descrC - descriptor of the sparse CSR matrix. Currently, only
   !>               `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[out]
-  !>   csrValC array of \p nnzb*blockDim*blockDim elements containing the values of the sparse CSR
-  !>   matrix.
-  !>   @param[out]
-  !>   csrRowPtrC array of \p m+1 where \p m=mb*blockDim elements that point to the start of every
-  !>   row of the
+  !>   @param[out] csrValC - array of \p nnzb*blockDim*blockDim elements containing the values of
+  !>   the sparse CSR matrix.
+  !>   @param[out] csrRowPtrC - array of \p m+1 where \p m=mb*blockDim elements that point to the
+  !>   start of every row of the
   !>               sparse CSR matrix.
-  !>   @param[out]
-  !>   csrColIndC array of \p nnzb*blockDim*blockDim elements containing the column indices of the
-  !>   sparse CSR matrix.
+  !>   @param[out] csrColIndC - array of \p nnzb*blockDim*blockDim elements containing the column
+  !>   indices of the sparse CSR matrix.
   !>
   !>   \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
   !>   \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
@@ -14699,20 +13940,14 @@ module hipfort_hipsparse
   !>   This function is non-blocking and executed asynchronously with respect to the host.
   !>   It can return before the actual computation has finished.
   !>
-  !>   @param[in]
-  !>   handle      handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   cooRowInd   array of \p nnz elements containing the row indices of the sparse COO
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] cooRowInd - array of \p nnz elements containing the row indices of the sparse COO
   !>               matrix.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of the sparse CSR matrix. Must be non-negative.
-  !>   @param[in]
-  !>   m           number of rows of the sparse CSR matrix. Must be non-negative.
-  !>   @param[out]
-  !>   csrRowPtr   array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix. Must be non-negative.
+  !>   @param[in] m - number of rows of the sparse CSR matrix. Must be non-negative.
+  !>   @param[out] csrRowPtr - array of \p m+1 elements that point to the start of every row of the
   !>               sparse CSR matrix.
-  !>   @param[in]
-  !>   idxBase     index base. `HIPSPARSE_INDEX_BASE_ZERO` for zero-based indexing or
+  !>   @param[in] idxBase - index base. `HIPSPARSE_INDEX_BASE_ZERO` for zero-based indexing or
   !>               `HIPSPARSE_INDEX_BASE_ONE` for one-based indexing.
   !>
   !>   \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
@@ -14755,22 +13990,15 @@ module hipfort_hipsparse
   !>   in bytes required by `hipsparseXcoosortByRow`() and `hipsparseXcoosortByColumn`().
   !>   The temporary storage buffer must be allocated by the user.
   !>
-  !>   @param[in]
-  !>   handle              handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m                   number of rows of the sparse COO matrix.
-  !>   @param[in]
-  !>   n                   number of columns of the sparse COO matrix.
-  !>   @param[in]
-  !>   nnz                 number of non-zero entries of the sparse COO matrix.
-  !>   @param[in]
-  !>   cooRows             array of \p nnz elements containing the row indices of the sparse
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse COO matrix.
+  !>   @param[in] n - number of columns of the sparse COO matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse COO matrix.
+  !>   @param[in] cooRows - array of \p nnz elements containing the row indices of the sparse
   !>                       COO matrix.
-  !>   @param[in]
-  !>   cooCols             array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] cooCols - array of \p nnz elements containing the column indices of the sparse
   !>                       COO matrix.
-  !>   @param[out]
-  !>   pBufferSizeInBytes  number of bytes of the temporary storage buffer required by
+  !>   @param[out] pBufferSizeInBytes - number of bytes of the temporary storage buffer required by
   !>                       `hipsparseXcoosortByRow()` and `hipsparseXcoosortByColumn()`.
   !>
   !>   \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
@@ -14826,25 +14054,17 @@ module hipfort_hipsparse
   !>   This function is non-blocking and executed asynchronously with respect to the host.
   !>   It can return before the actual computation has finished.
   !>
-  !>   @param[in]
-  !>   handle          handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m               number of rows of the sparse COO matrix.
-  !>   @param[in]
-  !>   n               number of columns of the sparse COO matrix.
-  !>   @param[in]
-  !>   nnz             number of non-zero entries of the sparse COO matrix.
-  !>   @param[inout]
-  !>   cooRows         array of \p nnz elements containing the row indices of the sparse
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse COO matrix.
+  !>   @param[in] n - number of columns of the sparse COO matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse COO matrix.
+  !>   @param[inout] cooRows - array of \p nnz elements containing the row indices of the sparse
   !>                   COO matrix.
-  !>   @param[inout]
-  !>   cooCols         array of \p nnz elements containing the column indices of the sparse
+  !>   @param[inout] cooCols - array of \p nnz elements containing the column indices of the sparse
   !>                   COO matrix.
-  !>   @param[inout]
-  !>   P               array of \p nnz integers containing the unsorted map indices. Can be
+  !>   @param[inout] P - array of \p nnz integers containing the unsorted map indices. Can be
   !>                   \p NULL.
-  !>   @param[in]
-  !>   pBuffer         temporary storage buffer allocated by the user. The size is returned by
+  !>   @param[in] pBuffer - temporary storage buffer allocated by the user. The size is returned by
   !>                   `hipsparseXcoosort_bufferSizeExt`().
   !>
   !>   \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
@@ -14901,25 +14121,17 @@ module hipfort_hipsparse
   !>   This function is non-blocking and executed asynchronously with respect to the host.
   !>   It can return before the actual computation has finished.
   !>
-  !>   @param[in]
-  !>   handle          handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m               number of rows of the sparse COO matrix.
-  !>   @param[in]
-  !>   n               number of columns of the sparse COO matrix.
-  !>   @param[in]
-  !>   nnz             number of non-zero entries of the sparse COO matrix.
-  !>   @param[inout]
-  !>   cooRows         array of \p nnz elements containing the row indices of the sparse
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse COO matrix.
+  !>   @param[in] n - number of columns of the sparse COO matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse COO matrix.
+  !>   @param[inout] cooRows - array of \p nnz elements containing the row indices of the sparse
   !>                   COO matrix.
-  !>   @param[inout]
-  !>   cooCols         array of \p nnz elements containing the column indices of the sparse
+  !>   @param[inout] cooCols - array of \p nnz elements containing the column indices of the sparse
   !>                   COO matrix.
-  !>   @param[inout]
-  !>   P               array of \p nnz integers containing the unsorted map indices. Can be
+  !>   @param[inout] P - array of \p nnz integers containing the unsorted map indices. Can be
   !>                   \p NULL.
-  !>   @param[in]
-  !>   pBuffer         temporary storage buffer allocated by the user. The size is returned by
+  !>   @param[in] pBuffer - temporary storage buffer allocated by the user. The size is returned by
   !>                   `hipsparseXcoosort_bufferSizeExt`().
   !>
   !>   \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
@@ -14973,12 +14185,9 @@ module hipfort_hipsparse
   !>   This function is non-blocking and executed asynchronously with respect to the host.
   !>   It can return before the actual computation has finished.
   !>
-  !>   @param[in]
-  !>   handle      handle to the hipSPASRE library context queue.
-  !>   @param[in]
-  !>   n           size of the map \p p.
-  !>   @param[out]
-  !>   p           array of \p n integers containing the map.
+  !>   @param[in] handle - handle to the hipSPASRE library context queue.
+  !>   @param[in] n - size of the map \p p.
+  !>   @param[out] p - array of \p n integers containing the map.
   !>
   !>   \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
   !>   \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p n, or \p p pointer is invalid.
@@ -15053,28 +14262,20 @@ module hipfort_hipsparse
   !>   This function is deprecated when using the CUDA backend (CUDA 11.0+) and will be
   !>   removed in CUDA 12.0. This deprecation does not apply to the ROCm backend.
   !>
-  !>   @param[in]
-  !>   handle      handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m           number of rows of the dense matrix \p A. Must be non-negative.
-  !>   @param[in]
-  !>   n           number of columns of the dense matrix \p A. Must be non-negative.
-  !>   @param[in]
-  !>   descr the descriptor of the dense matrix \p A. The supported matrix type is
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - number of rows of the dense matrix \p A. Must be non-negative.
+  !>   @param[in] n - number of columns of the dense matrix \p A. Must be non-negative.
+  !>   @param[in] descr - the descriptor of the dense matrix \p A. The supported matrix type is
   !>   `HIPSPARSE_MATRIX_TYPE_GENERAL` and
   !>               any valid value of the `hipsparseIndexBase_t`.
-  !>   @param[in]
-  !>   cscVal array of nnz ( = \p cscColPtr[n] - \p cscColPtr[0] ) non-zero elements of matrix \p A.
-  !>   @param[in]
-  !>   cscRowInd integer array of nnz ( = \p cscColPtr[n] - \p cscColPtr[0] ) column indices of the
-  !>   non-zero elements of matrix \p A.
-  !>   @param[in]
-  !>   cscColPtr integer array of \p n+1 elements that contains the start of every column and the
-  !>   end of the last column plus one.
-  !>   @param[out]
-  !>   A           array of dimensions (\p ld, \p n).
-  !>   @param[in]
-  !>   ld          leading dimension of dense array \p A. Must be at least \p m.
+  !>   @param[in] cscVal - array of nnz ( = \p cscColPtr[n] - \p cscColPtr[0] ) non-zero elements of
+  !>   matrix \p A.
+  !>   @param[in] cscRowInd - integer array of nnz ( = \p cscColPtr[n] - \p cscColPtr[0] ) column
+  !>   indices of the non-zero elements of matrix \p A.
+  !>   @param[in] cscColPtr - integer array of \p n+1 elements that contains the start of every
+  !>   column and the end of the last column plus one.
+  !>   @param[out] A - array of dimensions (\p ld, \p n).
+  !>   @param[in] ld - leading dimension of dense array \p A. Must be at least \p m.
   !>
   !>   \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
   !>   \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
@@ -15200,22 +14401,15 @@ module hipfort_hipsparse
   !>   in bytes required by `hipsparseXcscsort()`. The temporary storage buffer must be
   !>   allocated by the user.
   !>
-  !>   @param[in]
-  !>   handle              handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m                   number of rows of the sparse CSC matrix.
-  !>   @param[in]
-  !>   n                   number of columns of the sparse CSC matrix.
-  !>   @param[in]
-  !>   nnz                 number of non-zero entries of the sparse CSC matrix.
-  !>   @param[in]
-  !>   cscColPtr           array of \p n+1 elements that point to the start of every column of
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse CSC matrix.
+  !>   @param[in] n - number of columns of the sparse CSC matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSC matrix.
+  !>   @param[in] cscColPtr - array of \p n+1 elements that point to the start of every column of
   !>                       the sparse CSC matrix.
-  !>   @param[in]
-  !>   cscRowInd           array of \p nnz elements containing the row indices of the sparse
+  !>   @param[in] cscRowInd - array of \p nnz elements containing the row indices of the sparse
   !>                       CSC matrix.
-  !>   @param[out]
-  !>   pBufferSizeInBytes  number of bytes of the temporary storage buffer required by
+  !>   @param[out] pBufferSizeInBytes - number of bytes of the temporary storage buffer required by
   !>                       `hipsparseXcscsort`().
   !>
   !>   \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
@@ -15272,28 +14466,19 @@ module hipfort_hipsparse
   !>   This function is non-blocking and executed asynchronously with respect to the host.
   !>   It can return before the actual computation has finished.
   !>
-  !>   @param[in]
-  !>   handle          handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m               number of rows of the sparse CSC matrix.
-  !>   @param[in]
-  !>   n               number of columns of the sparse CSC matrix.
-  !>   @param[in]
-  !>   nnz             number of non-zero entries of the sparse CSC matrix.
-  !>   @param[in]
-  !>   descrA          descriptor of the sparse CSC matrix. Currently, only
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse CSC matrix.
+  !>   @param[in] n - number of columns of the sparse CSC matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSC matrix.
+  !>   @param[in] descrA - descriptor of the sparse CSC matrix. Currently, only
   !>                   `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[in]
-  !>   cscColPtr       array of \p n+1 elements that point to the start of every column of
+  !>   @param[in] cscColPtr - array of \p n+1 elements that point to the start of every column of
   !>                   the sparse CSC matrix.
-  !>   @param[inout]
-  !>   cscRowInd       array of \p nnz elements containing the row indices of the sparse
+  !>   @param[inout] cscRowInd - array of \p nnz elements containing the row indices of the sparse
   !>                   CSC matrix.
-  !>   @param[inout]
-  !>   P               array of \p nnz integers containing the unsorted map indices. Can be
+  !>   @param[inout] P - array of \p nnz integers containing the unsorted map indices. Can be
   !>                   \p NULL.
-  !>   @param[in]
-  !>   pBuffer         temporary storage buffer allocated by the user. The size is returned by
+  !>   @param[in] pBuffer - temporary storage buffer allocated by the user. The size is returned by
   !>                   `hipsparseXcscsort_bufferSizeExt`().
   !>
   !>   \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
@@ -15443,35 +14628,25 @@ module hipfort_hipsparse
   !>   \note
   !>   The routine supports asynchronous execution if the pointer mode is set to device.
   !>
-  !>   @param[in]
-  !>   handle      handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   dirA direction that specifies whether to count non-zero elements by `HIPSPARSE_DIRECTION_ROW`
-  !>   or by
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] dirA - direction that specifies whether to count non-zero elements by
+  !>   `HIPSPARSE_DIRECTION_ROW` or by
   !>               `HIPSPARSE_DIRECTION_COLUMN`.
-  !>   @param[in]
-  !>   m           number of rows of the sparse CSR matrix. Must be non-negative.
-  !>   @param[in]
-  !>   n           number of columns of the sparse CSR matrix.
-  !>   @param[in]
-  !>   descrA descriptor of the sparse CSR matrix. Currently, only `HIPSPARSE_MATRIX_TYPE_GENERAL`
-  !>   is supported.
-  !>   @param[in]
-  !>   csrRowPtrA integer array containing \p m+1 elements that points to the start of each row of
-  !>   the CSR matrix.
-  !>   @param[in]
-  !>   csrColIndA  integer array of the column indices for each non-zero element in the CSR matrix.
-  !>   @param[in]
-  !>   blockDim the block dimension of the BSR matrix, which is between \f$1\f$ and \f$\min(m,
-  !>   n)\f$.
-  !>   @param[in]
-  !>   descrC descriptor of the sparse BSR matrix. Currently, only `HIPSPARSE_MATRIX_TYPE_GENERAL`
-  !>   is supported.
-  !>   @param[out]
-  !>   bsrRowPtrC integer array containing \p mb+1 elements that point to the start of each block
-  !>   row of the BSR matrix.
-  !>   @param[out]
-  !>   bsrNnzb     total number of non-zero elements in device or host memory.
+  !>   @param[in] m - number of rows of the sparse CSR matrix. Must be non-negative.
+  !>   @param[in] n - number of columns of the sparse CSR matrix.
+  !>   @param[in] descrA - descriptor of the sparse CSR matrix. Currently, only
+  !>   `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
+  !>   @param[in] csrRowPtrA - integer array containing \p m+1 elements that points to the start of
+  !>   each row of the CSR matrix.
+  !>   @param[in] csrColIndA - integer array of the column indices for each non-zero element in the
+  !>   CSR matrix.
+  !>   @param[in] blockDim - the block dimension of the BSR matrix, which is between \f$1\f$ and
+  !>   \f$\min(m, n)\f$.
+  !>   @param[in] descrC - descriptor of the sparse BSR matrix. Currently, only
+  !>   `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
+  !>   @param[out] bsrRowPtrC - integer array containing \p mb+1 elements that point to the start of
+  !>   each block row of the BSR matrix.
+  !>   @param[out] bsrNnzb - total number of non-zero elements in device or host memory.
   !>
   !>   \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
   !>   \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p m, \p n, \p blockDim, \p csrRowPtrA, \p
@@ -15599,38 +14774,28 @@ module hipfort_hipsparse
   !>   \p hipsparseXcsr2bsr requires extra temporary storage that is allocated internally if
   !>   \p blockDim > 16.
   !>
-  !>   @param[in]
-  !>   handle       handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   dirA the storage format of the blocks, `HIPSPARSE_DIRECTION_ROW` or
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] dirA - the storage format of the blocks, `HIPSPARSE_DIRECTION_ROW` or
   !>   `HIPSPARSE_DIRECTION_COLUMN`.
-  !>   @param[in]
-  !>   m            number of rows in the sparse CSR matrix.
-  !>   @param[in]
-  !>   n            number of columns in the sparse CSR matrix.
-  !>   @param[in]
-  !>   descrA       descriptor of the sparse CSR matrix. Currently, only
+  !>   @param[in] m - number of rows in the sparse CSR matrix.
+  !>   @param[in] n - number of columns in the sparse CSR matrix.
+  !>   @param[in] descrA - descriptor of the sparse CSR matrix. Currently, only
   !>                `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[in]
-  !>   csrValA      array of \p nnz elements containing the values of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csrRowPtrA   array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] csrValA - array of \p nnz elements containing the values of the sparse CSR matrix.
+  !>   @param[in] csrRowPtrA - array of \p m+1 elements that point to the start of every row of the
   !>                sparse CSR matrix.
-  !>   @param[in]
-  !>   csrColIndA   array of \p nnz elements containing the column indices of the sparse CSR matrix.
-  !>   @param[in]
-  !>   blockDim     size of the blocks in the sparse BSR matrix.
-  !>   @param[in]
-  !>   descrC       descriptor of the sparse BSR matrix. Currently, only
+  !>   @param[in] csrColIndA - array of \p nnz elements containing the column indices of the sparse
+  !>   CSR matrix.
+  !>   @param[in] blockDim - size of the blocks in the sparse BSR matrix.
+  !>   @param[in] descrC - descriptor of the sparse BSR matrix. Currently, only
   !>                `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[out]
-  !>   bsrValC array of \p nnzb*blockDim*blockDim containing the values of the sparse BSR matrix.
-  !>   @param[out]
-  !>   bsrRowPtrC   array of \p mb+1 elements that point to the start of every block row of the
+  !>   @param[out] bsrValC - array of \p nnzb*blockDim*blockDim containing the values of the sparse
+  !>   BSR matrix.
+  !>   @param[out] bsrRowPtrC - array of \p mb+1 elements that point to the start of every block row
+  !>   of the
   !>                sparse BSR matrix.
-  !>   @param[out]
-  !>   bsrColIndC array of \p nnzb elements containing the block column indices of the sparse BSR
-  !>   matrix.
+  !>   @param[out] bsrColIndC - array of \p nnzb elements containing the block column indices of the
+  !>   sparse BSR matrix.
   !>
   !>   \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
   !>   \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p m, \p n, \p blockDim, \p bsrValC, \p
@@ -15811,20 +14976,14 @@ module hipfort_hipsparse
   !>   This function is non-blocking and executed asynchronously with respect to the host.
   !>   It can return before the actual computation has finished.
   !>
-  !>   @param[in]
-  !>   handle      handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   csrRowPtr   array of \p m+1 elements that point to the start of every row
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] csrRowPtr - array of \p m+1 elements that point to the start of every row
   !>               of the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of the sparse CSR matrix. Must be non-negative.
-  !>   @param[in]
-  !>   m           number of rows of the sparse CSR matrix. Must be non-negative.
-  !>   @param[out]
-  !>   cooRowInd   array of \p nnz elements containing the row indices of the sparse COO
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix. Must be non-negative.
+  !>   @param[in] m - number of rows of the sparse CSR matrix. Must be non-negative.
+  !>   @param[out] cooRowInd - array of \p nnz elements containing the row indices of the sparse COO
   !>               matrix.
-  !>   @param[in]
-  !>   idxBase     index base. `HIPSPARSE_INDEX_BASE_ZERO` for zero-based indexing or
+  !>   @param[in] idxBase - index base. `HIPSPARSE_INDEX_BASE_ZERO` for zero-based indexing or
   !>               `HIPSPARSE_INDEX_BASE_ONE` for one-based indexing.
   !>
   !>   \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
@@ -15911,34 +15070,27 @@ module hipfort_hipsparse
   !>   This function is deprecated when using the CUDA backend (CUDA 10.0+) and will be
   !>   removed in CUDA 11.0. This deprecation does not apply to the ROCm backend.
   !>
-  !>   @param[in]
-  !>   handle          handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m               number of rows of the sparse CSR matrix, which must be non-negative.
-  !>   @param[in]
-  !>   n               number of columns of the sparse CSR matrix, which must be non-negative.
-  !>   @param[in]
-  !>   nnz number of non-zero entries of the sparse CSR matrix, which must be non-negative.
-  !>   @param[in]
-  !>   csrSortedVal    array of \p nnz elements of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csrSortedRowPtr array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse CSR matrix, which must be non-negative.
+  !>   @param[in] n - number of columns of the sparse CSR matrix, which must be non-negative.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix, which must be
+  !>   non-negative.
+  !>   @param[in] csrSortedVal - array of \p nnz elements of the sparse CSR matrix.
+  !>   @param[in] csrSortedRowPtr - array of \p m+1 elements that point to the start of every row of
+  !>   the
   !>                   sparse CSR matrix.
-  !>   @param[in]
-  !>   csrSortedColInd array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] csrSortedColInd - array of \p nnz elements containing the column indices of the
+  !>   sparse
   !>                   CSR matrix.
-  !>   @param[out]
-  !>   cscSortedVal    array of \p nnz elements of the sparse CSC matrix.
-  !>   @param[out]
-  !>   cscSortedRowInd array of \p nnz elements containing the row indices of the sparse CSC
+  !>   @param[out] cscSortedVal - array of \p nnz elements of the sparse CSC matrix.
+  !>   @param[out] cscSortedRowInd - array of \p nnz elements containing the row indices of the
+  !>   sparse CSC
   !>                   matrix.
-  !>   @param[out]
-  !>   cscSortedColPtr array of \p n+1 elements that point to the start of every column of the
+  !>   @param[out] cscSortedColPtr - array of \p n+1 elements that point to the start of every
+  !>   column of the
   !>                   sparse CSC matrix.
-  !>   @param[in]
-  !>   copyValues      `HIPSPARSE_ACTION_SYMBOLIC` or `HIPSPARSE_ACTION_NUMERIC`.
-  !>   @param[in]
-  !>   idxBase         index base. `HIPSPARSE_INDEX_BASE_ZERO` for zero-based indexing or
+  !>   @param[in] copyValues - `HIPSPARSE_ACTION_SYMBOLIC` or `HIPSPARSE_ACTION_NUMERIC`.
+  !>   @param[in] idxBase - index base. `HIPSPARSE_INDEX_BASE_ZERO` for zero-based indexing or
   !>                   `HIPSPARSE_INDEX_BASE_ONE` for one-based indexing.
   !>
   !>   \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
@@ -16096,41 +15248,29 @@ module hipfort_hipsparse
   !>   This function is non-blocking and executed asynchronously with respect to the host.
   !>   It can return before the actual computation has finished.
   !>
-  !>   @param[in]
-  !>   handle             handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m                  number of rows of the sparse CSR matrix.
-  !>   @param[in]
-  !>   n                  number of columns of the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnz                number of non-zero entries of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csrVal             array of \p nnz elements of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csrRowPtr          array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
+  !>   @param[in] n - number of columns of the sparse CSR matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix.
+  !>   @param[in] csrVal - array of \p nnz elements of the sparse CSR matrix.
+  !>   @param[in] csrRowPtr - array of \p m+1 elements that point to the start of every row of the
   !>                      sparse CSR matrix.
-  !>   @param[in]
-  !>   csrColInd          array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] csrColInd - array of \p nnz elements containing the column indices of the sparse
   !>                      CSR matrix.
-  !>   @param[in]
-  !>   cscVal             array of \p nnz elements of the sparse CSC matrix.
-  !>   @param[in]
-  !>   cscColPtr          array of \p n+1 elements that point to the start of every column of the
+  !>   @param[in] cscVal - array of \p nnz elements of the sparse CSC matrix.
+  !>   @param[in] cscColPtr - array of \p n+1 elements that point to the start of every column of
+  !>   the
   !>                      sparse CSC matrix.
-  !>   @param[in]
-  !>   cscRowInd          array of \p nnz elements containing the row indices of the sparse
+  !>   @param[in] cscRowInd - array of \p nnz elements containing the row indices of the sparse
   !>                      CSC matrix.
-  !>   @param[in]
-  !>   valType The data type of the values arrays \p csrVal and \p cscVal. Can be HIP_R_32F,
+  !>   @param[in] valType - The data type of the values arrays \p csrVal and \p cscVal. Can be
+  !>   HIP_R_32F,
   !>                      HIP_R_64F, HIP_C_32F, or HIP_C_64F.
-  !>   @param[in]
-  !>   copyValues         `HIPSPARSE_ACTION_SYMBOLIC` or `HIPSPARSE_ACTION_NUMERIC`.
-  !>   @param[in]
-  !>   idxBase            `HIPSPARSE_INDEX_BASE_ZERO` or `HIPSPARSE_INDEX_BASE_ONE`.
-  !>   @param[in]
-  !>   alg HIPSPARSE_CSR2CSC_ALG_DEFAULT, HIPSPARSE_CSR2CSC_ALG1, or HIPSPARSE_CSR2CSC_ALG2.
-  !>   @param[out]
-  !>   pBufferSizeInBytes number of bytes of the temporary storage buffer required by
+  !>   @param[in] copyValues - `HIPSPARSE_ACTION_SYMBOLIC` or `HIPSPARSE_ACTION_NUMERIC`.
+  !>   @param[in] idxBase - `HIPSPARSE_INDEX_BASE_ZERO` or `HIPSPARSE_INDEX_BASE_ONE`.
+  !>   @param[in] alg - HIPSPARSE_CSR2CSC_ALG_DEFAULT, HIPSPARSE_CSR2CSC_ALG1, or
+  !>   HIPSPARSE_CSR2CSC_ALG2.
+  !>   @param[out] pBufferSizeInBytes - number of bytes of the temporary storage buffer required by
   !>                      `hipsparseCsr2cscEx2()`.
   !>
   !>   \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
@@ -16187,41 +15327,29 @@ module hipfort_hipsparse
   !>   This function is non-blocking and executed asynchronously with respect to the host.
   !>   It can return before the actual computation has finished.
   !>
-  !>   @param[in]
-  !>   handle      handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m           number of rows of the sparse CSR matrix.
-  !>   @param[in]
-  !>   n           number of columns of the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csrVal      array of \p nnz elements of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csrRowPtr   array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
+  !>   @param[in] n - number of columns of the sparse CSR matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix.
+  !>   @param[in] csrVal - array of \p nnz elements of the sparse CSR matrix.
+  !>   @param[in] csrRowPtr - array of \p m+1 elements that point to the start of every row of the
   !>               sparse CSR matrix.
-  !>   @param[in]
-  !>   csrColInd   array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] csrColInd - array of \p nnz elements containing the column indices of the sparse
   !>               CSR matrix.
-  !>   @param[in]
-  !>   cscVal      array of \p nnz elements of the sparse CSC matrix.
-  !>   @param[in]
-  !>   cscColPtr   array of \p n+1 elements that point to the start of every column of the
+  !>   @param[in] cscVal - array of \p nnz elements of the sparse CSC matrix.
+  !>   @param[in] cscColPtr - array of \p n+1 elements that point to the start of every column of
+  !>   the
   !>               sparse CSC matrix.
-  !>   @param[in]
-  !>   cscRowInd   array of \p nnz elements containing the row indices of the sparse
+  !>   @param[in] cscRowInd - array of \p nnz elements containing the row indices of the sparse
   !>               CSC matrix.
-  !>   @param[in]
-  !>   valType     The data type of the values arrays \p csrVal and \p cscVal. Can be HIP_R_32F,
+  !>   @param[in] valType - The data type of the values arrays \p csrVal and \p cscVal. Can be
+  !>   HIP_R_32F,
   !>               HIP_R_64F, HIP_C_32F, or HIP_C_64F.
-  !>   @param[in]
-  !>   copyValues  `HIPSPARSE_ACTION_SYMBOLIC` or `HIPSPARSE_ACTION_NUMERIC`.
-  !>   @param[in]
-  !>   idxBase     `HIPSPARSE_INDEX_BASE_ZERO` or `HIPSPARSE_INDEX_BASE_ONE`.
-  !>   @param[in]
-  !>   alg         HIPSPARSE_CSR2CSC_ALG_DEFAULT, HIPSPARSE_CSR2CSC_ALG1 or HIPSPARSE_CSR2CSC_ALG2.
-  !>   @param[in]
-  !>   buffer      temporary storage buffer allocated by the user. The size is returned by
+  !>   @param[in] copyValues - `HIPSPARSE_ACTION_SYMBOLIC` or `HIPSPARSE_ACTION_NUMERIC`.
+  !>   @param[in] idxBase - `HIPSPARSE_INDEX_BASE_ZERO` or `HIPSPARSE_INDEX_BASE_ONE`.
+  !>   @param[in] alg - HIPSPARSE_CSR2CSC_ALG_DEFAULT, HIPSPARSE_CSR2CSC_ALG1 or
+  !>   HIPSPARSE_CSR2CSC_ALG2.
+  !>   @param[in] buffer - temporary storage buffer allocated by the user. The size is returned by
   !>               hipsparseCsr2cscEx2_bufferSize().
   !>
   !>   \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
@@ -16285,39 +15413,31 @@ module hipfort_hipsparse
   !>   \note
   !>   In the case of complex matrices, only the magnitude of the real part of \p tol is used.
   !>
-  !>   @param[in]
-  !>   handle        handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m             number of rows of the sparse CSR matrix.
-  !>   @param[in]
-  !>   n             number of columns of the sparse CSR matrix.
-  !>   @param[in]
-  !>   descrA        matrix descriptor for the CSR matrix.
-  !>   @param[in]
-  !>   csrValA       array of \p nnzA elements of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csrRowPtrA    array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
+  !>   @param[in] n - number of columns of the sparse CSR matrix.
+  !>   @param[in] descrA - matrix descriptor for the CSR matrix.
+  !>   @param[in] csrValA - array of \p nnzA elements of the sparse CSR matrix.
+  !>   @param[in] csrRowPtrA - array of \p m+1 elements that point to the start of every row of the
   !>                 uncompressed sparse CSR matrix.
-  !>   @param[in]
-  !>   csrColIndA    array of \p nnzA elements containing the column indices of the uncompressed
+  !>   @param[in] csrColIndA - array of \p nnzA elements containing the column indices of the
+  !>   uncompressed
   !>                 sparse CSR matrix.
-  !>   @param[in]
-  !>   nnzA          number of elements in the column indices and values arrays of the uncompressed
+  !>   @param[in] nnzA - number of elements in the column indices and values arrays of the
+  !>   uncompressed
   !>                 sparse CSR matrix.
-  !>   @param[in]
-  !>   nnzPerRow array of length \p m containing the number of entries that will be kept per row in
+  !>   @param[in] nnzPerRow - array of length \p m containing the number of entries that will be
+  !>   kept per row in
   !>                 the final compressed CSR matrix.
-  !>   @param[out]
-  !>   csrValC       array of \p nnzC elements of the compressed sparse CSC matrix.
-  !>   @param[out]
-  !>   csrRowPtrC array of \p m+1 elements that point to the start of every column of the compressed
+  !>   @param[out] csrValC - array of \p nnzC elements of the compressed sparse CSC matrix.
+  !>   @param[out] csrRowPtrC - array of \p m+1 elements that point to the start of every column of
+  !>   the compressed
   !>                 sparse CSR matrix.
-  !>   @param[out]
-  !>   csrColIndC    array of \p nnzC elements containing the row indices of the compressed
+  !>   @param[out] csrColIndC - array of \p nnzC elements containing the row indices of the
+  !>   compressed
   !>                 sparse CSR matrix.
-  !>   @param[in]
-  !>   tol the non-negative tolerance used for compression. If \p tol is complex, then only the
-  !>   magnitude
+  !>   @param[in] tol - the non-negative tolerance used for compression. If \p tol is complex, then
+  !>   only the magnitude
   !>                 of the real part is used. Entries in the input uncompressed CSR array that are
   !>                 below the tolerance
   !>                 are removed in the output compressed CSR matrix.
@@ -16646,28 +15766,20 @@ module hipfort_hipsparse
   !>   This function is deprecated when using the CUDA backend (CUDA 11.0+) and will be
   !>   removed in CUDA 12.0. This deprecation does not apply to the ROCm backend.
   !>
-  !>   @param[in]
-  !>   handle      handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m           number of rows of the dense matrix \p A. Must be non-negative.
-  !>   @param[in]
-  !>   n           number of columns of the dense matrix \p A. Must be non-negative.
-  !>   @param[in]
-  !>   descr the descriptor of the dense matrix \p A, the supported matrix type is
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - number of rows of the dense matrix \p A. Must be non-negative.
+  !>   @param[in] n - number of columns of the dense matrix \p A. Must be non-negative.
+  !>   @param[in] descr - the descriptor of the dense matrix \p A, the supported matrix type is
   !>   `HIPSPARSE_MATRIX_TYPE_GENERAL` and
   !>               any valid value of the `hipsparseIndexBase_t`.
-  !>   @param[in]
-  !>   csrVal array of nnz ( = \p csrRowPtr[m] - \p csrRowPtr[0] ) non-zero elements of matrix \p A.
-  !>   @param[in]
-  !>   csrRowPtr integer array of \p m+1 elements that contains the start of every row and the end
-  !>   of the last row plus one.
-  !>   @param[in]
-  !>   csrColInd integer array of nnz ( = \p csrRowPtr[m] - \p csrRowPtr[0] ) column indices of the
-  !>   non-zero elements of matrix \p A.
-  !>   @param[out]
-  !>   A           array of dimensions (\p ld, \p n).
-  !>   @param[in]
-  !>   ld          leading dimension of dense array \p A. Must be at least \p m.
+  !>   @param[in] csrVal - array of nnz ( = \p csrRowPtr[m] - \p csrRowPtr[0] ) non-zero elements of
+  !>   matrix \p A.
+  !>   @param[in] csrRowPtr - integer array of \p m+1 elements that contains the start of every row
+  !>   and the end of the last row plus one.
+  !>   @param[in] csrColInd - integer array of nnz ( = \p csrRowPtr[m] - \p csrRowPtr[0] ) column
+  !>   indices of the non-zero elements of matrix \p A.
+  !>   @param[out] A - array of dimensions (\p ld, \p n).
+  !>   @param[in] ld - leading dimension of dense array \p A. Must be at least \p m.
   !>
   !>   \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
   !>   \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
@@ -16799,31 +15911,24 @@ module hipfort_hipsparse
   !>   \note
   !>   The routine supports asynchronous execution if the pointer mode is set to device.
   !>
-  !>   @param[in]
-  !>   handle             handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   dir direction that specifies whether to count non-zero elements by `HIPSPARSE_DIRECTION_ROW`
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] dir - direction that specifies whether to count non-zero elements by
+  !>   `HIPSPARSE_DIRECTION_ROW`
   !>                      or by `HIPSPARSE_DIRECTION_COLUMN`.
-  !>   @param[in]
-  !>   m                  number of rows of the sparse CSR matrix.
-  !>   @param[in]
-  !>   n                  number of columns of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_descr          descriptor of the sparse CSR matrix. Currently, only
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
+  !>   @param[in] n - number of columns of the sparse CSR matrix.
+  !>   @param[in] csr_descr - descriptor of the sparse CSR matrix. Currently, only
   !>                      `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[in]
-  !>   csrVal             array of \p nnz elements containing the values of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csrRowPtr integer array containing \p m+1 elements that point to the start of each row of the
+  !>   @param[in] csrVal - array of \p nnz elements containing the values of the sparse CSR matrix.
+  !>   @param[in] csrRowPtr - integer array containing \p m+1 elements that point to the start of
+  !>   each row of the CSR matrix.
+  !>   @param[in] csrColInd - integer array of the column indices for each non-zero element in the
   !>   CSR matrix.
-  !>   @param[in]
-  !>   csrColInd integer array of the column indices for each non-zero element in the CSR matrix.
-  !>   @param[in]
-  !>   rowBlockDim        the row block dimension of the general BSR matrix. Between 1 and \p m.
-  !>   @param[in]
-  !>   colBlockDim        the col block dimension of the general BSR matrix. Between 1 and \p n.
-  !>   @param[out]
-  !>   pBufferSizeInBytes number of bytes of the temporary storage buffer required by
+  !>   @param[in] rowBlockDim - the row block dimension of the general BSR matrix. Between 1 and \p
+  !>   m.
+  !>   @param[in] colBlockDim - the col block dimension of the general BSR matrix. Between 1 and \p
+  !>   n.
+  !>   @param[out] pBufferSizeInBytes - number of bytes of the temporary storage buffer required by
   !>   `hipsparseXcsr2gebsrNnz` ()
   !>                      and `hipsparseScsr2gebsr` "hipsparseXcsr2gebsr()".
   !>
@@ -17062,44 +16167,32 @@ module hipfort_hipsparse
   !>
   !>   See `hipsparseScsr2gebsr()` for a full code example.
   !>
-  !>   @param[in]
-  !>   handle        handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   dir direction that specifies whether to count non-zero elements by `HIPSPARSE_DIRECTION_ROW`
-  !>   or by
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] dir - direction that specifies whether to count non-zero elements by
+  !>   `HIPSPARSE_DIRECTION_ROW` or by
   !>                 `HIPSPARSE_DIRECTION_COLUMN`.
-  !>   @param[in]
-  !>   m             number of rows of the sparse CSR matrix.
-  !>   @param[in]
-  !>   n             number of columns of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_descr     descriptor of the sparse CSR matrix. Currently, only
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
+  !>   @param[in] n - number of columns of the sparse CSR matrix.
+  !>   @param[in] csr_descr - descriptor of the sparse CSR matrix. Currently, only
   !>                 `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[in]
-  !>   csrRowPtr integer array containing \p m+1 elements that point to the start of each row of the
+  !>   @param[in] csrRowPtr - integer array containing \p m+1 elements that point to the start of
+  !>   each row of the CSR matrix.
+  !>   @param[in] csrColInd - integer array of the column indices for each non-zero element in the
   !>   CSR matrix.
-  !>   @param[in]
-  !>   csrColInd integer array of the column indices for each non-zero element in the CSR matrix.
-  !>   @param[in]
-  !>   bsr_descr     descriptor of the sparse general BSR matrix. Currently, only
+  !>   @param[in] bsr_descr - descriptor of the sparse general BSR matrix. Currently, only
   !>                 `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[out]
-  !>   bsrRowPtr integer array containing \p mb+1 elements that point to the start of each block row
-  !>   of the general BSR matrix.
+  !>   @param[out] bsrRowPtr - integer array containing \p mb+1 elements that point to the start of
+  !>   each block row of the general BSR matrix.
   !>
-  !>   @param[in]
-  !>   rowBlockDim the row block dimension of the general BSR matrix, which is between \f$1\f$ and
-  !>   \f$\min(m, n)\f$.
+  !>   @param[in] rowBlockDim - the row block dimension of the general BSR matrix, which is between
+  !>   \f$1\f$ and \f$\min(m, n)\f$.
   !>
-  !>   @param[in]
-  !>   colBlockDim the col block dimension of the general BSR matrix, which is between \f$1\f$ and
-  !>   \f$\min(m, n)\f$.
+  !>   @param[in] colBlockDim - the col block dimension of the general BSR matrix, which is between
+  !>   \f$1\f$ and \f$\min(m, n)\f$.
   !>
-  !>   @param[out]
-  !>   bsrNnzDevhost total number of non-zero elements in device or host memory.
+  !>   @param[out] bsrNnzDevhost - total number of non-zero elements in device or host memory.
   !>
-  !>   @param[in]
-  !>   pbuffer buffer allocated by the user whose size is determined by calling
+  !>   @param[in] pbuffer - buffer allocated by the user whose size is determined by calling
   !>   `hipsparseScsr2gebsr_bufferSize`
   !>                 "hipsparseXcsr2gebsr_bufferSize()".
   !>
@@ -17278,43 +16371,30 @@ module hipfort_hipsparse
   !>   \right]
   !>   \f]
   !>
-  !>   @param[in]
-  !>   handle       handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   dir the storage format of the blocks, `HIPSPARSE_DIRECTION_ROW` or
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] dir - the storage format of the blocks, `HIPSPARSE_DIRECTION_ROW` or
   !>   `HIPSPARSE_DIRECTION_COLUMN`.
-  !>   @param[in]
-  !>   m            number of rows in the sparse CSR matrix.
-  !>   @param[in]
-  !>   n            number of columns in the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_descr    descriptor of the sparse CSR matrix. Currently, only
+  !>   @param[in] m - number of rows in the sparse CSR matrix.
+  !>   @param[in] n - number of columns in the sparse CSR matrix.
+  !>   @param[in] csr_descr - descriptor of the sparse CSR matrix. Currently, only
   !>                `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[in]
-  !>   csrVal       array of \p nnz elements containing the values of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csrRowPtr    array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] csrVal - array of \p nnz elements containing the values of the sparse CSR matrix.
+  !>   @param[in] csrRowPtr - array of \p m+1 elements that point to the start of every row of the
   !>                sparse CSR matrix.
-  !>   @param[in]
-  !>   csrColInd    array of \p nnz elements containing the column indices of the sparse CSR matrix.
-  !>   @param[in]
-  !>   bsr_descr    descriptor of the sparse BSR matrix. Currently, only
+  !>   @param[in] csrColInd - array of \p nnz elements containing the column indices of the sparse
+  !>   CSR matrix.
+  !>   @param[in] bsr_descr - descriptor of the sparse BSR matrix. Currently, only
   !>                `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[out]
-  !>   bsrVal array of \p nnzb* \p rowBlockDim* \p colBlockDim containing the values of the sparse
-  !>   BSR matrix.
-  !>   @param[out]
-  !>   bsrRowPtr    array of \p mb+1 elements that point to the start of every block row of the
+  !>   @param[out] bsrVal - array of \p nnzb* \p rowBlockDim* \p colBlockDim containing the values
+  !>   of the sparse BSR matrix.
+  !>   @param[out] bsrRowPtr - array of \p mb+1 elements that point to the start of every block row
+  !>   of the
   !>                sparse BSR matrix.
-  !>   @param[out]
-  !>   bsrColInd array of \p nnzb elements containing the block column indices of the sparse BSR
-  !>   matrix.
-  !>   @param[in]
-  !>   rowBlockDim  row size of the blocks in the sparse general BSR matrix.
-  !>   @param[in]
-  !>   colBlockDim  col size of the blocks in the sparse general BSR matrix.
-  !>   @param[in]
-  !>   pbuffer buffer allocated by the user. The buffer size is determined by calling
+  !>   @param[out] bsrColInd - array of \p nnzb elements containing the block column indices of the
+  !>   sparse BSR matrix.
+  !>   @param[in] rowBlockDim - row size of the blocks in the sparse general BSR matrix.
+  !>   @param[in] colBlockDim - col size of the blocks in the sparse general BSR matrix.
+  !>   @param[in] pbuffer - buffer allocated by the user. The buffer size is determined by calling
   !>   `hipsparseScsr2gebsr_bufferSize`
   !>                "hipsparseXcsr2gebsr_bufferSize()".
   !>
@@ -17494,29 +16574,20 @@ module hipfort_hipsparse
   !>   This function is deprecated when using the CUDA backend (CUDA 10.0+) and will be
   !>   removed in CUDA 11.0. This deprecation does not apply to the ROCm backend.
   !>
-  !>   @param[in]
-  !>   handle            handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m                 number of rows of the sparse CSR matrix, which must be non-negative.
-  !>   @param[in]
-  !>   n                 number of columns of the sparse CSR matrix, which must be non-negative.
-  !>   @param[in]
-  !>   descrA            descriptor of the sparse CSR matrix. Currently, only
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse CSR matrix, which must be non-negative.
+  !>   @param[in] n - number of columns of the sparse CSR matrix, which must be non-negative.
+  !>   @param[in] descrA - descriptor of the sparse CSR matrix. Currently, only
   !>                     `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[in]
-  !>   csrSortedValA     array containing the values of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csrSortedRowPtrA  array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] csrSortedValA - array containing the values of the sparse CSR matrix.
+  !>   @param[in] csrSortedRowPtrA - array of \p m+1 elements that point to the start of every row
+  !>   of the
   !>                     sparse CSR matrix.
-  !>   @param[in]
-  !>   csrSortedColIndA  array containing the column indices of the sparse CSR matrix.
-  !>   @param[out]
-  !>   hybA              sparse matrix in HYB format.
-  !>   @param[in]
-  !>   userEllWidth      width of the ELL part of the HYB matrix (only required if
+  !>   @param[in] csrSortedColIndA - array containing the column indices of the sparse CSR matrix.
+  !>   @param[out] hybA - sparse matrix in HYB format.
+  !>   @param[in] userEllWidth - width of the ELL part of the HYB matrix (only required if
   !>                     \p partitionType == `HIPSPARSE_HYB_PARTITION_USER`). Must be non-negative.
-  !>   @param[in]
-  !>   partitionType     `HIPSPARSE_HYB_PARTITION_AUTO` (recommended),
+  !>   @param[in] partitionType - `HIPSPARSE_HYB_PARTITION_AUTO` (recommended),
   !>                     `HIPSPARSE_HYB_PARTITION_USER`, or
   !>                     `HIPSPARSE_HYB_PARTITION_MAX`.
   !>
@@ -17653,22 +16724,15 @@ module hipfort_hipsparse
   !>   in bytes required by `hipsparseXcsrsort()`. The temporary storage buffer must be allocated by
   !>   the user.
   !>
-  !>   @param[in]
-  !>   handle              handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m                   number of rows of the sparse CSR matrix.
-  !>   @param[in]
-  !>   n                   number of columns of the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnz                 number of non-zero entries of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csrRowPtr           array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
+  !>   @param[in] n - number of columns of the sparse CSR matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix.
+  !>   @param[in] csrRowPtr - array of \p m+1 elements that point to the start of every row of the
   !>                       sparse CSR matrix.
-  !>   @param[in]
-  !>   csrColInd           array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] csrColInd - array of \p nnz elements containing the column indices of the sparse
   !>                       CSR matrix.
-  !>   @param[out]
-  !>   pBufferSizeInBytes  number of bytes of the temporary storage buffer required by
+  !>   @param[out] pBufferSizeInBytes - number of bytes of the temporary storage buffer required by
   !>                       `hipsparseXcsrsort`().
   !>
   !>   \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
@@ -17725,28 +16789,20 @@ module hipfort_hipsparse
   !>   This function is non-blocking and executed asynchronously with respect to the host.
   !>   It can return before the actual computation has finished.
   !>
-  !>   @param[in]
-  !>   handle          handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m               number of rows of the sparse CSR matrix.
-  !>   @param[in]
-  !>   n               number of columns of the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnz             number of non-zero entries of the sparse CSR matrix.
-  !>   @param[in]
-  !>   descrA          descriptor of the sparse CSR matrix. Currently, only
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
+  !>   @param[in] n - number of columns of the sparse CSR matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix.
+  !>   @param[in] descrA - descriptor of the sparse CSR matrix. Currently, only
   !>                   `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[in]
-  !>   csrRowPtr       array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] csrRowPtr - array of \p m+1 elements that point to the start of every row of the
   !>                   sparse CSR matrix.
-  !>   @param[inout]
-  !>   csrColInd       array of \p nnz elements containing the column indices of the sparse
+  !>   @param[inout] csrColInd - array of \p nnz elements containing the column indices of the
+  !>   sparse
   !>                   CSR matrix.
-  !>   @param[inout]
-  !>   P               array of \p nnz integers containing the unsorted map indices. Can be
+  !>   @param[inout] P - array of \p nnz integers containing the unsorted map indices. Can be
   !>                   \p NULL.
-  !>   @param[in]
-  !>   pBuffer         temporary storage buffer allocated by the user. The size is returned by
+  !>   @param[in] pBuffer - temporary storage buffer allocated by the user. The size is returned by
   !>                   `hipsparseXcsrsort_bufferSizeExt`().
   !>
   !>   \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
@@ -18097,30 +17153,22 @@ module hipfort_hipsparse
   !>   This function is deprecated when using the CUDA backend (CUDA 11.0+) and will be
   !>   removed in CUDA 12.0. This deprecation does not apply to the ROCm backend.
   !>
-  !>   @param[in]
-  !>   handle       handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m            number of rows of the dense matrix \p A. Must be non-negative.
-  !>   @param[in]
-  !>   n            number of columns of the dense matrix \p A. Must be non-negative.
-  !>   @param[in]
-  !>   descr the descriptor of the dense matrix \p A. The supported matrix type is
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - number of rows of the dense matrix \p A. Must be non-negative.
+  !>   @param[in] n - number of columns of the dense matrix \p A. Must be non-negative.
+  !>   @param[in] descr - the descriptor of the dense matrix \p A. The supported matrix type is
   !>   `HIPSPARSE_MATRIX_TYPE_GENERAL` and
   !>                any valid value of the `hipsparseIndexBase_t`.
-  !>   @param[in]
-  !>   A            array of dimensions (\p ld, \p n).
-  !>   @param[in]
-  !>   ld           leading dimension of dense array \p A. Must be at least \p m.
-  !>   @param[in]
-  !>   nnzPerColumn array of size \p n containing the number of non-zero elements per column.
-  !>   @param[out]
-  !>   cscVal array of nnz ( = \p cscColPtr[n] - \p cscColPtr[0] ) nonzero elements of matrix \p A.
-  !>   @param[out]
-  !>   cscRowInd integer array of nnz ( = \p cscColPtr[n] - \p cscColPtr[0] ) column indices of the
-  !>   non-zero elements of matrix \p A.
-  !>   @param[out]
-  !>   cscColPtr integer array of \p n+1 elements that contains the start of every column and the
-  !>   end of the last column plus one.
+  !>   @param[in] A - array of dimensions (\p ld, \p n).
+  !>   @param[in] ld - leading dimension of dense array \p A. Must be at least \p m.
+  !>   @param[in] nnzPerColumn - array of size \p n containing the number of non-zero elements per
+  !>   column.
+  !>   @param[out] cscVal - array of nnz ( = \p cscColPtr[n] - \p cscColPtr[0] ) nonzero elements of
+  !>   matrix \p A.
+  !>   @param[out] cscRowInd - integer array of nnz ( = \p cscColPtr[n] - \p cscColPtr[0] ) column
+  !>   indices of the non-zero elements of matrix \p A.
+  !>   @param[out] cscColPtr - integer array of \p n+1 elements that contains the start of every
+  !>   column and the end of the last column plus one.
   !>
   !>   \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
   !>   \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
@@ -18283,30 +17331,21 @@ module hipfort_hipsparse
   !>   the
   !>   application on the host before the entire result is ready.
   !>
-  !>   @param[in]
-  !>   handle       handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m            number of rows of the dense matrix \p A. Must be non-negative.
-  !>   @param[in]
-  !>   n            number of columns of the dense matrix \p A. Must be non-negative.
-  !>   @param[in]
-  !>   descr the descriptor of the dense matrix \p A. The supported matrix type is
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - number of rows of the dense matrix \p A. Must be non-negative.
+  !>   @param[in] n - number of columns of the dense matrix \p A. Must be non-negative.
+  !>   @param[in] descr - the descriptor of the dense matrix \p A. The supported matrix type is
   !>   `HIPSPARSE_MATRIX_TYPE_GENERAL` and
   !>                any valid value of the `hipsparseIndexBase_t`.
-  !>   @param[in]
-  !>   A            array of dimensions (\p ld, \p n).
-  !>   @param[in]
-  !>   ld           leading dimension of dense array \p A, which must be at least \p m.
-  !>   @param[in]
-  !>   nnzPerRow    array of size \p m containing the number of non-zero elements per row.
-  !>   @param[out]
-  !>   csrVal array of nnz ( = \p csrRowPtr[m] - \p csrRowPtr[0] ) non-zero elements of matrix \p A.
-  !>   @param[out]
-  !>   csrRowPtr integer array of \p m+1 elements that contains the start of every row and the end
-  !>   of the last row plus one.
-  !>   @param[out]
-  !>   csrColInd integer array of nnz ( = \p csrRowPtr[m] - \p csrRowPtr[0] ) column indices of the
-  !>   non-zero elements of matrix \p A.
+  !>   @param[in] A - array of dimensions (\p ld, \p n).
+  !>   @param[in] ld - leading dimension of dense array \p A, which must be at least \p m.
+  !>   @param[in] nnzPerRow - array of size \p m containing the number of non-zero elements per row.
+  !>   @param[out] csrVal - array of nnz ( = \p csrRowPtr[m] - \p csrRowPtr[0] ) non-zero elements
+  !>   of matrix \p A.
+  !>   @param[out] csrRowPtr - integer array of \p m+1 elements that contains the start of every row
+  !>   and the end of the last row plus one.
+  !>   @param[out] csrColInd - integer array of nnz ( = \p csrRowPtr[m] - \p csrRowPtr[0] ) column
+  !>   indices of the non-zero elements of matrix \p A.
   !>
   !>   \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
   !>   \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
@@ -18493,44 +17532,31 @@ module hipfort_hipsparse
   !>   This function is non-blocking and executed asynchronously with respect to the host.
   !>   It can return before the actual computation has finished.
   !>
-  !>   @param[in]
-  !>   handle      handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   dirA the storage format of the blocks, `HIPSPARSE_DIRECTION_ROW` or
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] dirA - the storage format of the blocks, `HIPSPARSE_DIRECTION_ROW` or
   !>   `HIPSPARSE_DIRECTION_COLUMN`.
-  !>   @param[in]
-  !>   mb          number of block rows in the sparse general BSR matrix.
-  !>   @param[in]
-  !>   nb          number of block columns in the sparse general BSR matrix.
-  !>   @param[in]
-  !>   descrA      descriptor of the sparse general BSR matrix. Currently, only
+  !>   @param[in] mb - number of block rows in the sparse general BSR matrix.
+  !>   @param[in] nb - number of block columns in the sparse general BSR matrix.
+  !>   @param[in] descrA - descriptor of the sparse general BSR matrix. Currently, only
   !>               `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[in]
-  !>   bsrValA array of \p nnzb*rowBlockDim*colBlockDim containing the values of the sparse BSR
-  !>   matrix.
-  !>   @param[in]
-  !>   bsrRowPtrA  array of \p mb+1 elements that point to the start of every block row of the
+  !>   @param[in] bsrValA - array of \p nnzb*rowBlockDim*colBlockDim containing the values of the
+  !>   sparse BSR matrix.
+  !>   @param[in] bsrRowPtrA - array of \p mb+1 elements that point to the start of every block row
+  !>   of the
   !>               sparse BSR matrix.
-  !>   @param[in]
-  !>   bsrColIndA array of \p nnzb elements containing the block column indices of the sparse BSR
-  !>   matrix.
-  !>   @param[in]
-  !>   rowBlockDim row size of the blocks in the sparse general BSR matrix.
-  !>   @param[in]
-  !>   colBlockDim column size of the blocks in the sparse general BSR matrix.
-  !>   @param[in]
-  !>   descrC      descriptor of the sparse CSR matrix. Currently, only
+  !>   @param[in] bsrColIndA - array of \p nnzb elements containing the block column indices of the
+  !>   sparse BSR matrix.
+  !>   @param[in] rowBlockDim - row size of the blocks in the sparse general BSR matrix.
+  !>   @param[in] colBlockDim - column size of the blocks in the sparse general BSR matrix.
+  !>   @param[in] descrC - descriptor of the sparse CSR matrix. Currently, only
   !>               `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[out]
-  !>   csrValC array of \p nnzb*rowBlockDim*colBlockDim elements containing the values of the sparse
-  !>   CSR matrix.
-  !>   @param[out]
-  !>   csrRowPtrC array of \p m+1 where \p m=mb*rowBlockDim elements that point to the start of
-  !>   every row of the
+  !>   @param[out] csrValC - array of \p nnzb*rowBlockDim*colBlockDim elements containing the values
+  !>   of the sparse CSR matrix.
+  !>   @param[out] csrRowPtrC - array of \p m+1 where \p m=mb*rowBlockDim elements that point to the
+  !>   start of every row of the
   !>               sparse CSR matrix.
-  !>   @param[out]
-  !>   csrColIndC array of \p nnzb*block_dim*block_dim elements containing the column indices of the
-  !>   sparse CSR matrix.
+  !>   @param[out] csrColIndC - array of \p nnzb*block_dim*block_dim elements containing the column
+  !>   indices of the sparse CSR matrix.
   !>
   !>   \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
   !>   \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p mb, \p nb, \p block_dim, \p bsrValA,
@@ -18696,29 +17722,20 @@ module hipfort_hipsparse
   !>
   !>   See `hipsparseSgebsr2gebsc()` for a complete code example.
   !>
-  !>   @param[in]
-  !>   handle             handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   mb                 number of rows of the sparse General BSR matrix.
-  !>   @param[in]
-  !>   nb                 number of columns of the sparse General BSR matrix.
-  !>   @param[in]
-  !>   nnzb               number of non-zero entries of the sparse General BSR matrix.
-  !>   @param[in]
-  !>   bsrVal array of \p nnzb*rowBlockDim*colBlockDim containing the values of the sparse General
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] mb - number of rows of the sparse General BSR matrix.
+  !>   @param[in] nb - number of columns of the sparse General BSR matrix.
+  !>   @param[in] nnzb - number of non-zero entries of the sparse General BSR matrix.
+  !>   @param[in] bsrVal - array of \p nnzb*rowBlockDim*colBlockDim containing the values of the
+  !>   sparse General
   !>                      BSR matrix.
-  !>   @param[in]
-  !>   bsrRowPtr          array of \p mb+1 elements that point to the start of every row of the
+  !>   @param[in] bsrRowPtr - array of \p mb+1 elements that point to the start of every row of the
   !>                      sparse General BSR matrix.
-  !>   @param[in]
-  !>   bsrColInd          array of \p nnzb elements containing the column indices of the sparse
+  !>   @param[in] bsrColInd - array of \p nnzb elements containing the column indices of the sparse
   !>                      General BSR matrix.
-  !>   @param[in]
-  !>   rowBlockDim        row size of the blocks in the sparse General BSR matrix.
-  !>   @param[in]
-  !>   colBlockDim        column size of the blocks in the sparse General BSR matrix.
-  !>   @param[out]
-  !>   pBufferSizeInBytes number of bytes of the temporary storage buffer required by
+  !>   @param[in] rowBlockDim - row size of the blocks in the sparse General BSR matrix.
+  !>   @param[in] colBlockDim - column size of the blocks in the sparse General BSR matrix.
+  !>   @param[out] pBufferSizeInBytes - number of bytes of the temporary storage buffer required by
   !>                      `hipsparseSgebsr2gebsc()`, hipsparseDgebsr2gebsc(),
   !>                      hipsparseCgebsr2gebsc(), and
   !>                      hipsparseZgebsr2gebsc().
@@ -18912,41 +17929,28 @@ module hipfort_hipsparse
   !>   This function is non-blocking and executed asynchronously with respect to the host.
   !>   It can return before the actual computation has finished.
   !>
-  !>   @param[in]
-  !>   handle      handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   mb          number of rows of the sparse general BSR matrix.
-  !>   @param[in]
-  !>   nb          number of columns of the sparse general BSR matrix.
-  !>   @param[in]
-  !>   nnzb        number of non-zero entries of the sparse general BSR matrix.
-  !>   @param[in]
-  !>   bsrVal array of \p nnzb * \p rowBlockDim * \p colBlockDim elements of the sparse general BSR
-  !>   matrix.
-  !>   @param[in]
-  !>   bsrRowPtr   array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] mb - number of rows of the sparse general BSR matrix.
+  !>   @param[in] nb - number of columns of the sparse general BSR matrix.
+  !>   @param[in] nnzb - number of non-zero entries of the sparse general BSR matrix.
+  !>   @param[in] bsrVal - array of \p nnzb * \p rowBlockDim * \p colBlockDim elements of the sparse
+  !>   general BSR matrix.
+  !>   @param[in] bsrRowPtr - array of \p m+1 elements that point to the start of every row of the
   !>               sparse general BSR matrix.
-  !>   @param[in]
-  !>   bsrColInd   array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] bsrColInd - array of \p nnz elements containing the column indices of the sparse
   !>               general BSR matrix.
-  !>   @param[in]
-  !>   rowBlockDim row size of the blocks in the sparse general BSR matrix.
-  !>   @param[in]
-  !>   colBlockDim col size of the blocks in the sparse general BSR matrix.
-  !>   @param[out]
-  !>   bscVal      array of \p nnz elements of the sparse BSC matrix.
-  !>   @param[out]
-  !>   bscRowInd   array of \p nnz elements containing the row indices of the sparse BSC
+  !>   @param[in] rowBlockDim - row size of the blocks in the sparse general BSR matrix.
+  !>   @param[in] colBlockDim - col size of the blocks in the sparse general BSR matrix.
+  !>   @param[out] bscVal - array of \p nnz elements of the sparse BSC matrix.
+  !>   @param[out] bscRowInd - array of \p nnz elements containing the row indices of the sparse BSC
   !>               matrix.
-  !>   @param[out]
-  !>   bscColPtr   array of \p n+1 elements that point to the start of every column of the
+  !>   @param[out] bscColPtr - array of \p n+1 elements that point to the start of every column of
+  !>   the
   !>               sparse BSC matrix.
-  !>   @param[in]
-  !>   copyValues  `HIPSPARSE_ACTION_SYMBOLIC` or `HIPSPARSE_ACTION_NUMERIC`.
-  !>   @param[in]
-  !>   idxBase     `HIPSPARSE_INDEX_BASE_ZERO` or `HIPSPARSE_INDEX_BASE_ONE`.
-  !>   @param[in]
-  !>   temp_buffer temporary storage buffer allocated by the user. The size is returned by
+  !>   @param[in] copyValues - `HIPSPARSE_ACTION_SYMBOLIC` or `HIPSPARSE_ACTION_NUMERIC`.
+  !>   @param[in] idxBase - `HIPSPARSE_INDEX_BASE_ZERO` or `HIPSPARSE_INDEX_BASE_ONE`.
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user. The size is returned
+  !>   by
   !>               `hipsparseSgebsr2gebsc_bufferSize` "hipsparseXgebsr2gebsc_bufferSize()".
   !>
   !>   \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
@@ -19096,40 +18100,28 @@ module hipfort_hipsparse
   !>   temporary storage
   !>   buffer must be allocated by the user.
   !>
-  !>   @param[in]
-  !>   handle             handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   dirA the storage format of the blocks, `HIPSPARSE_DIRECTION_ROW` or
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] dirA - the storage format of the blocks, `HIPSPARSE_DIRECTION_ROW` or
   !>   `HIPSPARSE_DIRECTION_COLUMN`.
-  !>   @param[in]
-  !>   mb                 number of block rows of the general BSR sparse matrix \f$A\f$.
-  !>   @param[in]
-  !>   nb                 number of block columns of the general BSR sparse matrix \f$A\f$.
-  !>   @param[in]
-  !>   nnzb               number of blocks in the general BSR sparse matrix \f$A\f$.
-  !>   @param[in]
-  !>   descrA the descriptor of the general BSR sparse matrix \f$A\f$. The supported matrix type is
+  !>   @param[in] mb - number of block rows of the general BSR sparse matrix \f$A\f$.
+  !>   @param[in] nb - number of block columns of the general BSR sparse matrix \f$A\f$.
+  !>   @param[in] nnzb - number of blocks in the general BSR sparse matrix \f$A\f$.
+  !>   @param[in] descrA - the descriptor of the general BSR sparse matrix \f$A\f$. The supported
+  !>   matrix type is
   !>                      `HIPSPARSE_MATRIX_TYPE_GENERAL` and any valid value of the
   !>                      `hipsparseIndexBase_t`.
-  !>   @param[in]
-  !>   bsrValA array of \p nnzb*rowBlockDimA*colBlockDimA containing the values of the sparse
-  !>   general BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   bsrRowPtrA array of \p mb+1 elements that point to the start of every block row of the
+  !>   @param[in] bsrValA - array of \p nnzb*rowBlockDimA*colBlockDimA containing the values of the
+  !>   sparse general BSR matrix \f$A\f$.
+  !>   @param[in] bsrRowPtrA - array of \p mb+1 elements that point to the start of every block row
+  !>   of the
   !>                      sparse general BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   bsrColIndA array of \p nnzb elements containing the block column indices of the sparse
-  !>   general BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   rowBlockDimA       row size of the blocks in the sparse general BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   colBlockDimA       column size of the blocks in the sparse general BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   rowBlockDimC       row size of the blocks in the sparse general BSR matrix \f$C\f$.
-  !>   @param[in]
-  !>   colBlockDimC       column size of the blocks in the sparse general BSR matrix \f$C\f$.
-  !>   @param[out]
-  !>   pBufferSizeInBytes number of bytes of the temporary storage buffer required by
+  !>   @param[in] bsrColIndA - array of \p nnzb elements containing the block column indices of the
+  !>   sparse general BSR matrix \f$A\f$.
+  !>   @param[in] rowBlockDimA - row size of the blocks in the sparse general BSR matrix \f$A\f$.
+  !>   @param[in] colBlockDimA - column size of the blocks in the sparse general BSR matrix \f$A\f$.
+  !>   @param[in] rowBlockDimC - row size of the blocks in the sparse general BSR matrix \f$C\f$.
+  !>   @param[in] colBlockDimC - column size of the blocks in the sparse general BSR matrix \f$C\f$.
+  !>   @param[out] pBufferSizeInBytes - number of bytes of the temporary storage buffer required by
   !>   `hipsparseXgebsr2gebsrNnz()`,
   !>                      `hipsparseSgebsr2gebsr()`, hipsparseDgebsr2gebsr(),
   !>                      hipsparseCgebsr2gebsr(), and
@@ -19299,48 +18291,36 @@ module hipfort_hipsparse
   !>   \details
   !>   The routine supports asynchronous execution.
   !>
-  !>   @param[in]
-  !>   handle             handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   dirA the storage format of the blocks, `HIPSPARSE_DIRECTION_ROW` or
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] dirA - the storage format of the blocks, `HIPSPARSE_DIRECTION_ROW` or
   !>   `HIPSPARSE_DIRECTION_COLUMN`.
-  !>   @param[in]
-  !>   mb                 number of block rows of the general BSR sparse matrix \f$A\f$.
-  !>   @param[in]
-  !>   nb                 number of block columns of the general BSR sparse matrix \f$A\f$.
-  !>   @param[in]
-  !>   nnzb               number of blocks in the general BSR sparse matrix \f$A\f$.
-  !>   @param[in]
-  !>   descrA the descriptor of the general BSR sparse matrix \f$A\f$. The supported matrix type is
+  !>   @param[in] mb - number of block rows of the general BSR sparse matrix \f$A\f$.
+  !>   @param[in] nb - number of block columns of the general BSR sparse matrix \f$A\f$.
+  !>   @param[in] nnzb - number of blocks in the general BSR sparse matrix \f$A\f$.
+  !>   @param[in] descrA - the descriptor of the general BSR sparse matrix \f$A\f$. The supported
+  !>   matrix type is
   !>                      `HIPSPARSE_MATRIX_TYPE_GENERAL` and any valid value of the
   !>                      `hipsparseIndexBase_t`.
-  !>   @param[in]
-  !>   bsrRowPtrA array of \p mb+1 elements that point to the start of every block row of the
+  !>   @param[in] bsrRowPtrA - array of \p mb+1 elements that point to the start of every block row
+  !>   of the
   !>                      sparse general BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   bsrColIndA array of \p nnzb elements containing the block column indices of the sparse
-  !>   general BSR matrix \p A.
-  !>   @param[in]
-  !>   rowBlockDimA       row size of the blocks in the sparse general BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   colBlockDimA       column size of the blocks in the sparse general BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   descrC the descriptor of the general BSR sparse matrix \f$C\f$. The supported matrix type is
+  !>   @param[in] bsrColIndA - array of \p nnzb elements containing the block column indices of the
+  !>   sparse general BSR matrix \p A.
+  !>   @param[in] rowBlockDimA - row size of the blocks in the sparse general BSR matrix \f$A\f$.
+  !>   @param[in] colBlockDimA - column size of the blocks in the sparse general BSR matrix \f$A\f$.
+  !>   @param[in] descrC - the descriptor of the general BSR sparse matrix \f$C\f$. The supported
+  !>   matrix type is
   !>                      `HIPSPARSE_MATRIX_TYPE_GENERAL` and any valid value of the
   !>                      `hipsparseIndexBase_t`.
-  !>   @param[in]
-  !>   bsrRowPtrC array of \p mbC+1 elements that point to the start of every block row of the
+  !>   @param[in] bsrRowPtrC - array of \p mbC+1 elements that point to the start of every block row
+  !>   of the
   !>                      sparse general BSR matrix \f$C\f$ where \p mbC = ( \p m+rowBlockDimC-1 ) /
   !>                      \p rowBlockDimC.
-  !>   @param[in]
-  !>   rowBlockDimC       row size of the blocks in the sparse general BSR matrix \f$C\f$.
-  !>   @param[in]
-  !>   colBlockDimC       column size of the blocks in the sparse general BSR matrix \f$C\f$.
-  !>   @param[out]
-  !>   nnzTotalDevHostPtr total number of non-zero blocks in general BSR sparse matrix \f$C\f$,
-  !>   stored using device or host memory.
-  !>   @param[out]
-  !>   buffer buffer allocated by the user. The size is determined by calling
+  !>   @param[in] rowBlockDimC - row size of the blocks in the sparse general BSR matrix \f$C\f$.
+  !>   @param[in] colBlockDimC - column size of the blocks in the sparse general BSR matrix \f$C\f$.
+  !>   @param[out] nnzTotalDevHostPtr - total number of non-zero blocks in general BSR sparse matrix
+  !>   \f$C\f$, stored using device or host memory.
+  !>   @param[out] buffer - buffer allocated by the user. The size is determined by calling
   !>   `hipsparseSgebsr2gebsr_bufferSize`
   !>                      "hipsparseXgebsr2gebsr_bufferSize()".
   !>
@@ -19488,53 +18468,39 @@ module hipfort_hipsparse
   !>   \right]
   !>   \f]
   !>
-  !>   @param[in]
-  !>   handle        handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   dirA the storage format of the blocks, `HIPSPARSE_DIRECTION_ROW` or
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] dirA - the storage format of the blocks, `HIPSPARSE_DIRECTION_ROW` or
   !>   `HIPSPARSE_DIRECTION_COLUMN`.
-  !>   @param[in]
-  !>   mb            number of block rows of the general BSR sparse matrix \f$A\f$.
-  !>   @param[in]
-  !>   nb            number of block columns of the general BSR sparse matrix \f$A\f$.
-  !>   @param[in]
-  !>   nnzb          number of blocks in the general BSR sparse matrix \f$A\f$.
-  !>   @param[in]
-  !>   descrA the descriptor of the general BSR sparse matrix \f$A\f$. The supported matrix type is
+  !>   @param[in] mb - number of block rows of the general BSR sparse matrix \f$A\f$.
+  !>   @param[in] nb - number of block columns of the general BSR sparse matrix \f$A\f$.
+  !>   @param[in] nnzb - number of blocks in the general BSR sparse matrix \f$A\f$.
+  !>   @param[in] descrA - the descriptor of the general BSR sparse matrix \f$A\f$. The supported
+  !>   matrix type is
   !>                 `HIPSPARSE_MATRIX_TYPE_GENERAL` and also any valid value of the
   !>                 `hipsparseIndexBase_t`.
-  !>   @param[in]
-  !>   bsrValA array of \p nnzb*rowBlockDimA*colBlockDimA containing the values of the sparse
-  !>   general BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   bsrRowPtrA    array of \p mb+1 elements that point to the start of every block row of the
+  !>   @param[in] bsrValA - array of \p nnzb*rowBlockDimA*colBlockDimA containing the values of the
+  !>   sparse general BSR matrix \f$A\f$.
+  !>   @param[in] bsrRowPtrA - array of \p mb+1 elements that point to the start of every block row
+  !>   of the
   !>                 sparse general BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   bsrColIndA array of \p nnzb elements containing the block column indices of the sparse
-  !>   general BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   rowBlockDimA  row size of the blocks in the sparse general BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   colBlockDimA  column size of the blocks in the sparse general BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   descrC the descriptor of the general BSR sparse matrix \f$C\f$. The supported matrix type is
+  !>   @param[in] bsrColIndA - array of \p nnzb elements containing the block column indices of the
+  !>   sparse general BSR matrix \f$A\f$.
+  !>   @param[in] rowBlockDimA - row size of the blocks in the sparse general BSR matrix \f$A\f$.
+  !>   @param[in] colBlockDimA - column size of the blocks in the sparse general BSR matrix \f$A\f$.
+  !>   @param[in] descrC - the descriptor of the general BSR sparse matrix \f$C\f$. The supported
+  !>   matrix type is
   !>                 `HIPSPARSE_MATRIX_TYPE_GENERAL` and any valid value of the
   !>                 `hipsparseIndexBase_t`.
-  !>   @param[in]
-  !>   bsrValC array of \p nnzbC*rowBlockDimC*colBlockDimC containing the values of the sparse
-  !>   general BSR matrix \f$C\f$.
-  !>   @param[in]
-  !>   bsrRowPtrC    array of \p mbC+1 elements that point to the start of every block row of the
+  !>   @param[in] bsrValC - array of \p nnzbC*rowBlockDimC*colBlockDimC containing the values of the
+  !>   sparse general BSR matrix \f$C\f$.
+  !>   @param[in] bsrRowPtrC - array of \p mbC+1 elements that point to the start of every block row
+  !>   of the
   !>                 sparse general BSR matrix \f$C\f$.
-  !>   @param[in]
-  !>   bsrColIndC array of \p nnzbC elements containing the block column indices of the sparse
-  !>   general BSR matrix \f$C\f$.
-  !>   @param[in]
-  !>   rowBlockDimC  row size of the blocks in the sparse general BSR matrix \f$C\f$.
-  !>   @param[in]
-  !>   colBlockDimC  column size of the blocks in the sparse general BSR matrix \f$C\f$.
-  !>   @param[out]
-  !>   buffer buffer allocated by the user. The size is determined by calling
+  !>   @param[in] bsrColIndC - array of \p nnzbC elements containing the block column indices of the
+  !>   sparse general BSR matrix \f$C\f$.
+  !>   @param[in] rowBlockDimC - row size of the blocks in the sparse general BSR matrix \f$C\f$.
+  !>   @param[in] colBlockDimC - column size of the blocks in the sparse general BSR matrix \f$C\f$.
+  !>   @param[out] buffer - buffer allocated by the user. The size is determined by calling
   !>   `hipsparseSgebsr2gebsr_bufferSize`
   !>                 "hipsparseXgebsr2gebsr_bufferSize()".
   !>
@@ -19730,20 +18696,15 @@ module hipfort_hipsparse
   !>   This function is deprecated when using the CUDA backend (CUDA 10.0+) and will be
   !>   removed in CUDA 11.0. This deprecation does not apply to the ROCm backend.
   !>
-  !>   @param[in]
-  !>   handle            handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   descrA            descriptor of the sparse HYB matrix. Currently, only
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] descrA - descriptor of the sparse HYB matrix. Currently, only
   !>                     `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[in]
-  !>   hybA              sparse matrix in HYB format.
-  !>   @param[out]
-  !>   csrSortedValA     array containing the values of the sparse CSR matrix.
-  !>   @param[out]
-  !>   csrSortedRowPtrA  array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] hybA - sparse matrix in HYB format.
+  !>   @param[out] csrSortedValA - array containing the values of the sparse CSR matrix.
+  !>   @param[out] csrSortedRowPtrA - array of \p m+1 elements that point to the start of every row
+  !>   of the
   !>                     sparse CSR matrix.
-  !>   @param[out]
-  !>   csrSortedColIndA  array containing the column indices of the sparse CSR matrix.
+  !>   @param[out] csrSortedColIndA - array containing the column indices of the sparse CSR matrix.
   !>
   !>   \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
   !>   \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
@@ -19899,26 +18860,18 @@ module hipfort_hipsparse
   !>   \note
   !>   The routine supports asynchronous execution if the pointer mode is set to device.
   !>
-  !>   @param[in]
-  !>   handle             handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   dirA direction that specifies whether to count non-zero elements by `HIPSPARSE_DIRECTION_ROW`
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] dirA - direction that specifies whether to count non-zero elements by
+  !>   `HIPSPARSE_DIRECTION_ROW`
   !>                      or by `HIPSPARSE_DIRECTION_COLUMN`.
-  !>   @param[in]
-  !>   m                  number of rows of the dense matrix \p A. Must be non-negative.
-  !>   @param[in]
-  !>   n                  number of columns of the dense matrix \p A. Must be non-negative.
-  !>   @param[in]
-  !>   descrA             the descriptor of the dense matrix \p A.
-  !>   @param[in]
-  !>   A                  array of dimensions (\p lda, \p n).
-  !>   @param[in]
-  !>   lda                leading dimension of dense array \p A. Must be at least \p m.
-  !>   @param[out]
-  !>   nnzPerRowColumn array of size \p m or \p n containing the number of non-zero elements per row
-  !>   or column, respectively.
-  !>   @param[out]
-  !>   nnzTotalDevHostPtr total number of non-zero elements in device or host memory.
+  !>   @param[in] m - number of rows of the dense matrix \p A. Must be non-negative.
+  !>   @param[in] n - number of columns of the dense matrix \p A. Must be non-negative.
+  !>   @param[in] descrA - the descriptor of the dense matrix \p A.
+  !>   @param[in] A - array of dimensions (\p lda, \p n).
+  !>   @param[in] lda - leading dimension of dense array \p A. Must be at least \p m.
+  !>   @param[out] nnzPerRowColumn - array of size \p m or \p n containing the number of non-zero
+  !>   elements per row or column, respectively.
+  !>   @param[out] nnzTotalDevHostPtr - total number of non-zero elements in device or host memory.
   !>
   !>   \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
   !>   \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
@@ -20076,26 +19029,20 @@ module hipfort_hipsparse
   !>   \note
   !>   In the case of complex matrices, only the magnitude of the real part of \p tol is used.
   !>
-  !>   @param[in]
-  !>   handle        handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m             number of rows of the sparse CSR matrix.
-  !>   @param[in]
-  !>   descrA        the descriptor of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csrValA       array of \p nnzA elements of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csrRowPtrA    array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
+  !>   @param[in] descrA - the descriptor of the sparse CSR matrix.
+  !>   @param[in] csrValA - array of \p nnzA elements of the sparse CSR matrix.
+  !>   @param[in] csrRowPtrA - array of \p m+1 elements that point to the start of every row of the
   !>                 uncompressed sparse CSR matrix.
-  !>   @param[out]
-  !>   nnzPerRow array of length \p m containing the number of entries that will be kept per row in
+  !>   @param[out] nnzPerRow - array of length \p m containing the number of entries that will be
+  !>   kept per row in
   !>                 the final compressed CSR matrix.
-  !>   @param[out]
-  !>   nnzC          number of elements in the column indices and values arrays of the compressed
+  !>   @param[out] nnzC - number of elements in the column indices and values arrays of the
+  !>   compressed
   !>                 sparse CSR matrix. Can be either host or device pointer.
-  !>   @param[in]
-  !>   tol the non-negative tolerance used for compression. If \p tol is complex, then only the
-  !>   magnitude
+  !>   @param[in] tol - the non-negative tolerance used for compression. If \p tol is complex, then
+  !>   only the magnitude
   !>                 of the real part is used. Entries in the input uncompressed CSR array that are
   !>                 below the tolerance
   !>                 are removed in output compressed CSR matrix.
@@ -20228,41 +19175,29 @@ module hipfort_hipsparse
   !>   is required by \p hipsparseXpruneCsr2csrNnz and \p hipsparseXpruneCsr2csr. The
   !>   temporary storage buffer must be allocated by the user.
   !>
-  !>   @param[in]
-  !>   handle             handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m                  number of rows in the sparse CSR matrix.
-  !>   @param[in]
-  !>   n                  number of columns in the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnzA               number of non-zeros in the sparse CSR matrix A.
-  !>   @param[in]
-  !>   descrA             descriptor of the sparse CSR matrix A. Currently, only
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - number of rows in the sparse CSR matrix.
+  !>   @param[in] n - number of columns in the sparse CSR matrix.
+  !>   @param[in] nnzA - number of non-zeros in the sparse CSR matrix A.
+  !>   @param[in] descrA - descriptor of the sparse CSR matrix A. Currently, only
   !>                      `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[in]
-  !>   csrValA array of \p nnzA elements containing the values of the sparse CSR matrix A.
-  !>   @param[in]
-  !>   csrRowPtrA         array of \p m+1 elements that point to the start of every row of the
-  !>                      sparse CSR matrix A.
-  !>   @param[in]
-  !>   csrColIndA array of \p nnzA elements containing the column indices of the sparse CSR matrix
+  !>   @param[in] csrValA - array of \p nnzA elements containing the values of the sparse CSR matrix
   !>   A.
-  !>   @param[in]
-  !>   threshold pointer to the non-negative pruning threshold, which can exist in either host or
-  !>   device memory.
-  !>   @param[in]
-  !>   descrC             descriptor of the sparse CSR matrix C. Currently, only
+  !>   @param[in] csrRowPtrA - array of \p m+1 elements that point to the start of every row of the
+  !>                      sparse CSR matrix A.
+  !>   @param[in] csrColIndA - array of \p nnzA elements containing the column indices of the sparse
+  !>   CSR matrix A.
+  !>   @param[in] threshold - pointer to the non-negative pruning threshold, which can exist in
+  !>   either host or device memory.
+  !>   @param[in] descrC - descriptor of the sparse CSR matrix C. Currently, only
   !>                      `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[in]
-  !>   csrValC array of \p nnzC elements containing the values of the sparse CSR matrix C.
-  !>   @param[in]
-  !>   csrRowPtrC         array of \p m+1 elements that point to the start of every row of the
-  !>                      sparse CSR matrix C.
-  !>   @param[in]
-  !>   csrColIndC array of \p nnzC elements containing the column indices of the sparse CSR matrix
+  !>   @param[in] csrValC - array of \p nnzC elements containing the values of the sparse CSR matrix
   !>   C.
-  !>   @param[out]
-  !>   pBufferSizeInBytes number of bytes of the temporary storage buffer required by
+  !>   @param[in] csrRowPtrC - array of \p m+1 elements that point to the start of every row of the
+  !>                      sparse CSR matrix C.
+  !>   @param[in] csrColIndC - array of \p nnzC elements containing the column indices of the sparse
+  !>   CSR matrix C.
+  !>   @param[out] pBufferSizeInBytes - number of bytes of the temporary storage buffer required by
   !>   `hipsparseSpruneCsr2csrNnz()`,
   !>                      hipsparseDpruneCsr2csrNnz(), `hipsparseSpruneCsr2csr()`, and
   !>                      hipsparseDpruneCsr2csr().
@@ -20345,41 +19280,29 @@ module hipfort_hipsparse
   !>   `hipsparseSpruneCsr2csr` "hipsparseXpruneCsr2csr()". The temporary storage buffer
   !>   must be allocated by the user.
   !>
-  !>   @param[in]
-  !>   handle             handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m                  number of rows in the sparse CSR matrix.
-  !>   @param[in]
-  !>   n                  number of columns in the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnzA               number of non-zeros in the sparse CSR matrix A.
-  !>   @param[in]
-  !>   descrA             descriptor of the sparse CSR matrix A. Currently, only
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - number of rows in the sparse CSR matrix.
+  !>   @param[in] n - number of columns in the sparse CSR matrix.
+  !>   @param[in] nnzA - number of non-zeros in the sparse CSR matrix A.
+  !>   @param[in] descrA - descriptor of the sparse CSR matrix A. Currently, only
   !>                      `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[in]
-  !>   csrValA array of \p nnzA elements containing the values of the sparse CSR matrix A.
-  !>   @param[in]
-  !>   csrRowPtrA         array of \p m+1 elements that point to the start of every row of the
-  !>                      sparse CSR matrix A.
-  !>   @param[in]
-  !>   csrColIndA array of \p nnzA elements containing the column indices of the sparse CSR matrix
+  !>   @param[in] csrValA - array of \p nnzA elements containing the values of the sparse CSR matrix
   !>   A.
-  !>   @param[in]
-  !>   threshold pointer to the non-negative pruning threshold, which can exist in either host or
-  !>   device memory.
-  !>   @param[in]
-  !>   descrC             descriptor of the sparse CSR matrix C. Currently, only
+  !>   @param[in] csrRowPtrA - array of \p m+1 elements that point to the start of every row of the
+  !>                      sparse CSR matrix A.
+  !>   @param[in] csrColIndA - array of \p nnzA elements containing the column indices of the sparse
+  !>   CSR matrix A.
+  !>   @param[in] threshold - pointer to the non-negative pruning threshold, which can exist in
+  !>   either host or device memory.
+  !>   @param[in] descrC - descriptor of the sparse CSR matrix C. Currently, only
   !>                      `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[in]
-  !>   csrValC array of \p nnzC elements containing the values of the sparse CSR matrix C.
-  !>   @param[in]
-  !>   csrRowPtrC         array of \p m+1 elements that point to the start of every row of the
-  !>                      sparse CSR matrix C.
-  !>   @param[in]
-  !>   csrColIndC array of \p nnzC elements containing the column indices of the sparse CSR matrix
+  !>   @param[in] csrValC - array of \p nnzC elements containing the values of the sparse CSR matrix
   !>   C.
-  !>   @param[out]
-  !>   pBufferSizeInBytes number of bytes of the temporary storage buffer required by
+  !>   @param[in] csrRowPtrC - array of \p m+1 elements that point to the start of every row of the
+  !>                      sparse CSR matrix C.
+  !>   @param[in] csrColIndC - array of \p nnzC elements containing the column indices of the sparse
+  !>   CSR matrix C.
+  !>   @param[out] pBufferSizeInBytes - number of bytes of the temporary storage buffer required by
   !>   `hipsparseSpruneCsr2csrNnz()`,
   !>                      hipsparseDpruneCsr2csrNnz(), `hipsparseSpruneCsr2csr()`, and
   !>                      hipsparseDpruneCsr2csr().
@@ -20471,38 +19394,26 @@ module hipfort_hipsparse
   !>
   !>   \note The routine supports asynchronous execution if the pointer mode is set to device.
   !>
-  !>   @param[in]
-  !>   handle             handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m                  number of rows in the sparse CSR matrix.
-  !>   @param[in]
-  !>   n                  number of columns in the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnzA               number of non-zeros in the sparse CSR matrix A.
-  !>   @param[in]
-  !>   descrA             descriptor of the sparse CSR matrix A. Currently, only
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - number of rows in the sparse CSR matrix.
+  !>   @param[in] n - number of columns in the sparse CSR matrix.
+  !>   @param[in] nnzA - number of non-zeros in the sparse CSR matrix A.
+  !>   @param[in] descrA - descriptor of the sparse CSR matrix A. Currently, only
   !>                      `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[in]
-  !>   csrValA array of \p nnzA elements containing the values of the sparse CSR matrix A.
-  !>   @param[in]
-  !>   csrRowPtrA         array of \p m+1 elements that point to the start of every row of the
-  !>                      sparse CSR matrix A.
-  !>   @param[in]
-  !>   csrColIndA array of \p nnzA elements containing the column indices of the sparse CSR matrix
+  !>   @param[in] csrValA - array of \p nnzA elements containing the values of the sparse CSR matrix
   !>   A.
-  !>   @param[in]
-  !>   threshold pointer to the non-negative pruning threshold which can exist in either host or
-  !>   device memory.
-  !>   @param[in]
-  !>   descrC             descriptor of the sparse CSR matrix C. Currently, only
+  !>   @param[in] csrRowPtrA - array of \p m+1 elements that point to the start of every row of the
+  !>                      sparse CSR matrix A.
+  !>   @param[in] csrColIndA - array of \p nnzA elements containing the column indices of the sparse
+  !>   CSR matrix A.
+  !>   @param[in] threshold - pointer to the non-negative pruning threshold which can exist in
+  !>   either host or device memory.
+  !>   @param[in] descrC - descriptor of the sparse CSR matrix C. Currently, only
   !>                      `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[out]
-  !>   csrRowPtrC         array of \p m+1 elements that point to the start of every row of the
+  !>   @param[out] csrRowPtrC - array of \p m+1 elements that point to the start of every row of the
   !>                      sparse CSR matrix C.
-  !>   @param[out]
-  !>   nnzTotalDevHostPtr total number of nonzero elements in device or host memory.
-  !>   @param[out]
-  !>   buffer buffer allocated by the user whose size is determined by calling
+  !>   @param[out] nnzTotalDevHostPtr - total number of nonzero elements in device or host memory.
+  !>   @param[out] buffer - buffer allocated by the user whose size is determined by calling
   !>   `hipsparseSpruneCsr2csr_bufferSize`
   !>                      "hipsparseXpruneCsr2csr_bufferSize()".
   !>
@@ -20607,41 +19518,29 @@ module hipfort_hipsparse
   !>   with respect to the host and can return control to the application on the host before the
   !>   entire result is ready.
   !>
-  !>   @param[in]
-  !>   handle        handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m             number of rows in the sparse CSR matrix.
-  !>   @param[in]
-  !>   n             number of columns in the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnzA          number of non-zeros in the sparse CSR matrix A.
-  !>   @param[in]
-  !>   descrA        descriptor of the sparse CSR matrix A. Currently, only
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - number of rows in the sparse CSR matrix.
+  !>   @param[in] n - number of columns in the sparse CSR matrix.
+  !>   @param[in] nnzA - number of non-zeros in the sparse CSR matrix A.
+  !>   @param[in] descrA - descriptor of the sparse CSR matrix A. Currently, only
   !>                 `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[in]
-  !>   csrValA       array of \p nnzA elements containing the values of the sparse CSR matrix A.
-  !>   @param[in]
-  !>   csrRowPtrA    array of \p m+1 elements that point to the start of every row of the
-  !>                 sparse CSR matrix A.
-  !>   @param[in]
-  !>   csrColIndA array of \p nnzA elements containing the column indices of the sparse CSR matrix
+  !>   @param[in] csrValA - array of \p nnzA elements containing the values of the sparse CSR matrix
   !>   A.
-  !>   @param[in]
-  !>   threshold pointer to the non-negative pruning threshold which can exist in either host or
-  !>   device memory.
-  !>   @param[in]
-  !>   descrC        descriptor of the sparse CSR matrix C. Currently, only
+  !>   @param[in] csrRowPtrA - array of \p m+1 elements that point to the start of every row of the
+  !>                 sparse CSR matrix A.
+  !>   @param[in] csrColIndA - array of \p nnzA elements containing the column indices of the sparse
+  !>   CSR matrix A.
+  !>   @param[in] threshold - pointer to the non-negative pruning threshold which can exist in
+  !>   either host or device memory.
+  !>   @param[in] descrC - descriptor of the sparse CSR matrix C. Currently, only
   !>                 `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[out]
-  !>   csrValC       array of \p nnzC elements containing the values of the sparse CSR matrix C.
-  !>   @param[in]
-  !>   csrRowPtrC    array of \p m+1 elements that point to the start of every row of the
+  !>   @param[out] csrValC - array of \p nnzC elements containing the values of the sparse CSR
+  !>   matrix C.
+  !>   @param[in] csrRowPtrC - array of \p m+1 elements that point to the start of every row of the
   !>                 sparse CSR matrix C.
-  !>   @param[out]
-  !>   csrColIndC array of \p nnzC elements containing the column indices of the sparse CSR matrix
-  !>   C.
-  !>   @param[in]
-  !>   buffer buffer allocated by the user whose size is determined by calling
+  !>   @param[out] csrColIndC - array of \p nnzC elements containing the column indices of the
+  !>   sparse CSR matrix C.
+  !>   @param[in] buffer - buffer allocated by the user whose size is determined by calling
   !>   `hipsparseSpruneCsr2csr_bufferSize`
   !>                 "hipsparseXpruneCsr2csr_bufferSize()".
   !>
@@ -20734,42 +19633,29 @@ module hipfort_hipsparse
   !>   "hipsparseXpruneCsr2csrNnzByPercentage()".
   !>   The temporary storage buffer must be allocated by the user.
   !>
-  !>   @param[in]
-  !>   handle              handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m                   number of rows in the sparse CSR matrix.
-  !>   @param[in]
-  !>   n                   number of columns in the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnzA                number of non-zeros in the sparse CSR matrix A.
-  !>   @param[in]
-  !>   descrA              descriptor of the sparse CSR matrix A. Currently, only
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - number of rows in the sparse CSR matrix.
+  !>   @param[in] n - number of columns in the sparse CSR matrix.
+  !>   @param[in] nnzA - number of non-zeros in the sparse CSR matrix A.
+  !>   @param[in] descrA - descriptor of the sparse CSR matrix A. Currently, only
   !>                       `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[in]
-  !>   csrValA array of \p nnzA elements containing the values of the sparse CSR matrix A.
-  !>   @param[in]
-  !>   csrRowPtrA          array of \p m+1 elements that point to the start of every row of the
-  !>                       sparse CSR matrix A.
-  !>   @param[in]
-  !>   csrColIndA array of \p nnzA elements containing the column indices of the sparse CSR matrix
+  !>   @param[in] csrValA - array of \p nnzA elements containing the values of the sparse CSR matrix
   !>   A.
-  !>   @param[in]
-  !>   percentage          \p percentage>=0 and \p percentage<=100.
-  !>   @param[in]
-  !>   descrC              descriptor of the sparse CSR matrix C. Currently, only
+  !>   @param[in] csrRowPtrA - array of \p m+1 elements that point to the start of every row of the
+  !>                       sparse CSR matrix A.
+  !>   @param[in] csrColIndA - array of \p nnzA elements containing the column indices of the sparse
+  !>   CSR matrix A.
+  !>   @param[in] percentage - \p percentage>=0 and \p percentage<=100.
+  !>   @param[in] descrC - descriptor of the sparse CSR matrix C. Currently, only
   !>                       `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[in]
-  !>   csrValC array of \p nnzC elements containing the values of the sparse CSR matrix C.
-  !>   @param[in]
-  !>   csrRowPtrC          array of \p m+1 elements that point to the start of every row of the
-  !>                       sparse CSR matrix C.
-  !>   @param[in]
-  !>   csrColIndC array of \p nnzC elements containing the column indices of the sparse CSR matrix
+  !>   @param[in] csrValC - array of \p nnzC elements containing the values of the sparse CSR matrix
   !>   C.
-  !>   @param[in]
-  !>   info                prune info structure.
-  !>   @param[out]
-  !>   pBufferSizeInBytes number of bytes of the temporary storage buffer required by
+  !>   @param[in] csrRowPtrC - array of \p m+1 elements that point to the start of every row of the
+  !>                       sparse CSR matrix C.
+  !>   @param[in] csrColIndC - array of \p nnzC elements containing the column indices of the sparse
+  !>   CSR matrix C.
+  !>   @param[in] myInfo - prune info structure.
+  !>   @param[out] pBufferSizeInBytes - number of bytes of the temporary storage buffer required by
   !>   `hipsparseSpruneCsr2csrNnzByPercentage()`,
   !>                       hipsparseDpruneCsr2csrNnzByPercentage(),
   !>                       hipsparseSpruneCsr2csrByPercentage(),
@@ -20858,42 +19744,29 @@ module hipfort_hipsparse
   !>   "hipsparseXpruneCsr2csrNnzByPercentage()".
   !>   The temporary storage buffer must be allocated by the user.
   !>
-  !>   @param[in]
-  !>   handle              handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m                   number of rows in the sparse CSR matrix.
-  !>   @param[in]
-  !>   n                   number of columns in the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnzA                number of non-zeros in the sparse CSR matrix A.
-  !>   @param[in]
-  !>   descrA              descriptor of the sparse CSR matrix A. Currently, only
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - number of rows in the sparse CSR matrix.
+  !>   @param[in] n - number of columns in the sparse CSR matrix.
+  !>   @param[in] nnzA - number of non-zeros in the sparse CSR matrix A.
+  !>   @param[in] descrA - descriptor of the sparse CSR matrix A. Currently, only
   !>                       `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[in]
-  !>   csrValA array of \p nnzA elements containing the values of the sparse CSR matrix A.
-  !>   @param[in]
-  !>   csrRowPtrA          array of \p m+1 elements that point to the start of every row of the
-  !>                       sparse CSR matrix A.
-  !>   @param[in]
-  !>   csrColIndA array of \p nnzA elements containing the column indices of the sparse CSR matrix
+  !>   @param[in] csrValA - array of \p nnzA elements containing the values of the sparse CSR matrix
   !>   A.
-  !>   @param[in]
-  !>   percentage          \p percentage>=0 and \p percentage<=100.
-  !>   @param[in]
-  !>   descrC              descriptor of the sparse CSR matrix C. Currently, only
+  !>   @param[in] csrRowPtrA - array of \p m+1 elements that point to the start of every row of the
+  !>                       sparse CSR matrix A.
+  !>   @param[in] csrColIndA - array of \p nnzA elements containing the column indices of the sparse
+  !>   CSR matrix A.
+  !>   @param[in] percentage - \p percentage>=0 and \p percentage<=100.
+  !>   @param[in] descrC - descriptor of the sparse CSR matrix C. Currently, only
   !>                       `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[in]
-  !>   csrValC array of \p nnzC elements containing the values of the sparse CSR matrix C.
-  !>   @param[in]
-  !>   csrRowPtrC          array of \p m+1 elements that point to the start of every row of the
-  !>                       sparse CSR matrix C.
-  !>   @param[in]
-  !>   csrColIndC array of \p nnzC elements containing the column indices of the sparse CSR matrix
+  !>   @param[in] csrValC - array of \p nnzC elements containing the values of the sparse CSR matrix
   !>   C.
-  !>   @param[in]
-  !>   info                prune info structure.
-  !>   @param[out]
-  !>   pBufferSizeInBytes number of bytes of the temporary storage buffer required by
+  !>   @param[in] csrRowPtrC - array of \p m+1 elements that point to the start of every row of the
+  !>                       sparse CSR matrix C.
+  !>   @param[in] csrColIndC - array of \p nnzC elements containing the column indices of the sparse
+  !>   CSR matrix C.
+  !>   @param[in] myInfo - prune info structure.
+  !>   @param[out] pBufferSizeInBytes - number of bytes of the temporary storage buffer required by
   !>   `hipsparseSpruneCsr2csrNnzByPercentage()`,
   !>                       hipsparseDpruneCsr2csrNnzByPercentage(),
   !>                       hipsparseSpruneCsr2csrByPercentage(),
@@ -20993,39 +19866,26 @@ module hipfort_hipsparse
   !>
   !>   \note The routine supports asynchronous execution if the pointer mode is set to device.
   !>
-  !>   @param[in]
-  !>   handle             handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m                  number of rows in the sparse CSR matrix.
-  !>   @param[in]
-  !>   n                  number of columns in the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnzA               number of non-zeros in the sparse CSR matrix A.
-  !>   @param[in]
-  !>   descrA             descriptor of the sparse CSR matrix A. Currently, only
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - number of rows in the sparse CSR matrix.
+  !>   @param[in] n - number of columns in the sparse CSR matrix.
+  !>   @param[in] nnzA - number of non-zeros in the sparse CSR matrix A.
+  !>   @param[in] descrA - descriptor of the sparse CSR matrix A. Currently, only
   !>                      `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[in]
-  !>   csrValA array of \p nnzA elements containing the values of the sparse CSR matrix A.
-  !>   @param[in]
-  !>   csrRowPtrA         array of \p m+1 elements that point to the start of every row of the
-  !>                      sparse CSR matrix A.
-  !>   @param[in]
-  !>   csrColIndA array of \p nnzA elements containing the column indices of the sparse CSR matrix
+  !>   @param[in] csrValA - array of \p nnzA elements containing the values of the sparse CSR matrix
   !>   A.
-  !>   @param[in]
-  !>   percentage         \p percentage>=0 and \p percentage<=100.
-  !>   @param[in]
-  !>   descrC             descriptor of the sparse CSR matrix C. Currently, only
+  !>   @param[in] csrRowPtrA - array of \p m+1 elements that point to the start of every row of the
+  !>                      sparse CSR matrix A.
+  !>   @param[in] csrColIndA - array of \p nnzA elements containing the column indices of the sparse
+  !>   CSR matrix A.
+  !>   @param[in] percentage - \p percentage>=0 and \p percentage<=100.
+  !>   @param[in] descrC - descriptor of the sparse CSR matrix C. Currently, only
   !>                      `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[out]
-  !>   csrRowPtrC         array of \p m+1 elements that point to the start of every row of the
+  !>   @param[out] csrRowPtrC - array of \p m+1 elements that point to the start of every row of the
   !>                      sparse CSR matrix C.
-  !>   @param[out]
-  !>   nnzTotalDevHostPtr total number of non-zero elements in device or host memory.
-  !>   @param[in]
-  !>   info               prune info structure.
-  !>   @param[out]
-  !>   buffer             buffer allocated by the user whose size is determined by calling
+  !>   @param[out] nnzTotalDevHostPtr - total number of non-zero elements in device or host memory.
+  !>   @param[in] myInfo - prune info structure.
+  !>   @param[out] buffer - buffer allocated by the user whose size is determined by calling
   !>                      `hipsparseSpruneCsr2csrByPercentage_bufferSize`
   !>                      "hipsparseXpruneCsr2csrByPercentage_bufferSize()".
   !>
@@ -21133,42 +19993,29 @@ module hipfort_hipsparse
   !>   on the host
   !>   before the entire result is ready.
   !>
-  !>   @param[in]
-  !>   handle        handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m             number of rows in the sparse CSR matrix.
-  !>   @param[in]
-  !>   n             number of columns in the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnzA          number of non-zeros in the sparse CSR matrix A.
-  !>   @param[in]
-  !>   descrA        descriptor of the sparse CSR matrix A. Currently, only
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - number of rows in the sparse CSR matrix.
+  !>   @param[in] n - number of columns in the sparse CSR matrix.
+  !>   @param[in] nnzA - number of non-zeros in the sparse CSR matrix A.
+  !>   @param[in] descrA - descriptor of the sparse CSR matrix A. Currently, only
   !>                 `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[in]
-  !>   csrValA       array of \p nnzA elements containing the values of the sparse CSR matrix A.
-  !>   @param[in]
-  !>   csrRowPtrA    array of \p m+1 elements that point to the start of every row of the
-  !>                 sparse CSR matrix A.
-  !>   @param[in]
-  !>   csrColIndA array of \p nnzA elements containing the column indices of the sparse CSR matrix
+  !>   @param[in] csrValA - array of \p nnzA elements containing the values of the sparse CSR matrix
   !>   A.
-  !>   @param[in]
-  !>   percentage    \p percentage>=0 and \p percentage<=100.
-  !>   @param[in]
-  !>   descrC        descriptor of the sparse CSR matrix C. Currently, only
+  !>   @param[in] csrRowPtrA - array of \p m+1 elements that point to the start of every row of the
+  !>                 sparse CSR matrix A.
+  !>   @param[in] csrColIndA - array of \p nnzA elements containing the column indices of the sparse
+  !>   CSR matrix A.
+  !>   @param[in] percentage - \p percentage>=0 and \p percentage<=100.
+  !>   @param[in] descrC - descriptor of the sparse CSR matrix C. Currently, only
   !>                 `HIPSPARSE_MATRIX_TYPE_GENERAL` is supported.
-  !>   @param[out]
-  !>   csrValC       array of \p nnz_C elements containing the values of the sparse CSR matrix C.
-  !>   @param[in]
-  !>   csrRowPtrC    array of \p m+1 elements that point to the start of every row of the
+  !>   @param[out] csrValC - array of \p nnz_C elements containing the values of the sparse CSR
+  !>   matrix C.
+  !>   @param[in] csrRowPtrC - array of \p m+1 elements that point to the start of every row of the
   !>                 sparse CSR matrix C.
-  !>   @param[out]
-  !>   csrColIndC array of \p nnz_C elements containing the column indices of the sparse CSR matrix
-  !>   C.
-  !>   @param[in]
-  !>   info          prune info structure.
-  !>   @param[in]
-  !>   buffer        buffer allocated by the user whose size is determined by calling
+  !>   @param[out] csrColIndC - array of \p nnz_C elements containing the column indices of the
+  !>   sparse CSR matrix C.
+  !>   @param[in] myInfo - prune info structure.
+  !>   @param[in] buffer - buffer allocated by the user whose size is determined by calling
   !>                 `hipsparseSpruneCsr2csrByPercentage_bufferSize`
   !>                 "hipsparseXpruneCsr2csrByPercentage_bufferSize()".
   !>
@@ -21285,33 +20132,23 @@ module hipfort_hipsparse
   !>   This function is deprecated when using the CUDA backend (CUDA 12.0+) and will be
   !>   removed in CUDA 13.0. This deprecation does not apply to the ROCm backend.
   !>
-  !>   @param[in]
-  !>   handle             handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m                  number of rows of the dense matrix \p A. Must be non-negative.
-  !>   @param[in]
-  !>   n                  number of columns of the dense matrix \p A. Must be non-negative.
-  !>   @param[in]
-  !>   A                  array of dimensions (\p lda, \p n).
-  !>   @param[in]
-  !>   lda                leading dimension of dense array \p A. Must be at least \p m.
-  !>   @param[in]
-  !>   threshold pointer to the pruning non-negative threshold, which can exist in either host or
-  !>   device memory.
-  !>   @param[in]
-  !>   descr the descriptor of the dense matrix \p A. The supported matrix type is
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - number of rows of the dense matrix \p A. Must be non-negative.
+  !>   @param[in] n - number of columns of the dense matrix \p A. Must be non-negative.
+  !>   @param[in] A - array of dimensions (\p lda, \p n).
+  !>   @param[in] lda - leading dimension of dense array \p A. Must be at least \p m.
+  !>   @param[in] threshold - pointer to the pruning non-negative threshold, which can exist in
+  !>   either host or device memory.
+  !>   @param[in] descr - the descriptor of the dense matrix \p A. The supported matrix type is
   !>   `HIPSPARSE_MATRIX_TYPE_GENERAL`
   !>                      and any valid value of the `hipsparseIndexBase_t`.
-  !>   @param[in]
-  !>   csrVal array of nnz ( = \p csrRowPtr[m] - \p csrRowPtr[0] ) non-zero elements of matrix \p A.
-  !>   @param[in]
-  !>   csrRowPtr integer array of \p m+1 elements that contains the start of every row and the end
-  !>   of the last row plus one.
-  !>   @param[in]
-  !>   csrColInd integer array of nnz ( = \p csrRowPtr[m] - \p csrRowPtr[0] ) column indices of the
-  !>   non-zero elements of matrix \p A.
-  !>   @param[out]
-  !>   pBufferSizeInBytes number of bytes of the temporary storage buffer required by
+  !>   @param[in] csrVal - array of nnz ( = \p csrRowPtr[m] - \p csrRowPtr[0] ) non-zero elements of
+  !>   matrix \p A.
+  !>   @param[in] csrRowPtr - integer array of \p m+1 elements that contains the start of every row
+  !>   and the end of the last row plus one.
+  !>   @param[in] csrColInd - integer array of nnz ( = \p csrRowPtr[m] - \p csrRowPtr[0] ) column
+  !>   indices of the non-zero elements of matrix \p A.
+  !>   @param[out] pBufferSizeInBytes - number of bytes of the temporary storage buffer required by
   !>                      `hipsparseSpruneDense2csrNnz()`, hipsparseDpruneDense2csrNnz(),
   !>                      `hipsparseSpruneDense2csr()`, and hipsparseDpruneDense2csr().
   !>
@@ -21517,28 +20354,18 @@ module hipfort_hipsparse
   !>   \note
   !>   The routine supports asynchronous execution if the pointer mode is set to device.
   !>
-  !>   @param[in]
-  !>   handle             handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m                  number of rows of the dense matrix \p A.
-  !>   @param[in]
-  !>   n                  number of columns of the dense matrix \p A.
-  !>   @param[in]
-  !>   A                  array of dimensions (\p lda, \p n).
-  !>   @param[in]
-  !>   lda                leading dimension of the dense array \p A.
-  !>   @param[in]
-  !>   threshold pointer to the pruning non-negative threshold, which can exist in either host or
-  !>   device memory.
-  !>   @param[in]
-  !>   descr              the descriptor of the dense matrix \p A.
-  !>   @param[out]
-  !>   csrRowPtr integer array of \p m+1 elements that contains the start of every row and the end
-  !>   of the last row plus one.
-  !>   @param[out]
-  !>   nnzTotalDevHostPtr total number of non-zero elements in device or host memory.
-  !>   @param[out]
-  !>   buffer             buffer allocated by the user whose size is determined by calling
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - number of rows of the dense matrix \p A.
+  !>   @param[in] n - number of columns of the dense matrix \p A.
+  !>   @param[in] A - array of dimensions (\p lda, \p n).
+  !>   @param[in] lda - leading dimension of the dense array \p A.
+  !>   @param[in] threshold - pointer to the pruning non-negative threshold, which can exist in
+  !>   either host or device memory.
+  !>   @param[in] descr - the descriptor of the dense matrix \p A.
+  !>   @param[out] csrRowPtr - integer array of \p m+1 elements that contains the start of every row
+  !>   and the end of the last row plus one.
+  !>   @param[out] nnzTotalDevHostPtr - total number of non-zero elements in device or host memory.
+  !>   @param[out] buffer - buffer allocated by the user whose size is determined by calling
   !>                      `hipsparseSpruneDense2csr_bufferSize`
   !>                      "hipsparseXpruneDense2csr_bufferSize()" or
   !>                      `hipsparseSpruneDense2csr_bufferSizeExt`
@@ -21679,34 +20506,24 @@ module hipfort_hipsparse
   !>   and can
   !>   return control to the application on the host before the entire result is ready.
   !>
-  !>   @param[in]
-  !>   handle      handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m           number of rows of the dense matrix \p A.
-  !>   @param[in]
-  !>   n           number of columns of the dense matrix \p A.
-  !>   @param[in]
-  !>   A           array of dimensions (\p lda, \p n).
-  !>   @param[in]
-  !>   lda         leading dimension of dense array \p A.
-  !>   @param[in]
-  !>   threshold pointer to the non-negative pruning threshold, which can exist in either host or
-  !>   device memory.
-  !>   @param[in]
-  !>   descr the descriptor of the dense matrix \p A. The supported matrix type is
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - number of rows of the dense matrix \p A.
+  !>   @param[in] n - number of columns of the dense matrix \p A.
+  !>   @param[in] A - array of dimensions (\p lda, \p n).
+  !>   @param[in] lda - leading dimension of dense array \p A.
+  !>   @param[in] threshold - pointer to the non-negative pruning threshold, which can exist in
+  !>   either host or device memory.
+  !>   @param[in] descr - the descriptor of the dense matrix \p A. The supported matrix type is
   !>   `HIPSPARSE_MATRIX_TYPE_GENERAL`
   !>               and any valid value of the `hipsparseIndexBase_t`.
-  !>   @param[out]
-  !>   csrVal array of nnz ( = \p csrRowPtr[m] - \p csrRowPtr[0] ) non-zero elements of matrix \p A.
-  !>   @param[in]
-  !>   csrRowPtr integer array of \p m+1 elements that contains the start of every row and the end
-  !>   of the last row plus one.
-  !>   @param[out]
-  !>   csrColInd integer array of nnz ( = \p csrRowPtr[m] - \p csrRowPtr[0] ) column indices of the
-  !>   non-zero elements of matrix \p A.
+  !>   @param[out] csrVal - array of nnz ( = \p csrRowPtr[m] - \p csrRowPtr[0] ) non-zero elements
+  !>   of matrix \p A.
+  !>   @param[in] csrRowPtr - integer array of \p m+1 elements that contains the start of every row
+  !>   and the end of the last row plus one.
+  !>   @param[out] csrColInd - integer array of nnz ( = \p csrRowPtr[m] - \p csrRowPtr[0] ) column
+  !>   indices of the non-zero elements of matrix \p A.
   !>
-  !>   @param[in]
-  !>   buffer     temporary storage buffer allocated by the user. The size is returned by
+  !>   @param[in] buffer - temporary storage buffer allocated by the user. The size is returned by
   !>              `hipsparseSpruneDense2csr_bufferSize` "hipsparseXpruneDense2csr_bufferSize()" or
   !>              `hipsparseSpruneDense2csr_bufferSizeExt`
   !>              "hipsparseXpruneDense2csr_bufferSizeExt()".
@@ -21822,34 +20639,23 @@ module hipfort_hipsparse
   !>   the
   !>   application on the host before the entire result is ready.
   !>
-  !>   @param[in]
-  !>   handle             handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m                  number of rows of the dense matrix \p A.
-  !>   @param[in]
-  !>   n                  number of columns of the dense matrix \p A.
-  !>   @param[in]
-  !>   A                  array of dimensions (\p lda, \p n).
-  !>   @param[in]
-  !>   lda                leading dimension of dense array \p A.
-  !>   @param[in]
-  !>   percentage         \p percentage>=0 and \p percentage<=100.
-  !>   @param[in]
-  !>   descr the descriptor of the dense matrix \p A. The supported matrix type is
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - number of rows of the dense matrix \p A.
+  !>   @param[in] n - number of columns of the dense matrix \p A.
+  !>   @param[in] A - array of dimensions (\p lda, \p n).
+  !>   @param[in] lda - leading dimension of dense array \p A.
+  !>   @param[in] percentage - \p percentage>=0 and \p percentage<=100.
+  !>   @param[in] descr - the descriptor of the dense matrix \p A. The supported matrix type is
   !>   `HIPSPARSE_MATRIX_TYPE_GENERAL` and
   !>                      any valid value of the `hipsparseIndexBase_t`.
-  !>   @param[in]
-  !>   csrVal array of nnz ( = \p csrRowPtr[m] - \p csrRowPtr[0] ) nonzero elements of matrix \p A.
-  !>   @param[in]
-  !>   csrRowPtr integer array of \p m+1 elements that contains the start of every row and the end
-  !>   of the last row plus one.
-  !>   @param[in]
-  !>   csrColInd integer array of nnz ( = \p csrRowPtr[m] - \p csrRowPtr[0] ) column indices of the
-  !>   non-zero elements of matrix \p A.
-  !>   @param[in]
-  !>   info               prune information structure.
-  !>   @param[out]
-  !>   pBufferSizeInBytes number of bytes of the temporary storage buffer required by
+  !>   @param[in] csrVal - array of nnz ( = \p csrRowPtr[m] - \p csrRowPtr[0] ) nonzero elements of
+  !>   matrix \p A.
+  !>   @param[in] csrRowPtr - integer array of \p m+1 elements that contains the start of every row
+  !>   and the end of the last row plus one.
+  !>   @param[in] csrColInd - integer array of nnz ( = \p csrRowPtr[m] - \p csrRowPtr[0] ) column
+  !>   indices of the non-zero elements of matrix \p A.
+  !>   @param[in] myInfo - prune information structure.
+  !>   @param[out] pBufferSizeInBytes - number of bytes of the temporary storage buffer required by
   !>                      `hipsparseSpruneDense2csrNnzByPercentage()` and
   !>                      hipsparseDpruneDense2csrNnzByPercentage().
   !>
@@ -21955,34 +20761,23 @@ module hipfort_hipsparse
   !>   the
   !>   application on the host before the entire result is ready.
   !>
-  !>   @param[in]
-  !>   handle             handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m                  number of rows of the dense matrix \p A.
-  !>   @param[in]
-  !>   n                  number of columns of the dense matrix \p A.
-  !>   @param[in]
-  !>   A                  array of dimensions (\p lda, \p n).
-  !>   @param[in]
-  !>   lda                leading dimension of dense array \p A.
-  !>   @param[in]
-  !>   percentage         \p percentage>=0 and \p percentage<=100.
-  !>   @param[in]
-  !>   descr the descriptor of the dense matrix \p A. The supported matrix type is
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - number of rows of the dense matrix \p A.
+  !>   @param[in] n - number of columns of the dense matrix \p A.
+  !>   @param[in] A - array of dimensions (\p lda, \p n).
+  !>   @param[in] lda - leading dimension of dense array \p A.
+  !>   @param[in] percentage - \p percentage>=0 and \p percentage<=100.
+  !>   @param[in] descr - the descriptor of the dense matrix \p A. The supported matrix type is
   !>   `HIPSPARSE_MATRIX_TYPE_GENERAL` and
   !>                      any valid value of the `hipsparseIndexBase_t`.
-  !>   @param[in]
-  !>   csrVal array of nnz ( = \p csrRowPtr[m] - \p csrRowPtr[0] ) non-zero elements of matrix \p A.
-  !>   @param[in]
-  !>   csrRowPtr integer array of \p m+1 elements that contains the start of every row and the end
-  !>   of the last row plus one.
-  !>   @param[in]
-  !>   csrColInd integer array of nnz ( = \p csrRowPtr[m] - \p csrRowPtr[0] ) column indices of the
-  !>   non-zero elements of matrix \p A.
-  !>   @param[in]
-  !>   info               prune information structure.
-  !>   @param[out]
-  !>   pBufferSizeInBytes number of bytes of the temporary storage buffer required by
+  !>   @param[in] csrVal - array of nnz ( = \p csrRowPtr[m] - \p csrRowPtr[0] ) non-zero elements of
+  !>   matrix \p A.
+  !>   @param[in] csrRowPtr - integer array of \p m+1 elements that contains the start of every row
+  !>   and the end of the last row plus one.
+  !>   @param[in] csrColInd - integer array of nnz ( = \p csrRowPtr[m] - \p csrRowPtr[0] ) column
+  !>   indices of the non-zero elements of matrix \p A.
+  !>   @param[in] myInfo - prune information structure.
+  !>   @param[out] pBufferSizeInBytes - number of bytes of the temporary storage buffer required by
   !>                      `hipsparseSpruneDense2csrNnzByPercentage()` and
   !>                      hipsparseDpruneDense2csrNnzByPercentage().
   !>
@@ -22098,29 +20893,18 @@ module hipfort_hipsparse
   !>   \note
   !>   This routine supports asynchronous execution if the pointer mode is set to device.
   !>
-  !>   @param[in]
-  !>   handle             handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m                  number of rows of the dense matrix \p A.
-  !>   @param[in]
-  !>   n                  number of columns of the dense matrix \p A.
-  !>   @param[in]
-  !>   A                  array of dimensions (\p lda, \p n).
-  !>   @param[in]
-  !>   lda                leading dimension of dense array \p A.
-  !>   @param[in]
-  !>   percentage         \p percentage>=0 and \p percentage<=100.
-  !>   @param[in]
-  !>   descr              the descriptor of the dense matrix \p A.
-  !>   @param[out]
-  !>   csrRowPtr integer array of \p m+1 elements that contains the start of every row and the end
-  !>   of the last row plus one.
-  !>   @param[out]
-  !>   nnzTotalDevHostPtr total number of non-zero elements in device or host memory.
-  !>   @param[in]
-  !>   info               prune information structure
-  !>   @param[out]
-  !>   buffer             buffer allocated by the user whose size is determined by calling
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - number of rows of the dense matrix \p A.
+  !>   @param[in] n - number of columns of the dense matrix \p A.
+  !>   @param[in] A - array of dimensions (\p lda, \p n).
+  !>   @param[in] lda - leading dimension of dense array \p A.
+  !>   @param[in] percentage - \p percentage>=0 and \p percentage<=100.
+  !>   @param[in] descr - the descriptor of the dense matrix \p A.
+  !>   @param[out] csrRowPtr - integer array of \p m+1 elements that contains the start of every row
+  !>   and the end of the last row plus one.
+  !>   @param[out] nnzTotalDevHostPtr - total number of non-zero elements in device or host memory.
+  !>   @param[in] myInfo - prune information structure
+  !>   @param[out] buffer - buffer allocated by the user whose size is determined by calling
   !>                      `hipsparseSpruneDense2csrByPercentage_bufferSize`
   !>                      "hipsparseXpruneDense2csrByPercentage_bufferSize()"
   !>                      or `hipsparseSpruneDense2csrByPercentage_bufferSizeExt`
@@ -22236,34 +21020,23 @@ module hipfort_hipsparse
   !>   \note
   !>   This routine support asynchronous execution if the pointer mode is set to device.
   !>
-  !>   @param[in]
-  !>   handle      handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m           number of rows of the dense matrix \p A.
-  !>   @param[in]
-  !>   n           number of columns of the dense matrix \p A.
-  !>   @param[in]
-  !>   A           array of dimensions (\p lda, \p n).
-  !>   @param[in]
-  !>   lda         leading dimension of dense array \p A.
-  !>   @param[in]
-  !>   percentage  \p percentage>=0 and \p percentage<=100.
-  !>   @param[in]
-  !>   descr the descriptor of the dense matrix \p A. The supported matrix type is
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - number of rows of the dense matrix \p A.
+  !>   @param[in] n - number of columns of the dense matrix \p A.
+  !>   @param[in] A - array of dimensions (\p lda, \p n).
+  !>   @param[in] lda - leading dimension of dense array \p A.
+  !>   @param[in] percentage - \p percentage>=0 and \p percentage<=100.
+  !>   @param[in] descr - the descriptor of the dense matrix \p A. The supported matrix type is
   !>   `HIPSPARSE_MATRIX_TYPE_GENERAL` and
   !>               any valid value of the `hipsparseIndexBase_t`.
-  !>   @param[out]
-  !>   csrVal array of nnz ( = \p csrRowPtr[m] - \p csrRowPtr[0] ) non-zero elements of matrix \p A.
-  !>   @param[in]
-  !>   csrRowPtr integer array of \p m+1 elements that contains the start of every row and the end
-  !>   of the last row plus one.
-  !>   @param[out]
-  !>   csrColInd integer array of nnz ( = \p csrRowPtr[m] - \p csrRowPtr[0] ) column indices of the
-  !>   non-zero elements of matrix \p A.
-  !>   @param[in]
-  !>   info prune  information structure
-  !>   @param[in]
-  !>   buffer      temporary storage buffer allocated by the user. The size is returned by
+  !>   @param[out] csrVal - array of nnz ( = \p csrRowPtr[m] - \p csrRowPtr[0] ) non-zero elements
+  !>   of matrix \p A.
+  !>   @param[in] csrRowPtr - integer array of \p m+1 elements that contains the start of every row
+  !>   and the end of the last row plus one.
+  !>   @param[out] csrColInd - integer array of nnz ( = \p csrRowPtr[m] - \p csrRowPtr[0] ) column
+  !>   indices of the non-zero elements of matrix \p A.
+  !>   @param[in] myInfo - prune  information structure
+  !>   @param[in] buffer - temporary storage buffer allocated by the user. The size is returned by
   !>               `hipsparseSpruneDense2csrByPercentage_bufferSize`
   !>               "hipsparseXpruneDense2csrByPercentage_bufferSize()" or
   !>               `hipsparseSpruneDense2csrByPercentage_bufferSizeExt`
@@ -22367,34 +21140,24 @@ module hipfort_hipsparse
   !>   This function is deprecated when using the CUDA backend (CUDA 12.0+) and will be
   !>   removed in CUDA 13.0. This deprecation does not apply to the ROCm backend.
   !>
-  !>   @param[in]
-  !>   handle          handle to the hipSPARSE library context queue.
-  !>   @param[in]
-  !>   m               number of rows of sparse matrix \f$A\f$. Must be non-negative.
-  !>   @param[in]
-  !>   nnz             number of non-zero entries of sparse matrix \f$A\f$. Must be non-negative.
-  !>   @param[in]
-  !>   descrA          sparse matrix descriptor.
-  !>   @param[in]
-  !>   csrValA         array of \p nnz elements of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csrRowPtrA      array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] handle - handle to the hipSPARSE library context queue.
+  !>   @param[in] m - number of rows of sparse matrix \f$A\f$. Must be non-negative.
+  !>   @param[in] nnz - number of non-zero entries of sparse matrix \f$A\f$. Must be non-negative.
+  !>   @param[in] descrA - sparse matrix descriptor.
+  !>   @param[in] csrValA - array of \p nnz elements of the sparse CSR matrix.
+  !>   @param[in] csrRowPtrA - array of \p m+1 elements that point to the start of every row of the
   !>                   sparse CSR matrix.
-  !>   @param[in]
-  !>   csrColIndA      array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] csrColIndA - array of \p nnz elements containing the column indices of the sparse
   !>                   CSR matrix.
-  !>   @param[in]
-  !>   fractionToColor fraction of nodes to be colored, which should be in the interval
+  !>   @param[in] fractionToColor - fraction of nodes to be colored, which should be in the interval
   !>   \f$[0.0,1.0]\f$. For example, \f$0.8\f$ implies that
   !>                   \f$80\f$ percent of nodes will be colored.
-  !>   @param[out]
-  !>   ncolors         resulting number of distinct colors.
-  !>   @param[out]
-  !>   coloring        resulting mapping of colors.
-  !>   @param[out]
-  !>   reordering optional resulting reordering permutation if \p reordering is a non-null pointer.
-  !>   @param[inout]
-  !>   info            structure that holds the information collected during the coloring algorithm.
+  !>   @param[out] ncolors - resulting number of distinct colors.
+  !>   @param[out] coloring - resulting mapping of colors.
+  !>   @param[out] reordering - optional resulting reordering permutation if \p reordering is a
+  !>   non-null pointer.
+  !>   @param[inout] myInfo - structure that holds the information collected during the coloring
+  !>   algorithm.
   !>
   !>   \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
   !>   \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.

--- a/lib/hipfort/hipfort_rocblas.F90
+++ b/lib/hipfort/hipfort_rocblas.F90
@@ -234,21 +234,15 @@ module hipfort_rocblas
   end interface
 
   !>  \brief Copy vector from host to device.
-  !>     @param[in]
-  !>     n           [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>                 number of elements in the vector
-  !>     @param[in]
-  !>     elem_size   [rocblas_int]
+  !>     @param[in] elem_size - [rocblas_int]
   !>                 number of bytes per element in the matrix
-  !>     @param[in]
-  !>     x           pointer to vector on the host
-  !>     @param[in]
-  !>     incx        [rocblas_int]
+  !>     @param[in] x - pointer to vector on the host
+  !>     @param[in] incx - [rocblas_int]
   !>                 specifies the increment for the elements of the vector
-  !>     @param[out]
-  !>     y           pointer to vector on the device
-  !>     @param[in]
-  !>     incy        [rocblas_int]
+  !>     @param[out] y - pointer to vector on the device
+  !>     @param[in] incy - [rocblas_int]
   !>                 specifies the increment for the elements of the vector
   interface rocblas_set_vector
     function rocblas_set_vector_(n,elem_size,x,incx,y,incy) bind(c, name="rocblas_set_vector")
@@ -281,21 +275,15 @@ module hipfort_rocblas
   end interface
 
   !>  \brief Copy vector from device to host.
-  !>     @param[in]
-  !>     n           [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>                 number of elements in the vector
-  !>     @param[in]
-  !>     elem_size   [rocblas_int]
+  !>     @param[in] elem_size - [rocblas_int]
   !>                 number of bytes per element in the matrix
-  !>     @param[in]
-  !>     x           pointer to vector on the device
-  !>     @param[in]
-  !>     incx        [rocblas_int]
+  !>     @param[in] x - pointer to vector on the device
+  !>     @param[in] incx - [rocblas_int]
   !>                 specifies the increment for the elements of the vector
-  !>     @param[out]
-  !>     y           pointer to vector on the host
-  !>     @param[in]
-  !>     incy        [rocblas_int]
+  !>     @param[out] y - pointer to vector on the host
+  !>     @param[in] incy - [rocblas_int]
   !>                 specifies the increment for the elements of the vector
   interface rocblas_get_vector
     function rocblas_get_vector_(n,elem_size,x,incx,y,incy) bind(c, name="rocblas_get_vector")
@@ -328,24 +316,17 @@ module hipfort_rocblas
   end interface
 
   !>  \brief Copy matrix from host to device.
-  !>     @param[in]
-  !>     rows        [rocblas_int]
+  !>     @param[in] rows - [rocblas_int]
   !>                 number of rows in matrices
-  !>     @param[in]
-  !>     cols        [rocblas_int]
+  !>     @param[in] cols - [rocblas_int]
   !>                 number of columns in matrices
-  !>     @param[in]
-  !>     elem_size   [rocblas_int]
+  !>     @param[in] elem_size - [rocblas_int]
   !>                 number of bytes per element in the matrix
-  !>     @param[in]
-  !>     a           pointer to matrix on the host
-  !>     @param[in]
-  !>     lda         [rocblas_int]
+  !>     @param[in] a - pointer to matrix on the host
+  !>     @param[in] lda - [rocblas_int]
   !>                 specifies the leading dimension of A, lda >= rows
-  !>     @param[out]
-  !>     b           pointer to matrix on the GPU
-  !>     @param[in]
-  !>     ldb         [rocblas_int]
+  !>     @param[out] b - pointer to matrix on the GPU
+  !>     @param[in] ldb - [rocblas_int]
   !>                 specifies the leading dimension of B, ldb >= rows
   interface rocblas_set_matrix
     function rocblas_set_matrix_(rows,cols,elem_size,a,lda,b,ldb) bind(c, name="rocblas_set_matrix")
@@ -381,24 +362,17 @@ module hipfort_rocblas
   end interface
 
   !>  \brief Copy matrix from device to host.
-  !>     @param[in]
-  !>     rows        [rocblas_int]
+  !>     @param[in] rows - [rocblas_int]
   !>                 number of rows in matrices
-  !>     @param[in]
-  !>     cols        [rocblas_int]
+  !>     @param[in] cols - [rocblas_int]
   !>                 number of columns in matrices
-  !>     @param[in]
-  !>     elem_size   [rocblas_int]
+  !>     @param[in] elem_size - [rocblas_int]
   !>                 number of bytes per element in the matrix
-  !>     @param[in]
-  !>     a           pointer to matrix on the GPU
-  !>     @param[in]
-  !>     lda         [rocblas_int]
+  !>     @param[in] a - pointer to matrix on the GPU
+  !>     @param[in] lda - [rocblas_int]
   !>                 specifies the leading dimension of A, lda >= rows
-  !>     @param[out]
-  !>     b           pointer to matrix on the host
-  !>     @param[in]
-  !>     ldb         [rocblas_int]
+  !>     @param[out] b - pointer to matrix on the host
+  !>     @param[in] ldb - [rocblas_int]
   !>                 specifies the leading dimension of B, ldb >= rows
   interface rocblas_get_matrix
     function rocblas_get_matrix_(rows,cols,elem_size,a,lda,b,ldb) bind(c, name="rocblas_get_matrix")
@@ -439,24 +413,17 @@ module hipfort_rocblas
   !>     asynchronously.
   !>     Memory on the host must be allocated with ``hipHostMalloc`` or the transfer will be
   !>     synchronous.
-  !>     @param[in]
-  !>     n           [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>                 number of elements in the vector
-  !>     @param[in]
-  !>     elem_size   [rocblas_int]
+  !>     @param[in] elem_size - [rocblas_int]
   !>                 number of bytes per element in the matrix
-  !>     @param[in]
-  !>     x           pointer to vector on the host
-  !>     @param[in]
-  !>     incx        [rocblas_int]
+  !>     @param[in] x - pointer to vector on the host
+  !>     @param[in] incx - [rocblas_int]
   !>                 specifies the increment for the elements of the vector
-  !>     @param[out]
-  !>     y           pointer to vector on the device
-  !>     @param[in]
-  !>     incy        [rocblas_int]
+  !>     @param[out] y - pointer to vector on the device
+  !>     @param[in] incy - [rocblas_int]
   !>                 specifies the increment for the elements of the vector
-  !>     @param[in]
-  !>     stream      specifies the stream into which this transfer request is queued
+  !>     @param[in] stream - specifies the stream into which this transfer request is queued
   interface rocblas_set_vector_async
     function rocblas_set_vector_async_(n,elem_size,x,incx,y,incy,stream) &
         bind(c, name="rocblas_set_vector_async")
@@ -497,24 +464,17 @@ module hipfort_rocblas
   !>     asynchronously.
   !>     Memory on the host must be allocated with ``hipHostMalloc`` or the transfer will be
   !>     synchronous.
-  !>     @param[in]
-  !>     n           [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>                 number of elements in the vector
-  !>     @param[in]
-  !>     elem_size   [rocblas_int]
+  !>     @param[in] elem_size - [rocblas_int]
   !>                 number of bytes per element in the matrix
-  !>     @param[in]
-  !>     x           pointer to vector on the device
-  !>     @param[in]
-  !>     incx        [rocblas_int]
+  !>     @param[in] x - pointer to vector on the device
+  !>     @param[in] incx - [rocblas_int]
   !>                 specifies the increment for the elements of the vector
-  !>     @param[out]
-  !>     y           pointer to vector on the host
-  !>     @param[in]
-  !>     incy        [rocblas_int]
+  !>     @param[out] y - pointer to vector on the host
+  !>     @param[in] incy - [rocblas_int]
   !>                 specifies the increment for the elements of the vector
-  !>     @param[in]
-  !>     stream      specifies the stream into which this transfer request is queued
+  !>     @param[in] stream - specifies the stream into which this transfer request is queued
   interface rocblas_get_vector_async
     function rocblas_get_vector_async_(n,elem_size,x,incx,y,incy,stream) &
         bind(c, name="rocblas_get_vector_async")
@@ -555,27 +515,19 @@ module hipfort_rocblas
   !>     asynchronously.
   !>     Memory on the host must be allocated with ``hipHostMalloc`` or the transfer will be
   !>     synchronous.
-  !>     @param[in]
-  !>     rows        [rocblas_int]
+  !>     @param[in] rows - [rocblas_int]
   !>                 number of rows in matrices
-  !>     @param[in]
-  !>     cols        [rocblas_int]
+  !>     @param[in] cols - [rocblas_int]
   !>                 number of columns in matrices
-  !>     @param[in]
-  !>     elem_size   [rocblas_int]
+  !>     @param[in] elem_size - [rocblas_int]
   !>                 number of bytes per element in the matrix
-  !>     @param[in]
-  !>     a           pointer to matrix on the host
-  !>     @param[in]
-  !>     lda         [rocblas_int]
+  !>     @param[in] a - pointer to matrix on the host
+  !>     @param[in] lda - [rocblas_int]
   !>                 specifies the leading dimension of A, lda >= rows
-  !>     @param[out]
-  !>     b           pointer to matrix on the GPU
-  !>     @param[in]
-  !>     ldb         [rocblas_int]
+  !>     @param[out] b - pointer to matrix on the GPU
+  !>     @param[in] ldb - [rocblas_int]
   !>                 specifies the leading dimension of B, ldb >= rows
-  !>     @param[in]
-  !>     stream      specifies the stream into which this transfer request is queued
+  !>     @param[in] stream - specifies the stream into which this transfer request is queued
   interface rocblas_set_matrix_async
     function rocblas_set_matrix_async_(rows,cols,elem_size,a,lda,b,ldb,stream) &
         bind(c, name="rocblas_set_matrix_async")
@@ -618,27 +570,19 @@ module hipfort_rocblas
   !>     asynchronously.
   !>     Memory on the host must be allocated with ``hipHostMalloc`` or the transfer will be
   !>     synchronous.
-  !>     @param[in]
-  !>     rows        [rocblas_int]
+  !>     @param[in] rows - [rocblas_int]
   !>                 number of rows in matrices
-  !>     @param[in]
-  !>     cols        [rocblas_int]
+  !>     @param[in] cols - [rocblas_int]
   !>                 number of columns in matrices
-  !>     @param[in]
-  !>     elem_size   [rocblas_int]
+  !>     @param[in] elem_size - [rocblas_int]
   !>                 number of bytes per element in the matrix
-  !>     @param[in]
-  !>     a           pointer to matrix on the GPU
-  !>     @param[in]
-  !>     lda         [rocblas_int]
+  !>     @param[in] a - pointer to matrix on the GPU
+  !>     @param[in] lda - [rocblas_int]
   !>                 specifies the leading dimension of A, lda >= rows
-  !>     @param[out]
-  !>     b           pointer to matrix on the host
-  !>     @param[in]
-  !>     ldb         [rocblas_int]
+  !>     @param[out] b - pointer to matrix on the host
+  !>     @param[in] ldb - [rocblas_int]
   !>                 specifies the leading dimension of B, ldb >= rows
-  !>     @param[in]
-  !>     stream      specifies the stream into which this transfer request is queued
+  !>     @param[in] stream - specifies the stream into which this transfer request is queued
   interface rocblas_get_matrix_async
     function rocblas_get_matrix_async_(rows,cols,elem_size,a,lda,b,ldb,stream) &
         bind(c, name="rocblas_get_matrix_async")
@@ -709,11 +653,9 @@ module hipfort_rocblas
   !>     exist
   !>     for a problem, Tensile will default to a solution benchmarked for overall performance
   !>     instead.
-  !>     @param[in]
-  !>     handle      [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>                 the handle of device
-  !>     @param[in]
-  !>     metric      [rocblas_performance_metric]
+  !>     @param[in] metric - [rocblas_performance_metric]
   !>                 the performance metric to be used
   interface rocblas_set_performance_metric
     function rocblas_set_performance_metric_(handle,metric) &
@@ -731,11 +673,9 @@ module hipfort_rocblas
   !>      \details
   !>     Returns the performance metric used by Tensile to select the optimal solution for gemm
   !>     problems.
-  !>     @param[in]
-  !>     handle      [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>                 the handle of device
-  !>     @param[out]
-  !>     metric      [rocblas_performance_metric*]
+  !>     @param[out] metric - [rocblas_performance_metric*]
   !>                 pointer to where the metric will be stored
   interface rocblas_get_performance_metric
     function rocblas_get_performance_metric_(handle,metric) &
@@ -756,18 +696,13 @@ module hipfort_rocblas
   !>
   !>         x := alpha * x
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the number of elements in x.
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer for the scalar alpha.
-  !>     @param[in, out]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] alpha - device pointer or host pointer for the scalar alpha.
+  !>     @param[in, out] x - device pointer storing vector x.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of x.
   interface rocblas_sscal
     function rocblas_sscal_(handle,n,alpha,x,incx) bind(c, name="rocblas_sscal")
@@ -971,21 +906,15 @@ module hipfort_rocblas
   !>
   !>     where (``x_i``) is the i-th instance of the batch.
   !>
-  !>     @param[in]
-  !>     handle      [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>                 handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     n           [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>                 the number of elements in each x_i.
-  !>     @param[in]
-  !>     alpha       host pointer or device pointer for the scalar alpha.
-  !>     @param[in, out]
-  !>     x           device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx        [rocblas_int]
+  !>     @param[in] alpha - host pointer or device pointer for the scalar alpha.
+  !>     @param[in, out] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [rocblas_int]
   !>                 specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 specifies the number of batches in x.
   interface rocblas_sscal_batched
     function rocblas_sscal_batched_(handle,n,alpha,x,incx,batch_count) &
@@ -1189,27 +1118,20 @@ module hipfort_rocblas
   !>
   !>     where (``x_i``) is the i-th instance of the batch.
   !>
-  !>      @param[in]
-  !>     handle      [rocblas_handle]
+  !>      @param[in] handle - [rocblas_handle]
   !>                 handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     n           [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>                 the number of elements in each x_i.
-  !>     @param[in]
-  !>     alpha       host pointer or device pointer for the scalar alpha.
-  !>     @param[in, out]
-  !>     x           device pointer to the first vector (x_1) in the batch.
-  !>     @param[in]
-  !>     incx        [rocblas_int]
+  !>     @param[in] alpha - host pointer or device pointer for the scalar alpha.
+  !>     @param[in, out] x - device pointer to the first vector (x_1) in the batch.
+  !>     @param[in] incx - [rocblas_int]
   !>                 specifies the increment for the elements of x.
-  !>     @param[in]
-  !>     stride_x    [rocblas_stride]
+  !>     @param[in] stride_x - [rocblas_stride]
   !>                 stride from the start of one vector (x_i) and the next one (x_i+1).
   !>                 There are no restrictions placed on stride_x. However, ensure that stride_x is
   !>                 of an appropriate size. For a typical
   !>                 case, this means stride_x >= n * incx.
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 specifies the number of batches in x.
   interface rocblas_sscal_strided_batched
     function rocblas_sscal_strided_batched_(handle,n,alpha,x,incx,stride_x,batch_count) &
@@ -1458,21 +1380,15 @@ module hipfort_rocblas
   !>
   !>         y := x
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the number of elements in x to be copied to y.
-  !>     @param[in]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device pointer storing vector x.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of x.
-  !>     @param[out]
-  !>     y         device pointer storing vector y.
-  !>     @param[in]
-  !>     incy      [rocblas_int]
+  !>     @param[out] y - device pointer storing vector y.
+  !>     @param[in] incy - [rocblas_int]
   !>               specifies the increment for the elements of y.
   interface rocblas_scopy
     function rocblas_scopy_(handle,n,x,incx,y,incy) bind(c, name="rocblas_scopy")
@@ -1629,24 +1545,17 @@ module hipfort_rocblas
   !>     where (``x_i``, ``y_i``) is the i-th instance of the batch and
   !>     ``x_i`` and``y_i`` are vectors.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the number of elements in each x_i to be copied to y_i.
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each vector x_i.
-  !>     @param[out]
-  !>     y         device array of device pointers storing each vector y_i.
-  !>     @param[in]
-  !>     incy      [rocblas_int]
+  !>     @param[out] y - device array of device pointers storing each vector y_i.
+  !>     @param[in] incy - [rocblas_int]
   !>               specifies the increment for the elements of each vector y_i.
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_scopy_batched
     function rocblas_scopy_batched_(handle,n,x,incx,y,incy,batch_count) &
@@ -1795,36 +1704,27 @@ module hipfort_rocblas
   !>     where (``x_i``, ``y_i``) is the i-th instance of the batch and
   !>     ``x_i`` and ``y_i`` are vectors.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the number of elements in each x_i to be copied to y_i.
-  !>     @param[in]
-  !>     x         device pointer to the first vector (x_1) in the batch.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device pointer to the first vector (x_1) in the batch.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increments for the elements of vectors x_i.
-  !>     @param[in]
-  !>     stridex     [rocblas_stride]
+  !>     @param[in] stridex - [rocblas_stride]
   !>                 stride from the start of one vector (x_i) and the next one (x_i+1).
   !>                 There are no restrictions placed on stride_x. However,
   !>                 ensure that stride_x is of an appropriate size. For a typical
   !>                 case, this means stride_x >= n * incx.
-  !>     @param[out]
-  !>     y         device pointer to the first vector (y_1) in the batch.
-  !>     @param[in]
-  !>     incy      [rocblas_int]
+  !>     @param[out] y - device pointer to the first vector (y_1) in the batch.
+  !>     @param[in] incy - [rocblas_int]
   !>               specifies the increment for the elements of vectors y_i.
-  !>     @param[in]
-  !>     stridey     [rocblas_stride]
+  !>     @param[in] stridey - [rocblas_stride]
   !>                 stride from the start of one vector (y_i) and the next one (y_i+1).
   !>                 There are no restrictions placed on stride_y, However, ensure that stride_y is
   !>                 of an appropriate size. For a typical
   !>                 case, this means stride_y >= n * incy. stridey should be non zero.
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_scopy_strided_batched
     function rocblas_scopy_strided_batched_(handle,n,x,incx,stridex,y,incy,stridey,batch_count) &
@@ -2014,24 +1914,17 @@ module hipfort_rocblas
   !>
   !>         result = conjugate (x) * y;
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the number of elements in x and y.
-  !>     @param[in]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device pointer storing vector x.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of y.
-  !>     @param[in]
-  !>     y         device pointer storing vector y.
-  !>     @param[in]
-  !>     incy      [rocblas_int]
+  !>     @param[in] y - device pointer storing vector y.
+  !>     @param[in] incy - [rocblas_int]
   !>               specifies the increment for the elements of y.
-  !>     @param[in, out]
-  !>     result
+  !>     @param[in, out] myResult
   !>               device pointer or host pointer to store the dot product.
   !>               Return value is 0.0 if n <= 0.
   interface rocblas_sdot
@@ -2341,27 +2234,19 @@ module hipfort_rocblas
   !>     where (``x_i``, ``y_i``) is the i-th instance of the batch and
   !>     ``x_i`` and ``y_i`` are vectors, for ``i`` = 1, ..., ``batch_count``.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the number of elements in each x_i and y_i.
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     y         device array of device pointers storing each vector y_i.
-  !>     @param[in]
-  !>     incy      [rocblas_int]
+  !>     @param[in] y - device array of device pointers storing each vector y_i.
+  !>     @param[in] incy - [rocblas_int]
   !>               specifies the increment for the elements of each y_i.
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
-  !>     @param[in, out]
-  !>     result
+  !>     @param[in, out] myResult
   !>               device array or host array of batch_count size to store the dot products of each
   !>               batch.
   !>               Return 0.0 for each element if n <= 0.
@@ -2669,33 +2554,23 @@ module hipfort_rocblas
   !>     where (``x_i``, ``y_i``) is the i-th instance of the batch.
   !>     ``x_i`` and ``y_i`` are vectors, for ``i`` = 1, ..., ``batch_count``.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the number of elements in each x_i and y_i.
-  !>     @param[in]
-  !>     x         device pointer to the first vector (x_1) in the batch.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device pointer to the first vector (x_1) in the batch.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     stridex     [rocblas_stride]
+  !>     @param[in] stridex - [rocblas_stride]
   !>                 stride from the start of one vector (x_i) and the next one (x_i+1).
-  !>     @param[in]
-  !>     y         device pointer to the first vector (y_1) in the batch.
-  !>     @param[in]
-  !>     incy      [rocblas_int]
+  !>     @param[in] y - device pointer to the first vector (y_1) in the batch.
+  !>     @param[in] incy - [rocblas_int]
   !>               specifies the increment for the elements of each y_i.
-  !>     @param[in]
-  !>     stridey     [rocblas_stride]
+  !>     @param[in] stridey - [rocblas_stride]
   !>                 stride from the start of one vector (y_i) and the next one (y_i+1).
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
-  !>     @param[in, out]
-  !>     result
+  !>     @param[in, out] myResult
   !>               device array or host array of batch_count size to store the dot products of each
   !>               batch.
   !>               Return 0.0 for each element if n <= 0.
@@ -3079,21 +2954,15 @@ module hipfort_rocblas
   !>         y := x;
   !>         x := y
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the number of elements in x and y.
-  !>     @param[in, out]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in, out] x - device pointer storing vector x.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of x.
-  !>     @param[in, out]
-  !>     y         device pointer storing vector y.
-  !>     @param[in]
-  !>     incy      [rocblas_int]
+  !>     @param[in, out] y - device pointer storing vector y.
+  !>     @param[in] incy - [rocblas_int]
   !>               specifies the increment for the elements of y.
   interface rocblas_sswap
     function rocblas_sswap_(handle,n,x,incx,y,incy) bind(c, name="rocblas_sswap")
@@ -3236,24 +3105,17 @@ module hipfort_rocblas
   !>         y_i := x_i;
   !>         x_i := y_i
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the number of elements in each x_i and y_i.
-  !>     @param[in, out]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in, out] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in, out]
-  !>     y         device array of device pointers storing each vector y_i.
-  !>     @param[in]
-  !>     incy      [rocblas_int]
+  !>     @param[in, out] y - device array of device pointers storing each vector y_i.
+  !>     @param[in] incy - [rocblas_int]
   !>               specifies the increment for the elements of each y_i.
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_sswap_batched
     function rocblas_sswap_batched_(handle,n,x,incx,y,incy,batch_count) &
@@ -3400,36 +3262,27 @@ module hipfort_rocblas
   !>         y_i := x_i;
   !>         x_i := y_i
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the number of elements in each x_i and y_i.
-  !>     @param[in, out]
-  !>     x         device pointer to the first vector x_1.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in, out] x - device pointer to the first vector x_1.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of x.
-  !>     @param[in]
-  !>     stridex   [rocblas_stride]
+  !>     @param[in] stridex - [rocblas_stride]
   !>               stride from the start of one vector (x_i) and the next one (x_i+1).
   !>               There are no restrictions placed on stride_x. However, ensure that stride_x is of
   !>               an appropriate size. For a typical
   !>               case, this means stride_x >= n * incx.
-  !>     @param[in, out]
-  !>     y         device pointer to the first vector y_1.
-  !>     @param[in]
-  !>     incy      [rocblas_int]
+  !>     @param[in, out] y - device pointer to the first vector y_1.
+  !>     @param[in] incy - [rocblas_int]
   !>               specifies the increment for the elements of y.
-  !>     @param[in]
-  !>     stridey   [rocblas_stride]
+  !>     @param[in] stridey - [rocblas_stride]
   !>               stride from the start of one vector (y_i) and the next one (y_i+1).
   !>               There are no restrictions placed on stride_x. However, ensure that stride_y is of
   !>               an appropriate size. For a typical
   !>               case, this means stride_y >= n * incy. stridey should be non zero.
-  !>      @param[in]
-  !>      batch_count [rocblas_int]
+  !>      @param[in] batch_count - [rocblas_int]
   !>                  number of instances in the batch.
   interface rocblas_sswap_strided_batched
     function rocblas_sswap_strided_batched_(handle,n,x,incx,stridex,y,incy,stridey,batch_count) &
@@ -3615,23 +3468,16 @@ module hipfort_rocblas
   !>
   !>         y := alpha * x + y
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the number of elements in x and y.
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer to specify the scalar alpha.
-  !>     @param[in]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] alpha - device pointer or host pointer to specify the scalar alpha.
+  !>     @param[in] x - device pointer storing vector x.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of x.
-  !>     @param[out]
-  !>     y         device pointer storing vector y.
-  !>     @param[in, out]
-  !>     incy      [rocblas_int]
+  !>     @param[out] y - device pointer storing vector y.
+  !>     @param[in, out] incy - [rocblas_int]
   !>               specifies the increment for the elements of y.
   interface rocblas_haxpy
     function rocblas_haxpy_(handle,n,alpha,x,incx,y,incy) bind(c, name="rocblas_haxpy")
@@ -3822,26 +3668,18 @@ module hipfort_rocblas
   !>     \details
   !>     The axpy_batched functions compute ``y := alpha * x + y`` over a set of batched vectors.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     n         [rocblas_int]
-  !>     @param[in]
-  !>     alpha     specifies the scalar alpha.
-  !>     @param[in]
-  !>     x         pointer storing vector x on the GPU.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
+  !>     @param[in] alpha - specifies the scalar alpha.
+  !>     @param[in] x - pointer storing vector x on the GPU.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of x.
-  !>     @param[out]
-  !>     y         pointer storing vector y on the GPU.
-  !>     @param[in, out]
-  !>     incy      [rocblas_int]
+  !>     @param[out] y - pointer storing vector y on the GPU.
+  !>     @param[in, out] incy - [rocblas_int]
   !>               specifies the increment for the elements of y.
   !>
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>               number of instances in the batch.
   interface rocblas_haxpy_batched
     function rocblas_haxpy_batched_(handle,n,alpha,x,incx,y,incy,batch_count) &
@@ -4029,32 +3867,22 @@ module hipfort_rocblas
   !>     The axpy_strided_batched functions compute ``y := alpha * x + y`` over a set of strided
   !>     batched vectors.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     n         [rocblas_int]
-  !>     @param[in]
-  !>     alpha     specifies the scalar alpha.
-  !>     @param[in]
-  !>     x         pointer storing vector x on the GPU.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
+  !>     @param[in] alpha - specifies the scalar alpha.
+  !>     @param[in] x - pointer storing vector x on the GPU.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of x.
-  !>     @param[in]
-  !>     stridex   [rocblas_stride]
+  !>     @param[in] stridex - [rocblas_stride]
   !>               specifies the increment between vectors of x.
-  !>     @param[out]
-  !>     y         pointer storing vector y on the GPU.
-  !>     @param[in, out]
-  !>     incy      [rocblas_int]
+  !>     @param[out] y - pointer storing vector y on the GPU.
+  !>     @param[in, out] incy - [rocblas_int]
   !>               specifies the increment for the elements of y.
-  !>     @param[in]
-  !>     stridey   [rocblas_stride]
+  !>     @param[in] stridey - [rocblas_stride]
   !>               specifies the increment between vectors of y.
   !>
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>               number of instances in the batch.
   interface rocblas_haxpy_strided_batched
     function rocblas_haxpy_strided_batched_(handle,n,alpha,x,incx,stridex,y,incy,stridey, &
@@ -4297,19 +4125,14 @@ module hipfort_rocblas
   !>     or the sum of magnitudes of the real and imaginary parts of elements if ``x`` is a complex
   !>     vector.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the number of elements in x and y.
-  !>     @param[in]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device pointer storing vector x.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of x. incx must be > 0.
-  !>     @param[in, out]
-  !>     result
+  !>     @param[in, out] myResult
   !>               device pointer or host pointer to store the asum product.
   !>               Return value is 0.0 if n <= 0.
   interface rocblas_sasum
@@ -4445,22 +4268,16 @@ module hipfort_rocblas
   !>     complex
   !>     vector, for ``i`` = 1, ..., ``batch_count``.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               number of elements in each vector x_i.
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each x_i. incx must be > 0.
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>               number of instances in the batch.
-  !>     @param[out]
-  !>     results
+  !>     @param[out] results
   !>               device array or host array of batch_count size for results.
   !>               Return value is 0.0 if n, incx<=0.
   interface rocblas_sasum_batched
@@ -4600,30 +4417,23 @@ module hipfort_rocblas
   !>     complex
   !>     vector, for ``i`` = 1, ..., ``batch_count``.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               number of elements in each vector x_i.
-  !>     @param[in]
-  !>     x         device pointer to the first vector x_1.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device pointer to the first vector x_1.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each x_i. incx must be > 0.
-  !>     @param[in]
-  !>     stridex   [rocblas_stride]
+  !>     @param[in] stridex - [rocblas_stride]
   !>               stride from the start of one vector (x_i) to the next one (x_i+1).
   !>               There are no restrictions placed on stride_x. However, ensure that stride_x is of
   !>               an appropriate size. For a typical
   !>               case, this means stride_x >= n * incx.
-  !>     @param[out]
-  !>     results
+  !>     @param[out] results
   !>               device pointer or host pointer to array for storing contiguous batch_count
   !>               results.
   !>               Return value is 0.0 if n, incx<=0.
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>               number of instances in the batch.
   interface rocblas_sasum_strided_batched
     function rocblas_sasum_strided_batched_(handle,n,x,incx,stridex,batch_count,results) &
@@ -4793,19 +4603,14 @@ module hipfort_rocblas
   !>         result := sqrt( x'*x ) for real vectors
   !>         result := sqrt( x**H*x ) for complex vectors
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the number of elements in x.
-  !>     @param[in]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device pointer storing vector x.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of y.
-  !>     @param[in, out]
-  !>     result
+  !>     @param[in, out] myResult
   !>               device pointer or host pointer to store the nrm2 product.
   !>               Return value is 0.0 if n, incx<=0.
   interface rocblas_snrm2
@@ -4941,22 +4746,16 @@ module hipfort_rocblas
   !>         result := sqrt( x_i'*x_i ) for real vectors x, for i = 1, ..., batch_count
   !>         result := sqrt( x_i**H*x_i ) for complex vectors x, for i = 1, ..., batch_count
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               number of elements in each x_i.
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each x_i. incx must be > 0.
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>               number of instances in the batch.
-  !>     @param[out]
-  !>     results
+  !>     @param[out] results
   !>               device pointer or host pointer to array of batch_count size for nrm2 results.
   !>               Return value is 0.0 for each element if n <= 0, incx<=0.
   interface rocblas_snrm2_batched
@@ -5096,28 +4895,21 @@ module hipfort_rocblas
   !>         result := sqrt( x_i'*x_i ) for real vectors x, for i = 1, ..., batch_count
   !>         result := sqrt( x_i**H*x_i ) for complex vectors, for i = 1, ..., batch_count
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               number of elements in each x_i.
-  !>     @param[in]
-  !>     x         device pointer to the first vector x_1.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device pointer to the first vector x_1.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each x_i. incx must be > 0.
-  !>     @param[in]
-  !>     stridex   [rocblas_stride]
+  !>     @param[in] stridex - [rocblas_stride]
   !>               stride from the start of one vector (x_i) to the next one (x_i+1).
   !>               There are no restrictions placed on stride_x. However, ensure that stride_x is of
   !>               an appropriate size. For a typical
   !>               case, this means stride_x >= n * incx.
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>               number of instances in the batch.
-  !>     @param[out]
-  !>     results
+  !>     @param[out] results
   !>               device pointer or host pointer to array for storing contiguous batch_count
   !>               results.
   !>               Return value is 0.0 for each element if n <= 0, incx<=0.
@@ -5287,19 +5079,14 @@ module hipfort_rocblas
   !>     The amax functions find the first index of the element of maximum magnitude of a vector
   !>     ``x``.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocblas library context queue.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the number of elements in x.
-  !>     @param[in]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device pointer storing vector x.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of y.
-  !>     @param[in, out]
-  !>     result
+  !>     @param[in, out] myResult
   !>               device pointer or host pointer to store the amax index.
   !>               Return value is 0.0 if n, incx<=0.
   interface rocblas_isamax
@@ -5432,22 +5219,16 @@ module hipfort_rocblas
   !>      The amax_batched functions find the first index of the element of maximum magnitude of
   !>      each vector ``x_i`` in a batch, for ``i`` = 1, ..., ``batch_count``.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               number of elements in each vector x_i.
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each x_i. incx must be > 0.
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>               number of instances in the batch. Must be > 0.
-  !>     @param[out]
-  !>     result
+  !>     @param[out] myResult
   !>               device or host array of pointers of batch_count size for results.
   !>               Return is 0 if n, incx<=0.
   interface rocblas_isamax_batched
@@ -5584,25 +5365,18 @@ module hipfort_rocblas
   !>      The amax_strided_batched functions find the first index of the element of maximum
   !>      magnitude of each vector ``x_i`` in a batch, for ``i`` = 1, ..., ``batch_count``.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               number of elements in each vector x_i.
-  !>     @param[in]
-  !>     x         device pointer to the first vector x_1.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device pointer to the first vector x_1.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each x_i. incx must be > 0.
-  !>     @param[in]
-  !>     stridex   [rocblas_stride]
+  !>     @param[in] stridex - [rocblas_stride]
   !>               specifies the pointer increment between one x_i and the next x_(i + 1).
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>               number of instances in the batch.
-  !>     @param[out]
-  !>     result
+  !>     @param[out] myResult
   !>               device or host pointer for storing contiguous batch_count results.
   !>               Return is 0 if n <= 0, incx<=0.
   interface rocblas_isamax_strided_batched
@@ -5771,19 +5545,14 @@ module hipfort_rocblas
   !>     The amin functions find the first index of the element of minimum magnitude of a vector
   !>     ``x``.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the number of elements in x.
-  !>     @param[in]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device pointer storing vector x.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of y.
-  !>     @param[in, out]
-  !>     result
+  !>     @param[in, out] myResult
   !>               device pointer or host pointer to store the amin index.
   !>               Return value is 0.0 if n, incx<=0.
   interface rocblas_isamin
@@ -5916,22 +5685,16 @@ module hipfort_rocblas
   !>     The amin_batched functions find the first index of the element of minimum magnitude of each
   !>     vector ``x_i`` in a batch, for ``i`` = 1, ..., ``batch_count``.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               number of elements in each vector x_i.
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each x_i. incx must be > 0.
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>               number of instances in the batch. Must be > 0.
-  !>     @param[out]
-  !>     result
+  !>     @param[out] myResult
   !>               device or host pointers to array of batch_count size for results.
   !>               Return is 0 if n, incx<=0.
   interface rocblas_isamin_batched
@@ -6068,25 +5831,18 @@ module hipfort_rocblas
   !>      The amin_strided_batched functions find the first index of the element of minimum
   !>      magnitude of each vector ``x_i`` in a batch, for ``i`` = 1, ..., ``batch_count``.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               number of elements in each vector x_i.
-  !>     @param[in]
-  !>     x         device pointer to the first vector x_1.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device pointer to the first vector x_1.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each x_i. incx must be > 0.
-  !>     @param[in]
-  !>     stridex   [rocblas_stride]
+  !>     @param[in] stridex - [rocblas_stride]
   !>               specifies the pointer increment between one x_i and the next x_(i + 1).
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>               number of instances in the batch.
-  !>     @param[out]
-  !>     result
+  !>     @param[out] myResult
   !>               device or host pointer to array for storing contiguous batch_count results.
   !>               Return is 0 if n <= 0, incx<=0.
   interface rocblas_isamin_strided_batched
@@ -6257,27 +6013,20 @@ module hipfort_rocblas
   !>     Scalars ``c`` and ``s`` can be stored in either host or device memory. The location is
   !>     specified by calling ``rocblas_set_pointer_mode``.
   !>
-  !>     @param[in]
-  !>     handle  [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>             handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     n       [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>             number of elements in the x and y vectors.
-  !>     @param[in, out]
-  !>     x       device pointer storing vector x.
-  !>     @param[in]
-  !>     incx    [rocblas_int]
+  !>     @param[in, out] x - device pointer storing vector x.
+  !>     @param[in] incx - [rocblas_int]
   !>             specifies the increment between elements of x.
-  !>     @param[in, out]
-  !>     y       device pointer storing vector y.
-  !>     @param[in]
-  !>     incy    [rocblas_int]
+  !>     @param[in, out] y - device pointer storing vector y.
+  !>     @param[in] incy - [rocblas_int]
   !>             specifies the increment between elements of y.
-  !>     @param[in]
-  !>     c device pointer or host pointer storing the scalar cosine component of the rotation
-  !>     matrix.
-  !>     @param[in]
-  !>     s device pointer or host pointer storing the scalar sine component of the rotation matrix.
+  !>     @param[in] c - device pointer or host pointer storing the scalar cosine component of the
+  !>     rotation matrix.
+  !>     @param[in] s - device pointer or host pointer storing the scalar sine component of the
+  !>     rotation matrix.
   interface rocblas_srot
     function rocblas_srot_(handle,n,x,incx,y,incy,c,s) bind(c, name="rocblas_srot")
       use iso_c_binding
@@ -6527,28 +6276,21 @@ module hipfort_rocblas
   !>     Scalars ``c`` and ``s`` can be stored in either host or device memory. The location is
   !>     specified by calling ``rocblas_set_pointer_mode``.
   !>
-  !>     @param[in]
-  !>     handle  [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>             handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     n       [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>             number of elements in each x_i and y_i vectors.
-  !>     @param[in, out]
-  !>     x       device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx    [rocblas_int]
+  !>     @param[in, out] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [rocblas_int]
   !>             specifies the increment between elements of each x_i.
-  !>     @param[in, out]
-  !>     y       device array of device pointers storing each vector y_i.
-  !>     @param[in]
-  !>     incy    [rocblas_int]
+  !>     @param[in, out] y - device array of device pointers storing each vector y_i.
+  !>     @param[in] incy - [rocblas_int]
   !>             specifies the increment between elements of each y_i.
-  !>     @param[in]
-  !>     c       device pointer or host pointer to scalar cosine component of the rotation matrix.
-  !>     @param[in]
-  !>     s       device pointer or host pointer to scalar sine component of the rotation matrix.
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] c - device pointer or host pointer to scalar cosine component of the rotation
+  !>     matrix.
+  !>     @param[in] s - device pointer or host pointer to scalar sine component of the rotation
+  !>     matrix.
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 the number of x and y arrays, that is, the number of batches.
   interface rocblas_srot_batched
     function rocblas_srot_batched_(handle,n,x,incx,y,incy,c,s,batch_count) &
@@ -6787,34 +6529,25 @@ module hipfort_rocblas
   !>     Scalars ``c`` and ``s`` can be stored in either host or device memory. The location is
   !>     specified by calling ``rocblas_set_pointer_mode``.
   !>
-  !>     @param[in]
-  !>     handle  [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>             handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     n       [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>             number of elements in each x_i and y_i vectors.
-  !>     @param[in, out]
-  !>     x       device pointer to the first vector x_1.
-  !>     @param[in]
-  !>     incx    [rocblas_int]
+  !>     @param[in, out] x - device pointer to the first vector x_1.
+  !>     @param[in] incx - [rocblas_int]
   !>             specifies the increment between elements of each x_i.
-  !>     @param[in]
-  !>     stride_x [rocblas_stride]
+  !>     @param[in] stride_x - [rocblas_stride]
   !>              specifies the increment from the beginning of x_i to the beginning of x_(i+1).
-  !>     @param[in, out]
-  !>     y       device pointer to the first vector y_1.
-  !>     @param[in]
-  !>     incy    [rocblas_int]
+  !>     @param[in, out] y - device pointer to the first vector y_1.
+  !>     @param[in] incy - [rocblas_int]
   !>             specifies the increment between elements of each y_i.
-  !>     @param[in]
-  !>     stride_y [rocblas_stride]
+  !>     @param[in] stride_y - [rocblas_stride]
   !>              specifies the increment from the beginning of y_i to the beginning of y_(i+1)
-  !>     @param[in]
-  !>     c       device pointer or host pointer to scalar cosine component of the rotation matrix.
-  !>     @param[in]
-  !>     s       device pointer or host pointer to scalar sine component of the rotation matrix.
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] c - device pointer or host pointer to scalar cosine component of the rotation
+  !>     matrix.
+  !>     @param[in] s - device pointer or host pointer to scalar sine component of the rotation
+  !>     matrix.
+  !>     @param[in] batch_count - [rocblas_int]
   !>             the number of x and y arrays, that is, the number of batches.
   interface rocblas_srot_strided_batched
     function rocblas_srot_strided_batched_(handle,n,x,incx,stride_x,y,incy,stride_y,c,s, &
@@ -7142,17 +6875,12 @@ module hipfort_rocblas
   !>         If |z| < 1, set c = sqrt(1 - z**2) and s = z.
   !>         If |z| > 1, set c = 1/z and s = sqrt( 1 - c**2).
   !>
-  !>     @param[in]
-  !>     handle  [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>             handle to the rocBLAS library context queue.
-  !>     @param[in, out]
-  !>     a       pointer to a, an element in vector (a,b), overwritten with r.
-  !>     @param[in, out]
-  !>     b       pointer to b, an element in vector (a,b), overwritten with z.
-  !>     @param[out]
-  !>     c       pointer to c, cosine element of the Givens rotation.
-  !>     @param[out]
-  !>     s       pointer to s, sine element of the Givens rotation.
+  !>     @param[in, out] a - pointer to a, an element in vector (a,b), overwritten with r.
+  !>     @param[in, out] b - pointer to b, an element in vector (a,b), overwritten with z.
+  !>     @param[out] c - pointer to c, cosine element of the Givens rotation.
+  !>     @param[out] s - pointer to s, sine element of the Givens rotation.
   interface rocblas_srotg
     function rocblas_srotg_(handle,a,b,c,s) bind(c, name="rocblas_srotg")
       use iso_c_binding
@@ -7274,19 +7002,13 @@ module hipfort_rocblas
   !>     device, where each device pointer points
   !>     to a scalar value of ``a_i``, ``b_i``, ``c_i``, or ``s_i``.
   !>
-  !>     @param[in]
-  !>     handle  [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>             handle to the rocBLAS library context queue.
-  !>     @param[in, out]
-  !>     a       a, overwritten with r.
-  !>     @param[in, out]
-  !>     b       b overwritten with z.
-  !>     @param[out]
-  !>     c       cosine element of the Givens rotation for the batch.
-  !>     @param[out]
-  !>     s       sine element of the Givens rotation for the batch.
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in, out] a - a, overwritten with r.
+  !>     @param[in, out] b - b overwritten with z.
+  !>     @param[out] c - cosine element of the Givens rotation for the batch.
+  !>     @param[out] s - sine element of the Givens rotation for the batch.
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of batches (length of arrays a, b, c, and s).
   interface rocblas_srotg_batched
     function rocblas_srotg_batched_(handle,a,b,c,s,batch_count) &
@@ -7424,31 +7146,25 @@ module hipfort_rocblas
   !>     ``a``, ``b``, ``c``, and ``s`` are host pointers to arrays ``a``, ``b``, ``c``, and ``s``
   !>     on the device.
   !>
-  !>     @param[in]
-  !>     handle  [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>             handle to the rocBLAS library context queue.
-  !>     @param[in, out]
-  !>     a host pointer to first single input vector element a_1 on the device, overwritten with r.
-  !>     @param[in]
-  !>     stride_a [rocblas_stride]
+  !>     @param[in, out] a - host pointer to first single input vector element a_1 on the device,
+  !>     overwritten with r.
+  !>     @param[in] stride_a - [rocblas_stride]
   !>              distance between elements of a in batch (distance between a_i and a_(i + 1)).
-  !>     @param[in, out]
-  !>     b host pointer to first single input vector element b_1 on the device, overwritten with z.
-  !>     @param[in]
-  !>     stride_b [rocblas_stride]
+  !>     @param[in, out] b - host pointer to first single input vector element b_1 on the device,
+  !>     overwritten with z.
+  !>     @param[in] stride_b - [rocblas_stride]
   !>              distance between elements of b in batch (distance between b_i and b_(i + 1)).
-  !>     @param[out]
-  !>     c host pointer to first single cosine element of the Givens rotations c_1 on the device.
-  !>     @param[in]
-  !>     stride_c [rocblas_stride]
+  !>     @param[out] c - host pointer to first single cosine element of the Givens rotations c_1 on
+  !>     the device.
+  !>     @param[in] stride_c - [rocblas_stride]
   !>              distance between elements of c in batch (distance between c_i and c_(i + 1)).
-  !>     @param[out]
-  !>     s host pointer to first single sine element of the Givens rotations s_1 on the device.
-  !>     @param[in]
-  !>     stride_s [rocblas_stride]
+  !>     @param[out] s - host pointer to first single sine element of the Givens rotations s_1 on
+  !>     the device.
+  !>     @param[in] stride_s - [rocblas_stride]
   !>              distance between elements of s in batch (distance between s_i and s_(i + 1)).
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of batches (length of arrays a, b, c, and s).
   interface rocblas_srotg_strided_batched
     function rocblas_srotg_strided_batched_(handle,a,stride_a,b,stride_b,c,stride_c,s,stride_s, &
@@ -7624,24 +7340,17 @@ module hipfort_rocblas
   !>     The rotm functions apply the modified Givens rotation matrix defined by ``param`` to
   !>     vectors ``x`` and ``y``.
   !>
-  !>     @param[in]
-  !>     handle  [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>             handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     n       [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>             number of elements in the x and y vectors.
-  !>     @param[in, out]
-  !>     x       device pointer storing vector x.
-  !>     @param[in]
-  !>     incx    [rocblas_int]
+  !>     @param[in, out] x - device pointer storing vector x.
+  !>     @param[in] incx - [rocblas_int]
   !>             specifies the increment between elements of x.
-  !>     @param[in, out]
-  !>     y       device pointer storing vector y.
-  !>     @param[in]
-  !>     incy    [rocblas_int]
+  !>     @param[in, out] y - device pointer storing vector y.
+  !>     @param[in] incy - [rocblas_int]
   !>             specifies the increment between elements of y.
-  !>     @param[in]
-  !>     param   device vector or host vector of five elements defining the rotation.
+  !>     @param[in] param - device vector or host vector of five elements defining the rotation.
   !>
   !>         param[0] = flag
   !>         param[1] = H11
@@ -7740,24 +7449,17 @@ module hipfort_rocblas
   !>     The rotm_batched functions apply the modified Givens rotation matrix defined by ``param_i``
   !>     to batched vectors ``x_i`` and ``y_i``, for ``i`` = 1, ..., ``batch_count``.
   !>
-  !>     @param[in]
-  !>     handle  [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>             handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     n       [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>             number of elements in the x and y vectors.
-  !>     @param[in, out]
-  !>     x       device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx    [rocblas_int]
+  !>     @param[in, out] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [rocblas_int]
   !>             specifies the increment between elements of each x_i.
-  !>     @param[in, out]
-  !>     y       device array of device pointers storing each vector y_1.
-  !>     @param[in]
-  !>     incy    [rocblas_int]
+  !>     @param[in, out] y - device array of device pointers storing each vector y_1.
+  !>     @param[in] incy - [rocblas_int]
   !>             specifies the increment between elements of each y_i.
-  !>     @param[in]
-  !>     param   device array of device vectors of five elements defining the rotation.
+  !>     @param[in] param - device array of device vectors of five elements defining the rotation.
   !>
   !>         param[0] = flag
   !>         param[1] = H11
@@ -7774,8 +7476,7 @@ module hipfort_rocblas
   !>
   !>     param can **only** be stored on the device for the batched version of this function.
   !>
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 the number of x and y arrays, that is, the number of batches.
   interface rocblas_srotm_batched
     function rocblas_srotm_batched_(handle,n,x,incx,y,incy,param,batch_count) &
@@ -7856,31 +7557,22 @@ module hipfort_rocblas
   !>     ``param_i`` to strided batched vectors ``x_i`` and ``y_i``, for ``i`` = 1, ...,
   !>     ``batch_count``.
   !>
-  !>     @param[in]
-  !>     handle  [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>             handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     n       [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>             number of elements in the x and y vectors.
-  !>     @param[in, out]
-  !>     x       device pointer pointing to first strided batched vector x_1.
-  !>     @param[in]
-  !>     incx    [rocblas_int]
+  !>     @param[in, out] x - device pointer pointing to first strided batched vector x_1.
+  !>     @param[in] incx - [rocblas_int]
   !>             specifies the increment between elements of each x_i.
-  !>     @param[in]
-  !>     stride_x [rocblas_stride]
+  !>     @param[in] stride_x - [rocblas_stride]
   !>              specifies the increment between the beginning of x_i and x_(i + 1)
-  !>     @param[in, out]
-  !>     y       device pointer pointing to first strided batched vector y_1.
-  !>     @param[in]
-  !>     incy    [rocblas_int]
+  !>     @param[in, out] y - device pointer pointing to first strided batched vector y_1.
+  !>     @param[in] incy - [rocblas_int]
   !>             specifies the increment between elements of each y_i.
-  !>     @param[in]
-  !>     stride_y [rocblas_stride]
+  !>     @param[in] stride_y - [rocblas_stride]
   !>              specifies the increment between the beginning of y_i and y_(i + 1).
-  !>     @param[in]
-  !>     param device pointer pointing to the first array of five elements defining the rotation
-  !>     (param_1).
+  !>     @param[in] param - device pointer pointing to the first array of five elements defining the
+  !>     rotation (param_1).
   !>
   !>         param[0] = flag
   !>         param[1] = H11
@@ -7898,11 +7590,9 @@ module hipfort_rocblas
   !>     param can **only** be stored on the device for the strided_batched
   !>     version of this function.
   !>
-  !>     @param[in]
-  !>     stride_param [rocblas_stride]
+  !>     @param[in] stride_param - [rocblas_stride]
   !>                  specifies the increment between the beginning of param_i and param_(i + 1).
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 the number of x and y arrays, that is, the number of batches.
   interface rocblas_srotm_strided_batched
     function rocblas_srotm_strided_batched_(handle,n,x,incx,stride_x,y,incy,stride_y,param, &
@@ -8012,19 +7702,13 @@ module hipfort_rocblas
   !>           Parameters can be stored in either host or device memory. The location is specified
   !>           by calling ``rocblas_set_pointer_mode``:
   !>
-  !>     @param[in]
-  !>     handle  [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>             handle to the rocBLAS library context queue.
-  !>     @param[in, out]
-  !>     d1      device pointer or host pointer to input scalar that is overwritten.
-  !>     @param[in, out]
-  !>     d2      device pointer or host pointer to input scalar that is overwritten.
-  !>     @param[in, out]
-  !>     x1      device pointer or host pointer to input scalar that is overwritten.
-  !>     @param[in]
-  !>     y1      device pointer or host pointer to input scalar.
-  !>     @param[out]
-  !>     param   device vector or host vector of five elements defining the rotation.
+  !>     @param[in, out] d1 - device pointer or host pointer to input scalar that is overwritten.
+  !>     @param[in, out] d2 - device pointer or host pointer to input scalar that is overwritten.
+  !>     @param[in, out] x1 - device pointer or host pointer to input scalar that is overwritten.
+  !>     @param[in] y1 - device pointer or host pointer to input scalar.
+  !>     @param[out] param - device vector or host vector of five elements defining the rotation.
   !>
   !>         param[0] = flag
   !>         param[1] = H11
@@ -8114,20 +7798,17 @@ module hipfort_rocblas
   !>     - If the pointer mode is set to ``rocblas_pointer_mode_device``, then this function returns
   !>     immediately and synchronization is required to read the results.
   !>
-  !>     @param[in]
-  !>     handle  [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>             handle to the rocBLAS library context queue.
-  !>     @param[in, out]
-  !>     d1      device batched array or host batched array of input scalars that is overwritten.
-  !>     @param[in, out]
-  !>     d2      device batched array or host batched array of input scalars that is overwritten.
-  !>     @param[in, out]
-  !>     x1      device batched array or host batched array of input scalars that is overwritten.
-  !>     @param[in]
-  !>     y1      device batched array or host batched array of input scalars.
-  !>     @param[out]
-  !>     param device batched array or host batched array of vectors of five elements defining the
-  !>     rotation.
+  !>     @param[in, out] d1 - device batched array or host batched array of input scalars that is
+  !>     overwritten.
+  !>     @param[in, out] d2 - device batched array or host batched array of input scalars that is
+  !>     overwritten.
+  !>     @param[in, out] x1 - device batched array or host batched array of input scalars that is
+  !>     overwritten.
+  !>     @param[in] y1 - device batched array or host batched array of input scalars.
+  !>     @param[out] param - device batched array or host batched array of vectors of five elements
+  !>     defining the rotation.
   !>
   !>         param[0] = flag
   !>         param[1] = H11
@@ -8145,8 +7826,7 @@ module hipfort_rocblas
   !>     param can be stored in either host or device memory.
   !>     The location is specified by calling rocblas_set_pointer_mode.
   !>
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 the number of instances in the batch.
   interface rocblas_srotmg_batched
     function rocblas_srotmg_batched_(handle,d1,d2,x1,y1,param,batch_count) &
@@ -8230,35 +7910,26 @@ module hipfort_rocblas
   !>     - If the pointer mode is set to ``rocblas_pointer_mode_device``, then this function returns
   !>     immediately and synchronization is required to read the results.
   !>
-  !>     @param[in]
-  !>     handle  [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>             handle to the rocBLAS library context queue.
-  !>     @param[in, out]
-  !>     d1 device strided_batched array or host strided_batched array of input scalars that is
-  !>     overwritten.
-  !>     @param[in]
-  !>     stride_d1 [rocblas_stride]
+  !>     @param[in, out] d1 - device strided_batched array or host strided_batched array of input
+  !>     scalars that is overwritten.
+  !>     @param[in] stride_d1 - [rocblas_stride]
   !>               specifies the increment between the beginning of d1_i and d1_(i+1).
-  !>     @param[in, out]
-  !>     d2 device strided_batched array or host strided_batched array of input scalars that is
-  !>     overwritten.
-  !>     @param[in]
-  !>     stride_d2 [rocblas_stride]
+  !>     @param[in, out] d2 - device strided_batched array or host strided_batched array of input
+  !>     scalars that is overwritten.
+  !>     @param[in] stride_d2 - [rocblas_stride]
   !>               specifies the increment between the beginning of d2_i and d2_(i+1).
-  !>     @param[in, out]
-  !>     x1 device strided_batched array or host strided_batched array of input scalars that is
-  !>     overwritten.
-  !>     @param[in]
-  !>     stride_x1 [rocblas_stride]
+  !>     @param[in, out] x1 - device strided_batched array or host strided_batched array of input
+  !>     scalars that is overwritten.
+  !>     @param[in] stride_x1 - [rocblas_stride]
   !>               specifies the increment between the beginning of x1_i and x1_(i+1).
-  !>     @param[in]
-  !>     y1      device strided_batched array or host strided_batched array of input scalars.
-  !>     @param[in]
-  !>     stride_y1 [rocblas_stride]
+  !>     @param[in] y1 - device strided_batched array or host strided_batched array of input
+  !>     scalars.
+  !>     @param[in] stride_y1 - [rocblas_stride]
   !>               specifies the increment between the beginning of y1_i and y1_(i+1).
-  !>     @param[out]
-  !>     param device strided_batched array or host strided_batched array of vectors of five
-  !>     elements defining the rotation.
+  !>     @param[out] param - device strided_batched array or host strided_batched array of vectors
+  !>     of five elements defining the rotation.
   !>
   !>         param[0] = flag
   !>         param[1] = H11
@@ -8276,11 +7947,9 @@ module hipfort_rocblas
   !>     param can be stored in either host or device memory.
   !>     The location is specified by calling rocblas_set_pointer_mode.
   !>
-  !>     @param[in]
-  !>     stride_param [rocblas_stride]
+  !>     @param[in] stride_param - [rocblas_stride]
   !>                  specifies the increment between the beginning of param_i and param_(i + 1).
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 the number of instances in the batch.
   interface rocblas_srotmg_strided_batched
     function rocblas_srotmg_strided_batched_(handle,d1,stride_d1,d2,stride_d2,x1,stride_x1,y1, &
@@ -8386,28 +8055,20 @@ module hipfort_rocblas
   !>     where ``alpha`` and ``beta`` are scalars, ``x`` and ``y`` are vectors, and ``A`` is an
   !>     ``m`` by ``n`` banded matrix with ``kl`` sub-diagonals and ``ku`` super-diagonals.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     trans     [rocblas_operation]
+  !>     @param[in] trans - [rocblas_operation]
   !>               indicates whether matrix A is tranposed (conjugated) or not.
-  !>     @param[in]
-  !>     m         [rocblas_int]
+  !>     @param[in] m - [rocblas_int]
   !>               number of rows of matrix A.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               number of columns of matrix A.
-  !>     @param[in]
-  !>     kl        [rocblas_int]
+  !>     @param[in] kl - [rocblas_int]
   !>               number of sub-diagonals of A.
-  !>     @param[in]
-  !>     ku        [rocblas_int]
+  !>     @param[in] ku - [rocblas_int]
   !>               number of super-diagonals of A.
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>         A     device pointer storing banded matrix A.
+  !>     @param[in] alpha - device pointer or host pointer to scalar alpha.
+  !>     @param[in] A - device pointer storing banded matrix A.
   !>               The leading (kl + ku + 1) by n part of the matrix contains the coefficients
   !>               of the banded matrix. The leading diagonal resides in row (ku + 1) with
   !>               the first super-diagonal above on the RHS of row ku. The first sub-diagonal
@@ -8425,20 +8086,14 @@ module hipfort_rocblas
   !>
   !>               Note that empty elements that do not correspond to data will not
   !>               be referenced.
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of A. Must be >= (kl + ku + 1).
-  !>     @param[in]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device pointer storing vector x.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of x.
-  !>     @param[in]
-  !>     beta      device pointer or host pointer to scalar beta.
-  !>     @param[in, out]
-  !>     y         device pointer storing vector y.
-  !>     @param[in]
-  !>     incy      [rocblas_int]
+  !>     @param[in] beta - device pointer or host pointer to scalar beta.
+  !>     @param[in, out] y - device pointer storing vector y.
+  !>     @param[in] incy - [rocblas_int]
   !>               specifies the increment for the elements of y.
   interface rocblas_sgbmv
     function rocblas_sgbmv_(handle,trans,m,n,kl,ku,alpha,A,lda,x,incx,beta,y,incy) &
@@ -8674,28 +8329,20 @@ module hipfort_rocblas
   !>     ``m`` by ``n`` banded matrix with ``kl`` sub-diagonals and ``ku`` super-diagonals,
   !>     for ``i`` = 1, ..., ``batch_count``.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     trans     [rocblas_operation]
+  !>     @param[in] trans - [rocblas_operation]
   !>               indicates whether matrix A is tranposed (conjugated) or not.
-  !>     @param[in]
-  !>     m         [rocblas_int]
+  !>     @param[in] m - [rocblas_int]
   !>               number of rows of each matrix A_i.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               number of columns of each matrix A_i.
-  !>     @param[in]
-  !>     kl        [rocblas_int]
+  !>     @param[in] kl - [rocblas_int]
   !>               number of sub-diagonals of each A_i.
-  !>     @param[in]
-  !>     ku        [rocblas_int]
+  !>     @param[in] ku - [rocblas_int]
   !>               number of super-diagonals of each A_i.
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>         A     device array of device pointers storing each banded matrix A_i.
+  !>     @param[in] alpha - device pointer or host pointer to scalar alpha.
+  !>     @param[in] A - device array of device pointers storing each banded matrix A_i.
   !>               The leading (kl + ku + 1) by n part of the matrix contains the coefficients
   !>               of the banded matrix. The leading diagonal resides in row (ku + 1) with
   !>               the first super-diagonal above on the RHS of row ku. The first sub-diagonal
@@ -8713,23 +8360,16 @@ module hipfort_rocblas
   !>
   !>               Note that empty elements that do not correspond to data will not
   !>               be referenced.
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of each A_i. Must be >= (kl + ku + 1)
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     beta      device pointer or host pointer to scalar beta.
-  !>     @param[in, out]
-  !>     y         device array of device pointers storing each vector y_i.
-  !>     @param[in]
-  !>     incy      [rocblas_int]
+  !>     @param[in] beta - device pointer or host pointer to scalar beta.
+  !>     @param[in, out] y - device array of device pointers storing each vector y_i.
+  !>     @param[in] incy - [rocblas_int]
   !>               specifies the increment for the elements of each y_i.
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 specifies the number of instances in the batch.
   interface rocblas_sgbmv_batched
     function rocblas_sgbmv_batched_(handle,trans,m,n,kl,ku,alpha,A,lda,x,incx,beta,y,incy, &
@@ -8953,28 +8593,20 @@ module hipfort_rocblas
   !>     ``m`` by ``n`` banded matrix with ``kl`` sub-diagonals and ``ku`` super-diagonals,
   !>     for ``i`` = 1, ..., ``batch_count``.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     trans     [rocblas_operation]
+  !>     @param[in] trans - [rocblas_operation]
   !>               indicates whether matrix A is tranposed (conjugated) or not.
-  !>     @param[in]
-  !>     m         [rocblas_int]
+  !>     @param[in] m - [rocblas_int]
   !>               number of rows of matrix A.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               number of columns of matrix A.
-  !>     @param[in]
-  !>     kl        [rocblas_int]
+  !>     @param[in] kl - [rocblas_int]
   !>               number of sub-diagonals of A.
-  !>     @param[in]
-  !>     ku        [rocblas_int]
+  !>     @param[in] ku - [rocblas_int]
   !>               number of super-diagonals of A.
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>         A     device pointer to first banded matrix (A_1).
+  !>     @param[in] alpha - device pointer or host pointer to scalar alpha.
+  !>     @param[in] A - device pointer to first banded matrix (A_1).
   !>               The leading (kl + ku + 1) by n part of the matrix contains the coefficients
   !>               of the banded matrix. The leading diagonal resides in row (ku + 1) with
   !>               the first super-diagonal above on the RHS of row ku. The first sub-diagonal
@@ -8992,32 +8624,22 @@ module hipfort_rocblas
   !>
   !>               Note that empty elements that do not correspond to data will not
   !>               be referenced.
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of A. Must be >= (kl + ku + 1).
-  !>     @param[in]
-  !>     stride_A  [rocblas_stride]
+  !>     @param[in] stride_A - [rocblas_stride]
   !>               stride from the start of one matrix (A_i) to the next one (A_i+1).
-  !>     @param[in]
-  !>     x         device pointer to first vector (x_1).
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device pointer to first vector (x_1).
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of x.
-  !>     @param[in]
-  !>     stride_x  [rocblas_stride]
+  !>     @param[in] stride_x - [rocblas_stride]
   !>               stride from the start of one vector (x_i) to the next one (x_i+1).
-  !>     @param[in]
-  !>     beta      device pointer or host pointer to scalar beta.
-  !>     @param[in, out]
-  !>     y         device pointer to first vector (y_1).
-  !>     @param[in]
-  !>     incy      [rocblas_int]
+  !>     @param[in] beta - device pointer or host pointer to scalar beta.
+  !>     @param[in, out] y - device pointer to first vector (y_1).
+  !>     @param[in] incy - [rocblas_int]
   !>               specifies the increment for the elements of y.
-  !>     @param[in]
-  !>     stride_y  [rocblas_stride]
+  !>     @param[in] stride_y - [rocblas_stride]
   !>               stride from the start of one vector (y_i) to the next one (y_i+1).
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 specifies the number of instances in the batch.
   interface rocblas_sgbmv_strided_batched
     function rocblas_sgbmv_strided_batched_(handle,trans,m,n,kl,ku,alpha,A,lda,stride_A,x,incx, &
@@ -9291,36 +8913,24 @@ module hipfort_rocblas
   !>     where ``alpha`` and ``beta`` are scalars, ``x`` and ``y`` are vectors, and ``A`` is an
   !>     ``m`` by ``n`` matrix.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     trans     [rocblas_operation]
+  !>     @param[in] trans - [rocblas_operation]
   !>               indicates whether matrix A is tranposed (conjugated) or not.
-  !>     @param[in]
-  !>     m         [rocblas_int]
+  !>     @param[in] m - [rocblas_int]
   !>               number of rows of matrix A.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               number of columns of matrix A.
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     A         device pointer storing matrix A.
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in] alpha - device pointer or host pointer to scalar alpha.
+  !>     @param[in] A - device pointer storing matrix A.
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of A.
-  !>     @param[in]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device pointer storing vector x.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of x.
-  !>     @param[in]
-  !>     beta      device pointer or host pointer to scalar beta.
-  !>     @param[in, out]
-  !>     y         device pointer storing vector y.
-  !>     @param[in]
-  !>     incy      [rocblas_int]
+  !>     @param[in] beta - device pointer or host pointer to scalar beta.
+  !>     @param[in, out] y - device pointer storing vector y.
+  !>     @param[in] incy - [rocblas_int]
   !>               specifies the increment for the elements of y.
   interface rocblas_sgemv
     function rocblas_sgemv_(handle,trans,m,n,alpha,A,lda,x,incx,beta,y,incy) &
@@ -9539,39 +9149,26 @@ module hipfort_rocblas
   !>     ``alpha`` and ``beta`` are scalars, ``x_i`` and ``y_i`` are vectors, and ``A_i`` is an
   !>     ``m`` by ``n`` matrix, for ``i`` = 1, ..., ``batch_count``.
   !>
-  !>     @param[in]
-  !>     handle      [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>                 handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     trans       [rocblas_operation]
+  !>     @param[in] trans - [rocblas_operation]
   !>                 indicates whether matrices A_i are tranposed (conjugated) or not.
-  !>     @param[in]
-  !>     m           [rocblas_int]
+  !>     @param[in] m - [rocblas_int]
   !>                 number of rows of each matrix A_i.
-  !>     @param[in]
-  !>     n           [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>                 number of columns of each matrix A_i.
-  !>     @param[in]
-  !>     alpha       device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     A           device array of device pointers storing each matrix A_i.
-  !>     @param[in]
-  !>     lda         [rocblas_int]
+  !>     @param[in] alpha - device pointer or host pointer to scalar alpha.
+  !>     @param[in] A - device array of device pointers storing each matrix A_i.
+  !>     @param[in] lda - [rocblas_int]
   !>                 specifies the leading dimension of each matrix A_i.
-  !>     @param[in]
-  !>     x           device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx        [rocblas_int]
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [rocblas_int]
   !>                 specifies the increment for the elements of each vector x_i.
-  !>     @param[in]
-  !>     beta        device pointer or host pointer to scalar beta.
-  !>     @param[in, out]
-  !>     y           device array of device pointers storing each vector y_i.
-  !>     @param[in]
-  !>     incy        [rocblas_int]
+  !>     @param[in] beta - device pointer or host pointer to scalar beta.
+  !>     @param[in, out] y - device array of device pointers storing each vector y_i.
+  !>     @param[in] incy - [rocblas_int]
   !>                 specifies the increment for the elements of each vector y_i.
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_sgemv_batched
     function rocblas_sgemv_batched_(handle,trans,m,n,alpha,A,lda,x,incx,beta,y,incy,batch_count) &
@@ -9962,55 +9559,39 @@ module hipfort_rocblas
   !>     ``alpha`` and ``beta`` are scalars, ``x_i`` and ``y_i`` are vectors, and ``A_i`` is an
   !>     ``m`` by ``n`` matrix, for ``i`` = 1, ..., ``batch_count``.
   !>
-  !>     @param[in]
-  !>     handle      [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>                 handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     transA      [rocblas_operation]
+  !>     @param[in] transA - [rocblas_operation]
   !>                 indicates whether matrices A_i are tranposed (conjugated) or not.
-  !>     @param[in]
-  !>     m           [rocblas_int]
+  !>     @param[in] m - [rocblas_int]
   !>                 number of rows of matrices A_i.
-  !>     @param[in]
-  !>     n           [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>                 number of columns of matrices A_i.
-  !>     @param[in]
-  !>     alpha       device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     A           device pointer to the first matrix (A_1) in the batch.
-  !>     @param[in]
-  !>     lda         [rocblas_int]
+  !>     @param[in] alpha - device pointer or host pointer to scalar alpha.
+  !>     @param[in] A - device pointer to the first matrix (A_1) in the batch.
+  !>     @param[in] lda - [rocblas_int]
   !>                 specifies the leading dimension of matrices A_i.
-  !>     @param[in]
-  !>     strideA     [rocblas_stride]
+  !>     @param[in] strideA - [rocblas_stride]
   !>                 stride from the start of one matrix (A_i) to the next one (A_i+1).
-  !>     @param[in]
-  !>     x           device pointer to the first vector (x_1) in the batch.
-  !>     @param[in]
-  !>     incx        [rocblas_int]
+  !>     @param[in] x - device pointer to the first vector (x_1) in the batch.
+  !>     @param[in] incx - [rocblas_int]
   !>                 specifies the increment for the elements of vectors x_i.
-  !>     @param[in]
-  !>     stridex     [rocblas_stride]
+  !>     @param[in] stridex - [rocblas_stride]
   !>                 stride from the start of one vector (x_i) to the next one (x_i+1).
   !>                 There are no restrictions placed on stride_x. However, ensure that stride_x is
   !>                 of an appropriate size. When trans equals rocblas_operation_none,
   !>                 this typically means stride_x >= n * incx. Otherwise, stride_x >= m * incx.
-  !>     @param[in]
-  !>     beta        device pointer or host pointer to scalar beta.
-  !>     @param[in, out]
-  !>     y           device pointer to the first vector (y_1) in the batch.
-  !>     @param[in]
-  !>     incy        [rocblas_int]
+  !>     @param[in] beta - device pointer or host pointer to scalar beta.
+  !>     @param[in, out] y - device pointer to the first vector (y_1) in the batch.
+  !>     @param[in] incy - [rocblas_int]
   !>                 specifies the increment for the elements of vectors y_i.
-  !>     @param[in]
-  !>     stridey     [rocblas_stride]
+  !>     @param[in] stridey - [rocblas_stride]
   !>                 stride from the start of one vector (y_i) to the next one (y_i+1).
   !>                 There are no restrictions placed on stride_y. However, ensure that stride_y is
   !>                 of an appropriate size. When trans equals rocblas_operation_none,
   !>                 this typically means stride_y >= m * incy. Otherwise, stride_y >= n * incy.
   !>                 stridey should be non zero.
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_sgemv_strided_batched
     function rocblas_sgemv_strided_batched_(handle,transA,m,n,alpha,A,lda,strideA,x,incx,stridex, &
@@ -10483,23 +10064,17 @@ module hipfort_rocblas
   !>     ``A`` is an
   !>     ``n`` by ``n`` Hermitian band matrix, with ``k`` super-diagonals.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper: The upper triangular part of A is being supplied.
   !>             - rocblas_fill_lower: The lower triangular part of A is being supplied.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the order of the matrix A.
-  !>     @param[in]
-  !>     k         [rocblas_int]
+  !>     @param[in] k - [rocblas_int]
   !>               the number of super-diagonals of the matrix A. Must be >= 0.
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     A         device pointer storing matrix A. Of dimension (lda, n).
+  !>     @param[in] alpha - device pointer or host pointer to scalar alpha.
+  !>     @param[in] A - device pointer storing matrix A. Of dimension (lda, n).
   !>
   !>             if uplo == rocblas_fill_upper:
   !>                 The leading (k + 1) by n part of A must contain the upper
@@ -10529,20 +10104,14 @@ module hipfort_rocblas
   !>
   !>               As a Hermitian matrix, the imaginary part of the main diagonal
   !>               of A will not be referenced and is assumed to be == 0.
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of A. Must be >= k + 1.
-  !>     @param[in]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device pointer storing vector x.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of x.
-  !>     @param[in]
-  !>     beta      device pointer or host pointer to scalar beta.
-  !>     @param[in, out]
-  !>     y         device pointer storing vector y.
-  !>     @param[in]
-  !>     incy      [rocblas_int]
+  !>     @param[in] beta - device pointer or host pointer to scalar beta.
+  !>     @param[in, out] y - device pointer storing vector y.
+  !>     @param[in] incy - [rocblas_int]
   !>               specifies the increment for the elements of y.
   interface rocblas_chbmv
     function rocblas_chbmv_(handle,uplo,n,k,alpha,A,lda,x,incx,beta,y,incy) &
@@ -10658,23 +10227,18 @@ module hipfort_rocblas
   !>     ``n`` by ``n`` Hermitian band matrix with ``k`` super-diagonals, for each batch in
   !>     ``i = [1, batch_count`` ].
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper: The upper triangular part of each A_i is being supplied.
   !>             - rocblas_fill_lower: The lower triangular part of each A_i is being supplied.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the order of each matrix A_i.
-  !>     @param[in]
-  !>     k         [rocblas_int]
+  !>     @param[in] k - [rocblas_int]
   !>               the number of super-diagonals of each matrix A_i. Must be >= 0.
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     A         device array of device pointers storing each matrix A_i of dimension (lda, n).
+  !>     @param[in] alpha - device pointer or host pointer to scalar alpha.
+  !>     @param[in] A - device array of device pointers storing each matrix A_i of dimension (lda,
+  !>     n).
   !>
   !>             if uplo == rocblas_fill_upper:
   !>                 The leading (k + 1) by n part of each A_i must contain the upper
@@ -10704,23 +10268,16 @@ module hipfort_rocblas
   !>
   !>               As a Hermitian matrix, the imaginary part of the main diagonal
   !>               of each A_i will not be referenced and is assumed to be == 0.
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of each A_i. Must be >= max(1, n).
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     beta      device pointer or host pointer to scalar beta.
-  !>     @param[in, out]
-  !>     y         device array of device pointers storing each vector y_i.
-  !>     @param[in]
-  !>     incy      [rocblas_int]
+  !>     @param[in] beta - device pointer or host pointer to scalar beta.
+  !>     @param[in, out] y - device array of device pointers storing each vector y_i.
+  !>     @param[in] incy - [rocblas_int]
   !>               specifies the increment for the elements of y.
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_chbmv_batched
     function rocblas_chbmv_batched_(handle,uplo,n,k,alpha,A,lda,x,incx,beta,y,incy,batch_count) &
@@ -10826,23 +10383,18 @@ module hipfort_rocblas
   !>     ``n`` by ``n`` Hermitian band matrix with ``k`` super-diagonals, for each batch in
   !>     ``i = [1, batch_count`` ].
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper: The upper triangular part of each A_i is being supplied.
   !>             - rocblas_fill_lower: The lower triangular part of each A_i is being supplied.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the order of each matrix A_i.
-  !>     @param[in]
-  !>     k         [rocblas_int]
+  !>     @param[in] k - [rocblas_int]
   !>               the number of super-diagonals of each matrix A_i. Must be >= 0.
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     A         device array pointing to the first matrix A_1. Each A_i is of dimension (lda, n).
+  !>     @param[in] alpha - device pointer or host pointer to scalar alpha.
+  !>     @param[in] A - device array pointing to the first matrix A_1. Each A_i is of dimension
+  !>     (lda, n).
   !>
   !>             if uplo == rocblas_fill_upper:
   !>                 The leading (k + 1) by n part of each A_i must contain the upper
@@ -10872,32 +10424,22 @@ module hipfort_rocblas
   !>
   !>               As a Hermitian matrix, the imaginary part of the main diagonal
   !>               of each A_i will not be referenced and is assumed to be == 0.
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of each A_i. Must be >= max(1, n).
-  !>     @param[in]
-  !>     stride_A  [rocblas_stride]
+  !>     @param[in] stride_A - [rocblas_stride]
   !>               stride from the start of one matrix (A_i) to the next one (A_i+1).
-  !>     @param[in]
-  !>     x         device array pointing to the first vector y_1.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device array pointing to the first vector y_1.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     stride_x  [rocblas_stride]
+  !>     @param[in] stride_x - [rocblas_stride]
   !>               stride from the start of one vector (x_i) to the next one (x_i+1).
-  !>     @param[in]
-  !>     beta      device pointer or host pointer to scalar beta.
-  !>     @param[in, out]
-  !>     y         device array pointing to the first vector y_1.
-  !>     @param[in]
-  !>     incy      [rocblas_int]
+  !>     @param[in] beta - device pointer or host pointer to scalar beta.
+  !>     @param[in, out] y - device array pointing to the first vector y_1.
+  !>     @param[in] incy - [rocblas_int]
   !>               specifies the increment for the elements of y.
-  !>     @param[in]
-  !>     stride_y  [rocblas_stride]
+  !>     @param[in] stride_y - [rocblas_stride]
   !>               stride from the start of one vector (y_i) to the next one (y_i+1).
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_chbmv_strided_batched
     function rocblas_chbmv_strided_batched_(handle,uplo,n,k,alpha,A,lda,stride_A,x,incx,stride_x, &
@@ -11032,22 +10574,17 @@ module hipfort_rocblas
   !>     ``A`` is an
   !>     ``n`` by ``n`` Hermitian matrix.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper: the upper triangular part of the Hermitian matrix A is
   !>             supplied.
   !>             - rocblas_fill_lower: the lower triangular part of the Hermitian matrix A is
   !>             supplied.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the order of the matrix A.
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     A         device pointer storing matrix A. Of dimension (lda, n).
+  !>     @param[in] alpha - device pointer or host pointer to scalar alpha.
+  !>     @param[in] A - device pointer storing matrix A. Of dimension (lda, n).
   !>
   !>         if uplo == rocblas_fill_upper:
   !>             The upper triangular part of A must contain
@@ -11060,20 +10597,14 @@ module hipfort_rocblas
   !>             triangular part of A will not be referenced.
   !>             As a Hermitian matrix, the imaginary part of the main diagonal
   !>             of A will not be referenced and is assumed to be == 0.
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of A. Must be >= max(1, n).
-  !>     @param[in]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device pointer storing vector x.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of x.
-  !>     @param[in]
-  !>     beta      device pointer or host pointer to scalar beta.
-  !>     @param[in, out]
-  !>     y         device pointer storing vector y.
-  !>     @param[in]
-  !>     incy      [rocblas_int]
+  !>     @param[in] beta - device pointer or host pointer to scalar beta.
+  !>     @param[in, out] y - device pointer storing vector y.
+  !>     @param[in] incy - [rocblas_int]
   !>               specifies the increment for the elements of y.
   interface rocblas_chemv
     function rocblas_chemv_(handle,uplo,n,alpha,A,lda,x,incx,beta,y,incy) &
@@ -11184,22 +10715,18 @@ module hipfort_rocblas
   !>     and ``A_i`` is an
   !>     ``n`` by ``n`` Hermitian matrix, for each batch in ``i = [1, batch_count``].
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper: the upper triangular part of the Hermitian matrix A is
   !>             supplied.
   !>             - rocblas_fill_lower: the lower triangular part of the Hermitian matrix A is
   !>             supplied.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the order of each matrix A_i.
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     A         device array of device pointers storing each matrix A_i of dimension (lda, n).
+  !>     @param[in] alpha - device pointer or host pointer to scalar alpha.
+  !>     @param[in] A - device array of device pointers storing each matrix A_i of dimension (lda,
+  !>     n).
   !>
   !>         if uplo == rocblas_fill_upper:
   !>             The upper triangular part of each A_i must contain
@@ -11212,23 +10739,16 @@ module hipfort_rocblas
   !>             triangular part of each A_i will not be referenced.
   !>             As a Hermitian matrix, the imaginary part of the main diagonal
   !>             of each A_i will not be referenced and is assumed to be == 0.
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of each A_i. Must be >= max(1, n).
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     beta      device pointer or host pointer to scalar beta.
-  !>     @param[in, out]
-  !>     y         device array of device pointers storing each vector y_i.
-  !>     @param[in]
-  !>     incy      [rocblas_int]
+  !>     @param[in] beta - device pointer or host pointer to scalar beta.
+  !>     @param[in, out] y - device array of device pointers storing each vector y_i.
+  !>     @param[in] incy - [rocblas_int]
   !>               specifies the increment for the elements of y.
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_chemv_batched
     function rocblas_chemv_batched_(handle,uplo,n,alpha,A,lda,x,incx,beta,y,incy,batch_count) &
@@ -11329,22 +10849,18 @@ module hipfort_rocblas
   !>     and ``A_i`` is an
   !>     ``n`` by ``n`` Hermitian matrix, for each batch in ``i = [1, batch_count``].
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper: the upper triangular part of the Hermitian matrix A is
   !>             supplied.
   !>             - rocblas_fill_lower: the lower triangular part of the Hermitian matrix A is
   !>             supplied.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the order of each matrix A_i.
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     A         device array of device pointers storing each matrix A_i of dimension (lda, n).
+  !>     @param[in] alpha - device pointer or host pointer to scalar alpha.
+  !>     @param[in] A - device array of device pointers storing each matrix A_i of dimension (lda,
+  !>     n).
   !>
   !>         if uplo == rocblas_fill_upper:
   !>             The upper triangular part of each A_i must contain
@@ -11357,32 +10873,22 @@ module hipfort_rocblas
   !>             triangular part of each A_i will not be referenced.
   !>             As a Hermitian matrix, the imaginary part of the main diagonal
   !>             of each A_i will not be referenced and is assumed to be == 0.
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of each A_i. Must be >= max(1, n).
-  !>     @param[in]
-  !>     stride_A    [rocblas_stride]
+  !>     @param[in] stride_A - [rocblas_stride]
   !>                 stride from the start of one (A_i) to the next (A_i+1).
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     stride_x  [rocblas_stride]
+  !>     @param[in] stride_x - [rocblas_stride]
   !>               stride from the start of one vector (x_i) to the next one (x_i+1).
-  !>     @param[in]
-  !>     beta      device pointer or host pointer to scalar beta.
-  !>     @param[in, out]
-  !>     y         device array of device pointers storing each vector y_i.
-  !>     @param[in]
-  !>     incy      [rocblas_int]
+  !>     @param[in] beta - device pointer or host pointer to scalar beta.
+  !>     @param[in, out] y - device array of device pointers storing each vector y_i.
+  !>     @param[in] incy - [rocblas_int]
   !>               specifies the increment for the elements of y.
-  !>     @param[in]
-  !>     stride_y  [rocblas_stride]
+  !>     @param[in] stride_y - [rocblas_stride]
   !>               stride from the start of one vector (y_i) to the next one (y_i+1).
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_chemv_strided_batched
     function rocblas_chemv_strided_batched_(handle,uplo,n,alpha,A,lda,stride_A,x,incx,stride_x, &
@@ -11512,27 +11018,21 @@ module hipfort_rocblas
   !>     where ``alpha`` is a real scalar, ``x`` is a vector, and ``A`` is an
   !>     ``n`` by ``n`` Hermitian matrix.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             specifies either upper (rocblas_fill_upper) or lower (rocblas_fill_lower).
   !>             - rocblas_fill_upper: The upper triangular part of A is supplied in A.
   !>             - rocblas_fill_lower: The lower triangular part of A is supplied in A.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the number of rows and columns of matrix A. Must be at least 0.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device pointer storing vector x.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of x.
-  !>     @param[in, out]
-  !>     A device pointer storing the specified triangular portion of the Hermitian matrix A.
+  !>     @param[in, out] A - device pointer storing the specified triangular portion of the
+  !>     Hermitian matrix A.
   !>               Of size (lda * n).
   !>
   !>                     if uplo == rocblas_fill_upper:
@@ -11545,8 +11045,7 @@ module hipfort_rocblas
   !>                Note that the imaginary parts of the diagonal elements are not accessed
   !>                and are assumed to be 0.
   !>
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of A. Must be at least max(1, n).
   interface rocblas_cher
     function rocblas_cher_(handle,uplo,n,alpha,x,incx,A,lda) bind(c, name="rocblas_cher")
@@ -11640,27 +11139,21 @@ module hipfort_rocblas
   !>     where ``alpha`` is a real scalar, ``x_i`` is a vector, and ``A_i`` is an
   !>     ``n`` by ``n`` symmetric matrix, for ``i`` = 1, ..., ``batch_count``.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             specifies either upper (rocblas_fill_upper) or lower (rocblas_fill_lower).
   !>             - rocblas_fill_upper: The upper triangular part of each A_i is supplied in A.
   !>             - rocblas_fill_lower: The lower triangular part of each A_i is supplied in A.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the number of rows and columns of each matrix A_i. Must be at least 0.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in, out]
-  !>     A         device array of device pointers storing the specified triangular portion of
+  !>     @param[in, out] A - device array of device pointers storing the specified triangular
+  !>     portion of
   !>               each Hermitian matrix A_i of at least size ((n * (n + 1)) / 2). Array is of at
   !>               least size batch_count.
   !>
@@ -11674,11 +11167,9 @@ module hipfort_rocblas
   !>                Note that the imaginary parts of the diagonal elements are not accessed
   !>                and are assumed to be 0.
   !>
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of each A_i. Must be at least max(1, n).
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_cher_batched
     function rocblas_cher_batched_(handle,uplo,n,alpha,x,incx,A,lda,batch_count) &
@@ -11766,30 +11257,23 @@ module hipfort_rocblas
   !>     where ``alpha`` is a real scalar, ``x_i`` is a vector, and ``A_i`` is an
   !>     ``n`` by ``n`` Hermitian matrix, for ``i`` = 1, ..., ``batch_count``.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>               specifies either upper (rocblas_fill_upper) or lower (rocblas_fill_lower).
   !>             - rocblas_fill_upper: The upper triangular part of each A_i is supplied in A.
   !>             - rocblas_fill_lower: The lower triangular part of each A_i is supplied in A.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the number of rows and columns of each matrix A_i. Must be at least 0.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     x         device pointer pointing to the first vector (x_1).
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device pointer pointing to the first vector (x_1).
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     stride_x  [rocblas_stride]
+  !>     @param[in] stride_x - [rocblas_stride]
   !>               stride from the start of one vector (x_i) to the next one (x_i+1).
-  !>     @param[in, out]
-  !>     A         device array of device pointers storing the specified triangular portion of
+  !>     @param[in, out] A - device array of device pointers storing the specified triangular
+  !>     portion of
   !>               each Hermitian matrix A_i. Points to the first matrix (A_1).
   !>
   !>                     if uplo == rocblas_fill_upper:
@@ -11801,14 +11285,11 @@ module hipfort_rocblas
   !>                         The upper triangular portion of each A_i will not be touched.
   !>                Note that the imaginary parts of the diagonal elements are not accessed
   !>                and are assumed to be 0.
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of each A_i.
-  !>     @param[in]
-  !>     stride_A    [rocblas_stride]
+  !>     @param[in] stride_A - [rocblas_stride]
   !>                 stride from the start of one (A_i) to the next (A_i+1).
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_cher_strided_batched
     function rocblas_cher_strided_batched_(handle,uplo,n,alpha,x,incx,stride_x,A,lda,stride_A, &
@@ -11922,32 +11403,23 @@ module hipfort_rocblas
   !>     where ``alpha`` is a complex scalar, ``x`` and ``y`` are vectors, and ``A`` is an
   !>     ``n`` by ``n`` Hermitian matrix.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             specifies either upper (rocblas_fill_upper) or lower (rocblas_fill_lower).
   !>             - rocblas_fill_upper: The upper triangular part of A is supplied.
   !>             - rocblas_fill_lower: The lower triangular part of A is supplied.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the number of rows and columns of matrix A. Must be at least 0.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device pointer storing vector x.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of x.
-  !>     @param[in]
-  !>     y         device pointer storing vector y.
-  !>     @param[in]
-  !>     incy      [rocblas_int]
+  !>     @param[in] y - device pointer storing vector y.
+  !>     @param[in] incy - [rocblas_int]
   !>               specifies the increment for the elements of y.
-  !>     @param[in, out]
-  !>     A         device pointer storing the specified triangular portion of
+  !>     @param[in, out] A - device pointer storing the specified triangular portion of
   !>               the Hermitian matrix A. Of size (lda, n).
   !>
   !>                     if uplo == rocblas_fill_upper:
@@ -11959,8 +11431,7 @@ module hipfort_rocblas
   !>                         The upper triangular portion of A will not be touched.
   !>                Note that the imaginary parts of the diagonal elements are not accessed
   !>                and are assumed to be 0.
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of A. Must be at least max(lda, 1).
   interface rocblas_cher2
     function rocblas_cher2_(handle,uplo,n,alpha,x,incx,y,incy,A,lda) bind(c, name="rocblas_cher2")
@@ -12064,32 +11535,24 @@ module hipfort_rocblas
   !>     where ``alpha`` is a complex scalar, ``x_i`` and ``y_i`` are vectors, and ``A_i`` is an
   !>     ``n`` by ``n`` Hermitian matrix for each batch in ``i = [1, batch_count``].
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             specifies either upper (rocblas_fill_upper) or lower (rocblas_fill_lower).
   !>             - rocblas_fill_upper: The upper triangular part of each A_i is supplied.
   !>             - rocblas_fill_lower: The lower triangular part of each A_i is supplied.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the number of rows and columns of each matrix A_i. Must be at least 0.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of x.
-  !>     @param[in]
-  !>     y         device array of device pointers storing each vector y_i.
-  !>     @param[in]
-  !>     incy      [rocblas_int]
+  !>     @param[in] y - device array of device pointers storing each vector y_i.
+  !>     @param[in] incy - [rocblas_int]
   !>               specifies the increment for the elements of each y_i.
-  !>     @param[in, out]
-  !>     A         device array of device pointers storing the specified triangular portion of
+  !>     @param[in, out] A - device array of device pointers storing the specified triangular
+  !>     portion of
   !>               each Hermitian matrix A_i of size (lda, n).
   !>
   !>                     if uplo == rocblas_fill_upper:
@@ -12101,11 +11564,9 @@ module hipfort_rocblas
   !>                         The upper triangular portion of each A_i will not be touched.
   !>                Note that the imaginary parts of the diagonal elements are not accessed
   !>                and are assumed to be 0.
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of each A_i. Must be at least max(lda, 1).
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_cher2_batched
     function rocblas_cher2_batched_(handle,uplo,n,alpha,x,incx,y,incy,A,lda,batch_count) &
@@ -12201,41 +11662,30 @@ module hipfort_rocblas
   !>     where ``alpha`` is a complex scalar, ``x_i`` and ``y_i`` are vectors, and ``A_i`` is an
   !>     ``n`` by ``n`` Hermitian matrix for each batch in ``i = [1, batch_count``].
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             specifies either upper (rocblas_fill_upper) or lower (rocblas_fill_lower).
   !>             - rocblas_fill_upper: The upper triangular part of each A_i is supplied.
   !>             - rocblas_fill_lower: The lower triangular part of each A_i is supplied.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the number of rows and columns of each matrix A_i. Must be at least 0.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     x         device pointer pointing to the first vector x_1.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device pointer pointing to the first vector x_1.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     stride_x  [rocblas_stride]
+  !>     @param[in] stride_x - [rocblas_stride]
   !>               specifies the stride between the beginning of one vector (x_i) and the next
   !>               (x_i+1).
-  !>     @param[in]
-  !>     y         device pointer pointing to the first vector y_i.
-  !>     @param[in]
-  !>     incy      [rocblas_int]
+  !>     @param[in] y - device pointer pointing to the first vector y_i.
+  !>     @param[in] incy - [rocblas_int]
   !>               specifies the increment for the elements of each y_i.
-  !>     @param[in]
-  !>     stride_y  [rocblas_stride]
+  !>     @param[in] stride_y - [rocblas_stride]
   !>               specifies the stride between the beginning of one vector (y_i) and the next
   !>               (y_i+1).
-  !>     @param[in, out]
-  !>     A device pointer pointing to the first matrix (A_1). Stores the specified triangular
-  !>     portion of
+  !>     @param[in, out] A - device pointer pointing to the first matrix (A_1). Stores the specified
+  !>     triangular portion of
   !>               each Hermitian matrix A_i.
   !>
   !>                     if uplo == rocblas_fill_upper:
@@ -12247,15 +11697,12 @@ module hipfort_rocblas
   !>                         The upper triangular portion of each A_i will not be touched.
   !>                 Note that the imaginary parts of the diagonal elements are not accessed
   !>                 and are assumed to be 0.
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of each A_i. Must be at least max(lda, 1).
-  !>     @param[in]
-  !>     stride_A  [rocblas_stride]
+  !>     @param[in] stride_A - [rocblas_stride]
   !>               specifies the stride between the beginning of one matrix (A_i) and the next
   !>               (A_i+1).
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_cher2_strided_batched
     function rocblas_cher2_strided_batched_(handle,uplo,n,alpha,x,incx,stride_x,y,incy,stride_y,A, &
@@ -12382,22 +11829,18 @@ module hipfort_rocblas
   !>     is an
   !>     ``n`` by ``n`` Hermitian matrix, supplied in packed form (see description below).
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper: the upper triangular part of the Hermitian matrix A is
   !>             supplied in AP.
   !>             - rocblas_fill_lower: the lower triangular part of the Hermitian matrix A is
   !>             supplied in AP.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the order of the matrix A. Must be >= 0.
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     AP        device pointer storing the packed version of the specified triangular portion of
+  !>     @param[in] alpha - device pointer or host pointer to scalar alpha.
+  !>     @param[in] AP - device pointer storing the packed version of the specified triangular
+  !>     portion of
   !>               the Hermitian matrix A. Of at least size ((n * (n + 1)) / 2).
   !>
   !>                     if uplo == rocblas_fill_upper:
@@ -12427,17 +11870,12 @@ module hipfort_rocblas
   !>                             (3,-2) (5, 1) (6, 0)
   !>                 Note that the imaginary parts of the diagonal elements are not accessed
   !>                 and are assumed to be 0.
-  !>     @param[in]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device pointer storing vector x.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of x.
-  !>     @param[in]
-  !>     beta      device pointer or host pointer to scalar beta.
-  !>     @param[in, out]
-  !>     y         device pointer storing vector y.
-  !>     @param[in]
-  !>     incy      [rocblas_int]
+  !>     @param[in] beta - device pointer or host pointer to scalar beta.
+  !>     @param[in, out] y - device pointer storing vector y.
+  !>     @param[in] incy - [rocblas_int]
   !>               specifies the increment for the elements of y.
   interface rocblas_chpmv
     function rocblas_chpmv_(handle,uplo,n,alpha,AP,x,incx,beta,y,incy) bind(c, name="rocblas_chpmv")
@@ -12541,22 +11979,18 @@ module hipfort_rocblas
   !>     ``n`` by ``n`` Hermitian matrix, supplied in packed form (see description below),
   !>     for each batch in ``i = [1, batch_count``].
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper: the upper triangular part of each Hermitian matrix A_i is
   !>             supplied in AP.
   !>             - rocblas_fill_lower: the lower triangular part of each Hermitian matrix A_i is
   !>             supplied in AP.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the order of each matrix A_i.
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     AP device pointer of device pointers storing the packed version of the specified triangular
+  !>     @param[in] alpha - device pointer or host pointer to scalar alpha.
+  !>     @param[in] AP - device pointer of device pointers storing the packed version of the
+  !>     specified triangular
   !>             portion of each Hermitian matrix A_i. Each A_i is of at least size ((n * (n + 1)) /
   !>             2).
   !>
@@ -12589,20 +12023,14 @@ module hipfort_rocblas
   !>                             (3,-2) (5, 1) (6, 0)
   !>                Note that the imaginary parts of the diagonal elements are not accessed
   !>                and are assumed to be 0.
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     beta      device pointer or host pointer to scalar beta.
-  !>     @param[in, out]
-  !>     y         device array of device pointers storing each vector y_i.
-  !>     @param[in]
-  !>     incy      [rocblas_int]
+  !>     @param[in] beta - device pointer or host pointer to scalar beta.
+  !>     @param[in, out] y - device array of device pointers storing each vector y_i.
+  !>     @param[in] incy - [rocblas_int]
   !>               specifies the increment for the elements of y.
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_chpmv_batched
     function rocblas_chpmv_batched_(handle,uplo,n,alpha,AP,x,incx,beta,y,incy,batch_count) &
@@ -12700,22 +12128,18 @@ module hipfort_rocblas
   !>     ``n`` by ``n`` Hermitian matrix, supplied in packed form (see description below),
   !>     for each batch in ``i = [1, batch_count``].
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper: the upper triangular part of each Hermitian matrix A_i is
   !>             supplied in AP.
   !>             - rocblas_fill_lower: the lower triangular part of each Hermitian matrix A_i is
   !>             supplied in AP.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the order of each matrix A_i.
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     AP device pointer pointing to the beginning of the first matrix (AP_1). Stores the packed
+  !>     @param[in] alpha - device pointer or host pointer to scalar alpha.
+  !>     @param[in] AP - device pointer pointing to the beginning of the first matrix (AP_1). Stores
+  !>     the packed
   !>               version of the specified triangular portion of each Hermitian matrix AP_i of size
   !>               ((n * (n + 1)) / 2).
   !>
@@ -12748,29 +12172,20 @@ module hipfort_rocblas
   !>                             (3,-2) (5, 1) (6, 0)
   !>                Note that the imaginary parts of the diagonal elements are not accessed
   !>                and are assumed to be 0.
-  !>     @param[in]
-  !>     stride_A  [rocblas_stride]
+  !>     @param[in] stride_A - [rocblas_stride]
   !>               stride from the start of one matrix (AP_i) to the next one (AP_i+1).
-  !>     @param[in]
-  !>     x         device array pointing to the beginning of the first vector (x_1).
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device array pointing to the beginning of the first vector (x_1).
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     stride_x  [rocblas_stride]
+  !>     @param[in] stride_x - [rocblas_stride]
   !>               stride from the start of one vector (x_i) to the next one (x_i+1).
-  !>     @param[in]
-  !>     beta      device pointer or host pointer to scalar beta.
-  !>     @param[in, out]
-  !>     y         device array pointing to the beginning of the first vector (y_1).
-  !>     @param[in]
-  !>     incy      [rocblas_int]
+  !>     @param[in] beta - device pointer or host pointer to scalar beta.
+  !>     @param[in, out] y - device array pointing to the beginning of the first vector (y_1).
+  !>     @param[in] incy - [rocblas_int]
   !>               specifies the increment for the elements of y.
-  !>     @param[in]
-  !>     stride_y  [rocblas_stride]
+  !>     @param[in] stride_y - [rocblas_stride]
   !>               stride from the start of one vector (y_i) to the next one (y_i+1).
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_chpmv_strided_batched
     function rocblas_chpmv_strided_batched_(handle,uplo,n,alpha,AP,stride_A,x,incx,stride_x,beta, &
@@ -12894,27 +12309,21 @@ module hipfort_rocblas
   !>     where ``alpha`` is a real scalar, ``x`` is a vector, and ``A`` is an
   !>     ``n`` by ``n`` Hermitian matrix, supplied in packed form.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             specifies either upper (rocblas_fill_upper) or lower (rocblas_fill_lower).
   !>             - rocblas_fill_upper: The upper triangular part of A is supplied in AP.
   !>             - rocblas_fill_lower: The lower triangular part of A is supplied in AP.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the number of rows and columns of matrix A. Must be at least 0.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device pointer storing vector x.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of x.
-  !>     @param[in, out]
-  !>     AP        device pointer storing the packed version of the specified triangular portion of
+  !>     @param[in, out] AP - device pointer storing the packed version of the specified triangular
+  !>     portion of
   !>               the Hermitian matrix A. Of at least size ((n * (n + 1)) / 2).
   !>
   !>                     if uplo == rocblas_fill_upper:
@@ -13031,28 +12440,21 @@ module hipfort_rocblas
   !>     ``n`` by ``n`` symmetric matrix, supplied in packed form, for ``i`` = 1, ...,
   !>     ``batch_count``.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             specifies either upper (rocblas_fill_upper) or lower (rocblas_fill_lower).
   !>             - rocblas_fill_upper: The upper triangular part of each A_i is supplied in AP.
   !>             - rocblas_fill_lower: The lower triangular part of each A_i is supplied in AP.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the number of rows and columns of each matrix A_i. Must be at least 0.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in, out]
-  !>     AP device array of device pointers storing the packed version of the specified triangular
-  !>     portion of
+  !>     @param[in, out] AP - device array of device pointers storing the packed version of the
+  !>     specified triangular portion of
   !>               each Hermitian matrix A_i of at least size ((n * (n + 1)) / 2). Array is of at
   !>               least size batch_count.
   !>
@@ -13083,8 +12485,7 @@ module hipfort_rocblas
   !>                             (4,-9) (5,-3) (6,0)
   !>                Note that the imaginary parts of the diagonal elements are not accessed
   !>                and are assumed to be 0.
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_chpr_batched
     function rocblas_chpr_batched_(handle,uplo,n,alpha,x,incx,AP,batch_count) &
@@ -13169,31 +12570,23 @@ module hipfort_rocblas
   !>     ``n`` by ``n`` symmetric matrix, supplied in packed form, for ``i`` = 1, ...,
   !>     ``batch_count``.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             specifies either upper (rocblas_fill_upper) or lower (rocblas_fill_lower).
   !>             - rocblas_fill_upper: The upper triangular part of each A_i is supplied in AP.
   !>             - rocblas_fill_lower: The lower triangular part of each A_i is supplied in AP.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the number of rows and columns of each matrix A_i. Must be at least 0.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     x         device pointer pointing to the first vector (x_1).
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device pointer pointing to the first vector (x_1).
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     stride_x  [rocblas_stride]
+  !>     @param[in] stride_x - [rocblas_stride]
   !>               stride from the start of one vector (x_i) to the next one (x_i+1).
-  !>     @param[in, out]
-  !>     AP device array of device pointers storing the packed version of the specified triangular
-  !>     portion of
+  !>     @param[in, out] AP - device array of device pointers storing the packed version of the
+  !>     specified triangular portion of
   !>               each Hermitian matrix A_i. Points to the first matrix (A_1).
   !>
   !>                     if uplo == rocblas_fill_upper:
@@ -13223,11 +12616,9 @@ module hipfort_rocblas
   !>                             (4,-9) (5,-3) (6,0)
   !>                Note that the imaginary parts of the diagonal elements are not accessed
   !>                and are assumed to be 0.
-  !>     @param[in]
-  !>     stride_A    [rocblas_stride]
+  !>     @param[in] stride_A - [rocblas_stride]
   !>                 stride from the start of one (A_i) to the next (A_i+1).
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_chpr_strided_batched
     function rocblas_chpr_strided_batched_(handle,uplo,n,alpha,x,incx,stride_x,AP,stride_A, &
@@ -13335,32 +12726,24 @@ module hipfort_rocblas
   !>     where ``alpha`` is a complex scalar, ``x`` and ``y`` are vectors, and ``A`` is an
   !>     ``n`` by ``n`` Hermitian matrix, supplied in packed form.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             specifies either upper (rocblas_fill_upper) or lower (rocblas_fill_lower).
   !>             - rocblas_fill_upper: The upper triangular part of A is supplied in AP.
   !>             - rocblas_fill_lower: The lower triangular part of A is supplied in AP.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the number of rows and columns of matrix A. Must be at least 0.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device pointer storing vector x.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of x.
-  !>     @param[in]
-  !>     y         device pointer storing vector y.
-  !>     @param[in]
-  !>     incy      [rocblas_int]
+  !>     @param[in] y - device pointer storing vector y.
+  !>     @param[in] incy - [rocblas_int]
   !>               specifies the increment for the elements of y.
-  !>     @param[in, out]
-  !>     AP        device pointer storing the packed version of the specified triangular portion of
+  !>     @param[in, out] AP - device pointer storing the packed version of the specified triangular
+  !>     portion of
   !>               the Hermitian matrix A. Of at least size ((n * (n + 1)) / 2).
   !>
   !>                     if uplo == rocblas_fill_upper:
@@ -13487,33 +12870,24 @@ module hipfort_rocblas
   !>     ``n`` by ``n`` symmetric matrix, supplied in packed form, for ``i`` = 1, ...,
   !>     ``batch_count``.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             specifies either upper (rocblas_fill_upper) or lower (rocblas_fill_lower).
   !>             - rocblas_fill_upper: The upper triangular part of each A_i is supplied in AP.
   !>             - rocblas_fill_lower: The lower triangular part of each A_i is supplied in AP.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the number of rows and columns of each matrix A_i. Must be at least 0.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     y         device array of device pointers storing each vector y_i.
-  !>     @param[in]
-  !>     incy      [rocblas_int]
+  !>     @param[in] y - device array of device pointers storing each vector y_i.
+  !>     @param[in] incy - [rocblas_int]
   !>               specifies the increment for the elements of each y_i.
-  !>     @param[in, out]
-  !>     AP device array of device pointers storing the packed version of the specified triangular
-  !>     portion of
+  !>     @param[in, out] AP - device array of device pointers storing the packed version of the
+  !>     specified triangular portion of
   !>               each Hermitian matrix A_i of at least size ((n * (n + 1)) / 2). Array is of at
   !>               least size batch_count.
   !>
@@ -13544,8 +12918,7 @@ module hipfort_rocblas
   !>                             (4,-9) (5,-3) (6,0)
   !>                Note that the imaginary parts of the diagonal elements are not accessed
   !>                and are assumed to be 0.
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_chpr2_batched
     function rocblas_chpr2_batched_(handle,uplo,n,alpha,x,incx,y,incy,AP,batch_count) &
@@ -13638,39 +13011,28 @@ module hipfort_rocblas
   !>     ``n`` by ``n`` symmetric matrix, supplied in packed form, for ``i`` = 1, ...,
   !>     ``batch_count``.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             specifies either upper (rocblas_fill_upper) or lower (rocblas_fill_lower).
   !>             - rocblas_fill_upper: The upper triangular part of each A_i is supplied in AP.
   !>             - rocblas_fill_lower: The lower triangular part of each A_i is supplied in AP.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the number of rows and columns of each matrix A_i. Must be at least 0.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     x         device pointer pointing to the first vector (x_1).
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device pointer pointing to the first vector (x_1).
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     stride_x  [rocblas_stride]
+  !>     @param[in] stride_x - [rocblas_stride]
   !>               stride from the start of one vector (x_i) to the next one (x_i+1).
-  !>     @param[in]
-  !>     y         device pointer pointing to the first vector (y_1).
-  !>     @param[in]
-  !>     incy      [rocblas_int]
+  !>     @param[in] y - device pointer pointing to the first vector (y_1).
+  !>     @param[in] incy - [rocblas_int]
   !>               specifies the increment for the elements of each y_i.
-  !>     @param[in]
-  !>     stride_y  [rocblas_stride]
+  !>     @param[in] stride_y - [rocblas_stride]
   !>               stride from the start of one vector (y_i) to the next one (y_i+1).
-  !>     @param[in, out]
-  !>     AP device array of device pointers storing the packed version of the specified triangular
-  !>     portion of
+  !>     @param[in, out] AP - device array of device pointers storing the packed version of the
+  !>     specified triangular portion of
   !>               each Hermitian matrix A_i. Points to the first matrix (A_1).
   !>
   !>                     if uplo == rocblas_fill_upper:
@@ -13701,11 +13063,9 @@ module hipfort_rocblas
   !>                                 (4,-9) (5,-3) (6,0)
   !>                Note that the imaginary parts of the diagonal elements are not accessed
   !>                and are assumed to be 0.
-  !>     @param[in]
-  !>     stride_A    [rocblas_stride]
+  !>     @param[in] stride_A - [rocblas_stride]
   !>                 stride from the start of one (A_i) to the next (A_i+1).
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_chpr2_strided_batched
     function rocblas_chpr2_strided_batched_(handle,uplo,n,alpha,x,incx,stride_x,y,incy,stride_y, &
@@ -13828,44 +13188,37 @@ module hipfort_rocblas
   !>     upper or lower triangular matrix.
   !>     The vector ``x`` is overwritten.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper:  A is an upper triangular matrix.
   !>             - rocblas_fill_lower:  A is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA     [rocblas_operation]
+  !>     @param[in] transA - [rocblas_operation]
   !>             - rocblas_operation_none:    op(A) = A.
   !>             - rocblas_operation_transpose:   op(A) = A^T.
   !>             - rocblas_operation_conjugate_transpose:  op(A) = A^H.
   !>
-  !>     @param[in]
-  !>     diag    [rocblas_diagonal]
+  !>     @param[in] diag - [rocblas_diagonal]
   !>             - rocblas_diagonal_unit:     A is assumed to be unit triangular.
   !>             - rocblas_diagonal_non_unit:  A is not assumed to be unit triangular.
   !>
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               n specifies the number of rows of A. n >= 0.
   !>
-  !>     @param[in]
-  !>     A device pointer storing matrix A, of dimension ( lda, n ). If uplo == rocblas_fill_upper,
-  !>     the upper triangular part of the leading n-by-n array contains the matrix A. Otherwise, the
-  !>     lower triangular part of the leading n-by-n array contains the matrix A.
+  !>     @param[in] A - device pointer storing matrix A, of dimension ( lda, n ). If uplo ==
+  !>     rocblas_fill_upper, the upper triangular part of the leading n-by-n array contains the
+  !>     matrix A. Otherwise, the lower triangular part of the leading n-by-n array contains the
+  !>     matrix A.
   !>
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of A. lda must be at least max( 1, n ).
   !>
-  !>     @param[in, out]
-  !>     x device pointer storing vector x. On exit, x is overwritten with the transformed vector x.
+  !>     @param[in, out] x - device pointer storing vector x. On exit, x is overwritten with the
+  !>     transformed vector x.
   !>
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of x.
   interface rocblas_strmv
     function rocblas_strmv_(handle,uplo,transA,diag,n,A,lda,x,incx) bind(c, name="rocblas_strmv")
@@ -14056,50 +13409,40 @@ module hipfort_rocblas
   !>     non-unit, upper or lower triangular matrix).
   !>     The vectors ``x_i`` are overwritten.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper:  A_i is an upper triangular matrix.
   !>             - rocblas_fill_lower:  A_i is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA     [rocblas_operation]
+  !>     @param[in] transA - [rocblas_operation]
   !>             - rocblas_operation_none:    op(A) = A.
   !>             - rocblas_operation_transpose:   op(A) = A^T.
   !>             - rocblas_operation_conjugate_transpose:  op(A) = A^H.
   !>
-  !>     @param[in]
-  !>     diag    [rocblas_diagonal]
+  !>     @param[in] diag - [rocblas_diagonal]
   !>             - rocblas_diagonal_unit:     A_i is assumed to be unit triangular.
   !>             - rocblas_diagonal_non_unit:  A_i is not assumed to be unit triangular.
   !>
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               n specifies the number of rows of matrices A_i. n >= 0.
   !>
-  !>     @param[in]
-  !>     A device pointer to an array of device pointers to the A_i matrices, of dimension ( lda, n
-  !>     ). If uplo == rocblas_fill_upper, the upper triangular part of the leading n-by-n array
-  !>     contains the matrix A_i. Otherwise the lower triangular part of the leading n-by-n array
-  !>     contains the matrix A_i.
+  !>     @param[in] A - device pointer to an array of device pointers to the A_i matrices, of
+  !>     dimension ( lda, n ). If uplo == rocblas_fill_upper, the upper triangular part of the
+  !>     leading n-by-n array contains the matrix A_i. Otherwise the lower triangular part of the
+  !>     leading n-by-n array contains the matrix A_i.
   !>
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of A_i. lda must be at least max( 1, n ).
   !>
-  !>     @param[in, out]
-  !>     x device pointer to an array of device pointers to the x_i vectors. On exit, each x_i is
-  !>     overwritten with the transformed vector x_i.
+  !>     @param[in, out] x - device pointer to an array of device pointers to the x_i vectors. On
+  !>     exit, each x_i is overwritten with the transformed vector x_i.
   !>
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of vectors x_i.
   !>
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>               The number of batched matrices/vectors.
   interface rocblas_strmv_batched
     function rocblas_strmv_batched_(handle,uplo,transA,diag,n,A,lda,x,incx,batch_count) &
@@ -14277,58 +13620,46 @@ module hipfort_rocblas
   !>
   !>     The vectors ``x_i`` are overwritten.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper:  A_i is an upper triangular matrix.
   !>             - rocblas_fill_lower:  A_i is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA     [rocblas_operation]
+  !>     @param[in] transA - [rocblas_operation]
   !>             - rocblas_operation_none:    op(A) = A.
   !>             - rocblas_operation_transpose:   op(A) = A^T.
   !>             - rocblas_operation_conjugate_transpose:  op(A) = A^H.
   !>
-  !>     @param[in]
-  !>     diag    [rocblas_diagonal]
+  !>     @param[in] diag - [rocblas_diagonal]
   !>             - rocblas_diagonal_unit:     A_i is assumed to be unit triangular.
   !>             - rocblas_diagonal_non_unit:  A_i is not assumed to be unit triangular.
   !>
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               n specifies the number of rows of matrices A_i. n >= 0.
   !>
-  !>     @param[in]
-  !>     A device pointer to the matrix A_1 of the batch, of dimension ( lda, n ). If uplo ==
-  !>     rocblas_fill_upper, the upper triangular part of the leading n-by-n array contains the
-  !>     matrix A_i. Otherwise, the lower triangular part of the leading n-by-n array contains the
-  !>     matrix A_i.
+  !>     @param[in] A - device pointer to the matrix A_1 of the batch, of dimension ( lda, n ). If
+  !>     uplo == rocblas_fill_upper, the upper triangular part of the leading n-by-n array contains
+  !>     the matrix A_i. Otherwise, the lower triangular part of the leading n-by-n array contains
+  !>     the matrix A_i.
   !>
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of A_i. lda must be at least max( 1, n ).
   !>
-  !>     @param[in]
-  !>     stride_A  [rocblas_stride]
+  !>     @param[in] stride_A - [rocblas_stride]
   !>               stride from the start of one A_i matrix to the next A_{i + 1}.
   !>
-  !>     @param[in, out]
-  !>     x device pointer to the vector x_1 of the batch. On exit, each x_i is overwritten with the
-  !>     transformed vector x_i.
+  !>     @param[in, out] x - device pointer to the vector x_1 of the batch. On exit, each x_i is
+  !>     overwritten with the transformed vector x_i.
   !>
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of one vector x.
   !>
-  !>     @param[in]
-  !>     stride_x  [rocblas_stride]
+  !>     @param[in] stride_x - [rocblas_stride]
   !>               stride from the start of one x_i vector to the next x_{i + 1}.
   !>
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>               The number of batched matrices/vectors.
   interface rocblas_strmv_strided_batched
     function rocblas_strmv_strided_batched_(handle,uplo,transA,diag,n,A,lda,stride_A,x,incx, &
@@ -14555,32 +13886,26 @@ module hipfort_rocblas
   !>     upper or lower triangular matrix, supplied in the pack form.
   !>     The vector ``x`` is overwritten.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper:  A is an upper triangular matrix.
   !>             - rocblas_fill_lower:  A is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA     [rocblas_operation]
+  !>     @param[in] transA - [rocblas_operation]
   !>             - rocblas_operation_none:    op(A) = A.
   !>             - rocblas_operation_transpose:   op(A) = A^T
   !>             - rocblas_operation_conjugate_transpose:  op(A) = A^H
   !>
-  !>     @param[in]
-  !>     diag    [rocblas_diagonal]
+  !>     @param[in] diag - [rocblas_diagonal]
   !>             - rocblas_diagonal_unit:     A is assumed to be unit triangular.
   !>             - rocblas_diagonal_non_unit:  A is not assumed to be unit triangular.
   !>
-  !>     @param[in]
-  !>     n       [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>             n specifies the number of rows of A. n >= 0.
   !>
-  !>     @param[in]
-  !>     A       device pointer storing matrix A,
+  !>     @param[in] A - device pointer storing matrix A,
   !>             of dimension at leat ( n * ( n + 1 ) / 2 ).
   !>         - Before entry with uplo = rocblas_fill_upper, the array A
   !>             must contain the upper triangular matrix packed sequentially,
@@ -14597,11 +13922,10 @@ module hipfort_rocblas
   !>           Note that when DIAG = rocblas_diagonal_unit, the diagonal elements of A are
   !>           not referenced, but are assumed to be unity.
   !>
-  !>     @param[in, out]
-  !>     x device pointer storing vector x. On exit, x is overwritten with the transformed vector x.
+  !>     @param[in, out] x - device pointer storing vector x. On exit, x is overwritten with the
+  !>     transformed vector x.
   !>
-  !>     @param[in]
-  !>     incx    [rocblas_int]
+  !>     @param[in] incx - [rocblas_int]
   !>             specifies the increment for the elements of x. incx must not be zero.
   interface rocblas_stpmv
     function rocblas_stpmv_(handle,uplo,transA,diag,n,A,x,incx) bind(c, name="rocblas_stpmv")
@@ -14776,46 +14100,37 @@ module hipfort_rocblas
   !>     non-unit, upper or lower triangular matrix).
   !>     The vectors ``x_i`` are overwritten.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper:  A_i is an upper triangular matrix.
   !>             - rocblas_fill_lower:  A_i is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA     [rocblas_operation]
+  !>     @param[in] transA - [rocblas_operation]
   !>             - rocblas_operation_none:    op(A) = A.
   !>             - rocblas_operation_transpose:   op(A) = A^T
   !>             - rocblas_operation_conjugate_transpose:  op(A) = A^H
   !>
-  !>     @param[in]
-  !>     diag    [rocblas_diagonal]
+  !>     @param[in] diag - [rocblas_diagonal]
   !>             - rocblas_diagonal_unit:     A_i is assumed to be unit triangular.
   !>             - rocblas_diagonal_non_unit:  A_i is not assumed to be unit triangular.
   !>
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               n specifies the number of rows of matrices A_i. n >= 0.
   !>
-  !>     @param[in]
-  !>     A device pointer to an array of device pointers to the A_i matrices, of dimension ( lda, n
-  !>     ). If uplo == rocblas_fill_upper, the upper triangular part of the leading n-by-n array
-  !>     contains the matrix A_i. Otherwise the lower triangular part of the leading n-by-n array
-  !>     contains the matrix A_i.
+  !>     @param[in] A - device pointer to an array of device pointers to the A_i matrices, of
+  !>     dimension ( lda, n ). If uplo == rocblas_fill_upper, the upper triangular part of the
+  !>     leading n-by-n array contains the matrix A_i. Otherwise the lower triangular part of the
+  !>     leading n-by-n array contains the matrix A_i.
   !>
-  !>     @param[in, out]
-  !>     x device pointer to an array of device pointers to the x_i vectors. On exit, each x_i is
-  !>     overwritten with the transformed vector x_i.
+  !>     @param[in, out] x - device pointer to an array of device pointers to the x_i vectors. On
+  !>     exit, each x_i is overwritten with the transformed vector x_i.
   !>
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of vectors x_i.
   !>
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>               The number of batched matrices/vectors.
   interface rocblas_stpmv_batched
     function rocblas_stpmv_batched_(handle,uplo,transA,diag,n,A,x,incx,batch_count) &
@@ -14984,54 +14299,43 @@ module hipfort_rocblas
   !>     (resp. ``$A_i$`` ).
   !>     The vectors ``x_i`` are overwritten.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper:  A_i is an upper triangular matrix.
   !>             - rocblas_fill_lower:  A_i is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA     [rocblas_operation]
+  !>     @param[in] transA - [rocblas_operation]
   !>             - rocblas_operation_none:    op(A) = A.
   !>             - rocblas_operation_transpose:   op(A) = A^T
   !>             - rocblas_operation_conjugate_transpose:  op(A) = A^H
   !>
-  !>     @param[in]
-  !>     diag    [rocblas_diagonal]
+  !>     @param[in] diag - [rocblas_diagonal]
   !>             - rocblas_diagonal_unit:     A_i is assumed to be unit triangular.
   !>             - rocblas_diagonal_non_unit:  A_i is not assumed to be unit triangular.
   !>
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>             n specifies the number of rows of matrices A_i. n >= 0.
   !>
-  !>     @param[in]
-  !>     A device pointer to the matrix A_1 of the batch, of dimension ( lda, n ). If uplo ==
-  !>     rocblas_fill_upper, the upper triangular part of the leading n-by-n array contains the
-  !>     matrix A_i. Otherwise, the lower triangular part of the leading n-by-n array contains the
-  !>     matrix A_i.
+  !>     @param[in] A - device pointer to the matrix A_1 of the batch, of dimension ( lda, n ). If
+  !>     uplo == rocblas_fill_upper, the upper triangular part of the leading n-by-n array contains
+  !>     the matrix A_i. Otherwise, the lower triangular part of the leading n-by-n array contains
+  !>     the matrix A_i.
   !>
-  !>     @param[in]
-  !>     stride_A  [rocblas_stride]
+  !>     @param[in] stride_A - [rocblas_stride]
   !>             stride from the start of one A_i matrix to the next A_{i + 1}.
   !>
-  !>     @param[in, out]
-  !>     x device pointer to the vector x_1 of the batch. On exit, each x_i is overwritten with the
-  !>     transformed vector x_i.
+  !>     @param[in, out] x - device pointer to the vector x_1 of the batch. On exit, each x_i is
+  !>     overwritten with the transformed vector x_i.
   !>
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] incx - [rocblas_int]
   !>             specifies the increment for the elements of one vector x.
   !>
-  !>     @param[in]
-  !>     stride_x  [rocblas_stride]
+  !>     @param[in] stride_x - [rocblas_stride]
   !>             stride from the start of one x_i vector to the next x_{i + 1}.
   !>
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>             The number of batched matrices/vectors.
   interface rocblas_stpmv_strided_batched
     function rocblas_stpmv_strided_batched_(handle,uplo,transA,diag,n,A,stride_A,x,incx,stride_x, &
@@ -15244,26 +14548,20 @@ module hipfort_rocblas
   !>
   !>     ``x`` is a vector, and ``A`` is a banded ``n`` by ``n`` matrix (see description below).
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper: A is an upper banded triangular matrix.
   !>             - rocblas_fill_lower: A is a  lower banded triangular matrix.
-  !>     @param[in]
-  !>     trans     [rocblas_operation]
+  !>     @param[in] trans - [rocblas_operation]
   !>               indicates whether matrix A is tranposed (conjugated) or not.
-  !>     @param[in]
-  !>     diag      [rocblas_diagonal]
+  !>     @param[in] diag - [rocblas_diagonal]
   !>             - rocblas_diagonal_unit: The main diagonal of A is assumed to consist of only
   !>                                      1's and is not referenced.
   !>             - rocblas_diagonal_non_unit: No assumptions are made about the main diagonal of A.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the number of rows and columns of the matrix represented by A.
-  !>     @param[in]
-  !>     k         [rocblas_int]
+  !>     @param[in] k - [rocblas_int]
   !>
   !>             if uplo == rocblas_fill_upper, k specifies the number of super-diagonals
   !>             of the matrix A.
@@ -15271,8 +14569,7 @@ module hipfort_rocblas
   !>             if uplo == rocblas_fill_lower, k specifies the number of sub-diagonals
   !>             of the matrix A.
   !>             k must satisfy k > 0 && k < lda.
-  !>     @param[in]
-  !>     A         device pointer storing banded triangular matrix A.
+  !>     @param[in] A - device pointer storing banded triangular matrix A.
   !>
   !>             if uplo == rocblas_fill_upper:
   !>                 The matrix represented is an upper banded triangular matrix
@@ -15301,13 +14598,10 @@ module hipfort_rocblas
   !>                       9 7 3 0 0     ---->    9 8 7 0 0
   !>                       0 8 8 4 0              0 0 0 0 0
   !>                       0 0 7 9 5              0 0 0 0 0
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of A. lda must satisfy lda > k.
-  !>     @param[in, out]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in, out] x - device pointer storing vector x.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of x.
   interface rocblas_stbmv
     function rocblas_stbmv_(handle,uplo,trans,diag,n,k,A,lda,x,incx) bind(c, name="rocblas_stbmv")
@@ -15506,28 +14800,22 @@ module hipfort_rocblas
   !>     ``x_i`` is a vector, and ``A_i`` is an ``n`` by ``n`` matrix, for ``i`` = 1, ...,
   !>     ``batch_count``.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper: each A_i is an upper banded triangular matrix.
   !>             - rocblas_fill_lower: each A_i is a  lower banded triangular matrix.
-  !>     @param[in]
-  !>     trans     [rocblas_operation]
+  !>     @param[in] trans - [rocblas_operation]
   !>               indicates whether each matrix A_i is tranposed (conjugated) or not.
-  !>     @param[in]
-  !>     diag      [rocblas_diagonal]
+  !>     @param[in] diag - [rocblas_diagonal]
   !>             - rocblas_diagonal_unit: The main diagonal of each A_i is assumed to consist of
   !>             only
   !>                                      1's and is not referenced.
   !>             - rocblas_diagonal_non_unit: No assumptions are made of the main diagonal of each
   !>             A_i.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the number of rows and columns of the matrix represented by each A_i.
-  !>     @param[in]
-  !>     k         [rocblas_int]
+  !>     @param[in] k - [rocblas_int]
   !>
   !>             if uplo == rocblas_fill_upper, k specifies the number of super-diagonals
   !>             of each matrix A_i.
@@ -15535,8 +14823,7 @@ module hipfort_rocblas
   !>             if uplo == rocblas_fill_lower, k specifies the number of sub-diagonals
   !>             of each matrix A_i.
   !>             k must satisfy k > 0 && k < lda.
-  !>     @param[in]
-  !>     A         device array of device pointers storing each banded triangular matrix A_i.
+  !>     @param[in] A - device array of device pointers storing each banded triangular matrix A_i.
   !>
   !>             if uplo == rocblas_fill_upper:
   !>                 The matrix represented is an upper banded triangular matrix
@@ -15565,16 +14852,12 @@ module hipfort_rocblas
   !>                       9 7 3 0 0     ---->    9 8 7 0 0
   !>                       0 8 8 4 0              0 0 0 0 0
   !>                       0 0 7 9 5              0 0 0 0 0
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of each A_i. lda must satisfy lda > k.
-  !>     @param[in, out]
-  !>     x         device array of device pointer storing each vector x_i.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in, out] x - device array of device pointer storing each vector x_i.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_stbmv_batched
     function rocblas_stbmv_batched_(handle,uplo,trans,diag,n,k,A,lda,x,incx,batch_count) &
@@ -15757,28 +15040,22 @@ module hipfort_rocblas
   !>     ``x_i`` is a vector, and ``A_i`` is an ``n`` by ``n`` matrix, for ``i`` = 1, ...,
   !>     ``batch_count``.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper: each A_i is an upper banded triangular matrix.
   !>             - rocblas_fill_lower: each A_i is a  lower banded triangular matrix.
-  !>     @param[in]
-  !>     trans     [rocblas_operation]
+  !>     @param[in] trans - [rocblas_operation]
   !>               indicates whether each matrix A_i is tranposed (conjugated) or not.
-  !>     @param[in]
-  !>     diag      [rocblas_diagonal]
+  !>     @param[in] diag - [rocblas_diagonal]
   !>             - rocblas_diagonal_unit: The main diagonal of each A_i is assumed to consist of
   !>             only
   !>                                      1's and is not referenced.
   !>             - rocblas_diagonal_non_unit: No assumptions are made of the main diagonal of each
   !>             A_i.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the number of rows and columns of the matrix represented by each A_i.
-  !>     @param[in]
-  !>     k         [rocblas_int]
+  !>     @param[in] k - [rocblas_int]
   !>
   !>             if uplo == rocblas_fill_upper, k specifies the number of super-diagonals
   !>             of each matrix A_i.
@@ -15786,9 +15063,8 @@ module hipfort_rocblas
   !>             if uplo == rocblas_fill_lower, k specifies the number of sub-diagonals
   !>             of each matrix A_i.
   !>             k must satisfy k > 0 && k < lda.
-  !>     @param[in]
-  !>     A device array to the first matrix A_i of the batch. Stores each banded triangular matrix
-  !>     A_i.
+  !>     @param[in] A - device array to the first matrix A_i of the batch. Stores each banded
+  !>     triangular matrix A_i.
   !>
   !>             if uplo == rocblas_fill_upper:
   !>                 The matrix represented is an upper banded triangular matrix
@@ -15817,22 +15093,16 @@ module hipfort_rocblas
   !>                       9 7 3 0 0     ---->    9 8 7 0 0
   !>                       0 8 8 4 0              0 0 0 0 0
   !>                       0 0 7 9 5              0 0 0 0 0
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of each A_i. lda must satisfy lda > k.
-  !>     @param[in]
-  !>     stride_A  [rocblas_stride]
+  !>     @param[in] stride_A - [rocblas_stride]
   !>               stride from the start of one A_i matrix to the next A_(i + 1).
-  !>     @param[in, out]
-  !>     x         device array to the first vector x_i of the batch.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in, out] x - device array to the first vector x_i of the batch.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     stride_x  [rocblas_stride]
+  !>     @param[in] stride_x - [rocblas_stride]
   !>               stride from the start of one x_i matrix to the next x_(i + 1).
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_stbmv_strided_batched
     function rocblas_stbmv_strided_batched_(handle,uplo,trans,diag,n,k,A,lda,stride_A,x,incx, &
@@ -16065,32 +15335,26 @@ module hipfort_rocblas
   !>
   !>     where ``x`` and ``b`` are vectors and ``A`` is a banded triangular matrix.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper:  A is an upper triangular matrix.
   !>             - rocblas_fill_lower:  A is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA     [rocblas_operation]
+  !>     @param[in] transA - [rocblas_operation]
   !>             - rocblas_operation_none: Solves A*x = b
   !>             - rocblas_operation_transpose: Solves A**T*x = b
   !>             - rocblas_operation_conjugate_transpose: Solves A**H*x = b
   !>
-  !>     @param[in]
-  !>     diag    [rocblas_diagonal]
+  !>     @param[in] diag - [rocblas_diagonal]
   !>             - rocblas_diagonal_unit: A is assumed to be unit triangular (the diagonal elements
   !>             of A are not used in computations).
   !>             - rocblas_diagonal_non_unit: A is not assumed to be unit triangular.
   !>
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               n specifies the number of rows of b. n >= 0.
-  !>     @param[in]
-  !>     k         [rocblas_int]
+  !>     @param[in] k - [rocblas_int]
   !>
   !>             if(uplo == rocblas_fill_upper)
   !>                 k specifies the number of super-diagonals of A.
@@ -16098,19 +15362,16 @@ module hipfort_rocblas
   !>                 k specifies the number of sub-diagonals of A.
   !>             k >= 0.
   !>
-  !>     @param[in]
-  !>     A         device pointer storing the matrix A in banded format.
+  !>     @param[in] A - device pointer storing the matrix A in banded format.
   !>
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of A.
   !>               lda >= (k + 1).
   !>
-  !>     @param[in, out]
-  !>     x         device pointer storing input vector b. Overwritten by the output vector x.
+  !>     @param[in, out] x - device pointer storing input vector b. Overwritten by the output vector
+  !>     x.
   !>
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of x.
   interface rocblas_stbsv
     function rocblas_stbsv_(handle,uplo,transA,diag,n,k,A,lda,x,incx) bind(c, name="rocblas_stbsv")
@@ -16310,33 +15571,27 @@ module hipfort_rocblas
   !>
   !>     The input vectors ``b_i`` are overwritten by the output vectors ``x_i``.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper:  A_i is an upper triangular matrix.
   !>             - rocblas_fill_lower:  A_i is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA     [rocblas_operation]
+  !>     @param[in] transA - [rocblas_operation]
   !>             - rocblas_operation_none: Solves A_i*x_i = b_i
   !>             - rocblas_operation_transpose: Solves A_i**T*x_i = b_i
   !>             - rocblas_operation_conjugate_transpose: Solves A_i**H*x_i = b_i
   !>
-  !>     @param[in]
-  !>     diag    [rocblas_diagonal]
+  !>     @param[in] diag - [rocblas_diagonal]
   !>             - rocblas_diagonal_unit: each A_i is assumed to be unit triangular (the diagonal
   !>             elements
   !>             of each A_i are not used in computations).
   !>             - rocblas_diagonal_non_unit: each A_i is not assumed to be unit triangular.
   !>
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               n specifies the number of rows of each b_i. n >= 0.
-  !>     @param[in]
-  !>     k         [rocblas_int]
+  !>     @param[in] k - [rocblas_int]
   !>
   !>             if(uplo == rocblas_fill_upper)
   !>                 k specifies the number of super-diagonals of each A_i.
@@ -16344,23 +15599,18 @@ module hipfort_rocblas
   !>                 k specifies the number of sub-diagonals of each A_i.
   !>             k >= 0.
   !>
-  !>     @param[in]
-  !>     A         device vector of device pointers storing each matrix A_i in banded format.
+  !>     @param[in] A - device vector of device pointers storing each matrix A_i in banded format.
   !>
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of each A_i.
   !>               lda >= (k + 1).
   !>
-  !>     @param[in, out]
-  !>     x device vector of device pointers storing each input vector b_i. Overwritten by each
-  !>     output
+  !>     @param[in, out] x - device vector of device pointers storing each input vector b_i.
+  !>     Overwritten by each output
   !>               vector x_i.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_stbsv_batched
     function rocblas_stbsv_batched_(handle,uplo,transA,diag,n,k,A,lda,x,incx,batch_count) &
@@ -16544,33 +15794,27 @@ module hipfort_rocblas
   !>
   !>     The input vectors ``b_i`` are overwritten by the output vectors ``x_i``.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper:  A_i is an upper triangular matrix.
   !>             - rocblas_fill_lower:  A_i is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA     [rocblas_operation]
+  !>     @param[in] transA - [rocblas_operation]
   !>             - rocblas_operation_none: Solves A_i*x_i = b_i
   !>             - rocblas_operation_transpose: Solves A_i**T*x_i = b_i
   !>             - rocblas_operation_conjugate_transpose: Solves A_i**H*x_i = b_i
   !>
-  !>     @param[in]
-  !>     diag    [rocblas_diagonal]
+  !>     @param[in] diag - [rocblas_diagonal]
   !>             - rocblas_diagonal_unit: each A_i is assumed to be unit triangular (the diagonal
   !>             elements
   !>             of each A_i are not used in computations).
   !>             - rocblas_diagonal_non_unit: each A_i is not assumed to be unit triangular.
   !>
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               n specifies the number of rows of each b_i. n >= 0.
-  !>     @param[in]
-  !>     k         [rocblas_int]
+  !>     @param[in] k - [rocblas_int]
   !>
   !>             if(uplo == rocblas_fill_upper)
   !>                 k specifies the number of super-diagonals of each A_i.
@@ -16578,29 +15822,23 @@ module hipfort_rocblas
   !>                 k specifies the number of sub-diagonals of each A_i.
   !>             k >= 0.
   !>
-  !>     @param[in]
-  !>     A         device pointer pointing to the first banded matrix A_1.
+  !>     @param[in] A - device pointer pointing to the first banded matrix A_1.
   !>
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of each A_i.
   !>               lda >= (k + 1).
-  !>     @param[in]
-  !>     stride_A  [rocblas_stride]
+  !>     @param[in] stride_A - [rocblas_stride]
   !>               specifies the distance between the start of one matrix (A_i) and the next
   !>               (A_i+1).
   !>
-  !>     @param[in, out]
-  !>     x device pointer pointing to the first input vector b_1. Overwritten by output vectors x.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in, out] x - device pointer pointing to the first input vector b_1. Overwritten by
+  !>     output vectors x.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     stride_x  [rocblas_stride]
+  !>     @param[in] stride_x - [rocblas_stride]
   !>               specifies the distance between the start of one vector (x_i) and the next
   !>               (x_i+1).
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_stbsv_strided_batched
     function rocblas_stbsv_strided_batched_(handle,uplo,transA,diag,n,k,A,lda,stride_A,x,incx, &
@@ -16837,44 +16075,37 @@ module hipfort_rocblas
   !>     Although not widespread, some GEMM kernels used by trsv might use atomic operations.
   !>     See Atomic Operations in the API Reference Guide for more information.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper:  A is an upper triangular matrix.
   !>             - rocblas_fill_lower:  A is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA     [rocblas_operation]
+  !>     @param[in] transA - [rocblas_operation]
   !>             - rocblas_operation_none:    op(A) = A.
   !>             - rocblas_operation_transpose:   op(A) = A^T.
   !>             - rocblas_operation_conjugate_transpose:  op(A) = A^H.
   !>
-  !>     @param[in]
-  !>     diag    [rocblas_diagonal]
+  !>     @param[in] diag - [rocblas_diagonal]
   !>             - rocblas_diagonal_unit:     A is assumed to be unit triangular.
   !>             - rocblas_diagonal_non_unit:  A is not assumed to be unit triangular.
   !>
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               n specifies the number of rows of b. n >= 0.
   !>
-  !>     @param[in]
-  !>     A device pointer storing matrix A, of dimension ( lda, n ). If uplo == rocblas_fill_upper,
-  !>     the upper triangular part of the leading n-by-n array contains the matrix A. Otherwise, the
-  !>     lower triangular part of the leading n-by-n array contains the matrix A.
+  !>     @param[in] A - device pointer storing matrix A, of dimension ( lda, n ). If uplo ==
+  !>     rocblas_fill_upper, the upper triangular part of the leading n-by-n array contains the
+  !>     matrix A. Otherwise, the lower triangular part of the leading n-by-n array contains the
+  !>     matrix A.
   !>
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of A. lda must be at least max( 1, n ).
   !>
-  !>     @param[in, out]
-  !>     x device pointer storing vector x. On exit, x is overwritten with the transformed vector x.
+  !>     @param[in, out] x - device pointer storing vector x. On exit, x is overwritten with the
+  !>     transformed vector x.
   !>
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of x.
   interface rocblas_strsv
     function rocblas_strsv_(handle,uplo,transA,diag,n,A,lda,x,incx) bind(c, name="rocblas_strsv")
@@ -17067,50 +16298,40 @@ module hipfort_rocblas
   !>
   !>     The vector ``x`` is overwritten on ``b``.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper:  A is an upper triangular matrix.
   !>             - rocblas_fill_lower:  A is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA     [rocblas_operation]
+  !>     @param[in] transA - [rocblas_operation]
   !>             - rocblas_operation_none:    op(A) = A.
   !>             - rocblas_operation_transpose:   op(A) = A^T.
   !>             - rocblas_operation_conjugate_transpose:  op(A) = A^H.
   !>
-  !>     @param[in]
-  !>     diag    [rocblas_diagonal]
+  !>     @param[in] diag - [rocblas_diagonal]
   !>             - rocblas_diagonal_unit:     A is assumed to be unit triangular.
   !>             - rocblas_diagonal_non_unit:  A is not assumed to be unit triangular.
   !>
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               n specifies the number of rows of b. n >= 0.
   !>
-  !>     @param[in]
-  !>     A device pointer to an array of device pointers to the A_i matrices, of dimension ( lda, n
-  !>     ). If uplo == rocblas_fill_upper, the upper triangular part of the leading n-by-n array
-  !>     contains the matrix A_i. Otherwise, the lower triangular part of the leading n-by-n array
-  !>     contains the matrix A_i.
+  !>     @param[in] A - device pointer to an array of device pointers to the A_i matrices, of
+  !>     dimension ( lda, n ). If uplo == rocblas_fill_upper, the upper triangular part of the
+  !>     leading n-by-n array contains the matrix A_i. Otherwise, the lower triangular part of the
+  !>     leading n-by-n array contains the matrix A_i.
   !>
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of A_i. lda must be at least max( 1, n ).
   !>
-  !>     @param[in, out]
-  !>     x device pointer to an array of device pointers to the x_i vectors. On exit, each x_i is
-  !>     overwritten with the transformed vector x_i.
+  !>     @param[in, out] x - device pointer to an array of device pointers to the x_i vectors. On
+  !>     exit, each x_i is overwritten with the transformed vector x_i.
   !>
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of x.
   !>
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_strsv_batched
     function rocblas_strsv_batched_(handle,uplo,transA,diag,n,A,lda,x,incx,batch_count) &
@@ -17287,58 +16508,46 @@ module hipfort_rocblas
   !>
   !>     The vector ``x`` is overwritten on ``b``.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper:  A is an upper triangular matrix.
   !>             - rocblas_fill_lower:  A is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA     [rocblas_operation]
+  !>     @param[in] transA - [rocblas_operation]
   !>             - rocblas_operation_none:    op(A) = A.
   !>             - rocblas_operation_transpose:   op(A) = A^T.
   !>             - rocblas_operation_conjugate_transpose:  op(A) = A^H.
   !>
-  !>     @param[in]
-  !>     diag    [rocblas_diagonal]
+  !>     @param[in] diag - [rocblas_diagonal]
   !>             - rocblas_diagonal_unit:     A is assumed to be unit triangular.
   !>             - rocblas_diagonal_non_unit:  A is not assumed to be unit triangular.
   !>
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               n specifies the number of rows of each b_i. n >= 0.
   !>
-  !>     @param[in]
-  !>     A device pointer to the matrix A_1 of the batch, of dimension ( lda, n ). If uplo ==
-  !>     rocblas_fill_upper, the upper triangular part of the leading n-by-n array contains the
-  !>     matrix A_i. Otherwise, the lower triangular part of the leading n-by-n array contains the
-  !>     matrix A_i.
+  !>     @param[in] A - device pointer to the matrix A_1 of the batch, of dimension ( lda, n ). If
+  !>     uplo == rocblas_fill_upper, the upper triangular part of the leading n-by-n array contains
+  !>     the matrix A_i. Otherwise, the lower triangular part of the leading n-by-n array contains
+  !>     the matrix A_i.
   !>
-  !>     @param[in]
-  !>     stride_A  [rocblas_stride]
+  !>     @param[in] stride_A - [rocblas_stride]
   !>               stride from the start of one A_i matrix to the next A_(i + 1).
   !>
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of A_i. lda must be at least max( 1, n ).
   !>
-  !>     @param[in, out]
-  !>     x device pointer to the vector x_1 of the batch. On exit, each x_i is overwritten with the
-  !>     transformed vector x_i.
+  !>     @param[in, out] x - device pointer to the vector x_1 of the batch. On exit, each x_i is
+  !>     overwritten with the transformed vector x_i.
   !>
-  !>     @param[in]
-  !>     stride_x [rocblas_stride]
+  !>     @param[in] stride_x - [rocblas_stride]
   !>              stride from the start of one x_i vector to the next x_(i + 1)
   !>
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each x_i.
   !>
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_strsv_strided_batched
     function rocblas_strsv_strided_batched_(handle,uplo,transA,diag,n,A,lda,stride_A,x,incx, &
@@ -17566,40 +16775,32 @@ module hipfort_rocblas
   !>
   !>     The input vector ``b`` is overwritten by the output vector ``x``.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper:  A is an upper triangular matrix.
   !>             - rocblas_fill_lower:  A is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA  [rocblas_operation]
+  !>     @param[in] transA - [rocblas_operation]
   !>             - rocblas_operation_none: Solves A*x = b.
   !>             - rocblas_operation_transpose: Solves A**T*x = b.
   !>             - rocblas_operation_conjugate_transpose: Solves A**H*x = b.
   !>
-  !>     @param[in]
-  !>     diag    [rocblas_diagonal]
+  !>     @param[in] diag - [rocblas_diagonal]
   !>             - rocblas_diagonal_unit:  A is assumed to be unit triangular (the diagonal elements
   !>             of A are not used in computations).
   !>             - rocblas_diagonal_non_unit: A is not assumed to be unit triangular.
   !>
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               n specifies the number of rows of b. n >= 0.
   !>
-  !>     @param[in]
-  !>     AP        device pointer storing the packed version of matrix A,
+  !>     @param[in] AP - device pointer storing the packed version of matrix A,
   !>               of dimension >= (n * (n + 1) / 2).
   !>
-  !>     @param[in, out]
-  !>     x         device pointer storing vector b on input, overwritten by x on output.
+  !>     @param[in, out] x - device pointer storing vector b on input, overwritten by x on output.
   !>
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of x.
   interface rocblas_stpsv
     function rocblas_stpsv_(handle,uplo,transA,diag,n,AP,x,incx) bind(c, name="rocblas_stpsv")
@@ -17776,45 +16977,37 @@ module hipfort_rocblas
   !>
   !>     The input vectors ``b_i`` are overwritten by the output vectors ``x_i``.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper:  each A_i is an upper triangular matrix.
   !>             - rocblas_fill_lower:  each A_i is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA  [rocblas_operation]
+  !>     @param[in] transA - [rocblas_operation]
   !>             - rocblas_operation_none: Solves A*x = b.
   !>             - rocblas_operation_transpose: Solves A**T*x = b.
   !>             - rocblas_operation_conjugate_transpose: Solves A**H*x = b.
   !>
-  !>     @param[in]
-  !>     diag    [rocblas_diagonal]
+  !>     @param[in] diag - [rocblas_diagonal]
   !>             - rocblas_diagonal_unit: Each A_i is assumed to be unit triangular (the diagonal
   !>             elements
   !>             of each A_i are not used in computations).
   !>             - rocblas_diagonal_non_unit: each A_i is not assumed to be unit triangular.
   !>
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               n specifies the number of rows of each b_i. n >= 0.
   !>
-  !>     @param[in]
-  !>     AP        device array of device pointers storing the packed versions of each matrix A_i,
+  !>     @param[in] AP - device array of device pointers storing the packed versions of each matrix
+  !>     A_i,
   !>               of dimension >= (n * (n + 1) / 2).
   !>
-  !>     @param[in, out]
-  !>     x device array of device pointers storing each input vector b_i, overwritten by x_i on
-  !>     output.
+  !>     @param[in, out] x - device array of device pointers storing each input vector b_i,
+  !>     overwritten by x_i on output.
   !>
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 specifies the number of instances in the batch.
   interface rocblas_stpsv_batched
     function rocblas_stpsv_batched_(handle,uplo,transA,diag,n,AP,x,incx,batch_count) &
@@ -17983,51 +17176,41 @@ module hipfort_rocblas
   !>
   !>     The input vectors ``b_i`` are overwritten by the output vectors ``x_i``.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper:  each A_i is an upper triangular matrix.
   !>             - rocblas_fill_lower:  each A_i is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA  [rocblas_operation]
+  !>     @param[in] transA - [rocblas_operation]
   !>             - rocblas_operation_none: Solves A*x = b.
   !>             - rocblas_operation_transpose: Solves A**T*x = b.
   !>             - rocblas_operation_conjugate_transpose: Solves A**H*x = b.
   !>
-  !>     @param[in]
-  !>     diag    [rocblas_diagonal]
+  !>     @param[in] diag - [rocblas_diagonal]
   !>             - rocblas_diagonal_unit: each A_i is assumed to be unit triangular (the diagonal
   !>             elements
   !>             of each A_i are not used in computations).
   !>             - rocblas_diagonal_non_unit: each A_i is not assumed to be unit triangular.
   !>
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               n specifies the number of rows of each b_i. n >= 0.
   !>
-  !>     @param[in]
-  !>     AP        device pointer pointing to the first packed matrix A_1,
+  !>     @param[in] AP - device pointer pointing to the first packed matrix A_1,
   !>               of dimension >= (n * (n + 1) / 2).
   !>
-  !>     @param[in]
-  !>     stride_A  [rocblas_stride]
+  !>     @param[in] stride_A - [rocblas_stride]
   !>               stride from the beginning of one packed matrix (AP_i) to the next (AP_i+1).
   !>
-  !>     @param[in, out]
-  !>     x device pointer pointing to the first input vector b_1. Overwritten by each x_i on output.
+  !>     @param[in, out] x - device pointer pointing to the first input vector b_1. Overwritten by
+  !>     each x_i on output.
   !>
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     stride_x  [rocblas_stride]
+  !>     @param[in] stride_x - [rocblas_stride]
   !>               stride from the beginning of one vector (x_i) to the next (x_i+1).
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 specifies the number of instances in the batch.
   interface rocblas_stpsv_strided_batched
     function rocblas_stpsv_strided_batched_(handle,uplo,transA,diag,n,AP,stride_A,x,incx,stride_x, &
@@ -18242,35 +17425,24 @@ module hipfort_rocblas
   !>     symv has an implementation which uses atomic operations. See Atomic Operations
   !>     in the API Reference Guide for more information.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     uplo     [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             specifies either upper (rocblas_fill_upper) or lower (rocblas_fill_lower).
   !>             - if rocblas_fill_upper, the lower part of A is not referenced.
   !>             - if rocblas_fill_lower, the upper part of A is not referenced.
-  !>     @param[in]
-  !>     n         [rocblas_int]
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] n - [rocblas_int]
+  !>     @param[in] alpha
   !>               specifies the scalar alpha.
-  !>     @param[in]
-  !>     A         pointer storing matrix A on the GPU.
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in] A - pointer storing matrix A on the GPU.
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of A.
-  !>     @param[in]
-  !>     x         pointer storing vector x on the GPU.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - pointer storing vector x on the GPU.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of x.
-  !>     @param[in]
-  !>     beta      specifies the scalar beta.
-  !>     @param[out]
-  !>     y         pointer storing vector y on the GPU.
-  !>     @param[in]
-  !>     incy      [rocblas_int]
+  !>     @param[in] beta - specifies the scalar beta.
+  !>     @param[out] y - pointer storing vector y on the GPU.
+  !>     @param[in] incy - [rocblas_int]
   !>               specifies the increment for the elements of y.
   interface rocblas_ssymv
     function rocblas_ssymv_(handle,uplo,n,alpha,A,lda,x,incx,beta,y,incy) &
@@ -18481,39 +17653,27 @@ module hipfort_rocblas
   !>     ``A`` should contain an upper or lower triangular symmetric matrix.
   !>     The opposing triangular part of ``A`` is not referenced.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             specifies either upper (rocblas_fill_upper) or lower (rocblas_fill_lower).
   !>             - if rocblas_fill_upper, the lower part of A is not referenced.
   !>             - if rocblas_fill_lower, the upper part of A is not referenced.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               number of rows and columns of each matrix A_i.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     A         device array of device pointers storing each matrix A_i.
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in] A - device array of device pointers storing each matrix A_i.
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of each matrix A_i.
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each vector x_i.
-  !>     @param[in]
-  !>     beta      device pointer or host pointer to scalar beta.
-  !>     @param[out]
-  !>     y         device array of device pointers storing each vector y_i.
-  !>     @param[in]
-  !>     incy      [rocblas_int]
+  !>     @param[in] beta - device pointer or host pointer to scalar beta.
+  !>     @param[out] y - device array of device pointers storing each vector y_i.
+  !>     @param[in] incy - [rocblas_int]
   !>               specifies the increment for the elements of each vector y_i.
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_ssymv_batched
     function rocblas_ssymv_batched_(handle,uplo,n,alpha,A,lda,x,incx,beta,y,incy,batch_count) &
@@ -18704,54 +17864,39 @@ module hipfort_rocblas
   !>     ``A`` should contain an upper or lower triangular symmetric matrix.
   !>     The opposing triangular part of ``A`` is not referenced.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             specifies either upper (rocblas_fill_upper) or lower (rocblas_fill_lower).
   !>             - if rocblas_fill_upper, the lower part of A is not referenced.
   !>             - if rocblas_fill_lower, the upper part of A is not referenced.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               number of rows and columns of each matrix A_i.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     A         Device pointer to the first matrix A_1 on the GPU.
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in] A - Device pointer to the first matrix A_1 on the GPU.
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of each matrix A_i.
-  !>     @param[in]
-  !>     strideA     [rocblas_stride]
+  !>     @param[in] strideA - [rocblas_stride]
   !>                 stride from the start of one matrix (A_i) to the next one (A_i+1).
-  !>     @param[in]
-  !>     x         Device pointer to the first vector x_1 on the GPU.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - Device pointer to the first vector x_1 on the GPU.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each vector x_i.
-  !>     @param[in]
-  !>     stridex     [rocblas_stride]
+  !>     @param[in] stridex - [rocblas_stride]
   !>                 stride from the start of one vector (x_i) to the next one (x_i+1).
   !>                 There are no restrictions placed on stride_x. However, ensure that stridex is
   !>                 of an appropriate size.
   !>                 This typically means stridex >= n * incx. stridex should be non zero.
-  !>     @param[in]
-  !>     beta      device pointer or host pointer to scalar beta.
-  !>     @param[out]
-  !>     y         Device pointer to the first vector y_1 on the GPU.
-  !>     @param[in]
-  !>     incy      [rocblas_int]
+  !>     @param[in] beta - device pointer or host pointer to scalar beta.
+  !>     @param[out] y - Device pointer to the first vector y_1 on the GPU.
+  !>     @param[in] incy - [rocblas_int]
   !>               specifies the increment for the elements of each vector y_i.
-  !>     @param[in]
-  !>     stridey     [rocblas_stride]
+  !>     @param[in] stridey - [rocblas_stride]
   !>                 stride from the start of one vector (y_i) to the next one (y_i+1).
   !>                 There are no restrictions placed on stride_y. However, ensure that stridey is
   !>                 of an appropriate size.
   !>                 This typically means stridey >= n * incy. stridey should be non zero.
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_ssymv_strided_batched
     function rocblas_ssymv_strided_batched_(handle,uplo,n,alpha,A,lda,strideA,x,incx,stridex,beta, &
@@ -18999,32 +18144,22 @@ module hipfort_rocblas
   !>     where ``alpha`` and ``beta`` are scalars, and ``x`` and ``y`` are ``n``-element vectors.
   !>     ``A`` should contain an upper or lower triangular ``n`` by ``n`` packed symmetric matrix.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             specifies either upper (rocblas_fill_upper) or lower (rocblas_fill_lower).
   !>             - if rocblas_fill_upper, the lower part of A is not referenced.
   !>             - if rocblas_fill_lower, the upper part of A is not referenced.
-  !>     @param[in]
-  !>     n         [rocblas_int]
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] n - [rocblas_int]
+  !>     @param[in] alpha
   !>               specifies the scalar alpha.
-  !>     @param[in]
-  !>     A         pointer storing matrix A on the GPU.
-  !>     @param[in]
-  !>     x         pointer storing vector x on the GPU.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] A - pointer storing matrix A on the GPU.
+  !>     @param[in] x - pointer storing vector x on the GPU.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of x.
-  !>     @param[in]
-  !>     beta      specifies the scalar beta.
-  !>     @param[out]
-  !>     y         pointer storing vector y on the GPU.
-  !>     @param[in]
-  !>     incy      [rocblas_int]
+  !>     @param[in] beta - specifies the scalar beta.
+  !>     @param[out] y - pointer storing vector y on the GPU.
+  !>     @param[in] incy - [rocblas_int]
   !>               specifies the increment for the elements of y.
   interface rocblas_sspmv
     function rocblas_sspmv_(handle,uplo,n,alpha,A,x,incx,beta,y,incy) bind(c, name="rocblas_sspmv")
@@ -19128,36 +18263,25 @@ module hipfort_rocblas
   !>     ``n`` by ``n`` symmetric matrix, for ``i`` = 1, ..., ``batch_count``.
   !>     ``A`` should contain an upper or lower triangular ``n`` by ``n`` packed symmetric matrix.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             specifies either upper (rocblas_fill_upper) or lower (rocblas_fill_lower).
   !>             - if rocblas_fill_upper, the lower part of A is not referenced.
   !>             - if rocblas_fill_lower, the upper part of A is not referenced.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               number of rows and columns of each matrix A_i.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     A         device array of device pointers storing each matrix A_i.
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] A - device array of device pointers storing each matrix A_i.
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each vector x_i.
-  !>     @param[in]
-  !>     beta      device pointer or host pointer to scalar beta.
-  !>     @param[out]
-  !>     y         device array of device pointers storing each vector y_i.
-  !>     @param[in]
-  !>     incy      [rocblas_int]
+  !>     @param[in] beta - device pointer or host pointer to scalar beta.
+  !>     @param[out] y - device array of device pointers storing each vector y_i.
+  !>     @param[in] incy - [rocblas_int]
   !>               specifies the increment for the elements of each vector y_i.
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_sspmv_batched
     function rocblas_sspmv_batched_(handle,uplo,n,alpha,A,x,incx,beta,y,incy,batch_count) &
@@ -19255,51 +18379,37 @@ module hipfort_rocblas
   !>     ``n`` by ``n`` symmetric matrix, for ``i`` = 1, ..., ``batch_count``.
   !>     ``A`` should contain an upper or lower triangular ``n`` by ``n`` packed symmetric matrix.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             specifies either upper (rocblas_fill_upper) or lower (rocblas_fill_lower).
   !>             - if rocblas_fill_upper, the lower part of A is not referenced.
   !>             - if rocblas_fill_lower, the upper part of A is not referenced.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               number of rows and columns of each matrix A_i.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     A         Device pointer to the first matrix A_1 on the GPU.
-  !>     @param[in]
-  !>     strideA     [rocblas_stride]
+  !>     @param[in] A - Device pointer to the first matrix A_1 on the GPU.
+  !>     @param[in] strideA - [rocblas_stride]
   !>                 stride from the start of one matrix (A_i) to the next one (A_i+1).
-  !>     @param[in]
-  !>     x         Device pointer to the first vector x_1 on the GPU.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - Device pointer to the first vector x_1 on the GPU.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each vector x_i.
-  !>     @param[in]
-  !>     stridex     [rocblas_stride]
+  !>     @param[in] stridex - [rocblas_stride]
   !>                 stride from the start of one vector (x_i) to the next one (x_i+1).
   !>                 There are no restrictions placed on stridex. However, ensure that stridex is of
   !>                 an appropriate size.
   !>                 This typically means stridex >= n * incx. stridex should be non zero.
-  !>     @param[in]
-  !>     beta      device pointer or host pointer to scalar beta.
-  !>     @param[out]
-  !>     y         Device pointer to the first vector y_1 on the GPU.
-  !>     @param[in]
-  !>     incy      [rocblas_int]
+  !>     @param[in] beta - device pointer or host pointer to scalar beta.
+  !>     @param[out] y - Device pointer to the first vector y_1 on the GPU.
+  !>     @param[in] incy - [rocblas_int]
   !>               specifies the increment for the elements of each vector y_i.
-  !>     @param[in]
-  !>     stridey     [rocblas_stride]
+  !>     @param[in] stridey - [rocblas_stride]
   !>                 stride from the start of one vector (y_i) to the next one (y_i+1).
   !>                 There are no restrictions placed on stridey. However, ensure that stridey is of
   !>                 an appropriate size.
   !>                 This typically means stridey >= n * incy. stridey should be non zero.
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_sspmv_strided_batched
     function rocblas_sspmv_strided_batched_(handle,uplo,n,alpha,A,strideA,x,incx,stridex,beta,y, &
@@ -19423,38 +18533,26 @@ module hipfort_rocblas
   !>     where ``alpha`` and ``beta`` are scalars, and ``x`` and ``y`` are ``n``-element vectors.
   !>     ``A`` should contain an upper or lower triangular ``n`` by ``n ``symmetric banded matrix.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>               specifies either upper (rocblas_fill_upper) or lower (rocblas_fill_lower).
   !>               - if rocblas_fill_upper, the lower part of A is not referenced.
   !>               - if rocblas_fill_lower, the upper part of A is not referenced.
-  !>     @param[in]
-  !>     n         [rocblas_int]
-  !>     @param[in]
-  !>     k         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
+  !>     @param[in] k - [rocblas_int]
   !>               specifies the number of sub- and super-diagonals.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               specifies the scalar alpha.
-  !>     @param[in]
-  !>     A         pointer storing matrix A on the GPU.
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in] A - pointer storing matrix A on the GPU.
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of matrix A.
-  !>     @param[in]
-  !>     x         pointer storing vector x on the GPU.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - pointer storing vector x on the GPU.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of x.
-  !>     @param[in]
-  !>     beta      specifies the scalar beta.
-  !>     @param[out]
-  !>     y         pointer storing vector y on the GPU.
-  !>     @param[in]
-  !>     incy      [rocblas_int]
+  !>     @param[in] beta - specifies the scalar beta.
+  !>     @param[out] y - pointer storing vector y on the GPU.
+  !>     @param[in] incy - [rocblas_int]
   !>               specifies the increment for the elements of y.
   interface rocblas_ssbmv
     function rocblas_ssbmv_(handle,uplo,n,k,alpha,A,lda,x,incx,beta,y,incy) &
@@ -19570,42 +18668,29 @@ module hipfort_rocblas
   !>     ``n`` by ``n`` symmetric banded matrix, for ``i`` = 1, ..., ``batch_count``.
   !>     ``A`` should contain an upper or lower triangular ``n`` by ``n`` symmetric banded matrix.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             specifies either upper (rocblas_fill_upper) or lower (rocblas_fill_lower).
   !>             - if rocblas_fill_upper, the lower part of A is not referenced.
   !>             - if rocblas_fill_lower, the upper part of A is not referenced.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               number of rows and columns of each matrix A_i.
-  !>     @param[in]
-  !>     k         [rocblas_int]
+  !>     @param[in] k - [rocblas_int]
   !>               specifies the number of sub- and super-diagonals.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     A         device array of device pointers storing each matrix A_i.
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in] A - device array of device pointers storing each matrix A_i.
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of each matrix A_i.
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each vector x_i.
-  !>     @param[in]
-  !>     beta      device pointer or host pointer to scalar beta.
-  !>     @param[out]
-  !>     y         device array of device pointers storing each vector y_i.
-  !>     @param[in]
-  !>     incy      [rocblas_int]
+  !>     @param[in] beta - device pointer or host pointer to scalar beta.
+  !>     @param[out] y - device array of device pointers storing each vector y_i.
+  !>     @param[in] incy - [rocblas_int]
   !>               specifies the increment for the elements of each vector y_i.
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_ssbmv_batched
     function rocblas_ssbmv_batched_(handle,uplo,n,k,alpha,A,lda,x,incx,beta,y,incy,batch_count) &
@@ -19711,57 +18796,41 @@ module hipfort_rocblas
   !>     ``n`` by ``n`` symmetric banded matrix, for ``i`` = 1, ..., ``batch_count``.
   !>     ``A`` should contain an upper or lower triangular ``n`` by ``n`` symmetric banded matrix.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             specifies either upper (rocblas_fill_upper) or lower (rocblas_fill_lower).
   !>             - if rocblas_fill_upper, the lower part of A is not referenced.
   !>             - if rocblas_fill_lower, the upper part of A is not referenced.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               number of rows and columns of each matrix A_i.
-  !>     @param[in]
-  !>     k         [rocblas_int]
+  !>     @param[in] k - [rocblas_int]
   !>               specifies the number of sub- and super-diagonals.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     A         Device pointer to the first matrix A_1 on the GPU.
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in] A - Device pointer to the first matrix A_1 on the GPU.
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of each matrix A_i.
-  !>     @param[in]
-  !>     strideA     [rocblas_stride]
+  !>     @param[in] strideA - [rocblas_stride]
   !>                 stride from the start of one matrix (A_i) to the next one (A_i+1).
-  !>     @param[in]
-  !>     x         Device pointer to the first vector x_1 on the GPU.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - Device pointer to the first vector x_1 on the GPU.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each vector x_i.
-  !>     @param[in]
-  !>     stridex     [rocblas_stride]
+  !>     @param[in] stridex - [rocblas_stride]
   !>                 stride from the start of one vector (x_i) to the next one (x_i+1).
   !>                 There are no restrictions placed on stridex. However, ensure that stridex is of
   !>                 an appropriate size.
   !>                 This typically means stridex >= n * incx. stridex should be non zero.
-  !>     @param[in]
-  !>     beta      device pointer or host pointer to scalar beta.
-  !>     @param[out]
-  !>     y         Device pointer to the first vector y_1 on the GPU.
-  !>     @param[in]
-  !>     incy      [rocblas_int]
+  !>     @param[in] beta - device pointer or host pointer to scalar beta.
+  !>     @param[out] y - Device pointer to the first vector y_1 on the GPU.
+  !>     @param[in] incy - [rocblas_int]
   !>               specifies the increment for the elements of each vector y_i.
-  !>     @param[in]
-  !>     stridey     [rocblas_stride]
+  !>     @param[in] stridey - [rocblas_stride]
   !>                 stride from the start of one vector (y_i) to the next one (y_i+1).
   !>                 There are no restrictions placed on stridey. However, ensure that stridey is of
   !>                 an appropriate size.
   !>                 This typically means stridey >= n * incy. stridey should be non zero.
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_ssbmv_strided_batched
     function rocblas_ssbmv_strided_batched_(handle,uplo,n,k,alpha,A,lda,strideA,x,incx,stridex, &
@@ -19896,32 +18965,22 @@ module hipfort_rocblas
   !>     where ``alpha`` is a scalar, ``x`` and ``y`` are vectors, and ``A`` is an
   !>     ``m`` by ``n`` matrix.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     m         [rocblas_int]
+  !>     @param[in] m - [rocblas_int]
   !>               the number of rows of the matrix A.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the number of columns of the matrix A.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device pointer storing vector x.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of x.
-  !>     @param[in]
-  !>     y         device pointer storing vector y.
-  !>     @param[in]
-  !>     incy      [rocblas_int]
+  !>     @param[in] y - device pointer storing vector y.
+  !>     @param[in] incy - [rocblas_int]
   !>               specifies the increment for the elements of y.
-  !>     @param[in, out]
-  !>     A         device pointer storing matrix A.
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in, out] A - device pointer storing matrix A.
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of A.
   interface rocblas_sger
     function rocblas_sger_(handle,m,n,alpha,x,incx,y,incy,A,lda) bind(c, name="rocblas_sger")
@@ -20210,35 +19269,24 @@ module hipfort_rocblas
   !>     ``alpha`` is a scalar, ``x_i`` and ``y_i`` are vectors, and ``A_i`` is an
   !>     ``m`` by ``n`` matrix, for ``i`` = 1, ..., ``batch_count``.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     m         [rocblas_int]
+  !>     @param[in] m - [rocblas_int]
   !>               the number of rows of each matrix A_i.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the number of columns of each matrix A_i.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each vector x_i.
-  !>     @param[in]
-  !>     y         device array of device pointers storing each vector y_i.
-  !>     @param[in]
-  !>     incy      [rocblas_int]
+  !>     @param[in] y - device array of device pointers storing each vector y_i.
+  !>     @param[in] incy - [rocblas_int]
   !>               specifies the increment for the elements of each vector y_i.
-  !>     @param[in, out]
-  !>     A         device array of device pointers storing each matrix A_i.
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in, out] A - device array of device pointers storing each matrix A_i.
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of each A_i.
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_sger_batched
     function rocblas_sger_batched_(handle,m,n,alpha,x,incx,y,incy,A,lda,batch_count) &
@@ -20505,50 +19553,36 @@ module hipfort_rocblas
   !>     ``alpha`` is a scalar, ``x_i`` and ``y_i`` are vectors, and ``A_i`` is an
   !>     ``m`` by ``n`` matrix, for ``i`` = 1, ..., ``batch_count``.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     m         [rocblas_int]
+  !>     @param[in] m - [rocblas_int]
   !>               the number of rows of each matrix A_i.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the number of columns of each matrix A_i.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     x         device pointer to the first vector (x_1) in the batch.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device pointer to the first vector (x_1) in the batch.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increments for the elements of each vector x_i.
-  !>     @param[in]
-  !>     stridex   [rocblas_stride]
+  !>     @param[in] stridex - [rocblas_stride]
   !>               stride from the start of one vector (x_i) to the next one (x_i+1).
   !>               There are no restrictions placed on stride_x. However, ensure that stride_x is of
   !>               an appropriate size. For a typical
   !>               case, this means stride_x >= m * incx.
-  !>     @param[in, out]
-  !>     y         device pointer to the first vector (y_1) in the batch.
-  !>     @param[in]
-  !>     incy      [rocblas_int]
+  !>     @param[in, out] y - device pointer to the first vector (y_1) in the batch.
+  !>     @param[in] incy - [rocblas_int]
   !>               specifies the increment for the elements of each vector y_i.
-  !>     @param[in]
-  !>     stridey   [rocblas_stride]
+  !>     @param[in] stridey - [rocblas_stride]
   !>               stride from the start of one vector (y_i) to the next one (y_i+1).
   !>               There are no restrictions placed on stride_y. However, ensure that stride_y is of
   !>               an appropriate size. For a typical
   !>               case, this means stride_y >= n * incy.
-  !>     @param[in, out]
-  !>     A         device pointer to the first matrix (A_1) in the batch.
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in, out] A - device pointer to the first matrix (A_1) in the batch.
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of each A_i.
-  !>     @param[in]
-  !>     strideA     [rocblas_stride]
+  !>     @param[in] strideA - [rocblas_stride]
   !>                 stride from the start of one matrix (A_i) to the next one (A_i+1).
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_sger_strided_batched
     function rocblas_sger_strided_batched_(handle,m,n,alpha,x,incx,stridex,y,incy,stridey,A,lda, &
@@ -20902,27 +19936,21 @@ module hipfort_rocblas
   !>     where ``alpha`` is a scalar, ``x`` is a vector, and ``A`` is an
   !>     ``n`` by ``n`` symmetric matrix, supplied in packed form.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             specifies either upper (rocblas_fill_upper) or lower (rocblas_fill_lower).
   !>             - rocblas_fill_upper: The upper triangular part of A is supplied in AP.
   !>             - rocblas_fill_lower: The lower triangular part of A is supplied in AP.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>             the number of rows and columns of matrix A. Must be at least 0.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device pointer storing vector x.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of x.
-  !>     @param[in, out]
-  !>     AP        device pointer storing the packed version of the specified triangular portion of
+  !>     @param[in, out] AP - device pointer storing the packed version of the specified triangular
+  !>     portion of
   !>               the symmetric matrix A. Of at least size ((n * (n + 1)) / 2).
   !>
   !>                     if uplo == rocblas_fill_upper:
@@ -21115,28 +20143,21 @@ module hipfort_rocblas
   !>     ``n`` by ``n`` symmetric matrix, supplied in packed form, for ``i`` = 1, ...,
   !>     ``batch_count``.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             specifies  either upper (rocblas_fill_upper) or lower (rocblas_fill_lower).
   !>             - rocblas_fill_upper: The upper triangular part of each A_i is supplied in AP.
   !>             - rocblas_fill_lower: The lower triangular part of each A_i is supplied in AP.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>             the number of rows and columns of each matrix A_i. Must be at least 0.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in, out]
-  !>     AP device array of device pointers storing the packed version of the specified triangular
-  !>     portion of
+  !>     @param[in, out] AP - device array of device pointers storing the packed version of the
+  !>     specified triangular portion of
   !>               each symmetric matrix A_i of at least size ((n * (n + 1)) / 2). The array is of
   !>               at least size batch_count.
   !>
@@ -21167,8 +20188,7 @@ module hipfort_rocblas
   !>                                 2 5 6 7    -----> [1, 2, 3, 4, 5, 6, 7, 8, 9, 0]
   !>                                 3 6 8 9
   !>                                 4 7 9 0
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_sspr_batched
     function rocblas_sspr_batched_(handle,uplo,n,alpha,x,incx,AP,batch_count) &
@@ -21325,30 +20345,23 @@ module hipfort_rocblas
   !>     ``n`` by ``n`` symmetric matrix, supplied in packed form, for ``i`` = 1, ...,
   !>     ``batch_count``.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             specifies either upper (rocblas_fill_upper) or lower (rocblas_fill_lower).
   !>             - rocblas_fill_upper: The upper triangular part of each A_i is supplied in AP.
   !>             - rocblas_fill_lower: The lower triangular part of each A_i is supplied in AP.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>             the number of rows and columns of each matrix A_i. Must be at least 0.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     x         device pointer pointing to the first vector (x_1).
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device pointer pointing to the first vector (x_1).
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     stride_x  [rocblas_stride]
+  !>     @param[in] stride_x - [rocblas_stride]
   !>               stride from the start of one vector (x_i) and the next one (x_i+1).
-  !>     @param[in, out]
-  !>     AP        device pointer storing the packed version of the specified triangular portion of
+  !>     @param[in, out] AP - device pointer storing the packed version of the specified triangular
+  !>     portion of
   !>               each symmetric matrix A_i. Points to the first A_1.
   !>
   !>                     if uplo == rocblas_fill_upper:
@@ -21378,11 +20391,9 @@ module hipfort_rocblas
   !>                                 2 5 6 7    -----> [1, 2, 3, 4, 5, 6, 7, 8, 9, 0]
   !>                                 3 6 8 9
   !>                                 4 7 9 0
-  !>     @param[in]
-  !>     stride_A    [rocblas_stride]
+  !>     @param[in] stride_A - [rocblas_stride]
   !>                 stride from the start of one (A_i) to the next (A_i+1).
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_sspr_strided_batched
     function rocblas_sspr_strided_batched_(handle,uplo,n,alpha,x,incx,stride_x,AP,stride_A, &
@@ -21586,32 +20597,24 @@ module hipfort_rocblas
   !>     where ``alpha`` is a scalar, ``x`` and ``y`` are vectors, and ``A`` is an
   !>     ``n`` by ``n`` symmetric matrix, supplied in packed form.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             specifies either upper (rocblas_fill_upper) or lower (rocblas_fill_lower).
   !>             - rocblas_fill_upper: The upper triangular part of A is supplied in AP.
   !>             - rocblas_fill_lower: The lower triangular part of A is supplied in AP.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>             the number of rows and columns of matrix A. Must be at least 0.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device pointer storing vector x.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of x.
-  !>     @param[in]
-  !>     y         device pointer storing vector y.
-  !>     @param[in]
-  !>     incy      [rocblas_int]
+  !>     @param[in] y - device pointer storing vector y.
+  !>     @param[in] incy - [rocblas_int]
   !>               specifies the increment for the elements of y.
-  !>     @param[in, out]
-  !>     AP        device pointer storing the packed version of the specified triangular portion of
+  !>     @param[in, out] AP - device pointer storing the packed version of the specified triangular
+  !>     portion of
   !>               the symmetric matrix A. Of at least size ((n * (n + 1)) / 2).
   !>
   !>                     if uplo == rocblas_fill_upper:
@@ -21738,33 +20741,24 @@ module hipfort_rocblas
   !>     ``n`` by ``n`` symmetric matrix, supplied in packed form, for ``i`` = 1, ...,
   !>     ``batch_count``.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             specifies either upper (rocblas_fill_upper) or lower (rocblas_fill_lower).
   !>             - rocblas_fill_upper: The upper triangular part of each A_i is supplied in AP.
   !>             - rocblas_fill_lower: The lower triangular part of each A_i is supplied in AP.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>             the number of rows and columns of each matrix A_i. Must be at least 0.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     y         device array of device pointers storing each vector y_i.
-  !>     @param[in]
-  !>     incy      [rocblas_int]
+  !>     @param[in] y - device array of device pointers storing each vector y_i.
+  !>     @param[in] incy - [rocblas_int]
   !>               specifies the increment for the elements of each y_i.
-  !>     @param[in, out]
-  !>     AP device array of device pointers storing the packed version of the specified triangular
-  !>     portion of
+  !>     @param[in, out] AP - device array of device pointers storing the packed version of the
+  !>     specified triangular portion of
   !>               each symmetric matrix A_i of at least size ((n * (n + 1)) / 2). Array is of at
   !>               least size batch_count.
   !>
@@ -21795,8 +20789,7 @@ module hipfort_rocblas
   !>                                 2 5 6 7    -----> [1, 2, 3, 4, 5, 6, 7, 8, 9, 0]
   !>                                 3 6 8 9
   !>                                 4 7 9 0
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_sspr2_batched
     function rocblas_sspr2_batched_(handle,uplo,n,alpha,x,incx,y,incy,AP,batch_count) &
@@ -21889,38 +20882,28 @@ module hipfort_rocblas
   !>     ``n`` by ``n`` symmetric matrix, supplied in packed form, for ``i`` = 1, ...,
   !>     ``batch_count``.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             specifies either upper (rocblas_fill_upper) or lower (rocblas_fill_lower).
   !>             - rocblas_fill_upper: The upper triangular part of each A_i is supplied in AP.
   !>             - rocblas_fill_lower: The lower triangular part of each A_i is supplied in AP.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>             the number of rows and columns of each matrix A_i. Must be at least 0.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     x         device pointer pointing to the first vector (x_1).
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device pointer pointing to the first vector (x_1).
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     stride_x  [rocblas_stride]
+  !>     @param[in] stride_x - [rocblas_stride]
   !>               stride from the start of one vector (x_i) to the next one (x_i+1).
-  !>     @param[in]
-  !>     y         device pointer pointing to the first vector (y_1).
-  !>     @param[in]
-  !>     incy      [rocblas_int]
+  !>     @param[in] y - device pointer pointing to the first vector (y_1).
+  !>     @param[in] incy - [rocblas_int]
   !>               specifies the increment for the elements of each y_i.
-  !>     @param[in]
-  !>     stride_y  [rocblas_stride]
+  !>     @param[in] stride_y - [rocblas_stride]
   !>               stride from the start of one vector (y_i) to the next one (y_i+1).
-  !>     @param[in, out]
-  !>     AP        device pointer storing the packed version of the specified triangular portion of
+  !>     @param[in, out] AP - device pointer storing the packed version of the specified triangular
+  !>     portion of
   !>               each symmetric matrix A_i. Points to the first A_1.
   !>
   !>                     if uplo == rocblas_fill_upper:
@@ -21950,11 +20933,9 @@ module hipfort_rocblas
   !>                                 2 5 6 7    -----> [1, 2, 3, 4, 5, 6, 7, 8, 9, 0]
   !>                                 3 6 8 9
   !>                                 4 7 9 0
-  !>     @param[in]
-  !>     stride_A    [rocblas_stride]
+  !>     @param[in] stride_A - [rocblas_stride]
   !>                 stride from the start of one (A_i) to the next (A_i+1).
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_sspr2_strided_batched
     function rocblas_sspr2_strided_batched_(handle,uplo,n,alpha,x,incx,stride_x,y,incy,stride_y, &
@@ -22074,30 +21055,22 @@ module hipfort_rocblas
   !>     where ``alpha`` is a scalar, ``x`` is a vector, and ``A`` is an
   !>     ``n`` by ``n`` symmetric matrix.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             specifies either upper (rocblas_fill_upper) or lower (rocblas_fill_lower).
   !>             - if rocblas_fill_upper, the lower part of A is not referenced.
   !>             - if rocblas_fill_lower, the upper part of A is not referenced.
   !>
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the number of rows and columns of matrix A.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device pointer storing vector x.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of x.
-  !>     @param[in, out]
-  !>     A         device pointer storing matrix A.
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in, out] A - device pointer storing matrix A.
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of A.
   interface rocblas_ssyr
     function rocblas_ssyr_(handle,uplo,n,alpha,x,incx,A,lda) bind(c, name="rocblas_ssyr")
@@ -22273,32 +21246,23 @@ module hipfort_rocblas
   !>     where ``alpha`` is a scalar, ``x`` is an array of vectors, and ``A`` is an array of
   !>       ``n`` by ``n`` symmetric matrices, for ``i`` = 1 , ... , ``batch_count``.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             specifies either upper (rocblas_fill_upper) or lower (rocblas_fill_lower).
   !>             - if rocblas_fill_upper, the lower part of A is not referenced.
   !>             - if rocblas_fill_lower, the upper part of A is not referenced.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the number of rows and columns of matrix A.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in, out]
-  !>     A         device array of device pointers storing each matrix A_i.
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in, out] A - device array of device pointers storing each matrix A_i.
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of each A_i.
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_ssyr_batched
     function rocblas_ssyr_batched_(handle,uplo,n,alpha,x,incx,A,lda,batch_count) &
@@ -22462,38 +21426,27 @@ module hipfort_rocblas
   !>     where ``alpha`` is a scalar, ``x`` is an array of vectors, and ``A`` is an array of
   !>     ``n`` by ``n`` symmetric matrices, for ``i`` = 1 , ... , ``batch_count``.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             specifies either upper (rocblas_fill_upper) or lower (rocblas_fill_lower).
   !>             - if rocblas_fill_upper, the lower part of A is not referenced.
   !>             - if rocblas_fill_lower, the upper part of A is not referenced.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the number of rows and columns of each matrix A.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     x         device pointer to the first vector x_1.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device pointer to the first vector x_1.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     stridex   [rocblas_stride]
+  !>     @param[in] stridex - [rocblas_stride]
   !>               specifies the pointer increment between vectors (x_i) and (x_i+1).
-  !>     @param[in, out]
-  !>     A         device pointer to the first matrix A_1.
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in, out] A - device pointer to the first matrix A_1.
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of each A_i.
-  !>     @param[in]
-  !>     strideA   [rocblas_stride]
+  !>     @param[in] strideA - [rocblas_stride]
   !>               stride from the start of one matrix (A_i) to the next one (A_i+1).
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>               number of instances in the batch.
   interface rocblas_ssyr_strided_batched
     function rocblas_ssyr_strided_batched_(handle,uplo,n,alpha,x,incx,stridex,A,lda,strideA, &
@@ -22709,35 +21662,25 @@ module hipfort_rocblas
   !>     where ``alpha`` is a scalar, ``x`` and ``y`` are vectors, and ``A`` is an
   !>     ``n`` by ``n`` symmetric matrix.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             specifies either upper (rocblas_fill_upper) or lower (rocblas_fill_lower).
   !>             - if rocblas_fill_upper, the lower part of A is not referenced.
   !>             - if rocblas_fill_lower, the upper part of A is not referenced.
   !>
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the number of rows and columns of matrix A.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device pointer storing vector x.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of x.
-  !>     @param[in]
-  !>     y         device pointer storing vector y.
-  !>     @param[in]
-  !>     incy      [rocblas_int]
+  !>     @param[in] y - device pointer storing vector y.
+  !>     @param[in] incy - [rocblas_int]
   !>               specifies the increment for the elements of y.
-  !>     @param[in, out]
-  !>     A         device pointer storing matrix A.
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in, out] A - device pointer storing matrix A.
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of A.
   interface rocblas_ssyr2
     function rocblas_ssyr2_(handle,uplo,n,alpha,x,incx,y,incy,A,lda) bind(c, name="rocblas_ssyr2")
@@ -22933,37 +21876,26 @@ module hipfort_rocblas
   !>     where ``alpha`` is a scalar, x[i] and y[i] are vectors, and A[i] is a
   !>     ``n`` by ``n`` symmetric matrix, for ``i`` = 1 , ... , ``batch_count``.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             specifies either upper (rocblas_fill_upper) or lower (rocblas_fill_lower).
   !>             - if rocblas_fill_upper, the lower part of A is not referenced.
   !>             - if rocblas_fill_lower, the upper part of A is not referenced.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the number of rows and columns of matrix A.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     y         device array of device pointers storing each vector y_i.
-  !>     @param[in]
-  !>     incy      [rocblas_int]
+  !>     @param[in] y - device array of device pointers storing each vector y_i.
+  !>     @param[in] incy - [rocblas_int]
   !>               specifies the increment for the elements of each y_i.
-  !>     @param[in, out]
-  !>     A         device array of device pointers storing each matrix A_i.
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in, out] A - device array of device pointers storing each matrix A_i.
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of each A_i.
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_ssyr2_batched
     function rocblas_ssyr2_batched_(handle,uplo,n,alpha,x,incx,y,incy,A,lda,batch_count) &
@@ -23143,46 +22075,32 @@ module hipfort_rocblas
   !>     where ``alpha`` is a scalar, x[i] and y[i] are vectors, and A[i] is a
   !>     ``n`` by ``n`` symmetric matrices, for ``i`` = 1 , ... , ``batch_count``.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             specifies either upper (rocblas_fill_upper) or lower (rocblas_fill_lower).
   !>             - if rocblas_fill_upper, the lower part of A is not referenced.
   !>             - if rocblas_fill_lower, the upper part of A is not referenced.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the number of rows and columns of each matrix A.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>               device pointer or host pointer to scalar alpha.
-  !>     @param[in]
-  !>     x         device pointer to the first vector x_1.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device pointer to the first vector x_1.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     stridex   [rocblas_stride]
+  !>     @param[in] stridex - [rocblas_stride]
   !>               specifies the pointer increment between vectors (x_i) and (x_i+1).
-  !>     @param[in]
-  !>     y         device pointer to the first vector y_1.
-  !>     @param[in]
-  !>     incy      [rocblas_int]
+  !>     @param[in] y - device pointer to the first vector y_1.
+  !>     @param[in] incy - [rocblas_int]
   !>               specifies the increment for the elements of each y_i.
-  !>     @param[in]
-  !>     stridey   [rocblas_stride]
+  !>     @param[in] stridey - [rocblas_stride]
   !>               specifies the pointer increment between vectors (y_i) and (y_i+1).
-  !>     @param[in, out]
-  !>     A         device pointer to the first matrix A_1.
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in, out] A - device pointer to the first matrix A_1.
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of each A_i.
-  !>     @param[in]
-  !>     strideA   [rocblas_stride]
+  !>     @param[in] strideA - [rocblas_stride]
   !>               stride from the start of one matrix (A_i) to the next one (A_i+1).
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>               number of instances in the batch.
   interface rocblas_ssyr2_strided_batched
     function rocblas_ssyr2_strided_batched_(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey,A, &
@@ -23423,65 +22341,52 @@ module hipfort_rocblas
   !>     where ``alpha`` and ``beta`` are scalars, ``B`` and ``C`` are ``m`` by ``n`` matrices, and
   !>     ``A`` is a Hermitian matrix stored as either upper or lower.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     side  [rocblas_side]
+  !>     @param[in] side - [rocblas_side]
   !>             - rocblas_side_left:      C := alpha*A*B + beta*C
   !>             - rocblas_side_right:     C := alpha*B*A + beta*C
   !>
-  !>     @param[in]
-  !>     uplo    [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper:  A is an upper triangular matrix.
   !>             - rocblas_fill_lower:  A is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     m       [rocblas_int]
+  !>     @param[in] m - [rocblas_int]
   !>             m specifies the number of rows of B and C. m >= 0.
   !>
-  !>     @param[in]
-  !>     n       [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>             n specifies the number of columns of B and C. n >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             alpha specifies the scalar alpha. When alpha is
   !>             zero, then A and B are not referenced.
   !>
-  !>     @param[in]
-  !>     A       pointer storing matrix A on the GPU.
+  !>     @param[in] A - pointer storing matrix A on the GPU.
   !>             - A is m by m if side == rocblas_side_left.
   !>             - A is n by n if side == rocblas_side_right.
   !>             - Only the upper/lower triangular part is accessed.
   !>             - The imaginary component of the diagonal elements is not used.
   !>
-  !>     @param[in]
-  !>     lda     [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>             lda specifies the first dimension of A.
   !>             - If side = rocblas_side_left,  lda >= max( 1, m ).
   !>             - Otherwise, lda >= max( 1, n ).
   !>
-  !>     @param[in]
-  !>     B       pointer storing matrix B on the GPU.
+  !>     @param[in] B - pointer storing matrix B on the GPU.
   !>             Matrix dimension is m by n.
   !>
-  !>     @param[in]
-  !>     ldb     [rocblas_int]
+  !>     @param[in] ldb - [rocblas_int]
   !>             ldb specifies the first dimension of B. ldb >= max( 1, m ).
   !>
-  !>     @param[in]
-  !>     beta
+  !>     @param[in] beta
   !>             beta specifies the scalar beta. When beta is
   !>             zero, then C need not be set before entry.
   !>
-  !>     @param[in]
-  !>     C       pointer storing matrix C on the GPU.
+  !>     @param[in] C - pointer storing matrix C on the GPU.
   !>             Matrix dimension is m by n.
   !>
-  !>     @param[in]
-  !>     ldc    [rocblas_int]
+  !>     @param[in] ldc - [rocblas_int]
   !>            ldc specifies the first dimension of C. ldc >= max( 1, m ).
   interface rocblas_chemm
     function rocblas_chemm_(handle,side,uplo,m,n,alpha,A,lda,B,ldb,beta,C,ldc) &
@@ -23601,69 +22506,55 @@ module hipfort_rocblas
   !>     and
   !>     ``A_i`` is a Hermitian matrix stored as either upper or lower.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     side  [rocblas_side]
+  !>     @param[in] side - [rocblas_side]
   !>             - rocblas_side_left:      C_i := alpha*A_i*B_i + beta*C_i
   !>             - rocblas_side_right:     C_i := alpha*B_i*A_i + beta*C_i
   !>
-  !>     @param[in]
-  !>     uplo    [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper:  A_i is an upper triangular matrix.
   !>             - rocblas_fill_lower:  A_i is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     m       [rocblas_int]
+  !>     @param[in] m - [rocblas_int]
   !>             m specifies the number of rows of B_i and C_i. m >= 0.
   !>
-  !>     @param[in]
-  !>     n       [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>             n specifies the number of columns of B_i and C_i. n >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             alpha specifies the scalar alpha. When alpha is
   !>             zero, then A_i and B_i are not referenced.
   !>
-  !>     @param[in]
-  !>     A       device array of device pointers storing each matrix A_i on the GPU.
+  !>     @param[in] A - device array of device pointers storing each matrix A_i on the GPU.
   !>             - A_i is m by m if side == rocblas_side_left.
   !>             - A_i is n by n if side == rocblas_side_right.
   !>             - Only the upper/lower triangular part is accessed.
   !>             - The imaginary component of the diagonal elements is not used.
   !>
-  !>     @param[in]
-  !>     lda     [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>             lda specifies the first dimension of A_i.
   !>             - If side = rocblas_side_left,  lda >= max( 1, m ).
   !>             - Otherwise, lda >= max( 1, n ).
   !>
-  !>     @param[in]
-  !>     B       device array of device pointers storing each matrix B_i on the GPU.
+  !>     @param[in] B - device array of device pointers storing each matrix B_i on the GPU.
   !>             Matrix dimension is m by n.
   !>
-  !>     @param[in]
-  !>     ldb     [rocblas_int]
+  !>     @param[in] ldb - [rocblas_int]
   !>             ldb specifies the first dimension of B_i. ldb >= max( 1, m ).
   !>
-  !>     @param[in]
-  !>     beta
+  !>     @param[in] beta
   !>             beta specifies the scalar beta. When beta is
   !>             zero, then C_i need not be set before entry.
   !>
-  !>     @param[in]
-  !>     C       device array of device pointers storing each matrix C_i on the GPU.
+  !>     @param[in] C - device array of device pointers storing each matrix C_i on the GPU.
   !>             Matrix dimension is m by n.
   !>
-  !>     @param[in]
-  !>     ldc    [rocblas_int]
+  !>     @param[in] ldc - [rocblas_int]
   !>            ldc specifies the first dimension of C_i. ldc >= max( 1, m ).
   !>
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_chemm_batched
     function rocblas_chemm_batched_(handle,side,uplo,m,n,alpha,A,lda,B,ldb,beta,C,ldc,batch_count) &
@@ -23775,81 +22666,64 @@ module hipfort_rocblas
   !>     and
   !>     ``A_i`` is a Hermitian matrix stored as either upper or lower.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     side  [rocblas_side]
+  !>     @param[in] side - [rocblas_side]
   !>             - rocblas_side_left:      C_i := alpha*A_i*B_i + beta*C_i
   !>             - rocblas_side_right:     C_i := alpha*B_i*A_i + beta*C_i
   !>
-  !>     @param[in]
-  !>     uplo    [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper:  A_i is an upper triangular matrix.
   !>             - rocblas_fill_lower:  A_i is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     m       [rocblas_int]
+  !>     @param[in] m - [rocblas_int]
   !>             m specifies the number of rows of B_i and C_i. m >= 0.
   !>
-  !>     @param[in]
-  !>     n       [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>             n specifies the number of columns of B_i and C_i. n >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             alpha specifies the scalar alpha. When alpha is
   !>             zero, then A_i and B_i are not referenced.
   !>
-  !>     @param[in]
-  !>     A       device pointer to first matrix A_1.
+  !>     @param[in] A - device pointer to first matrix A_1.
   !>             - A_i is m by m if side == rocblas_side_left.
   !>             - A_i is n by n if side == rocblas_side_right.
   !>             - Only the upper/lower triangular part is accessed.
   !>             - The imaginary component of the diagonal elements is not used.
   !>
-  !>     @param[in]
-  !>     lda     [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>             lda specifies the first dimension of A_i.
   !>             - If side = rocblas_side_left,  lda >= max( 1, m ).
   !>             - Otherwise, lda >= max( 1, n ).
   !>
-  !>     @param[in]
-  !>     stride_A  [rocblas_stride]
+  !>     @param[in] stride_A - [rocblas_stride]
   !>               stride from the start of one matrix (A_i) to the next one (A_i+1).
   !>
-  !>     @param[in]
-  !>     B       device pointer to first matrix B_1 of dimension (ldb, n) on the GPU.
+  !>     @param[in] B - device pointer to first matrix B_1 of dimension (ldb, n) on the GPU.
   !>
-  !>     @param[in]
-  !>     ldb     [rocblas_int]
+  !>     @param[in] ldb - [rocblas_int]
   !>             ldb specifies the first dimension of B_i.
   !>             - If side = rocblas_operation_none, ldb >= max( 1, m ).
   !>             - Otherwise, ldb >= max( 1, n ).
   !>
-  !>     @param[in]
-  !>     stride_B  [rocblas_stride]
+  !>     @param[in] stride_B - [rocblas_stride]
   !>               stride from the start of one matrix (B_i) to the next one (B_i+1).
   !>
-  !>     @param[in]
-  !>     beta
+  !>     @param[in] beta
   !>             beta specifies the scalar beta. When beta is
   !>             zero, then C need not be set before entry.
   !>
-  !>     @param[in]
-  !>     C        device pointer to first matrix C_1 of dimension (ldc, n) on the GPU.
+  !>     @param[in] C - device pointer to first matrix C_1 of dimension (ldc, n) on the GPU.
   !>
-  !>     @param[in]
-  !>     ldc    [rocblas_int]
+  !>     @param[in] ldc - [rocblas_int]
   !>            ldc specifies the first dimension of C. ldc >= max( 1, m ).
   !>
-  !>     @param[in, out]
-  !>     stride_C  [rocblas_stride]
+  !>     @param[in, out] stride_C - [rocblas_stride]
   !>               stride from the start of one matrix (C_i) to the next one (C_i+1).
   !>
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_chemm_strided_batched
     function rocblas_chemm_strided_batched_(handle,side,uplo,m,n,alpha,A,lda,stride_A,B,ldb, &
@@ -23991,58 +22865,47 @@ module hipfort_rocblas
   !>         op( A ) = A, and A is n by k if transA == rocblas_operation_none
   !>         op( A ) = A^H and A is k by n if transA == rocblas_operation_conjugate_transpose
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper:  C is an upper triangular matrix.
   !>             - rocblas_fill_lower:  C is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA  [rocblas_operation]
+  !>     @param[in] transA - [rocblas_operation]
   !>             - rocblas_operation_conjugate_transpose:  op(A) = A^H
   !>             - rocblas_operation_none:                 op(A) = A
   !>
-  !>     @param[in]
-  !>     n       [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>             n specifies the number of rows and columns of C. n >= 0.
   !>
-  !>     @param[in]
-  !>     k       [rocblas_int]
+  !>     @param[in] k - [rocblas_int]
   !>             k specifies the number of columns of op(A). k >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             alpha specifies the scalar alpha. When alpha is
   !>             zero, then A is not referenced and A need not be set before
   !>             entry.
   !>
-  !>     @param[in]
-  !>     A       pointer storing matrix A on the GPU.
+  !>     @param[in] A - pointer storing matrix A on the GPU.
   !>             Matrix dimension is ( lda, k ) when transA = rocblas_operation_none. Otherwise,
   !>             (lda, n).
   !>
-  !>     @param[in]
-  !>     lda     [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>             lda specifies the first dimension of A.
   !>             - If transA = rocblas_operation_none,  lda >= max( 1, n ).
   !>             - Otherwise, lda >= max( 1, k ).
   !>
-  !>     @param[in]
-  !>     beta
+  !>     @param[in] beta
   !>             beta specifies the scalar beta. When beta is
   !>             zero, then C need not be set before entry.
   !>
-  !>     @param[in]
-  !>     C       pointer storing matrix C on the GPU.
+  !>     @param[in] C - pointer storing matrix C on the GPU.
   !>             The imaginary component of the diagonal elements are not used but are set to zero
   !>             unless quick return.
   !>             Only the upper/lower triangular part is accessed.
   !>
-  !>     @param[in]
-  !>     ldc    [rocblas_int]
+  !>     @param[in] ldc - [rocblas_int]
   !>            ldc specifies the first dimension of C. ldc >= max( 1, n ).
   interface rocblas_cherk
     function rocblas_cherk_(handle,uplo,transA,n,k,alpha,A,lda,beta,C,ldc) &
@@ -24156,60 +23019,49 @@ module hipfort_rocblas
   !>         op( A_i ) = A_i, and A_i is n by k if transA == rocblas_operation_none
   !>         op( A_i ) = A_i^H and A_i is k by n if transA == rocblas_operation_conjugate_transpose
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper:  C_i is an upper triangular matrix.
   !>             - rocblas_fill_lower:  C_i is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA  [rocblas_operation]
+  !>     @param[in] transA - [rocblas_operation]
   !>             - rocblas_operation_conjugate_transpose: op(A) = A^H
   !>             - rocblas_operation_none:                op(A) = A
   !>
-  !>     @param[in]
-  !>     n       [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>             n specifies the number of rows and columns of C_i. n >= 0.
   !>
-  !>     @param[in]
-  !>     k       [rocblas_int]
+  !>     @param[in] k - [rocblas_int]
   !>             k specifies the number of columns of op(A). k >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             alpha specifies the scalar alpha. When alpha is
   !>             zero, then A is not referenced and A need not be set before
   !>             entry.
   !>
-  !>     @param[in]
-  !>     A       device array of device pointers storing each matrix_i A of dimension (lda, k)
+  !>     @param[in] A - device array of device pointers storing each matrix_i A of dimension (lda,
+  !>     k)
   !>             when transA is rocblas_operation_none. Otherwise, of dimension (lda, n).
   !>
-  !>     @param[in]
-  !>     lda     [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>             lda specifies the first dimension of A_i.
   !>             - If transA = rocblas_operation_none,  lda >= max( 1, n ).
   !>             - Otherwise, lda >= max( 1, k ).
   !>
-  !>     @param[in]
-  !>     beta
+  !>     @param[in] beta
   !>             beta specifies the scalar beta. When beta is
   !>             zero, then C need not be set before entry.
   !>
-  !>     @param[in]
-  !>     C       device array of device pointers storing each matrix C_i on the GPU.
+  !>     @param[in] C - device array of device pointers storing each matrix C_i on the GPU.
   !>             The imaginary component of the diagonal elements are not used but are set to zero
   !>             unless quick return.
   !>             Only the upper/lower triangular part of each C_i is accessed.
   !>
-  !>     @param[in]
-  !>     ldc    [rocblas_int]
+  !>     @param[in] ldc - [rocblas_int]
   !>            ldc specifies the first dimension of C. ldc >= max( 1, n ).
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_cherk_batched
     function rocblas_cherk_batched_(handle,uplo,transA,n,k,alpha,A,lda,beta,C,ldc,batch_count) &
@@ -24314,69 +23166,55 @@ module hipfort_rocblas
   !>         op( A_i ) = A_i^H and A_i is k by n if transA == rocblas_operation_conjugate_transpose
   !>
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper:  C_i is an upper triangular matrix.
   !>             - rocblas_fill_lower:  C_i is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA  [rocblas_operation]
+  !>     @param[in] transA - [rocblas_operation]
   !>             - rocblas_operation_conjugate_transpose: op(A) = A^H
   !>             - rocblas_operation_none:                op(A) = A
   !>
-  !>     @param[in]
-  !>     n       [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>             n specifies the number of rows and columns of C_i. n >= 0.
   !>
-  !>     @param[in]
-  !>     k       [rocblas_int]
+  !>     @param[in] k - [rocblas_int]
   !>             k specifies the number of columns of op(A). k >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             alpha specifies the scalar alpha. When alpha is
   !>             zero, then A is not referenced and A need not be set before
   !>             entry.
   !>
-  !>     @param[in]
-  !>     A       Device pointer to the first matrix A_1 on the GPU of dimension (lda, k)
+  !>     @param[in] A - Device pointer to the first matrix A_1 on the GPU of dimension (lda, k)
   !>             when transA is rocblas_operation_none. Otherwise, of dimension (lda, n).
   !>
-  !>     @param[in]
-  !>     lda     [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>             lda specifies the first dimension of A_i.
   !>             - If transA = rocblas_operation_none,  lda >= max( 1, n ).
   !>             - Otherwise, lda >= max( 1, k ).
   !>
-  !>     @param[in]
-  !>     stride_A  [rocblas_stride]
+  !>     @param[in] stride_A - [rocblas_stride]
   !>               stride from the start of one matrix (A_i) to the next one (A_i+1).
   !>
-  !>     @param[in]
-  !>     beta
+  !>     @param[in] beta
   !>             beta specifies the scalar beta. When beta is
   !>             zero, then C need not be set before entry.
   !>
-  !>     @param[in]
-  !>     C       Device pointer to the first matrix C_1 on the GPU.
+  !>     @param[in] C - Device pointer to the first matrix C_1 on the GPU.
   !>             The imaginary component of the diagonal elements are not used but are set to zero
   !>             unless quick return.
   !>             Only the upper/lower triangular part of each C_i is accessed.
   !>
-  !>     @param[in]
-  !>     ldc    [rocblas_int]
+  !>     @param[in] ldc - [rocblas_int]
   !>            ldc specifies the first dimension of C. ldc >= max( 1, n ).
   !>
-  !>     @param[in, out]
-  !>     stride_C  [rocblas_stride]
+  !>     @param[in, out] stride_C - [rocblas_stride]
   !>               stride from the start of one matrix (C_i) to the next one (C_i+1).
   !>
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_cherk_strided_batched
     function rocblas_cherk_strided_batched_(handle,uplo,transA,n,k,alpha,A,lda,stride_A,beta,C, &
@@ -24508,69 +23346,56 @@ module hipfort_rocblas
   !>         op( A ) = A^H, op( B ) = B^H, and A and B are k by n if trans ==
   !>         rocblas_operation_conjugate_transpose
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper:  C is an upper triangular matrix.
   !>             - rocblas_fill_lower:  C is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     trans  [rocblas_operation]
+  !>     @param[in] trans - [rocblas_operation]
   !>             - rocblas_operation_conjugate_transpose:  op( A ) = A^H, op( B ) = B^H
   !>             - rocblas_operation_none:                 op( A ) = A, op( B ) = B
   !>
-  !>     @param[in]
-  !>     n       [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>             n specifies the number of rows and columns of C. n >= 0.
   !>
-  !>     @param[in]
-  !>     k       [rocblas_int]
+  !>     @param[in] k - [rocblas_int]
   !>             k specifies the number of columns of op(A). k >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             alpha specifies the scalar alpha. When alpha is
   !>             zero, then A is not referenced and A need not be set before
   !>             entry.
   !>
-  !>     @param[in]
-  !>     A       pointer storing matrix A on the GPU.
+  !>     @param[in] A - pointer storing matrix A on the GPU.
   !>             Matrix dimension is ( lda, k ) if trans = rocblas_operation_none. Otherwise, (lda,
   !>             n).
   !>
-  !>     @param[in]
-  !>     lda     [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>             lda specifies the first dimension of A.
   !>             - If trans = rocblas_operation_none,  lda >= max( 1, n ).
   !>             - Otherwise, lda >= max( 1, k ).
   !>
-  !>     @param[in]
-  !>     B       pointer storing matrix B on the GPU.
+  !>     @param[in] B - pointer storing matrix B on the GPU.
   !>             Matrix dimension is ( ldb, k ) if trans = rocblas_operation_none. Otherwise, (ldb,
   !>             n).
   !>
-  !>     @param[in]
-  !>     ldb     [rocblas_int]
+  !>     @param[in] ldb - [rocblas_int]
   !>             ldb specifies the first dimension of B.
   !>             - If trans = rocblas_operation_none,  ldb >= max( 1, n ).
   !>             - Otherwise, ldb >= max( 1, k ).
   !>
-  !>     @param[in]
-  !>     beta
+  !>     @param[in] beta
   !>             beta specifies the scalar beta. When beta is
   !>             zero, then C need not be set before entry.
   !>
-  !>     @param[in]
-  !>     C       pointer storing matrix C on the GPU.
+  !>     @param[in] C - pointer storing matrix C on the GPU.
   !>             The imaginary component of the diagonal elements are not used but are set to zero
   !>             unless quick return.
   !>             Only the upper/lower triangular part is accessed.
   !>
-  !>     @param[in]
-  !>     ldc    [rocblas_int]
+  !>     @param[in] ldc - [rocblas_int]
   !>            ldc specifies the first dimension of C. ldc >= max( 1, n ).
   interface rocblas_cher2k
     function rocblas_cher2k_(handle,uplo,trans,n,k,alpha,A,lda,B,ldb,beta,C,ldc) &
@@ -24695,68 +23520,56 @@ module hipfort_rocblas
   !>         op( A_i ) = A_i^H, op( B_i ) = B_i^H, and A_i and B_i are k by n if trans ==
   !>         rocblas_operation_conjugate_transpose
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper:  C_i is an upper triangular matrix.
   !>             - rocblas_fill_lower:  C_i is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     trans  [rocblas_operation]
+  !>     @param[in] trans - [rocblas_operation]
   !>             - rocblas_operation_conjugate_transpose: op(A) = A^H
   !>             - rocblas_operation_none:                op(A) = A
   !>
-  !>     @param[in]
-  !>     n       [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>             n specifies the number of rows and columns of C_i. n >= 0.
   !>
-  !>     @param[in]
-  !>     k       [rocblas_int]
+  !>     @param[in] k - [rocblas_int]
   !>             k specifies the number of columns of op(A). k >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             alpha specifies the scalar alpha. When alpha is
   !>             zero, then A is not referenced and A need not be set before
   !>             entry.
   !>
-  !>     @param[in]
-  !>     A       device array of device pointers storing each matrix_i A of dimension (lda, k)
+  !>     @param[in] A - device array of device pointers storing each matrix_i A of dimension (lda,
+  !>     k)
   !>             when trans is rocblas_operation_none. Otherwise, of dimension (lda, n).
   !>
-  !>     @param[in]
-  !>     lda     [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>             lda specifies the first dimension of A_i.
   !>             - If trans = rocblas_operation_none,  lda >= max( 1, n ).
   !>             - Otherwise, lda >= max( 1, k ).
-  !>     @param[in]
-  !>     B       device array of device pointers storing each matrix_i B of dimension (ldb, k)
+  !>     @param[in] B - device array of device pointers storing each matrix_i B of dimension (ldb,
+  !>     k)
   !>             when trans is rocblas_operation_none. Otherwise, of dimension (ldb, n).
   !>
-  !>     @param[in]
-  !>     ldb     [rocblas_int]
+  !>     @param[in] ldb - [rocblas_int]
   !>             ldb specifies the first dimension of B_i.
   !>             - If trans = rocblas_operation_none,  ldb >= max( 1, n ).
   !>             - Otherwise, ldb >= max( 1, k ).
-  !>     @param[in]
-  !>     beta
+  !>     @param[in] beta
   !>             beta specifies the scalar beta. When beta is
   !>             zero, then C need not be set before entry.
   !>
-  !>     @param[in]
-  !>     C       device array of device pointers storing each matrix C_i on the GPU.
+  !>     @param[in] C - device array of device pointers storing each matrix C_i on the GPU.
   !>             The imaginary component of the diagonal elements are not used but are set to zero
   !>             unless quick return.
   !>             Only the upper/lower triangular part of each C_i is accessed.
   !>
-  !>     @param[in]
-  !>     ldc    [rocblas_int]
+  !>     @param[in] ldc - [rocblas_int]
   !>            ldc specifies the first dimension of C. ldc >= max( 1, n ).
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_cher2k_batched
     function rocblas_cher2k_batched_(handle,uplo,trans,n,k,alpha,A,lda,B,ldb,beta,C,ldc, &
@@ -24875,83 +23688,66 @@ module hipfort_rocblas
   !>         op( A_i ) = A_i^H, op( B_i ) = B_i^H, and A_i and B_i are k by n if trans ==
   !>         rocblas_operation_conjugate_transpose
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper:  C_i is an upper triangular matrix.
   !>             - rocblas_fill_lower:  C_i is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     trans  [rocblas_operation]
+  !>     @param[in] trans - [rocblas_operation]
   !>             - rocblas_operation_conjugate_transpose: op( A_i ) = A_i^H, op( B_i ) = B_i^H
   !>             - rocblas_operation_none:                op( A_i ) = A_i, op( B_i ) = B_i
   !>
-  !>     @param[in]
-  !>     n       [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>             n specifies the number of rows and columns of C_i. n >= 0.
   !>
-  !>     @param[in]
-  !>     k       [rocblas_int]
+  !>     @param[in] k - [rocblas_int]
   !>             k specifies the number of columns of op(A). k >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             alpha specifies the scalar alpha. When alpha is
   !>             zero, then A is not referenced and A need not be set before
   !>             entry.
   !>
-  !>     @param[in]
-  !>     A       Device pointer to the first matrix A_1 on the GPU of dimension (lda, k)
+  !>     @param[in] A - Device pointer to the first matrix A_1 on the GPU of dimension (lda, k)
   !>             when trans is rocblas_operation_none. Otherwise, of dimension (lda, n).
   !>
-  !>     @param[in]
-  !>     lda     [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>             lda specifies the first dimension of A_i.
   !>             - If trans = rocblas_operation_none,  lda >= max( 1, n ).
   !>             - Otherwise, lda >= max( 1, k ).
   !>
-  !>     @param[in]
-  !>     stride_A  [rocblas_stride]
+  !>     @param[in] stride_A - [rocblas_stride]
   !>               stride from the start of one matrix (A_i) to the next one (A_i+1).
   !>
-  !>     @param[in]
-  !>     B       Device pointer to the first matrix B_1 on the GPU of dimension (ldb, k)
+  !>     @param[in] B - Device pointer to the first matrix B_1 on the GPU of dimension (ldb, k)
   !>             when trans is rocblas_operation_none. Otherwise, of dimension (ldb, n).
   !>
-  !>     @param[in]
-  !>     ldb     [rocblas_int]
+  !>     @param[in] ldb - [rocblas_int]
   !>             ldb specifies the first dimension of B_i.
   !>             - If trans = rocblas_operation_none,  ldb >= max( 1, n ).
   !>             - Otherwise, ldb >= max( 1, k ).
   !>
-  !>     @param[in]
-  !>     stride_B  [rocblas_stride]
+  !>     @param[in] stride_B - [rocblas_stride]
   !>               stride from the start of one matrix (B_i) to the next one (B_i+1).
   !>
-  !>     @param[in]
-  !>     beta
+  !>     @param[in] beta
   !>             beta specifies the scalar beta. When beta is
   !>             zero, then C need not be set before entry.
   !>
-  !>     @param[in]
-  !>     C       Device pointer to the first matrix C_1 on the GPU.
+  !>     @param[in] C - Device pointer to the first matrix C_1 on the GPU.
   !>             The imaginary component of the diagonal elements are not used but are set to zero
   !>             unless quick return.
   !>             Only the upper/lower triangular part of each C_i is accessed.
   !>
-  !>     @param[in]
-  !>     ldc    [rocblas_int]
+  !>     @param[in] ldc - [rocblas_int]
   !>            ldc specifies the first dimension of C. ldc >= max( 1, n ).
   !>
-  !>     @param[in, out]
-  !>     stride_C  [rocblas_stride]
+  !>     @param[in, out] stride_C - [rocblas_stride]
   !>               stride from the start of one matrix (C_i) to the next one (C_i+1).
   !>
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_cher2k_strided_batched
     function rocblas_cher2k_strided_batched_(handle,uplo,trans,n,k,alpha,A,lda,stride_A,B,ldb, &
@@ -25098,68 +23894,55 @@ module hipfort_rocblas
   !>         op( A ) = A^H, op( B ) = B^H, and A and B are k by n if trans ==
   !>         rocblas_operation_conjugate_transpose
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper:  C is an upper triangular matrix.
   !>             - rocblas_fill_lower:  C is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     trans  [rocblas_operation]
+  !>     @param[in] trans - [rocblas_operation]
   !>             - rocblas_operation_conjugate_transpose:  op( A ) = A^H, op( B ) = B^H
   !>             - rocblas_operation_none:                 op( A ) = A, op( B ) = B
   !>
-  !>     @param[in]
-  !>     n       [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>             n specifies the number of rows and columns of C. n >= 0.
   !>
-  !>     @param[in]
-  !>     k       [rocblas_int]
+  !>     @param[in] k - [rocblas_int]
   !>             k specifies the number of columns of op(A). k >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             alpha specifies the scalar alpha. When alpha is
   !>             zero, then A is not referenced and A need not be set before
   !>             entry.
   !>
-  !>     @param[in]
-  !>     A       pointer storing matrix A on the GPU.
+  !>     @param[in] A - pointer storing matrix A on the GPU.
   !>             Matrix dimension is ( lda, k ) when trans = rocblas_operation_none. Otherwise,
   !>             (lda, n).
   !>
-  !>     @param[in]
-  !>     lda     [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>             lda specifies the first dimension of A.
   !>             - If trans = rocblas_operation_none,  lda >= max( 1, n ).
   !>             - Otherwise, lda >= max( 1, k ).
-  !>     @param[in]
-  !>     B       pointer storing matrix B on the GPU.
+  !>     @param[in] B - pointer storing matrix B on the GPU.
   !>             Matrix dimension is ( ldb, k ) when trans = rocblas_operation_none. Otherwise,
   !>             (ldb, n).
   !>
-  !>     @param[in]
-  !>     ldb     [rocblas_int]
+  !>     @param[in] ldb - [rocblas_int]
   !>             ldb specifies the first dimension of B.
   !>             - If trans = rocblas_operation_none,  ldb >= max( 1, n ).
   !>             - Otherwise, ldb >= max( 1, k ).
   !>
-  !>     @param[in]
-  !>     beta
+  !>     @param[in] beta
   !>             beta specifies the scalar beta. When beta is
   !>             zero, then C need not be set before entry.
   !>
-  !>     @param[in]
-  !>     C       pointer storing matrix C on the GPU.
+  !>     @param[in] C - pointer storing matrix C on the GPU.
   !>             The imaginary component of the diagonal elements are not used but are set to zero
   !>             unless quick return.
   !>             Only the upper/lower triangular part is accessed.
   !>
-  !>     @param[in]
-  !>     ldc    [rocblas_int]
+  !>     @param[in] ldc - [rocblas_int]
   !>            ldc specifies the first dimension of C. ldc >= max( 1, n ).
   interface rocblas_cherkx
     function rocblas_cherkx_(handle,uplo,trans,n,k,alpha,A,lda,B,ldb,beta,C,ldc) &
@@ -25287,71 +24070,59 @@ module hipfort_rocblas
   !>         op( A_i ) = A_i^H, op( B_i ) = B_i^H, and A_i and B_i are k by n if trans ==
   !>         rocblas_operation_conjugate_transpose
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper:  C_i is an upper triangular matrix.
   !>             - rocblas_fill_lower:  C_i is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     trans  [rocblas_operation]
+  !>     @param[in] trans - [rocblas_operation]
   !>             - rocblas_operation_conjugate_transpose: op(A) = A^H
   !>             - rocblas_operation_none:                op(A) = A
   !>
-  !>     @param[in]
-  !>     n       [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>             n specifies the number of rows and columns of C_i. n >= 0.
   !>
-  !>     @param[in]
-  !>     k       [rocblas_int]
+  !>     @param[in] k - [rocblas_int]
   !>             k specifies the number of columns of op(A). k >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             alpha specifies the scalar alpha. When alpha is
   !>             zero, then A is not referenced and A need not be set before
   !>             entry.
   !>
-  !>     @param[in]
-  !>     A       device array of device pointers storing each matrix_i A of dimension (lda, k)
+  !>     @param[in] A - device array of device pointers storing each matrix_i A of dimension (lda,
+  !>     k)
   !>             when trans is rocblas_operation_none. Otherwise, of dimension (lda, n).
   !>
-  !>     @param[in]
-  !>     lda     [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>             lda specifies the first dimension of A_i.
   !>             - If trans = rocblas_operation_none,  lda >= max( 1, n ).
   !>             - Otherwise, lda >= max( 1, k ).
   !>
-  !>     @param[in]
-  !>     B       device array of device pointers storing each matrix_i B of dimension (ldb, k)
+  !>     @param[in] B - device array of device pointers storing each matrix_i B of dimension (ldb,
+  !>     k)
   !>             when trans is rocblas_operation_none. Otherwise, of dimension (ldb, n).
   !>
-  !>     @param[in]
-  !>     ldb     [rocblas_int]
+  !>     @param[in] ldb - [rocblas_int]
   !>             ldb specifies the first dimension of B_i.
   !>             - If trans = rocblas_operation_none,  ldb >= max( 1, n ).
   !>             - Otherwise, ldb >= max( 1, k ).
   !>
-  !>     @param[in]
-  !>     beta
+  !>     @param[in] beta
   !>             beta specifies the scalar beta. When beta is
   !>             zero, then C need not be set before entry.
   !>
-  !>     @param[in]
-  !>     C       device array of device pointers storing each matrix C_i on the GPU.
+  !>     @param[in] C - device array of device pointers storing each matrix C_i on the GPU.
   !>             The imaginary component of the diagonal elements are not used but are set to zero
   !>             unless quick return.
   !>             Only the upper/lower triangular part of each C_i is accessed.
   !>
-  !>     @param[in]
-  !>     ldc    [rocblas_int]
+  !>     @param[in] ldc - [rocblas_int]
   !>            ldc specifies the first dimension of C. ldc >= max( 1, n ).
   !>
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_cherkx_batched
     function rocblas_cherkx_batched_(handle,uplo,trans,n,k,alpha,A,lda,B,ldb,beta,C,ldc, &
@@ -25473,83 +24244,66 @@ module hipfort_rocblas
   !>         op( A_i ) = A_i^H, op( B_i ) = B_i^H, and A_i and B_i are k by n if trans ==
   !>         rocblas_operation_conjugate_transpose
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper:  C_i is an upper triangular matrix.
   !>             - rocblas_fill_lower:  C_i is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     trans  [rocblas_operation]
+  !>     @param[in] trans - [rocblas_operation]
   !>             - rocblas_operation_conjugate_transpose: op( A_i ) = A_i^H, op( B_i ) = B_i^H
   !>             - rocblas_operation_none:                op( A_i ) = A_i, op( B_i ) = B_i
   !>
-  !>     @param[in]
-  !>     n       [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>             n specifies the number of rows and columns of C_i. n >= 0.
   !>
-  !>     @param[in]
-  !>     k       [rocblas_int]
+  !>     @param[in] k - [rocblas_int]
   !>             k specifies the number of columns of op(A). k >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             alpha specifies the scalar alpha. When alpha is
   !>             zero, then A is not referenced and A need not be set before
   !>             entry.
   !>
-  !>     @param[in]
-  !>     A       Device pointer to the first matrix A_1 on the GPU of dimension (lda, k)
+  !>     @param[in] A - Device pointer to the first matrix A_1 on the GPU of dimension (lda, k)
   !>             when trans is rocblas_operation_none. Otherwise, of dimension (lda, n).
   !>
-  !>     @param[in]
-  !>     lda     [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>             lda specifies the first dimension of A_i.
   !>             - If trans = rocblas_operation_none,  lda >= max( 1, n ).
   !>             - Otherwise, lda >= max( 1, k ).
   !>
-  !>     @param[in]
-  !>     stride_A  [rocblas_stride]
+  !>     @param[in] stride_A - [rocblas_stride]
   !>               stride from the start of one matrix (A_i) to the next one (A_i+1).
   !>
-  !>     @param[in]
-  !>     B       Device pointer to the first matrix B_1 on the GPU of dimension (ldb, k)
+  !>     @param[in] B - Device pointer to the first matrix B_1 on the GPU of dimension (ldb, k)
   !>             when trans is rocblas_operation_none. Otherwise, of dimension (ldb, n).
   !>
-  !>     @param[in]
-  !>     ldb     [rocblas_int]
+  !>     @param[in] ldb - [rocblas_int]
   !>             ldb specifies the first dimension of B_i.
   !>             - If trans = rocblas_operation_none,  ldb >= max( 1, n ).
   !>             - Otherwise, ldb >= max( 1, k ).
   !>
-  !>     @param[in]
-  !>     stride_B  [rocblas_stride]
+  !>     @param[in] stride_B - [rocblas_stride]
   !>               stride from the start of one matrix (B_i) to the next one (B_i+1).
   !>
-  !>     @param[in]
-  !>     beta
+  !>     @param[in] beta
   !>             beta specifies the scalar beta. When beta is
   !>             zero, then C need not be set before entry.
   !>
-  !>     @param[in]
-  !>     C       Device pointer to the first matrix C_1 on the GPU.
+  !>     @param[in] C - Device pointer to the first matrix C_1 on the GPU.
   !>             The imaginary component of the diagonal elements are not used but are set to zero
   !>             unless quick return.
   !>             Only the upper/lower triangular part of each C_i is accessed.
   !>
-  !>     @param[in]
-  !>     ldc    [rocblas_int]
+  !>     @param[in] ldc - [rocblas_int]
   !>            ldc specifies the first dimension of C. ldc >= max( 1, n ).
   !>
-  !>     @param[in, out]
-  !>     stride_C  [rocblas_stride]
+  !>     @param[in, out] stride_C - [rocblas_stride]
   !>               stride from the start of one matrix (C_i) to the next one (C_i+1).
   !>
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_cherkx_strided_batched
     function rocblas_cherkx_strided_batched_(handle,uplo,trans,n,k,alpha,A,lda,stride_A,B,ldb, &
@@ -25688,64 +24442,51 @@ module hipfort_rocblas
   !>     where ``alpha`` and ``beta`` are scalars, ``B`` and ``C`` are ``m`` by ``n`` matrices, and
   !>     ``A`` is a symmetric matrix stored as either upper or lower.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     side  [rocblas_side]
+  !>     @param[in] side - [rocblas_side]
   !>             - rocblas_side_left:      C := alpha*A*B + beta*C
   !>             - rocblas_side_right:     C := alpha*B*A + beta*C
   !>
-  !>     @param[in]
-  !>     uplo    [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper:  A is an upper triangular matrix
   !>             - rocblas_fill_lower:  A is a  lower triangular matrix
   !>
-  !>     @param[in]
-  !>     m       [rocblas_int]
+  !>     @param[in] m - [rocblas_int]
   !>             m specifies the number of rows of B and C. m >= 0.
   !>
-  !>     @param[in]
-  !>     n       [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>             n specifies the number of columns of B and C. n >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             alpha specifies the scalar alpha. When alpha is
   !>             zero, A and B are not referenced.
   !>
-  !>     @param[in]
-  !>     A       pointer storing matrix A on the GPU.
+  !>     @param[in] A - pointer storing matrix A on the GPU.
   !>             - A is m by m if side == rocblas_side_left.
   !>             - A is n by n if side == rocblas_side_right.
   !>             - Only the upper/lower triangular part is accessed.
   !>
-  !>     @param[in]
-  !>     lda     [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>             lda specifies the first dimension of A.
   !>             - If side = rocblas_side_left,  lda >= max( 1, m ).
   !>             - Otherwise, lda >= max( 1, n ).
   !>
-  !>     @param[in]
-  !>     B       pointer storing matrix B on the GPU.
+  !>     @param[in] B - pointer storing matrix B on the GPU.
   !>             Matrix dimension is m by n.
   !>
-  !>     @param[in]
-  !>     ldb     [rocblas_int]
+  !>     @param[in] ldb - [rocblas_int]
   !>             ldb specifies the first dimension of B. ldb >= max( 1, m ).
   !>
-  !>     @param[in]
-  !>     beta
+  !>     @param[in] beta
   !>             beta specifies the scalar beta. When beta is
   !>             zero, then C need not be set before entry.
   !>
-  !>     @param[in]
-  !>     C       pointer storing matrix C on the GPU.
+  !>     @param[in] C - pointer storing matrix C on the GPU.
   !>             Matrix dimension is m by n.
   !>
-  !>     @param[in]
-  !>     ldc    [rocblas_int]
+  !>     @param[in] ldc - [rocblas_int]
   !>            ldc specifies the first dimension of C. ldc >= max( 1, m ).
   interface rocblas_ssymm
     function rocblas_ssymm_(handle,side,uplo,m,n,alpha,A,lda,B,ldb,beta,C,ldc) &
@@ -25971,68 +24712,54 @@ module hipfort_rocblas
   !>     and
   !>     ``A_i`` is a symmetric matrix stored as either upper or lower.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     side  [rocblas_side]
+  !>     @param[in] side - [rocblas_side]
   !>             - rocblas_side_left:      C_i := alpha*A_i*B_i + beta*C_i
   !>             - rocblas_side_right:     C_i := alpha*B_i*A_i + beta*C_i
   !>
-  !>     @param[in]
-  !>     uplo    [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper:  A_i is an upper triangular matrix
   !>             - rocblas_fill_lower:  A_i is a  lower triangular matrix
   !>
-  !>     @param[in]
-  !>     m       [rocblas_int]
+  !>     @param[in] m - [rocblas_int]
   !>             m specifies the number of rows of B_i and C_i. m >= 0.
   !>
-  !>     @param[in]
-  !>     n       [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>             n specifies the number of columns of B_i and C_i. n >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             alpha specifies the scalar alpha. When alpha is
   !>             zero, A_i and B_i are not referenced.
   !>
-  !>     @param[in]
-  !>     A       device array of device pointers storing each matrix A_i on the GPU.
+  !>     @param[in] A - device array of device pointers storing each matrix A_i on the GPU.
   !>             - A_i is m by m if side == rocblas_side_left.
   !>             - A_i is n by n if side == rocblas_side_right.
   !>             - Only the upper/lower triangular part is accessed.
   !>
-  !>     @param[in]
-  !>     lda     [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>             lda specifies the first dimension of A_i.
   !>             - If side = rocblas_side_left,  lda >= max( 1, m ).
   !>             - Otherwise, lda >= max( 1, n ).
   !>
-  !>     @param[in]
-  !>     B       device array of device pointers storing each matrix B_i on the GPU.
+  !>     @param[in] B - device array of device pointers storing each matrix B_i on the GPU.
   !>             Matrix dimension is m by n.
   !>
-  !>     @param[in]
-  !>     ldb     [rocblas_int]
+  !>     @param[in] ldb - [rocblas_int]
   !>             ldb specifies the first dimension of B_i. ldb >= max( 1, m ).
   !>
-  !>     @param[in]
-  !>     beta
+  !>     @param[in] beta
   !>             beta specifies the scalar beta. When beta is
   !>             zero, then C_i need not be set before entry.
   !>
-  !>     @param[in]
-  !>     C       device array of device pointers storing each matrix C_i on the GPU.
+  !>     @param[in] C - device array of device pointers storing each matrix C_i on the GPU.
   !>             Matrix dimension is m by n.
   !>
-  !>     @param[in]
-  !>     ldc    [rocblas_int]
+  !>     @param[in] ldc - [rocblas_int]
   !>            ldc specifies the first dimension of C_i. ldc >= max( 1, m ).
   !>
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_ssymm_batched
     function rocblas_ssymm_batched_(handle,side,uplo,m,n,alpha,A,lda,B,ldb,beta,C,ldc,batch_count) &
@@ -26242,77 +24969,60 @@ module hipfort_rocblas
   !>     and
   !>     ``A_i`` is a symmetric matrix stored as either upper or lower.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     side  [rocblas_side]
+  !>     @param[in] side - [rocblas_side]
   !>             - rocblas_side_left:      C_i := alpha*A_i*B_i + beta*C_i
   !>             - rocblas_side_right:     C_i := alpha*B_i*A_i + beta*C_i
   !>
-  !>     @param[in]
-  !>     uplo    [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper:  A_i is an upper triangular matrix.
   !>             - rocblas_fill_lower:  A_i is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     m       [rocblas_int]
+  !>     @param[in] m - [rocblas_int]
   !>             m specifies the number of rows of B_i and C_i. m >= 0.
   !>
-  !>     @param[in]
-  !>     n       [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>             n specifies the number of columns of B_i and C_i. n >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             alpha specifies the scalar alpha. When alpha is
   !>             zero, A_i and B_i are not referenced.
   !>
-  !>     @param[in]
-  !>     A       device pointer to first matrix A_1.
+  !>     @param[in] A - device pointer to first matrix A_1.
   !>             - A_i is m by m if side == rocblas_side_left.
   !>             - A_i is n by n if side == rocblas_side_right.
   !>             - Only the upper/lower triangular part is accessed.
   !>
-  !>     @param[in]
-  !>     lda     [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>             lda specifies the first dimension of A_i.
   !>             - If side = rocblas_side_left,  lda >= max( 1, m ).
   !>             - Otherwise, lda >= max( 1, n ).
   !>
-  !>     @param[in]
-  !>     stride_A  [rocblas_stride]
+  !>     @param[in] stride_A - [rocblas_stride]
   !>               stride from the start of one matrix (A_i) to the next one (A_i+1).
   !>
-  !>     @param[in]
-  !>     B       device pointer to first matrix B_1 of dimension (ldb, n) on the GPU.
+  !>     @param[in] B - device pointer to first matrix B_1 of dimension (ldb, n) on the GPU.
   !>
-  !>     @param[in]
-  !>     ldb     [rocblas_int]
+  !>     @param[in] ldb - [rocblas_int]
   !>             ldb specifies the first dimension of B_i. ldb >= max( 1, m ).
   !>
-  !>     @param[in]
-  !>     stride_B  [rocblas_stride]
+  !>     @param[in] stride_B - [rocblas_stride]
   !>               stride from the start of one matrix (B_i) to the next one (B_i+1).
-  !>     @param[in]
-  !>     beta
+  !>     @param[in] beta
   !>             beta specifies the scalar beta. When beta is
   !>             zero, then C need not be set before entry.
   !>
-  !>     @param[in]
-  !>     C        device pointer to first matrix C_1 of dimension (ldc, n) on the GPU.
+  !>     @param[in] C - device pointer to first matrix C_1 of dimension (ldc, n) on the GPU.
   !>
-  !>     @param[in]
-  !>     ldc    [rocblas_int]
+  !>     @param[in] ldc - [rocblas_int]
   !>            ldc specifies the first dimension of C. ldc >= max( 1, m ).
   !>
-  !>     @param[in, out]
-  !>     stride_C  [rocblas_stride]
+  !>     @param[in, out] stride_C - [rocblas_stride]
   !>               stride from the start of one matrix (C_i) to the next one (C_i+1).
   !>
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_ssymm_strided_batched
     function rocblas_ssymm_strided_batched_(handle,side,uplo,m,n,alpha,A,lda,stride_A,B,ldb, &
@@ -26580,17 +25290,14 @@ module hipfort_rocblas
   !>         op( A ) = A, and A is n by k if transA == rocblas_operation_none
   !>         op( A ) = A^T and A is k by n if transA == rocblas_operation_transpose
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper:  C is an upper triangular matrix.
   !>             - rocblas_fill_lower:  C is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA  [rocblas_operation]
+  !>     @param[in] transA - [rocblas_operation]
   !>             - rocblas_operation_transpose:           op(A) = A^T
   !>             - rocblas_operation_none:                op(A) = A
   !>             - rocblas_operation_conjugate_transpose: op(A) = A^T
@@ -26598,42 +25305,34 @@ module hipfort_rocblas
   !>             cherk
   !>             and zherk.
   !>
-  !>     @param[in]
-  !>     n       [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>             n specifies the number of rows and columns of C. n >= 0.
   !>
-  !>     @param[in]
-  !>     k       [rocblas_int]
+  !>     @param[in] k - [rocblas_int]
   !>             k specifies the number of columns of op(A). k >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             alpha specifies the scalar alpha. When alpha is
   !>             zero, A is not referenced and A need not be set before
   !>             entry.
   !>
-  !>     @param[in]
-  !>     A       pointer storing matrix A on the GPU.
+  !>     @param[in] A - pointer storing matrix A on the GPU.
   !>             Matrix dimension is ( lda, k ) if transA = rocblas_operation_none. Otherwise, (lda,
   !>             n).
   !>
-  !>     @param[in]
-  !>     lda     [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>             lda specifies the first dimension of A.
   !>             - If transA = rocblas_operation_none,  lda >= max( 1, n ).
   !>             - Otherwise, lda >= max( 1, k ).
   !>
-  !>     @param[in]
-  !>     beta
+  !>     @param[in] beta
   !>             beta specifies the scalar beta. When beta is
   !>             zero, then C need not be set before entry.
   !>
-  !>     @param[in]
-  !>     C       pointer storing matrix C on the GPU.
+  !>     @param[in] C - pointer storing matrix C on the GPU.
   !>             Only the upper/lower triangular part is accessed.
   !>
-  !>     @param[in]
-  !>     ldc    [rocblas_int]
+  !>     @param[in] ldc - [rocblas_int]
   !>            ldc specifies the first dimension of C. ldc >= max( 1, n ).
   interface rocblas_ssyrk
     function rocblas_ssyrk_(handle,uplo,transA,n,k,alpha,A,lda,beta,C,ldc) &
@@ -26845,17 +25544,14 @@ module hipfort_rocblas
   !>         op( A_i ) = A_i, and A_i is n by k if transA == rocblas_operation_none
   !>         op( A_i ) = A_i^T and A_i is k by n if transA == rocblas_operation_transpose
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper:  C_i is an upper triangular matrix.
   !>             - rocblas_fill_lower:  C_i is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA  [rocblas_operation]
+  !>     @param[in] transA - [rocblas_operation]
   !>             - rocblas_operation_transpose:           op(A) = A^T
   !>             - rocblas_operation_none:                op(A) = A
   !>             - rocblas_operation_conjugate_transpose: op(A) = A^T
@@ -26863,44 +25559,36 @@ module hipfort_rocblas
   !>             cherk
   !>             and zherk.
   !>
-  !>     @param[in]
-  !>     n       [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>             n specifies the number of rows and columns of C_i. n >= 0.
   !>
-  !>     @param[in]
-  !>     k       [rocblas_int]
+  !>     @param[in] k - [rocblas_int]
   !>             k specifies the number of columns of op(A). k >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             alpha specifies the scalar alpha. When alpha is
   !>             zero, A is not referenced and A need not be set before
   !>             entry.
   !>
-  !>     @param[in]
-  !>     A       device array of device pointers storing each matrix_i A of dimension (lda, k)
+  !>     @param[in] A - device array of device pointers storing each matrix_i A of dimension (lda,
+  !>     k)
   !>             when transA is rocblas_operation_none. Otherwise, of dimension (lda, n).
   !>
-  !>     @param[in]
-  !>     lda     [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>             lda specifies the first dimension of A_i.
   !>             - If transA = rocblas_operation_none,  lda >= max( 1, n ),
   !>             - Otherwise, lda >= max( 1, k ).
   !>
-  !>     @param[in]
-  !>     beta
+  !>     @param[in] beta
   !>             beta specifies the scalar beta. When beta is
   !>             zero, then C need not be set before entry.
   !>
-  !>     @param[in]
-  !>     C       device array of device pointers storing each matrix C_i on the GPU.
+  !>     @param[in] C - device array of device pointers storing each matrix C_i on the GPU.
   !>             Only the upper/lower triangular part of each C_i is accessed.
   !>
-  !>     @param[in]
-  !>     ldc    [rocblas_int]
+  !>     @param[in] ldc - [rocblas_int]
   !>            ldc specifies the first dimension of C. ldc >= max( 1, n ).
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_ssyrk_batched
     function rocblas_ssyrk_batched_(handle,uplo,transA,n,k,alpha,A,lda,beta,C,ldc,batch_count) &
@@ -27092,17 +25780,14 @@ module hipfort_rocblas
   !>         op( A_i ) = A_i, and A_i is n by k if transA == rocblas_operation_none
   !>         op( A_i ) = A_i^T and A_i is k by n if transA == rocblas_operation_transpose
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper:  C_i is an upper triangular matrix.
   !>             - rocblas_fill_lower:  C_i is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA  [rocblas_operation]
+  !>     @param[in] transA - [rocblas_operation]
   !>             - rocblas_operation_transpose:           op(A) = A^T
   !>             - rocblas_operation_none:                op(A) = A
   !>             - rocblas_operation_conjugate_transpose: op(A) = A^T
@@ -27110,53 +25795,42 @@ module hipfort_rocblas
   !>             cherk
   !>             and zherk.
   !>
-  !>     @param[in]
-  !>     n       [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>             n specifies the number of rows and columns of C_i. n >= 0.
   !>
-  !>     @param[in]
-  !>     k       [rocblas_int]
+  !>     @param[in] k - [rocblas_int]
   !>             k specifies the number of columns of op(A). k >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             alpha specifies the scalar alpha. When alpha is
   !>             zero, A is not referenced and A need not be set before
   !>             entry.
   !>
-  !>     @param[in]
-  !>     A       Device pointer to the first matrix A_1 on the GPU of dimension (lda, k)
+  !>     @param[in] A - Device pointer to the first matrix A_1 on the GPU of dimension (lda, k)
   !>             when transA is rocblas_operation_none. Otherwise, of dimension (lda, n).
   !>
-  !>     @param[in]
-  !>     lda     [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>             lda specifies the first dimension of A_i.
   !>             - If transA = rocblas_operation_none,  lda >= max( 1, n ).
   !>             - Otherwise, lda >= max( 1, k ).
   !>
-  !>     @param[in]
-  !>     stride_A  [rocblas_stride]
+  !>     @param[in] stride_A - [rocblas_stride]
   !>               stride from the start of one matrix (A_i) to the next one (A_i+1).
   !>
-  !>     @param[in]
-  !>     beta
+  !>     @param[in] beta
   !>             beta specifies the scalar beta. When beta is
   !>             zero, then C need not be set before entry.
   !>
-  !>     @param[in]
-  !>     C       Device pointer to the first matrix C_1 on the GPU.
+  !>     @param[in] C - Device pointer to the first matrix C_1 on the GPU.
   !>             Only the upper/lower triangular part of each C_i is accessed.
   !>
-  !>     @param[in]
-  !>     ldc    [rocblas_int]
+  !>     @param[in] ldc - [rocblas_int]
   !>            ldc specifies the first dimension of C. ldc >= max( 1, n ).
   !>
-  !>     @param[in, out]
-  !>     stride_C  [rocblas_stride]
+  !>     @param[in, out] stride_C - [rocblas_stride]
   !>               stride from the start of one matrix (C_i) to the next one (C_i+1)
   !>
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_ssyrk_strided_batched
     function rocblas_ssyrk_strided_batched_(handle,uplo,transA,n,k,alpha,A,lda,stride_A,beta,C, &
@@ -27403,70 +26077,57 @@ module hipfort_rocblas
   !>         rocblas_operation_transpose
   !>         or for ssyr2k and dsyr2k when trans == rocblas_operation_conjugate_transpose
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper:  C is an upper triangular matrix.
   !>             - rocblas_fill_lower:  C is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     trans  [rocblas_operation]
+  !>     @param[in] trans - [rocblas_operation]
   !>             - rocblas_operation_transpose:           op( A ) = A^T, op( B ) = B^T
   !>             - rocblas_operation_none:                op( A ) = A, op( B ) = B
   !>             - rocblas_operation_conjugate_transpose: op( A ) = A^T, op( B ) = B^T
   !>             - rocblas_operation_conjugate_transpose is not supported for complex types in
   !>             csyr2k and zsyr2k.
   !>
-  !>     @param[in]
-  !>     n       [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>             n specifies the number of rows and columns of C. n >= 0.
   !>
-  !>     @param[in]
-  !>     k       [rocblas_int]
+  !>     @param[in] k - [rocblas_int]
   !>             k specifies the number of columns of op(A) and op(B). k >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             alpha specifies the scalar alpha. When alpha is
   !>             zero, A is not referenced and A need not be set before
   !>             entry.
   !>
-  !>     @param[in]
-  !>     A       pointer storing matrix A on the GPU.
+  !>     @param[in] A - pointer storing matrix A on the GPU.
   !>             Matrix dimension is ( lda, k ) when trans = rocblas_operation_none. Otherwise,
   !>             (lda, n).
   !>             Only the upper/lower triangular part is accessed.
   !>
-  !>     @param[in]
-  !>     lda     [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>             lda specifies the first dimension of A.
   !>             - If trans = rocblas_operation_none,  lda >= max( 1, n ).
   !>             - Otherwise, lda >= max( 1, k ).
   !>
-  !>     @param[in]
-  !>     B       pointer storing matrix B on the GPU.
+  !>     @param[in] B - pointer storing matrix B on the GPU.
   !>             Matrix dimension is ( ldb, k ) when trans = rocblas_operation_none. Otherwise,
   !>             (ldb, n).
   !>             Only the upper/lower triangular part is accessed.
   !>
-  !>     @param[in]
-  !>     ldb     [rocblas_int]
+  !>     @param[in] ldb - [rocblas_int]
   !>             ldb specifies the first dimension of B.
   !>             - If trans = rocblas_operation_none,  ldb >= max( 1, n ).
   !>             - Otherwise, ldb >= max( 1, k ).
-  !>     @param[in]
-  !>     beta
+  !>     @param[in] beta
   !>             beta specifies the scalar beta. When beta is
   !>             zero, C need not be set before entry.
   !>
-  !>     @param[in]
-  !>     C       pointer storing matrix C on the GPU.
+  !>     @param[in] C - pointer storing matrix C on the GPU.
   !>
-  !>     @param[in]
-  !>     ldc    [rocblas_int]
+  !>     @param[in] ldc - [rocblas_int]
   !>            ldc specifies the first dimension of C. ldc >= max( 1, n ).
   interface rocblas_ssyr2k
     function rocblas_ssyr2k_(handle,uplo,trans,n,k,alpha,A,lda,B,ldb,beta,C,ldc) &
@@ -27699,67 +26360,55 @@ module hipfort_rocblas
   !>         or for ssyr2k_batched and dsyr2k_batched when trans ==
   !>         rocblas_operation_conjugate_transpose
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper:  C_i is an upper triangular matrix.
   !>             - rocblas_fill_lower:  C_i is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     trans  [rocblas_operation]
+  !>     @param[in] trans - [rocblas_operation]
   !>             - rocblas_operation_transpose:           op( A_i ) = A_i^T, op( B_i ) = B_i^T
   !>             - rocblas_operation_none:                op( A_i ) = A_i, op( B_i ) = B_i
   !>             - rocblas_operation_conjugate_transpose: op( A_i ) = A_i^T, op( B_i ) = B_i^T
   !>             - rocblas_operation_conjugate_transpose is not supported for complex types in
   !>             csyr2k_batched and zsyr2k_batched.
   !>
-  !>     @param[in]
-  !>     n       [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>             n specifies the number of rows and columns of C_i. n >= 0.
   !>
-  !>     @param[in]
-  !>     k       [rocblas_int]
+  !>     @param[in] k - [rocblas_int]
   !>             k specifies the number of columns of op(A). k >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             alpha specifies the scalar alpha. When alpha is
   !>             zero, A is not referenced and A need not be set before
   !>             entry.
   !>
-  !>     @param[in]
-  !>     A       device array of device pointers storing each matrix_i A of dimension (lda, k)
+  !>     @param[in] A - device array of device pointers storing each matrix_i A of dimension (lda,
+  !>     k)
   !>             when trans is rocblas_operation_none. Otherwise, of dimension (lda, n).
   !>
-  !>     @param[in]
-  !>     lda     [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>             lda specifies the first dimension of A_i.
   !>             - If trans = rocblas_operation_none,  lda >= max( 1, n ).
   !>             - Otherwise, lda >= max( 1, k ).
-  !>     @param[in]
-  !>     B       device array of device pointers storing each matrix_i B of dimension (ldb, k)
+  !>     @param[in] B - device array of device pointers storing each matrix_i B of dimension (ldb,
+  !>     k)
   !>             when trans is rocblas_operation_none. Otherwise, of dimension (ldb, n).
-  !>     @param[in]
-  !>     ldb     [rocblas_int]
+  !>     @param[in] ldb - [rocblas_int]
   !>             ldb specifies the first dimension of B.
   !>             - If trans = rocblas_operation_none,  ldb >= max( 1, n ),
   !>             - Otherwise, ldb >= max( 1, k ).
-  !>     @param[in]
-  !>     beta
+  !>     @param[in] beta
   !>             beta specifies the scalar beta. When beta is
   !>             zero, C need not be set before entry.
   !>
-  !>     @param[in]
-  !>     C       device array of device pointers storing each matrix C_i on the GPU.
+  !>     @param[in] C - device array of device pointers storing each matrix C_i on the GPU.
   !>
-  !>     @param[in]
-  !>     ldc    [rocblas_int]
+  !>     @param[in] ldc - [rocblas_int]
   !>            ldc specifies the first dimension of C. ldc >= max( 1, n ).
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_ssyr2k_batched
     function rocblas_ssyr2k_batched_(handle,uplo,trans,n,k,alpha,A,lda,B,ldb,beta,C,ldc, &
@@ -27980,83 +26629,66 @@ module hipfort_rocblas
   !>         or for ssyr2k_strided_batched and dsyr2k_strided_batched when trans ==
   !>         rocblas_operation_conjugate_transpose
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper:  C_i is an upper triangular matrix.
   !>             - rocblas_fill_lower:  C_i is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     trans  [rocblas_operation]
+  !>     @param[in] trans - [rocblas_operation]
   !>             - rocblas_operation_transpose:           op( A_i ) = A_i^T, op( B_i ) = B_i^T
   !>             - rocblas_operation_none:                op( A_i ) = A_i, op( B_i ) = B_i
   !>             - rocblas_operation_conjugate_transpose: op( A_i ) = A_i^T, op( B_i ) = B_i^T
   !>             - rocblas_operation_conjugate_transpose is not supported for complex types in
   !>             csyr2k_strided_batched and zsyr2k_strided_batched.
   !>
-  !>     @param[in]
-  !>     n       [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>             n specifies the number of rows and columns of C_i. n >= 0.
   !>
-  !>     @param[in]
-  !>     k       [rocblas_int]
+  !>     @param[in] k - [rocblas_int]
   !>             k specifies the number of columns of op(A). k >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             alpha specifies the scalar alpha. When alpha is
   !>             zero, A is not referenced and A need not be set before
   !>             entry.
   !>
-  !>     @param[in]
-  !>     A       Device pointer to the first matrix A_1 on the GPU of dimension (lda, k)
+  !>     @param[in] A - Device pointer to the first matrix A_1 on the GPU of dimension (lda, k)
   !>             when trans is rocblas_operation_none. Otherwise, of dimension (lda, n).
   !>
-  !>     @param[in]
-  !>     lda     [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>             lda specifies the first dimension of A_i.
   !>             - If trans = rocblas_operation_none,  lda >= max( 1, n ).
   !>             - Otherwise lda >= max( 1, k ).
   !>
-  !>     @param[in]
-  !>     stride_A  [rocblas_stride]
+  !>     @param[in] stride_A - [rocblas_stride]
   !>               stride from the start of one matrix (A_i) to the next one (A_i+1).
   !>
-  !>     @param[in]
-  !>     B       Device pointer to the first matrix B_1 on the GPU of dimension (ldb, k)
+  !>     @param[in] B - Device pointer to the first matrix B_1 on the GPU of dimension (ldb, k)
   !>             when trans is rocblas_operation_none. Otherwise, of dimension (ldb, n).
   !>
-  !>     @param[in]
-  !>     ldb     [rocblas_int]
+  !>     @param[in] ldb - [rocblas_int]
   !>             ldb specifies the first dimension of B_i.
   !>             - If trans = rocblas_operation_none,  ldb >= max( 1, n ).
   !>             - Otherwise, ldb >= max( 1, k ).
   !>
-  !>     @param[in]
-  !>     stride_B  [rocblas_stride]
+  !>     @param[in] stride_B - [rocblas_stride]
   !>               stride from the start of one matrix (B_i) to the next one (B_i+1).
   !>
-  !>     @param[in]
-  !>     beta
+  !>     @param[in] beta
   !>             beta specifies the scalar beta. When beta is
   !>             zero, C need not be set before entry.
   !>
-  !>     @param[in]
-  !>     C       Device pointer to the first matrix C_1 on the GPU.
+  !>     @param[in] C - Device pointer to the first matrix C_1 on the GPU.
   !>
-  !>     @param[in]
-  !>     ldc    [rocblas_int]
+  !>     @param[in] ldc - [rocblas_int]
   !>            ldc specifies the first dimension of C. ldc >= max( 1, n ).
   !>
-  !>     @param[in, out]
-  !>     stride_C  [rocblas_stride]
+  !>     @param[in, out] stride_C - [rocblas_stride]
   !>               stride from the start of one matrix (C_i) to the next one (C_i+1).
   !>
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_ssyr2k_strided_batched
     function rocblas_ssyr2k_strided_batched_(handle,uplo,trans,n,k,alpha,A,lda,stride_A,B,ldb, &
@@ -28330,70 +26962,57 @@ module hipfort_rocblas
   !>         rocblas_operation_transpose
   !>         or for ssyrkx and dsyrkx when trans == rocblas_operation_conjugate_transpose
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper:  C is an upper triangular matrix.
   !>             - rocblas_fill_lower:  C is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     trans  [rocblas_operation]
+  !>     @param[in] trans - [rocblas_operation]
   !>             - rocblas_operation_transpose:           op( A ) = A^T, op( B ) = B^T
   !>             - rocblas_operation_none:                op( A ) = A, op( B ) = B
   !>             - rocblas_operation_conjugate_transpose: op( A ) = A^T, op( B ) = B^T
   !>             - rocblas_operation_conjugate_transpose is not supported for complex types in
   !>             csyrkx and zsyrkx.
   !>
-  !>     @param[in]
-  !>     n       [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>             n specifies the number of rows and columns of C. n >= 0.
   !>
-  !>     @param[in]
-  !>     k       [rocblas_int]
+  !>     @param[in] k - [rocblas_int]
   !>             k specifies the number of columns of op(A) and op(B). k >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             alpha specifies the scalar alpha. When alpha is
   !>             zero, A is not referenced and A need not be set before
   !>             entry.
   !>
-  !>     @param[in]
-  !>     A       pointer storing matrix A on the GPU.
+  !>     @param[in] A - pointer storing matrix A on the GPU.
   !>             Matrix dimension is ( lda, k ) if trans = rocblas_operation_none. Otherwise, (lda,
   !>             n).
   !>
-  !>     @param[in]
-  !>     lda     [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>             lda specifies the first dimension of A.
   !>             - If trans = rocblas_operation_none,  lda >= max( 1, n ).
   !>             - Otherwise, lda >= max( 1, k ).
   !>
-  !>     @param[in]
-  !>     B       pointer storing matrix B on the GPU.
+  !>     @param[in] B - pointer storing matrix B on the GPU.
   !>             Matrix dimension is ( ldb, k ) if trans = rocblas_operation_none. Otherwise (ldb,
   !>             n).
   !>
-  !>     @param[in]
-  !>     ldb     [rocblas_int]
+  !>     @param[in] ldb - [rocblas_int]
   !>             ldb specifies the first dimension of B.
   !>             - If trans = rocblas_operation_none,  ldb >= max( 1, n ).
   !>             - Otherwise, ldb >= max( 1, k ).
   !>
-  !>     @param[in]
-  !>     beta
+  !>     @param[in] beta
   !>             beta specifies the scalar beta. When beta is
   !>             zero, C need not be set before entry.
   !>
-  !>     @param[in]
-  !>     C       pointer storing matrix C on the GPU.
+  !>     @param[in] C - pointer storing matrix C on the GPU.
   !>             Only the upper/lower triangular part is accessed.
   !>
-  !>     @param[in]
-  !>     ldc    [rocblas_int]
+  !>     @param[in] ldc - [rocblas_int]
   !>            ldc specifies the first dimension of C. ldc >= max( 1, n ).
   interface rocblas_ssyrkx
     function rocblas_ssyrkx_(handle,uplo,trans,n,k,alpha,A,lda,B,ldb,beta,C,ldc) &
@@ -28629,72 +27248,60 @@ module hipfort_rocblas
   !>         or for ssyrkx_batched and dsyrkx_batched when trans ==
   !>         rocblas_operation_conjugate_transpose
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper:  C_i is an upper triangular matrix.
   !>             - rocblas_fill_lower:  C_i is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     trans  [rocblas_operation]
+  !>     @param[in] trans - [rocblas_operation]
   !>             - rocblas_operation_transpose:           op( A_i ) = A_i^T, op( B_i ) = B_i^T
   !>             - rocblas_operation_none:                op( A_i ) = A_i, op( B_i ) = B_i
   !>             - rocblas_operation_conjugate_transpose: op( A_i ) = A_i^T, op( B_i ) = B_i^T
   !>             - rocblas_operation_conjugate_transpose is not supported for complex types in
   !>             csyrkx_batched and zsyrkx_batched.
   !>
-  !>     @param[in]
-  !>     n       [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>             n specifies the number of rows and columns of C_i. n >= 0.
   !>
-  !>     @param[in]
-  !>     k       [rocblas_int]
+  !>     @param[in] k - [rocblas_int]
   !>             k specifies the number of columns of op(A). k >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             alpha specifies the scalar alpha. When alpha is
   !>             zero, A is not referenced and A need not be set before
   !>             entry.
   !>
-  !>     @param[in]
-  !>     A       device array of device pointers storing each matrix_i A of dimension (lda, k)
+  !>     @param[in] A - device array of device pointers storing each matrix_i A of dimension (lda,
+  !>     k)
   !>             when trans is rocblas_operation_none. Otherwise, of dimension (lda, n).
   !>
-  !>     @param[in]
-  !>     lda     [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>             lda specifies the first dimension of A_i.
   !>             - if trans = rocblas_operation_none,  lda >= max( 1, n ).
   !>             - Otherwise, lda >= max( 1, k ).
   !>
-  !>     @param[in]
-  !>     B       device array of device pointers storing each matrix_i B of dimension (ldb, k)
+  !>     @param[in] B - device array of device pointers storing each matrix_i B of dimension (ldb,
+  !>     k)
   !>             when trans is rocblas_operation_none. Otherwise, of dimension (ldb, n).
   !>
-  !>     @param[in]
-  !>     ldb     [rocblas_int]
+  !>     @param[in] ldb - [rocblas_int]
   !>             ldb specifies the first dimension of B.
   !>             - If trans = rocblas_operation_none,  ldb >= max( 1, n ).
   !>             - Otherwise, ldb >= max( 1, k ).
   !>
-  !>     @param[in]
-  !>     beta
+  !>     @param[in] beta
   !>             beta specifies the scalar beta. When beta is
   !>             zero, then C need not be set before entry.
   !>
-  !>     @param[in]
-  !>     C       device array of device pointers storing each matrix C_i on the GPU.
+  !>     @param[in] C - device array of device pointers storing each matrix C_i on the GPU.
   !>             Only the upper/lower triangular part of each C_i is accessed.
   !>
-  !>     @param[in]
-  !>     ldc    [rocblas_int]
+  !>     @param[in] ldc - [rocblas_int]
   !>            ldc specifies the first dimension of C. ldc >= max( 1, n ).
   !>
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>             number of instances in the batch.
   interface rocblas_ssyrkx_batched
     function rocblas_ssyrkx_batched_(handle,uplo,trans,n,k,alpha,A,lda,B,ldb,beta,C,ldc, &
@@ -28918,84 +27525,67 @@ module hipfort_rocblas
   !>         or for ssyrkx_strided_batched and dsyrkx_strided_batched when trans ==
   !>         rocblas_operation_conjugate_transpose
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper:  C_i is an upper triangular matrix.
   !>             - rocblas_fill_lower:  C_i is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     trans  [rocblas_operation]
+  !>     @param[in] trans - [rocblas_operation]
   !>             - rocblas_operation_transpose:           op( A_i ) = A_i^T, op( B_i ) = B_i^T
   !>             - rocblas_operation_none:                op( A_i ) = A_i, op( B_i ) = B_i
   !>             - rocblas_operation_conjugate_transpose: op( A_i ) = A_i^T, op( B_i ) = B_i^T
   !>             - rocblas_operation_conjugate_transpose is not supported for complex types in
   !>             csyrkx_strided_batched and zsyrkx_strided_batched.
   !>
-  !>     @param[in]
-  !>     n       [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>             n specifies the number of rows and columns of C_i. n >= 0.
   !>
-  !>     @param[in]
-  !>     k       [rocblas_int]
+  !>     @param[in] k - [rocblas_int]
   !>             k specifies the number of columns of op(A). k >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             alpha specifies the scalar alpha. When alpha is
   !>             zero, A is not referenced and A need not be set before
   !>             entry.
   !>
-  !>     @param[in]
-  !>     A       Device pointer to the first matrix A_1 on the GPU of dimension (lda, k)
+  !>     @param[in] A - Device pointer to the first matrix A_1 on the GPU of dimension (lda, k)
   !>             when trans is rocblas_operation_none. Otherwise, of dimension (lda, n).
   !>
-  !>     @param[in]
-  !>     lda     [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>             lda specifies the first dimension of A_i.
   !>             - If trans = rocblas_operation_none,  lda >= max( 1, n ).
   !>             - Otherwise, lda >= max( 1, k ).
   !>
-  !>     @param[in]
-  !>     stride_A  [rocblas_stride]
+  !>     @param[in] stride_A - [rocblas_stride]
   !>               stride from the start of one matrix (A_i) to the next one (A_i+1).
   !>
-  !>     @param[in]
-  !>     B       Device pointer to the first matrix B_1 on the GPU of dimension (ldb, k)
+  !>     @param[in] B - Device pointer to the first matrix B_1 on the GPU of dimension (ldb, k)
   !>             when trans is rocblas_operation_none. Otherwise, of dimension (ldb, n).
   !>
-  !>     @param[in]
-  !>     ldb     [rocblas_int]
+  !>     @param[in] ldb - [rocblas_int]
   !>             ldb specifies the first dimension of B_i.
   !>             - If trans = rocblas_operation_none,  ldb >= max( 1, n ).
   !>             - Otherwise, ldb >= max( 1, k ).
   !>
-  !>     @param[in]
-  !>     stride_B  [rocblas_stride]
+  !>     @param[in] stride_B - [rocblas_stride]
   !>               stride from the start of one matrix (B_i) to the next one (B_i+1).
   !>
-  !>     @param[in]
-  !>     beta
+  !>     @param[in] beta
   !>             beta specifies the scalar beta. When beta is
   !>             zero, C need not be set before entry.
   !>
-  !>     @param[in]
-  !>     C       Device pointer to the first matrix C_1 on the GPU.
+  !>     @param[in] C - Device pointer to the first matrix C_1 on the GPU.
   !>             Only the upper/lower triangular part of each C_i is accessed.
   !>
-  !>     @param[in]
-  !>     ldc    [rocblas_int]
+  !>     @param[in] ldc - [rocblas_int]
   !>            ldc specifies the first dimension of C. ldc >= max( 1, n ).
   !>
-  !>     @param[in, out]
-  !>     stride_C  [rocblas_stride]
+  !>     @param[in, out] stride_C - [rocblas_stride]
   !>               stride from the start of one matrix (C_i) to the next one (C_i+1).
   !>
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_ssyrkx_strided_batched
     function rocblas_ssyrkx_strided_batched_(handle,uplo,trans,n,k,alpha,A,lda,stride_A,B,ldb, &
@@ -29287,51 +27877,42 @@ module hipfort_rocblas
   !>     Note that when ``diag == rocblas_diagonal_unit``, the diagonal elements of
   !>     ``A`` are not referenced either but are assumed to be unity.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     side    [rocblas_side]
+  !>     @param[in] side - [rocblas_side]
   !>             Specifies whether op(A) multiplies B from the left or right as follows:
   !>             - rocblas_side_left:       C := alpha*op( A )*B
   !>             - rocblas_side_right:      C := alpha*B*op( A )
   !>
-  !>     @param[in]
-  !>     uplo    [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             Specifies whether the matrix A is an upper or lower triangular matrix as follows:
   !>             - rocblas_fill_upper:  A is an upper triangular matrix.
   !>             - rocblas_fill_lower:  A is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA  [rocblas_operation]
+  !>     @param[in] transA - [rocblas_operation]
   !>             Specifies the form of op(A) to be used in the matrix multiplication as follows:
   !>             - rocblas_operation_none:    op(A) = A
   !>             - rocblas_operation_transpose:      op(A) = A^T
   !>             - rocblas_operation_conjugate_transpose:  op(A) = A^H
   !>
-  !>     @param[in]
-  !>     diag    [rocblas_diagonal]
+  !>     @param[in] diag - [rocblas_diagonal]
   !>             Specifies whether or not A is unit triangular as follows:
   !>             - rocblas_diagonal_unit:      A is assumed to be unit triangular.
   !>             - rocblas_diagonal_non_unit:  A is not assumed to be unit triangular.
   !>
-  !>     @param[in]
-  !>     m       [rocblas_int]
+  !>     @param[in] m - [rocblas_int]
   !>             m specifies the number of rows of B. m >= 0.
   !>
-  !>     @param[in]
-  !>     n       [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>             n specifies the number of columns of B. n >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             alpha specifies the scalar alpha. When alpha is
   !>             zero, A is not referenced and B need not be set before
   !>             entry.
   !>
-  !>     @param[in]
-  !>     A       Device pointer to matrix A on the GPU.
+  !>     @param[in] A - Device pointer to matrix A on the GPU.
   !>             A has dimension ( lda, k ), where k is m
   !>             when  side == rocblas_side_left  and
   !>             is  n  when  side == rocblas_side_right.
@@ -29346,24 +27927,19 @@ module hipfort_rocblas
   !>             - Note that when  diag == rocblas_diagonal_unit  the diagonal elements of
   !>             A  are not referenced either but are assumed to be  unity.
   !>
-  !>     @param[in]
-  !>     lda     [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>             lda specifies the first dimension of A.
   !>             - If side == rocblas_side_left,  lda >= max( 1, m ).
   !>             - If side == rocblas_side_right, lda >= max( 1, n ).
   !>
-  !>     @param[in]
-  !>     B       Device pointer to the matrix B on the GPU.
+  !>     @param[in] B - Device pointer to the matrix B on the GPU.
   !>
-  !>     @param[in]
-  !>     ldb    [rocblas_int]
+  !>     @param[in] ldb - [rocblas_int]
   !>            ldb specifies the first dimension of B. ldb >= max( 1, m ).
   !>
-  !>     @param[out]
-  !>     C      Device pointer to the matrix C on the GPU.
+  !>     @param[out] C - Device pointer to the matrix C on the GPU.
   !>
-  !>     @param[in]
-  !>     ldc   [rocblas_int]
+  !>     @param[in] ldc - [rocblas_int]
   !>           ldc specifies the first dimension of C. ldc >= max( 1, m).
   !>           If B and C are pointers to the same matrix, ldc must equal ldb or
   !>           rocblas_status_invalid_value will be returned.
@@ -29625,51 +28201,42 @@ module hipfort_rocblas
   !>     Note that when ``diag == rocblas_diagonal_unit``, the diagonal elements of
   !>     ``A`` are not referenced either but are assumed to be  unity.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     side    [rocblas_side]
+  !>     @param[in] side - [rocblas_side]
   !>             Specifies whether op(A_i) multiplies B_i from the left or right as follows:
   !>             - rocblas_side_left:       C_i := alpha*op( A_i )*B_i
   !>             - rocblas_side_right:      C_i := alpha*B_i*op( A_i )
   !>
-  !>     @param[in]
-  !>     uplo    [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             Specifies whether the matrix A is an upper or lower triangular matrix as follows:
   !>             - rocblas_fill_upper:  A is an upper triangular matrix.
   !>             - rocblas_fill_lower:  A is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA  [rocblas_operation]
+  !>     @param[in] transA - [rocblas_operation]
   !>             Specifies the form of op(A_i) to be used in the matrix multiplication as follows:
   !>             - rocblas_operation_none:    op(A_i) = A_i
   !>             - rocblas_operation_transpose:      op(A_i) = A_i^T
   !>             - rocblas_operation_conjugate_transpose:  op(A_i) = A_i^H
   !>
-  !>     @param[in]
-  !>     diag    [rocblas_diagonal]
+  !>     @param[in] diag - [rocblas_diagonal]
   !>             Specifies whether or not A_i is unit triangular as follows:
   !>             - rocblas_diagonal_unit:      A_i is assumed to be unit triangular.
   !>             - rocblas_diagonal_non_unit:  A_i is not assumed to be unit triangular.
   !>
-  !>     @param[in]
-  !>     m       [rocblas_int]
+  !>     @param[in] m - [rocblas_int]
   !>             m specifies the number of rows of B_i. m >= 0.
   !>
-  !>     @param[in]
-  !>     n       [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>             n specifies the number of columns of B_i. n >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             alpha specifies the scalar alpha. When alpha is
   !>             zero, then A_i is not referenced and B_i need not be set before
   !>             entry.
   !>
-  !>     @param[in]
-  !>     A       Device array of device pointers storing each matrix A_i on the GPU.
+  !>     @param[in] A - Device array of device pointers storing each matrix A_i on the GPU.
   !>             Each A_i is of dimension ( lda, k ), where k is m
   !>             when  side == rocblas_side_left  and
   !>             is  n  when  side == rocblas_side_right.
@@ -29684,30 +28251,24 @@ module hipfort_rocblas
   !>             - Note that when  diag == rocblas_diagonal_unit  the diagonal elements of
   !>             A_i  are not referenced either  but are assumed to be  unity.
   !>
-  !>     @param[in]
-  !>     lda     [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>             lda specifies the first dimension of A.
   !>             - If side == rocblas_side_left,  lda >= max( 1, m ).
   !>             - If side == rocblas_side_right, lda >= max( 1, n ).
   !>
-  !>     @param[in]
-  !>     B       device array of device pointers storing each matrix B_i on the GPU.
+  !>     @param[in] B - device array of device pointers storing each matrix B_i on the GPU.
   !>
-  !>     @param[in]
-  !>     ldb    [rocblas_int]
+  !>     @param[in] ldb - [rocblas_int]
   !>            ldb specifies the first dimension of B_i. ldb >= max( 1, m ).
   !>
-  !>     @param[out]
-  !>     C      device array of device pointers storing each matrix C_i on the GPU.
+  !>     @param[out] C - device array of device pointers storing each matrix C_i on the GPU.
   !>
-  !>     @param[in]
-  !>     ldc   [rocblas_int]
+  !>     @param[in] ldc - [rocblas_int]
   !>           ldc specifies the first dimension of C. ldc >= max( 1, m).
   !>           If B and C are pointers to the same array of pointers, then ldc must
   !>           equal ldb or rocblas_status_invalid_value will be returned.
   !>
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances i in the batch.
   interface rocblas_strmm_batched
     function rocblas_strmm_batched_(handle,side,uplo,transA,diag,m,n,alpha,A,lda,B,ldb,C,ldc, &
@@ -29956,51 +28517,42 @@ module hipfort_rocblas
   !>     Note that when ``diag == rocblas_diagonal_unit``, the diagonal elements of
   !>     ``A`` are not referenced either but are assumed to be unity.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     side    [rocblas_side]
+  !>     @param[in] side - [rocblas_side]
   !>             Specifies whether op(A_i) multiplies B_i from the left or right as follows:
   !>             - rocblas_side_left:       C_i := alpha*op( A_i )*B_i
   !>             - rocblas_side_right:      C_i := alpha*B_i*op( A_i )
   !>
-  !>     @param[in]
-  !>     uplo    [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             Specifies whether the matrix A is an upper or lower triangular matrix as follows:
   !>             - rocblas_fill_upper:  A is an upper triangular matrix.
   !>             - rocblas_fill_lower:  A is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA  [rocblas_operation]
+  !>     @param[in] transA - [rocblas_operation]
   !>             Specifies the form of op(A_i) to be used in the matrix multiplication as follows:
   !>             - rocblas_operation_none:    op(A_i) = A_i
   !>             - rocblas_operation_transpose:      op(A_i) = A_i^T
   !>             - rocblas_operation_conjugate_transpose:  op(A_i) = A_i^H
   !>
-  !>     @param[in]
-  !>     diag    [rocblas_diagonal]
+  !>     @param[in] diag - [rocblas_diagonal]
   !>             Specifies whether or not A_i is unit triangular as follows:
   !>             - rocblas_diagonal_unit:      A_i is assumed to be unit triangular.
   !>             - rocblas_diagonal_non_unit:  A_i is not assumed to be unit triangular.
   !>
-  !>     @param[in]
-  !>     m       [rocblas_int]
+  !>     @param[in] m - [rocblas_int]
   !>             m specifies the number of rows of B_i. m >= 0.
   !>
-  !>     @param[in]
-  !>     n       [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>             n specifies the number of columns of B_i. n >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             alpha specifies the scalar alpha. When alpha is
   !>             zero, then A_i is not referenced and B_i need not be set before
   !>             entry.
   !>
-  !>     @param[in]
-  !>     A       Device pointer to the first matrix A_0 on the GPU.
+  !>     @param[in] A - Device pointer to the first matrix A_0 on the GPU.
   !>             Each A_i is of dimension ( lda, k ), where k is m
   !>             when  side == rocblas_side_left  and
   !>             is  n  when  side == rocblas_side_right.
@@ -30015,44 +28567,35 @@ module hipfort_rocblas
   !>             - Note that when  diag == rocblas_diagonal_unit,  the diagonal elements of
   !>             A_i  are not referenced either but are assumed to be  unity.
   !>
-  !>     @param[in]
-  !>     lda     [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>             lda specifies the first dimension of A.
   !>             - If side == rocblas_side_left,  lda >= max( 1, m ).
   !>             - If side == rocblas_side_right, lda >= max( 1, n ).
   !>
-  !>     @param[in]
-  !>     stride_A  [rocblas_stride]
+  !>     @param[in] stride_A - [rocblas_stride]
   !>               stride from the start of one matrix (A_i) to the next one (A_i+1).
   !>
-  !>     @param[in]
-  !>     B       Device pointer to the first matrix B_0 on the GPU.
+  !>     @param[in] B - Device pointer to the first matrix B_0 on the GPU.
   !>
-  !>     @param[in]
-  !>     ldb    [rocblas_int]
+  !>     @param[in] ldb - [rocblas_int]
   !>            ldb specifies the first dimension of B_i. ldb >= max( 1, m ).
   !>
-  !>     @param[in]
-  !>     stride_B  [rocblas_stride]
+  !>     @param[in] stride_B - [rocblas_stride]
   !>               stride from the start of one matrix (B_i) to the next one (B_i+1).
   !>
-  !>     @param[out]
-  !>     C      Device pointer to the first matrix C_0 on the GPU.
+  !>     @param[out] C - Device pointer to the first matrix C_0 on the GPU.
   !>
-  !>     @param[in]
-  !>     ldc   [rocblas_int]
+  !>     @param[in] ldc - [rocblas_int]
   !>           ldc specifies the first dimension of C_i. ldc >= max( 1, m).
   !>           If B and C pointers are to the same matrix, then ldc must equal ldb or
   !>           rocblas_status_invalid_size will be returned.
   !>
-  !>     @param[in]
-  !>     stride_C  [rocblas_stride]
+  !>     @param[in] stride_C - [rocblas_stride]
   !>               stride from the start of one matrix (C_i) and the next one (C_i+1).
   !>               If B == C and ldb == ldc, then stride_C should equal stride_B or
   !>               behavior is undefined.
   !>
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances i in the batch.
   interface rocblas_strmm_strided_batched
     function rocblas_strmm_strided_batched_(handle,side,uplo,transA,diag,m,n,alpha,A,lda,stride_A, &
@@ -30292,28 +28835,21 @@ module hipfort_rocblas
   !>     The trtri functions compute the inverse of a matrix ``A``, namely, invA,
   !>     and write the result into ``invA``.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>               specifies whether upper (rocblas_fill_upper) or lower (rocblas_fill_lower):
   !>               - If rocblas_fill_upper, the lower part of A is not referenced.
   !>               - If rocblas_fill_lower, the upper part of A is not referenced.
-  !>     @param[in]
-  !>     diag      [rocblas_diagonal]
+  !>     @param[in] diag - [rocblas_diagonal]
   !>               - 'rocblas_diagonal_non_unit': A is non-unit triangular.
   !>               - 'rocblas_diagonal_unit': A is unit triangular.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               size of matrix A and invA.
-  !>     @param[in]
-  !>     A         device pointer storing matrix A.
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in] A - device pointer storing matrix A.
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of A.
-  !>     @param[out]
-  !>     invA      device pointer storing matrix invA.
+  !>     @param[out] invA - device pointer storing matrix invA.
   !>               Partial inplace operation is supported. See below:
   !>               - If UPLO = 'U', the leading N-by-N upper triangular part of the invA will store
   !>                 the inverse of the upper triangular matrix, and the strictly lower
@@ -30321,8 +28857,7 @@ module hipfort_rocblas
   !>               - If UPLO = 'L', the leading N-by-N lower triangular part of the invA will store
   !>                 the inverse of the lower triangular matrix, and the strictly upper
   !>                 triangular part of invA can be cleared.
-  !>     @param[in]
-  !>     ldinvA    [rocblas_int]
+  !>     @param[in] ldinvA - [rocblas_int]
   !>               specifies the leading dimension of invA.
   interface rocblas_strtri
     function rocblas_strtri_(handle,uplo,diag,n,A,lda,invA,ldinvA) bind(c, name="rocblas_strtri")
@@ -30427,25 +28962,18 @@ module hipfort_rocblas
   !>     ``A_i`` and ``invA_i`` are the ``i``-th matrices in the batch,
   !>     for ``i`` = 1, ..., ``batch_count``.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>               specifies whether upper (rocblas_fill_upper) or lower (rocblas_fill_lower).
-  !>     @param[in]
-  !>     diag      [rocblas_diagonal]
+  !>     @param[in] diag - [rocblas_diagonal]
   !>               - 'rocblas_diagonal_non_unit': A is non-unit triangular.
   !>               - 'rocblas_diagonal_unit': A is unit triangular.
-  !>     @param[in]
-  !>     n         [rocblas_int]
-  !>     @param[in]
-  !>     A         device array of device pointers storing each matrix A_i.
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
+  !>     @param[in] A - device array of device pointers storing each matrix A_i.
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of each A_i.
-  !>     @param[out]
-  !>     invA      device array of device pointers storing the inverse of each matrix A_i.
+  !>     @param[out] invA - device array of device pointers storing the inverse of each matrix A_i.
   !>               Partial inplace operation is supported. See below:
   !>               - If UPLO = 'U', the leading N-by-N upper triangular part of the invA will store
   !>                 the inverse of the upper triangular matrix, and the strictly lower
@@ -30453,11 +28981,9 @@ module hipfort_rocblas
   !>               - If UPLO = 'L', the leading N-by-N lower triangular part of the invA will store
   !>                 the inverse of the lower triangular matrix, and the strictly upper
   !>                 triangular part of invA can be cleared.
-  !>     @param[in]
-  !>     ldinvA    [rocblas_int]
+  !>     @param[in] ldinvA - [rocblas_int]
   !>               specifies the leading dimension of each invA_i.
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>               numbers of matrices in the batch.
   interface rocblas_strtri_batched
     function rocblas_strtri_batched_(handle,uplo,diag,n,A,lda,invA,ldinvA,batch_count) &
@@ -30543,28 +29069,20 @@ module hipfort_rocblas
   !>     ``A_i`` and ``invA_i`` are the ``i``-th matrices in the batch,
   !>     for ``i`` = 1, ..., ``batch_count``.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     uplo      [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>               specifies whether upper (rocblas_fill_upper) or lower (rocblas_fill_lower).
-  !>     @param[in]
-  !>     diag      [rocblas_diagonal]
+  !>     @param[in] diag - [rocblas_diagonal]
   !>               - 'rocblas_diagonal_non_unit': A is non-unit triangular.
   !>               - 'rocblas_diagonal_unit': A is unit triangular.
-  !>     @param[in]
-  !>     n         [rocblas_int]
-  !>     @param[in]
-  !>     A         device pointer pointing to address of first matrix A_1.
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
+  !>     @param[in] A - device pointer pointing to address of first matrix A_1.
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of each A.
-  !>     @param[in]
-  !>     stride_a  [rocblas_stride]
+  !>     @param[in] stride_a - [rocblas_stride]
   !>              "batch stride a": stride from the start of one A_i matrix to the next A_(i + 1).
-  !>     @param[out]
-  !>     invA      device pointer storing the inverses of each matrix A_i.
+  !>     @param[out] invA - device pointer storing the inverses of each matrix A_i.
   !>               Partial inplace operation is supported. See below:
   !>               - If UPLO = 'U', the leading N-by-N upper triangular part of the invA will store
   !>                 the inverse of the upper triangular matrix, and the strictly lower
@@ -30572,15 +29090,12 @@ module hipfort_rocblas
   !>               - If UPLO = 'L', the leading N-by-N lower triangular part of the invA will store
   !>                 the inverse of the lower triangular matrix, and the strictly upper
   !>                 triangular part of invA can be cleared.
-  !>     @param[in]
-  !>     ldinvA    [rocblas_int]
+  !>     @param[in] ldinvA - [rocblas_int]
   !>               specifies the leading dimension of each invA_i.
-  !>     @param[in]
-  !>     stride_invA  [rocblas_stride]
+  !>     @param[in] stride_invA - [rocblas_stride]
   !>                  "batch stride invA": stride from the start of one invA_i matrix to the next
   !>                  invA_(i + 1).
-  !>     @param[in]
-  !>     batch_count  [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                  numbers of matrices in the batch.
   interface rocblas_strtri_strided_batched
     function rocblas_strtri_strided_batched_(handle,uplo,diag,n,A,lda,stride_a,invA,ldinvA, &
@@ -30721,63 +29236,51 @@ module hipfort_rocblas
   !>     Although not widespread, some gemm kernels used by trsm might use atomic operations.
   !>     See Atomic Operations in the API Reference Guide for more information.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     side    [rocblas_side]
+  !>     @param[in] side - [rocblas_side]
   !>             - rocblas_side_left:       op(A)*X = alpha*B
   !>             - rocblas_side_right:      X*op(A) = alpha*B
   !>
-  !>     @param[in]
-  !>     uplo    [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper:  A is an upper triangular matrix.
   !>             - rocblas_fill_lower:  A is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA  [rocblas_operation]
+  !>     @param[in] transA - [rocblas_operation]
   !>             - transB:    op(A) = A.
   !>             - rocblas_operation_transpose:      op(A) = A^T
   !>             - rocblas_operation_conjugate_transpose:  op(A) = A^H
   !>
-  !>     @param[in]
-  !>     diag    [rocblas_diagonal]
+  !>     @param[in] diag - [rocblas_diagonal]
   !>             - rocblas_diagonal_unit:     A is assumed to be unit triangular.
   !>             - rocblas_diagonal_non_unit:  A is not assumed to be unit triangular.
   !>
-  !>     @param[in]
-  !>     m       [rocblas_int]
+  !>     @param[in] m - [rocblas_int]
   !>             m specifies the number of rows of B. m >= 0.
   !>
-  !>     @param[in]
-  !>     n       [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>             n specifies the number of columns of B. n >= 0.
   !>
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             device pointer or host pointer specifying the scalar alpha. When alpha is
   !>             &zero, then A is not referenced and B need not be set before
   !>             entry.
   !>
-  !>     @param[in]
-  !>     A       device pointer storing matrix A.
+  !>     @param[in] A - device pointer storing matrix A.
   !>             of dimension ( lda, k ), where k is m
   !>             when  rocblas_side_left  and
   !>             n  when  rocblas_side_right.
   !>             Only the upper/lower triangular part is accessed.
   !>
-  !>     @param[in]
-  !>     lda     [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>             lda specifies the first dimension of A.
   !>             - If side = rocblas_side_left,  lda >= max( 1, m ).
   !>             - If side = rocblas_side_right, lda >= max( 1, n ).
   !>
-  !>     @param[in,out]
-  !>     B       device pointer storing matrix B.
+  !>     @param[in,out] B - device pointer storing matrix B.
   !>
-  !>     @param[in]
-  !>     ldb    [rocblas_int]
+  !>     @param[in] ldb - [rocblas_int]
   !>            ldb specifies the first dimension of B. ldb >= max( 1, m ).
   interface rocblas_strsm
     function rocblas_strsm_(handle,side,uplo,transA,diag,m,n,alpha,A,lda,B,ldb) &
@@ -31006,54 +29509,41 @@ module hipfort_rocblas
   !>     memory found in the handle to increase overall performance (where ``k`` is ``m``
   !>     when ``rocblas_side_left`` and ``n`` when ``rocblas_side_right``).
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     side    [rocblas_side]
+  !>     @param[in] side - [rocblas_side]
   !>             - rocblas_side_left:       op(A)*X = alpha*B
   !>             - rocblas_side_right:      X*op(A) = alpha*B
-  !>     @param[in]
-  !>     uplo    [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper:  each A_i is an upper triangular matrix.
   !>             - rocblas_fill_lower:  each A_i is a  lower triangular matrix.
-  !>     @param[in]
-  !>     transA  [rocblas_operation]
+  !>     @param[in] transA - [rocblas_operation]
   !>             - transB:    op(A) = A
   !>             - rocblas_operation_transpose:      op(A) = A^T
   !>             - rocblas_operation_conjugate_transpose:  op(A) = A^H
-  !>     @param[in]
-  !>     diag    [rocblas_diagonal]
+  !>     @param[in] diag - [rocblas_diagonal]
   !>             - rocblas_diagonal_unit:     each A_i is assumed to be unit triangular.
   !>             - rocblas_diagonal_non_unit:  each A_i is not assumed to be unit triangular.
-  !>     @param[in]
-  !>     m       [rocblas_int]
+  !>     @param[in] m - [rocblas_int]
   !>             m specifies the number of rows of each B_i. m >= 0.
-  !>     @param[in]
-  !>     n       [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>             n specifies the number of columns of each B_i. n >= 0.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             device pointer or host pointer specifying the scalar alpha. When alpha is
   !>             &zero, then A is not referenced and B need not be set before
   !>             entry.
-  !>     @param[in]
-  !>     A       device array of device pointers storing each matrix A_i on the GPU.
+  !>     @param[in] A - device array of device pointers storing each matrix A_i on the GPU.
   !>             Matrices are of dimension ( lda, k ), where k is m
   !>             when  rocblas_side_left  and  n  when  rocblas_side_right.
   !>             Only the upper/lower triangular part is accessed.
-  !>     @param[in]
-  !>     lda     [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>             lda specifies the first dimension of each A_i.
   !>             - If side = rocblas_side_left,  lda >= max( 1, m ).
   !>             - If side = rocblas_side_right, lda >= max( 1, n ).
-  !>     @param[in,out]
-  !>     B       device array of device pointers storing each matrix B_i on the GPU.
-  !>     @param[in]
-  !>     ldb    [rocblas_int]
+  !>     @param[in,out] B - device array of device pointers storing each matrix B_i on the GPU.
+  !>     @param[in] ldb - [rocblas_int]
   !>            ldb specifies the first dimension of each B_i. ldb >= max( 1, m ).
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of trsm operatons in the batch.
   interface rocblas_strsm_batched
     function rocblas_strsm_batched_(handle,side,uplo,transA,diag,m,n,alpha,A,lda,B,ldb, &
@@ -31270,61 +29760,46 @@ module hipfort_rocblas
   !>     memory found in the handle to increase overall performance (where ``k`` is ``m`` when
   !>     ``HIPBLAS_SIDE_LEFT`` and ``n`` when ``HIPBLAS_SIDE_RIGHT``).
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     side    [rocblas_side]
+  !>     @param[in] side - [rocblas_side]
   !>             - rocblas_side_left:       op(A)*X = alpha*B.
   !>             - rocblas_side_right:      X*op(A) = alpha*B.
-  !>     @param[in]
-  !>     uplo    [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper:  each A_i is an upper triangular matrix.
   !>             - rocblas_fill_lower:  each A_i is a  lower triangular matrix.
-  !>     @param[in]
-  !>     transA  [rocblas_operation]
+  !>     @param[in] transA - [rocblas_operation]
   !>             - transB:    op(A) = A.
   !>             - rocblas_operation_transpose:      op(A) = A^T.
   !>             - rocblas_operation_conjugate_transpose:  op(A) = A^H.
-  !>     @param[in]
-  !>     diag    [rocblas_diagonal]
+  !>     @param[in] diag - [rocblas_diagonal]
   !>             - rocblas_diagonal_unit:     each A_i is assumed to be unit triangular.
   !>             - rocblas_diagonal_non_unit:  each A_i is not assumed to be unit triangular.
-  !>     @param[in]
-  !>     m       [rocblas_int]
+  !>     @param[in] m - [rocblas_int]
   !>             m specifies the number of rows of each B_i. m >= 0.
-  !>     @param[in]
-  !>     n       [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>             n specifies the number of columns of each B_i. n >= 0.
-  !>     @param[in]
-  !>     alpha
+  !>     @param[in] alpha
   !>             device pointer or host pointer specifying the scalar alpha. When alpha is
   !>             &zero, then A is not referenced and B need not be set before
   !>             entry.
-  !>     @param[in]
-  !>     A       device pointer pointing to the first matrix A_1.
+  !>     @param[in] A - device pointer pointing to the first matrix A_1.
   !>             of dimension ( lda, k ), where k is m
   !>             when  rocblas_side_left  and
   !>             n  when  rocblas_side_right.
   !>             Only the upper/lower triangular part is accessed.
-  !>     @param[in]
-  !>     lda     [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>             lda specifies the first dimension of each A_i.
   !>             - If side = rocblas_side_left,  lda >= max( 1, m ).
   !>             - If side = rocblas_side_right, lda >= max( 1, n ).
-  !>     @param[in]
-  !>     stride_a [rocblas_stride]
+  !>     @param[in] stride_a - [rocblas_stride]
   !>              stride from the start of one A_i matrix to the next A_(i + 1).
-  !>     @param[in,out]
-  !>     B       device pointer pointing to the first matrix B_1.
-  !>     @param[in]
-  !>     ldb    [rocblas_int]
+  !>     @param[in,out] B - device pointer pointing to the first matrix B_1.
+  !>     @param[in] ldb - [rocblas_int]
   !>            ldb specifies the first dimension of each B_i. ldb >= max( 1, m ).
-  !>     @param[in]
-  !>     stride_b [rocblas_stride]
+  !>     @param[in] stride_b - [rocblas_stride]
   !>              stride from the start of one B_i matrix to the next B_(i + 1).
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of trsm operatons in the batch.
   interface rocblas_strsm_strided_batched
     function rocblas_strsm_strided_batched_(handle,side,uplo,transA,diag,m,n,alpha,A,lda,stride_a, &
@@ -31583,42 +30058,28 @@ module hipfort_rocblas
   !>     Operations
   !>     in the API Reference Guide for more information.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     transA    [rocblas_operation]
+  !>     @param[in] transA - [rocblas_operation]
   !>               specifies the form of op( A ).
-  !>     @param[in]
-  !>     transB    [rocblas_operation]
+  !>     @param[in] transB - [rocblas_operation]
   !>               specifies the form of op( B ).
-  !>     @param[in]
-  !>     m         [rocblas_int]
+  !>     @param[in] m - [rocblas_int]
   !>               number or rows of matrices op( A ) and C.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               number of columns of matrices op( B ) and C.
-  !>     @param[in]
-  !>     k         [rocblas_int]
+  !>     @param[in] k - [rocblas_int]
   !>               number of columns of matrix op( A ) and number of rows of matrix op( B ).
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer specifying the scalar alpha.
-  !>     @param[in]
-  !>     A         device pointer storing matrix A.
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in] alpha - device pointer or host pointer specifying the scalar alpha.
+  !>     @param[in] A - device pointer storing matrix A.
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of A.
-  !>     @param[in]
-  !>     B         device pointer storing matrix B.
-  !>     @param[in]
-  !>     ldb       [rocblas_int]
+  !>     @param[in] B - device pointer storing matrix B.
+  !>     @param[in] ldb - [rocblas_int]
   !>               specifies the leading dimension of B.
-  !>     @param[in]
-  !>     beta      device pointer or host pointer specifying the scalar beta.
-  !>     @param[in, out]
-  !>     C         device pointer storing matrix C on the GPU.
-  !>     @param[in]
-  !>     ldc       [rocblas_int]
+  !>     @param[in] beta - device pointer or host pointer specifying the scalar beta.
+  !>     @param[in, out] C - device pointer storing matrix C on the GPU.
+  !>     @param[in] ldc - [rocblas_int]
   !>               specifies the leading dimension of C.
   interface rocblas_sgemm
     function rocblas_sgemm_(handle,transA,transB,m,n,k,alpha,A,lda,B,ldb,beta,C,ldc) &
@@ -31907,45 +30368,30 @@ module hipfort_rocblas
   !>     ``op( B )`` a ``k`` by ``n`` by ``batch_count`` matrix, and
   !>     ``C`` an ``m`` by ``n`` by ``batch_count`` matrix.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle
+  !>     @param[in] handle - [rocblas_handle
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     transA    [rocblas_operation]
+  !>     @param[in] transA - [rocblas_operation]
   !>               specifies the form of op( A ).
-  !>     @param[in]
-  !>     transB    [rocblas_operation]
+  !>     @param[in] transB - [rocblas_operation]
   !>               specifies the form of op( B ).
-  !>     @param[in]
-  !>     m         [rocblas_int]
+  !>     @param[in] m - [rocblas_int]
   !>               matrix dimention m.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               matrix dimention n.
-  !>     @param[in]
-  !>     k         [rocblas_int]
+  !>     @param[in] k - [rocblas_int]
   !>               matrix dimention k.
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer specifying the scalar alpha.
-  !>     @param[in]
-  !>     A         device array of device pointers storing each matrix A_i.
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in] alpha - device pointer or host pointer specifying the scalar alpha.
+  !>     @param[in] A - device array of device pointers storing each matrix A_i.
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of each A_i.
-  !>     @param[in]
-  !>     B         device array of device pointers storing each matrix B_i.
-  !>     @param[in]
-  !>     ldb       [rocblas_int]
+  !>     @param[in] B - device array of device pointers storing each matrix B_i.
+  !>     @param[in] ldb - [rocblas_int]
   !>               specifies the leading dimension of each B_i.
-  !>     @param[in]
-  !>     beta      device pointer or host pointer specifying the scalar beta.
-  !>     @param[in, out]
-  !>     C         device array of device pointers storing each matrix C_i.
-  !>     @param[in]
-  !>     ldc       [rocblas_int]
+  !>     @param[in] beta - device pointer or host pointer specifying the scalar beta.
+  !>     @param[in, out] C - device array of device pointers storing each matrix C_i.
+  !>     @param[in] ldc - [rocblas_int]
   !>               specifies the leading dimension of each C_i.
-  !>     @param[in]
-  !>     batch_count
+  !>     @param[in] batch_count
   !>               [rocblas_int]
   !>               number of gemm operations in the batch.
   interface rocblas_sgemm_batched
@@ -32228,54 +30674,36 @@ module hipfort_rocblas
   !>     ``op( B )`` a ``k`` by ``n`` by ``batch_count`` strided_batched matrix, and
   !>     ``C`` an ``m`` by ``n`` by ``batch_count`` strided_batched matrix.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     transA    [rocblas_operation]
+  !>     @param[in] transA - [rocblas_operation]
   !>               specifies the form of op( A ).
-  !>     @param[in]
-  !>     transB    [rocblas_operation]
+  !>     @param[in] transB - [rocblas_operation]
   !>               specifies the form of op( B ).
-  !>     @param[in]
-  !>     m         [rocblas_int]
+  !>     @param[in] m - [rocblas_int]
   !>               matrix dimention m.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               matrix dimention n.
-  !>     @param[in]
-  !>     k         [rocblas_int]
+  !>     @param[in] k - [rocblas_int]
   !>               matrix dimention k.
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer specifying the scalar alpha.
-  !>     @param[in]
-  !>     A         device pointer pointing to the first matrix A_1.
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in] alpha - device pointer or host pointer specifying the scalar alpha.
+  !>     @param[in] A - device pointer pointing to the first matrix A_1.
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of each A_i.
-  !>     @param[in]
-  !>     stride_a  [rocblas_stride]
+  !>     @param[in] stride_a - [rocblas_stride]
   !>               stride from the start of one A_i matrix to the next A_(i + 1).
-  !>     @param[in]
-  !>     B         device pointer pointing to the first matrix B_1.
-  !>     @param[in]
-  !>     ldb       [rocblas_int]
+  !>     @param[in] B - device pointer pointing to the first matrix B_1.
+  !>     @param[in] ldb - [rocblas_int]
   !>               specifies the leading dimension of each B_i.
-  !>     @param[in]
-  !>     stride_b  [rocblas_stride]
+  !>     @param[in] stride_b - [rocblas_stride]
   !>               stride from the start of one B_i matrix to the next B_(i + 1).
-  !>     @param[in]
-  !>     beta      device pointer or host pointer specifying the scalar beta.
-  !>     @param[in, out]
-  !>     C         device pointer pointing to the first matrix C_1.
-  !>     @param[in]
-  !>     ldc       [rocblas_int]
+  !>     @param[in] beta - device pointer or host pointer specifying the scalar beta.
+  !>     @param[in, out] C - device pointer pointing to the first matrix C_1.
+  !>     @param[in] ldc - [rocblas_int]
   !>               specifies the leading dimension of each C_i.
-  !>     @param[in]
-  !>     stride_c  [rocblas_stride]
+  !>     @param[in] stride_c - [rocblas_stride]
   !>               stride from the start of one C_i matrix to the next C_(i + 1).
-  !>     @param[in]
-  !>     batch_count
+  !>     @param[in] batch_count
   !>               [rocblas_int]
   !>               number of gemm operatons in the batch.
   interface rocblas_sgemm_strided_batched
@@ -32611,32 +31039,22 @@ module hipfort_rocblas
   !>     if ``side == rocblas_side_left``.
   !>
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     side      [rocblas_side]
+  !>     @param[in] side - [rocblas_side]
   !>               specifies the side of diag(x).
-  !>     @param[in]
-  !>     m         [rocblas_int]
+  !>     @param[in] m - [rocblas_int]
   !>               matrix dimension m.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               matrix dimension n.
-  !>     @param[in]
-  !>     A         device pointer storing matrix A.
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in] A - device pointer storing matrix A.
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of A.
-  !>     @param[in]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] x - device pointer storing vector x.
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment between values of x
-  !>     @param[in, out]
-  !>     C         device pointer storing matrix C.
-  !>     @param[in]
-  !>     ldc       [rocblas_int]
+  !>     @param[in, out] C - device pointer storing matrix C.
+  !>     @param[in] ldc - [rocblas_int]
   !>               specifies the leading dimension of C.
   interface rocblas_sdgmm
     function rocblas_sdgmm_(handle,side,m,n,A,lda,x,incx,C,ldc) bind(c, name="rocblas_sdgmm")
@@ -32832,39 +31250,28 @@ module hipfort_rocblas
   !>     ``m``
   !>     if ``side == rocblas_side_left``.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     side      [rocblas_side]
+  !>     @param[in] side - [rocblas_side]
   !>               specifies the side of diag(x).
-  !>     @param[in]
-  !>     m         [rocblas_int]
+  !>     @param[in] m - [rocblas_int]
   !>               matrix dimension m.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               matrix dimension n.
-  !>     @param[in]
-  !>     A         device array of device pointers storing each matrix A_i on the GPU.
+  !>     @param[in] A - device array of device pointers storing each matrix A_i on the GPU.
   !>               Each A_i is of dimension ( lda, n ).
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of A_i.
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i on the GPU.
+  !>     @param[in] x - device array of device pointers storing each vector x_i on the GPU.
   !>               Each x_i is of dimension n if side == rocblas_side_right and dimension
   !>               m if side == rocblas_side_left.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment between values of x_i.
-  !>     @param[in, out]
-  !>     C         device array of device pointers storing each matrix C_i on the GPU.
+  !>     @param[in, out] C - device array of device pointers storing each matrix C_i on the GPU.
   !>               Each C_i is of dimension ( ldc, n ).
-  !>     @param[in]
-  !>     ldc       [rocblas_int]
+  !>     @param[in] ldc - [rocblas_int]
   !>               specifies the leading dimension of C_i.
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
   interface rocblas_sdgmm_batched
     function rocblas_sdgmm_batched_(handle,side,m,n,A,lda,x,incx,C,ldc,batch_count) &
@@ -33048,48 +31455,34 @@ module hipfort_rocblas
   !>     ``m``
   !>     if ``side == rocblas_side_left``.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     side      [rocblas_side]
+  !>     @param[in] side - [rocblas_side]
   !>               specifies the side of diag(x).
-  !>     @param[in]
-  !>     m         [rocblas_int]
+  !>     @param[in] m - [rocblas_int]
   !>               matrix dimension m.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               matrix dimension n.
-  !>     @param[in]
-  !>     A         device pointer to the first matrix A_0 on the GPU.
+  !>     @param[in] A - device pointer to the first matrix A_0 on the GPU.
   !>               Each A_i is of dimension ( lda, n ).
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of A.
-  !>     @param[in]
-  !>     stride_A  [rocblas_stride]
+  !>     @param[in] stride_A - [rocblas_stride]
   !>               stride from the start of one matrix (A_i) to the next one (A_i+1).
-  !>     @param[in]
-  !>     x         pointer to the first vector x_0 on the GPU.
+  !>     @param[in] x - pointer to the first vector x_0 on the GPU.
   !>               Each x_i is of dimension n if side == rocblas_side_right and dimension
   !>               m if side == rocblas_side_left.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment between values of x.
-  !>     @param[in]
-  !>     stride_x  [rocblas_stride]
+  !>     @param[in] stride_x - [rocblas_stride]
   !>               stride from the start of one vector(x_i) to the next one (x_i+1).
-  !>     @param[in, out]
-  !>     C         device pointer to the first matrix C_0 on the GPU.
+  !>     @param[in, out] C - device pointer to the first matrix C_0 on the GPU.
   !>               Each C_i is of dimension ( ldc, n ).
-  !>     @param[in]
-  !>     ldc       [rocblas_int]
+  !>     @param[in] ldc - [rocblas_int]
   !>               specifies the leading dimension of C.
-  !>     @param[in]
-  !>     stride_C  [rocblas_stride]
+  !>     @param[in] stride_C - [rocblas_stride]
   !>               stride from the start of one matrix (C_i) to the next one (C_i+1).
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances i in the batch.
   interface rocblas_sdgmm_strided_batched
     function rocblas_sdgmm_strided_batched_(handle,side,m,n,A,lda,stride_A,x,incx,stride_x,C,ldc, &
@@ -33336,39 +31729,26 @@ module hipfort_rocblas
   !>     ``op( A )`` an ``m`` by ``n`` matrix, ``op( B )`` an ``m`` by ``n`` matrix, and ``C`` an
   !>     ``m`` by ``n`` matrix.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     transA    [rocblas_operation]
+  !>     @param[in] transA - [rocblas_operation]
   !>               specifies the form of op( A ).
-  !>     @param[in]
-  !>     transB    [rocblas_operation]
+  !>     @param[in] transB - [rocblas_operation]
   !>               specifies the form of op( B ).
-  !>     @param[in]
-  !>     m         [rocblas_int]
+  !>     @param[in] m - [rocblas_int]
   !>               matrix dimension m.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               matrix dimension n.
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer specifying the scalar alpha.
-  !>     @param[in]
-  !>     A         device pointer storing matrix A.
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in] alpha - device pointer or host pointer specifying the scalar alpha.
+  !>     @param[in] A - device pointer storing matrix A.
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of A.
-  !>     @param[in]
-  !>     beta      device pointer or host pointer specifying the scalar beta.
-  !>     @param[in]
-  !>     B         device pointer storing matrix B.
-  !>     @param[in]
-  !>     ldb       [rocblas_int]
+  !>     @param[in] beta - device pointer or host pointer specifying the scalar beta.
+  !>     @param[in] B - device pointer storing matrix B.
+  !>     @param[in] ldb - [rocblas_int]
   !>               specifies the leading dimension of B.
-  !>     @param[in, out]
-  !>     C         device pointer storing matrix C.
-  !>     @param[in]
-  !>     ldc       [rocblas_int]
+  !>     @param[in, out] C - device pointer storing matrix C.
+  !>     @param[in] ldc - [rocblas_int]
   !>               specifies the leading dimension of C.
   interface rocblas_sgeam
     function rocblas_sgeam_(handle,transA,transB,m,n,alpha,A,lda,beta,B,ldb,C,ldc) &
@@ -33596,50 +31976,36 @@ module hipfort_rocblas
   !>         op( X ) = X      or
   !>         op( X ) = X**T
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     transA    [rocblas_operation]
+  !>     @param[in] transA - [rocblas_operation]
   !>               specifies the form of op( A ).
-  !>     @param[in]
-  !>     transB    [rocblas_operation]
+  !>     @param[in] transB - [rocblas_operation]
   !>               specifies the form of op( B ).
-  !>     @param[in]
-  !>     m         [rocblas_int]
+  !>     @param[in] m - [rocblas_int]
   !>               matrix dimension m.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               matrix dimension n.
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer specifying the scalar alpha.
-  !>     @param[in]
-  !>     A         device array of device pointers storing each matrix A_i on the GPU.
+  !>     @param[in] alpha - device pointer or host pointer specifying the scalar alpha.
+  !>     @param[in] A - device array of device pointers storing each matrix A_i on the GPU.
   !>               Each A_i is of dimension ( lda, k ), where k is m
   !>               when  transA == rocblas_operation_none and
   !>               is n  when  transA == rocblas_operation_transpose.
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of A.
-  !>     @param[in]
-  !>     beta      device pointer or host pointer specifying the scalar beta.
-  !>     @param[in]
-  !>     B         device array of device pointers storing each matrix B_i on the GPU.
+  !>     @param[in] beta - device pointer or host pointer specifying the scalar beta.
+  !>     @param[in] B - device array of device pointers storing each matrix B_i on the GPU.
   !>               Each B_i is of dimension ( ldb, k ), where k is m
   !>               when  transB == rocblas_operation_none and
   !>               is  n  when  transB == rocblas_operation_transpose.
-  !>     @param[in]
-  !>     ldb       [rocblas_int]
+  !>     @param[in] ldb - [rocblas_int]
   !>               specifies the leading dimension of B.
-  !>     @param[in, out]
-  !>     C         device array of device pointers storing each matrix C_i on the GPU.
+  !>     @param[in, out] C - device array of device pointers storing each matrix C_i on the GPU.
   !>               Each C_i is of dimension ( ldc, n ).
-  !>     @param[in]
-  !>     ldc       [rocblas_int]
+  !>     @param[in] ldc - [rocblas_int]
   !>               specifies the leading dimension of C.
   !>
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances i in the batch.
   interface rocblas_sgeam_batched
     function rocblas_sgeam_batched_(handle,transA,transB,m,n,alpha,A,lda,beta,B,ldb,C,ldc, &
@@ -33855,74 +32221,57 @@ module hipfort_rocblas
   !>         op( X ) = X      or
   !>         op( X ) = X**T
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     transA    [rocblas_operation]
+  !>     @param[in] transA - [rocblas_operation]
   !>               specifies the form of op( A ).
   !>
-  !>     @param[in]
-  !>     transB    [rocblas_operation]
+  !>     @param[in] transB - [rocblas_operation]
   !>               specifies the form of op( B ).
   !>
-  !>     @param[in]
-  !>     m         [rocblas_int]
+  !>     @param[in] m - [rocblas_int]
   !>               matrix dimension m.
   !>
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               matrix dimension n.
   !>
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer specifying the scalar alpha.
+  !>     @param[in] alpha - device pointer or host pointer specifying the scalar alpha.
   !>
-  !>     @param[in]
-  !>     A         device pointer to the first matrix A_0 on the GPU.
+  !>     @param[in] A - device pointer to the first matrix A_0 on the GPU.
   !>               Each A_i is of dimension ( lda, k ), where k is m
   !>               when  transA == rocblas_operation_none and
   !>               is  n  when  transA == rocblas_operation_transpose.
   !>
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of A.
   !>
-  !>     @param[in]
-  !>     stride_A  [rocblas_stride]
+  !>     @param[in] stride_A - [rocblas_stride]
   !>               stride from the start of one matrix (A_i) to the next one (A_i+1).
   !>
-  !>     @param[in]
-  !>     beta      device pointer or host pointer specifying the scalar beta.
+  !>     @param[in] beta - device pointer or host pointer specifying the scalar beta.
   !>
-  !>     @param[in]
-  !>     B         pointer to the first matrix B_0 on the GPU.
+  !>     @param[in] B - pointer to the first matrix B_0 on the GPU.
   !>               Each B_i is of dimension ( ldb, k ), where k is m
   !>               when  transB == rocblas_operation_none and
   !>               is  n  when  transB == rocblas_operation_transpose.
   !>
-  !>     @param[in]
-  !>     ldb       [rocblas_int]
+  !>     @param[in] ldb - [rocblas_int]
   !>               specifies the leading dimension of B.
   !>
-  !>     @param[in]
-  !>     stride_B  [rocblas_stride]
+  !>     @param[in] stride_B - [rocblas_stride]
   !>               stride from the start of one matrix (B_i) to the next one (B_i+1).
   !>
-  !>     @param[in, out]
-  !>     C         pointer to the first matrix C_0 on the GPU.
+  !>     @param[in, out] C - pointer to the first matrix C_0 on the GPU.
   !>               Each C_i is of dimension ( ldc, n ).
   !>
-  !>     @param[in]
-  !>     ldc       [rocblas_int]
+  !>     @param[in] ldc - [rocblas_int]
   !>               specifies the leading dimension of C.
   !>
-  !>     @param[in]
-  !>     stride_C  [rocblas_stride]
+  !>     @param[in] stride_C - [rocblas_stride]
   !>               stride from the start of one matrix (C_i) to the next one (C_i+1).
   !>
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances i in the batch.
   interface rocblas_sgeam_strided_batched
     function rocblas_sgeam_strided_batched_(handle,transA,transB,m,n,alpha,A,lda,stride_A,beta,B, &
@@ -34214,80 +32563,57 @@ module hipfort_rocblas
   !>     Although not widespread, some gemm kernels used by gemm_ex might use atomic operations.
   !>     See Atomic Operations in the API Reference Guide for more information.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     transA    [rocblas_operation]
+  !>     @param[in] transA - [rocblas_operation]
   !>               specifies the form of op( A ).
-  !>     @param[in]
-  !>     transB    [rocblas_operation]
+  !>     @param[in] transB - [rocblas_operation]
   !>               specifies the form of op( B ).
-  !>     @param[in]
-  !>     m         [rocblas_int]
+  !>     @param[in] m - [rocblas_int]
   !>               matrix dimension m.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               matrix dimension n.
-  !>     @param[in]
-  !>     k         [rocblas_int]
+  !>     @param[in] k - [rocblas_int]
   !>               matrix dimension k.
-  !>     @param[in]
-  !>     alpha     [const void *]
+  !>     @param[in] alpha - [const void *]
   !>               device pointer or host pointer specifying the scalar alpha. Same datatype as
   !>               compute_type.
-  !>     @param[in]
-  !>     a         [void *]
+  !>     @param[in] a - [void *]
   !>               device pointer storing matrix A.
-  !>     @param[in]
-  !>     a_type    [rocblas_datatype]
+  !>     @param[in] a_type - [rocblas_datatype]
   !>               specifies the datatype of matrix A.
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of A.
-  !>     @param[in]
-  !>     b         [void *]
+  !>     @param[in] b - [void *]
   !>               device pointer storing matrix B.
-  !>     @param[in]
-  !>     b_type    [rocblas_datatype]
+  !>     @param[in] b_type - [rocblas_datatype]
   !>               specifies the datatype of matrix B.
-  !>     @param[in]
-  !>     ldb       [rocblas_int]
+  !>     @param[in] ldb - [rocblas_int]
   !>               specifies the leading dimension of B.
-  !>     @param[in]
-  !>     beta      [const void *]
+  !>     @param[in] beta - [const void *]
   !>               device pointer or host pointer specifying the scalar beta. Same datatype as
   !>               compute_type.
-  !>     @param[in]
-  !>     c         [void *]
+  !>     @param[in] c - [void *]
   !>               device pointer storing matrix C.
-  !>     @param[in]
-  !>     c_type    [rocblas_datatype]
+  !>     @param[in] c_type - [rocblas_datatype]
   !>               specifies the datatype of matrix C.
-  !>     @param[in]
-  !>     ldc       [rocblas_int]
+  !>     @param[in] ldc - [rocblas_int]
   !>               specifies the leading dimension of C.
-  !>     @param[out]
-  !>     d         [void *]
+  !>     @param[out] d - [void *]
   !>               device pointer storing matrix D.
   !>               If d and c pointers are to the same matrix, then d_type must equal c_type and ldd
   !>               must equal ldc
   !>               or the respective invalid status will be returned.
-  !>     @param[in]
-  !>     d_type    [rocblas_datatype]
+  !>     @param[in] d_type - [rocblas_datatype]
   !>               specifies the datatype of matrix D.
-  !>     @param[in]
-  !>     ldd       [rocblas_int]
+  !>     @param[in] ldd - [rocblas_int]
   !>               specifies the leading dimension of D.
-  !>     @param[in]
-  !>     compute_type
+  !>     @param[in] compute_type
   !>               [rocblas_datatype]
   !>               specifies the datatype of computation.
-  !>     @param[in]
-  !>     algo      [rocblas_gemm_algo]
+  !>     @param[in] algo - [rocblas_gemm_algo]
   !>               enumerant specifying the algorithm type.
-  !>     @param[in]
-  !>     solution_index
+  !>     @param[in] solution_index
   !>               [int32_t]
   !>               if algo is rocblas_gemm_algo_solution_index, this controls which solution is
   !>               used.
@@ -34295,8 +32621,7 @@ module hipfort_rocblas
   !>               default solution is used.
   !>               Passing rocblas_gemm_algo_solution_index and solution_index < 0 to use the
   !>               default solution is deprecated.
-  !>     @param[in]
-  !>     flags     [uint32_t]
+  !>     @param[in] flags - [uint32_t]
   !>               optional gemm flags.
   interface rocblas_gemm_ex
     function rocblas_gemm_ex_(handle,transA,transB,m,n,k,alpha,a,a_type,lda,b,b_type,ldb,beta,c, &
@@ -34403,84 +32728,60 @@ module hipfort_rocblas
   !>         - rocblas_datatype_f32_c  = a_type = b_type = c_type = d_type = compute_type
   !>         - rocblas_datatype_f64_c  = a_type = b_type = c_type = d_type = compute_type
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     transA    [rocblas_operation]
+  !>     @param[in] transA - [rocblas_operation]
   !>               specifies the form of op( A ).
-  !>     @param[in]
-  !>     transB    [rocblas_operation]
+  !>     @param[in] transB - [rocblas_operation]
   !>               specifies the form of op( B ).
-  !>     @param[in]
-  !>     m         [rocblas_int]
+  !>     @param[in] m - [rocblas_int]
   !>               matrix dimension m.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               matrix dimension n.
-  !>     @param[in]
-  !>     k         [rocblas_int]
+  !>     @param[in] k - [rocblas_int]
   !>               matrix dimension k.
-  !>     @param[in]
-  !>     alpha     [const void *]
+  !>     @param[in] alpha - [const void *]
   !>               device pointer or host pointer specifying the scalar alpha. Same datatype as
   !>               compute_type.
-  !>     @param[in]
-  !>     a         [void *]
+  !>     @param[in] a - [void *]
   !>               device pointer storing array of pointers to each matrix A_i.
-  !>     @param[in]
-  !>     a_type    [rocblas_datatype]
+  !>     @param[in] a_type - [rocblas_datatype]
   !>               specifies the datatype of each matrix A_i.
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of each A_i.
-  !>     @param[in]
-  !>     b         [void *]
+  !>     @param[in] b - [void *]
   !>               device pointer storing array of pointers to each matrix B_i.
-  !>     @param[in]
-  !>     b_type    [rocblas_datatype]
+  !>     @param[in] b_type - [rocblas_datatype]
   !>               specifies the datatype of each matrix B_i.
-  !>     @param[in]
-  !>     ldb       [rocblas_int]
+  !>     @param[in] ldb - [rocblas_int]
   !>               specifies the leading dimension of each B_i.
-  !>     @param[in]
-  !>     beta      [const void *]
+  !>     @param[in] beta - [const void *]
   !>               device pointer or host pointer specifying the scalar beta. Same datatype as
   !>               compute_type.
-  !>     @param[in]
-  !>     c         [void *]
+  !>     @param[in] c - [void *]
   !>               device array of device pointers to each matrix C_i.
-  !>     @param[in]
-  !>     c_type    [rocblas_datatype]
+  !>     @param[in] c_type - [rocblas_datatype]
   !>               specifies the datatype of each matrix C_i.
-  !>     @param[in]
-  !>     ldc       [rocblas_int]
+  !>     @param[in] ldc - [rocblas_int]
   !>               specifies the leading dimension of each C_i.
-  !>     @param[out]
-  !>     d         [void *]
+  !>     @param[out] d - [void *]
   !>               device array of device pointers to each matrix D_i.
   !>               If d and c are the same array of matrix pointers, then d_type must equal c_type
   !>               and ldd must equal ldc
   !>               or the respective invalid status will be returned.
-  !>     @param[in]
-  !>     d_type    [rocblas_datatype]
+  !>     @param[in] d_type - [rocblas_datatype]
   !>               specifies the datatype of each matrix D_i.
-  !>     @param[in]
-  !>     ldd       [rocblas_int]
+  !>     @param[in] ldd - [rocblas_int]
   !>               specifies the leading dimension of each D_i.
-  !>     @param[in]
-  !>     batch_count
+  !>     @param[in] batch_count
   !>               [rocblas_int]
   !>               number of gemm operations in the batch.
-  !>     @param[in]
-  !>     compute_type
+  !>     @param[in] compute_type
   !>               [rocblas_datatype]
   !>               specifies the datatype of computation.
-  !>     @param[in]
-  !>     algo      [rocblas_gemm_algo]
+  !>     @param[in] algo - [rocblas_gemm_algo]
   !>               enumerant specifying the algorithm type.
-  !>     @param[in]
-  !>     solution_index
+  !>     @param[in] solution_index
   !>               [int32_t]
   !>               if algo is rocblas_gemm_algo_solution_index, this controls which solution is
   !>               used.
@@ -34488,8 +32789,7 @@ module hipfort_rocblas
   !>               default solution is used.
   !>               Passing rocblas_gemm_algo_solution_index and solution_index < 0 to use the
   !>               default solution is deprecated.
-  !>     @param[in]
-  !>     flags     [uint32_t]
+  !>     @param[in] flags - [uint32_t]
   !>               optional gemm flags.
   interface rocblas_gemm_batched_ex
     function rocblas_gemm_batched_ex_(handle,transA,transB,m,n,k,alpha,a,a_type,lda,b,b_type,ldb, &
@@ -34600,97 +32900,69 @@ module hipfort_rocblas
   !>         - rocblas_datatype_f32_c  = a_type = b_type = c_type = d_type = compute_type
   !>         - rocblas_datatype_f64_c  = a_type = b_type = c_type = d_type = compute_type
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     transA    [rocblas_operation]
+  !>     @param[in] transA - [rocblas_operation]
   !>               specifies the form of op( A ).
-  !>     @param[in]
-  !>     transB    [rocblas_operation]
+  !>     @param[in] transB - [rocblas_operation]
   !>               specifies the form of op( B ).
-  !>     @param[in]
-  !>     m         [rocblas_int]
+  !>     @param[in] m - [rocblas_int]
   !>               matrix dimension m.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               matrix dimension n.
-  !>     @param[in]
-  !>     k         [rocblas_int]
+  !>     @param[in] k - [rocblas_int]
   !>               matrix dimension k.
-  !>     @param[in]
-  !>     alpha     [const void *]
+  !>     @param[in] alpha - [const void *]
   !>               device pointer or host pointer specifying the scalar alpha. Same datatype as
   !>               compute_type.
-  !>     @param[in]
-  !>     a         [void *]
+  !>     @param[in] a - [void *]
   !>               device pointer pointing to first matrix A_1.
-  !>     @param[in]
-  !>     a_type    [rocblas_datatype]
+  !>     @param[in] a_type - [rocblas_datatype]
   !>               specifies the datatype of each matrix A_i.
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of each A_i.
-  !>     @param[in]
-  !>     stride_a  [rocblas_stride]
+  !>     @param[in] stride_a - [rocblas_stride]
   !>               specifies stride from start of one A_i matrix to the next A_(i + 1).
-  !>     @param[in]
-  !>     b         [void *]
+  !>     @param[in] b - [void *]
   !>               device pointer pointing to first matrix B_1.
-  !>     @param[in]
-  !>     b_type    [rocblas_datatype]
+  !>     @param[in] b_type - [rocblas_datatype]
   !>               specifies the datatype of each matrix B_i.
-  !>     @param[in]
-  !>     ldb       [rocblas_int]
+  !>     @param[in] ldb - [rocblas_int]
   !>               specifies the leading dimension of each B_i.
-  !>     @param[in]
-  !>     stride_b  [rocblas_stride]
+  !>     @param[in] stride_b - [rocblas_stride]
   !>               specifies stride from start of one B_i matrix to the next B_(i + 1).
-  !>     @param[in]
-  !>     beta      [const void *]
+  !>     @param[in] beta - [const void *]
   !>               device pointer or host pointer specifying the scalar beta. Same datatype as
   !>               compute_type.
-  !>     @param[in]
-  !>     c         [void *]
+  !>     @param[in] c - [void *]
   !>               device pointer pointing to first matrix C_1.
-  !>     @param[in]
-  !>     c_type    [rocblas_datatype]
+  !>     @param[in] c_type - [rocblas_datatype]
   !>               specifies the datatype of each matrix C_i.
-  !>     @param[in]
-  !>     ldc       [rocblas_int]
+  !>     @param[in] ldc - [rocblas_int]
   !>               specifies the leading dimension of each C_i.
-  !>     @param[in]
-  !>     stride_c  [rocblas_stride]
+  !>     @param[in] stride_c - [rocblas_stride]
   !>               specifies stride from start of one C_i matrix to the next C_(i + 1).
-  !>     @param[out]
-  !>     d         [void *]
+  !>     @param[out] d - [void *]
   !>               device pointer storing each matrix D_i.
   !>               If d and c pointers are to the same matrix, then d_type must equal c_type, ldd
   !>               must equal ldc,
   !>               and stride_d must equal stride_c or the respective invalid status will be
   !>               returned.
-  !>     @param[in]
-  !>     d_type    [rocblas_datatype]
+  !>     @param[in] d_type - [rocblas_datatype]
   !>               specifies the datatype of each matrix D_i.
-  !>     @param[in]
-  !>     ldd       [rocblas_int]
+  !>     @param[in] ldd - [rocblas_int]
   !>               specifies the leading dimension of each D_i.
-  !>     @param[in]
-  !>     stride_d  [rocblas_stride]
+  !>     @param[in] stride_d - [rocblas_stride]
   !>               specifies stride from start of one D_i matrix to the next D_(i + 1).
-  !>     @param[in]
-  !>     batch_count
+  !>     @param[in] batch_count
   !>               [rocblas_int]
   !>               number of gemm operations in the batch.
-  !>     @param[in]
-  !>     compute_type
+  !>     @param[in] compute_type
   !>               [rocblas_datatype]
   !>               specifies the datatype of computation.
-  !>     @param[in]
-  !>     algo      [rocblas_gemm_algo]
+  !>     @param[in] algo - [rocblas_gemm_algo]
   !>               enumerant specifying the algorithm type.
-  !>     @param[in]
-  !>     solution_index
+  !>     @param[in] solution_index
   !>               [int32_t]
   !>               if algo is rocblas_gemm_algo_solution_index, this controls which solution is
   !>               used.
@@ -34698,8 +32970,7 @@ module hipfort_rocblas
   !>               default solution is used.
   !>               Passing rocblas_gemm_algo_solution_index and solution_index < 0 to use the
   !>               default solution is deprecated.
-  !>     @param[in]
-  !>     flags     [uint32_t]
+  !>     @param[in] flags - [uint32_t]
   !>               optional gemm flags.
   interface rocblas_gemm_strided_batched_ex
     function rocblas_gemm_strided_batched_ex_(handle,transA,transB,m,n,k,alpha,a,a_type,lda, &
@@ -34802,55 +33073,42 @@ module hipfort_rocblas
   !>     ``op( A )`` an ``n`` by ``k`` matrix, ``op( B )`` a ``k`` by ``n`` matrix, and ``C`` an
   !>     ``n`` by ``n`` matrix.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     uplo    [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper:  C is an upper triangular matrix.
   !>             - rocblas_fill_lower:  C is a  lower triangular matrix.
-  !>     @param[in]
-  !>     transA    [rocblas_operation]
+  !>     @param[in] transA - [rocblas_operation]
   !>             - rocblas_operation_none:    op(A) = A.
   !>             - rocblas_operation_transpose:      op(A) = A^T
   !>             - rocblas_operation_conjugate_transpose:  op(A) = A^H
-  !>     @param[in]
-  !>     transB    [rocblas_operation]
+  !>     @param[in] transB - [rocblas_operation]
   !>             - rocblas_operation_none:    op(B) = B.
   !>             - rocblas_operation_transpose:      op(B) = B^T
   !>             - rocblas_operation_conjugate_transpose:  op(B) = B^H
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               number or rows of matrices op( A ), columns of op( B ), and (rows, columns) of C.
-  !>     @param[in]
-  !>     k         [rocblas_int]
+  !>     @param[in] k - [rocblas_int]
   !>               number of rows of matrices op( B ) and columns of op( A ).
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer specifying the scalar alpha.
-  !>     @param[in]
-  !>     A device pointer storing matrix A. If transa = rocblas_operation_none, then the leading
-  !>     n-by-k part of the array contains the matrix A. Otherwise, the leading k-by-n part of the
-  !>     array contains the matrix A.
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in] alpha - device pointer or host pointer specifying the scalar alpha.
+  !>     @param[in] A - device pointer storing matrix A. If transa = rocblas_operation_none, then
+  !>     the leading n-by-k part of the array contains the matrix A. Otherwise, the leading k-by-n
+  !>     part of the array contains the matrix A.
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of A. If transA == rocblas_operation_none, must
   !>               have lda >= max(1, n). Otherwise, must have lda >= max(1, k).
-  !>     @param[in]
-  !>     B device pointer storing matrix B. If transB = rocblas_operation_none, then the leading
-  !>     k-by-n part of the array contains the matrix B. Otherwise, the leading n-by-k part of the
-  !>     array contains the matrix B.
-  !>     @param[in]
-  !>     ldb       [rocblas_int]
+  !>     @param[in] B - device pointer storing matrix B. If transB = rocblas_operation_none, then
+  !>     the leading k-by-n part of the array contains the matrix B. Otherwise, the leading n-by-k
+  !>     part of the array contains the matrix B.
+  !>     @param[in] ldb - [rocblas_int]
   !>               specifies the leading dimension of B. If transB == rocblas_operation_none, must
   !>               have ldb >= max(1, k). Otherwise, must have ldb >= max(1, n).
-  !>     @param[in]
-  !>     beta      device pointer or host pointer specifying the scalar beta.
-  !>     @param[in, out]
-  !>     C device pointer storing matrix C on the GPU. If uplo == rocblas_fill_upper, the upper
-  !>     triangular part of the leading n-by-n array contains the matrix C. Otherwise, the lower
-  !>     triangular part of the leading n-by-n array contains the matrix C.
-  !>     @param[in]
-  !>     ldc       [rocblas_int]
+  !>     @param[in] beta - device pointer or host pointer specifying the scalar beta.
+  !>     @param[in, out] C - device pointer storing matrix C on the GPU. If uplo ==
+  !>     rocblas_fill_upper, the upper triangular part of the leading n-by-n array contains the
+  !>     matrix C. Otherwise, the lower triangular part of the leading n-by-n array contains the
+  !>     matrix C.
+  !>     @param[in] ldc - [rocblas_int]
   !>               specifies the leading dimension of C. Must have ldc >= max(1, n).
   interface rocblas_sgemmt
     function rocblas_sgemmt_(handle,uplo,transA,transB,n,k,alpha,A,lda,B,ldb,beta,C,ldc) &
@@ -35064,59 +33322,45 @@ module hipfort_rocblas
   !>     ``op( B )`` consisting of ``k`` by ``n`` by ``batch_count`` matrices, and
   !>     ``C`` consisting of ``n`` by ``n`` by ``batch_count`` matrices.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle
+  !>     @param[in] handle - [rocblas_handle
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     uplo    [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper:  C is an upper triangular matrix.
   !>             - rocblas_fill_lower:  C is a  lower triangular matrix.
-  !>     @param[in]
-  !>     transA    [rocblas_operation]
+  !>     @param[in] transA - [rocblas_operation]
   !>             - rocblas_operation_none:    op(A_i) = A_i.
   !>             - rocblas_operation_transpose:      op(A_i) = A_i^T
   !>             - rocblas_operation_conjugate_transpose:  op(A_i) = A_i^H
-  !>     @param[in]
-  !>     transB    [rocblas_operation]
+  !>     @param[in] transB - [rocblas_operation]
   !>             - rocblas_operation_none:    op(B_i) = B_i.
   !>             - rocblas_operation_transpose:      op(B_i) = B_i^T
   !>             - rocblas_operation_conjugate_transpose:  op(B_i) = B_i^H
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               number or rows of matrices op( A_i ), columns of op( B_i ), and (rows, columns)
   !>               of C_i.
-  !>     @param[in]
-  !>     k         [rocblas_int]
+  !>     @param[in] k - [rocblas_int]
   !>               number of rows of matrices op( B_i ) and columns of op( A_i ).
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer specifying the scalar alpha.
-  !>     @param[in]
-  !>     A device array of device pointers storing each matrix A_i. If transa =
+  !>     @param[in] alpha - device pointer or host pointer specifying the scalar alpha.
+  !>     @param[in] A - device array of device pointers storing each matrix A_i. If transa =
   !>     rocblas_operation_none, then the leading n-by-k part of the array contains each matrix A_i.
   !>     Otherwise, the leading k-by-n part of the array contains each matrix A_i.
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of each A_i. If transA == rocblas_operation_none,
   !>               must have lda >= max(1, n). Otherwise, must have lda >= max(1, k).
-  !>     @param[in]
-  !>     B device array of device pointers storing each matrix B_i. If transB =
+  !>     @param[in] B - device array of device pointers storing each matrix B_i. If transB =
   !>     rocblas_operation_none, then the leading k-by-n part of the array contains each matrix B_i.
   !>     Otherwise, the leading n-by-k part of the array contains each matrix B_i.
-  !>     @param[in]
-  !>     ldb       [rocblas_int]
+  !>     @param[in] ldb - [rocblas_int]
   !>               specifies the leading dimension of each B_i. If transB == rocblas_operation_none,
   !>               must have ldb >= max(1, k). Otherwise, must have ldb >= max(1, n).
-  !>     @param[in]
-  !>     beta      device pointer or host pointer specifying the scalar beta.
-  !>     @param[in, out]
-  !>     C device array of device pointers storing each matrix C_i. If uplo == rocblas_fill_upper,
-  !>     the upper triangular part of the leading n-by-n array contains each matrix C_i. Otherwise,
-  !>     the lower triangular part of the leading n-by-n array contains each matrix C_i.
-  !>     @param[in]
-  !>     ldc       [rocblas_int]
+  !>     @param[in] beta - device pointer or host pointer specifying the scalar beta.
+  !>     @param[in, out] C - device array of device pointers storing each matrix C_i. If uplo ==
+  !>     rocblas_fill_upper, the upper triangular part of the leading n-by-n array contains each
+  !>     matrix C_i. Otherwise, the lower triangular part of the leading n-by-n array contains each
+  !>     matrix C_i.
+  !>     @param[in] ldc - [rocblas_int]
   !>               specifies the leading dimension of each C_i. Must have ldc >= max(1, n).
-  !>     @param[in]
-  !>     batch_count
+  !>     @param[in] batch_count
   !>               [rocblas_int]
   !>               number of gemm operations in the batch.
   interface rocblas_sgemmt_batched
@@ -35347,68 +33591,51 @@ module hipfort_rocblas
   !>     ``op( B )`` a ``k`` by ``n`` by ``batch_count`` strided_batched matrix, and
   !>     ``C`` an ``n`` by ``n`` by ``batch_count`` strided_batched matrix.
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     uplo    [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper:  C is an upper triangular matrix.
   !>             - rocblas_fill_lower:  C is a  lower triangular matrix.
-  !>     @param[in]
-  !>     transA    [rocblas_operation]
+  !>     @param[in] transA - [rocblas_operation]
   !>             - rocblas_operation_none:    op(A_i) = A_i.
   !>             - rocblas_operation_transpose:      op(A_i) = A_i^T
   !>             - rocblas_operation_conjugate_transpose:  op(A_i) = A_i^H
-  !>     @param[in]
-  !>     transB    [rocblas_operation]
+  !>     @param[in] transB - [rocblas_operation]
   !>             - rocblas_operation_none:    op(B_i) = B_i.
   !>             - rocblas_operation_transpose:      op(B_i) = B_i^T
   !>             - rocblas_operation_conjugate_transpose:  op(B_i) = B_i^H
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               number or rows of matrices op( A_i ), columns of op( B_i ), and (rows, columns)
   !>               of C_i.
-  !>     @param[in]
-  !>     k         [rocblas_int]
+  !>     @param[in] k - [rocblas_int]
   !>               number of rows of matrices op( B_i ) and columns of op( A_i ).
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer specifying the scalar alpha.
-  !>     @param[in]
-  !>     A device array of device pointers storing each matrix A_i. If transa =
+  !>     @param[in] alpha - device pointer or host pointer specifying the scalar alpha.
+  !>     @param[in] A - device array of device pointers storing each matrix A_i. If transa =
   !>     rocblas_operation_none, then the leading n-by-k part of the array contains each matrix A_i.
   !>     Otherwise, the leading k-by-n part of the array contains each matrix A_i.
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of each A_i. If transA == rocblas_operation_none,
   !>               must have lda >= max(1, n). Otherwise, must have lda >= max(1, k).
-  !>     @param[in]
-  !>     stride_a  [rocblas_stride]
+  !>     @param[in] stride_a - [rocblas_stride]
   !>               stride from the start of one A_i matrix to the next A_(i + 1).
-  !>     @param[in]
-  !>     B device array of device pointers storing each matrix B_i. If transB =
+  !>     @param[in] B - device array of device pointers storing each matrix B_i. If transB =
   !>     rocblas_operation_none, then the leading k-by-n part of the array contains each matrix B_i.
   !>     Otherwise, the leading n-by-k part of the array contains each matrix B_i.
-  !>     @param[in]
-  !>     ldb       [rocblas_int]
+  !>     @param[in] ldb - [rocblas_int]
   !>               specifies the leading dimension of each B_i. If transB == rocblas_operation_none,
   !>               must have ldb >= max(1, k). Otherwise, must have ldb >= max(1, n).
-  !>     @param[in]
-  !>     stride_b  [rocblas_stride]
+  !>     @param[in] stride_b - [rocblas_stride]
   !>               stride from the start of one B_i matrix to the next B_(i + 1).
-  !>     @param[in]
-  !>     beta      device pointer or host pointer specifying the scalar beta.
-  !>     @param[in, out]
-  !>     C device array of device pointers storing each matrix C_i. If uplo == rocblas_fill_upper,
-  !>     the upper triangular part of the leading n-by-n array contains each matrix C_i. Otherwise,
-  !>     the lower triangular part of the leading n-by-n array contains each matrix C_i.
-  !>     @param[in]
-  !>     ldc       [rocblas_int]
+  !>     @param[in] beta - device pointer or host pointer specifying the scalar beta.
+  !>     @param[in, out] C - device array of device pointers storing each matrix C_i. If uplo ==
+  !>     rocblas_fill_upper, the upper triangular part of the leading n-by-n array contains each
+  !>     matrix C_i. Otherwise, the lower triangular part of the leading n-by-n array contains each
+  !>     matrix C_i.
+  !>     @param[in] ldc - [rocblas_int]
   !>               specifies the leading dimension of each C_i. Must have ldc >= max(1, n).
-  !>     @param[in]
-  !>     stride_c  [rocblas_stride]
+  !>     @param[in] stride_c - [rocblas_stride]
   !>               stride from the start of one C_i matrix to the next C_(i + 1).
-  !>     @param[in]
-  !>     batch_count
+  !>     @param[in] batch_count
   !>               [rocblas_int]
   !>               number of gemm operatons in the batch.
   interface rocblas_sgemmt_strided_batched
@@ -35668,81 +33895,59 @@ module hipfort_rocblas
   !>         - rocblas_datatype_f32_r = a_type = b_type = c_type = d_type = compute_type
   !>         - rocblas_datatype_f16_r = a_type = b_type = c_type = d_type = compute_type
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     transA    [rocblas_operation]
+  !>     @param[in] transA - [rocblas_operation]
   !>               specifies the form of op( A ).
-  !>     @param[in]
-  !>     transB    [rocblas_operation]
+  !>     @param[in] transB - [rocblas_operation]
   !>               specifies the form of op( B ).
-  !>     @param[in]
-  !>     m         [rocblas_int]
+  !>     @param[in] m - [rocblas_int]
   !>               matrix dimension m.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               matrix dimension n.
-  !>     @param[in]
-  !>     k         [rocblas_int]
+  !>     @param[in] k - [rocblas_int]
   !>               matrix dimension k.
-  !>     @param[in]
-  !>     alpha     [const void *]
+  !>     @param[in] alpha - [const void *]
   !>               device pointer or host pointer specifying the scalar alpha. Same datatype as
   !>               compute_type.
-  !>     @param[in]
-  !>     A         [void *]
+  !>     @param[in] A - [void *]
   !>               device pointer storing matrix A.
-  !>     @param[in]
-  !>     a_type    [rocblas_datatype]
+  !>     @param[in] a_type - [rocblas_datatype]
   !>               specifies the datatype of matrix A.
-  !>     @param[in]
-  !>     lda       [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>               specifies the leading dimension of A.
   !>               - If transA == N, must have lda >= max(1, m).
   !>               - Otherwise, must have lda >= max(1, k).
-  !>     @param[in]
-  !>     B         [void *]
+  !>     @param[in] B - [void *]
   !>               device pointer storing matrix B.
-  !>     @param[in]
-  !>     b_type    [rocblas_datatype]
+  !>     @param[in] b_type - [rocblas_datatype]
   !>               specifies the datatype of matrix B.
-  !>     @param[in]
-  !>     ldb       [rocblas_int]
+  !>     @param[in] ldb - [rocblas_int]
   !>               specifies the leading dimension of B.
   !>               - If transB == N, must have ldb >= max(1, k).
   !>               - Otherwise, must have ldb >= max(1, n).
-  !>     @param[in]
-  !>     beta      [const void *]
+  !>     @param[in] beta - [const void *]
   !>               device pointer or host pointer specifying the scalar beta. Same datatype as
   !>               compute_type.
-  !>     @param[in]
-  !>     C         [void *]
+  !>     @param[in] C - [void *]
   !>               device pointer storing matrix C.
-  !>     @param[in]
-  !>     c_type    [rocblas_datatype]
+  !>     @param[in] c_type - [rocblas_datatype]
   !>               specifies the datatype of matrix C.
-  !>     @param[in]
-  !>     ldc       [rocblas_int]
+  !>     @param[in] ldc - [rocblas_int]
   !>               specifies the leading dimension of C. Must have ldc >= max(1, m).
-  !>     @param[out]
-  !>     D         [void *]
+  !>     @param[out] D - [void *]
   !>               device pointer storing matrix D.
   !>               If D and C pointers are to the same matrix, then d_type must equal c_type and ldd
   !>               must equal ldc
   !>               or the respective invalid status will be returned.
-  !>     @param[in]
-  !>     d_type    [rocblas_datatype]
+  !>     @param[in] d_type - [rocblas_datatype]
   !>               specifies the datatype of matrix D.
-  !>     @param[in]
-  !>     ldd       [rocblas_int]
+  !>     @param[in] ldd - [rocblas_int]
   !>               specifies the leading dimension of D. Must have ldd >= max(1, m).
-  !>     @param[in]
-  !>     compute_type
+  !>     @param[in] compute_type
   !>               [rocblas_datatype]
   !>               specifies the datatype of computation.
-  !>     @param[in]
-  !>     geam_ex_op [rocblas_geam_ex_operation]
+  !>     @param[in] geam_ex_op - [rocblas_geam_ex_operation]
   !>               enumerant specifying the operation type and support for
   !>               rocblas_geam_ex_operation_min_plus and rocblas_geam_ex_operation_plus_min.
   interface rocblas_geam_ex
@@ -35821,86 +34026,71 @@ module hipfort_rocblas
   !>     Although not widespread, some gemm kernels used by trsm_ex may use atomic operations.
   !>     See Atomic Operations in the API Reference Guide for more information.
   !>
-  !>     @param[in]
-  !>     handle  [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>             handle to the rocblas library context queue.
   !>
-  !>     @param[in]
-  !>     side    [rocblas_side]
+  !>     @param[in] side - [rocblas_side]
   !>             - rocblas_side_left:       op(A)*X = alpha*B
   !>             - rocblas_side_right:      X*op(A) = alpha*B
   !>
-  !>     @param[in]
-  !>     uplo    [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper:  A is an upper triangular matrix.
   !>             - rocblas_fill_lower:  A is a lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA  [rocblas_operation]
+  !>     @param[in] transA - [rocblas_operation]
   !>             - transB:    op(A) = A.
   !>             - rocblas_operation_transpose:      op(A) = A^T
   !>             - rocblas_operation_conjugate_transpose:  op(A) = A^H
   !>
-  !>     @param[in]
-  !>     diag    [rocblas_diagonal]
+  !>     @param[in] diag - [rocblas_diagonal]
   !>             - rocblas_diagonal_unit:     A is assumed to be unit triangular.
   !>             - rocblas_diagonal_non_unit:  A is not assumed to be unit triangular.
   !>
-  !>     @param[in]
-  !>     m       [rocblas_int]
+  !>     @param[in] m - [rocblas_int]
   !>             m specifies the number of rows of B. m >= 0.
   !>
-  !>     @param[in]
-  !>     n       [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>             n specifies the number of columns of B. n >= 0.
   !>
-  !>     @param[in]
-  !>     alpha   [void *]
+  !>     @param[in] alpha - [void *]
   !>             device pointer or host pointer specifying the scalar alpha. When alpha is
   !>             &zero then A is not referenced, and B need not be set before
   !>             entry.
   !>
-  !>     @param[in]
-  !>     A       [void *]
+  !>     @param[in] A - [void *]
   !>             device pointer storing matrix A.
   !>             of dimension ( lda, k ), where k is m
   !>             when rocblas_side_left and
   !>             is n when rocblas_side_right
   !>             only the upper/lower triangular part is accessed.
   !>
-  !>     @param[in]
-  !>     lda     [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>             lda specifies the first dimension of A.
   !>
   !>                 if side = rocblas_side_left,  lda >= max( 1, m ),
   !>                 if side = rocblas_side_right, lda >= max( 1, n ).
   !>
-  !>     @param[in, out]
-  !>     B       [void *]
+  !>     @param[in, out] B - [void *]
   !>             device pointer storing matrix B.
   !>             B is of dimension ( ldb, n ).
   !>             Before entry, the leading m by n part of the array B must
   !>             contain the right-hand side matrix B, and on exit is
   !>             overwritten by the solution matrix X.
   !>
-  !>     @param[in]
-  !>     ldb    [rocblas_int]
+  !>     @param[in] ldb - [rocblas_int]
   !>            ldb specifies the first dimension of B. ldb >= max( 1, m ).
   !>
-  !>     @param[in]
-  !>     invA    [void *]
+  !>     @param[in] invA - [void *]
   !>             device pointer storing the inverse diagonal blocks of A.
   !>             invA is of dimension ( ld_invA, k ), where k is m
   !>             when rocblas_side_left and
   !>             is n when rocblas_side_right.
   !>             ld_invA must be equal to 128.
   !>
-  !>     @param[in]
-  !>     invA_size [rocblas_int]
+  !>     @param[in] invA_size - [rocblas_int]
   !>             invA_size specifies the number of elements of device memory in invA.
   !>
-  !>     @param[in]
-  !>     compute_type [rocblas_datatype]
+  !>     @param[in] compute_type - [rocblas_datatype]
   !>             specifies the datatype of computation.
   interface rocblas_trsm_ex
     function rocblas_trsm_ex_(handle,side,uplo,transA,diag,m,n,alpha,A,lda,B,ldb,invA,invA_size, &
@@ -35975,90 +34165,74 @@ module hipfort_rocblas
   !>       - ldinvA = 128
   !>       - batch_count = 1
   !>
-  !>     @param[in]
-  !>     handle  [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>             handle to the rocblas library context queue.
   !>
-  !>     @param[in]
-  !>     side    [rocblas_side]
+  !>     @param[in] side - [rocblas_side]
   !>             - rocblas_side_left:       op(A)*X = alpha*B
   !>             - rocblas_side_right:      X*op(A) = alpha*B
   !>
-  !>     @param[in]
-  !>     uplo    [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper:  each A_i is an upper triangular matrix.
   !>             - rocblas_fill_lower:  each A_i is a lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA  [rocblas_operation]
+  !>     @param[in] transA - [rocblas_operation]
   !>             - transB:    op(A) = A.
   !>             - rocblas_operation_transpose:      op(A) = A^T
   !>             - rocblas_operation_conjugate_transpose:  op(A) = A^H
   !>
-  !>     @param[in]
-  !>     diag    [rocblas_diagonal]
+  !>     @param[in] diag - [rocblas_diagonal]
   !>             - rocblas_diagonal_unit:     each A_i is assumed to be unit triangular.
   !>             - rocblas_diagonal_non_unit:  each A_i is not assumed to be unit triangular.
   !>
-  !>     @param[in]
-  !>     m       [rocblas_int]
+  !>     @param[in] m - [rocblas_int]
   !>             m specifies the number of rows of each B_i. m >= 0.
   !>
-  !>     @param[in]
-  !>     n       [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>             n specifies the number of columns of each B_i. n >= 0.
   !>
-  !>     @param[in]
-  !>     alpha   [void *]
+  !>     @param[in] alpha - [void *]
   !>             device pointer or host pointer alpha specifying the scalar alpha. When alpha is
   !>             &zero then A is not referenced, and B need not be set before
   !>             entry.
   !>
-  !>     @param[in]
-  !>     A       [void *]
+  !>     @param[in] A - [void *]
   !>             device array of device pointers storing each matrix A_i.
   !>             each A_i is of dimension ( lda, k ), where k is m
   !>             when rocblas_side_left and
   !>             is n when rocblas_side_right
   !>             only the upper/lower triangular part is accessed.
   !>
-  !>     @param[in]
-  !>     lda     [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>             lda specifies the first dimension of each A_i.
   !>
   !>                 if side = rocblas_side_left,  lda >= max( 1, m ),
   !>                 if side = rocblas_side_right, lda >= max( 1, n ).
   !>
-  !>     @param[in, out]
-  !>     B       [void *]
+  !>     @param[in, out] B - [void *]
   !>             device array of device pointers storing each matrix B_i.
   !>             each B_i is of dimension ( ldb, n ).
   !>             Before entry, the leading m by n part of the array B_i must
   !>             contain the right-hand side matrix B_i, and on exit is
   !>             overwritten by the solution matrix X_i
   !>
-  !>     @param[in]
-  !>     ldb    [rocblas_int]
+  !>     @param[in] ldb - [rocblas_int]
   !>            ldb specifies the first dimension of each B_i. ldb >= max( 1, m ).
   !>
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>             specifies how many batches.
   !>
-  !>     @param[in]
-  !>     invA    [void *]
+  !>     @param[in] invA - [void *]
   !>             device array of device pointers storing the inverse diagonal blocks of each A_i.
   !>             each invA_i is of dimension ( ld_invA, k ), where k is m
   !>             when rocblas_side_left and
   !>             is n when rocblas_side_right.
   !>             ld_invA must be equal to 128.
   !>
-  !>     @param[in]
-  !>     invA_size [rocblas_int]
+  !>     @param[in] invA_size - [rocblas_int]
   !>             invA_size specifies the number of elements of device memory in each invA_i.
   !>
-  !>     @param[in]
-  !>     compute_type [rocblas_datatype]
+  !>     @param[in] compute_type - [rocblas_datatype]
   !>             specifies the datatype of computation.
   interface rocblas_trsm_batched_ex
     function rocblas_trsm_batched_ex_(handle,side,uplo,transA,diag,m,n,alpha,A,lda,B,ldb, &
@@ -36134,85 +34308,69 @@ module hipfort_rocblas
   !>       - ldinvA = 128
   !>       - batch_count = 1
   !>
-  !>     @param[in]
-  !>     handle  [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>             handle to the rocBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     side    [rocblas_side]
+  !>     @param[in] side - [rocblas_side]
   !>             - rocblas_side_left:       op(A)*X = alpha*B
   !>             - rocblas_side_right:      X*op(A) = alpha*B
   !>
-  !>     @param[in]
-  !>     uplo    [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper:  each A_i is an upper triangular matrix.
   !>             - rocblas_fill_lower:  each A_i is a lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA  [rocblas_operation]
+  !>     @param[in] transA - [rocblas_operation]
   !>             - transB:    op(A) = A.
   !>             - rocblas_operation_transpose:      op(A) = A^T
   !>             - rocblas_operation_conjugate_transpose:  op(A) = A^H
   !>
-  !>     @param[in]
-  !>     diag    [rocblas_diagonal]
+  !>     @param[in] diag - [rocblas_diagonal]
   !>             - rocblas_diagonal_unit:     each A_i is assumed to be unit triangular.
   !>             - rocblas_diagonal_non_unit:  each A_i is not assumed to be unit triangular.
   !>
-  !>     @param[in]
-  !>     m       [rocblas_int]
+  !>     @param[in] m - [rocblas_int]
   !>             m specifies the number of rows of each B_i. m >= 0.
   !>
-  !>     @param[in]
-  !>     n       [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>             n specifies the number of columns of each B_i. n >= 0.
   !>
-  !>     @param[in]
-  !>     alpha   [void *]
+  !>     @param[in] alpha - [void *]
   !>             device pointer or host pointer specifying the scalar alpha. When alpha is
   !>             &zero, then A is not referenced, and B need not be set before
   !>             entry.
   !>
-  !>     @param[in]
-  !>     A       [void *]
+  !>     @param[in] A - [void *]
   !>             device pointer storing matrix A.
   !>             Of dimension ( lda, k ), where k is m
   !>             when rocblas_side_left and
   !>             is n when rocblas_side_right.
   !>             Only the upper/lower triangular part is accessed.
   !>
-  !>     @param[in]
-  !>     lda     [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>             lda specifies the first dimension of A.
   !>             - If side = rocblas_side_left,  lda >= max( 1, m ).
   !>             - If side = rocblas_side_right, lda >= max( 1, n ).
   !>
-  !>     @param[in]
-  !>     stride_A [rocblas_stride]
+  !>     @param[in] stride_A - [rocblas_stride]
   !>             The stride between each A matrix.
   !>
-  !>     @param[in, out]
-  !>     B       [void *]
+  !>     @param[in, out] B - [void *]
   !>             device pointer pointing to first matrix B_i.
   !>             Each B_i is of dimension ( ldb, n ).
   !>             Before entry, the leading m by n part of each array B_i must
   !>             contain the right-hand side of matrix B_i, and on exit is
   !>             overwritten by the solution matrix X_i.
   !>
-  !>     @param[in]
-  !>     ldb    [rocblas_int]
+  !>     @param[in] ldb - [rocblas_int]
   !>            ldb specifies the first dimension of each B_i. ldb >= max( 1, m ).
   !>
-  !>     @param[in]
-  !>     stride_B [rocblas_stride]
+  !>     @param[in] stride_B - [rocblas_stride]
   !>             The stride between each B_i matrix.
   !>
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>             specifies how many batches.
   !>
-  !>     @param[in]
-  !>     invA    [void *]
+  !>     @param[in] invA - [void *]
   !>             device pointer storing the inverse diagonal blocks of each A_i.
   !>             invA points to the first invA_1.
   !>             Each invA_i is of dimension ( ld_invA, k ), where k is m
@@ -36220,16 +34378,13 @@ module hipfort_rocblas
   !>             is n when rocblas_side_right.
   !>             ld_invA must be equal to 128.
   !>
-  !>     @param[in]
-  !>     invA_size [rocblas_int]
+  !>     @param[in] invA_size - [rocblas_int]
   !>             invA_size specifies the number of elements of device memory in each invA_i.
   !>
-  !>     @param[in]
-  !>     stride_invA [rocblas_stride]
+  !>     @param[in] stride_invA - [rocblas_stride]
   !>             The stride between each invA matrix.
   !>
-  !>     @param[in]
-  !>     compute_type [rocblas_datatype]
+  !>     @param[in] compute_type - [rocblas_datatype]
   !>             specifies the datatype of computation.
   interface rocblas_trsm_strided_batched_ex
     function rocblas_trsm_strided_batched_ex_(handle,side,uplo,transA,diag,m,n,alpha,A,lda, &
@@ -36288,17 +34443,14 @@ module hipfort_rocblas
   !>     | f32_r  | f64_r  |      f64_r     |
   !>     ------------------------------------
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper:  C is an upper triangular matrix.
   !>             - rocblas_fill_lower:  C is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA  [rocblas_operation]
+  !>     @param[in] transA - [rocblas_operation]
   !>             - rocblas_operation_transpose:           op(A) = A^T
   !>             - rocblas_operation_none:                op(A) = A
   !>             - rocblas_operation_conjugate_transpose: op(A) = A^T
@@ -36306,50 +34458,39 @@ module hipfort_rocblas
   !>             cherk
   !>             and zherk.
   !>
-  !>     @param[in]
-  !>     n       [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>             n specifies the number of rows and columns of C. n >= 0.
   !>
-  !>     @param[in]
-  !>     k       [rocblas_int]
+  !>     @param[in] k - [rocblas_int]
   !>             k specifies the number of columns of op(A). k >= 0.
   !>
-  !>     @param[in]
-  !>     alpha     [const void *]
+  !>     @param[in] alpha - [const void *]
   !>             device pointer or host pointer specifying the scalar alpha. When alpha is
   !>             zero, then A is not referenced and A need not be set before
   !>             entry. Same datatype as compute_type.
   !>
-  !>     @param[in]
-  !>     A       pointer storing matrix A on the GPU.
+  !>     @param[in] A - pointer storing matrix A on the GPU.
   !>             Matrix dimension is ( lda, k ) when transA = rocblas_operation_none. Otherwise,
   !>             (lda, n).
-  !>     @param[in]
-  !>     a_type [rocblas_datatype]
+  !>     @param[in] a_type - [rocblas_datatype]
   !>            specifies the datatype of matrix A.
-  !>     @param[in]
-  !>     lda     [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>             lda specifies the first dimension of A.
   !>             - If transA = rocblas_operation_none,  lda >= max( 1, n ).
   !>             - Otherwise, lda >= max( 1, k ).
   !>
-  !>     @param[in]
-  !>     beta     [const void *]
+  !>     @param[in] beta - [const void *]
   !>             device pointer or host pointer specifying the scalar beta. When beta is
   !>             zero, then C need not be set before
   !>             entry. Same datatype as compute_type.
   !>
-  !>     @param[in]
-  !>     C       pointer storing matrix C on the GPU.
+  !>     @param[in] C - pointer storing matrix C on the GPU.
   !>             Only the upper/lower triangular part is accessed.
-  !>     @param[in]
-  !>     c_type [rocblas_datatype]
+  !>     @param[in] c_type - [rocblas_datatype]
   !>            specifies the datatype of matrix C.
-  !>     @param[in]
-  !>     ldc    [rocblas_int]
+  !>     @param[in] ldc - [rocblas_int]
   !>            ldc specifies the first dimension of C. ldc >= max( 1, n ).
-  !>     @param[in]
-  !>     execution_type [rocblas_datatype]
+  !>     @param[in] execution_type - [rocblas_datatype]
   !>                   specifies the datatype of computation.
   interface rocblas_syrk_ex
     function rocblas_syrk_ex_(handle,uplo,transA,n,k,alpha,A,a_type,lda,beta,C,c_type,ldc, &
@@ -36399,69 +34540,55 @@ module hipfort_rocblas
   !>     | f32_c  | f64_c  |      f64_c     |
   !>     ------------------------------------
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
   !>
-  !>     @param[in]
-  !>     uplo    [rocblas_fill]
+  !>     @param[in] uplo - [rocblas_fill]
   !>             - rocblas_fill_upper:  C is an upper triangular matrix.
   !>             - rocblas_fill_lower:  C is a  lower triangular matrix.
   !>
-  !>     @param[in]
-  !>     transA  [rocblas_operation]
+  !>     @param[in] transA - [rocblas_operation]
   !>             - rocblas_operation_conjugate_transpose:  op(A) = A^H
   !>             - rocblas_operation_none:                 op(A) = A
   !>
-  !>     @param[in]
-  !>     n       [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>             n specifies the number of rows and columns of C. n >= 0.
   !>
-  !>     @param[in]
-  !>     k       [rocblas_int]
+  !>     @param[in] k - [rocblas_int]
   !>             k specifies the number of columns of op(A). k >= 0.
   !>
-  !>     @param[in]
-  !>     alpha     [const void *]
+  !>     @param[in] alpha - [const void *]
   !>             device pointer or host pointer specifying the scalar alpha. When alpha is
   !>             zero, then A is not referenced and A need not be set before
   !>             entry. Same datatype as the real component of the compute_type.
   !>
-  !>     @param[in]
-  !>     A       pointer storing matrix A on the GPU.
+  !>     @param[in] A - pointer storing matrix A on the GPU.
   !>             Matrix dimension is ( lda, k ) when transA = rocblas_operation_none. Otherwise,
   !>             (lda, n).
   !>
-  !>     @param[in]
-  !>     a_type [rocblas_datatype]
+  !>     @param[in] a_type - [rocblas_datatype]
   !>            specifies the datatype of matrix A.
   !>
-  !>     @param[in]
-  !>     lda     [rocblas_int]
+  !>     @param[in] lda - [rocblas_int]
   !>             lda specifies the first dimension of A.
   !>             - If transA = rocblas_operation_none,  lda >= max( 1, n ).
   !>             - Otherwise, lda >= max( 1, k ).
   !>
-  !>     @param[in]
-  !>     beta     [const void *]
+  !>     @param[in] beta - [const void *]
   !>             device pointer or host pointer specifying the scalar beta. When beta is
   !>             zero, then C need not be set before
   !>             entry. Same datatype as the real component of the compute_type.
   !>
-  !>     @param[in]
-  !>     C       pointer storing matrix C on the GPU.
+  !>     @param[in] C - pointer storing matrix C on the GPU.
   !>             Only the upper/lower triangular part is accessed.
   !>
-  !>     @param[in]
-  !>     c_type [rocblas_datatype]
+  !>     @param[in] c_type - [rocblas_datatype]
   !>            specifies the datatype of matrix C.
   !>
-  !>     @param[in]
-  !>     ldc    [rocblas_int]
+  !>     @param[in] ldc - [rocblas_int]
   !>            ldc specifies the first dimension of C. ldc >= max( 1, n ).
   !>
-  !>     @param[in]
-  !>     execution_type [rocblas_datatype]
+  !>     @param[in] execution_type - [rocblas_datatype]
   !>            specifies the datatype of computation.
   interface rocblas_herk_ex
     function rocblas_herk_ex_(handle,uplo,transA,n,k,alpha,A,a_type,lda,beta,C,c_type,ldc, &
@@ -36511,35 +34638,24 @@ module hipfort_rocblas
   !>     |  f64_c     | f64_c  |  f64_c |      f64_c     |
   !>     -------------------------------------------------
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocblas library context queue.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the number of elements in x and y.
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer to specify the scalar alpha.
-  !>     @param[in]
-  !>     alpha_type [rocblas_datatype]
+  !>     @param[in] alpha - device pointer or host pointer to specify the scalar alpha.
+  !>     @param[in] alpha_type - [rocblas_datatype]
   !>               specifies the datatype of alpha.
-  !>     @param[in]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     x_type [rocblas_datatype]
+  !>     @param[in] x - device pointer storing vector x.
+  !>     @param[in] x_type - [rocblas_datatype]
   !>            specifies the datatype of vector x.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of x.
-  !>     @param[in, out]
-  !>     y         device pointer storing vector y.
-  !>     @param[in]
-  !>     y_type [rocblas_datatype]
+  !>     @param[in, out] y - device pointer storing vector y.
+  !>     @param[in] y_type - [rocblas_datatype]
   !>           specifies the datatype of vector y.
-  !>     @param[in]
-  !>     incy      [rocblas_int]
+  !>     @param[in] incy - [rocblas_int]
   !>               specifies the increment for the elements of y.
-  !>     @param[in]
-  !>     execution_type [rocblas_datatype]
+  !>     @param[in] execution_type - [rocblas_datatype]
   !>                   specifies the datatype of computation.
   interface rocblas_axpy_ex
     function rocblas_axpy_ex_(handle,n,alpha,alpha_type,x,x_type,incx,y,y_type,incy, &
@@ -36609,38 +34725,26 @@ module hipfort_rocblas
   !>     |  f64_c     | f64_c  |  f64_c |      f64_c     |
   !>     -------------------------------------------------
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocblas library context queue.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the number of elements in each x_i and y_i.
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer to specify the scalar alpha.
-  !>     @param[in]
-  !>     alpha_type [rocblas_datatype]
+  !>     @param[in] alpha - device pointer or host pointer to specify the scalar alpha.
+  !>     @param[in] alpha_type - [rocblas_datatype]
   !>               specifies the datatype of alpha.
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     x_type [rocblas_datatype]
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] x_type - [rocblas_datatype]
   !>            specifies the datatype of each vector x_i.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in, out]
-  !>     y         device array of device pointers storing each vector y_i.
-  !>     @param[in]
-  !>     y_type [rocblas_datatype]
+  !>     @param[in, out] y - device array of device pointers storing each vector y_i.
+  !>     @param[in] y_type - [rocblas_datatype]
   !>           specifies the datatype of each vector y_i.
-  !>     @param[in]
-  !>     incy      [rocblas_int]
+  !>     @param[in] incy - [rocblas_int]
   !>               specifies the increment for the elements of each y_i.
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
-  !>     @param[in]
-  !>     execution_type [rocblas_datatype]
+  !>     @param[in] execution_type - [rocblas_datatype]
   !>                   specifies the datatype of computation.
   interface rocblas_axpy_batched_ex
     function rocblas_axpy_batched_ex_(handle,n,alpha,alpha_type,x,x_type,incx,y,y_type,incy, &
@@ -36713,50 +34817,36 @@ module hipfort_rocblas
   !>     |  f64_c     | f64_c  |  f64_c |      f64_c     |
   !>     -------------------------------------------------
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the number of elements in each x_i and y_i.
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer to specify the scalar alpha.
-  !>     @param[in]
-  !>     alpha_type [rocblas_datatype]
+  !>     @param[in] alpha - device pointer or host pointer to specify the scalar alpha.
+  !>     @param[in] alpha_type - [rocblas_datatype]
   !>               specifies the datatype of alpha.
-  !>     @param[in]
-  !>     x         device pointer to the first vector x_1.
-  !>     @param[in]
-  !>     x_type [rocblas_datatype]
+  !>     @param[in] x - device pointer to the first vector x_1.
+  !>     @param[in] x_type - [rocblas_datatype]
   !>            specifies the datatype of each vector x_i.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     stridex   [rocblas_stride]
+  !>     @param[in] stridex - [rocblas_stride]
   !>               stride from the start of one vector (x_i) to the next one (x_i+1).
   !>               There are no restrictions placed on stridex. However, ensure that stridex is of
   !>               an appropriate size. For a typical
   !>               case, this means stridex >= n * incx.
-  !>     @param[in, out]
-  !>     y         device pointer to the first vector y_1.
-  !>     @param[in]
-  !>     y_type [rocblas_datatype]
+  !>     @param[in, out] y - device pointer to the first vector y_1.
+  !>     @param[in] y_type - [rocblas_datatype]
   !>           specifies the datatype of each vector y_i.
-  !>     @param[in]
-  !>     incy      [rocblas_int]
+  !>     @param[in] incy - [rocblas_int]
   !>               specifies the increment for the elements of each y_i.
-  !>     @param[in]
-  !>     stridey   [rocblas_stride]
+  !>     @param[in] stridey - [rocblas_stride]
   !>               stride from the start of one vector (y_i) to the next one (y_i+1).
   !>               There are no restrictions placed on stridey. However, ensure that stridey is of
   !>               an appropriate size. For a typical
   !>               case, this means stridey >= n * incy.
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
-  !>     @param[in]
-  !>     execution_type [rocblas_datatype]
+  !>     @param[in] execution_type - [rocblas_datatype]
   !>                   specifies the datatype of computation.
   interface rocblas_axpy_strided_batched_ex
     function rocblas_axpy_strided_batched_ex_(handle,n,alpha,alpha_type,x,x_type,incx,stridex,y, &
@@ -36834,37 +34924,26 @@ module hipfort_rocblas
   !>     | f64_c  | f64_c  |    f64_c    |     f64_c      |
   !>     --------------------------------------------------
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocblas library context queue.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the number of elements in x and y.
-  !>     @param[in]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     x_type [rocblas_datatype]
+  !>     @param[in] x - device pointer storing vector x.
+  !>     @param[in] x_type - [rocblas_datatype]
   !>            specifies the datatype of vector x.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of y.
-  !>     @param[in]
-  !>     y         device pointer storing vector y.
-  !>     @param[in]
-  !>     y_type [rocblas_datatype]
+  !>     @param[in] y - device pointer storing vector y.
+  !>     @param[in] y_type - [rocblas_datatype]
   !>           specifies the datatype of vector y.
-  !>     @param[in]
-  !>     incy      [rocblas_int]
+  !>     @param[in] incy - [rocblas_int]
   !>               specifies the increment for the elements of y.
-  !>     @param[in, out]
-  !>     result
+  !>     @param[in, out] myResult
   !>               device pointer or host pointer to store the dot product.
   !>               Return value is 0.0 if n <= 0.
-  !>     @param[in]
-  !>     result_type [rocblas_datatype]
+  !>     @param[in] result_type - [rocblas_datatype]
   !>                 specifies the datatype of the result.
-  !>     @param[in]
-  !>     execution_type [rocblas_datatype]
+  !>     @param[in] execution_type - [rocblas_datatype]
   !>                   specifies the datatype of computation.
   interface rocblas_dot_ex
     function rocblas_dot_ex_(handle,n,x,x_type,incx,y,y_type,incy,myResult,result_type, &
@@ -36984,41 +35063,29 @@ module hipfort_rocblas
   !>     | f64_c  | f64_c  |    f64_c    |     f64_c      |
   !>     --------------------------------------------------
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocblas library context queue.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the number of elements in each x_i and y_i.
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     x_type [rocblas_datatype]
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] x_type - [rocblas_datatype]
   !>            specifies the datatype of each vector x_i.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     y         device array of device pointers storing each vector y_i.
-  !>     @param[in]
-  !>     y_type [rocblas_datatype]
+  !>     @param[in] y - device array of device pointers storing each vector y_i.
+  !>     @param[in] y_type - [rocblas_datatype]
   !>           specifies the datatype of each vector y_i.
-  !>     @param[in]
-  !>     incy      [rocblas_int]
+  !>     @param[in] incy - [rocblas_int]
   !>               specifies the increment for the elements of each y_i.
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
-  !>     @param[in, out]
-  !>     result
+  !>     @param[in, out] myResult
   !>               device array or host array of batch_count size to store the dot products of each
   !>               batch.
   !>               Return value is 0.0 for each element if n <= 0.
-  !>     @param[in]
-  !>     result_type [rocblas_datatype]
+  !>     @param[in] result_type - [rocblas_datatype]
   !>                 specifies the datatype of the result.
-  !>     @param[in]
-  !>     execution_type [rocblas_datatype]
+  !>     @param[in] execution_type - [rocblas_datatype]
   !>                   specifies the datatype of computation.
   interface rocblas_dot_batched_ex
     function rocblas_dot_batched_ex_(handle,n,x,x_type,incx,y,y_type,incy,batch_count,myResult, &
@@ -37137,47 +35204,33 @@ module hipfort_rocblas
   !>     | f64_c  | f64_c  |    f64_c    |     f64_c      |
   !>     --------------------------------------------------
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the number of elements in each x_i and y_i.
-  !>     @param[in]
-  !>     x         device pointer to the first vector (x_1) in the batch.
-  !>     @param[in]
-  !>     x_type [rocblas_datatype]
+  !>     @param[in] x - device pointer to the first vector (x_1) in the batch.
+  !>     @param[in] x_type - [rocblas_datatype]
   !>            specifies the datatype of each vector x_i.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     stride_x    [rocblas_stride]
+  !>     @param[in] stride_x - [rocblas_stride]
   !>                 stride from the start of one vector (x_i) to the next one (x_i+1).
-  !>     @param[in]
-  !>     y         device pointer to the first vector (y_1) in the batch.
-  !>     @param[in]
-  !>     y_type [rocblas_datatype]
+  !>     @param[in] y - device pointer to the first vector (y_1) in the batch.
+  !>     @param[in] y_type - [rocblas_datatype]
   !>           specifies the datatype of each vector y_i.
-  !>     @param[in]
-  !>     incy      [rocblas_int]
+  !>     @param[in] incy - [rocblas_int]
   !>               specifies the increment for the elements of each y_i.
-  !>     @param[in]
-  !>     stride_y    [rocblas_stride]
+  !>     @param[in] stride_y - [rocblas_stride]
   !>                 stride from the start of one vector (y_i) to the next one (y_i+1).
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
-  !>     @param[in, out]
-  !>     result
+  !>     @param[in, out] myResult
   !>               device array or host array of batch_count size to store the dot products of each
   !>               batch.
   !>               Returns 0.0 for each element if n <= 0.
-  !>     @param[in]
-  !>     result_type [rocblas_datatype]
+  !>     @param[in] result_type - [rocblas_datatype]
   !>                 specifies the datatype of the result.
-  !>     @param[in]
-  !>     execution_type [rocblas_datatype]
+  !>     @param[in] execution_type - [rocblas_datatype]
   !>                   specifies the datatype of computation.
   interface rocblas_dot_strided_batched_ex
     function rocblas_dot_strided_batched_ex_(handle,n,x,x_type,incx,stride_x,y,y_type,incy, &
@@ -37255,47 +35308,33 @@ module hipfort_rocblas
   !>     | f64_c  | f64_c  |    f64_c    |     f64_c      |
   !>     --------------------------------------------------
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the number of elements in each x_i and y_i.
-  !>     @param[in]
-  !>     x         device pointer to the first vector (x_1) in the batch.
-  !>     @param[in]
-  !>     x_type [rocblas_datatype]
+  !>     @param[in] x - device pointer to the first vector (x_1) in the batch.
+  !>     @param[in] x_type - [rocblas_datatype]
   !>            specifies the datatype of each vector x_i.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     stride_x    [rocblas_stride]
+  !>     @param[in] stride_x - [rocblas_stride]
   !>                 stride from the start of one vector (x_i) to the next one (x_i+1).
-  !>     @param[in]
-  !>     y         device pointer to the first vector (y_1) in the batch.
-  !>     @param[in]
-  !>     y_type [rocblas_datatype]
+  !>     @param[in] y - device pointer to the first vector (y_1) in the batch.
+  !>     @param[in] y_type - [rocblas_datatype]
   !>           specifies the datatype of each vector y_i.
-  !>     @param[in]
-  !>     incy      [rocblas_int]
+  !>     @param[in] incy - [rocblas_int]
   !>               specifies the increment for the elements of each y_i.
-  !>     @param[in]
-  !>     stride_y    [rocblas_stride]
+  !>     @param[in] stride_y - [rocblas_stride]
   !>                 stride from the start of one vector (y_i) to the next one (y_i+1).
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
-  !>     @param[in, out]
-  !>     result
+  !>     @param[in, out] myResult
   !>               device array or host array of batch_count size to store the dot products of each
   !>               batch.
   !>               Returns 0.0 for each element if n <= 0.
-  !>     @param[in]
-  !>     result_type [rocblas_datatype]
+  !>     @param[in] result_type - [rocblas_datatype]
   !>                 specifies the datatype of the result.
-  !>     @param[in]
-  !>     execution_type [rocblas_datatype]
+  !>     @param[in] execution_type - [rocblas_datatype]
   !>                   specifies the datatype of computation.
   interface rocblas_dotc_strided_batched_ex
     function rocblas_dotc_strided_batched_ex_(handle,n,x,x_type,incx,stride_x,y,y_type,incy, &
@@ -37368,29 +35407,21 @@ module hipfort_rocblas
   !>     |  f64_c  |  f64_r |     f64_r      |
   !>     -------------------------------------
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocblas library context queue.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the number of elements in x.
-  !>     @param[in]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     x_type [rocblas_datatype]
+  !>     @param[in] x - device pointer storing vector x.
+  !>     @param[in] x_type - [rocblas_datatype]
   !>            specifies the datatype of the vector x.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of y.
-  !>     @param[in, out]
-  !>     results
+  !>     @param[in, out] results
   !>               device pointer or host pointer to store the nrm2 product.
   !>               Return value is 0.0 if n, incx<=0.
-  !>     @param[in]
-  !>     result_type [rocblas_datatype]
+  !>     @param[in] result_type - [rocblas_datatype]
   !>                 specifies the datatype of the result.
-  !>     @param[in]
-  !>     execution_type [rocblas_datatype]
+  !>     @param[in] execution_type - [rocblas_datatype]
   !>                   specifies the datatype of computation.
   interface rocblas_nrm2_ex
     function rocblas_nrm2_ex_(handle,n,x,x_type,incx,results,result_type,execution_type) &
@@ -37449,32 +35480,23 @@ module hipfort_rocblas
   !>     |  f64_c  |  f64_r |     f64_r      |
   !>     -------------------------------------
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocblas library context queue.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               number of elements in each x_i.
-  !>     @param[in]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     x_type [rocblas_datatype]
+  !>     @param[in] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] x_type - [rocblas_datatype]
   !>            specifies the datatype of each vector x_i.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each x_i. incx must be > 0.
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>               number of instances in the batch.
-  !>     @param[out]
-  !>     results
+  !>     @param[out] results
   !>               device pointer or host pointer to array of batch_count size for nrm2 results.
   !>               Return value is 0.0 for each element if n <= 0, incx<=0.
-  !>     @param[in]
-  !>     result_type [rocblas_datatype]
+  !>     @param[in] result_type - [rocblas_datatype]
   !>                 specifies the datatype of the result.
-  !>     @param[in]
-  !>     execution_type [rocblas_datatype]
+  !>     @param[in] execution_type - [rocblas_datatype]
   !>                   specifies the datatype of computation.
   interface rocblas_nrm2_batched_ex
     function rocblas_nrm2_batched_ex_(handle,n,x,x_type,incx,batch_count,results,result_type, &
@@ -37538,39 +35560,29 @@ module hipfort_rocblas
   !>     |  f64_c  |  f64_r |     f64_r      |
   !>     -------------------------------------
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               number of elements in each x_i.
-  !>     @param[in]
-  !>     x         device pointer to the first vector x_1.
-  !>     @param[in]
-  !>     x_type [rocblas_datatype]
+  !>     @param[in] x - device pointer to the first vector x_1.
+  !>     @param[in] x_type - [rocblas_datatype]
   !>            specifies the datatype of each vector x_i.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each x_i. incx must be > 0.
-  !>     @param[in]
-  !>     stride_x  [rocblas_stride]
+  !>     @param[in] stride_x - [rocblas_stride]
   !>               stride from the start of one vector (x_i) to the next one (x_i+1).
   !>               There are no restrictions placed on stride_x. However, ensure that stride_x is of
   !>               an appropriate size. For a typical
   !>               case, this means stride_x >= n * incx.
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>               number of instances in the batch.
-  !>     @param[out]
-  !>     results
+  !>     @param[out] results
   !>               device pointer or host pointer to array for storing contiguous batch_count
   !>               results.
   !>               Returns 0.0 for each element if n <= 0, incx<=0.
-  !>     @param[in]
-  !>     result_type [rocblas_datatype]
+  !>     @param[in] result_type - [rocblas_datatype]
   !>                 specifies the datatype of the result.
-  !>     @param[in]
-  !>     execution_type [rocblas_datatype]
+  !>     @param[in] execution_type - [rocblas_datatype]
   !>                   specifies the datatype of computation.
   interface rocblas_nrm2_strided_batched_ex
     function rocblas_nrm2_strided_batched_ex_(handle,n,x,x_type,incx,stride_x,batch_count,results, &
@@ -37647,37 +35659,27 @@ module hipfort_rocblas
   !>     |  f64_c  |  f64_c  | f64_r   |  f64_c         |
   !>     ------------------------------------------------
   !>
-  !>     @param[in]
-  !>     handle  [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>             handle to the rocblas library context queue.
-  !>     @param[in]
-  !>     n       [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>             number of elements in the x and y vectors.
-  !>     @param[in, out]
-  !>     x       device pointer storing vector x.
-  !>     @param[in]
-  !>     x_type [rocblas_datatype]
+  !>     @param[in, out] x - device pointer storing vector x.
+  !>     @param[in] x_type - [rocblas_datatype]
   !>            specifies the datatype of vector x.
-  !>     @param[in]
-  !>     incx    [rocblas_int]
+  !>     @param[in] incx - [rocblas_int]
   !>             specifies the increment between elements of x.
-  !>     @param[in, out]
-  !>     y       device pointer storing vector y.
-  !>     @param[in]
-  !>     y_type [rocblas_datatype]
+  !>     @param[in, out] y - device pointer storing vector y.
+  !>     @param[in] y_type - [rocblas_datatype]
   !>            specifies the datatype of vector y.
-  !>     @param[in]
-  !>     incy    [rocblas_int]
+  !>     @param[in] incy - [rocblas_int]
   !>             specifies the increment between elements of y.
-  !>     @param[in]
-  !>     c device pointer or host pointer storing scalar cosine component of the rotation matrix.
-  !>     @param[in]
-  !>     s device pointer or host pointer storing scalar sine component of the rotation matrix.
-  !>     @param[in]
-  !>     cs_type [rocblas_datatype]
+  !>     @param[in] c - device pointer or host pointer storing scalar cosine component of the
+  !>     rotation matrix.
+  !>     @param[in] s - device pointer or host pointer storing scalar sine component of the rotation
+  !>     matrix.
+  !>     @param[in] cs_type - [rocblas_datatype]
   !>             specifies the datatype of c and s.
-  !>     @param[in]
-  !>     execution_type [rocblas_datatype]
+  !>     @param[in] execution_type - [rocblas_datatype]
   !>                    specifies the datatype of computation.
   interface rocblas_rot_ex
     function rocblas_rot_ex_(handle,n,x,x_type,incx,y,y_type,incy,c,s,cs_type,execution_type) &
@@ -37756,40 +35758,29 @@ module hipfort_rocblas
   !>     |  f64_c  |  f64_c  | f64_r   |  f64_c         |
   !>     ------------------------------------------------
   !>
-  !>     @param[in]
-  !>     handle  [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>             handle to the rocblas library context queue.
-  !>     @param[in]
-  !>     n       [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>             number of elements in each x_i and y_i vectors.
-  !>     @param[in, out]
-  !>     x       device array of deivce pointers storing each vector x_i.
-  !>     @param[in]
-  !>     x_type [rocblas_datatype]
+  !>     @param[in, out] x - device array of deivce pointers storing each vector x_i.
+  !>     @param[in] x_type - [rocblas_datatype]
   !>            specifies the datatype of each vector x_i.
-  !>     @param[in]
-  !>     incx    [rocblas_int]
+  !>     @param[in] incx - [rocblas_int]
   !>             specifies the increment between elements of each x_i.
-  !>     @param[in, out]
-  !>     y       device array of device pointers storing each vector y_i.
-  !>     @param[in]
-  !>     y_type [rocblas_datatype]
+  !>     @param[in, out] y - device array of device pointers storing each vector y_i.
+  !>     @param[in] y_type - [rocblas_datatype]
   !>            specifies the datatype of each vector y_i.
-  !>     @param[in]
-  !>     incy    [rocblas_int]
+  !>     @param[in] incy - [rocblas_int]
   !>             specifies the increment between elements of each y_i.
-  !>     @param[in]
-  !>     c       device pointer or host pointer to scalar cosine component of the rotation matrix.
-  !>     @param[in]
-  !>     s       device pointer or host pointer to scalar sine component of the rotation matrix.
-  !>     @param[in]
-  !>     cs_type [rocblas_datatype]
+  !>     @param[in] c - device pointer or host pointer to scalar cosine component of the rotation
+  !>     matrix.
+  !>     @param[in] s - device pointer or host pointer to scalar sine component of the rotation
+  !>     matrix.
+  !>     @param[in] cs_type - [rocblas_datatype]
   !>             specifies the datatype of c and s.
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 the number of x and y arrays, the number of batches.
-  !>     @param[in]
-  !>     execution_type [rocblas_datatype]
+  !>     @param[in] execution_type - [rocblas_datatype]
   !>                    specifies the datatype of computation.
   interface rocblas_rot_batched_ex
     function rocblas_rot_batched_ex_(handle,n,x,x_type,incx,y,y_type,incy,c,s,cs_type,batch_count, &
@@ -37873,46 +35864,33 @@ module hipfort_rocblas
   !>     |  f64_c  |  f64_c  | f64_r   |  f64_c         |
   !>     ------------------------------------------------
   !>
-  !>     @param[in]
-  !>     handle  [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>             handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     n       [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>             number of elements in each of the x_i and y_i vectors.
-  !>     @param[in, out]
-  !>     x       device pointer to the first vector x_1.
-  !>     @param[in]
-  !>     x_type [rocblas_datatype]
+  !>     @param[in, out] x - device pointer to the first vector x_1.
+  !>     @param[in] x_type - [rocblas_datatype]
   !>            specifies the datatype of each vector x_i.
-  !>     @param[in]
-  !>     incx    [rocblas_int]
+  !>     @param[in] incx - [rocblas_int]
   !>             specifies the increment between elements of each x_i.
-  !>     @param[in]
-  !>     stride_x [rocblas_stride]
+  !>     @param[in] stride_x - [rocblas_stride]
   !>              specifies the increment from the beginning of x_i to the beginning of x_(i+1).
-  !>     @param[in, out]
-  !>     y       device pointer to the first vector y_1.
-  !>     @param[in]
-  !>     y_type [rocblas_datatype]
+  !>     @param[in, out] y - device pointer to the first vector y_1.
+  !>     @param[in] y_type - [rocblas_datatype]
   !>            specifies the datatype of each vector y_i.
-  !>     @param[in]
-  !>     incy    [rocblas_int]
+  !>     @param[in] incy - [rocblas_int]
   !>             specifies the increment between elements of each y_i.
-  !>     @param[in]
-  !>     stride_y [rocblas_stride]
+  !>     @param[in] stride_y - [rocblas_stride]
   !>              specifies the increment from the beginning of y_i to the beginning of y_(i+1).
-  !>     @param[in]
-  !>     c       device pointer or host pointer to scalar cosine component of the rotation matrix.
-  !>     @param[in]
-  !>     s       device pointer or host pointer to scalar sine component of the rotation matrix.
-  !>     @param[in]
-  !>     cs_type [rocblas_datatype]
+  !>     @param[in] c - device pointer or host pointer to scalar cosine component of the rotation
+  !>     matrix.
+  !>     @param[in] s - device pointer or host pointer to scalar sine component of the rotation
+  !>     matrix.
+  !>     @param[in] cs_type - [rocblas_datatype]
   !>             specifies the datatype of c and s.
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>             the number of x and y arrays, the number of batches.
-  !>     @param[in]
-  !>     execution_type [rocblas_datatype]
+  !>     @param[in] execution_type - [rocblas_datatype]
   !>                    specifies the datatype of computation.
   interface rocblas_rot_strided_batched_ex
     function rocblas_rot_strided_batched_ex_(handle,n,x,x_type,incx,stride_x,y,y_type,incy, &
@@ -37991,27 +35969,19 @@ module hipfort_rocblas
   !>     |  f64_r     | f64_c  |     f64_c      |
   !>     ----------------------------------------
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocblas library context queue.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the number of elements in x.
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer for the scalar alpha.
-  !>     @param[in]
-  !>     alpha_type [rocblas_datatype]
+  !>     @param[in] alpha - device pointer or host pointer for the scalar alpha.
+  !>     @param[in] alpha_type - [rocblas_datatype]
   !>                specifies the datatype of alpha.
-  !>     @param[in, out]
-  !>     x         device pointer storing vector x.
-  !>     @param[in]
-  !>     x_type [rocblas_datatype]
+  !>     @param[in, out] x - device pointer storing vector x.
+  !>     @param[in] x_type - [rocblas_datatype]
   !>            specifies the datatype of vector x.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of x.
-  !>     @param[in]
-  !>     execution_type [rocblas_datatype]
+  !>     @param[in] execution_type - [rocblas_datatype]
   !>                    specifies the datatype of computation.
   interface rocblas_scal_ex
     function rocblas_scal_ex_(handle,n,alpha,alpha_type,x,x_type,incx,execution_type) &
@@ -38074,30 +36044,21 @@ module hipfort_rocblas
   !>     |  f64_r     | f64_c  |     f64_c      |
   !>     ----------------------------------------
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocblas library context queue.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the number of elements in x.
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer for the scalar alpha.
-  !>     @param[in]
-  !>     alpha_type [rocblas_datatype]
+  !>     @param[in] alpha - device pointer or host pointer for the scalar alpha.
+  !>     @param[in] alpha_type - [rocblas_datatype]
   !>                specifies the datatype of alpha.
-  !>     @param[in, out]
-  !>     x         device array of device pointers storing each vector x_i.
-  !>     @param[in]
-  !>     x_type [rocblas_datatype]
+  !>     @param[in, out] x - device array of device pointers storing each vector x_i.
+  !>     @param[in] x_type - [rocblas_datatype]
   !>            specifies the datatype of each vector x_i.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
-  !>     @param[in]
-  !>     execution_type [rocblas_datatype]
+  !>     @param[in] execution_type - [rocblas_datatype]
   !>                    specifies the datatype of computation.
   interface rocblas_scal_batched_ex
     function rocblas_scal_batched_ex_(handle,n,alpha,alpha_type,x,x_type,incx,batch_count, &
@@ -38166,36 +36127,26 @@ module hipfort_rocblas
   !>     |  f64_r     | f64_c  |     f64_c      |
   !>     ----------------------------------------
   !>
-  !>     @param[in]
-  !>     handle    [rocblas_handle]
+  !>     @param[in] handle - [rocblas_handle]
   !>               handle to the rocBLAS library context queue.
-  !>     @param[in]
-  !>     n         [rocblas_int]
+  !>     @param[in] n - [rocblas_int]
   !>               the number of elements in x.
-  !>     @param[in]
-  !>     alpha     device pointer or host pointer for the scalar alpha.
-  !>     @param[in]
-  !>     alpha_type [rocblas_datatype]
+  !>     @param[in] alpha - device pointer or host pointer for the scalar alpha.
+  !>     @param[in] alpha_type - [rocblas_datatype]
   !>                specifies the datatype of alpha.
-  !>     @param[in, out]
-  !>     x         device pointer to the first vector x_1.
-  !>     @param[in]
-  !>     x_type [rocblas_datatype]
+  !>     @param[in, out] x - device pointer to the first vector x_1.
+  !>     @param[in] x_type - [rocblas_datatype]
   !>            specifies the datatype of each vector x_i.
-  !>     @param[in]
-  !>     incx      [rocblas_int]
+  !>     @param[in] incx - [rocblas_int]
   !>               specifies the increment for the elements of each x_i.
-  !>     @param[in]
-  !>     stridex   [rocblas_stride]
+  !>     @param[in] stridex - [rocblas_stride]
   !>               stride from the start of one vector (x_i) to the next one (x_i+1).
   !>               There are no restrictions placed on stridex. However, ensure that stridex is of
   !>               an appropriate size. For a typical
   !>               case, this means stridex >= n * incx.
-  !>     @param[in]
-  !>     batch_count [rocblas_int]
+  !>     @param[in] batch_count - [rocblas_int]
   !>                 number of instances in the batch.
-  !>     @param[in]
-  !>     execution_type [rocblas_datatype]
+  !>     @param[in] execution_type - [rocblas_datatype]
   !>                    specifies the datatype of computation.
   interface rocblas_scal_strided_batched_ex
     function rocblas_scal_strided_batched_ex_(handle,n,alpha,alpha_type,x,x_type,incx,stridex, &
@@ -38242,8 +36193,7 @@ module hipfort_rocblas
   !>     \details
   !>     Returns a string representing the ``rocblas_status`` value.
   !>
-  !>     @param[in]
-  !>     status  [rocblas_status]
+  !>     @param[in] status - [rocblas_status]
   !>             rocBLAS status to convert to string
   interface rocblas_status_to_string
     function rocblas_status_to_string_(status) bind(c, name="rocblas_status_to_string")
@@ -38275,11 +36225,9 @@ module hipfort_rocblas
   !>     is the maximum length of the ``char* buf``.
   !>     \details
   !>
-  !>     @param[in, out]
-  !>     buf             pointer to buffer for version string
+  !>     @param[in, out] buf - pointer to buffer for version string
   !>
-  !>     @param[in]
-  !>     len             length of buf
+  !>     @param[in] len - length of buf
   interface rocblas_get_version_string
     function rocblas_get_version_string_(buf,len) bind(c, name="rocblas_get_version_string")
       use iso_c_binding
@@ -38295,8 +36243,7 @@ module hipfort_rocblas
   !>     `rocblas_get_version_string`
   !>     \details
   !>
-  !>     @param[out]
-  !>     len             pointer to size_t for storing the length
+  !>     @param[out] len - pointer to size_t for storing the length
   interface rocblas_get_version_string_size
     function rocblas_get_version_string_size_(len) bind(c, name="rocblas_get_version_string_size")
       use iso_c_binding
@@ -38311,11 +36258,9 @@ module hipfort_rocblas
   !>     is the maximum length of char* buf.
   !>     \details
   !>
-  !>     @param[in, out]
-  !>     buf             pointer to buffer for version string
+  !>     @param[in, out] buf - pointer to buffer for version string
   !>
-  !>     @param[in]
-  !>     len             length of buf
+  !>     @param[in] len - length of buf
   interface rocblas_get_commit_hash_string
     function rocblas_get_commit_hash_string_(buf,len) bind(c, name="rocblas_get_commit_hash_string")
       use iso_c_binding
@@ -38331,8 +36276,7 @@ module hipfort_rocblas
   !>     `rocblas_get_commit_hash_string`
   !>     \details
   !>
-  !>     @param[out]
-  !>     len             pointer to size_t for storing the length
+  !>     @param[out] len - pointer to size_t for storing the length
   interface rocblas_get_commit_hash_string_size
     function rocblas_get_commit_hash_string_size_(len) &
         bind(c, name="rocblas_get_commit_hash_string_size")
@@ -38353,8 +36297,7 @@ module hipfort_rocblas
   !>     collected.
   !>     Returns ``rocblas_status_size_query_mismatch`` if another size query is already in
   !>     progress. Returns ``rocblas_status_success`` otherwise.
-  !>     @param[in]
-  !>     handle          rocblas handle
+  !>     @param[in] handle - rocblas handle
   interface rocblas_start_device_memory_size_query
     function rocblas_start_device_memory_size_query_(handle) &
         bind(c, name="rocblas_start_device_memory_size_query")
@@ -38373,10 +36316,8 @@ module hipfort_rocblas
   !>     ``rocblas_status_invalid_handle`` if ``handle`` is nullptr,
   !>     and ``rocblas_status_invalid_pointer`` if ``size`` is nullptr. Returns
   !>     ``rocblas_status_success`` otherwise.
-  !>     @param[in]
-  !>     handle          rocblas handle
-  !>     @param[out]
-  !>     size            maximum of the optimal sizes collected
+  !>     @param[in] handle - rocblas handle
+  !>     @param[out] mySize - maximum of the optimal sizes collected
   interface rocblas_stop_device_memory_size_query
     function rocblas_stop_device_memory_size_query_(handle,mySize) &
         bind(c, name="rocblas_stop_device_memory_size_query")
@@ -38484,10 +36425,8 @@ module hipfort_rocblas
   !>     Returns ``rocblas_status_invalid_handle`` if ``handle`` is nullptr,
   !>     ``rocblas_status_invalid_pointer`` if ``size`` is nullptr, and ``rocblas_status_success``
   !>     otherwise.
-  !>     @param[in]
-  !>     handle          rocblas handle
-  !>     @param[out]
-  !>     size            current device memory size for the handle
+  !>     @param[in] handle - rocblas handle
+  !>     @param[out] mySize - current device memory size for the handle
   interface rocblas_get_device_memory_size
     function rocblas_get_device_memory_size_(handle,mySize) &
         bind(c, name="rocblas_get_device_memory_size")
@@ -38511,10 +36450,8 @@ module hipfort_rocblas
   !>     the future, expanding it when necessary.
   !>     Returns rocblas_status_invalid_handle if handle is nullptr; rocblas_status_invalid_pointer
   !>     if size is nullptr; rocblas_status_success otherwise
-  !>     @param[in]
-  !>     handle          rocblas handle
-  !>     @param[in]
-  !>     size            size of allocated device memory
+  !>     @param[in] handle - rocblas handle
+  !>     @param[in] mySize - size of allocated device memory
   interface rocblas_set_device_memory_size
     function rocblas_set_device_memory_size_(handle,mySize) &
         bind(c, name="rocblas_set_device_memory_size")
@@ -38535,12 +36472,9 @@ module hipfort_rocblas
   !>
   !>     Returns ``rocblas_status_invalid_handle`` if ``handle`` is nullptr and
   !>     ``rocblas_status_success`` otherwise.
-  !>     @param[in]
-  !>     handle          rocblas handle
-  !>     @param[in]
-  !>     addr            address of workspace memory
-  !>     @param[in]
-  !>     size            size of workspace memory
+  !>     @param[in] handle - rocblas handle
+  !>     @param[in] addr - address of workspace memory
+  !>     @param[in] mySize - size of workspace memory
   interface rocblas_set_workspace
     function rocblas_set_workspace_(handle,addr,mySize) bind(c, name="rocblas_set_workspace")
       use iso_c_binding
@@ -38556,8 +36490,7 @@ module hipfort_rocblas
   !>  \brief
   !>     \details
   !>     Returns ``true`` when the device memory in ``handle`` is managed by rocBLAS.
-  !>     @param[in]
-  !>     handle          rocblas handle
+  !>     @param[in] handle - rocblas handle
   interface rocblas_is_managing_device_memory
     function rocblas_is_managing_device_memory_(handle) &
         bind(c, name="rocblas_is_managing_device_memory")
@@ -38572,8 +36505,7 @@ module hipfort_rocblas
   !>  \brief
   !>     \details
   !>     Returns true when device memory in ``handle`` is managed by the user.
-  !>     @param[in]
-  !>     handle          rocblas handle
+  !>     @param[in] handle - rocblas handle
   interface rocblas_is_user_managing_device_memory
     function rocblas_is_user_managing_device_memory_(handle) &
         bind(c, name="rocblas_is_user_managing_device_memory")

--- a/lib/hipfort/hipfort_rocsolver.F90
+++ b/lib/hipfort/hipfort_rocsolver.F90
@@ -31,10 +31,8 @@ module hipfort_rocsolver
   !>  \brief The GET_VERSION_STRING function queries the library version.
   !>
   !>     \details
-  !>     @param[out]
-  !>     buf         A buffer that the version string will be written into.
-  !>     @param[in]
-  !>     len         The size of the given buffer in bytes.
+  !>     @param[out] buf - A buffer that the version string will be written into.
+  !>     @param[in] len - The size of the given buffer in bytes.
   interface rocsolver_get_version_string
     function rocsolver_get_version_string_(buf,len) bind(c, name="rocsolver_get_version_string")
       use iso_c_binding
@@ -51,8 +49,7 @@ module hipfort_rocsolver
   !>     successful call to `rocsolver_get_version_string`.
   !>
   !>     \details
-  !>     @param[out]
-  !>     len         pointer to size_t.
+  !>     @param[out] len - pointer to size_t.
   !>                 The minimum length of buffer to pass to
   !>                 `rocsolver_get_version_string`.
   interface rocsolver_get_version_string_size
@@ -108,8 +105,7 @@ module hipfort_rocsolver
   !>     logging environment.
   !>
   !>     \details
-  !>     @param[in]
-  !>     layer_mode  rocblas_layer_mode_flags.
+  !>     @param[in] layer_mode - rocblas_layer_mode_flags.
   !>                 Specifies the logging mode.
   interface rocsolver_log_set_layer_mode
     function rocsolver_log_set_layer_mode_(layer_mode) bind(c, name="rocsolver_log_set_layer_mode")
@@ -126,8 +122,7 @@ module hipfort_rocsolver
   !>     multi-level logging environment.
   !>
   !>     \details
-  !>     @param[in]
-  !>     max_levels  rocblas_int. max_levels >= 1.
+  !>     @param[in] max_levels - rocblas_int. max_levels >= 1.
   !>                 Specifies the maximum depth for which nested function calls
   !>                 will appear in the trace and profile logs.
   interface rocsolver_log_set_max_levels
@@ -182,13 +177,10 @@ module hipfort_rocsolver
 
   !>  \brief The SET_ALG_MODE function sets the algorithm mode to be used by the specified function.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     func        `rocsolver_function`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] func - `rocsolver_function`.
   !>                 The function that will use the selected algorithm mode.
-  !>     @param[in]
-  !>     mode        `rocsolver_alg_mode`.
+  !>     @param[in] mode - `rocsolver_alg_mode`.
   !>                 The algorithm mode that will be used by the specified function.
   !>                 rocsolver_alg_mode_mixed is not supported.
   interface rocsolver_set_alg_mode
@@ -206,13 +198,10 @@ module hipfort_rocsolver
 
   !>  \brief The GET_ALG_MODE function gets the algorithm mode being used by the specified function.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     func        `rocsolver_function`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] func - `rocsolver_function`.
   !>                 The specified function.
-  !>     @param[out]
-  !>     mode        pointer to `rocsolver_alg_mode`.
+  !>     @param[out] mode - pointer to `rocsolver_alg_mode`.
   !>                 On exit, the value is overwritten by the algorithm mode used
   !>                 by the specified function.
   interface rocsolver_get_alg_mode
@@ -233,17 +222,14 @@ module hipfort_rocsolver
   !>     \details
   !>     Conjugates the ``n`` entries of a complex vector ``x`` with increment ``incx``.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The dimension of vector x.
-  !>     @param[inout]
-  !>     x pointer to type. Array on the GPU of size at least n (size depends on the value of incx).
+  !>     @param[inout] x - pointer to type. Array on the GPU of size at least n (size depends on the
+  !>     value of incx).
   !>                 On entry, the vector x.
   !>                 On exit, each entry is overwritten with its conjugate value.
-  !>     @param[in]
-  !>     incx        rocblas_int. incx != 0.
+  !>     @param[in] incx - rocblas_int. incx != 0.
   !>                 The distance between two consecutive elements of x.
   !>                 If incx is negative, the elements of x are indexed in
   !>                 reverse order.
@@ -325,25 +311,18 @@ module hipfort_rocsolver
   !>     - ``rocsolver_norm_type_infinity``: the infinity-norm (maximum row sum), or
   !>     - ``rocsolver_norm_type_max``: the maximum absolute value of any element.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     norm_type   rocsolver_norm_type.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] norm_type - rocsolver_norm_type.
   !>                 Specifies the type of norm to compute.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of the matrix A.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of the matrix A.
-  !>     @param[in]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[in] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 The m-by-n matrix A.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 The leading dimension of A.
-  !>     @param[out]
-  !>     norm       pointer to real type. Scalar on the GPU.
+  !>     @param[out] norm - pointer to real type. Scalar on the GPU.
   !>                 The computed norm of the matrix A.
   interface rocsolver_slange
     function rocsolver_slange_(handle,norm_type,m,n,A,lda,norm) bind(c, name="rocsolver_slange")
@@ -504,29 +483,22 @@ module hipfort_rocsolver
   !>     A is poorly conditioned (nearly singular). When rcond is close to 1, the matrix A is well
   !>     conditioned.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     norm_type   rocsolver_norm_type.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] norm_type - rocsolver_norm_type.
   !>                 Specifies the norm to be used. The 1-norm and the infinity-norm
   !>                 are supported, specified by values of rocsolver_norm_type_one and
   !>                 rocsolver_norm_type_infinity.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows and columns of the matrix A.
-  !>     @param[in]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[in] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 The factors L and U of the factorization \f$A = PLU\f$ as returned by \ref
   !>                 rocsolver_sgetrf "GETRF".
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 The leading dimension of A.
-  !>     @param[in]
-  !>     anorm       pointer to real type. Scalar on the GPU.
+  !>     @param[in] anorm - pointer to real type. Scalar on the GPU.
   !>                 The norm of the original matrix A (before factorization) as returned by \ref
   !>                 rocsolver_slange "LANGE".
-  !>     @param[out]
-  !>     rcond       pointer to real type. Scalar on the GPU.
+  !>     @param[out] rcond - pointer to real type. Scalar on the GPU.
   !>                 The reciprocal condition number estimate.
   interface rocsolver_sgecon
     function rocsolver_sgecon_(handle,norm_type,n,A,lda,anorm,rcond) &
@@ -680,36 +652,28 @@ module hipfort_rocsolver
   !>     will be interchanged with the r-th row of ``A``, for \f$j = k_1,k_1+1,\dots,k_2\f$. Indices
   !>     \f$k_1\f$ and \f$k_2\f$ are 1-based indices.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of the matrix A.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the matrix to which the row
   !>                 interchanges will be applied. On exit, the resulting permuted matrix.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda > 0.
+  !>     @param[in] lda - rocblas_int. lda > 0.
   !>                 The leading dimension of the array A.
-  !>     @param[in]
-  !>     k1          rocblas_int. k1 > 0.
+  !>     @param[in] k1 - rocblas_int. k1 > 0.
   !>                 The k_1 index. This is the first element of ipiv for which a row interchange
   !>                 will
   !>                 be done. This is a 1-based index.
-  !>     @param[in]
-  !>     k2          rocblas_int. k2 > k1 > 0.
+  !>     @param[in] k2 - rocblas_int. k2 > k1 > 0.
   !>                 The k_2 index. k_2 - k_1 + 1 is the number of elements of ipiv for which a row
   !>                 interchange will be done. This is a 1-based index.
-  !>     @param[in]
-  !>     ipiv pointer to rocblas_int. Array on the GPU of dimension at least \f$k_1 + (k_2 -
-  !>     k_1)\cdot \text{abs}(\text{incx})\f$.
+  !>     @param[in] ipiv - pointer to rocblas_int. Array on the GPU of dimension at least \f$k_1 +
+  !>     (k_2 - k_1)\cdot \text{abs}(\text{incx})\f$.
   !>                 The vector of pivot indices. Only the elements in positions
   !>                 \f$k_1\f$ through \f$k_1 + (k_2 - k_1)\cdot \text{abs}(\text{incx})\f$ of this
   !>                 vector are accessed.
   !>                 Elements of ipiv are considered 1-based.
-  !>     @param[in]
-  !>     incx        rocblas_int. incx != 0.
+  !>     @param[in] incx - rocblas_int. incx != 0.
   !>                 The distance between successive values of ipiv.  If incx
   !>                 is negative, the pivots are applied in reverse order.
   interface rocsolver_slaswp
@@ -855,25 +819,19 @@ module hipfort_rocsolver
   !>     real (that is, \f$H^T=H\f$), but not Hermitian when complex
   !>     (that is, \f$H^H&ne; H\f$ in general).
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The order (size) of reflector H.
-  !>     @param[inout]
-  !>     alpha       pointer to type. A scalar on the GPU.
+  !>     @param[inout] alpha - pointer to type. A scalar on the GPU.
   !>                 On entry, the scalar alpha.
   !>                 On exit, it is overwritten with beta.
-  !>     @param[inout]
-  !>     x pointer to type. Array on the GPU of size at least n-1 (size depends on the value of
-  !>     incx).
+  !>     @param[inout] x - pointer to type. Array on the GPU of size at least n-1 (size depends on
+  !>     the value of incx).
   !>                 On entry, the vector x,
   !>                 On exit, it is overwritten with vector v.
-  !>     @param[in]
-  !>     incx        rocblas_int. incx > 0.
+  !>     @param[in] incx - rocblas_int. incx > 0.
   !>                 The distance between two consecutive elements of x.
-  !>     @param[out]
-  !>     tau         pointer to type. A scalar on the GPU.
+  !>     @param[out] tau - pointer to type. A scalar on the GPU.
   !>                 The Householder scalar tau.
   interface rocsolver_slarfg
     function rocsolver_slarfg_(handle,n,alpha,x,incx,tau) bind(c, name="rocsolver_slarfg")
@@ -1058,36 +1016,27 @@ module hipfort_rocsolver
   !>     where the \f$i\f$th row of matrix ``V`` contains the Householder vector associated with
   !>     \f$H(i)\f$.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     direct      `rocblas_direct`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] myDirect - `rocblas_direct`.
   !>                 Specifies the direction in which the Householder matrices are applied.
-  !>     @param[in]
-  !>     storev      `rocblas_storev`.
+  !>     @param[in] storev - `rocblas_storev`.
   !>                 Specifies how the Householder vectors are stored in matrix V.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The order (size) of the block reflector.
-  !>     @param[in]
-  !>     k           rocblas_int. k >= 1.
+  !>     @param[in] k - rocblas_int. k >= 1.
   !>                 The number of Householder matrices forming H.
-  !>     @param[in]
-  !>     V pointer to type. Array on the GPU of size ldv*k if column-wise or ldv*n if row-wise.
+  !>     @param[in] V - pointer to type. Array on the GPU of size ldv*k if column-wise or ldv*n if
+  !>     row-wise.
   !>                 The matrix of Householder vectors.
-  !>     @param[in]
-  !>     ldv         rocblas_int. ldv >= n if column-wise or ldv >= k if row-wise.
+  !>     @param[in] ldv - rocblas_int. ldv >= n if column-wise or ldv >= k if row-wise.
   !>                 The leading dimension of V.
-  !>     @param[in]
-  !>     tau         pointer to type. Array of k scalars on the GPU.
+  !>     @param[in] tau - pointer to type. Array of k scalars on the GPU.
   !>                 The vector of all the Householder scalars.
-  !>     @param[out]
-  !>     T           pointer to type. Array on the GPU of dimension ldt*k.
+  !>     @param[out] T - pointer to type. Array on the GPU of dimension ldt*k.
   !>                 The triangular factor. T is upper triangular if direct indicates forward
   !>                 direction. Otherwise, it is
   !>                 lower triangular. The rest of the array is not used.
-  !>     @param[in]
-  !>     ldt         rocblas_int. ldt >= k.
+  !>     @param[in] ldt - rocblas_int. ldt >= k.
   !>                 The leading dimension of T.
   interface rocsolver_slarft
     function rocsolver_slarft_(handle,myDirect,storev,n,k,V,ldv,tau,T,ldt) &
@@ -1215,35 +1164,27 @@ module hipfort_rocsolver
   !>     where ``alpha`` is the Householder scalar and ``x`` is a Householder vector. H is never
   !>     actually computed.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     side        rocblas_side.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] side - rocblas_side.
   !>                 Determines whether H is applied from the left or the right.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 Number of rows of A.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of columns of A.
-  !>     @param[in]
-  !>     x pointer to type. Array on the GPU of size at least 1 + (m-1)*abs(incx) if left side, or
+  !>     @param[in] x - pointer to type. Array on the GPU of size at least 1 + (m-1)*abs(incx) if
+  !>     left side, or
   !>                 at least 1 + (n-1)*abs(incx) if right side.
   !>                 The Householder vector x.
-  !>     @param[in]
-  !>     incx        rocblas_int. incx != 0.
+  !>     @param[in] incx - rocblas_int. incx != 0.
   !>                 Distance between two consecutive elements of x.
   !>                 If incx < 0, the elements of x are indexed in reverse order.
-  !>     @param[in]
-  !>     alpha       pointer to type. A scalar on the GPU.
+  !>     @param[in] alpha - pointer to type. A scalar on the GPU.
   !>                 The Householder scalar. If \f$\alpha = 0\f$, then \f$H = I\f$ (A will remain
   !>                 the same, and x is never used).
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of size lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of size lda*n.
   !>                 On entry, the matrix A. On exit, it is overwritten with
   !>                 \f$HA\f$ (or \f$AH\f$).
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Leading dimension of A.
   interface rocsolver_slarf
     function rocsolver_slarf_(handle,side,m,n,x,incx,alpha,A,lda) bind(c, name="rocsolver_slarf")
@@ -1471,53 +1412,39 @@ module hipfort_rocsolver
   !>     \f$H(i)\f$, if ``storev`` is row-wise.
   !>     ``T`` is the associated triangular factor as computed by \ref rocsolver_slarft "LARFT".
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     side        rocblas_side.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] side - rocblas_side.
   !>                 Specifies from which side to apply H.
-  !>     @param[in]
-  !>     trans       rocblas_operation.
+  !>     @param[in] trans - rocblas_operation.
   !>                 Specifies whether the block reflector or its transpose/conjugate transpose is
   !>                 to be applied.
-  !>     @param[in]
-  !>     direct      `rocblas_direct`.
+  !>     @param[in] myDirect - `rocblas_direct`.
   !>                 Specifies the direction in which the Householder matrices are to be applied to
   !>                 generate H.
-  !>     @param[in]
-  !>     storev      `rocblas_storev`.
+  !>     @param[in] storev - `rocblas_storev`.
   !>                 Specifies how the Householder vectors are stored in matrix V.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 Number of rows of matrix A.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of columns of matrix A.
-  !>     @param[in]
-  !>     k           rocblas_int. k >= 1.
+  !>     @param[in] k - rocblas_int. k >= 1.
   !>                 The number of Householder matrices.
-  !>     @param[in]
-  !>     V pointer to type. Array on the GPU of size ldv*k if column-wise, ldv*n if row-wise and
-  !>     applying from the right,
+  !>     @param[in] V - pointer to type. Array on the GPU of size ldv*k if column-wise, ldv*n if
+  !>     row-wise and applying from the right,
   !>                 or ldv*m if row-wise and applying from the left.
   !>                 The matrix of Householder vectors.
-  !>     @param[in]
-  !>     ldv rocblas_int. ldv >= k if row-wise, ldv >= m if column-wise and applying from the left,
-  !>     or ldv >= n if
+  !>     @param[in] ldv - rocblas_int. ldv >= k if row-wise, ldv >= m if column-wise and applying
+  !>     from the left, or ldv >= n if
   !>                 column-wise and applying from the right.
   !>                 The leading dimension of V.
-  !>     @param[in]
-  !>     T           pointer to type. Array on the GPU of dimension ldt*k.
+  !>     @param[in] T - pointer to type. Array on the GPU of dimension ldt*k.
   !>                 The triangular factor of the block reflector.
-  !>     @param[in]
-  !>     ldt         rocblas_int. ldt >= k.
+  !>     @param[in] ldt - rocblas_int. ldt >= k.
   !>                 The leading dimension of T.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of size lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of size lda*n.
   !>                 On entry, the matrix A. On exit, it is overwritten with
   !>                 \f$HA\f$, \f$AH\f$, \f$H^H A\f$, or \f$AH^H\f$.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 The leading dimension of A.
   interface rocsolver_slarfb
     function rocsolver_slarfb_(handle,side,trans,myDirect,storev,m,n,k,V,ldv,T,ldt,A,lda) &
@@ -1696,38 +1623,28 @@ module hipfort_rocsolver
   !>
   !>     All rotations are applied directly without ever forming P(i) explicitly.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     side        rocblas_side.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] side - rocblas_side.
   !>                 Specifies from which side to apply P.
-  !>     @param[in]
-  !>     pivot       `rocblas_pivot`.
+  !>     @param[in] pivot - `rocblas_pivot`.
   !>                 Specifies the planes on which the rotations are applied.
-  !>     @param[in]
-  !>     direct      `rocblas_direct`.
+  !>     @param[in] myDirect - `rocblas_direct`.
   !>                 Specifies the direction in which the plane rotations are to be applied to
   !>                 generate P.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 Number of rows of matrix A.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of columns of matrix A.
-  !>     @param[in]
-  !>     C           pointer to real type. Array on the GPU of size n-1 if side is right, or m-1
+  !>     @param[in] C - pointer to real type. Array on the GPU of size n-1 if side is right, or m-1
   !>                 if side is left.
   !>                 Contains the series of cosine factors defining the Givens rotations.
-  !>     @param[in]
-  !>     S           pointer to real type. Array on the GPU of size n-1 if side is right, or m-1
+  !>     @param[in] S - pointer to real type. Array on the GPU of size n-1 if side is right, or m-1
   !>                 if side is left.
   !>                 Contains the series of sine factors defining the Givens rotations.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of size lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of size lda*n.
   !>                 On entry, the matrix A. On exit, it is overwritten with
   !>                 \f$PA\f$, or \f$AP^T\f$.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 The leading dimension of A.
   interface rocsolver_slasr
     function rocsolver_slasr_(handle,side,pivot,myDirect,m,n,C,S,A,lda) &
@@ -1864,19 +1781,14 @@ module hipfort_rocsolver
   !>     where V and U are the ``m`` -by-``k`` and ``n`` -by-``k`` matrices formed with the vectors
   !>     \f$v_i\f$ and \f$u_i\f$, respectively.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of the matrix A.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of the matrix A.
-  !>     @param[in]
-  !>     k           rocblas_int. min(m,n) >= k >= 0.
+  !>     @param[in] k - rocblas_int. min(m,n) >= k >= 0.
   !>                 The number of leading rows and columns of matrix A that will be reduced.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the m-by-n matrix to be reduced.
   !>                 On exit, the first k elements on the diagonal and superdiagonal (if m >= n) or
   !>                 subdiagonal (if m < n) contain the bidiagonal form B.
@@ -1890,32 +1802,23 @@ module hipfort_rocsolver
   !>                 elements of the Householder vectors related to Q, while the elements above the
   !>                 diagonal of the first k rows are the n - i (possibly non-zero) elements of the
   !>                 vectors associated with P.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of A.
-  !>     @param[out]
-  !>     D           pointer to real type. Array on the GPU of dimension k.
+  !>     @param[out] D - pointer to real type. Array on the GPU of dimension k.
   !>                 The diagonal elements of B.
-  !>     @param[out]
-  !>     E           pointer to real type. Array on the GPU of dimension k.
+  !>     @param[out] E - pointer to real type. Array on the GPU of dimension k.
   !>                 The off-diagonal elements of B.
-  !>     @param[out]
-  !>     tauq        pointer to type. Array on the GPU of dimension k.
+  !>     @param[out] tauq - pointer to type. Array on the GPU of dimension k.
   !>                 The Householder scalars associated with matrix Q.
-  !>     @param[out]
-  !>     taup        pointer to type. Array on the GPU of dimension k.
+  !>     @param[out] taup - pointer to type. Array on the GPU of dimension k.
   !>                 The Householder scalars associated with matrix P.
-  !>     @param[out]
-  !>     X           pointer to type. Array on the GPU of dimension ldx*k.
+  !>     @param[out] X - pointer to type. Array on the GPU of dimension ldx*k.
   !>                 The m-by-k matrix needed to update the unreduced part of A.
-  !>     @param[in]
-  !>     ldx         rocblas_int. ldx >= m.
+  !>     @param[in] ldx - rocblas_int. ldx >= m.
   !>                 The leading dimension of X.
-  !>     @param[out]
-  !>     Y           pointer to type. Array on the GPU of dimension ldy*k.
+  !>     @param[out] Y - pointer to type. Array on the GPU of dimension ldy*k.
   !>                 The n-by-k matrix needed to update the unreduced part of A.
-  !>     @param[in]
-  !>     ldy         rocblas_int. ldy >= n.
+  !>     @param[in] ldy - rocblas_int. ldy >= n.
   !>                 The leading dimension of Y.
   interface rocsolver_slabrd
     function rocsolver_slabrd_(handle,m,n,k,A,lda,D,E,tauq,taup,X,ldx,Y,ldy) &
@@ -2090,21 +1993,16 @@ module hipfort_rocsolver
   !>
   !>     where V is the n-by-k matrix formed by the vectors \f$v_i\f$.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the matrix A is stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower)
   !>                 part of A is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows and columns of the matrix A.
-  !>     @param[in]
-  !>     k           rocblas_int. 0 <= k <= n.
+  !>     @param[in] k - rocblas_int. 0 <= k <= n.
   !>                 The number of rows and columns of the matrix A to be reduced.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the n-by-n matrix to be reduced.
   !>                 On exit, if uplo is lower, the first k columns have been reduced to tridiagonal
   !>                 form
@@ -2117,23 +2015,18 @@ module hipfort_rocsolver
   !>                 diagonal
   !>                 contain the possibly non-zero entries of the Householder vectors associated
   !>                 with Q, stored as columns.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 The leading dimension of A.
-  !>     @param[out]
-  !>     E           pointer to real type. Array on the GPU of dimension n-1.
+  !>     @param[out] E - pointer to real type. Array on the GPU of dimension n-1.
   !>                 If upper (lower), the last (first) k elements of E are the off-diagonal
   !>                 elements of the
   !>                 computed tridiagonal block.
-  !>     @param[out]
-  !>     tau         pointer to type. Array on the GPU of dimension n-1.
+  !>     @param[out] tau - pointer to type. Array on the GPU of dimension n-1.
   !>                 If upper (lower), the last (first) k elements of tau are the Householder
   !>                 scalars related to Q.
-  !>     @param[out]
-  !>     W           pointer to type. Array on the GPU of dimension ldw*k.
+  !>     @param[out] W - pointer to type. Array on the GPU of dimension ldw*k.
   !>                 The n-by-k matrix needed to update the unreduced part of A.
-  !>     @param[in]
-  !>     ldw         rocblas_int. ldw >= n.
+  !>     @param[in] ldw - rocblas_int. ldw >= n.
   !>                 The leading dimension of W.
   interface rocsolver_slatrd
     function rocsolver_slatrd_(handle,uplo,n,k,A,lda,E,tau,W,ldw) bind(c, name="rocsolver_slatrd")
@@ -2280,32 +2173,24 @@ module hipfort_rocsolver
   !>     depending on the value of ``uplo``. The order of the block diagonal matrix \f$D\f$
   !>     is either \f$nb\f$ or \f$nb-1\f$ and is returned in the argument \f$kb\f$.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the matrix A is stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower)
   !>                 part of A is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows and columns of the matrix A.
-  !>     @param[in]
-  !>     nb          rocblas_int. 2 <= nb <= n.
+  !>     @param[in] nb - rocblas_int. 2 <= nb <= n.
   !>                 The number of columns of A to be factored.
-  !>     @param[out]
-  !>     kb          pointer to a rocblas_int on the GPU.
+  !>     @param[out] kb - pointer to a rocblas_int on the GPU.
   !>                 The number of columns of A that were actually factored (either nb or
   !>                 nb-1).
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the symmetric matrix A to be factored.
   !>                 On exit, the partially factored matrix.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of A.
-  !>     @param[out]
-  !>     ipiv        pointer to rocblas_int. Array on the GPU of dimension n.
+  !>     @param[out] ipiv - pointer to rocblas_int. Array on the GPU of dimension n.
   !>                 The vector of pivot indices. Elements of ipiv are 1-based indices.
   !>                 - If uplo is upper, then only the last kb elements of ipiv will be
   !>                 set. For n - kb < k <= n, if ipiv[k] > 0, then rows and columns k
@@ -2319,8 +2204,7 @@ module hipfort_rocsolver
   !>                 If, instead, ipiv[k] = ipiv[k+1] < 0, then rows and columns k+1
   !>                 and -ipiv[k] were interchanged and D[k,k] to D[k+1,k+1] is a 2-by-2
   !>                 diagonal block.
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info = 0, successful exit.
   !>                 If info = i > 0, D is singular. D[i,i] is the first diagonal zero.
   interface rocsolver_slasyf
@@ -2439,24 +2323,19 @@ module hipfort_rocsolver
   !>     If ``uplo`` indicates upper, then \f$U U^H\f$ is computed. If ``uplo`` indicates lower,
   !>     then \f$L^H L\f$ is computed instead.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower triangular part of A will be used.
   !>                 If uplo indicates lower (or upper), then the upper (or lower)
   !>                 part of A is not referenced.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns and rows of the matrix A.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, it contains the upper (or lower) part of the symmetric/Hermitian
   !>                 matrix.
   !>                 On exit, the upper (or lower) part is overwritten with the result of \f$U
   !>                 U^H\f$ (or \f$L^H L\f$).
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 The leading dimension of the array A.
   interface rocsolver_slauum
     function rocsolver_slauum_(handle,uplo,n,A,lda) bind(c, name="rocsolver_slauum")
@@ -2535,27 +2414,20 @@ module hipfort_rocsolver
   !>     Householder vectors \f$v_i\f$ and scalars \f$\text{ipiv}[i]\f$, as returned by \ref
   !>     rocsolver_sgeqrf "GEQRF".
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of the matrix Q.
-  !>     @param[in]
-  !>     n           rocblas_int. 0 <= n <= m.
+  !>     @param[in] n - rocblas_int. 0 <= n <= m.
   !>                 The number of columns of the matrix Q.
-  !>     @param[in]
-  !>     k           rocblas_int. 0 <= k <= n.
+  !>     @param[in] k - rocblas_int. 0 <= k <= n.
   !>                 The number of Householder reflectors.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the matrix A as returned by \ref rocsolver_sgeqrf "GEQRF", with the
   !>                 Householder vectors in the first k columns.
   !>                 On exit, the computed matrix Q.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of A.
-  !>     @param[in]
-  !>     ipiv        pointer to type. Array on the GPU of dimension at least k.
+  !>     @param[in] ipiv - pointer to type. Array on the GPU of dimension at least k.
   !>                 The Householder scalars as returned by \ref rocsolver_sgeqrf "GEQRF".
   interface rocsolver_sorg2r
     function rocsolver_sorg2r_(handle,m,n,k,A,lda,ipiv) bind(c, name="rocsolver_sorg2r")
@@ -2623,27 +2495,20 @@ module hipfort_rocsolver
   !>     Householder vectors \f$v_i\f$ and scalars \f$\text{ipiv}[i]\f$, as returned by \ref
   !>     rocsolver_sgeqrf "GEQRF".
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of the matrix Q.
-  !>     @param[in]
-  !>     n           rocblas_int. 0 <= n <= m.
+  !>     @param[in] n - rocblas_int. 0 <= n <= m.
   !>                 The number of columns of the matrix Q.
-  !>     @param[in]
-  !>     k           rocblas_int. 0 <= k <= n.
+  !>     @param[in] k - rocblas_int. 0 <= k <= n.
   !>                 The number of Householder reflectors.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the matrix A as returned by \ref rocsolver_sgeqrf "GEQRF", with the
   !>                 Householder vectors in the first k columns.
   !>                 On exit, the computed matrix Q.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of A.
-  !>     @param[in]
-  !>     ipiv        pointer to type. Array on the GPU of dimension at least k.
+  !>     @param[in] ipiv - pointer to type. Array on the GPU of dimension at least k.
   !>                 The Householder scalars as returned by \ref rocsolver_sgeqrf "GEQRF".
   interface rocsolver_cung2r
     function rocsolver_cung2r_(handle,m,n,k,A,lda,ipiv) bind(c, name="rocsolver_cung2r")
@@ -2710,27 +2575,20 @@ module hipfort_rocsolver
   !>     Householder vectors \f$v_i\f$ and scalars \f$\text{ipiv}[i]\f$, as returned by \ref
   !>     rocsolver_sgeqrf "GEQRF".
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of the matrix Q.
-  !>     @param[in]
-  !>     n           rocblas_int. 0 <= n <= m.
+  !>     @param[in] n - rocblas_int. 0 <= n <= m.
   !>                 The number of columns of the matrix Q.
-  !>     @param[in]
-  !>     k           rocblas_int. 0 <= k <= n.
+  !>     @param[in] k - rocblas_int. 0 <= k <= n.
   !>                 The number of Householder reflectors.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the matrix A as returned by \ref rocsolver_sgeqrf "GEQRF", with the
   !>                 Householder vectors in the first k columns.
   !>                 On exit, the computed matrix Q.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of A.
-  !>     @param[in]
-  !>     ipiv        pointer to type. Array on the GPU of dimension at least k.
+  !>     @param[in] ipiv - pointer to type. Array on the GPU of dimension at least k.
   !>                 The Householder scalars as returned by \ref rocsolver_sgeqrf "GEQRF".
   interface rocsolver_sorgqr
     function rocsolver_sorgqr_(handle,m,n,k,A,lda,ipiv) bind(c, name="rocsolver_sorgqr")
@@ -2797,27 +2655,20 @@ module hipfort_rocsolver
   !>     Householder vectors \f$v_i\f$ and scalars \f$\text{ipiv}[i]\f$, as returned by \ref
   !>     rocsolver_sgeqrf "GEQRF".
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of the matrix Q.
-  !>     @param[in]
-  !>     n           rocblas_int. 0 <= n <= m.
+  !>     @param[in] n - rocblas_int. 0 <= n <= m.
   !>                 The number of columns of the matrix Q.
-  !>     @param[in]
-  !>     k           rocblas_int. 0 <= k <= n.
+  !>     @param[in] k - rocblas_int. 0 <= k <= n.
   !>                 The number of Householder reflectors.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the matrix A as returned by \ref rocsolver_sgeqrf "GEQRF", with the
   !>                 Householder vectors in the first k columns.
   !>                 On exit, the computed matrix Q.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of A.
-  !>     @param[in]
-  !>     ipiv        pointer to type. Array on the GPU of dimension at least k.
+  !>     @param[in] ipiv - pointer to type. Array on the GPU of dimension at least k.
   !>                 The Householder scalars as returned by \ref rocsolver_sgeqrf "GEQRF".
   interface rocsolver_cungqr
     function rocsolver_cungqr_(handle,m,n,k,A,lda,ipiv) bind(c, name="rocsolver_cungqr")
@@ -2884,27 +2735,20 @@ module hipfort_rocsolver
   !>     Householder vectors \f$v_i\f$ and scalars \f$\text{ipiv}[i]\f$, as returned by \ref
   !>     rocsolver_sgelqf "GELQF".
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. 0 <= m <= n.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. 0 <= m <= n.
   !>                 The number of rows of the matrix Q.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of the matrix Q.
-  !>     @param[in]
-  !>     k           rocblas_int. 0 <= k <= m.
+  !>     @param[in] k - rocblas_int. 0 <= k <= m.
   !>                 The number of Householder reflectors.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the matrix A as returned by \ref rocsolver_sgeqrf "GELQF", with the
   !>                 Householder vectors in the first k rows.
   !>                 On exit, the computed matrix Q.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of A.
-  !>     @param[in]
-  !>     ipiv        pointer to type. Array on the GPU, of dimension at least k.
+  !>     @param[in] ipiv - pointer to type. Array on the GPU, of dimension at least k.
   !>                 The Householder scalars as returned by \ref rocsolver_sgelqf "GELQF".
   interface rocsolver_sorgl2
     function rocsolver_sorgl2_(handle,m,n,k,A,lda,ipiv) bind(c, name="rocsolver_sorgl2")
@@ -2972,27 +2816,20 @@ module hipfort_rocsolver
   !>     Householder vectors \f$v_i\f$ and scalars \f$\text{ipiv}[i]\f$, as returned by \ref
   !>     rocsolver_sgelqf "GELQF".
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. 0 <= m <= n.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. 0 <= m <= n.
   !>                 The number of rows of the matrix Q.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of the matrix Q.
-  !>     @param[in]
-  !>     k           rocblas_int. 0 <= k <= m.
+  !>     @param[in] k - rocblas_int. 0 <= k <= m.
   !>                 The number of Householder reflectors.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the matrix A as returned by \ref rocsolver_sgeqrf "GELQF", with the
   !>                 Householder vectors in the first k rows.
   !>                 On exit, the computed matrix Q.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of A.
-  !>     @param[in]
-  !>     ipiv        pointer to type. Array on the GPU of dimension at least k.
+  !>     @param[in] ipiv - pointer to type. Array on the GPU of dimension at least k.
   !>                 The Householder scalars as returned by \ref rocsolver_sgelqf "GELQF".
   interface rocsolver_cungl2
     function rocsolver_cungl2_(handle,m,n,k,A,lda,ipiv) bind(c, name="rocsolver_cungl2")
@@ -3059,27 +2896,20 @@ module hipfort_rocsolver
   !>     Householder vectors \f$v_i\f$ and scalars \f$\text{ipiv}[i]\f$, as returned by \ref
   !>     rocsolver_sgelqf "GELQF".
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. 0 <= m <= n.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. 0 <= m <= n.
   !>                 The number of rows of the matrix Q.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of the matrix Q.
-  !>     @param[in]
-  !>     k           rocblas_int. 0 <= k <= m.
+  !>     @param[in] k - rocblas_int. 0 <= k <= m.
   !>                 The number of Householder reflectors.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the matrix A as returned by \ref rocsolver_sgeqrf "GELQF", with the
   !>                 Householder vectors in the first k rows.
   !>                 On exit, the computed matrix Q.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of A.
-  !>     @param[in]
-  !>     ipiv        pointer to type. Array on the GPU of dimension at least k.
+  !>     @param[in] ipiv - pointer to type. Array on the GPU of dimension at least k.
   !>                 The Householder scalars as returned by \ref rocsolver_sgelqf "GELQF".
   interface rocsolver_sorglq
     function rocsolver_sorglq_(handle,m,n,k,A,lda,ipiv) bind(c, name="rocsolver_sorglq")
@@ -3147,27 +2977,20 @@ module hipfort_rocsolver
   !>     Householder vectors \f$v_i\f$ and scalars \f$\text{ipiv}[i]\f$, as returned by \ref
   !>     rocsolver_sgelqf "GELQF".
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. 0 <= m <= n.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. 0 <= m <= n.
   !>                 The number of rows of the matrix Q.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of the matrix Q.
-  !>     @param[in]
-  !>     k           rocblas_int. 0 <= k <= m.
+  !>     @param[in] k - rocblas_int. 0 <= k <= m.
   !>                 The number of Householder reflectors.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the matrix A as returned by \ref rocsolver_sgeqrf "GELQF", with the
   !>                 Householder vectors in the first k rows.
   !>                 On exit, the computed matrix Q.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of A.
-  !>     @param[in]
-  !>     ipiv        pointer to type. Array on the GPU of dimension at least k.
+  !>     @param[in] ipiv - pointer to type. Array on the GPU of dimension at least k.
   !>                 The Householder scalars as returned by \ref rocsolver_sgelqf "GELQF".
   interface rocsolver_cunglq
     function rocsolver_cunglq_(handle,m,n,k,A,lda,ipiv) bind(c, name="rocsolver_cunglq")
@@ -3233,27 +3056,20 @@ module hipfort_rocsolver
   !>     corresponding Householder vectors \f$v_i\f$ and scalars \f$\text{ipiv}[i]\f$, as returned
   !>     by \ref rocsolver_sgeqlf "GEQLF".
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of the matrix Q.
-  !>     @param[in]
-  !>     n           rocblas_int. 0 <= n <= m.
+  !>     @param[in] n - rocblas_int. 0 <= n <= m.
   !>                 The number of columns of the matrix Q.
-  !>     @param[in]
-  !>     k           rocblas_int. 0 <= k <= n.
+  !>     @param[in] k - rocblas_int. 0 <= k <= n.
   !>                 The number of Householder reflectors.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the matrix A as returned by \ref rocsolver_sgeqrf "GEQLF", with the
   !>                 Householder vectors in the last k columns.
   !>                 On exit, the computed matrix Q.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of A.
-  !>     @param[in]
-  !>     ipiv        pointer to type. Array on the GPU of dimension at least k.
+  !>     @param[in] ipiv - pointer to type. Array on the GPU of dimension at least k.
   !>                 The Householder scalars as returned by \ref rocsolver_sgeqlf "GEQLF".
   interface rocsolver_sorg2l
     function rocsolver_sorg2l_(handle,m,n,k,A,lda,ipiv) bind(c, name="rocsolver_sorg2l")
@@ -3320,27 +3136,20 @@ module hipfort_rocsolver
   !>     corresponding Householder vectors \f$v_i\f$ and scalars \f$\text{ipiv}[i]\f$, as returned
   !>     by \ref rocsolver_sgeqlf "GEQLF".
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of the matrix Q.
-  !>     @param[in]
-  !>     n           rocblas_int. 0 <= n <= m.
+  !>     @param[in] n - rocblas_int. 0 <= n <= m.
   !>                 The number of columns of the matrix Q.
-  !>     @param[in]
-  !>     k           rocblas_int. 0 <= k <= n.
+  !>     @param[in] k - rocblas_int. 0 <= k <= n.
   !>                 The number of Householder reflectors.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the matrix A as returned by \ref rocsolver_sgeqrf "GEQLF", with the
   !>                 Householder vectors in the last k columns.
   !>                 On exit, the computed matrix Q.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of A.
-  !>     @param[in]
-  !>     ipiv        pointer to type. Array on the GPU of dimension at least k.
+  !>     @param[in] ipiv - pointer to type. Array on the GPU of dimension at least k.
   !>                 The Householder scalars as returned by \ref rocsolver_sgeqlf "GEQLF".
   interface rocsolver_cung2l
     function rocsolver_cung2l_(handle,m,n,k,A,lda,ipiv) bind(c, name="rocsolver_cung2l")
@@ -3406,27 +3215,20 @@ module hipfort_rocsolver
   !>     corresponding Householder vectors \f$v_i\f$ and scalars \f$\text{ipiv}[i]\f$, as returned
   !>     by \ref rocsolver_sgeqlf "GEQLF".
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of the matrix Q.
-  !>     @param[in]
-  !>     n           rocblas_int. 0 <= n <= m.
+  !>     @param[in] n - rocblas_int. 0 <= n <= m.
   !>                 The number of columns of the matrix Q.
-  !>     @param[in]
-  !>     k           rocblas_int. 0 <= k <= n.
+  !>     @param[in] k - rocblas_int. 0 <= k <= n.
   !>                 The number of Householder reflectors.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the matrix A as returned by \ref rocsolver_sgeqrf "GEQLF", with the
   !>                 Householder vectors in the last k columns.
   !>                 On exit, the computed matrix Q.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of A.
-  !>     @param[in]
-  !>     ipiv        pointer to type. Array on the GPU of dimension at least k.
+  !>     @param[in] ipiv - pointer to type. Array on the GPU of dimension at least k.
   !>                 The Householder scalars as returned by \ref rocsolver_sgeqlf "GEQLF".
   interface rocsolver_sorgql
     function rocsolver_sorgql_(handle,m,n,k,A,lda,ipiv) bind(c, name="rocsolver_sorgql")
@@ -3493,27 +3295,20 @@ module hipfort_rocsolver
   !>     corresponding Householder vectors \f$v_i\f$ and scalars \f$\text{ipiv}[i]\f$, as returned
   !>     by \ref rocsolver_sgeqlf "GEQLF".
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of the matrix Q.
-  !>     @param[in]
-  !>     n           rocblas_int. 0 <= n <= m.
+  !>     @param[in] n - rocblas_int. 0 <= n <= m.
   !>                 The number of columns of the matrix Q.
-  !>     @param[in]
-  !>     k           rocblas_int. 0 <= k <= n.
+  !>     @param[in] k - rocblas_int. 0 <= k <= n.
   !>                 The number of Householder reflectors.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the matrix A as returned by \ref rocsolver_sgeqrf "GEQLF", with the
   !>                 Householder vectors in the last k columns.
   !>                 On exit, the computed matrix Q.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of A.
-  !>     @param[in]
-  !>     ipiv        pointer to type. Array on the GPU of dimension at least k.
+  !>     @param[in] ipiv - pointer to type. Array on the GPU of dimension at least k.
   !>                 The Householder scalars as returned by \ref rocsolver_sgeqlf "GEQLF".
   interface rocsolver_cungql
     function rocsolver_cungql_(handle,m,n,k,A,lda,ipiv) bind(c, name="rocsolver_cungql")
@@ -3600,33 +3395,25 @@ module hipfort_rocsolver
   !>     Householder vectors \f$v_i\f$ and scalars \f$\text{ipiv}[i]\f$, as returned by \ref
   !>     rocsolver_sgebrd "GEBRD" in its arguments ``A`` and tauq or taup.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     storev      `rocblas_storev`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] storev - `rocblas_storev`.
   !>                 Specifies whether to work column-wise or row-wise.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of the matrix Q.
   !>                 If row-wise, then min(n,k) <= m <= n.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of the matrix Q.
   !>                 If column-wise, then min(m,k) <= n <= m.
-  !>     @param[in]
-  !>     k           rocblas_int. k >= 0.
+  !>     @param[in] k - rocblas_int. k >= 0.
   !>                 The number of columns (if storev is column-wise) or rows (if row-wise) of the
   !>                 original matrix reduced by \ref rocsolver_sgebrd "GEBRD".
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the Householder vectors as returned by \ref rocsolver_sgebrd "GEBRD".
   !>                 On exit, the computed matrix Q.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of A.
-  !>     @param[in]
-  !>     ipiv pointer to type. Array on the GPU of dimension min(m,k) if column-wise, or min(n,k) if
-  !>     row-wise.
+  !>     @param[in] ipiv - pointer to type. Array on the GPU of dimension min(m,k) if column-wise,
+  !>     or min(n,k) if row-wise.
   !>                 The Householder scalars as returned by \ref rocsolver_sgebrd "GEBRD".
   interface rocsolver_sorgbr
     function rocsolver_sorgbr_(handle,storev,m,n,k,A,lda,ipiv) bind(c, name="rocsolver_sorgbr")
@@ -3716,33 +3503,25 @@ module hipfort_rocsolver
   !>     Householder vectors \f$v_i\f$ and scalars \f$\text{ipiv}[i]\f$, as returned by \ref
   !>     rocsolver_sgebrd "GEBRD" in its arguments ``A`` and tauq or taup.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     storev      `rocblas_storev`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] storev - `rocblas_storev`.
   !>                 Specifies whether to work column-wise or row-wise.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of the matrix Q.
   !>                 If row-wise, then min(n,k) <= m <= n.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of the matrix Q.
   !>                 If column-wise, then min(m,k) <= n <= m.
-  !>     @param[in]
-  !>     k           rocblas_int. k >= 0.
+  !>     @param[in] k - rocblas_int. k >= 0.
   !>                 The number of columns (if storev is column-wise) or rows (if row-wise) of the
   !>                 original matrix reduced by \ref rocsolver_sgebrd "GEBRD".
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the Householder vectors as returned by \ref rocsolver_sgebrd "GEBRD".
   !>                 On exit, the computed matrix Q.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of A.
-  !>     @param[in]
-  !>     ipiv pointer to type. Array on the GPU of dimension min(m,k) if column-wise or min(n,k) if
-  !>     row-wise.
+  !>     @param[in] ipiv - pointer to type. Array on the GPU of dimension min(m,k) if column-wise or
+  !>     min(n,k) if row-wise.
   !>                 The Householder scalars as returned by \ref rocsolver_sgebrd "GEBRD".
   interface rocsolver_cungbr
     function rocsolver_cungbr_(handle,storev,m,n,k,A,lda,ipiv) bind(c, name="rocsolver_cungbr")
@@ -3815,26 +3594,20 @@ module hipfort_rocsolver
   !>     by
   !>     \ref rocsolver_ssytrd "SYTRD" in its arguments ``A`` and tau.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the \ref rocsolver_ssytrd "SYTRD" factorization was upper or
   !>                 lower
   !>                 triangular. If uplo indicates lower (or upper), then the upper (or lower)
   !>                 part of A is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows and columns of the matrix Q.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the Householder vectors as returned
   !>                 by \ref rocsolver_ssytrd "SYTRD". On exit, the computed matrix Q.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of A.
-  !>     @param[in]
-  !>     ipiv        pointer to type. Array on the GPU of dimension n-1.
+  !>     @param[in] ipiv - pointer to type. Array on the GPU of dimension n-1.
   !>                 The Householder scalars as returned by \ref rocsolver_ssytrd "SYTRD".
   interface rocsolver_sorgtr
     function rocsolver_sorgtr_(handle,uplo,n,A,lda,ipiv) bind(c, name="rocsolver_sorgtr")
@@ -3903,26 +3676,20 @@ module hipfort_rocsolver
   !>     by
   !>     \ref rocsolver_chetrd "HETRD" in its arguments ``A`` and tau.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the \ref rocsolver_chetrd "HETRD" factorization was upper or
   !>                 lower
   !>                 triangular. If uplo indicates lower (or upper), then the upper (or lower)
   !>                 part of A is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows and columns of the matrix Q.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the Householder vectors as returned
   !>                 by \ref rocsolver_chetrd "HETRD". On exit, the computed matrix Q.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of A.
-  !>     @param[in]
-  !>     ipiv        pointer to type. Array on the GPU of dimension n-1.
+  !>     @param[in] ipiv - pointer to type. Array on the GPU of dimension n-1.
   !>                 The Householder scalars as returned by \ref rocsolver_chetrd "HETRD".
   interface rocsolver_cungtr
     function rocsolver_cungtr_(handle,uplo,n,A,lda,ipiv) bind(c, name="rocsolver_cungtr")
@@ -4000,39 +3767,28 @@ module hipfort_rocsolver
   !>     calculated from the Householder vectors and scalars returned by the QR factorization \ref
   !>     rocsolver_sgeqrf "GEQRF".
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     side        rocblas_side.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] side - rocblas_side.
   !>                 Specifies from which side to apply Q.
-  !>     @param[in]
-  !>     trans       rocblas_operation.
+  !>     @param[in] trans - rocblas_operation.
   !>                 Specifies whether the matrix Q or its transpose is to be applied.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 Number of rows of matrix C.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of columns of matrix C.
-  !>     @param[in]
-  !>     k           rocblas_int. k >= 0. k <= m if side is left, and k <= n if side is right.
+  !>     @param[in] k - rocblas_int. k >= 0. k <= m if side is left, and k <= n if side is right.
   !>                 The number of Householder reflectors that form Q.
-  !>     @param[in]
-  !>     A           pointer to type. Array on the GPU of size lda*k.
+  !>     @param[in] A - pointer to type. Array on the GPU of size lda*k.
   !>                 The Householder vectors as returned by \ref rocsolver_sgeqrf "GEQRF"
   !>                 in the first k columns of its argument A.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m if side is left, or lda >= n if side is right.
+  !>     @param[in] lda - rocblas_int. lda >= m if side is left, or lda >= n if side is right.
   !>                 Leading dimension of A.
-  !>     @param[in]
-  !>     ipiv        pointer to type. Array on the GPU of dimension at least k.
+  !>     @param[in] ipiv - pointer to type. Array on the GPU of dimension at least k.
   !>                 The Householder scalars as returned by \ref rocsolver_sgeqrf "GEQRF".
-  !>     @param[inout]
-  !>     C           pointer to type. Array on the GPU of size ldc*n.
+  !>     @param[inout] C - pointer to type. Array on the GPU of size ldc*n.
   !>                 On entry, the matrix C. On exit, it is overwritten with
   !>                 \f$QC\f$, \f$CQ\f$, \f$Q^TC\f$, or \f$CQ^T\f$.
-  !>     @param[in]
-  !>     ldc         rocblas_int. ldc >= m.
+  !>     @param[in] ldc - rocblas_int. ldc >= m.
   !>                 Leading dimension of C.
   interface rocsolver_sorm2r
     function rocsolver_sorm2r_(handle,side,trans,m,n,k,A,lda,ipiv,C,ldc) &
@@ -4121,39 +3877,28 @@ module hipfort_rocsolver
   !>     calculated from the Householder vectors and scalars returned by the QR factorization \ref
   !>     rocsolver_sgeqrf "GEQRF".
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     side        rocblas_side.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] side - rocblas_side.
   !>                 Specifies from which side to apply Q.
-  !>     @param[in]
-  !>     trans       rocblas_operation.
+  !>     @param[in] trans - rocblas_operation.
   !>                 Specifies whether the matrix Q or its conjugate transpose is to be applied.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 Number of rows of matrix C.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of columns of matrix C.
-  !>     @param[in]
-  !>     k           rocblas_int. k >= 0. k <= m if side is left, and k <= n if side is right.
+  !>     @param[in] k - rocblas_int. k >= 0. k <= m if side is left, and k <= n if side is right.
   !>                 The number of Householder reflectors that form Q.
-  !>     @param[in]
-  !>     A           pointer to type. Array on the GPU of size lda*k.
+  !>     @param[in] A - pointer to type. Array on the GPU of size lda*k.
   !>                 The Householder vectors as returned by \ref rocsolver_sgeqrf "GEQRF"
   !>                 in the first k columns of its argument A.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m if side is left, or lda >= n if side is right.
+  !>     @param[in] lda - rocblas_int. lda >= m if side is left, or lda >= n if side is right.
   !>                 Leading dimension of A.
-  !>     @param[in]
-  !>     ipiv        pointer to type. Array on the GPU of dimension at least k.
+  !>     @param[in] ipiv - pointer to type. Array on the GPU of dimension at least k.
   !>                 The Householder scalars as returned by \ref rocsolver_sgeqrf "GEQRF".
-  !>     @param[inout]
-  !>     C           pointer to type. Array on the GPU of size ldc*n.
+  !>     @param[inout] C - pointer to type. Array on the GPU of size ldc*n.
   !>                 On entry, the matrix C. On exit, it is overwritten with
   !>                 \f$QC\f$, \f$CQ\f$, \f$Q^H C\f$, or \f$CQ^H\f$.
-  !>     @param[in]
-  !>     ldc         rocblas_int. ldc >= m.
+  !>     @param[in] ldc - rocblas_int. ldc >= m.
   !>                 Leading dimension of C.
   interface rocsolver_cunm2r
     function rocsolver_cunm2r_(handle,side,trans,m,n,k,A,lda,ipiv,C,ldc) &
@@ -4243,39 +3988,28 @@ module hipfort_rocsolver
   !>     calculated from the Householder vectors and scalars returned by the QR factorization \ref
   !>     rocsolver_sgeqrf "GEQRF".
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     side        rocblas_side.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] side - rocblas_side.
   !>                 Specifies from which side to apply Q.
-  !>     @param[in]
-  !>     trans       rocblas_operation.
+  !>     @param[in] trans - rocblas_operation.
   !>                 Specifies whether the matrix Q or its transpose is to be applied.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 Number of rows of matrix C.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of columns of matrix C.
-  !>     @param[in]
-  !>     k           rocblas_int. k >= 0. k <= m if side is left, and k <= n if side is right.
+  !>     @param[in] k - rocblas_int. k >= 0. k <= m if side is left, and k <= n if side is right.
   !>                 The number of Householder reflectors that form Q.
-  !>     @param[in]
-  !>     A           pointer to type. Array on the GPU of size lda*k.
+  !>     @param[in] A - pointer to type. Array on the GPU of size lda*k.
   !>                 The Householder vectors as returned by \ref rocsolver_sgeqrf "GEQRF"
   !>                 in the first k columns of its argument A.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m if side is left, or lda >= n if side is right.
+  !>     @param[in] lda - rocblas_int. lda >= m if side is left, or lda >= n if side is right.
   !>                 Leading dimension of A.
-  !>     @param[in]
-  !>     ipiv        pointer to type. Array on the GPU of dimension at least k.
+  !>     @param[in] ipiv - pointer to type. Array on the GPU of dimension at least k.
   !>                 The Householder scalars as returned by \ref rocsolver_sgeqrf "GEQRF".
-  !>     @param[inout]
-  !>     C           pointer to type. Array on the GPU of size ldc*n.
+  !>     @param[inout] C - pointer to type. Array on the GPU of size ldc*n.
   !>                 On entry, the matrix C. On exit, it is overwritten with
   !>                 \f$QC\f$, \f$CQ\f$, \f$Q^TC\f$, or \f$CQ^T\f$.
-  !>     @param[in]
-  !>     ldc         rocblas_int. ldc >= m.
+  !>     @param[in] ldc - rocblas_int. ldc >= m.
   !>                 Leading dimension of C.
   interface rocsolver_sormqr
     function rocsolver_sormqr_(handle,side,trans,m,n,k,A,lda,ipiv,C,ldc) &
@@ -4364,39 +4098,28 @@ module hipfort_rocsolver
   !>     calculated from the Householder vectors and scalars returned by the QR factorization \ref
   !>     rocsolver_sgeqrf "GEQRF".
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     side        rocblas_side.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] side - rocblas_side.
   !>                 Specifies from which side to apply Q.
-  !>     @param[in]
-  !>     trans       rocblas_operation.
+  !>     @param[in] trans - rocblas_operation.
   !>                 Specifies whether the matrix Q or its conjugate transpose is to be applied.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 Number of rows of matrix C.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of columns of matrix C.
-  !>     @param[in]
-  !>     k           rocblas_int. k >= 0. k <= m if side is left, and k <= n if side is right.
+  !>     @param[in] k - rocblas_int. k >= 0. k <= m if side is left, and k <= n if side is right.
   !>                 The number of Householder reflectors that form Q.
-  !>     @param[in]
-  !>     A           pointer to type. Array on the GPU of size lda*k.
+  !>     @param[in] A - pointer to type. Array on the GPU of size lda*k.
   !>                 The Householder vectors as returned by \ref rocsolver_sgeqrf "GEQRF"
   !>                 in the first k columns of its argument A.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m if side is left, or lda >= n if side is right.
+  !>     @param[in] lda - rocblas_int. lda >= m if side is left, or lda >= n if side is right.
   !>                 Leading dimension of A.
-  !>     @param[in]
-  !>     ipiv        pointer to type. Array on the GPU of dimension at least k.
+  !>     @param[in] ipiv - pointer to type. Array on the GPU of dimension at least k.
   !>                 The Householder scalars as returned by \ref rocsolver_sgeqrf "GEQRF".
-  !>     @param[inout]
-  !>     C           pointer to type. Array on the GPU of size ldc*n.
+  !>     @param[inout] C - pointer to type. Array on the GPU of size ldc*n.
   !>                 On entry, the matrix C. On exit, it is overwritten with
   !>                 \f$QC\f$, \f$CQ\f$, \f$Q^H C\f$, or \f$CQ^H\f$.
-  !>     @param[in]
-  !>     ldc         rocblas_int. ldc >= m.
+  !>     @param[in] ldc - rocblas_int. ldc >= m.
   !>                 Leading dimension of C.
   interface rocsolver_cunmqr
     function rocsolver_cunmqr_(handle,side,trans,m,n,k,A,lda,ipiv,C,ldc) &
@@ -4486,40 +4209,29 @@ module hipfort_rocsolver
   !>     calculated from the Householder vectors and scalars returned by the LQ factorization \ref
   !>     rocsolver_sgelqf "GELQF".
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     side        rocblas_side.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] side - rocblas_side.
   !>                 Specifies from which side to apply Q.
-  !>     @param[in]
-  !>     trans       rocblas_operation.
+  !>     @param[in] trans - rocblas_operation.
   !>                 Specifies whether the matrix Q or its transpose is to be applied.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 Number of rows of matrix C.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of columns of matrix C.
-  !>     @param[in]
-  !>     k           rocblas_int. k >= 0. k <= m if side is left, and k <= n if side is right.
+  !>     @param[in] k - rocblas_int. k >= 0. k <= m if side is left, and k <= n if side is right.
   !>                 The number of Householder reflectors that form Q.
-  !>     @param[in]
-  !>     A pointer to type. Array on the GPU of size lda*m if side is left, or lda*n if side is
-  !>     right.
+  !>     @param[in] A - pointer to type. Array on the GPU of size lda*m if side is left, or lda*n if
+  !>     side is right.
   !>                 The Householder vectors as returned by \ref rocsolver_sgelqf "GELQF"
   !>                 in the first k rows of its argument A.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= k.
+  !>     @param[in] lda - rocblas_int. lda >= k.
   !>                 Leading dimension of A.
-  !>     @param[in]
-  !>     ipiv        pointer to type. Array on the GPU of dimension at least k.
+  !>     @param[in] ipiv - pointer to type. Array on the GPU of dimension at least k.
   !>                 The Householder scalars as returned by \ref rocsolver_sgelqf "GELQF".
-  !>     @param[inout]
-  !>     C           pointer to type. Array on the GPU of size ldc*n.
+  !>     @param[inout] C - pointer to type. Array on the GPU of size ldc*n.
   !>                 On entry, the matrix C. On exit, it is overwritten with
   !>                 \f$QC\f$, \f$CQ\f$, \f$Q^TC\f$, or \f$CQ^T\f$.
-  !>     @param[in]
-  !>     ldc         rocblas_int. ldc >= m.
+  !>     @param[in] ldc - rocblas_int. ldc >= m.
   !>                 Leading dimension of C.
   interface rocsolver_sorml2
     function rocsolver_sorml2_(handle,side,trans,m,n,k,A,lda,ipiv,C,ldc) &
@@ -4608,40 +4320,29 @@ module hipfort_rocsolver
   !>     calculated from the Householder vectors and scalars returned by the LQ factorization \ref
   !>     rocsolver_sgelqf "GELQF".
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     side        rocblas_side.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] side - rocblas_side.
   !>                 Specifies from which side to apply Q.
-  !>     @param[in]
-  !>     trans       rocblas_operation.
+  !>     @param[in] trans - rocblas_operation.
   !>                 Specifies whether the matrix Q or its conjugate transpose is to be applied.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 Number of rows of matrix C.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of columns of matrix C.
-  !>     @param[in]
-  !>     k           rocblas_int. k >= 0. k <= m if side is left, and k <= n if side is right.
+  !>     @param[in] k - rocblas_int. k >= 0. k <= m if side is left, and k <= n if side is right.
   !>                 The number of Householder reflectors that form Q.
-  !>     @param[in]
-  !>     A pointer to type. Array on the GPU of size lda*m if side is left or lda*n if side is
-  !>     right.
+  !>     @param[in] A - pointer to type. Array on the GPU of size lda*m if side is left or lda*n if
+  !>     side is right.
   !>                 The Householder vectors as returned by \ref rocsolver_sgelqf "GELQF"
   !>                 in the first k rows of its argument A.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= k.
+  !>     @param[in] lda - rocblas_int. lda >= k.
   !>                 Leading dimension of A.
-  !>     @param[in]
-  !>     ipiv        pointer to type. Array on the GPU of dimension at least k.
+  !>     @param[in] ipiv - pointer to type. Array on the GPU of dimension at least k.
   !>                 The Householder scalars as returned by \ref rocsolver_sgelqf "GELQF".
-  !>     @param[inout]
-  !>     C           pointer to type. Array on the GPU of size ldc*n.
+  !>     @param[inout] C - pointer to type. Array on the GPU of size ldc*n.
   !>                 On entry, the matrix C. On exit, it is overwritten with
   !>                 \f$QC\f$, \f$CQ\f$, \f$Q^H C\f$, or \f$CQ^H\f$.
-  !>     @param[in]
-  !>     ldc         rocblas_int. ldc >= m.
+  !>     @param[in] ldc - rocblas_int. ldc >= m.
   !>                 Leading dimension of C.
   interface rocsolver_cunml2
     function rocsolver_cunml2_(handle,side,trans,m,n,k,A,lda,ipiv,C,ldc) &
@@ -4731,40 +4432,29 @@ module hipfort_rocsolver
   !>     calculated from the Householder vectors and scalars returned by the LQ factorization \ref
   !>     rocsolver_sgelqf "GELQF".
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     side        rocblas_side.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] side - rocblas_side.
   !>                 Specifies from which side to apply Q.
-  !>     @param[in]
-  !>     trans       rocblas_operation.
+  !>     @param[in] trans - rocblas_operation.
   !>                 Specifies whether the matrix Q or its transpose is to be applied.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 Number of rows of matrix C.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of columns of matrix C.
-  !>     @param[in]
-  !>     k           rocblas_int. k >= 0. k <= m if side is left, and k <= n if side is right.
+  !>     @param[in] k - rocblas_int. k >= 0. k <= m if side is left, and k <= n if side is right.
   !>                 The number of Householder reflectors that form Q.
-  !>     @param[in]
-  !>     A pointer to type. Array on the GPU of size lda*m if side is left, or lda*n if side is
-  !>     right.
+  !>     @param[in] A - pointer to type. Array on the GPU of size lda*m if side is left, or lda*n if
+  !>     side is right.
   !>                 The Householder vectors as returned by \ref rocsolver_sgelqf "GELQF"
   !>                 in the first k rows of its argument A.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= k.
+  !>     @param[in] lda - rocblas_int. lda >= k.
   !>                 Leading dimension of A.
-  !>     @param[in]
-  !>     ipiv        pointer to type. Array on the GPU of dimension at least k.
+  !>     @param[in] ipiv - pointer to type. Array on the GPU of dimension at least k.
   !>                 The Householder scalars as returned by \ref rocsolver_sgelqf "GELQF".
-  !>     @param[inout]
-  !>     C           pointer to type. Array on the GPU of size ldc*n.
+  !>     @param[inout] C - pointer to type. Array on the GPU of size ldc*n.
   !>                 On entry, the matrix C. On exit, it is overwritten with
   !>                 \f$QC\f$, \f$CQ\f$, \f$Q^TC\f$, or \f$CQ^T\f$.
-  !>     @param[in]
-  !>     ldc         rocblas_int. ldc >= m.
+  !>     @param[in] ldc - rocblas_int. ldc >= m.
   !>                 Leading dimension of C.
   interface rocsolver_sormlq
     function rocsolver_sormlq_(handle,side,trans,m,n,k,A,lda,ipiv,C,ldc) &
@@ -4853,40 +4543,29 @@ module hipfort_rocsolver
   !>     calculated from the Householder vectors and scalars returned by the LQ factorization \ref
   !>     rocsolver_sgelqf "GELQF".
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     side        rocblas_side.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] side - rocblas_side.
   !>                 Specifies from which side to apply Q.
-  !>     @param[in]
-  !>     trans       rocblas_operation.
+  !>     @param[in] trans - rocblas_operation.
   !>                 Specifies whether the matrix Q or its conjugate transpose is to be applied.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 Number of rows of matrix C.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of columns of matrix C.
-  !>     @param[in]
-  !>     k           rocblas_int. k >= 0. k <= m if side is left, and k <= n if side is right.
+  !>     @param[in] k - rocblas_int. k >= 0. k <= m if side is left, and k <= n if side is right.
   !>                 The number of Householder reflectors that form Q.
-  !>     @param[in]
-  !>     A pointer to type. Array on the GPU of size lda*m if side is left or lda*n if side is
-  !>     right.
+  !>     @param[in] A - pointer to type. Array on the GPU of size lda*m if side is left or lda*n if
+  !>     side is right.
   !>                 The Householder vectors as returned by \ref rocsolver_sgelqf "GELQF"
   !>                 in the first k rows of its argument A.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= k.
+  !>     @param[in] lda - rocblas_int. lda >= k.
   !>                 Leading dimension of A.
-  !>     @param[in]
-  !>     ipiv        pointer to type. Array on the GPU of dimension at least k.
+  !>     @param[in] ipiv - pointer to type. Array on the GPU of dimension at least k.
   !>                 The Householder scalars as returned by \ref rocsolver_sgelqf "GELQF".
-  !>     @param[inout]
-  !>     C           pointer to type. Array on the GPU of size ldc*n.
+  !>     @param[inout] C - pointer to type. Array on the GPU of size ldc*n.
   !>                 On entry, the matrix C. On exit, it is overwritten with
   !>                 \f$QC\f$, \f$CQ\f$, \f$Q^H C\f$, or \f$CQ^H\f$.
-  !>     @param[in]
-  !>     ldc         rocblas_int. ldc >= m.
+  !>     @param[in] ldc - rocblas_int. ldc >= m.
   !>                 Leading dimension of C.
   interface rocsolver_cunmlq
     function rocsolver_cunmlq_(handle,side,trans,m,n,k,A,lda,ipiv,C,ldc) &
@@ -4975,42 +4654,31 @@ module hipfort_rocsolver
   !>     never stored. It is calculated from the Householder vectors and scalars
   !>     returned by the QL factorization \ref rocsolver_sgeqlf "GEQLF".
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     side        rocblas_side.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] side - rocblas_side.
   !>                 Specifies from which side to apply Q.
-  !>     @param[in]
-  !>     trans       rocblas_operation.
+  !>     @param[in] trans - rocblas_operation.
   !>                 Specifies whether the matrix Q or its transpose is to be
   !>                 applied.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 Number of rows of matrix C.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of columns of matrix C.
-  !>     @param[in]
-  !>     k           rocblas_int. k >= 0. k <= m if side is left, and k <= n if side is right.
+  !>     @param[in] k - rocblas_int. k >= 0. k <= m if side is left, and k <= n if side is right.
   !>                 The number of Householder reflectors that form Q.
-  !>     @param[in]
-  !>     A           pointer to type. Array on the GPU of size lda*k.
+  !>     @param[in] A - pointer to type. Array on the GPU of size lda*k.
   !>                 The Householder vectors as returned by \ref rocsolver_sgeqlf "GEQLF" in the
   !>                 last k columns of its
   !>                 argument A.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m if side is left, and lda >= n if side is right.
+  !>     @param[in] lda - rocblas_int. lda >= m if side is left, and lda >= n if side is right.
   !>                 Leading dimension of A.
-  !>     @param[in]
-  !>     ipiv        pointer to type. Array on the GPU of dimension at least k.
+  !>     @param[in] ipiv - pointer to type. Array on the GPU of dimension at least k.
   !>                 The Householder scalars as returned by
   !>                 \ref rocsolver_sgeqlf "GEQLF".
-  !>     @param[inout]
-  !>     C           pointer to type. Array on the GPU of size ldc*n.
+  !>     @param[inout] C - pointer to type. Array on the GPU of size ldc*n.
   !>                 On entry, the matrix C. On exit, it is overwritten with
   !>                 \f$QC\f$, \f$CQ\f$, \f$Q^TC\f$, or \f$CQ^T\f$.
-  !>     @param[in]
-  !>     ldc         rocblas_int. ldc >= m.
+  !>     @param[in] ldc - rocblas_int. ldc >= m.
   !>                 Leading dimension of C.
   interface rocsolver_sorm2l
     function rocsolver_sorm2l_(handle,side,trans,m,n,k,A,lda,ipiv,C,ldc) &
@@ -5098,42 +4766,31 @@ module hipfort_rocsolver
   !>     never stored. It is calculated from the Householder vectors and scalars
   !>     returned by the QL factorization \ref rocsolver_sgeqlf "GEQLF".
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     side        rocblas_side.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] side - rocblas_side.
   !>                 Specifies from which side to apply Q.
-  !>     @param[in]
-  !>     trans       rocblas_operation.
+  !>     @param[in] trans - rocblas_operation.
   !>                 Specifies whether the matrix Q or its conjugate
   !>                 transpose is to be applied.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 Number of rows of matrix C.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of columns of matrix C.
-  !>     @param[in]
-  !>     k           rocblas_int. k >= 0. k <= m if side is left, and k <= n if side is right.
+  !>     @param[in] k - rocblas_int. k >= 0. k <= m if side is left, and k <= n if side is right.
   !>                 The number of Householder reflectors that form Q.
-  !>     @param[in]
-  !>     A           pointer to type. Array on the GPU of size lda*k.
+  !>     @param[in] A - pointer to type. Array on the GPU of size lda*k.
   !>                 The Householder vectors as returned by \ref rocsolver_sgeqlf "GEQLF" in the
   !>                 last k columns of its
   !>                 argument A.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m if side is left, and lda >= n if side is right.
+  !>     @param[in] lda - rocblas_int. lda >= m if side is left, and lda >= n if side is right.
   !>                 Leading dimension of A.
-  !>     @param[in]
-  !>     ipiv        pointer to type. Array on the GPU of dimension at least k.
+  !>     @param[in] ipiv - pointer to type. Array on the GPU of dimension at least k.
   !>                 The Householder scalars as returned by
   !>                 \ref rocsolver_sgeqlf "GEQLF".
-  !>     @param[inout]
-  !>     C           pointer to type. Array on the GPU of size ldc*n.
+  !>     @param[inout] C - pointer to type. Array on the GPU of size ldc*n.
   !>                 On entry, the matrix C. On exit, it is overwritten with
   !>                 \f$QC\f$, \f$CQ\f$, \f$Q^HC\f$, or \f$CQ^H\f$.
-  !>     @param[in]
-  !>     ldc         rocblas_int. ldc >= m.
+  !>     @param[in] ldc - rocblas_int. ldc >= m.
   !>                 Leading dimension of C.
   interface rocsolver_cunm2l
     function rocsolver_cunm2l_(handle,side,trans,m,n,k,A,lda,ipiv,C,ldc) &
@@ -5222,42 +4879,31 @@ module hipfort_rocsolver
   !>     never stored. It is calculated from the Householder vectors and scalars
   !>     returned by the QL factorization \ref rocsolver_sgeqlf "GEQLF".
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     side        rocblas_side.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] side - rocblas_side.
   !>                 Specifies from which side to apply Q.
-  !>     @param[in]
-  !>     trans       rocblas_operation.
+  !>     @param[in] trans - rocblas_operation.
   !>                 Specifies whether the matrix Q or its transpose is to be
   !>                 applied.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 Number of rows of matrix C.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of columns of matrix C.
-  !>     @param[in]
-  !>     k           rocblas_int. k >= 0. k <= m if side is left, and k <= n if side is right.
+  !>     @param[in] k - rocblas_int. k >= 0. k <= m if side is left, and k <= n if side is right.
   !>                 The number of Householder reflectors that form Q.
-  !>     @param[in]
-  !>     A           pointer to type. Array on the GPU of size lda*k.
+  !>     @param[in] A - pointer to type. Array on the GPU of size lda*k.
   !>                 The Householder vectors as returned by \ref rocsolver_sgeqlf "GEQLF" in the
   !>                 last k columns of its
   !>                 argument A.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m if side is left, and lda >= n if side is right.
+  !>     @param[in] lda - rocblas_int. lda >= m if side is left, and lda >= n if side is right.
   !>                 Leading dimension of A.
-  !>     @param[in]
-  !>     ipiv        pointer to type. Array on the GPU of dimension at least k.
+  !>     @param[in] ipiv - pointer to type. Array on the GPU of dimension at least k.
   !>                 The Householder scalars as returned by
   !>                 \ref rocsolver_sgeqlf "GEQLF".
-  !>     @param[inout]
-  !>     C           pointer to type. Array on the GPU of size ldc*n.
+  !>     @param[inout] C - pointer to type. Array on the GPU of size ldc*n.
   !>                 On entry, the matrix C. On exit, it is overwritten with
   !>                 \f$QC\f$, \f$CQ\f$, \f$Q^TC\f$, or \f$CQ^T\f$.
-  !>     @param[in]
-  !>     ldc         rocblas_int. ldc >= m.
+  !>     @param[in] ldc - rocblas_int. ldc >= m.
   !>                 Leading dimension of C.
   interface rocsolver_sormql
     function rocsolver_sormql_(handle,side,trans,m,n,k,A,lda,ipiv,C,ldc) &
@@ -5345,42 +4991,31 @@ module hipfort_rocsolver
   !>     never stored. It is calculated from the Householder vectors and scalars
   !>     returned by the QL factorization \ref rocsolver_sgeqlf "GEQLF".
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     side        rocblas_side.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] side - rocblas_side.
   !>                 Specifies from which side to apply Q.
-  !>     @param[in]
-  !>     trans       rocblas_operation.
+  !>     @param[in] trans - rocblas_operation.
   !>                 Specifies whether the matrix Q or its conjugate
   !>                 transpose is to be applied.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 Number of rows of matrix C.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of columns of matrix C.
-  !>     @param[in]
-  !>     k           rocblas_int. k >= 0. k <= m if side is left, and k <= n if side is right.
+  !>     @param[in] k - rocblas_int. k >= 0. k <= m if side is left, and k <= n if side is right.
   !>                 The number of Householder reflectors that form Q.
-  !>     @param[in]
-  !>     A           pointer to type. Array on the GPU of size lda*k.
+  !>     @param[in] A - pointer to type. Array on the GPU of size lda*k.
   !>                 The Householder vectors as returned by \ref rocsolver_sgeqlf "GEQLF" in the
   !>                 last k columns of its
   !>                 argument A.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m if side is left, and lda >= n if side is right.
+  !>     @param[in] lda - rocblas_int. lda >= m if side is left, and lda >= n if side is right.
   !>                 Leading dimension of A.
-  !>     @param[in]
-  !>     ipiv        pointer to type. Array on the GPU of dimension at least k.
+  !>     @param[in] ipiv - pointer to type. Array on the GPU of dimension at least k.
   !>                 The Householder scalars as returned by
   !>                 \ref rocsolver_sgeqlf "GEQLF".
-  !>     @param[inout]
-  !>     C           pointer to type. Array on the GPU of size ldc*n.
+  !>     @param[inout] C - pointer to type. Array on the GPU of size ldc*n.
   !>                 On entry, the matrix C. On exit, it is overwritten with
   !>                 \f$QC\f$, \f$CQ\f$, \f$Q^HC\f$, or \f$CQ^H\f$.
-  !>     @param[in]
-  !>     ldc         rocblas_int. ldc >= m.
+  !>     @param[in] ldc - rocblas_int. ldc >= m.
   !>                 Leading dimension of C.
   interface rocsolver_cunmql
     function rocsolver_cunmql_(handle,side,trans,m,n,k,A,lda,ipiv,C,ldc) &
@@ -5492,43 +5127,31 @@ module hipfort_rocsolver
   !>     Householder vectors and scalars as returned by \ref rocsolver_sgebrd "GEBRD" in its
   !>     arguments ``A`` and tauq or taup.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     storev      `rocblas_storev`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] storev - `rocblas_storev`.
   !>                 Specifies whether to work column-wise or row-wise.
-  !>     @param[in]
-  !>     side        rocblas_side.
+  !>     @param[in] side - rocblas_side.
   !>                 Specifies from which side to apply Q.
-  !>     @param[in]
-  !>     trans       rocblas_operation.
+  !>     @param[in] trans - rocblas_operation.
   !>                 Specifies whether the matrix Q or its transpose is to be applied.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 Number of rows of matrix C.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of columns of matrix C.
-  !>     @param[in]
-  !>     k           rocblas_int. k >= 0.
+  !>     @param[in] k - rocblas_int. k >= 0.
   !>                 The number of columns (if storev is column-wise) or rows (if row-wise) of the
   !>                 original matrix reduced by \ref rocsolver_sgebrd "GEBRD".
-  !>     @param[in]
-  !>     A pointer to type. Array on the GPU of size lda*min(q,k) if column-wise, or lda*q if
-  !>     row-wise.
+  !>     @param[in] A - pointer to type. Array on the GPU of size lda*min(q,k) if column-wise, or
+  !>     lda*q if row-wise.
   !>                 The Householder vectors as returned by \ref rocsolver_sgebrd "GEBRD".
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= q if column-wise, or lda >= min(q,k) if row-wise.
+  !>     @param[in] lda - rocblas_int. lda >= q if column-wise, or lda >= min(q,k) if row-wise.
   !>                 Leading dimension of A.
-  !>     @param[in]
-  !>     ipiv        pointer to type. Array on the GPU of dimension at least min(q,k).
+  !>     @param[in] ipiv - pointer to type. Array on the GPU of dimension at least min(q,k).
   !>                 The Householder scalars as returned by \ref rocsolver_sgebrd "GEBRD".
-  !>     @param[inout]
-  !>     C           pointer to type. Array on the GPU of size ldc*n.
+  !>     @param[inout] C - pointer to type. Array on the GPU of size ldc*n.
   !>                 On entry, the matrix C. On exit, it is overwritten with
   !>                 \f$QC\f$, \f$CQ\f$, \f$Q^TC\f$, or \f$CQ^T\f$.
-  !>     @param[in]
-  !>     ldc         rocblas_int. ldc >= m.
+  !>     @param[in] ldc - rocblas_int. ldc >= m.
   !>                 Leading dimension of C.
   interface rocsolver_sormbr
     function rocsolver_sormbr_(handle,storev,side,trans,m,n,k,A,lda,ipiv,C,ldc) &
@@ -5642,43 +5265,31 @@ module hipfort_rocsolver
   !>     Householder vectors and scalars as returned by \ref rocsolver_sgebrd "GEBRD" in its
   !>     arguments ``A`` and tauq or taup.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     storev      `rocblas_storev`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] storev - `rocblas_storev`.
   !>                 Specifies whether to work column-wise or row-wise.
-  !>     @param[in]
-  !>     side        rocblas_side.
+  !>     @param[in] side - rocblas_side.
   !>                 Specifies from which side to apply Q.
-  !>     @param[in]
-  !>     trans       rocblas_operation.
+  !>     @param[in] trans - rocblas_operation.
   !>                 Specifies whether the matrix Q or its conjugate transpose is to be applied.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 Number of rows of matrix C.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of columns of matrix C.
-  !>     @param[in]
-  !>     k           rocblas_int. k >= 0.
+  !>     @param[in] k - rocblas_int. k >= 0.
   !>                 The number of columns (if storev is column-wise) or rows (if row-wise) of the
   !>                 original matrix reduced by \ref rocsolver_sgebrd "GEBRD".
-  !>     @param[in]
-  !>     A pointer to type. Array on the GPU of size lda*min(q,k) if column-wise, or lda*q if
-  !>     row-wise.
+  !>     @param[in] A - pointer to type. Array on the GPU of size lda*min(q,k) if column-wise, or
+  !>     lda*q if row-wise.
   !>                 The Householder vectors as returned by \ref rocsolver_sgebrd "GEBRD".
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= q if column-wise, or lda >= min(q,k) if row-wise.
+  !>     @param[in] lda - rocblas_int. lda >= q if column-wise, or lda >= min(q,k) if row-wise.
   !>                 Leading dimension of A.
-  !>     @param[in]
-  !>     ipiv        pointer to type. Array on the GPU of dimension at least min(q,k).
+  !>     @param[in] ipiv - pointer to type. Array on the GPU of dimension at least min(q,k).
   !>                 The Householder scalars as returned by \ref rocsolver_sgebrd "GEBRD".
-  !>     @param[inout]
-  !>     C           pointer to type. Array on the GPU of size ldc*n.
+  !>     @param[inout] C - pointer to type. Array on the GPU of size ldc*n.
   !>                 On entry, the matrix C. On exit, it is overwritten with
   !>                 \f$QC\f$, \f$CQ\f$, \f$Q^H C\f$, or \f$CQ^H\f$.
-  !>     @param[in]
-  !>     ldc         rocblas_int. ldc >= m.
+  !>     @param[in] ldc - rocblas_int. ldc >= m.
   !>                 Leading dimension of C.
   interface rocsolver_cunmbr
     function rocsolver_cunmbr_(handle,storev,side,trans,m,n,k,A,lda,ipiv,C,ldc) &
@@ -5776,43 +5387,32 @@ module hipfort_rocsolver
   !>     corresponding Householder vectors and scalars as returned by
   !>     \ref rocsolver_ssytrd "SYTRD" in its arguments ``A`` and tau.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     side        rocblas_side.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] side - rocblas_side.
   !>                 Specifies from which side to apply Q.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the \ref rocsolver_ssytrd "SYTRD" factorization was upper or
   !>                 lower triangular. If uplo indicates lower (or upper), then the upper (or
   !>                 lower) part of A is not used.
-  !>     @param[in]
-  !>     trans       rocblas_operation.
+  !>     @param[in] trans - rocblas_operation.
   !>                 Specifies whether the matrix Q or its transpose is to be
   !>                 applied.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 Number of rows of matrix C.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of columns of matrix C.
-  !>     @param[in]
-  !>     A           pointer to type. Array on the GPU of size lda*q.
+  !>     @param[in] A - pointer to type. Array on the GPU of size lda*q.
   !>                 On entry, the Householder vectors as
   !>                 returned by \ref rocsolver_ssytrd "SYTRD".
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= q.
+  !>     @param[in] lda - rocblas_int. lda >= q.
   !>                 Leading dimension of A.
-  !>     @param[in]
-  !>     ipiv        pointer to type. Array on the GPU of dimension at least q-1.
+  !>     @param[in] ipiv - pointer to type. Array on the GPU of dimension at least q-1.
   !>                 The Householder scalars as returned by
   !>                 \ref rocsolver_ssytrd "SYTRD".
-  !>     @param[inout]
-  !>     C           pointer to type. Array on the GPU of size ldc*n.
+  !>     @param[inout] C - pointer to type. Array on the GPU of size ldc*n.
   !>                 On entry, the matrix C. On exit, it is overwritten with
   !>                 \f$QC\f$, \f$CQ\f$, \f$Q^TC\f$, or \f$CQ^T\f$.
-  !>     @param[in]
-  !>     ldc         rocblas_int. ldc >= m.
+  !>     @param[in] ldc - rocblas_int. ldc >= m.
   !>                 Leading dimension of C.
   interface rocsolver_sormtr
     function rocsolver_sormtr_(handle,side,uplo,trans,m,n,A,lda,ipiv,C,ldc) &
@@ -5908,43 +5508,32 @@ module hipfort_rocsolver
   !>     corresponding Householder vectors and scalars as returned by
   !>     \ref rocsolver_chetrd "HETRD" in its arguments ``A`` and tau.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     side        rocblas_side.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] side - rocblas_side.
   !>                 Specifies from which side to apply Q.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the \ref rocsolver_chetrd "HETRD" factorization was upper or
   !>                 lower triangular. If uplo indicates lower (or upper), then the upper (or
   !>                 lower) part of A is not used.
-  !>     @param[in]
-  !>     trans       rocblas_operation.
+  !>     @param[in] trans - rocblas_operation.
   !>                 Specifies whether the matrix Q or its conjugate
   !>                 transpose is to be applied.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 Number of rows of matrix C.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of columns of matrix C.
-  !>     @param[in]
-  !>     A           pointer to type. Array on the GPU of size lda*q.
+  !>     @param[in] A - pointer to type. Array on the GPU of size lda*q.
   !>                 On entry, the Householder vectors as
   !>                 returned by \ref rocsolver_chetrd "HETRD".
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= q.
+  !>     @param[in] lda - rocblas_int. lda >= q.
   !>                 Leading dimension of A.
-  !>     @param[in]
-  !>     ipiv        pointer to type. Array on the GPU of dimension at least q-1.
+  !>     @param[in] ipiv - pointer to type. Array on the GPU of dimension at least q-1.
   !>                 The Householder scalars as returned by
   !>                 \ref rocsolver_chetrd "HETRD".
-  !>     @param[inout]
-  !>     C           pointer to type. Array on the GPU of size ldc*n.
+  !>     @param[inout] C - pointer to type. Array on the GPU of size ldc*n.
   !>                 On entry, the matrix C. On exit, it is overwritten with
   !>                 \f$QC\f$, \f$CQ\f$, \f$Q^HC\f$, or \f$CQ^H\f$.
-  !>     @param[in]
-  !>     ldc         rocblas_int. ldc >= m.
+  !>     @param[in] ldc - rocblas_int. ldc >= m.
   !>                 Leading dimension of C.
   interface rocsolver_cunmtr
     function rocsolver_cunmtr_(handle,side,uplo,trans,m,n,A,lda,ipiv,C,ldc) &
@@ -6036,57 +5625,42 @@ module hipfort_rocsolver
   !>     architectures.
   !>     Use \ref rocsolver_set_alg_mode to enable it.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether B is upper or lower bidiagonal.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows and columns of matrix B.
-  !>     @param[in]
-  !>     nv          rocblas_int. nv >= 0.
+  !>     @param[in] nv - rocblas_int. nv >= 0.
   !>                 The number of columns of matrix V.
-  !>     @param[in]
-  !>     nu          rocblas_int. nu >= 0.
+  !>     @param[in] nu - rocblas_int. nu >= 0.
   !>                 The number of rows of matrix U.
-  !>     @param[in]
-  !>     nc          rocblas_int. nc >= 0.
+  !>     @param[in] nc - rocblas_int. nc >= 0.
   !>                 The number of columns of matrix C.
-  !>     @param[inout]
-  !>     D           pointer to real type. Array on the GPU of dimension n.
+  !>     @param[inout] D - pointer to real type. Array on the GPU of dimension n.
   !>                 On entry, the diagonal elements of B. On exit, if info = 0,
   !>                 the singular values of B in decreasing order, and if info > 0,
   !>                 the diagonal elements of a bidiagonal matrix
   !>                 orthogonally equivalent to B.
-  !>     @param[inout]
-  !>     E           pointer to real type. Array on the GPU of dimension n-1.
+  !>     @param[inout] E - pointer to real type. Array on the GPU of dimension n-1.
   !>                 On entry, the off-diagonal elements of B. On exit, if info > 0,
   !>                 the off-diagonal elements of a bidiagonal matrix
   !>                 orthogonally equivalent to B (if info = 0 this matrix converges to zero).
-  !>     @param[inout]
-  !>     V           pointer to type. Array on the GPU of dimension ldv*nv.
+  !>     @param[inout] V - pointer to type. Array on the GPU of dimension ldv*nv.
   !>                 On entry, the matrix V. On exit, it is overwritten with \f$P^H V\f$.
   !>                 (Not referenced if nv = 0.)
-  !>     @param[in]
-  !>     ldv         rocblas_int. ldv >= n if nv > 0, or ldv >=1 if nv = 0.
+  !>     @param[in] ldv - rocblas_int. ldv >= n if nv > 0, or ldv >=1 if nv = 0.
   !>                 The leading dimension of V.
-  !>     @param[inout]
-  !>     U           pointer to type. Array on the GPU of dimension ldu*n.
+  !>     @param[inout] U - pointer to type. Array on the GPU of dimension ldu*n.
   !>                 On entry, the matrix U. On exit, it is overwritten with \f$UQ\f$.
   !>                 (Not referenced if nu = 0.)
-  !>     @param[in]
-  !>     ldu         rocblas_int. ldu >= nu.
+  !>     @param[in] ldu - rocblas_int. ldu >= nu.
   !>                 The leading dimension of U.
-  !>     @param[inout]
-  !>     C           pointer to type. Array on the GPU of dimension ldc*nc.
+  !>     @param[inout] C - pointer to type. Array on the GPU of dimension ldc*nc.
   !>                 On entry, the matrix C. On exit, it is overwritten with \f$Q^H C\f$.
   !>                 (Not referenced if nc = 0.)
-  !>     @param[in]
-  !>     ldc         rocblas_int. ldc >= n if nc > 0, or ldc >=1 if nc = 0.
+  !>     @param[in] ldc - rocblas_int. ldc >= n if nc > 0, or ldc >=1 if nc = 0.
   !>                 The leading dimension of C.
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info = 0, successful exit.
   !>                 If info = i > 0, i elements of E have not converged to zero.
   interface rocsolver_sbdsqr
@@ -6235,27 +5809,22 @@ module hipfort_rocsolver
   !>     A hybrid (CPU+GPU) approach is available for STERF, primarily intended for
   !>     homogeneous architectures. Use \ref rocsolver_set_alg_mode to enable it.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows and columns of the tridiagonal matrix.
-  !>     @param[inout]
-  !>     D           pointer to real type. Array on the GPU of dimension n.
+  !>     @param[inout] D - pointer to real type. Array on the GPU of dimension n.
   !>                 On entry, the diagonal elements of the tridiagonal matrix.
   !>                 On exit, if info = 0, the eigenvalues in increasing order.
   !>                 If info > 0, the diagonal elements of a tridiagonal matrix
   !>                 that is similar to the original matrix (that is, it has the same
   !>                 eigenvalues).
-  !>     @param[inout]
-  !>     E           pointer to real type. Array on the GPU of dimension n-1.
+  !>     @param[inout] E - pointer to real type. Array on the GPU of dimension n-1.
   !>                 On entry, the off-diagonal elements of the tridiagonal matrix.
   !>                 On exit, if info = 0, this array converges to zero.
   !>                 If info > 0, the off-diagonal elements of a tridiagonal matrix
   !>                 that is similar to the original matrix (that is, it has the same
   !>                 eigenvalues).
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info = 0, successful exit.
   !>                 If info = i > 0, STERF did not converge. i elements of E did not
   !>                 converge to zero.
@@ -6316,30 +5885,24 @@ module hipfort_rocsolver
   !>     original matrix can also
   !>     be computed, depending on the value of ``evect``.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies how the eigenvectors are computed.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows and columns of the tridiagonal matrix.
-  !>     @param[inout]
-  !>     D           pointer to real type. Array on the GPU of dimension n.
+  !>     @param[inout] D - pointer to real type. Array on the GPU of dimension n.
   !>                 On entry, the diagonal elements of the tridiagonal matrix.
   !>                 On exit, if info = 0, the eigenvalues in increasing order.
   !>                 If info > 0, the diagonal elements of a tridiagonal matrix
   !>                 that is similar to the original matrix (that is, it has the same
   !>                 eigenvalues).
-  !>     @param[inout]
-  !>     E           pointer to real type. Array on the GPU of dimension n-1.
+  !>     @param[inout] E - pointer to real type. Array on the GPU of dimension n-1.
   !>                 On entry, the off-diagonal elements of the tridiagonal matrix.
   !>                 On exit, if info = 0, this array converges to zero.
   !>                 If info > 0, the off-diagonal elements of a tridiagonal matrix
   !>                 that is similar to the original matrix (that is, it has the same
   !>                 eigenvalues).
-  !>     @param[inout]
-  !>     C           pointer to type. Array on the GPU of dimension ldc*n.
+  !>     @param[inout] C - pointer to type. Array on the GPU of dimension ldc*n.
   !>                 On entry, if evect is original, the orthogonal/unitary matrix
   !>                 used for the reduction to tridiagonal form as returned by, for example,
   !>                 \ref rocsolver_sorgtr "ORGTR" or \ref rocsolver_cungtr "UNGTR".
@@ -6347,12 +5910,10 @@ module hipfort_rocsolver
   !>                 symmetric/Hermitian matrix (if evect is original) or the
   !>                 eigenvectors of the tridiagonal matrix (if evect is tridiagonal).
   !>                 (Not referenced if evect is none.)
-  !>     @param[in]
-  !>     ldc         rocblas_int. ldc >= n if evect is original or tridiagonal.
+  !>     @param[in] ldc - rocblas_int. ldc >= n if evect is original or tridiagonal.
   !>                 Specifies the leading dimension of C.
   !>                 (Not referenced if evect is none.)
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info = 0, successful exit.
   !>                 If info = i > 0, STEQR did not converge. i elements of E did not
   !>                 converge to zero.
@@ -6471,24 +6032,18 @@ module hipfort_rocsolver
   !>     original matrix can also
   !>     be computed, depending on the value of ``evect``.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies how the eigenvectors are computed.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows and columns of the tridiagonal matrix.
-  !>     @param[inout]
-  !>     D           pointer to real type. Array on the GPU of dimension n.
+  !>     @param[inout] D - pointer to real type. Array on the GPU of dimension n.
   !>                 On entry, the diagonal elements of the tridiagonal matrix.
   !>                 On exit, if info = 0, the eigenvalues in increasing order.
-  !>     @param[inout]
-  !>     E           pointer to real type. Array on the GPU of dimension n-1.
+  !>     @param[inout] E - pointer to real type. Array on the GPU of dimension n-1.
   !>                 On entry, the off-diagonal elements of the tridiagonal matrix.
   !>                 On exit, if info = 0, the values of this array are destroyed.
-  !>     @param[inout]
-  !>     C           pointer to type. Array on the GPU of dimension ldc*n.
+  !>     @param[inout] C - pointer to type. Array on the GPU of dimension ldc*n.
   !>                 On entry, if evect is original, the orthogonal/unitary matrix
   !>                 used for the reduction to tridiagonal form as returned by, for example,
   !>                 \ref rocsolver_sorgtr "ORGTR" or \ref rocsolver_cungtr "UNGTR".
@@ -6496,11 +6051,9 @@ module hipfort_rocsolver
   !>                 symmetric/Hermitian matrix (if evect is original) or the
   !>                 eigenvectors of the tridiagonal matrix (if evect is tridiagonal).
   !>                 (Not referenced if evect is none.)
-  !>     @param[in]
-  !>     ldc         rocblas_int. ldc >= n if evect is original or tridiagonal.
+  !>     @param[in] ldc - rocblas_int. ldc >= n if evect is original or tridiagonal.
   !>                 Specifies the leading dimension of C. (Not referenced if evect is none.)
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info = 0, successful exit.
   !>                 If info = i > 0, STEDC failed to compute an eigenvalue on the sub-matrix formed
   !>                 by
@@ -6617,41 +6170,32 @@ module hipfort_rocsolver
   !>     independent
   !>     diagonal blocks (if they exist), depending on the value of ``eorder``.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     erange      `rocblas_erange`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] erange - `rocblas_erange`.
   !>                 Specifies the type of range or interval of the eigenvalues to be computed.
-  !>     @param[in]
-  !>     eorder      `rocblas_eorder`.
+  !>     @param[in] eorder - `rocblas_eorder`.
   !>                 Specifies whether the computed eigenvalues will be ordered by their position in
   !>                 the
   !>                 entire spectrum or grouped by independent diagonal (split off) blocks.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The order of the tridiagonal matrix T.
-  !>     @param[in]
-  !>     vl          real type. vl < vu.
+  !>     @param[in] vl - real type. vl < vu.
   !>                 The lower bound of the search interval (vl, vu]. Ignored if erange indicates to
   !>                 look
   !>                 for all the eigenvalues of T or the eigenvalues within a set of indices.
-  !>     @param[in]
-  !>     vu          real type. vl < vu.
+  !>     @param[in] vu - real type. vl < vu.
   !>                 The upper bound of the search interval (vl, vu]. Ignored if erange indicates to
   !>                 look
   !>                 for all the eigenvalues of T or the eigenvalues within a set of indices.
-  !>     @param[in]
-  !>     il          rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] il - rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the smallest eigenvalue to be computed. Ignored if erange
   !>                 indicates to look
   !>                 for all the eigenvalues of T or the eigenvalues in a half-open interval.
-  !>     @param[in]
-  !>     iu          rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] iu - rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the largest eigenvalue to be computed. Ignored if erange indicates
   !>                 to look
   !>                 for all the eigenvalues of T or the eigenvalues in a half-open interval.
-  !>     @param[in]
-  !>     abstol      real type.
+  !>     @param[in] abstol - real type.
   !>                 The absolute tolerance. An eigenvalue is considered to be located if it lies
   !>                 in an interval whose width is <= abstol. If abstol is negative, then
   !>                 machine-epsilon times
@@ -6659,36 +6203,28 @@ module hipfort_rocsolver
   !>                 abstol=0, then the tolerance will be set
   !>                 to twice the underflow threshold. This is the tolerance that could get the most
   !>                 accurate results.
-  !>     @param[in]
-  !>     D           pointer to real type. Array on the GPU of dimension n.
+  !>     @param[in] D - pointer to real type. Array on the GPU of dimension n.
   !>                 The diagonal elements of the tridiagonal matrix.
-  !>     @param[in]
-  !>     E           pointer to real type. Array on the GPU of dimension n-1.
+  !>     @param[in] E - pointer to real type. Array on the GPU of dimension n-1.
   !>                 The off-diagonal elements of the tridiagonal matrix.
-  !>     @param[out]
-  !>     nev         pointer to a rocblas_int on the GPU.
+  !>     @param[out] nev - pointer to a rocblas_int on the GPU.
   !>                 The total number of eigenvalues found.
-  !>     @param[out]
-  !>     nsplit      pointer to a rocblas_int on the GPU.
+  !>     @param[out] nsplit - pointer to a rocblas_int on the GPU.
   !>                 The number of split off blocks in the matrix.
-  !>     @param[out]
-  !>     W           pointer to real type. Array on the GPU of dimension n.
+  !>     @param[out] W - pointer to real type. Array on the GPU of dimension n.
   !>                 The first nev elements contain the computed eigenvalues. (The remaining
   !>                 elements
   !>                 can be used as workspace for internal computations.)
-  !>     @param[out]
-  !>     iblock      pointer to rocblas_int. Array on the GPU of dimension n.
+  !>     @param[out] iblock - pointer to rocblas_int. Array on the GPU of dimension n.
   !>                 The block indices corresponding to each eigenvalue. When matrix T has
   !>                 split off blocks (nsplit > 1), then if iblock[i] = k, the
   !>                 eigenvalue W[i] belongs to the k-th diagonal block from the top.
-  !>     @param[out]
-  !>     isplit      pointer to rocblas_int. Array on the GPU of dimension n.
+  !>     @param[out] isplit - pointer to rocblas_int. Array on the GPU of dimension n.
   !>                 The splitting indices that divide the tridiagonal matrix into
   !>                 diagonal blocks. The k-th block stretches from the end of the (k-1)-th
   !>                 block (or the top left corner of the tridiagonal matrix,
   !>                 in the case of the 1st block) to the isplit[k]-th row/column.
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info = 0, successful exit.
   !>                 If info = 1, the bisection did not converge for some eigenvalues, that is, the
   !>                 returned
@@ -6765,51 +6301,39 @@ module hipfort_rocsolver
   !>     The eigenvalues must be provided in the array ``W``, as returned by \ref rocsolver_sstebz
   !>     "STEBZ".
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows and columns of the tridiagonal matrix.
-  !>     @param[in]
-  !>     D           pointer to real type. Array on the GPU of dimension n.
+  !>     @param[in] D - pointer to real type. Array on the GPU of dimension n.
   !>                 The diagonal elements of the tridiagonal matrix.
-  !>     @param[in]
-  !>     E           pointer to real type. Array on the GPU of dimension n-1.
+  !>     @param[in] E - pointer to real type. Array on the GPU of dimension n-1.
   !>                 The off-diagonal elements of the tridiagonal matrix.
-  !>     @param[in]
-  !>     nev         pointer to a rocblas_int on the GPU. 0 <= nev <= n.
+  !>     @param[in] nev - pointer to a rocblas_int on the GPU. 0 <= nev <= n.
   !>                 The number of provided eigenvalues and the number of eigenvectors
   !>                 to be computed.
-  !>     @param[in]
-  !>     W           pointer to real type. Array on the GPU of dimension >= nev.
+  !>     @param[in] W - pointer to real type. Array on the GPU of dimension >= nev.
   !>                 A subset of nev eigenvalues of the tridiagonal matrix, as returned
   !>                 by \ref rocsolver_sstebz "STEBZ".
-  !>     @param[in]
-  !>     iblock      pointer to rocblas_int. Array on the GPU of dimension n.
+  !>     @param[in] iblock - pointer to rocblas_int. Array on the GPU of dimension n.
   !>                 The block indices corresponding to each eigenvalue, as
   !>                 returned by \ref rocsolver_sstebz "STEBZ". If iblock[i] = k,
   !>                 then eigenvalue W[i] belongs to the k-th block from the top.
-  !>     @param[in]
-  !>     isplit      pointer to rocblas_int. Array on the GPU of dimension n.
+  !>     @param[in] isplit - pointer to rocblas_int. Array on the GPU of dimension n.
   !>                 The splitting indices that divide the tridiagonal matrix into
   !>                 diagonal blocks, as returned by \ref rocsolver_sstebz "STEBZ".
   !>                 The k-th block stretches from the end of the (k-1)-th
   !>                 block (or the top left corner of the tridiagonal matrix,
   !>                 in the case of the 1st block) to the isplit[k]-th row/column.
-  !>     @param[out]
-  !>     Z           pointer to type. Array on the GPU of dimension ldz*nev.
+  !>     @param[out] Z - pointer to type. Array on the GPU of dimension ldz*nev.
   !>                 On exit, contains the eigenvectors of the tridiagonal matrix
   !>                 corresponding to the provided eigenvalues, stored by columns.
-  !>     @param[in]
-  !>     ldz         rocblas_int. ldz >= n.
+  !>     @param[in] ldz - rocblas_int. ldz >= n.
   !>                 Specifies the leading dimension of Z.
-  !>     @param[out]
-  !>     ifail       pointer to rocblas_int. Array on the GPU of dimension n.
+  !>     @param[out] ifail - pointer to rocblas_int. Array on the GPU of dimension n.
   !>                 If info = 0, the first nev elements of ifail are zero.
   !>                 Otherwise, contains the indices of those eigenvectors that failed
   !>                 to converge.
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info = 0, successful exit.
   !>                 If info = i > 0, i eigenvectors did not converge. Their indices are stored in
   !>                 ifail.
@@ -6928,65 +6452,51 @@ module hipfort_rocsolver
   !>     corresponding right
   !>     singular vectors.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether B is upper or lower bidiagonal.
-  !>     @param[in]
-  !>     svect       `rocblas_svect`.
+  !>     @param[in] svect - `rocblas_svect`.
   !>                 Specifies how the singular vectors are computed. Only rocblas_svect_none and
   !>                 rocblas_svect_singular are accepted.
-  !>     @param[in]
-  !>     srange      `rocblas_srange`.
+  !>     @param[in] srange - `rocblas_srange`.
   !>                 Specifies the type of range or interval of the singular values to be computed.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The order of the bidiagonal matrix B.
-  !>     @param[in]
-  !>     D           pointer to real type. Array on the GPU of dimension n.
+  !>     @param[in] D - pointer to real type. Array on the GPU of dimension n.
   !>                 The diagonal elements of the bidiagonal matrix.
-  !>     @param[in]
-  !>     E           pointer to real type. Array on the GPU of dimension n-1.
+  !>     @param[in] E - pointer to real type. Array on the GPU of dimension n-1.
   !>                 The off-diagonal elements of the bidiagonal matrix.
-  !>     @param[in]
-  !>     vl          real type. 0 <= vl < vu.
+  !>     @param[in] vl - real type. 0 <= vl < vu.
   !>                 The lower bound of the search interval [vl, vu). Ignored if srange indicates to
   !>                 look
   !>                 for all the singular values of B or the singular values within a set of
   !>                 indices.
-  !>     @param[in]
-  !>     vu          real type. 0 <= vl < vu.
+  !>     @param[in] vu - real type. 0 <= vl < vu.
   !>                 The upper bound of the search interval [vl, vu). Ignored if srange indicates to
   !>                 look
   !>                 for all the singular values of B or the singular values within a set of
   !>                 indices.
-  !>     @param[in]
-  !>     il          rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] il - rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the largest singular value to be computed. Ignored if srange
   !>                 indicates to look
   !>                 for all the singular values of B or the singular values in a half-open
   !>                 interval.
-  !>     @param[in]
-  !>     iu          rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] iu - rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the smallest singular value to be computed. Ignored if srange
   !>                 indicates to look
   !>                 for all the singular values of B or the singular values in a half-open
   !>                 interval.
-  !>     @param[out]
-  !>     nsv         pointer to a rocblas_int on the GPU.
+  !>     @param[out] nsv - pointer to a rocblas_int on the GPU.
   !>                 The total number of singular values found. If srange is rocblas_srange_all, nsv
   !>                 = n.
   !>                 If srange is rocblas_srange_index, nsv = iu - il + 1. Otherwise, 0 <= nsv <= n.
-  !>     @param[out]
-  !>     S           pointer to real type. Array on the GPU of dimension nsv.
+  !>     @param[out] S - pointer to real type. Array on the GPU of dimension nsv.
   !>                 The first nsv elements contain the computed singular values in descending
   !>                 order.
   !>                 - Note: If srange is rocblas_srange_value, then the value of nsv is not known
   !>                 in advance.
   !>                 In this case, the user should ensure that S is large enough to hold n values.
-  !>     @param[out]
-  !>     Z           pointer to real type. Array on the GPU of dimension ldz*nsv.
+  !>     @param[out] Z - pointer to real type. Array on the GPU of dimension ldz*nsv.
   !>                 If info = 0, the first nsv columns contain the computed singular vectors
   !>                 corresponding to the
   !>                 singular values in S. The first n rows of Z contain the matrix U, and the next
@@ -6995,17 +6505,15 @@ module hipfort_rocsolver
   !>                 - Note: If srange is rocblas_srange_value, then the value of nsv is not known
   !>                 in advance.
   !>                 In this case, the user should ensure that Z is large enough to hold n columns.
-  !>     @param[in]
-  !>     ldz rocblas_int. ldz >= 2*n if svect is rocblas_svect_singular and ldz >= 1 otherwise.
+  !>     @param[in] ldz - rocblas_int. ldz >= 2*n if svect is rocblas_svect_singular and ldz >= 1
+  !>     otherwise.
   !>                 Specifies the leading dimension of Z.
-  !>     @param[out]
-  !>     ifail       pointer to rocblas_int. Array on the GPU of dimension n.
+  !>     @param[out] ifail - pointer to rocblas_int. Array on the GPU of dimension n.
   !>                 If info = 0, the first nsv elements of ifail are zero.
   !>                 Otherwise, contains the indices of those eigenvectors that failed
   !>                 to converge, as returned by \ref rocsolver_sstein "STEIN".
   !>                 Not referenced if svect is rocblas_svect_none.
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info = 0, successful exit.
   !>                 If info = i > 0, i eigenvectors did not converge in \ref rocsolver_sstein
   !>                 "STEIN". Their
@@ -7095,24 +6603,18 @@ module hipfort_rocsolver
   !>     If numerical accuracy is compromised, use the legacy-LAPACK API \ref rocsolver_sgetf2
   !>     "GETF2" routines instead.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of the matrix A.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of the matrix A.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the m-by-n matrix A to be factored.
   !>                 On exit, the factors L and U from the factorization.
   !>                 The unit diagonal elements of L are not stored.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of A.
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info = 0, successful exit.
   !>                 If info = i > 0, U is singular. U[i,i] is the first zero element in the
   !>                 diagonal. The factorization from
@@ -7303,30 +6805,24 @@ module hipfort_rocsolver
   !>     If numerical accuracy is compromised, use the legacy-LAPACK API \ref
   !>     rocsolver_sgetf2_batched "GETF2_BATCHED" routines instead.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of all matrices A_l in the batch.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of all matrices A_l in the batch.
-  !>     @param[inout]
-  !>     A array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the m-by-n matrices A_l to be factored.
   !>                 On exit, the factors L_l and U_l from the factorizations.
   !>                 The unit diagonal elements of L_l are not stored.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for factorization of A_l.
   !>                 If info[l] = i > 0, U_l is singular. U_l[i,i] is the first zero element in the
   !>                 diagonal. The factorization from
   !>                 this point might be incomplete.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_sgetf2_npvt_batched
     function rocsolver_sgetf2_npvt_batched_(handle,m,n,A,lda,myInfo,batch_count) &
@@ -7498,35 +6994,28 @@ module hipfort_rocsolver
   !>     If numerical accuracy is compromised, use \ref rocsolver_sgetf2_strided_batched
   !>     "GETF2_STRIDED_BATCHED" routines instead.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of all matrices A_l in the batch.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of all matrices A_l in the batch.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the m-by-n matrices A_l to be factored.
   !>                 On exit, the factors L_l and U_l from the factorization.
   !>                 The unit diagonal elements of L_l are not stored.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for factorization of A_l.
   !>                 If info[l] = i > 0, U_l is singular. U_l[i,i] is the first zero element in the
   !>                 diagonal. The factorization from
   !>                 this point might be incomplete.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_sgetf2_npvt_strided_batched
     function rocsolver_sgetf2_npvt_strided_batched_(handle,m,n,A,lda,strideA,myInfo,batch_count) &
@@ -7738,24 +7227,18 @@ module hipfort_rocsolver
   !>     pivoting is not backward stable.
   !>     If numerical accuracy is compromised, use \ref rocsolver_sgetrf "GETRF" routines instead.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of the matrix A.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of the matrix A.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the m-by-n matrix A to be factored.
   !>                 On exit, the factors L and U from the factorization.
   !>                 The unit diagonal elements of L are not stored.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of A.
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info = 0, successful exit.
   !>                 If info = i > 0, U is singular. U[i,i] is the first zero element in the
   !>                 diagonal. The factorization from
@@ -7946,30 +7429,24 @@ module hipfort_rocsolver
   !>     If numerical accuracy is compromised, use \ref rocsolver_sgetrf_batched "GETRF_BATCHED"
   !>     routines instead.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of all matrices A_l in the batch.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of all matrices A_l in the batch.
-  !>     @param[inout]
-  !>     A array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the m-by-n matrices A_l to be factored.
   !>                 On exit, the factors L_l and U_l from the factorizations.
   !>                 The unit diagonal elements of L_l are not stored.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for factorization of A_l.
   !>                 If info[l] = i > 0, U_l is singular. U_l[i,i] is the first zero element in the
   !>                 diagonal. The factorization from
   !>                 this point might be incomplete.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_sgetrf_npvt_batched
     function rocsolver_sgetrf_npvt_batched_(handle,m,n,A,lda,myInfo,batch_count) &
@@ -8141,35 +7618,28 @@ module hipfort_rocsolver
   !>     If numerical accuracy is compromised, use \ref rocsolver_sgetrf_strided_batched
   !>     "GETRF_STRIDED_BATCHED" routines instead.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of all matrices A_l in the batch.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of all matrices A_l in the batch.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the m-by-n matrices A_l to be factored.
   !>                 On exit, the factors L_l and U_l from the factorization.
   !>                 The unit diagonal elements of L_l are not stored.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for factorization of A_l.
   !>                 If info[l] = i > 0, U_l is singular. U_l[i,i] is the first zero element in the
   !>                 diagonal. The factorization from
   !>                 this point might be incomplete.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_sgetrf_npvt_strided_batched
     function rocsolver_sgetrf_npvt_strided_batched_(handle,m,n,A,lda,strideA,myInfo,batch_count) &
@@ -8376,30 +7846,23 @@ module hipfort_rocsolver
   !>     diagonal elements (lower trapezoidal if ``m`` > ``n``), and U is upper
   !>     triangular (upper trapezoidal if ``m`` < ``n``).
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of the matrix A.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of the matrix A.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the m-by-n matrix A to be factored.
   !>                 On exit, the factors L and U from the factorization.
   !>                 The unit diagonal elements of L are not stored.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of A.
-  !>     @param[out]
-  !>     ipiv        pointer to rocblas_int. Array on the GPU of dimension min(m,n).
+  !>     @param[out] ipiv - pointer to rocblas_int. Array on the GPU of dimension min(m,n).
   !>                 The vector of pivot indices. Elements of ipiv are 1-based indices.
   !>                 For 1 <= i <= min(m,n), row i of the
   !>                 matrix was interchanged with row ipiv[i].
   !>                 Matrix P of the factorization can be derived from ipiv.
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info = 0, successful exit.
   !>                 If info = i > 0, U is singular. U[i,i] is the first zero pivot.
   interface rocsolver_sgetf2
@@ -8586,41 +8049,34 @@ module hipfort_rocsolver
   !>     diagonal elements (lower trapezoidal if ``m`` > ``n``), and \f$U_l\f$ is upper
   !>     triangular (upper trapezoidal if ``m`` < ``n``).
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of all matrices A_l in the batch.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of all matrices A_l in the batch.
-  !>     @param[inout]
-  !>     A array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the m-by-n matrices A_l to be factored.
   !>                 On exit, the factors L_l and U_l from the factorizations.
   !>                 The unit diagonal elements of L_l are not stored.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[out]
-  !>     ipiv pointer to rocblas_int. Array on the GPU (the size depends on the value of strideP).
+  !>     @param[out] ipiv - pointer to rocblas_int. Array on the GPU (the size depends on the value
+  !>     of strideP).
   !>                 Contains the vectors of pivot indices ipiv_l (corresponding to A_l).
   !>                 Dimension of ipiv_l is min(m,n).
   !>                 Elements of ipiv_l are 1-based indices.
   !>                 For each instance A_l in the batch and for 1 <= i <= min(m,n), row i of the
   !>                 matrix A_l was interchanged with row ipiv_l[i].
   !>                 Matrix P_l of the factorization can be derived from ipiv_l.
-  !>     @param[in]
-  !>     strideP     rocblas_stride.
+  !>     @param[in] strideP - rocblas_stride.
   !>                 Stride from the start of one vector ipiv_l to the next one ipiv_(l+1).
   !>                 There is no restriction for the value of strideP. The normal use case is
   !>                 strideP >= min(m,n).
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for factorization of A_l.
   !>                 If info[l] = i > 0, U_l is singular. U_l[i,i] is the first zero pivot.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_sgetf2_batched
     function rocsolver_sgetf2_batched_(handle,m,n,A,lda,ipiv,strideP,myInfo,batch_count) &
@@ -8826,46 +8282,38 @@ module hipfort_rocsolver
   !>     diagonal elements (lower trapezoidal if ``m`` > ``n``), and \f$U_l\f$ is upper
   !>     triangular (upper trapezoidal if ``m`` < ``n``).
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of all matrices A_l in the batch.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of all matrices A_l in the batch.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the m-by-n matrices A_l to be factored.
   !>                 On exit, the factors L_l and U_l from the factorization.
   !>                 The unit diagonal elements of L_l are not stored.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[out]
-  !>     ipiv pointer to rocblas_int. Array on the GPU (the size depends on the value of strideP).
+  !>     @param[out] ipiv - pointer to rocblas_int. Array on the GPU (the size depends on the value
+  !>     of strideP).
   !>                 Contains the vectors of pivots indices ipiv_l (corresponding to A_l).
   !>                 Dimension of ipiv_l is min(m,n).
   !>                 Elements of ipiv_l are 1-based indices.
   !>                 For each instance A_l in the batch and for 1 <= i <= min(m,n), row i of the
   !>                 matrix A_l was interchanged with row ipiv_l[i].
   !>                 Matrix P_l of the factorization can be derived from ipiv_l.
-  !>     @param[in]
-  !>     strideP     rocblas_stride.
+  !>     @param[in] strideP - rocblas_stride.
   !>                 Stride from the start of one vector ipiv_l to the next one ipiv_(l+1).
   !>                 There is no restriction for the value of strideP. The normal use case is
   !>                 strideP >= min(m,n).
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for factorization of A_l.
   !>                 If info[l] = i > 0, U_l is singular. U_l[i,i] is the first zero pivot.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_sgetf2_strided_batched
     function rocsolver_sgetf2_strided_batched_(handle,m,n,A,lda,strideA,ipiv,strideP,myInfo, &
@@ -9092,30 +8540,23 @@ module hipfort_rocsolver
   !>     diagonal elements (lower trapezoidal if ``m`` > ``n``), and U is upper
   !>     triangular (upper trapezoidal if ``m`` < ``n``).
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of the matrix A.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of the matrix A.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the m-by-n matrix A to be factored.
   !>                 On exit, the factors L and U from the factorization.
   !>                 The unit diagonal elements of L are not stored.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of A.
-  !>     @param[out]
-  !>     ipiv        pointer to rocblas_int. Array on the GPU of dimension min(m,n).
+  !>     @param[out] ipiv - pointer to rocblas_int. Array on the GPU of dimension min(m,n).
   !>                 The vector of pivot indices. Elements of ipiv are 1-based indices.
   !>                 For 1 <= i <= min(m,n), row i of the
   !>                 matrix was interchanged with row ipiv[i].
   !>                 Matrix P of the factorization can be derived from ipiv.
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info = 0, successful exit.
   !>                 If info = i > 0, U is singular. U[i,i] is the first zero pivot.
   interface rocsolver_sgetrf
@@ -9302,41 +8743,34 @@ module hipfort_rocsolver
   !>     diagonal elements (lower trapezoidal if ``m`` > ``n``), and \f$U_l\f$ is upper
   !>     triangular (upper trapezoidal if ``m`` < ``n``).
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of all matrices A_l in the batch.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of all matrices A_l in the batch.
-  !>     @param[inout]
-  !>     A array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the m-by-n matrices A_l to be factored.
   !>                 On exit, the factors L_l and U_l from the factorizations.
   !>                 The unit diagonal elements of L_l are not stored.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[out]
-  !>     ipiv pointer to rocblas_int. Array on the GPU (the size depends on the value of strideP).
+  !>     @param[out] ipiv - pointer to rocblas_int. Array on the GPU (the size depends on the value
+  !>     of strideP).
   !>                 Contains the vectors of pivot indices ipiv_l (corresponding to A_l).
   !>                 Dimension of ipiv_l is min(m,n).
   !>                 Elements of ipiv_l are 1-based indices.
   !>                 For each instance A_l in the batch and for 1 <= i <= min(m,n), row i of the
   !>                 matrix A_l was interchanged with row ipiv_l[i].
   !>                 Matrix P_l of the factorization can be derived from ipiv_l.
-  !>     @param[in]
-  !>     strideP     rocblas_stride.
+  !>     @param[in] strideP - rocblas_stride.
   !>                 Stride from the start of one vector ipiv_l to the next one ipiv_(l+1).
   !>                 There is no restriction for the value of strideP. The normal use case is
   !>                 strideP >= min(m,n).
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for factorization of A_l.
   !>                 If info[l] = i > 0, U_l is singular. U_l[i,i] is the first zero pivot.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_sgetrf_batched
     function rocsolver_sgetrf_batched_(handle,m,n,A,lda,ipiv,strideP,myInfo,batch_count) &
@@ -9542,46 +8976,38 @@ module hipfort_rocsolver
   !>     diagonal elements (lower trapezoidal if ``m`` > ``n``), and \f$U_l\f$ is upper
   !>     triangular (upper trapezoidal if ``m`` < ``n``).
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of all matrices A_l in the batch.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of all matrices A_l in the batch.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the m-by-n matrices A_l to be factored.
   !>                 On exit, the factors L_l and U_l from the factorization.
   !>                 The unit diagonal elements of L_l are not stored.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[out]
-  !>     ipiv pointer to rocblas_int. Array on the GPU (the size depends on the value of strideP).
+  !>     @param[out] ipiv - pointer to rocblas_int. Array on the GPU (the size depends on the value
+  !>     of strideP).
   !>                 Contains the vectors of pivots indices ipiv_l (corresponding to A_l).
   !>                 Dimension of ipiv_l is min(m,n).
   !>                 Elements of ipiv_l are 1-based indices.
   !>                 For each instance A_l in the batch and for 1 <= i <= min(m,n), row i of the
   !>                 matrix A_l was interchanged with row ipiv_l[i].
   !>                 Matrix P_l of the factorization can be derived from ipiv_l.
-  !>     @param[in]
-  !>     strideP     rocblas_stride.
+  !>     @param[in] strideP - rocblas_stride.
   !>                 Stride from the start of one vector ipiv_l to the next one ipiv_(l+1).
   !>                 There is no restriction for the value of strideP. The normal use case is
   !>                 strideP >= min(m,n).
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for factorization of A_l.
   !>                 If info[l] = i > 0, U_l is singular. U_l[i,i] is the first zero pivot.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_sgetrf_strided_batched
     function rocsolver_sgetrf_strided_batched_(handle,m,n,A,lda,strideA,ipiv,strideP,myInfo, &
@@ -9819,25 +9245,19 @@ module hipfort_rocsolver
   !>     where the first i-1 elements of the Householder vector \f$v_i\f$ are zero, and \f$v_i[i] =
   !>     1\f$.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of the matrix A.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of the matrix A.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the m-by-n matrix to be factored.
   !>                 On exit, the elements on and above the diagonal contain the
   !>                 factor R, and the elements below the diagonal are the last m - i elements
   !>                 of Householder vector v_i.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of A.
-  !>     @param[out]
-  !>     ipiv        pointer to type. Array on the GPU of dimension min(m,n).
+  !>     @param[out] ipiv - pointer to type. Array on the GPU of dimension min(m,n).
   !>                 The Householder scalars.
   interface rocsolver_sgeqr2
     function rocsolver_sgeqr2_(handle,m,n,A,lda,ipiv) bind(c, name="rocsolver_sgeqr2")
@@ -10027,33 +9447,27 @@ module hipfort_rocsolver
   !>     where the first i-1 elements of Householder vector \f$v_{l_i}\f$ are zero, and
   !>     \f$v_{l_i}[i] = 1\f$.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of all the matrices A_l in the batch.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of all the matrices A_l in the batch.
-  !>     @param[inout]
-  !>     A Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - Array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the m-by-n matrices A_l to be factored.
   !>                 On exit, the elements on and above the diagonal contain the
   !>                 factor R_l. The elements below the diagonal are the last m - i elements
   !>                 of Householder vector v_(l_i).
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[out]
-  !>     ipiv        pointer to type. Array on the GPU (the size depends on the value of strideP).
+  !>     @param[out] ipiv - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideP).
   !>                 Contains the vectors ipiv_l of corresponding Householder scalars.
-  !>     @param[in]
-  !>     strideP     rocblas_stride.
+  !>     @param[in] strideP - rocblas_stride.
   !>                 Stride from the start of one vector ipiv_l to the next one ipiv_(l+1).
   !>                 There is no restriction for the value
   !>                 of strideP. Normal usage is strideP >= min(m,n).
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_sgeqr2_batched
     function rocsolver_sgeqr2_batched_(handle,m,n,A,lda,ipiv,strideP,batch_count) &
@@ -10263,38 +9677,31 @@ module hipfort_rocsolver
   !>     where the first i-1 elements of Householder vector \f$v_{l_i}\f$ are zero, and
   !>     \f$v_{l_i}[i] = 1\f$.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of all the matrices A_l in the batch.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of all the matrices A_l in the batch.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the m-by-n matrices A_l to be factored.
   !>                 On exit, the elements on and above the diagonal contain the
   !>                 factor R_l. The elements below the diagonal are the last m - i elements
   !>                 of Householder vector v_(l_i).
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[out]
-  !>     ipiv        pointer to type. Array on the GPU (the size depends on the value of strideP).
+  !>     @param[out] ipiv - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideP).
   !>                 Contains the vectors ipiv_l of corresponding Householder scalars.
-  !>     @param[in]
-  !>     strideP     rocblas_stride.
+  !>     @param[in] strideP - rocblas_stride.
   !>                 Stride from the start of one vector ipiv_l to the next one ipiv_(l+1).
   !>                 There is no restriction for the value
   !>                 of strideP. Normal usage is strideP >= min(m,n).
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_sgeqr2_strided_batched
     function rocsolver_sgeqr2_strided_batched_(handle,m,n,A,lda,strideA,ipiv,strideP,batch_count) &
@@ -10519,26 +9926,20 @@ module hipfort_rocsolver
   !>     where the last n-i elements of the Householder vector \f$v_i\f$ are zero, and \f$v_i[i] =
   !>     1\f$.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of the matrix A.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of the matrix A.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the m-by-n matrix to be factored.
   !>                 On exit, the elements on and above the (m-n)-th subdiagonal (when
   !>                 m >= n) or the (n-m)-th superdiagonal (when n > m) contain the
   !>                 factor R, and the elements below the sub/superdiagonal are the first i - 1
   !>                 elements of Householder vector v_i.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of A.
-  !>     @param[out]
-  !>     ipiv        pointer to type. Array on the GPU of dimension min(m,n).
+  !>     @param[out] ipiv - pointer to type. Array on the GPU of dimension min(m,n).
   !>                 The Householder scalars.
   interface rocsolver_sgerq2
     function rocsolver_sgerq2_(handle,m,n,A,lda,ipiv) bind(c, name="rocsolver_sgerq2")
@@ -10663,34 +10064,28 @@ module hipfort_rocsolver
   !>     where the last n-i elements of Householder vector \f$v_{l_i}\f$ are zero, and \f$v_{l_i}[i]
   !>     = 1\f$.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of all the matrices A_l in the batch.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of all the matrices A_l in the batch.
-  !>     @param[inout]
-  !>     A Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - Array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the m-by-n matrices A_l to be factored.
   !>                 On exit, the elements on and above the (m-n)-th subdiagonal (when
   !>                 m >= n) or the (n-m)-th superdiagonal (when n > m) contain the
   !>                 factor R_l, and the elements below the sub/superdiagonal are the first i - 1
   !>                 elements of Householder vector v_(l_i).
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[out]
-  !>     ipiv        pointer to type. Array on the GPU (the size depends on the value of strideP).
+  !>     @param[out] ipiv - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideP).
   !>                 Contains the vectors ipiv_l of corresponding Householder scalars.
-  !>     @param[in]
-  !>     strideP     rocblas_stride.
+  !>     @param[in] strideP - rocblas_stride.
   !>                 Stride from the start of one vector ipiv_l to the next one ipiv_(l+1).
   !>                 There is no restriction for the value
   !>                 of strideP. Normal usage is strideP >= min(m,n).
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_sgerq2_batched
     function rocsolver_sgerq2_batched_(handle,m,n,A,lda,ipiv,strideP,batch_count) &
@@ -10823,39 +10218,32 @@ module hipfort_rocsolver
   !>     where the last n-i elements of Householder vector \f$v_{l_i}\f$ are zero, and \f$v_{l_i}[i]
   !>     = 1\f$.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of all the matrices A_l in the batch.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of all the matrices A_l in the batch.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the m-by-n matrices A_l to be factored.
   !>                 On exit, the elements on and above the (m-n)-th subdiagonal (when
   !>                 m >= n) or the (n-m)-th superdiagonal (when n > m) contain the
   !>                 factor R_l, and the elements below the sub/superdiagonal are the first i - 1
   !>                 elements of Householder vector v_(l_i).
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[out]
-  !>     ipiv        pointer to type. Array on the GPU (the size depends on the value of strideP).
+  !>     @param[out] ipiv - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideP).
   !>                 Contains the vectors ipiv_l of corresponding Householder scalars.
-  !>     @param[in]
-  !>     strideP     rocblas_stride.
+  !>     @param[in] strideP - rocblas_stride.
   !>                 Stride from the start of one vector ipiv_l to the next one ipiv_(l+1).
   !>                 There is no restriction for the value
   !>                 of strideP. Normal usage is strideP >= min(m,n).
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_sgerq2_strided_batched
     function rocsolver_sgerq2_strided_batched_(handle,m,n,A,lda,strideA,ipiv,strideP,batch_count) &
@@ -10997,26 +10385,20 @@ module hipfort_rocsolver
   !>     where the last m-i elements of the Householder vector \f$v_i\f$ are zero, and \f$v_i[i] =
   !>     1\f$.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of the matrix A.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of the matrix A.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the m-by-n matrix to be factored.
   !>                 On exit, the elements on and below the (m-n)-th subdiagonal (when
   !>                 m >= n) or the (n-m)-th superdiagonal (when n > m) contain the
   !>                 factor L, and the elements above the sub/superdiagonal are the first i - 1
   !>                 elements of Householder vector v_i.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of A.
-  !>     @param[out]
-  !>     ipiv        pointer to type. Array on the GPU of dimension min(m,n).
+  !>     @param[out] ipiv - pointer to type. Array on the GPU of dimension min(m,n).
   !>                 The Householder scalars.
   interface rocsolver_sgeql2
     function rocsolver_sgeql2_(handle,m,n,A,lda,ipiv) bind(c, name="rocsolver_sgeql2")
@@ -11142,34 +10524,28 @@ module hipfort_rocsolver
   !>     where the last m-i elements of the Householder vector \f$v_{l_i}\f$ are zero, and
   !>     \f$v_{l_i}[i] = 1\f$.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of all the matrices A_l in the batch.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of all the matrices A_l in the batch.
-  !>     @param[inout]
-  !>     A Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - Array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the m-by-n matrices A_l to be factored.
   !>                 On exit, the elements on and below the (m-n)-th subdiagonal (when
   !>                 m >= n) or the (n-m)-th superdiagonal (when n > m) contain the
   !>                 factor L_l, and the elements above the sub/superdiagonal are the first i - 1
   !>                 elements of Householder vector v_(l_i).
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[out]
-  !>     ipiv        pointer to type. Array on the GPU (the size depends on the value of strideP).
+  !>     @param[out] ipiv - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideP).
   !>                 Contains the vectors ipiv_l of corresponding Householder scalars.
-  !>     @param[in]
-  !>     strideP     rocblas_stride.
+  !>     @param[in] strideP - rocblas_stride.
   !>                 Stride from the start of one vector ipiv_l to the next one ipiv_(l+1).
   !>                 There is no restriction for the value
   !>                 of strideP. The normal use is strideP >= min(m,n).
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_sgeql2_batched
     function rocsolver_sgeql2_batched_(handle,m,n,A,lda,ipiv,strideP,batch_count) &
@@ -11303,39 +10679,32 @@ module hipfort_rocsolver
   !>     where the last m-i elements of the Householder vector \f$v_{l_i}\f$ are zero, and
   !>     \f$v_{l_i}[i] = 1\f$.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of all the matrices A_l in the batch.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of all the matrices A_l in the batch.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the m-by-n matrices A_l to be factored.
   !>                 On exit, the elements on and below the (m-n)-th subdiagonal (when
   !>                 m >= n) or the (n-m)-th superdiagonal (when n > m) contain the
   !>                 factor L_l, and the elements above the sub/superdiagonal are the first i - 1
   !>                 elements of Householder vector v_(l_i).
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[out]
-  !>     ipiv        pointer to type. Array on the GPU (the size depends on the value of strideP).
+  !>     @param[out] ipiv - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideP).
   !>                 Contains the vectors ipiv_l of corresponding Householder scalars.
-  !>     @param[in]
-  !>     strideP     rocblas_stride.
+  !>     @param[in] strideP - rocblas_stride.
   !>                 Stride from the start of one vector ipiv_l to the next one ipiv_(l+1).
   !>                 There is no restriction for the value
   !>                 of strideP. Normal usage is strideP >= min(m,n).
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_sgeql2_strided_batched
     function rocsolver_sgeql2_strided_batched_(handle,m,n,A,lda,strideA,ipiv,strideP,batch_count) &
@@ -11476,25 +10845,19 @@ module hipfort_rocsolver
   !>     where the first i-1 elements of the Householder vector \f$v_i\f$ are zero, and \f$v_i[i] =
   !>     1\f$.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of the matrix A.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of the matrix A.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the m-by-n matrix to be factored.
   !>                 On exit, the elements on and below the diagonal contain the
   !>                 factor L, and the elements above the diagonal are the last n - i elements
   !>                 of Householder vector v_i.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of A.
-  !>     @param[out]
-  !>     ipiv        pointer to type. Array on the GPU of dimension min(m,n).
+  !>     @param[out] ipiv - pointer to type. Array on the GPU of dimension min(m,n).
   !>                 The Householder scalars.
   interface rocsolver_sgelq2
     function rocsolver_sgelq2_(handle,m,n,A,lda,ipiv) bind(c, name="rocsolver_sgelq2")
@@ -11619,33 +10982,27 @@ module hipfort_rocsolver
   !>     where the first i-1 elements of Householder vector \f$v_{l_i}\f$ are zero, and
   !>     \f$v_{l_i}[i] = 1\f$.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of all the matrices A_l in the batch.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of all the matrices A_l in the batch.
-  !>     @param[inout]
-  !>     A Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - Array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the m-by-n matrices A_l to be factored.
   !>                 On exit, the elements on and below the diagonal contain the
   !>                 factor L_l. The elements above the diagonal are the last n - i elements
   !>                 of Householder vector v_(l_i).
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[out]
-  !>     ipiv        pointer to type. Array on the GPU (the size depends on the value of strideP).
+  !>     @param[out] ipiv - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideP).
   !>                 Contains the vectors ipiv_l of corresponding Householder scalars.
-  !>     @param[in]
-  !>     strideP     rocblas_stride.
+  !>     @param[in] strideP - rocblas_stride.
   !>                 Stride from the start of one vector ipiv_l to the next one ipiv_(l+1).
   !>                 There is no restriction for the value
   !>                 of strideP. Normal usage is strideP >= min(m,n).
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_sgelq2_batched
     function rocsolver_sgelq2_batched_(handle,m,n,A,lda,ipiv,strideP,batch_count) &
@@ -11778,38 +11135,31 @@ module hipfort_rocsolver
   !>     where the first i-1 elements of Householder vector \f$v_{l_i}\f$ are zero, and
   !>     \f$v_{l_i}[i] = 1\f$.
   !>
-  !>     @param[in]
-  !>     handle    rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of all the matrices A_l in the batch.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of all the matrices A_l in the batch.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the m-by-n matrices A_l to be factored.
   !>                 On exit, the elements on and below the diagonal contain the
   !>                 factor L_l. The elements above the diagonal are the last n - i elements
   !>                 of Householder vector v_(l_i).
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[out]
-  !>     ipiv        pointer to type. Array on the GPU (the size depends on the value of strideP).
+  !>     @param[out] ipiv - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideP).
   !>                 Contains the vectors ipiv_l of corresponding Householder scalars.
-  !>     @param[in]
-  !>     strideP     rocblas_stride.
+  !>     @param[in] strideP - rocblas_stride.
   !>                 Stride from the start of one vector ipiv_l to the next one ipiv_(l+1).
   !>                 There is no restriction for the value
   !>                 of strideP. Normal usage is strideP >= min(m,n).
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_sgelq2_strided_batched
     function rocsolver_sgelq2_strided_batched_(handle,m,n,A,lda,strideA,ipiv,strideP,batch_count) &
@@ -11951,25 +11301,19 @@ module hipfort_rocsolver
   !>     where the first i-1 elements of the Householder vector \f$v_i\f$ are zero, and \f$v_i[i] =
   !>     1\f$.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of the matrix A.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of the matrix A.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the m-by-n matrix to be factored.
   !>                 On exit, the elements on and above the diagonal contain the
   !>                 factor R, and the elements below the diagonal are the last m - i elements
   !>                 of Householder vector v_i.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of A.
-  !>     @param[out]
-  !>     ipiv        pointer to type. Array on the GPU of dimension min(m,n).
+  !>     @param[out] ipiv - pointer to type. Array on the GPU of dimension min(m,n).
   !>                 The Householder scalars.
   interface rocsolver_sgeqrf
     function rocsolver_sgeqrf_(handle,m,n,A,lda,ipiv) bind(c, name="rocsolver_sgeqrf")
@@ -12159,33 +11503,27 @@ module hipfort_rocsolver
   !>     where the first i-1 elements of Householder vector \f$v_{l_i}\f$ are zero, and
   !>     \f$v_{l_i}[i] = 1\f$.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of all the matrices A_l in the batch.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of all the matrices A_l in the batch.
-  !>     @param[inout]
-  !>     A Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - Array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the m-by-n matrices A_l to be factored.
   !>                 On exit, the elements on and above the diagonal contain the
   !>                 factor R_l. The elements below the diagonal are the last m - i elements
   !>                 of Householder vector v_(l_i).
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[out]
-  !>     ipiv        pointer to type. Array on the GPU (the size depends on the value of strideP).
+  !>     @param[out] ipiv - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideP).
   !>                 Contains the vectors ipiv_l of corresponding Householder scalars.
-  !>     @param[in]
-  !>     strideP     rocblas_stride.
+  !>     @param[in] strideP - rocblas_stride.
   !>                 Stride from the start of one vector ipiv_l to the next one ipiv_(l+1).
   !>                 There is no restriction for the value
   !>                 of strideP. Normal usage is strideP >= min(m,n).
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_sgeqrf_batched
     function rocsolver_sgeqrf_batched_(handle,m,n,A,lda,ipiv,strideP,batch_count) &
@@ -12395,38 +11733,31 @@ module hipfort_rocsolver
   !>     where the first i-1 elements of Householder vector \f$v_{l_i}\f$ are zero, and
   !>     \f$v_{l_i}[i] = 1\f$.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of all the matrices A_l in the batch.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of all the matrices A_l in the batch.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the m-by-n matrices A_l to be factored.
   !>                 On exit, the elements on and above the diagonal contain the
   !>                 factor R_l. The elements below the diagonal are the last m - i elements
   !>                 of Householder vector v_(l_i).
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[out]
-  !>     ipiv        pointer to type. Array on the GPU (the size depends on the value of strideP).
+  !>     @param[out] ipiv - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideP).
   !>                 Contains the vectors ipiv_l of corresponding Householder scalars.
-  !>     @param[in]
-  !>     strideP     rocblas_stride.
+  !>     @param[in] strideP - rocblas_stride.
   !>                 Stride from the start of one vector ipiv_l to the next one ipiv_(l+1).
   !>                 There is no restriction for the value
   !>                 of strideP. Normal usage is strideP >= min(m,n).
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_sgeqrf_strided_batched
     function rocsolver_sgeqrf_strided_batched_(handle,m,n,A,lda,strideA,ipiv,strideP,batch_count) &
@@ -12651,26 +11982,20 @@ module hipfort_rocsolver
   !>     where the last n-i elements of the Householder vector \f$v_i\f$ are zero, and \f$v_i[i] =
   !>     1\f$.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of the matrix A.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of the matrix A.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the m-by-n matrix to be factored.
   !>                 On exit, the elements on and above the (m-n)-th subdiagonal (when
   !>                 m >= n) or the (n-m)-th superdiagonal (when n > m) contain the
   !>                 factor R, and the elements below the sub/superdiagonal are the first i - 1
   !>                 elements of Householder vector v_i.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of A.
-  !>     @param[out]
-  !>     ipiv        pointer to type. Array on the GPU of dimension min(m,n).
+  !>     @param[out] ipiv - pointer to type. Array on the GPU of dimension min(m,n).
   !>                 The Householder scalars.
   interface rocsolver_sgerqf
     function rocsolver_sgerqf_(handle,m,n,A,lda,ipiv) bind(c, name="rocsolver_sgerqf")
@@ -12795,34 +12120,28 @@ module hipfort_rocsolver
   !>     where the last n-i elements of Householder vector \f$v_{l_i}\f$ are zero, and \f$v_{l_i}[i]
   !>     = 1\f$.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of all the matrices A_l in the batch.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of all the matrices A_l in the batch.
-  !>     @param[inout]
-  !>     A Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - Array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the m-by-n matrices A_l to be factored.
   !>                 On exit, the elements on and above the (m-n)-th subdiagonal (when
   !>                 m >= n) or the (n-m)-th superdiagonal (when n > m) contain the
   !>                 factor R_l, and the elements below the sub/superdiagonal are the first i - 1
   !>                 elements of Householder vector v_(l_i).
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[out]
-  !>     ipiv        pointer to type. Array on the GPU (the size depends on the value of strideP).
+  !>     @param[out] ipiv - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideP).
   !>                 Contains the vectors ipiv_l of corresponding Householder scalars.
-  !>     @param[in]
-  !>     strideP     rocblas_stride.
+  !>     @param[in] strideP - rocblas_stride.
   !>                 Stride from the start of one vector ipiv_l to the next one ipiv_(l+1).
   !>                 There is no restriction for the value
   !>                 of strideP. Normal usage is strideP >= min(m,n).
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_sgerqf_batched
     function rocsolver_sgerqf_batched_(handle,m,n,A,lda,ipiv,strideP,batch_count) &
@@ -12955,39 +12274,32 @@ module hipfort_rocsolver
   !>     where the last n-i elements of Householder vector \f$v_{l_i}\f$ are zero, and \f$v_{l_i}[i]
   !>     = 1\f$.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of all the matrices A_l in the batch.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of all the matrices A_l in the batch.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the m-by-n matrices A_l to be factored.
   !>                 On exit, the elements on and above the (m-n)-th subdiagonal (when
   !>                 m >= n) or the (n-m)-th superdiagonal (when n > m) contain the
   !>                 factor R_l, and the elements below the sub/superdiagonal are the first i - 1
   !>                 elements of Householder vector v_(l_i).
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[out]
-  !>     ipiv        pointer to type. Array on the GPU (the size depends on the value of strideP).
+  !>     @param[out] ipiv - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideP).
   !>                 Contains the vectors ipiv_l of corresponding Householder scalars.
-  !>     @param[in]
-  !>     strideP     rocblas_stride.
+  !>     @param[in] strideP - rocblas_stride.
   !>                 Stride from the start of one vector ipiv_l to the next one ipiv_(l+1).
   !>                 There is no restriction for the value
   !>                 of strideP. Normal usage is strideP >= min(m,n).
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_sgerqf_strided_batched
     function rocsolver_sgerqf_strided_batched_(handle,m,n,A,lda,strideA,ipiv,strideP,batch_count) &
@@ -13129,26 +12441,20 @@ module hipfort_rocsolver
   !>     where the last m-i elements of the Householder vector \f$v_i\f$ are zero, and \f$v_i[i] =
   !>     1\f$.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of the matrix A.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of the matrix A.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the m-by-n matrix to be factored.
   !>                 On exit, the elements on and below the (m-n)-th subdiagonal (when
   !>                 m >= n) or the (n-m)-th superdiagonal (when n > m) contain the
   !>                 factor L, and the elements above the sub/superdiagonal are the first i - 1
   !>                 elements of Householder vector v_i.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of A.
-  !>     @param[out]
-  !>     ipiv        pointer to type. Array on the GPU of dimension min(m,n).
+  !>     @param[out] ipiv - pointer to type. Array on the GPU of dimension min(m,n).
   !>                 The Householder scalars.
   interface rocsolver_sgeqlf
     function rocsolver_sgeqlf_(handle,m,n,A,lda,ipiv) bind(c, name="rocsolver_sgeqlf")
@@ -13274,34 +12580,28 @@ module hipfort_rocsolver
   !>     where the last m-i elements of the Householder vector \f$v_{l_i}\f$ are zero, and
   !>     \f$v_{l_i}[i] = 1\f$.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of all the matrices A_l in the batch.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of all the matrices A_l in the batch.
-  !>     @param[inout]
-  !>     A Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - Array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the m-by-n matrices A_l to be factored.
   !>                 On exit, the elements on and below the (m-n)-th subdiagonal (when
   !>                 m >= n) or the (n-m)-th superdiagonal (when n > m) contain the
   !>                 factor L_l, and the elements above the sub/superdiagonal are the first i - 1
   !>                 elements of Householder vector v_(l_i).
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[out]
-  !>     ipiv        pointer to type. Array on the GPU (the size depends on the value of strideP).
+  !>     @param[out] ipiv - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideP).
   !>                 Contains the vectors ipiv_l of corresponding Householder scalars.
-  !>     @param[in]
-  !>     strideP     rocblas_stride.
+  !>     @param[in] strideP - rocblas_stride.
   !>                 Stride from the start of one vector ipiv_l to the next one ipiv_(l+1).
   !>                 There is no restriction for the value
   !>                 of strideP. Normal usage is strideP >= min(m,n).
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_sgeqlf_batched
     function rocsolver_sgeqlf_batched_(handle,m,n,A,lda,ipiv,strideP,batch_count) &
@@ -13435,39 +12735,32 @@ module hipfort_rocsolver
   !>     where the last m-i elements of the Householder vector \f$v_{l_i}\f$ are zero, and
   !>     \f$v_{l_i}[i] = 1\f$.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of all the matrices A_l in the batch.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of all the matrices A_l in the batch.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the m-by-n matrices A_l to be factored.
   !>                 On exit, the elements on and below the (m-n)-th subdiagonal (when
   !>                 m >= n) or the (n-m)-th superdiagonal (when n > m) contain the
   !>                 factor L_l, and the elements above the sub/superdiagonal are the first i - 1
   !>                 elements of Householder vector v_(l_i).
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[out]
-  !>     ipiv        pointer to type. Array on the GPU (the size depends on the value of strideP).
+  !>     @param[out] ipiv - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideP).
   !>                 Contains the vectors ipiv_l of corresponding Householder scalars.
-  !>     @param[in]
-  !>     strideP     rocblas_stride.
+  !>     @param[in] strideP - rocblas_stride.
   !>                 Stride from the start of one vector ipiv_l to the next one ipiv_(l+1).
   !>                 There is no restriction for the value
   !>                 of strideP. Normal usage is strideP >= min(m,n).
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_sgeqlf_strided_batched
     function rocsolver_sgeqlf_strided_batched_(handle,m,n,A,lda,strideA,ipiv,strideP,batch_count) &
@@ -13608,25 +12901,19 @@ module hipfort_rocsolver
   !>     where the first i-1 elements of the Householder vector \f$v_i\f$ are zero, and \f$v_i[i] =
   !>     1\f$.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of the matrix A.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of the matrix A.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the m-by-n matrix to be factored.
   !>                 On exit, the elements on and below the diagonal contain the
   !>                 factor L, and the elements above the diagonal are the last n - i elements
   !>                 of Householder vector v_i.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of A.
-  !>     @param[out]
-  !>     ipiv        pointer to type. Array on the GPU of dimension min(m,n).
+  !>     @param[out] ipiv - pointer to type. Array on the GPU of dimension min(m,n).
   !>                 The Householder scalars.
   interface rocsolver_sgelqf
     function rocsolver_sgelqf_(handle,m,n,A,lda,ipiv) bind(c, name="rocsolver_sgelqf")
@@ -13751,33 +13038,27 @@ module hipfort_rocsolver
   !>     where the first i-1 elements of Householder vector \f$v_{l_i}\f$ are zero, and
   !>     \f$v_{l_i}[i] = 1\f$.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of all the matrices A_l in the batch.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of all the matrices A_l in the batch.
-  !>     @param[inout]
-  !>     A Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - Array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the m-by-n matrices A_l to be factored.
   !>                 On exit, the elements on and below the diagonal contain the
   !>                 factor L_l. The elements above the diagonal are the last n - i elements
   !>                 of Householder vector v_(l_i).
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[out]
-  !>     ipiv        pointer to type. Array on the GPU (the size depends on the value of strideP).
+  !>     @param[out] ipiv - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideP).
   !>                 Contains the vectors ipiv_l of corresponding Householder scalars.
-  !>     @param[in]
-  !>     strideP     rocblas_stride.
+  !>     @param[in] strideP - rocblas_stride.
   !>                 Stride from the start of one vector ipiv_l to the next one ipiv_(l+1).
   !>                 There is no restriction for the value
   !>                 of strideP. Normal usage is strideP >= min(m,n).
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_sgelqf_batched
     function rocsolver_sgelqf_batched_(handle,m,n,A,lda,ipiv,strideP,batch_count) &
@@ -13910,38 +13191,31 @@ module hipfort_rocsolver
   !>     where the first i-1 elements of Householder vector \f$v_{l_i}\f$ are zero, and
   !>     \f$v_{l_i}[i] = 1\f$.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of all the matrices A_l in the batch.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of all the matrices A_l in the batch.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the m-by-n matrices A_l to be factored.
   !>                 On exit, the elements on and below the diagonal contain the
   !>                 factor L_l. The elements above the diagonal are the last n - i elements
   !>                 of Householder vector v_(l_i).
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[out]
-  !>     ipiv        pointer to type. Array on the GPU (the size depends on the value of strideP).
+  !>     @param[out] ipiv - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideP).
   !>                 Contains the vectors ipiv_l of corresponding Householder scalars.
-  !>     @param[in]
-  !>     strideP     rocblas_stride.
+  !>     @param[in] strideP - rocblas_stride.
   !>                 Stride from the start of one vector ipiv_l to the next one ipiv_(l+1).
   !>                 There is no restriction for the value
   !>                 of strideP. Normal usage is strideP >= min(m,n).
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_sgelqf_strided_batched
     function rocsolver_sgelqf_strided_batched_(handle,m,n,A,lda,strideA,ipiv,strideP,batch_count) &
@@ -14094,16 +13368,12 @@ module hipfort_rocsolver
   !>     while the first i-1 elements of the Householder vector \f$u_i\f$ are zero, and \f$u_i[i] =
   !>     1\f$.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of the matrix A.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of the matrix A.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the m-by-n matrix to be factored.
   !>                 On exit, the elements on the diagonal and superdiagonal (if m >= n), or
   !>                 subdiagonal (if m < n) contain the bidiagonal form B.
@@ -14113,20 +13383,15 @@ module hipfort_rocsolver
   !>                 If m < n, the elements below the subdiagonal are the last m - i - 1
   !>                 elements of Householder vector v_i, and the elements above the
   !>                 diagonal are the last n - i elements of Householder vector u_i.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 specifies the leading dimension of A.
-  !>     @param[out]
-  !>     D           pointer to real type. Array on the GPU of dimension min(m,n).
+  !>     @param[out] D - pointer to real type. Array on the GPU of dimension min(m,n).
   !>                 The diagonal elements of B.
-  !>     @param[out]
-  !>     E           pointer to real type. Array on the GPU of dimension min(m,n)-1.
+  !>     @param[out] E - pointer to real type. Array on the GPU of dimension min(m,n)-1.
   !>                 The off-diagonal elements of B.
-  !>     @param[out]
-  !>     tauq        pointer to type. Array on the GPU of dimension min(m,n).
+  !>     @param[out] tauq - pointer to type. Array on the GPU of dimension min(m,n).
   !>                 The Householder scalars associated with matrix Q.
-  !>     @param[out]
-  !>     taup        pointer to type. Array on the GPU of dimension min(m,n).
+  !>     @param[out] taup - pointer to type. Array on the GPU of dimension min(m,n).
   !>                 The Householder scalars associated with matrix P.
   interface rocsolver_sgebd2
     function rocsolver_sgebd2_(handle,m,n,A,lda,D,E,tauq,taup) bind(c, name="rocsolver_sgebd2")
@@ -14276,16 +13541,13 @@ module hipfort_rocsolver
   !>     while the first i-1 elements of the Householder vector \f$u_{l_i}\f$ are zero, and
   !>     \f$u_{l_i}[i] = 1\f$.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of all the matrices A_l in the batch.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of all the matrices A_l in the batch.
-  !>     @param[inout]
-  !>     A Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - Array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the m-by-n matrices A_l to be factored.
   !>                 On exit, the elements on the diagonal and superdiagonal (if m >= n), or
   !>                 subdiagonal (if m < n) contain the bidiagonal form B_l.
@@ -14295,45 +13557,39 @@ module hipfort_rocsolver
   !>                 If m < n, the elements below the subdiagonal are the last m - i - 1
   !>                 elements of Householder vector v_(l_i), and the elements above the
   !>                 diagonal are the last n - i elements of Householder vector u_(l_i).
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[out]
-  !>     D pointer to real type. Array on the GPU (the size depends on the value of strideD).
+  !>     @param[out] D - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideD).
   !>                 The diagonal elements of B_l.
-  !>     @param[in]
-  !>     strideD     rocblas_stride.
+  !>     @param[in] strideD - rocblas_stride.
   !>                 Stride from the start of one vector D_l to the next one D_(l+1).
   !>                 There is no restriction for the value of strideD. The normal use case is
   !>                 strideD >= min(m,n).
-  !>     @param[out]
-  !>     E pointer to real type. Array on the GPU (the size depends on the value of strideE).
+  !>     @param[out] E - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideE).
   !>                 The off-diagonal elements of B_l.
-  !>     @param[in]
-  !>     strideE     rocblas_stride.
+  !>     @param[in] strideE - rocblas_stride.
   !>                 Stride from the start of one vector E_l to the next one E_(l+1).
   !>                 There is no restriction for the value of strideE. The normal use case is
   !>                 strideE >= min(m,n)-1.
-  !>     @param[out]
-  !>     tauq        pointer to type. Array on the GPU (the size depends on the value of strideQ).
+  !>     @param[out] tauq - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideQ).
   !>                 Contains the vectors tauq_l of Householder scalars associated with matrices
   !>                 Q_l.
-  !>     @param[in]
-  !>     strideQ     rocblas_stride.
+  !>     @param[in] strideQ - rocblas_stride.
   !>                 Stride from the start of one vector tauq_l to the next one tauq_(l+1).
   !>                 There is no restriction for the value
   !>                 of strideQ. Normal usage is strideQ >= min(m,n).
-  !>     @param[out]
-  !>     taup        pointer to type. Array on the GPU (the size depends on the value of strideP).
+  !>     @param[out] taup - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideP).
   !>                 Contains the vectors taup_l of Householder scalars associated with matrices
   !>                 P_l.
-  !>     @param[in]
-  !>     strideP     rocblas_stride.
+  !>     @param[in] strideP - rocblas_stride.
   !>                 Stride from the start of one vector taup_l to the next one taup_(l+1).
   !>                 There is no restriction for the value
   !>                 of strideP. Normal usage is strideP >= min(m,n).
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_sgebd2_batched
     function rocsolver_sgebd2_batched_(handle,m,n,A,lda,D,strideD,E,strideE,tauq,strideQ,taup, &
@@ -14507,16 +13763,13 @@ module hipfort_rocsolver
   !>     while the first i-1 elements of the Householder vector \f$u_{l_i}\f$ are zero, and
   !>     \f$u_{l_i}[i] = 1\f$.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of all the matrices A_l in the batch.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of all the matrices A_l in the batch.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the m-by-n matrices A_l to be factored.
   !>                 On exit, the elements on the diagonal and superdiagonal (if m >= n), or
   !>                 subdiagonal (if m < n) contain the bidiagonal form B_l.
@@ -14526,50 +13779,43 @@ module hipfort_rocsolver
   !>                 If m < n, the elements below the subdiagonal are the last m - i - 1
   !>                 elements of Householder vector v_(l_i), and the elements above the
   !>                 diagonal are the last n - i elements of Householder vector u_(l_i).
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[out]
-  !>     D pointer to real type. Array on the GPU (the size depends on the value of strideD).
+  !>     @param[out] D - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideD).
   !>                 The diagonal elements of B_l.
-  !>     @param[in]
-  !>     strideD     rocblas_stride.
+  !>     @param[in] strideD - rocblas_stride.
   !>                 Stride from the start of one vector D_l to the next one D_(l+1).
   !>                 There is no restriction for the value of strideD. The normal use case is
   !>                 strideD >= min(m,n).
-  !>     @param[out]
-  !>     E pointer to real type. Array on the GPU (the size depends on the value of strideE).
+  !>     @param[out] E - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideE).
   !>                 The off-diagonal elements of B_l.
-  !>     @param[in]
-  !>     strideE     rocblas_stride.
+  !>     @param[in] strideE - rocblas_stride.
   !>                 Stride from the start of one vector E_l to the next one E_(l+1).
   !>                 There is no restriction for the value of strideE. The normal use case is
   !>                 strideE >= min(m,n)-1.
-  !>     @param[out]
-  !>     tauq        pointer to type. Array on the GPU (the size depends on the value of strideQ).
+  !>     @param[out] tauq - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideQ).
   !>                 Contains the vectors tauq_l of Householder scalars associated with matrices
   !>                 Q_l.
-  !>     @param[in]
-  !>     strideQ     rocblas_stride.
+  !>     @param[in] strideQ - rocblas_stride.
   !>                 Stride from the start of one vector tauq_l to the next one tauq_(l+1).
   !>                 There is no restriction for the value
   !>                 of strideQ. Normal usage is strideQ >= min(m,n).
-  !>     @param[out]
-  !>     taup        pointer to type. Array on the GPU (the size depends on the value of strideP).
+  !>     @param[out] taup - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideP).
   !>                 Contains the vectors taup_l of Householder scalars associated with matrices
   !>                 P_l.
-  !>     @param[in]
-  !>     strideP     rocblas_stride.
+  !>     @param[in] strideP - rocblas_stride.
   !>                 Stride from the start of one vector taup_l to the next one taup_(l+1).
   !>                 There is no restriction for the value
   !>                 of strideP. Normal usage is strideP >= min(m,n).
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_sgebd2_strided_batched
     function rocsolver_sgebd2_strided_batched_(handle,m,n,A,lda,strideA,D,strideD,E,strideE,tauq, &
@@ -14750,16 +13996,12 @@ module hipfort_rocsolver
   !>     while the first i-1 elements of the Householder vector \f$u_i\f$ are zero, and \f$u_i[i] =
   !>     1\f$.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of the matrix A.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of the matrix A.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the m-by-n matrix to be factored.
   !>                 On exit, the elements on the diagonal and superdiagonal (if m >= n), or
   !>                 subdiagonal (if m < n) contain the bidiagonal form B.
@@ -14769,20 +14011,15 @@ module hipfort_rocsolver
   !>                 If m < n, the elements below the subdiagonal are the last m - i - 1
   !>                 elements of Householder vector v_i, and the elements above the
   !>                 diagonal are the last n - i elements of Householder vector u_i.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 specifies the leading dimension of A.
-  !>     @param[out]
-  !>     D           pointer to real type. Array on the GPU of dimension min(m,n).
+  !>     @param[out] D - pointer to real type. Array on the GPU of dimension min(m,n).
   !>                 The diagonal elements of B.
-  !>     @param[out]
-  !>     E           pointer to real type. Array on the GPU of dimension min(m,n)-1.
+  !>     @param[out] E - pointer to real type. Array on the GPU of dimension min(m,n)-1.
   !>                 The off-diagonal elements of B.
-  !>     @param[out]
-  !>     tauq        pointer to type. Array on the GPU of dimension min(m,n).
+  !>     @param[out] tauq - pointer to type. Array on the GPU of dimension min(m,n).
   !>                 The Householder scalars associated with matrix Q.
-  !>     @param[out]
-  !>     taup        pointer to type. Array on the GPU of dimension min(m,n).
+  !>     @param[out] taup - pointer to type. Array on the GPU of dimension min(m,n).
   !>                 The Householder scalars associated with matrix P.
   interface rocsolver_sgebrd
     function rocsolver_sgebrd_(handle,m,n,A,lda,D,E,tauq,taup) bind(c, name="rocsolver_sgebrd")
@@ -14932,16 +14169,13 @@ module hipfort_rocsolver
   !>     while the first i-1 elements of the Householder vector \f$u_{l_i}\f$ are zero, and
   !>     \f$u_{l_i}[i] = 1\f$.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of all the matrices A_l in the batch.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of all the matrices A_l in the batch.
-  !>     @param[inout]
-  !>     A Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - Array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the m-by-n matrices A_l to be factored.
   !>                 On exit, the elements on the diagonal and superdiagonal (if m >= n), or
   !>                 subdiagonal (if m < n) contain the bidiagonal form B_l.
@@ -14951,45 +14185,39 @@ module hipfort_rocsolver
   !>                 If m < n, the elements below the subdiagonal are the last m - i - 1
   !>                 elements of Householder vector v_(l_i), and the elements above the
   !>                 diagonal are the last n - i elements of Householder vector u_(l_i).
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[out]
-  !>     D pointer to real type. Array on the GPU (the size depends on the value of strideD).
+  !>     @param[out] D - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideD).
   !>                 The diagonal elements of B_l.
-  !>     @param[in]
-  !>     strideD     rocblas_stride.
+  !>     @param[in] strideD - rocblas_stride.
   !>                 Stride from the start of one vector D_l to the next one D_(l+1).
   !>                 There is no restriction for the value of strideD. The normal use case is
   !>                 strideD >= min(m,n).
-  !>     @param[out]
-  !>     E pointer to real type. Array on the GPU (the size depends on the value of strideE).
+  !>     @param[out] E - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideE).
   !>                 The off-diagonal elements of B_l.
-  !>     @param[in]
-  !>     strideE     rocblas_stride.
+  !>     @param[in] strideE - rocblas_stride.
   !>                 Stride from the start of one vector E_l to the next one E_(l+1).
   !>                 There is no restriction for the value of strideE. The normal use case is
   !>                 strideE >= min(m,n)-1.
-  !>     @param[out]
-  !>     tauq        pointer to type. Array on the GPU (the size depends on the value of strideQ).
+  !>     @param[out] tauq - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideQ).
   !>                 Contains the vectors tauq_l of Householder scalars associated with matrices
   !>                 Q_l.
-  !>     @param[in]
-  !>     strideQ     rocblas_stride.
+  !>     @param[in] strideQ - rocblas_stride.
   !>                 Stride from the start of one vector tauq_l to the next one tauq_(l+1).
   !>                 There is no restriction for the value
   !>                 of strideQ. Normal usage is strideQ >= min(m,n).
-  !>     @param[out]
-  !>     taup        pointer to type. Array on the GPU (the size depends on the value of strideP).
+  !>     @param[out] taup - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideP).
   !>                 Contains the vectors taup_l of Householder scalars associated with matrices
   !>                 P_l.
-  !>     @param[in]
-  !>     strideP     rocblas_stride.
+  !>     @param[in] strideP - rocblas_stride.
   !>                 Stride from the start of one vector taup_l to the next one taup_(l+1).
   !>                 There is no restriction for the value
   !>                 of strideP. Normal usage is strideP >= min(m,n).
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_sgebrd_batched
     function rocsolver_sgebrd_batched_(handle,m,n,A,lda,D,strideD,E,strideE,tauq,strideQ,taup, &
@@ -15163,16 +14391,13 @@ module hipfort_rocsolver
   !>     while the first i-1 elements of the Householder vector \f$u_{l_i}\f$ are zero, and
   !>     \f$u_{l_i}[i] = 1\f$.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of all the matrices A_l in the batch.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of all the matrices A_l in the batch.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the m-by-n matrices A_l to be factored.
   !>                 On exit, the elements on the diagonal and superdiagonal (if m >= n), or
   !>                 subdiagonal (if m < n) contain the bidiagonal form B_l.
@@ -15182,50 +14407,43 @@ module hipfort_rocsolver
   !>                 If m < n, the elements below the subdiagonal are the last m - i - 1
   !>                 elements of Householder vector v_(l_i), and the elements above the
   !>                 diagonal are the last n - i elements of Householder vector u_(l_i).
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[out]
-  !>     D pointer to real type. Array on the GPU (the size depends on the value of strideD).
+  !>     @param[out] D - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideD).
   !>                 The diagonal elements of B_l.
-  !>     @param[in]
-  !>     strideD     rocblas_stride.
+  !>     @param[in] strideD - rocblas_stride.
   !>                 Stride from the start of one vector D_l to the next one D_(l+1).
   !>                 There is no restriction for the value of strideD. The normal use case is
   !>                 strideD >= min(m,n).
-  !>     @param[out]
-  !>     E pointer to real type. Array on the GPU (the size depends on the value of strideE).
+  !>     @param[out] E - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideE).
   !>                 The off-diagonal elements of B_l.
-  !>     @param[in]
-  !>     strideE     rocblas_stride.
+  !>     @param[in] strideE - rocblas_stride.
   !>                 Stride from the start of one vector E_l to the next one E_(l+1).
   !>                 There is no restriction for the value of strideE. The normal use case is
   !>                 strideE >= min(m,n)-1.
-  !>     @param[out]
-  !>     tauq        pointer to type. Array on the GPU (the size depends on the value of strideQ).
+  !>     @param[out] tauq - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideQ).
   !>                 Contains the vectors tauq_l of Householder scalars associated with matrices
   !>                 Q_l.
-  !>     @param[in]
-  !>     strideQ     rocblas_stride.
+  !>     @param[in] strideQ - rocblas_stride.
   !>                 Stride from the start of one vector tauq_l to the next one tauq_(l+1).
   !>                 There is no restriction for the value
   !>                 of strideQ. Normal usage is strideQ >= min(m,n).
-  !>     @param[out]
-  !>     taup        pointer to type. Array on the GPU (the size depends on the value of strideP).
+  !>     @param[out] taup - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideP).
   !>                 Contains the vectors taup_l of Householder scalars associated with matrices
   !>                 P_l.
-  !>     @param[in]
-  !>     strideP     rocblas_stride.
+  !>     @param[in] strideP - rocblas_stride.
   !>                 Stride from the start of one vector taup_l to the next one taup_(l+1).
   !>                 There is no restriction for the value
   !>                 of strideP. Normal usage is strideP >= min(m,n).
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_sgebrd_strided_batched
     function rocsolver_sgebrd_strided_batched_(handle,m,n,A,lda,strideA,D,strideD,E,strideE,tauq, &
@@ -15380,34 +14598,25 @@ module hipfort_rocsolver
   !>     Matrix ``A`` is defined by its triangular factors, as returned by \ref rocsolver_sgetrf
   !>     "GETRF".
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     trans       rocblas_operation.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] trans - rocblas_operation.
   !>                 Specifies the form of the system of equations.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The order of the system, that is, the number of columns and rows of A.
-  !>     @param[in]
-  !>     nrhs        rocblas_int. nrhs >= 0.
+  !>     @param[in] nrhs - rocblas_int. nrhs >= 0.
   !>                 The number of right hand sides, that is, the number of columns
   !>                 of the matrix B.
-  !>     @param[in]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[in] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 The factors L and U of the factorization \f$A = PLU\f$ returned by \ref
   !>                 rocsolver_sgetrf "GETRF".
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 The leading dimension of A.
-  !>     @param[in]
-  !>     ipiv        pointer to rocblas_int. Array on the GPU of dimension n.
+  !>     @param[in] ipiv - pointer to rocblas_int. Array on the GPU of dimension n.
   !>                 The pivot indices returned by \ref rocsolver_sgetrf "GETRF".
-  !>     @param[inout]
-  !>     B           pointer to type. Array on the GPU of dimension ldb*nrhs.
+  !>     @param[inout] B - pointer to type. Array on the GPU of dimension ldb*nrhs.
   !>                 On entry, the right hand side matrix B.
   !>                 On exit, the solution matrix X.
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 The leading dimension of B.
   interface rocsolver_sgetrs
     function rocsolver_sgetrs_(handle,trans,n,nrhs,A,lda,ipiv,B,ldb) &
@@ -15616,45 +14825,36 @@ module hipfort_rocsolver
   !>     Matrix \f$A_l\f$ is defined by its triangular factors as returned by \ref
   !>     rocsolver_sgetrf_batched "GETRF_BATCHED".
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     trans       rocblas_operation.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] trans - rocblas_operation.
   !>                 Specifies the form of the system of equations of each instance in the batch.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The order of the system, that is, the number of columns and rows of all A_l
   !>                 matrices.
-  !>     @param[in]
-  !>     nrhs        rocblas_int. nrhs >= 0.
+  !>     @param[in] nrhs - rocblas_int. nrhs >= 0.
   !>                 The number of right hand sides, that is, the number of columns
   !>                 of all the matrices B_l.
-  !>     @param[in]
-  !>     A Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[in] A - Array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 The factors L_l and U_l of the factorization A_l = P_l*L_l*U_l returned by \ref
   !>                 rocsolver_sgetrf_batched "GETRF_BATCHED".
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 The leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     ipiv pointer to rocblas_int. Array on the GPU (the size depends on the value of strideP).
+  !>     @param[in] ipiv - pointer to rocblas_int. Array on the GPU (the size depends on the value
+  !>     of strideP).
   !>                 Contains the vectors ipiv_l of pivot indices returned by \ref
   !>                 rocsolver_sgetrf_batched "GETRF_BATCHED".
-  !>     @param[in]
-  !>     strideP     rocblas_stride.
+  !>     @param[in] strideP - rocblas_stride.
   !>                 Stride from the start of one vector ipiv_l to the next one ipiv_(l+1).
   !>                 There is no restriction for the value of strideP. The normal use case is
   !>                 strideP >= n.
-  !>     @param[inout]
-  !>     B Array of pointers to type. Each pointer points to an array on the GPU of dimension
-  !>     ldb*nrhs.
+  !>     @param[inout] B - Array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension ldb*nrhs.
   !>                 On entry, the right hand side matrices B_l.
   !>                 On exit, the solution matrix X_l of each system in the batch.
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 The leading dimension of matrices B_l.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of instances (systems) in the batch.
   interface rocsolver_sgetrs_batched
     function rocsolver_sgetrs_batched_(handle,trans,n,nrhs,A,lda,ipiv,strideP,B,ldb,batch_count) &
@@ -15879,54 +15079,43 @@ module hipfort_rocsolver
   !>     Matrix \f$A_l\f$ is defined by its triangular factors, as returned by \ref
   !>     rocsolver_sgetrf_strided_batched "GETRF_STRIDED_BATCHED".
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     trans       rocblas_operation.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] trans - rocblas_operation.
   !>                 Specifies the form of the system of equations of each instance in the batch.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The order of the system, that is, the number of columns and rows of all A_l
   !>                 matrices.
-  !>     @param[in]
-  !>     nrhs        rocblas_int. nrhs >= 0.
+  !>     @param[in] nrhs - rocblas_int. nrhs >= 0.
   !>                 The number of right hand sides, that is, the number of columns
   !>                 of all the matrices B_l.
-  !>     @param[in]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[in] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 The factors L_l and U_l of the factorization A_l = P_l*L_l*U_l returned by \ref
   !>                 rocsolver_sgetrf_strided_batched "GETRF_STRIDED_BATCHED".
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 The leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[in]
-  !>     ipiv pointer to rocblas_int. Array on the GPU (the size depends on the value of strideP).
+  !>     @param[in] ipiv - pointer to rocblas_int. Array on the GPU (the size depends on the value
+  !>     of strideP).
   !>                 Contains the vectors ipiv_l of pivot indices returned by \ref
   !>                 rocsolver_sgetrf_strided_batched "GETRF_STRIDED_BATCHED".
-  !>     @param[in]
-  !>     strideP     rocblas_stride.
+  !>     @param[in] strideP - rocblas_stride.
   !>                 Stride from the start of one vector ipiv_l to the next one ipiv_(l+1).
   !>                 There is no restriction for the value of strideP. The normal use case is
   !>                 strideP >= n.
-  !>     @param[inout]
-  !>     B           pointer to type. Array on the GPU (size depends on the value of strideB).
+  !>     @param[inout] B - pointer to type. Array on the GPU (size depends on the value of strideB).
   !>                 On entry, the right hand side matrices B_l.
   !>                 On exit, the solution matrix X_l of each system in the batch.
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 The leading dimension of matrices B_l.
-  !>     @param[in]
-  !>     strideB     rocblas_stride.
+  !>     @param[in] strideB - rocblas_stride.
   !>                 Stride from the start of one matrix B_l to the next one B_(l+1).
   !>                 There is no restriction for the value of strideB. The normal use case is
   !>                 strideB >= ldb*nrhs.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of instances (systems) in the batch.
   interface rocsolver_sgetrs_strided_batched
     function rocsolver_sgetrs_strided_batched_(handle,trans,n,nrhs,A,lda,strideA,ipiv,strideP,B, &
@@ -16176,35 +15365,26 @@ module hipfort_rocsolver
   !>     "SYTRF".
   !>     Matrix \f$D\f$ is a symmetric block diagonal matrix with 1-by-1 or 2-by-2 diagonal blocks.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the factorization of matrix \f$ A \f$ is upper or lower
   !>                 triangular.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The order of the system, that is, the number of columns and rows of A.
-  !>     @param[in]
-  !>     nrhs        rocblas_int. nrhs >= 0.
+  !>     @param[in] nrhs - rocblas_int. nrhs >= 0.
   !>                 The number of right hand sides, that is, the number of columns
   !>                 of the matrix B.
-  !>     @param[in]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[in] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 The factors L (or U) and D of the factorization A returned by \ref
   !>                 rocsolver_ssytrf "SYTRF".
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 The leading dimension of A.
-  !>     @param[in]
-  !>     ipiv        pointer to rocblas_int. Array on the GPU of dimension n.
+  !>     @param[in] ipiv - pointer to rocblas_int. Array on the GPU of dimension n.
   !>                 The pivot indices returned by \ref rocsolver_ssytrf "SYTRF".
-  !>     @param[inout]
-  !>     B           pointer to type. Array on the GPU of dimension ldb*nrhs.
+  !>     @param[inout] B - pointer to type. Array on the GPU of dimension ldb*nrhs.
   !>                 On entry, the right hand side matrix B.
   !>                 On exit, the solution matrix X.
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 The leading dimension of B.
   interface rocsolver_ssytrs
     function rocsolver_ssytrs_(handle,uplo,n,nrhs,A,lda,ipiv,B,ldb) bind(c, name="rocsolver_ssytrs")
@@ -16384,46 +15564,37 @@ module hipfort_rocsolver
   !>     \ref rocsolver_ssytrf_batched "SYTRF_BATCHED".
   !>     Note matrix \f$ D_l \f$ contains 1-by-1 or 2-by-2 blocks on the main diagonal.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the factorization of matrix \f$ A \f$ is upper or lower
   !>                 triangular.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The order of the system, that is, the number of columns and rows of all A_l
   !>                 matrices.
-  !>     @param[in]
-  !>     nrhs        rocblas_int. nrhs >= 0.
+  !>     @param[in] nrhs - rocblas_int. nrhs >= 0.
   !>                 The number of right hand sides, that is, the number of columns
   !>                 of all the matrices B_l.
-  !>     @param[in]
-  !>     A Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[in] A - Array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 The factors L_l (or U_l) and D_l of the factorization A_l returned by \ref
   !>                 rocsolver_ssytrf_batched "SYTRF_BATCHED".
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 The leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     ipiv pointer to rocblas_int. Array on the GPU (the size depends on the value of strideP).
+  !>     @param[in] ipiv - pointer to rocblas_int. Array on the GPU (the size depends on the value
+  !>     of strideP).
   !>                 Contains the vectors ipiv_l of pivot indices returned by \ref
   !>                 rocsolver_ssytrf_batched "SYTRF_BATCHED".
-  !>     @param[in]
-  !>     strideP     rocblas_stride.
+  !>     @param[in] strideP - rocblas_stride.
   !>                 Stride from the start of one vector ipiv_l to the next one ipiv_(l+1).
   !>                 There is no restriction for the value of strideP. The normal use case is
   !>                 strideP >= n.
-  !>     @param[inout]
-  !>     B Array of pointers to type. Each pointer points to an array on the GPU of dimension
-  !>     ldb*nrhs.
+  !>     @param[inout] B - Array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension ldb*nrhs.
   !>                 On entry, the right hand side matrices B_l.
   !>                 On exit, the solution matrix X_l of each system in the batch.
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 The leading dimension of matrices B_l.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of instances (systems) in the batch.
   interface rocsolver_ssytrs_batched
     function rocsolver_ssytrs_batched_(handle,uplo,n,nrhs,A,lda,ipiv,strideP,B,ldb,batch_count) &
@@ -16624,55 +15795,44 @@ module hipfort_rocsolver
   !>     Note matrix \f$ D_l \f$ contains 1-by-1 or 2-by-2 blocks on the main diagonal.
   !>
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the factorization of matrix \f$ A \f$ is upper or lower
   !>                 triangular.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The order of the system, that is, the number of columns and rows of all A_l
   !>                 matrices.
-  !>     @param[in]
-  !>     nrhs        rocblas_int. nrhs >= 0.
+  !>     @param[in] nrhs - rocblas_int. nrhs >= 0.
   !>                 The number of right hand sides, that is, the number of columns
   !>                 of all the matrices B_l.
-  !>     @param[in]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[in] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 The factors L_l (or U_l) and D_l of the factorization A_l returned by \ref
   !>                 rocsolver_ssytrf_strided_batched "SYTRF_STRIDED_BATCHED".
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 The leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[in]
-  !>     ipiv pointer to rocblas_int. Array on the GPU (the size depends on the value of strideP).
+  !>     @param[in] ipiv - pointer to rocblas_int. Array on the GPU (the size depends on the value
+  !>     of strideP).
   !>                 Contains the vectors ipiv_l of pivot indices returned by \ref
   !>                 rocsolver_ssytrf_strided_batched "SYTRF_STRIDED_BATCHED".
-  !>     @param[in]
-  !>     strideP     rocblas_stride.
+  !>     @param[in] strideP - rocblas_stride.
   !>                 Stride from the start of one vector ipiv_l to the next one ipiv_(l+1).
   !>                 There is no restriction for the value of strideP. The normal use case is
   !>                 strideP >= n.
-  !>     @param[inout]
-  !>     B           pointer to type. Array on the GPU (size depends on the value of strideB).
+  !>     @param[inout] B - pointer to type. Array on the GPU (size depends on the value of strideB).
   !>                 On entry, the right hand side matrices B_l.
   !>                 On exit, the solution matrix X_l of each system in the batch.
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 The leading dimension of matrices B_l.
-  !>     @param[in]
-  !>     strideB     rocblas_stride.
+  !>     @param[in] strideB - rocblas_stride.
   !>                 Stride from the start of one matrix B_l to the next one B_(l+1).
   !>                 There is no restriction for the value of strideB. The normal use case is
   !>                 strideB >= ldb*nrhs.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of instances (systems) in the batch.
   interface rocsolver_ssytrs_strided_batched
     function rocsolver_ssytrs_strided_batched_(handle,uplo,n,nrhs,A,lda,strideA,ipiv,strideP,B, &
@@ -16889,36 +16049,27 @@ module hipfort_rocsolver
   !>     using \ref rocsolver_sgetrf "GETRF", then the solution is computed with \ref
   !>     rocsolver_sgetrs "GETRS".
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The order of the system, that is, the number of columns and rows of A.
-  !>     @param[in]
-  !>     nrhs        rocblas_int. nrhs >= 0.
+  !>     @param[in] nrhs - rocblas_int. nrhs >= 0.
   !>                 The number of right hand sides, that is, the number of columns
   !>                 of the matrix B.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the matrix A.
   !>                 On exit, if info = 0, the factors L and U of the LU decomposition of A returned
   !>                 by
   !>                 \ref rocsolver_sgetrf "GETRF".
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 The leading dimension of A.
-  !>     @param[out]
-  !>     ipiv        pointer to rocblas_int. Array on the GPU of dimension n.
+  !>     @param[out] ipiv - pointer to rocblas_int. Array on the GPU of dimension n.
   !>                 The pivot indices returned by \ref rocsolver_sgetrf "GETRF".
-  !>     @param[inout]
-  !>     B           pointer to type. Array on the GPU of dimension ldb*nrhs.
+  !>     @param[inout] B - pointer to type. Array on the GPU of dimension ldb*nrhs.
   !>                 On entry, the right hand side matrix B.
   !>                 On exit, the solution matrix X.
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 The leading dimension of B.
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info = 0, successful exit.
   !>                 If info = i > 0, U is singular, and the solution could not be computed.
   !>                 U[i,i] is the first zero element in the diagonal.
@@ -17042,49 +16193,40 @@ module hipfort_rocsolver
   !>     using \ref rocsolver_sgetrf_batched "GETRF_BATCHED", then the solutions are computed with
   !>     \ref rocsolver_sgetrs_batched "GETRS_BATCHED".
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The order of the system, that is, the number of columns and rows of all A_l
   !>                 matrices.
-  !>     @param[in]
-  !>     nrhs        rocblas_int. nrhs >= 0.
+  !>     @param[in] nrhs - rocblas_int. nrhs >= 0.
   !>                 The number of right hand sides, that is, the number of columns
   !>                 of all the matrices B_l.
-  !>     @param[inout]
-  !>     A Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - Array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the matrices A_l.
   !>                 On exit, if info[l] = 0, the factors L_l and U_l of the LU decomposition of A_l
   !>                 returned by
   !>                 \ref rocsolver_sgetrf_batched "GETRF_BATCHED".
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 The leading dimension of matrices A_l.
-  !>     @param[out]
-  !>     ipiv pointer to rocblas_int. Array on the GPU (the size depends on the value of strideP).
+  !>     @param[out] ipiv - pointer to rocblas_int. Array on the GPU (the size depends on the value
+  !>     of strideP).
   !>                 The vectors ipiv_l of pivot indices returned by \ref rocsolver_sgetrf_batched
   !>                 "GETRF_BATCHED".
-  !>     @param[in]
-  !>     strideP     rocblas_stride.
+  !>     @param[in] strideP - rocblas_stride.
   !>                 Stride from the start of one vector ipiv_l to the next one ipiv_(l+1).
   !>                 There is no restriction for the value of strideP. The normal use case is
   !>                 strideP >= n.
-  !>     @param[inout]
-  !>     B Array of pointers to type. Each pointer points to an array on the GPU of dimension
-  !>     ldb*nrhs.
+  !>     @param[inout] B - Array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension ldb*nrhs.
   !>                 On entry, the right hand side matrices B_l.
   !>                 On exit, the solution matrix X_l of each system in the batch.
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 The leading dimension of matrices B_l.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for A_l.
   !>                 If info[l] = i > 0, U_l is singular, and the solution could not be computed.
   !>                 U_l[i,i] is the first zero element in the diagonal.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of instances (systems) in the batch.
   interface rocsolver_sgesv_batched
     function rocsolver_sgesv_batched_(handle,n,nrhs,A,lda,ipiv,strideP,B,ldb,myInfo,batch_count) &
@@ -17215,58 +16357,47 @@ module hipfort_rocsolver
   !>     are computed with
   !>     \ref rocsolver_sgetrs_strided_batched "GETRS_STRIDED_BATCHED".
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The order of the system, that is, the number of columns and rows of all A_l
   !>                 matrices.
-  !>     @param[in]
-  !>     nrhs        rocblas_int. nrhs >= 0.
+  !>     @param[in] nrhs - rocblas_int. nrhs >= 0.
   !>                 The number of right hand sides, that is, the number of columns
   !>                 of all the matrices B_l.
-  !>     @param[in]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[in] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the matrices A_l.
   !>                 On exit, if info[l] = 0, the factors L_l and U_l of the LU decomposition of A_l
   !>                 returned by
   !>                 \ref rocsolver_sgetrf_strided_batched "GETRF_STRIDED_BATCHED".
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 The leading dimension of matrices A_l.
-  !>     @param[inout]
-  !>     strideA     rocblas_stride.
+  !>     @param[inout] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[out]
-  !>     ipiv pointer to rocblas_int. Array on the GPU (the size depends on the value of strideP).
+  !>     @param[out] ipiv - pointer to rocblas_int. Array on the GPU (the size depends on the value
+  !>     of strideP).
   !>                 The vectors ipiv_l of pivot indices returned by \ref
   !>                 rocsolver_sgetrf_strided_batched "GETRF_STRIDED_BATCHED".
-  !>     @param[in]
-  !>     strideP     rocblas_stride.
+  !>     @param[in] strideP - rocblas_stride.
   !>                 Stride from the start of one vector ipiv_l to the next one ipiv_(l+1).
   !>                 There is no restriction for the value of strideP. The normal use case is
   !>                 strideP >= n.
-  !>     @param[inout]
-  !>     B           pointer to type. Array on the GPU (size depends on the value of strideB).
+  !>     @param[inout] B - pointer to type. Array on the GPU (size depends on the value of strideB).
   !>                 On entry, the right hand side matrices B_l.
   !>                 On exit, the solution matrix X_l of each system in the batch.
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 The leading dimension of matrices B_l.
-  !>     @param[in]
-  !>     strideB     rocblas_stride.
+  !>     @param[in] strideB - rocblas_stride.
   !>                 Stride from the start of one matrix B_l to the next one B_(l+1).
   !>                 There is no restriction for the value of strideB. The normal use case is
   !>                 strideB >= ldb*nrhs.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for A_l.
   !>                 If info[l] = i > 0, U_l is singular, and the solution could not be computed.
   !>                 U_l[i,i] is the first zero element in the diagonal.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of instances (systems) in the batch.
   interface rocsolver_sgesv_strided_batched
     function rocsolver_sgesv_strided_batched_(handle,n,nrhs,A,lda,strideA,ipiv,strideP,B,ldb, &
@@ -17413,32 +16544,24 @@ module hipfort_rocsolver
   !>     Matrix ``A`` is defined by its triangular factors, as returned by \ref
   !>     rocsolver_sgetrf_npvt "GETRF_NPVT".
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
+  !>     @param[in] handle - rocblas_handle.
   !>
-  !>     @param[in]
-  !>     trans       rocblas_operation.
+  !>     @param[in] trans - rocblas_operation.
   !>                 Specifies the form of the system of equations.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The order of the system, that is, the number of columns and rows of A.
-  !>     @param[in]
-  !>     nrhs        rocblas_int. nrhs >= 0.
+  !>     @param[in] nrhs - rocblas_int. nrhs >= 0.
   !>                 The number of right hand sides, that is, the number of columns
   !>                 of the matrix B.
-  !>     @param[in]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[in] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 The factors L and U of the factorization \f$A = LU\f$ returned by \ref
   !>                 rocsolver_sgetrf_npvt "GETRF_NPVT".
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 The leading dimension of A.
-  !>     @param[inout]
-  !>     B           pointer to type. Array on the GPU of dimension ldb*nrhs.
+  !>     @param[inout] B - pointer to type. Array on the GPU of dimension ldb*nrhs.
   !>                 On entry, the right hand side matrix B.
   !>                 On exit, the solution matrix X.
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 The leading dimension of B.
   interface rocsolver_sgetrs_npvt
     function rocsolver_sgetrs_npvt_(handle,trans,n,nrhs,A,lda,B,ldb) &
@@ -17611,37 +16734,29 @@ module hipfort_rocsolver
   !>     Matrix \f$A_l\f$ is defined by its triangular factors as returned by \ref
   !>     rocsolver_sgetrf_npvt_batched "GETRF_NPVT_BATCHED".
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
+  !>     @param[in] handle - rocblas_handle.
   !>
-  !>     @param[in]
-  !>     trans       rocblas_operation.
+  !>     @param[in] trans - rocblas_operation.
   !>                 Specifies the form of the system of equations of each instance in the batch.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The order of the system, that is, the number of columns and rows of all A_l
   !>                 matrices.
-  !>     @param[in]
-  !>     nrhs        rocblas_int. nrhs >= 0.
+  !>     @param[in] nrhs - rocblas_int. nrhs >= 0.
   !>                 The number of right hand sides, that is, the number of columns
   !>                 of all the matrices B_l.
-  !>     @param[in]
-  !>     A Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[in] A - Array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 The factors L_l and U_l of the factorization A_l = L_l*U_l returned by \ref
   !>                 rocsolver_sgetrf_npvt_batched "GETRF_NPVT_BATCHED".
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 The leading dimension of matrices A_l.
-  !>     @param[inout]
-  !>     B Array of pointers to type. Each pointer points to an array on the GPU of dimension
-  !>     ldb*nrhs.
+  !>     @param[inout] B - Array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension ldb*nrhs.
   !>                 On entry, the right hand side matrices B_l.
   !>                 On exit, the solution matrix X_l of each system in the batch.
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 The leading dimension of matrices B_l.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of instances (systems) in the batch.
   interface rocsolver_sgetrs_npvt_batched
     function rocsolver_sgetrs_npvt_batched_(handle,trans,n,nrhs,A,lda,B,ldb,batch_count) &
@@ -17822,46 +16937,36 @@ module hipfort_rocsolver
   !>     Matrix \f$A_l\f$ is defined by its triangular factors, as returned by \ref
   !>     rocsolver_sgetrf_npvt_strided_batched "GETRF_NPVT_STRIDED_BATCHED".
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
+  !>     @param[in] handle - rocblas_handle.
   !>
-  !>     @param[in]
-  !>     trans       rocblas_operation.
+  !>     @param[in] trans - rocblas_operation.
   !>                 Specifies the form of the system of equations of each instance in the batch.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The order of the system, that is, the number of columns and rows of all A_l
   !>                 matrices.
-  !>     @param[in]
-  !>     nrhs        rocblas_int. nrhs >= 0.
+  !>     @param[in] nrhs - rocblas_int. nrhs >= 0.
   !>                 The number of right hand sides, that is, the number of columns
   !>                 of all the matrices B_l.
-  !>     @param[in]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[in] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 The factors L_l and U_l of the factorization A_l = L_l*U_l returned by \ref
   !>                 rocsolver_sgetrf_npvt_strided_batched "GETRF_NPVT_STRIDED_BATCHED".
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 The leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[inout]
-  !>     B           pointer to type. Array on the GPU (size depends on the value of strideB).
+  !>     @param[inout] B - pointer to type. Array on the GPU (size depends on the value of strideB).
   !>                 On entry, the right hand side matrices B_l.
   !>                 On exit, the solution matrix X_l of each system in the batch.
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 The leading dimension of matrices B_l.
-  !>     @param[in]
-  !>     strideB     rocblas_stride.
+  !>     @param[in] strideB - rocblas_stride.
   !>                 Stride from the start of one matrix B_l to the next one B_(l+1).
   !>                 There is no restriction for the value of strideB. The normal use case is
   !>                 strideB >= ldb*nrhs.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of instances (systems) in the batch.
   interface rocsolver_sgetrs_npvt_strided_batched
     function rocsolver_sgetrs_npvt_strided_batched_(handle,trans,n,nrhs,A,lda,strideA,B,ldb, &
@@ -18061,24 +17166,18 @@ module hipfort_rocsolver
   !>     where L is the lower triangular factor of ``A`` with unit diagonal elements, and U is the
   !>     upper triangular factor.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows and columns of the matrix A.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the factors L and U of the factorization \f$A = PLU\f$ returned by
   !>                 \ref rocsolver_sgetrf "GETRF".
   !>                 On exit, the inverse of A if info = 0, and otherwise undefined.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of A.
-  !>     @param[in]
-  !>     ipiv        pointer to rocblas_int. Array on the GPU of dimension n.
+  !>     @param[in] ipiv - pointer to rocblas_int. Array on the GPU of dimension n.
   !>                 The pivot indices returned by \ref rocsolver_sgetrf "GETRF".
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info = 0, successful exit.
   !>                 If info = i > 0, U is singular. U[i,i] is the first zero pivot.
   interface rocsolver_sgetri
@@ -18187,34 +17286,28 @@ module hipfort_rocsolver
   !>     and \f$U_l\f$ is the
   !>     upper triangular factor.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows and columns of all matrices A_l in the batch.
-  !>     @param[inout]
-  !>     A array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the factors L_l and U_l of the factorization A_l = P_l*L_l*U_l
   !>                 returned by
   !>                 \ref rocsolver_sgetrf_batched "GETRF_BATCHED".
   !>                 On exit, the inverses of A_l if info[l] = 0, and otherwise undefined.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     ipiv pointer to rocblas_int. Array on the GPU (the size depends on the value of strideP).
+  !>     @param[in] ipiv - pointer to rocblas_int. Array on the GPU (the size depends on the value
+  !>     of strideP).
   !>                 The pivot indices returned by \ref rocsolver_sgetrf_batched "GETRF_BATCHED".
-  !>     @param[in]
-  !>     strideP     rocblas_stride.
+  !>     @param[in] strideP - rocblas_stride.
   !>                 Stride from the start of one vector ipiv_l to the next one ipiv_(l+j).
   !>                 There is no restriction for the value of strideP. The normal use case is
   !>                 strideP >= n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for inversion of A_l.
   !>                 If info[l] = i > 0, U_l is singular. U_l[i,i] is the first zero pivot.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_sgetri_batched
     function rocsolver_sgetri_batched_(handle,n,A,lda,ipiv,strideP,myInfo,batch_count) &
@@ -18332,40 +17425,33 @@ module hipfort_rocsolver
   !>     and \f$U_l\f$ is the
   !>     upper triangular factor.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows and columns of all matrices A_l in the batch.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the factors L_l and U_l of the factorization A_l = P_l*L_l*U_l
   !>                 returned by
   !>                 \ref rocsolver_sgetrf_strided_batched "GETRF_STRIDED_BATCHED".
   !>                 On exit, the inverses of A_l if info[l] = 0, and otherwise undefined.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[in]
-  !>     ipiv pointer to rocblas_int. Array on the GPU (the size depends on the value of strideP).
+  !>     @param[in] ipiv - pointer to rocblas_int. Array on the GPU (the size depends on the value
+  !>     of strideP).
   !>                 The pivot indices returned by \ref rocsolver_sgetrf_strided_batched
   !>                 "GETRF_STRIDED_BATCHED".
-  !>     @param[in]
-  !>     strideP     rocblas_stride.
+  !>     @param[in] strideP - rocblas_stride.
   !>                 Stride from the start of one vector ipiv_l to the next one ipiv_(l+1).
   !>                 There is no restriction for the value of strideP. The normal use case is
   !>                 strideP >= n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for inversion of A_l.
   !>                 If info[l] = i > 0, U_l is singular. U_l[i,i] is the first zero pivot.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_sgetri_strided_batched
     function rocsolver_sgetri_strided_batched_(handle,n,A,lda,strideA,ipiv,strideP,myInfo, &
@@ -18493,21 +17579,16 @@ module hipfort_rocsolver
   !>     where L is the lower triangular factor of ``A`` with unit diagonal elements, and U is the
   !>     upper triangular factor.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows and columns of the matrix A.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the factors L and U of the factorization \f$A = LU\f$ returned by
   !>                 \ref rocsolver_sgetrf_npvt "GETRF_NPVT".
   !>                 On exit, the inverse of A if info = 0, and otherwise undefined.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of A.
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info = 0, successful exit.
   !>                 If info = i > 0, U is singular. U[i,i] is the first zero pivot.
   interface rocsolver_sgetri_npvt
@@ -18613,26 +17694,21 @@ module hipfort_rocsolver
   !>     and \f$U_l\f$ is the
   !>     upper triangular factor.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows and columns of all matrices A_l in the batch.
-  !>     @param[inout]
-  !>     A array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the factors L_l and U_l of the factorization A_l = L_l*U_l returned
   !>                 by
   !>                 \ref rocsolver_sgetrf_npvt_batched "GETRF_NPVT_BATCHED".
   !>                 On exit, the inverses of A_l if info[l] = 0, and otherwise undefined.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for inversion of A_l.
   !>                 If info[l] = i > 0, U_l is singular. U_l[i,i] is the first zero pivot.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_sgetri_npvt_batched
     function rocsolver_sgetri_npvt_batched_(handle,n,A,lda,myInfo,batch_count) &
@@ -18718,31 +17794,25 @@ module hipfort_rocsolver
   !>     and \f$U_l\f$ is the
   !>     upper triangular factor.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows and columns of all matrices A_l in the batch.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the factors L_l and U_l of the factorization A_l = L_l*U_l returned
   !>                 by
   !>                 \ref rocsolver_sgetrf_npvt_strided_batched "GETRF_NPVT_STRIDED_BATCHED".
   !>                 On exit, the inverses of A_l if info[l] = 0, and otherwise undefined.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for inversion of A_l.
   !>                 If info[l] = i > 0, U_l is singular. U_l[i,i] is the first zero pivot.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_sgetri_npvt_strided_batched
     function rocsolver_sgetri_npvt_strided_batched_(handle,n,A,lda,strideA,myInfo,batch_count) &
@@ -18873,40 +17943,30 @@ module hipfort_rocsolver
   !>     system is underdetermined
   !>     and a unique solution for X is chosen such that \f$|| X ||\f$ is minimal.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     trans       rocblas_operation.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] trans - rocblas_operation.
   !>                 Specifies the form of the system of equations.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of matrix A.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of matrix A.
-  !>     @param[in]
-  !>     nrhs        rocblas_int. nrhs >= 0.
+  !>     @param[in] nrhs - rocblas_int. nrhs >= 0.
   !>                 The number of columns of matrices B and X,
   !>                 that is, the columns on the right hand side.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the matrix A.
   !>                 On exit, the QR (or LQ) factorization of A as returned by \ref rocsolver_sgeqrf
   !>                 "GEQRF" (or \ref rocsolver_sgelqf "GELQF").
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of matrix A.
-  !>     @param[inout]
-  !>     B           pointer to type. Array on the GPU of dimension ldb*nrhs.
+  !>     @param[inout] B - pointer to type. Array on the GPU of dimension ldb*nrhs.
   !>                 On entry, the matrix B.
   !>                 On exit, when info = 0, B is overwritten by the solution vectors (and the
   !>                 residuals in
   !>                 the overdetermined cases) stored as columns.
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= max(m,n).
+  !>     @param[in] ldb - rocblas_int. ldb >= max(m,n).
   !>                 Specifies the leading dimension of matrix B.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int on the GPU.
   !>                 If info = 0, successful exit.
   !>                 If info = i > 0, the solution could not be computed because input matrix A is
   !>                 rank deficient. The i-th diagonal element of its triangular factor is zero.
@@ -19053,48 +18113,38 @@ module hipfort_rocsolver
   !>     system is underdetermined
   !>     and a unique solution for X_l is chosen such that \f$|| X_l ||\f$ is minimal.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     trans       rocblas_operation.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] trans - rocblas_operation.
   !>                 Specifies the form of the system of equations.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of all matrices A_l in the batch.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of all matrices A_l in the batch.
-  !>     @param[in]
-  !>     nrhs        rocblas_int. nrhs >= 0.
+  !>     @param[in] nrhs - rocblas_int. nrhs >= 0.
   !>                 The number of columns of all matrices B_l and X_l in the batch,
   !>                 that is, the columns on the right hand side.
-  !>     @param[inout]
-  !>     A array of pointer to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - array of pointer to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the matrices A_l.
   !>                 On exit, the QR (or LQ) factorizations of A_l as returned by \ref
   !>                 rocsolver_sgeqrf_batched "GEQRF_BATCHED"
   !>                 (or \ref rocsolver_sgelqf_batched "GELQF_BATCHED").
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[inout]
-  !>     B array of pointer to type. Each pointer points to an array on the GPU of dimension
-  !>     ldb*nrhs.
+  !>     @param[inout] B - array of pointer to type. Each pointer points to an array on the GPU of
+  !>     dimension ldb*nrhs.
   !>                 On entry, the matrices B_l.
   !>                 On exit, when info[l] = 0, B_l is overwritten by the solution vectors (and the
   !>                 residuals in
   !>                 the overdetermined cases) stored as columns.
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= max(m,n).
+  !>     @param[in] ldb - rocblas_int. ldb >= max(m,n).
   !>                 Specifies the leading dimension of matrices B_l.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for solution of A_l.
   !>                 If info[l] = i > 0, the solution of A_l could not be computed because input
   !>                 matrix A_l is rank deficient. The i-th diagonal element of its triangular
   !>                 factor is zero.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_sgels_batched
     function rocsolver_sgels_batched_(handle,trans,m,n,nrhs,A,lda,B,ldb,myInfo,batch_count) &
@@ -19217,57 +18267,46 @@ module hipfort_rocsolver
   !>     system is underdetermined
   !>     and a unique solution for X_l is chosen such that \f$|| X_l ||\f$ is minimal.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     trans       rocblas_operation.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] trans - rocblas_operation.
   !>                 Specifies the form of the system of equations.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of all matrices A_l in the batch.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of all matrices A_l in the batch.
-  !>     @param[in]
-  !>     nrhs        rocblas_int. nrhs >= 0.
+  !>     @param[in] nrhs - rocblas_int. nrhs >= 0.
   !>                 The number of columns of all matrices B_l and X_l in the batch,
   !>                 that is, the columns on the right hand side.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the matrices A_l.
   !>                 On exit, the QR (or LQ) factorizations of A_l as returned by \ref
   !>                 rocsolver_sgeqrf_strided_batched "GEQRF_STRIDED_BATCHED"
   !>                 (or \ref rocsolver_sgelqf_strided_batched "GELQF_STRIDED_BATCHED").
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[inout]
-  !>     B           pointer to type. Array on the GPU (the size depends on the value of strideB).
+  !>     @param[inout] B - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideB).
   !>                 On entry, the matrices B_l.
   !>                 On exit, when info[l] = 0, each B_l is overwritten by the solution vectors (and
   !>                 the residuals in
   !>                 the overdetermined cases) stored as columns.
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= max(m,n).
+  !>     @param[in] ldb - rocblas_int. ldb >= max(m,n).
   !>                 Specifies the leading dimension of matrices B_l.
-  !>     @param[in]
-  !>     strideB     rocblas_stride.
+  !>     @param[in] strideB - rocblas_stride.
   !>                 Stride from the start of one matrix B_l to the next one B_(l+1).
   !>                 There is no restriction for the value of strideB. The normal use case is
   !>                 strideB >= ldb*nrhs.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for solution of A_l.
   !>                 If info[l] = i > 0, the solution of A_l could not be computed because input
   !>                 matrix A_l is rank deficient. The i-th diagonal element of its triangular
   !>                 factor is zero.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_sgels_strided_batched
     function rocsolver_sgels_strided_batched_(handle,trans,m,n,nrhs,A,lda,strideA,B,ldb,strideB, &
@@ -19414,25 +18453,19 @@ module hipfort_rocsolver
   !>
   !>     U is an upper triangular matrix and L is lower triangular.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the factorization is upper or lower triangular.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) part of A is not
   !>                 used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows and columns of matrix A.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the matrix A to be factored. On exit, the lower or upper triangular
   !>                 factor.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of A.
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info = 0, successful factorization of matrix A.
   !>                 If info = i > 0, the leading minor of order i of A is not positive definite.
   !>                 The factorization stopped at this point.
@@ -19609,31 +18642,25 @@ module hipfort_rocsolver
   !>
   !>     \f$U_l\f$ is an upper triangular matrix and \f$L_l\f$ is lower triangular.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the factorization is upper or lower triangular.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) part of A_l is
   !>                 not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows and columns of matrix A_l.
-  !>     @param[inout]
-  !>     A array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the matrices A_l to be factored. On exit, the upper or lower
   !>                 triangular factors.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of A_l.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful factorization of matrix A_l.
   !>                 If info[l] = i > 0, the leading minor of order i of A_l is not positive
   !>                 definite.
   !>                 The l-th factorization stopped at this point.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_spotf2_batched
     function rocsolver_spotf2_batched_(handle,uplo,n,A,lda,myInfo,batch_count) &
@@ -19796,36 +18823,29 @@ module hipfort_rocsolver
   !>
   !>     \f$U_l\f$ is an upper triangular matrix and \f$L_l\f$ is lower triangular.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the factorization is upper or lower triangular.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) part of A_l is
   !>                 not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows and columns of matrix A_l.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the matrices A_l to be factored. On exit, the upper or lower
   !>                 triangular factors.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of A_l.
-  !>     @param[in]
-  !>     strideA    rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful factorization of matrix A_l.
   !>                 If info[l] = i > 0, the leading minor of order i of A_l is not positive
   !>                 definite.
   !>                 The l-th factorization stopped at this point.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_spotf2_strided_batched
     function rocsolver_spotf2_strided_batched_(handle,uplo,n,A,lda,strideA,myInfo,batch_count) &
@@ -20024,25 +19044,19 @@ module hipfort_rocsolver
   !>
   !>     U is an upper triangular matrix and L is lower triangular.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the factorization is upper or lower triangular.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) part of A is not
   !>                 used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows and columns of matrix A.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the matrix A to be factored. On exit, the lower or upper triangular
   !>                 factor.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of A.
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info = 0, successful factorization of matrix A.
   !>                 If info = i > 0, the leading minor of order i of A is not positive definite.
   !>                 The factorization stopped at this point.
@@ -20219,31 +19233,25 @@ module hipfort_rocsolver
   !>
   !>     \f$U_l\f$ is an upper triangular matrix and \f$L_l\f$ is lower triangular.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the factorization is upper or lower triangular.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) part of A_l is
   !>                 not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows and columns of matrix A_l.
-  !>     @param[inout]
-  !>     A array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the matrices A_l to be factored. On exit, the upper or lower
   !>                 triangular factors.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of A_l.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful factorization of matrix A_l.
   !>                 If info[l] = i > 0, the leading minor of order i of A_l is not positive
   !>                 definite.
   !>                 The l-th factorization stopped at this point.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_spotrf_batched
     function rocsolver_spotrf_batched_(handle,uplo,n,A,lda,myInfo,batch_count) &
@@ -20406,36 +19414,29 @@ module hipfort_rocsolver
   !>
   !>     \f$U_l\f$ is an upper triangular matrix and \f$L_l\f$ is lower triangular.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the factorization is upper or lower triangular.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) part of A_l is
   !>                 not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows and columns of matrix A_l.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the matrices A_l to be factored. On exit, the upper or lower
   !>                 triangular factors.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful factorization of matrix A_l.
   !>                 If info[l] = i > 0, the leading minor of order i of A_l is not positive
   !>                 definite.
   !>                 The l-th factorization stopped at this point.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_spotrf_strided_batched
     function rocsolver_spotrf_strided_batched_(handle,uplo,n,A,lda,strideA,myInfo,batch_count) &
@@ -20639,33 +19640,25 @@ module hipfort_rocsolver
   !>
   !>     as returned by \ref rocsolver_spotrf "POTRF".
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the factorization is upper or lower triangular.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) part of A is not
   !>                 used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The order of the system, that is, the number of columns and rows of A.
-  !>     @param[in]
-  !>     nrhs        rocblas_int. nrhs >= 0.
+  !>     @param[in] nrhs - rocblas_int. nrhs >= 0.
   !>                 The number of right hand sides, that is, the number of columns
   !>                 of the matrix B.
-  !>     @param[in]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[in] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 The factor L or U of the Cholesky factorization of A returned by \ref
   !>                 rocsolver_spotrf "POTRF".
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 The leading dimension of A.
-  !>     @param[inout]
-  !>     B           pointer to type. Array on the GPU of dimension ldb*nrhs.
+  !>     @param[inout] B - pointer to type. Array on the GPU of dimension ldb*nrhs.
   !>                 On entry, the right hand side matrix B.
   !>                 On exit, the solution matrix X.
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 The leading dimension of B.
   interface rocsolver_spotrs
     function rocsolver_spotrs_(handle,uplo,n,nrhs,A,lda,B,ldb) bind(c, name="rocsolver_spotrs")
@@ -20867,38 +19860,30 @@ module hipfort_rocsolver
   !>
   !>     as returned by \ref rocsolver_spotrf "POTRF_BATCHED".
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the factorization is upper or lower triangular.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) part of A_l is
   !>                 not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The order of the system, that is, the number of columns and rows of all A_l
   !>                 matrices.
-  !>     @param[in]
-  !>     nrhs        rocblas_int. nrhs >= 0.
+  !>     @param[in] nrhs - rocblas_int. nrhs >= 0.
   !>                 The number of right hand sides, that is, the number of columns
   !>                 of all the matrices B_l.
-  !>     @param[in]
-  !>     A Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[in] A - Array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 The factor L_l or U_l of the Cholesky factorization of A_l returned by \ref
   !>                 rocsolver_spotrf_batched "POTRF_BATCHED".
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 The leading dimension of matrices A_l.
-  !>     @param[inout]
-  !>     B Array of pointers to type. Each pointer points to an array on the GPU of dimension
-  !>     ldb*nrhs.
+  !>     @param[inout] B - Array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension ldb*nrhs.
   !>                 On entry, the right hand side matrices B_l.
   !>                 On exit, the solution matrix X_l of each system in the batch.
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 The leading dimension of matrices B_l.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of instances (systems) in the batch.
   interface rocsolver_spotrs_batched
     function rocsolver_spotrs_batched_(handle,uplo,n,nrhs,A,lda,B,ldb,batch_count) &
@@ -21084,47 +20069,37 @@ module hipfort_rocsolver
   !>
   !>     as returned by \ref rocsolver_spotrf "POTRF_STRIDED_BATCHED".
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the factorization is upper or lower triangular.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) part of A_l is
   !>                 not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The order of the system, that is, the number of columns and rows of all A_l
   !>                 matrices.
-  !>     @param[in]
-  !>     nrhs        rocblas_int. nrhs >= 0.
+  !>     @param[in] nrhs - rocblas_int. nrhs >= 0.
   !>                 The number of right hand sides, that is, the number of columns
   !>                 of all the matrices B_l.
-  !>     @param[in]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[in] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 The factor L_l or U_l of the Cholesky factorization of A_l returned by \ref
   !>                 rocsolver_spotrf_strided_batched "POTRF_STRIDED_BATCHED".
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 The leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[inout]
-  !>     B           pointer to type. Array on the GPU (size depends on the value of strideB).
+  !>     @param[inout] B - pointer to type. Array on the GPU (size depends on the value of strideB).
   !>                 On entry, the right hand side matrices B_l.
   !>                 On exit, the solution matrix X_l of each system in the batch.
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 The leading dimension of matrices B_l.
-  !>     @param[in]
-  !>     strideB     rocblas_stride.
+  !>     @param[in] strideB - rocblas_stride.
   !>                 Stride from the start of one matrix B_l to the next one B_(l+1).
   !>                 There is no restriction for the value of strideB. The normal use case is
   !>                 strideB >= ldb*nrhs.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of instances (systems) in the batch.
   interface rocsolver_spotrs_strided_batched
     function rocsolver_spotrs_strided_batched_(handle,uplo,n,nrhs,A,lda,strideA,B,ldb,strideB, &
@@ -21354,38 +20329,29 @@ module hipfort_rocsolver
   !>     \ref rocsolver_spotrf "POTRF",
   !>     then the solution is computed with \ref rocsolver_spotrs "POTRS".
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the factorization is upper or lower triangular.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) part of A is not
   !>                 used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The order of the system, that is, the number of columns and rows of A.
-  !>     @param[in]
-  !>     nrhs        rocblas_int. nrhs >= 0.
+  !>     @param[in] nrhs - rocblas_int. nrhs >= 0.
   !>                 The number of right hand sides, that is, the number of columns
   !>                 of the matrix B.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the symmetric/Hermitian matrix A.
   !>                 On exit, if info = 0, the factor L or U of the Cholesky factorization of A
   !>                 returned by
   !>                 \ref rocsolver_spotrf "POTRF".
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 The leading dimension of A.
-  !>     @param[inout]
-  !>     B           pointer to type. Array on the GPU of dimension ldb*nrhs.
+  !>     @param[inout] B - pointer to type. Array on the GPU of dimension ldb*nrhs.
   !>                 On entry, the right hand side matrix B.
   !>                 On exit, the solution matrix X.
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 The leading dimension of B.
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info = 0, successful exit.
   !>                 If info = i > 0, the leading minor of order i of A is not positive definite.
   !>                 The solution could not be computed.
@@ -21510,46 +20476,37 @@ module hipfort_rocsolver
   !>     of ``uplo``, using \ref rocsolver_spotrf_batched "POTRF_BATCHED",
   !>     then the solution is computed with \ref rocsolver_spotrs_batched "POTRS_BATCHED".
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the factorization is upper or lower triangular.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) part of A_l is
   !>                 not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The order of the system, that is, the number of columns and rows of all A_l
   !>                 matrices.
-  !>     @param[in]
-  !>     nrhs        rocblas_int. nrhs >= 0.
+  !>     @param[in] nrhs - rocblas_int. nrhs >= 0.
   !>                 The number of right hand sides, that is, the number of columns
   !>                 of all the matrices B_l.
-  !>     @param[inout]
-  !>     A Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - Array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the symmetric/Hermitian matrices A_l.
   !>                 On exit, if info[l] = 0, the factor L_l or U_l of the Cholesky factorization of
   !>                 A_l returned by
   !>                 \ref rocsolver_spotrf_batched "POTRF_BATCHED".
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 The leading dimension of matrices A_l.
-  !>     @param[inout]
-  !>     B Array of pointers to type. Each pointer points to an array on the GPU of dimension
-  !>     ldb*nrhs.
+  !>     @param[inout] B - Array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension ldb*nrhs.
   !>                 On entry, the right hand side matrices B_l.
   !>                 On exit, the solution matrix X_l of each system in the batch.
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 The leading dimension of matrices B_l.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit.
   !>                 If info[l] = i > 0, the leading minor of order i of A_l is not positive
   !>                 definite.
   !>                 The l-th solution could not be computed.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of instances (systems) in the batch.
   interface rocsolver_sposv_batched
     function rocsolver_sposv_batched_(handle,uplo,n,nrhs,A,lda,B,ldb,myInfo,batch_count) &
@@ -21653,55 +20610,44 @@ module hipfort_rocsolver
   !>     then the solution is computed with \ref rocsolver_spotrs_strided_batched
   !>     "POTRS_STRIDED_BATCHED".
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the factorization is upper or lower triangular.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) part of A_l is
   !>                 not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The order of the system, that is, the number of columns and rows of all A_l
   !>                 matrices.
-  !>     @param[in]
-  !>     nrhs        rocblas_int. nrhs >= 0.
+  !>     @param[in] nrhs - rocblas_int. nrhs >= 0.
   !>                 The number of right hand sides, that is, the number of columns
   !>                 of all the matrices B_l.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the symmetric/Hermitian matrices A_l.
   !>                 On exit, if info[l] = 0, the factor L_l or U_l of the Cholesky factorization of
   !>                 A_l returned by
   !>                 \ref rocsolver_spotrf_strided_batched "POTRF_STRIDED_BATCHED".
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 The leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[inout]
-  !>     B           pointer to type. Array on the GPU (size depends on the value of strideB).
+  !>     @param[inout] B - pointer to type. Array on the GPU (size depends on the value of strideB).
   !>                 On entry, the right hand side matrices B_l.
   !>                 On exit, the solution matrix X_l of each system in the batch.
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 The leading dimension of matrices B_l.
-  !>     @param[in]
-  !>     strideB     rocblas_stride.
+  !>     @param[in] strideB - rocblas_stride.
   !>                 Stride from the start of one matrix B_l to the next one B_(l+1).
   !>                 There is no restriction for the value of strideB. The normal use case is
   !>                 strideB >= ldb*nrhs.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit.
   !>                 If info[l] = i > 0, the leading minor of order i of A_l is not positive
   !>                 definite.
   !>                 The l-th solution could not be computed.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of instances (systems) in the batch.
   interface rocsolver_sposv_strided_batched
     function rocsolver_sposv_strided_batched_(handle,uplo,n,nrhs,A,lda,strideA,B,ldb,strideB, &
@@ -21843,26 +20789,20 @@ module hipfort_rocsolver
   !>     returned by
   !>     \ref rocsolver_spotrf "POTRF".
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the factorization is upper or lower triangular.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) part of A is not
   !>                 used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows and columns of matrix A.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the factor L or U of the Cholesky factorization of A returned by
   !>                 \ref rocsolver_spotrf "POTRF".
   !>                 On exit, the inverse of A if info = 0.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of A.
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info = 0, successful exit for inversion of A.
   !>                 If info = i > 0, A is singular. L[i,i] or U[i,i] is zero.
   interface rocsolver_spotri
@@ -21974,31 +20914,25 @@ module hipfort_rocsolver
   !>     \f$A_l\f$ returned by
   !>     \ref rocsolver_spotrf_batched "POTRF_BATCHED".
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the factorization is upper or lower triangular.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) part of A_l is
   !>                 not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows and columns of matrix A_l.
-  !>     @param[inout]
-  !>     A array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the factor L_l or U_l of the Cholesky factorization of A_l returned
   !>                 by
   !>                 \ref rocsolver_spotrf_batched "POTRF_BATCHED".
   !>                 On exit, the inverses of A_l if info[l] = 0.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of A_l.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for inversion of A_l.
   !>                 If info[l] = i > 0, A_l is singular. L_l[i,i] or U_l[i,i] is zero.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_spotri_batched
     function rocsolver_spotri_batched_(handle,uplo,n,A,lda,myInfo,batch_count) &
@@ -22089,36 +21023,29 @@ module hipfort_rocsolver
   !>     \f$A_l\f$ returned by
   !>     \ref rocsolver_spotrf_strided_batched "POTRF_STRIDED_BATCHED".
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the factorization is upper or lower triangular.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) part of A_l is
   !>                 not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows and columns of matrix A_l.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the factor L_l or U_l of the Cholesky factorization of A_l returned
   !>                 by
   !>                 \ref rocsolver_spotrf_strided_batched "POTRF_STRIDED_BATCHED".
   !>                 On exit, the inverses of A_l if info[l] = 0.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for inversion of A_l.
   !>                 If info[l] = i > 0, A_l is singular. L_l[i,i] or U_l[i,i] is zero.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_spotri_strided_batched
     function rocsolver_spotri_strided_batched_(handle,uplo,n,A,lda,strideA,myInfo,batch_count) &
@@ -22279,51 +21206,40 @@ module hipfort_rocsolver
   !>     architectures.
   !>     Use \ref rocsolver_set_alg_mode to enable it.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     left_svect  `rocblas_svect`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] left_svect - `rocblas_svect`.
   !>                 Specifies how the left singular vectors are computed.
-  !>     @param[in]
-  !>     right_svect `rocblas_svect`.
+  !>     @param[in] right_svect - `rocblas_svect`.
   !>                 Specifies how the right singular vectors are computed.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of matrix A.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of matrix A.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the matrix A.
   !>                 On exit, if left_svect (or right_svect) is equal to overwrite,
   !>                 the first columns (or rows) contain the left (or right) singular vectors.
   !>                 Otherwise, the contents of A are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 The leading dimension of A.
-  !>     @param[out]
-  !>     S           pointer to real type. Array on the GPU of dimension min(m,n).
+  !>     @param[out] S - pointer to real type. Array on the GPU of dimension min(m,n).
   !>                 The singular values of A in decreasing order.
-  !>     @param[out]
-  !>     U           pointer to type. Array on the GPU of dimension ldu*min(m,n) if
+  !>     @param[out] U - pointer to type. Array on the GPU of dimension ldu*min(m,n) if
   !>                 left_svect is set to singular, or ldu*m when left_svect is equal to all.
   !>                 The matrix of left singular vectors stored as columns. Not
   !>                 referenced if left_svect is set to overwrite or none.
-  !>     @param[in]
-  !>     ldu         rocblas_int. ldu >= m if left_svect is all or singular, and ldu >= 1 otherwise.
+  !>     @param[in] ldu - rocblas_int. ldu >= m if left_svect is all or singular, and ldu >= 1
+  !>     otherwise.
   !>                 The leading dimension of U.
-  !>     @param[out]
-  !>     V           pointer to type. Array on the GPU of dimension ldv*n.
+  !>     @param[out] V - pointer to type. Array on the GPU of dimension ldv*n.
   !>                 The matrix of right singular vectors stored as rows (transposed /
   !>                 conjugate-transposed).
   !>                 Not referenced if right_svect is set to overwrite or none.
-  !>     @param[in]
-  !>     ldv rocblas_int. ldv >= n if right_svect is all, and ldv >= min(m,n) if right_svect is
+  !>     @param[in] ldv - rocblas_int. ldv >= n if right_svect is all, and ldv >= min(m,n) if
+  !>     right_svect is
   !>                 set to singular, or ldv >= 1 otherwise.
   !>                 The leading dimension of V.
-  !>     @param[out]
-  !>     E           pointer to real type. Array on the GPU of dimension min(m,n)-1.
+  !>     @param[out] E - pointer to real type. Array on the GPU of dimension min(m,n)-1.
   !>                 This array is used to work internally with the bidiagonal matrix
   !>                 B associated with A (using \ref rocsolver_sbdsqr "BDSQR"). On exit, if info >
   !>                 0, it contains the
@@ -22331,12 +21247,10 @@ module hipfort_rocsolver
   !>                 matrix orthogonally equivalent to B). The diagonal elements of this matrix
   !>                 are in S. Those that converged correspond to a subset of the singular values
   !>                 of A (not necessarily ordered).
-  !>     @param[in]
-  !>     fast_alg    `rocblas_workmode`.
+  !>     @param[in] fast_alg - `rocblas_workmode`.
   !>                 If set to rocblas_outofplace, the function will execute the
   !>                 fast thin-SVD version of the algorithm when possible.
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info = 0, successful exit.
   !>                 If info = i > 0, \ref rocsolver_sbdsqr "BDSQR" did not converge. i elements of
   !>                 E did not converge to zero.
@@ -22532,68 +21446,57 @@ module hipfort_rocsolver
   !>     A hybrid (CPU+GPU) approach is available for GESVD_BATCHED, primarily intended for
   !>     homogeneous architectures. Use \ref rocsolver_set_alg_mode to enable it.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     left_svect  `rocblas_svect`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] left_svect - `rocblas_svect`.
   !>                 Specifies how the left singular vectors are computed.
-  !>     @param[in]
-  !>     right_svect `rocblas_svect`.
+  !>     @param[in] right_svect - `rocblas_svect`.
   !>                 Specifies how the right singular vectors are computed.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of all matrices A_l in the batch.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of all matrices A_l in the batch.
-  !>     @param[inout]
-  !>     A           Array of pointers to type. Each pointer points to an array on
+  !>     @param[inout] A - Array of pointers to type. Each pointer points to an array on
   !>                 the GPU of dimension lda*n.
   !>                 On entry, the matrices A_l.
   !>                 On exit, if left_svect (or right_svect) is equal to overwrite,
   !>                 the first columns (or rows) of A_l contain the left (or right)
   !>                 corresponding singular vectors. Otherwise, the contents of A_l are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 The leading dimension of A_l.
-  !>     @param[out]
-  !>     S pointer to real type. Array on the GPU (the size depends on the value of strideS).
+  !>     @param[out] S - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideS).
   !>                 The singular values of A_l in decreasing order.
-  !>     @param[in]
-  !>     strideS     rocblas_stride.
+  !>     @param[in] strideS - rocblas_stride.
   !>                 Stride from the start of one vector S_l to the next one S_(l+1).
   !>                 There is no restriction for the value of strideS.
   !>                 The normal use case is strideS >= min(m,n).
-  !>     @param[out]
-  !>     U           pointer to type. Array on the GPU (the side depends on the value of strideU).
+  !>     @param[out] U - pointer to type. Array on the GPU (the side depends on the value of
+  !>     strideU).
   !>                 The matrices U_l of left singular vectors stored as columns.
   !>                 Not referenced if left_svect is set to overwrite or none.
-  !>     @param[in]
-  !>     ldu         rocblas_int. ldu >= m if left_svect is all or singular, and ldu >= 1 otherwise.
+  !>     @param[in] ldu - rocblas_int. ldu >= m if left_svect is all or singular, and ldu >= 1
+  !>     otherwise.
   !>                 The leading dimension of U_l.
-  !>     @param[in]
-  !>     strideU     rocblas_stride.
+  !>     @param[in] strideU - rocblas_stride.
   !>                 Stride from the start of one matrix U_l to the next one U_(l+1).
   !>                 There is no restriction for the value of strideU.
   !>                 The normal use case is strideU >= ldu*min(m,n) if left_svect is set to
   !>                 singular,
   !>                 or strideU >= ldu*m when left_svect is equal to all.
-  !>     @param[out]
-  !>     V           pointer to type. Array on the GPU (the size depends on the value of strideV).
+  !>     @param[out] V - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideV).
   !>                 The matrices V_l of right singular vectors stored as rows (transposed /
   !>                 conjugate-transposed).
   !>                 Not referenced if right_svect is set to overwrite or none.
-  !>     @param[in]
-  !>     ldv         rocblas_int. ldv >= n if right_svect is all, and ldv >= min(m,n) if
+  !>     @param[in] ldv - rocblas_int. ldv >= n if right_svect is all, and ldv >= min(m,n) if
   !>                 right_svect is set to singular or ldv >= 1 otherwise.
   !>                 The leading dimension of V_l.
-  !>     @param[in]
-  !>     strideV     rocblas_stride.
+  !>     @param[in] strideV - rocblas_stride.
   !>                 Stride from the start of one matrix V_l to the next one V_(l+1).
   !>                 There is no restriction for the value of strideV.
   !>                 The normal use case is strideV >= ldv*n.
-  !>     @param[out]
-  !>     E pointer to real type. Array on the GPU (the size depends on the value of strideE).
+  !>     @param[out] E - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideE).
   !>                 This array is used to work internally with the bidiagonal matrix B_l associated
   !>                 with A_l (using \ref rocsolver_sbdsqr "BDSQR").
   !>                 On exit, if info[l] > 0, E_l contains the unconverged off-diagonal elements of
@@ -22602,23 +21505,19 @@ module hipfort_rocsolver
   !>                 this matrix are in S_l.
   !>                 Those that converged correspond to a subset of the singular values of A_l (not
   !>                 necessarily ordered).
-  !>     @param[in]
-  !>     strideE     rocblas_stride.
+  !>     @param[in] strideE - rocblas_stride.
   !>                 Stride from the start of one vector E_l to the next one E_(l+1).
   !>                 There is no restriction for the value of strideE. The normal use case is
   !>                 strideE >= min(m,n)-1.
-  !>     @param[in]
-  !>     fast_alg    `rocblas_workmode`.
+  !>     @param[in] fast_alg - `rocblas_workmode`.
   !>                 If set to rocblas_outofplace, the function will execute the fast thin-SVD
   !>                 version
   !>                 of the algorithm when possible.
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info[l] = 0, successful exit.
   !>                 If info[l] = i > 0, \ref rocsolver_sbdsqr "BDSQR" did not converge. i elements
   !>                 of E_l did not converge to zero.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_sgesvd_batched
     function rocsolver_sgesvd_batched_(handle,left_svect,right_svect,m,n,A,lda,S,strideS,U,ldu, &
@@ -22832,71 +21731,61 @@ module hipfort_rocsolver
   !>     A hybrid (CPU+GPU) approach is available for GESVD_STRIDED_BATCHED, primarily intended
   !>     for homogeneous architectures. Use \ref rocsolver_set_alg_mode to enable it.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     left_svect  `rocblas_svect`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] left_svect - `rocblas_svect`.
   !>                 Specifies how the left singular vectors are computed.
-  !>     @param[in]
-  !>     right_svect `rocblas_svect`.
+  !>     @param[in] right_svect - `rocblas_svect`.
   !>                 Specifies how the right singular vectors are computed.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of all matrices A_l in the batch.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of all matrices A_l in the batch.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the matrices A_l. On exit, if left_svect (or right_svect) is equal to
   !>                 overwrite, the first columns (or rows) of A_l contain the left (or right)
   !>                 corresponding singular vectors. Otherwise, the contents of A_l are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 The leading dimension of A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA.
   !>                 The normal use case is strideA >= lda*n.
-  !>     @param[out]
-  !>     S pointer to real type. Array on the GPU (the size depends on the value of strideS).
+  !>     @param[out] S - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideS).
   !>                 The singular values of A_l in decreasing order.
-  !>     @param[in]
-  !>     strideS     rocblas_stride.
+  !>     @param[in] strideS - rocblas_stride.
   !>                 Stride from the start of one vector S_l to the next one S_(l+1).
   !>                 There is no restriction for the value of strideS.
   !>                 The normal use case is strideS >= min(m,n).
-  !>     @param[out]
-  !>     U           pointer to type. Array on the GPU (the side depends on the value of strideU).
+  !>     @param[out] U - pointer to type. Array on the GPU (the side depends on the value of
+  !>     strideU).
   !>                 The matrices U_l of left singular vectors stored as columns.
   !>                 Not referenced if left_svect is set to overwrite or none.
-  !>     @param[in]
-  !>     ldu         rocblas_int. ldu >= m if left_svect is all or singular and ldu >= 1 otherwise.
+  !>     @param[in] ldu - rocblas_int. ldu >= m if left_svect is all or singular and ldu >= 1
+  !>     otherwise.
   !>                 The leading dimension of U_l.
-  !>     @param[in]
-  !>     strideU     rocblas_stride.
+  !>     @param[in] strideU - rocblas_stride.
   !>                 Stride from the start of one matrix U_l to the next one U_(l+1).
   !>                 There is no restriction for the value of strideU.
   !>                 The normal use case is strideU >= ldu*min(m,n) if left_svect is set to
   !>                 singular,
   !>                 or strideU >= ldu*m when left_svect is equal to all.
-  !>     @param[out]
-  !>     V           pointer to type. Array on the GPU (the size depends on the value of strideV).
+  !>     @param[out] V - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideV).
   !>                 The matrices V_l of right singular vectors stored as rows (transposed /
   !>                 conjugate-transposed).
   !>                 Not referenced if right_svect is set to overwrite or none.
-  !>     @param[in]
-  !>     ldv rocblas_int. ldv >= n if right_svect is all, and ldv >= min(m,n) if right_svect is
+  !>     @param[in] ldv - rocblas_int. ldv >= n if right_svect is all, and ldv >= min(m,n) if
+  !>     right_svect is
   !>                 set to singular or ldv >= 1 otherwise.
   !>                 The leading dimension of V_l.
-  !>     @param[in]
-  !>     strideV     rocblas_stride.
+  !>     @param[in] strideV - rocblas_stride.
   !>                 Stride from the start of one matrix V_l to the next one V_(l+1).
   !>                 There is no restriction for the value of strideV.
   !>                 The normal use case is strideV >= ldv*n.
-  !>     @param[out]
-  !>     E pointer to real type. Array on the GPU (the size depends on the value of strideE).
+  !>     @param[out] E - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideE).
   !>                 This array is used to work internally with the bidiagonal matrix B_l associated
   !>                 with A_l (using \ref rocsolver_sbdsqr "BDSQR").
   !>                 On exit, if info[l] > 0, E_l contains the unconverged off-diagonal elements of
@@ -22905,23 +21794,19 @@ module hipfort_rocsolver
   !>                 this matrix are in S_l.
   !>                 Those that converged correspond to a subset of the singular values of A_l (not
   !>                 necessarily ordered).
-  !>     @param[in]
-  !>     strideE     rocblas_stride.
+  !>     @param[in] strideE - rocblas_stride.
   !>                 Stride from the start of one vector E_l to the next one E_(l+1).
   !>                 There is no restriction for the value of strideE.
   !>                 The normal use case is strideE >= min(m,n)-1.
-  !>     @param[in]
-  !>     fast_alg    `rocblas_workmode`.
+  !>     @param[in] fast_alg - `rocblas_workmode`.
   !>                 If set to rocblas_outofplace, the function will execute the fast thin-SVD
   !>                 version
   !>                 of the algorithm when possible.
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info[l] = 0, successful exit.
   !>                 If info[l] = i > 0, BDSQR did not converge. i elements of E_l did not converge
   !>                 to zero.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_sgesvd_strided_batched
     function rocsolver_sgesvd_strided_batched_(handle,left_svect,right_svect,m,n,A,lda,strideA,S, &
@@ -23117,51 +22002,40 @@ module hipfort_rocsolver
   !>     found as the
   !>     eigenvectors of \f$A^H A\f$ (resp. \f$A A^H\f$) using the Divide-and-Conquer eigensolver.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     left_svect  `rocblas_svect`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] left_svect - `rocblas_svect`.
   !>                 Specifies how the left singular vectors are computed.
   !>                 rocblas_svect_overwrite is not supported.
-  !>     @param[in]
-  !>     right_svect `rocblas_svect`.
+  !>     @param[in] right_svect - `rocblas_svect`.
   !>                 Specifies how the right singular vectors are computed.
   !>                 rocblas_svect_overwrite is not supported.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of matrix A.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of matrix A.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the matrix A.
   !>                 On exit, the contents of A are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 The leading dimension of A.
-  !>     @param[out]
-  !>     S           pointer to real type. Array on the GPU of dimension min(m,n).
+  !>     @param[out] S - pointer to real type. Array on the GPU of dimension min(m,n).
   !>                 The singular values of A in decreasing order.
-  !>     @param[out]
-  !>     U           pointer to type. Array on the GPU of dimension ldu*min(m,n) if
+  !>     @param[out] U - pointer to type. Array on the GPU of dimension ldu*min(m,n) if
   !>                 left_svect is set to singular, or ldu*m when left_svect is equal to all.
   !>                 The matrix of left singular vectors stored as columns. Not
   !>                 referenced if left_svect is set to none.
-  !>     @param[in]
-  !>     ldu rocblas_int. ldu >= m if left_svect is set to all or singular; ldu >= 1 otherwise.
+  !>     @param[in] ldu - rocblas_int. ldu >= m if left_svect is set to all or singular; ldu >= 1
+  !>     otherwise.
   !>                 The leading dimension of U.
-  !>     @param[out]
-  !>     V           pointer to type. Array on the GPU of dimension ldv*n.
+  !>     @param[out] V - pointer to type. Array on the GPU of dimension ldv*n.
   !>                 The matrix of right singular vectors stored as rows (transposed /
   !>                 conjugate-transposed).
   !>                 Not referenced if right_svect is set to none.
-  !>     @param[in]
-  !>     ldv rocblas_int. ldv >= n if right_svect is set to all; ldv >= min(m,n) if right_svect is
+  !>     @param[in] ldv - rocblas_int. ldv >= n if right_svect is set to all; ldv >= min(m,n) if
+  !>     right_svect is
   !>                 set to singular; or ldv >= 1 otherwise.
   !>                 The leading dimension of V.
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info = 0, successful exit. If info = 1, the algorithm did not converge.
   interface rocsolver_sgesdd
     function rocsolver_sgesdd_(handle,left_svect,right_svect,m,n,A,lda,S,U,ldu,V,ldv,myInfo) &
@@ -23295,71 +22169,59 @@ module hipfort_rocsolver
   !>     Divide-and-Conquer
   !>     eigensolver.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     left_svect  `rocblas_svect`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] left_svect - `rocblas_svect`.
   !>                 Specifies how the left singular vectors are computed.
   !>                 rocblas_svect_overwrite is not supported.
-  !>     @param[in]
-  !>     right_svect `rocblas_svect`.
+  !>     @param[in] right_svect - `rocblas_svect`.
   !>                 Specifies how the right singular vectors are computed.
   !>                 rocblas_svect_overwrite is not supported.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of all matrices A_l in the batch.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of all matrices A_l in the batch.
-  !>     @param[inout]
-  !>     A           Array of pointers to type. Each pointer points to an array on
+  !>     @param[inout] A - Array of pointers to type. Each pointer points to an array on
   !>                 the GPU of dimension lda*n.
   !>                 On entry, the matrices A_l.
   !>                 On exit, the contents of A_l are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 The leading dimension of A_l.
-  !>     @param[out]
-  !>     S pointer to real type. Array on the GPU (the size depends on the value of strideS).
+  !>     @param[out] S - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideS).
   !>                 The singular values of A_l in decreasing order.
-  !>     @param[in]
-  !>     strideS     rocblas_stride.
+  !>     @param[in] strideS - rocblas_stride.
   !>                 Stride from the start of one vector S_l to the next one S(l+1).
   !>                 There is no restriction for the value of strideS.
   !>                 Normal use case is strideS >= min(m,n).
-  !>     @param[out]
-  !>     U           pointer to type. Array on the GPU (the side depends on the value of strideU).
+  !>     @param[out] U - pointer to type. Array on the GPU (the side depends on the value of
+  !>     strideU).
   !>                 The matrices U_l of left singular vectors stored as columns.
   !>                 Not referenced if left_svect is set to none.
-  !>     @param[in]
-  !>     ldu rocblas_int. ldu >= m if left_svect is set to all or singular; ldu >= 1 otherwise.
+  !>     @param[in] ldu - rocblas_int. ldu >= m if left_svect is set to all or singular; ldu >= 1
+  !>     otherwise.
   !>                 The leading dimension of U_l.
-  !>     @param[in]
-  !>     strideU     rocblas_stride.
+  !>     @param[in] strideU - rocblas_stride.
   !>                 Stride from the start of one matrix U_l to the next one U(l+1).
   !>                 There is no restriction for the value of strideU.
   !>                 Normal use case is strideU >= ldu*min(m,n) if left_svect is set to singular,
   !>                 or strideU >= ldu*m when left_svect is equal to all.
-  !>     @param[out]
-  !>     V           pointer to type. Array on the GPU (the size depends on the value of strideV).
+  !>     @param[out] V - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideV).
   !>                 The matrices V_l of right singular vectors stored as rows (transposed /
   !>                 conjugate-transposed).
   !>                 Not referenced if right_svect is set to none.
-  !>     @param[in]
-  !>     ldv rocblas_int. ldv >= n if right_svect is set to all; ldv >= min(m,n) if right_svect is
+  !>     @param[in] ldv - rocblas_int. ldv >= n if right_svect is set to all; ldv >= min(m,n) if
+  !>     right_svect is
   !>                 set to singular; or ldv >= 1 otherwise.
   !>                 The leading dimension of V.
-  !>     @param[in]
-  !>     strideV     rocblas_stride.
+  !>     @param[in] strideV - rocblas_stride.
   !>                 Stride from the start of one matrix V_l to the next one V(l+1).
   !>                 There is no restriction for the value of strideV.
   !>                 Normal use case is strideV >= ldv*n.
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info[l] = 0, successful exit. If info[l] = 1, the algorithm did not
   !>                 converge.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_sgesdd_batched
     function rocsolver_sgesdd_batched_(handle,left_svect,right_svect,m,n,A,lda,S,strideS,U,ldu, &
@@ -23513,75 +22375,63 @@ module hipfort_rocsolver
   !>     Divide-and-Conquer
   !>     eigensolver.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     left_svect  `rocblas_svect`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] left_svect - `rocblas_svect`.
   !>                 Specifies how the left singular vectors are computed.
   !>                 rocblas_svect_overwrite is not supported.
-  !>     @param[in]
-  !>     right_svect `rocblas_svect`.
+  !>     @param[in] right_svect - `rocblas_svect`.
   !>                 Specifies how the right singular vectors are computed.
   !>                 rocblas_svect_overwrite is not supported.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of all matrices A_l in the batch.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of all matrices A_l in the batch.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the matrices A_l.
   !>                 On exit, the contents of A_l are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 The leading dimension of A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA.
   !>                 Normal use case is strideA >= lda*n.
-  !>     @param[out]
-  !>     S pointer to real type. Array on the GPU (the size depends on the value of strideS).
+  !>     @param[out] S - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideS).
   !>                 The singular values of A_l in decreasing order.
-  !>     @param[in]
-  !>     strideS     rocblas_stride.
+  !>     @param[in] strideS - rocblas_stride.
   !>                 Stride from the start of one vector S_l to the next one S_(j+1).
   !>                 There is no restriction for the value of strideS.
   !>                 Normal use case is strideS >= min(m,n).
-  !>     @param[out]
-  !>     U           pointer to type. Array on the GPU (the side depends on the value of strideU).
+  !>     @param[out] U - pointer to type. Array on the GPU (the side depends on the value of
+  !>     strideU).
   !>                 The matrices U_l of left singular vectors stored as columns.
   !>                 Not referenced if left_svect is set to none.
-  !>     @param[in]
-  !>     ldu rocblas_int. ldu >= m if left_svect is set to all or singular; ldu >= 1 otherwise.
+  !>     @param[in] ldu - rocblas_int. ldu >= m if left_svect is set to all or singular; ldu >= 1
+  !>     otherwise.
   !>                 The leading dimension of U_l.
-  !>     @param[in]
-  !>     strideU     rocblas_stride.
+  !>     @param[in] strideU - rocblas_stride.
   !>                 Stride from the start of one matrix U_l to the next one U_(j+1).
   !>                 There is no restriction for the value of strideU.
   !>                 Normal use case is strideU >= ldu*min(m,n) if left_svect is set to singular,
   !>                 or strideU >= ldu*m when left_svect is equal to all.
-  !>     @param[out]
-  !>     V           pointer to type. Array on the GPU (the size depends on the value of strideV).
+  !>     @param[out] V - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideV).
   !>                 The matrices V_l of right singular vectors stored as rows (transposed /
   !>                 conjugate-transposed).
   !>                 Not referenced if right_svect is set to none.
-  !>     @param[in]
-  !>     ldv rocblas_int. ldv >= n if right_svect is set to all; ldv >= min(m,n) if right_svect is
+  !>     @param[in] ldv - rocblas_int. ldv >= n if right_svect is set to all; ldv >= min(m,n) if
+  !>     right_svect is
   !>                 set to singular; or ldv >= 1 otherwise.
   !>                 The leading dimension of V.
-  !>     @param[in]
-  !>     strideV     rocblas_stride.
+  !>     @param[in] strideV - rocblas_stride.
   !>                 Stride from the start of one matrix V_l to the next one V_(j+1).
   !>                 There is no restriction for the value of strideV.
   !>                 Normal use case is strideV >= ldv*n.
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info[l] = 0, successful exit. If info[l] = 1, the algorithm did not
   !>                 converge.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_sgesdd_strided_batched
     function rocsolver_sgesdd_strided_batched_(handle,left_svect,right_svect,m,n,A,lda,strideA,S, &
@@ -23743,70 +22593,54 @@ module hipfort_rocsolver
   !>     contained within the
   !>     ``rocblas_handle``.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     left_svect  `rocblas_svect`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] left_svect - `rocblas_svect`.
   !>                 Specifies how the left singular vectors are computed.
   !>                 rocblas_svect_overwrite is not supported.
-  !>     @param[in]
-  !>     right_svect `rocblas_svect`.
+  !>     @param[in] right_svect - `rocblas_svect`.
   !>                 Specifies how the right singular vectors are computed.
   !>                 rocblas_svect_overwrite is not supported.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of matrix A.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of matrix A.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the matrix A.
   !>                 On exit, the contents of A are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 The leading dimension of A.
-  !>     @param[in]
-  !>     abstol      real type.
+  !>     @param[in] abstol - real type.
   !>                 The absolute tolerance. The algorithm is considered to have converged once
   !>                 \f$\mathrm{off}(A^H A) &le; \mathrm{norm}(A^H A) \cdot \mathrm{abstol}\f$
   !>                 [resp. \f$\mathrm{off}(A A^H) &le; \mathrm{norm}(A A^H) \cdot
   !>                 \mathrm{abstol}\f$]. If abstol <= 0,
   !>                 then the tolerance will be set to machine precision.
-  !>     @param[out]
-  !>     residual    pointer to real type on the GPU.
+  !>     @param[out] residual - pointer to real type on the GPU.
   !>                 The Frobenius norm of the off-diagonal elements of \f$A^H A\f$ (resp. \f$A
   !>                 A^H\f$) at the final
   !>                 iteration.
-  !>     @param[in]
-  !>     max_sweeps  rocblas_int. max_sweeps > 0.
+  !>     @param[in] max_sweeps - rocblas_int. max_sweeps > 0.
   !>                 Maximum number of sweeps (iterations) to be used by the algorithm.
-  !>     @param[out]
-  !>     n_sweeps    pointer to a rocblas_int on the GPU.
+  !>     @param[out] n_sweeps - pointer to a rocblas_int on the GPU.
   !>                 The actual number of sweeps (iterations) used by the algorithm.
-  !>     @param[out]
-  !>     S           pointer to real type. Array on the GPU of dimension min(m,n).
+  !>     @param[out] S - pointer to real type. Array on the GPU of dimension min(m,n).
   !>                 The singular values of A in decreasing order.
-  !>     @param[out]
-  !>     U           pointer to type. Array on the GPU of dimension ldu*min(m,n) if
+  !>     @param[out] U - pointer to type. Array on the GPU of dimension ldu*min(m,n) if
   !>                 left_svect is set to singular, or ldu*m when left_svect is equal to all.
   !>                 The matrix of left singular vectors stored as columns. Not
   !>                 referenced if left_svect is set to none.
-  !>     @param[in]
-  !>     ldu rocblas_int. ldu >= m if left_svect is set to all or singular, and ldu >= 1 otherwise.
+  !>     @param[in] ldu - rocblas_int. ldu >= m if left_svect is set to all or singular, and ldu >=
+  !>     1 otherwise.
   !>                 The leading dimension of U.
-  !>     @param[out]
-  !>     V           pointer to type. Array on the GPU of dimension ldv*n.
+  !>     @param[out] V - pointer to type. Array on the GPU of dimension ldv*n.
   !>                 The matrix of right singular vectors stored as rows (transposed /
   !>                 conjugate-transposed).
   !>                 Not referenced if right_svect is set to none.
-  !>     @param[in]
-  !>     ldv rocblas_int. ldv >= n if right_svect is set to all, and ldv >= min(m,n) if right_svect
-  !>     is
+  !>     @param[in] ldv - rocblas_int. ldv >= n if right_svect is set to all, and ldv >= min(m,n) if
+  !>     right_svect is
   !>                 set to singular; or ldv >= 1 otherwise.
   !>                 The leading dimension of V.
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info = 0, successful exit. If info = 1, the algorithm did not converge.
   interface rocsolver_sgesvdj
     function rocsolver_sgesvdj_(handle,left_svect,right_svect,m,n,A,lda,abstol,residual, &
@@ -23966,93 +22800,76 @@ module hipfort_rocsolver
   !>     contained within the
   !>     ``rocblas_handle``.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     left_svect  `rocblas_svect`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] left_svect - `rocblas_svect`.
   !>                 Specifies how the left singular vectors are computed.
   !>                 rocblas_svect_overwrite is not supported.
-  !>     @param[in]
-  !>     right_svect `rocblas_svect`.
+  !>     @param[in] right_svect - `rocblas_svect`.
   !>                 Specifies how the right singular vectors are computed.
   !>                 rocblas_svect_overwrite is not supported.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of all matrices A_l in the batch.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of all matrices A_l in the batch.
-  !>     @param[inout]
-  !>     A           Array of pointers to type. Each pointer points to an array on
+  !>     @param[inout] A - Array of pointers to type. Each pointer points to an array on
   !>                 the GPU of dimension lda*n.
   !>                 On entry, the matrices A_l.
   !>                 On exit, the contents of A_l are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 The leading dimension of A_l.
-  !>     @param[in]
-  !>     abstol      real type.
+  !>     @param[in] abstol - real type.
   !>                 The absolute tolerance. The algorithm is considered to have converged once
   !>                 \f$\mathrm{off}(A_l^H A_l) &le; \mathrm{norm}(A_l^H A_l) \cdot
   !>                 \mathrm{abstol}\f$
   !>                 [resp. \f$\mathrm{off}(A_l A_l^H) &le; \mathrm{norm}(A_l A_l^H) \cdot
   !>                 \mathrm{abstol}\f$]. If abstol <= 0,
   !>                 then the tolerance will be set to machine precision.
-  !>     @param[out]
-  !>     residual    pointer to real type on the GPU.
+  !>     @param[out] residual - pointer to real type on the GPU.
   !>                 The Frobenius norm of the off-diagonal elements of \f$A_l^H A_l\f$ (resp.
   !>                 \f$A_l A_l^H\f$) at the final
   !>                 iteration.
-  !>     @param[in]
-  !>     max_sweeps  rocblas_int. max_sweeps > 0.
+  !>     @param[in] max_sweeps - rocblas_int. max_sweeps > 0.
   !>                 Maximum number of sweeps (iterations) to be used by the algorithm.
-  !>     @param[out]
-  !>     n_sweeps    pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] n_sweeps - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 The actual number of sweeps (iterations) used by the algorithm for each batch
   !>                 instance.
-  !>     @param[out]
-  !>     S pointer to real type. Array on the GPU (the size depends on the value of strideS).
+  !>     @param[out] S - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideS).
   !>                 The singular values of A_l in decreasing order.
-  !>     @param[in]
-  !>     strideS     rocblas_stride.
+  !>     @param[in] strideS - rocblas_stride.
   !>                 Stride from the start of one vector S_l to the next one S(l+1).
   !>                 There is no restriction for the value of strideS.
   !>                 The normal use case is strideS >= min(m,n).
-  !>     @param[out]
-  !>     U           pointer to type. Array on the GPU (the side depends on the value of strideU).
+  !>     @param[out] U - pointer to type. Array on the GPU (the side depends on the value of
+  !>     strideU).
   !>                 The matrices U_l of left singular vectors stored as columns.
   !>                 Not referenced if left_svect is set to none.
-  !>     @param[in]
-  !>     ldu rocblas_int. ldu >= m if left_svect is set to all or singular, and ldu >= 1 otherwise.
+  !>     @param[in] ldu - rocblas_int. ldu >= m if left_svect is set to all or singular, and ldu >=
+  !>     1 otherwise.
   !>                 The leading dimension of U_l.
-  !>     @param[in]
-  !>     strideU     rocblas_stride.
+  !>     @param[in] strideU - rocblas_stride.
   !>                 Stride from the start of one matrix U_l to the next one U(l+1).
   !>                 There is no restriction for the value of strideU.
   !>                 The normal use case is strideU >= ldu*min(m,n) if left_svect is set to
   !>                 singular,
   !>                 or strideU >= ldu*m when left_svect is equal to all.
-  !>     @param[out]
-  !>     V           pointer to type. Array on the GPU (the size depends on the value of strideV).
+  !>     @param[out] V - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideV).
   !>                 The matrices V_l of right singular vectors stored as rows (transposed /
   !>                 conjugate-transposed).
   !>                 Not referenced if right_svect is set to none.
-  !>     @param[in]
-  !>     ldv rocblas_int. ldv >= n if right_svect is set to all, and ldv >= min(m,n) if right_svect
-  !>     is
+  !>     @param[in] ldv - rocblas_int. ldv >= n if right_svect is set to all, and ldv >= min(m,n) if
+  !>     right_svect is
   !>                 set to singular, or ldv >= 1 otherwise.
   !>                 The leading dimension of V.
-  !>     @param[in]
-  !>     strideV     rocblas_stride.
+  !>     @param[in] strideV - rocblas_stride.
   !>                 Stride from the start of one matrix V_l to the next one V(l+1).
   !>                 There is no restriction for the value of strideV.
   !>                 The normal use case is strideV >= ldv*n.
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info[l] = 0, successful exit. If info[l] = 1, the algorithm did not
   !>                 converge.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_sgesvdj_batched
     function rocsolver_sgesvdj_batched_(handle,left_svect,right_svect,m,n,A,lda,abstol,residual, &
@@ -24228,97 +23045,80 @@ module hipfort_rocsolver
   !>     contained within the
   !>     ``rocblas_handle``.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     left_svect  `rocblas_svect`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] left_svect - `rocblas_svect`.
   !>                 Specifies how the left singular vectors are computed.
   !>                 rocblas_svect_overwrite is not supported.
-  !>     @param[in]
-  !>     right_svect `rocblas_svect`.
+  !>     @param[in] right_svect - `rocblas_svect`.
   !>                 Specifies how the right singular vectors are computed.
   !>                 rocblas_svect_overwrite is not supported.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of all matrices A_l in the batch.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of all matrices A_l in the batch.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the matrices A_l.
   !>                 On exit, the contents of A_l are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 The leading dimension of A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA.
   !>                 The normal use case is strideA >= lda*n.
-  !>     @param[in]
-  !>     abstol      real type.
+  !>     @param[in] abstol - real type.
   !>                 The absolute tolerance. The algorithm is considered to have converged once
   !>                 \f$\mathrm{off}(A_l^H A_l) &le; \mathrm{norm}(A_l^H A_l) \cdot
   !>                 \mathrm{abstol}\f$
   !>                 [resp. \f$\mathrm{off}(A_l A_l^H) &le; \mathrm{norm}(A_l A_l^H) \cdot
   !>                 \mathrm{abstol}\f$]. If abstol <= 0,
   !>                 then the tolerance will be set to machine precision.
-  !>     @param[out]
-  !>     residual    pointer to real type on the GPU.
+  !>     @param[out] residual - pointer to real type on the GPU.
   !>                 The Frobenius norm of the off-diagonal elements of \f$A_l^H A_l\f$ (resp.
   !>                 \f$A_l A_l^H\f$) at the final
   !>                 iteration.
-  !>     @param[in]
-  !>     max_sweeps  rocblas_int. max_sweeps > 0.
+  !>     @param[in] max_sweeps - rocblas_int. max_sweeps > 0.
   !>                 Maximum number of sweeps (iterations) to be used by the algorithm.
-  !>     @param[out]
-  !>     n_sweeps    pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] n_sweeps - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 The actual number of sweeps (iterations) used by the algorithm for each batch
   !>                 instance.
-  !>     @param[out]
-  !>     S pointer to real type. Array on the GPU (the size depends on the value of strideS).
+  !>     @param[out] S - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideS).
   !>                 The singular values of A_l in decreasing order.
-  !>     @param[in]
-  !>     strideS     rocblas_stride.
+  !>     @param[in] strideS - rocblas_stride.
   !>                 Stride from the start of one vector S_l to the next one S_(j+1).
   !>                 There is no restriction for the value of strideS.
   !>                 The normal use case is strideS >= min(m,n).
-  !>     @param[out]
-  !>     U           pointer to type. Array on the GPU (the side depends on the value of strideU).
+  !>     @param[out] U - pointer to type. Array on the GPU (the side depends on the value of
+  !>     strideU).
   !>                 The matrices U_l of left singular vectors stored as columns.
   !>                 Not referenced if left_svect is set to none.
-  !>     @param[in]
-  !>     ldu rocblas_int. ldu >= m if left_svect is set to all or singular, and ldu >= 1 otherwise.
+  !>     @param[in] ldu - rocblas_int. ldu >= m if left_svect is set to all or singular, and ldu >=
+  !>     1 otherwise.
   !>                 The leading dimension of U_l.
-  !>     @param[in]
-  !>     strideU     rocblas_stride.
+  !>     @param[in] strideU - rocblas_stride.
   !>                 Stride from the start of one matrix U_l to the next one U_(j+1).
   !>                 There is no restriction for the value of strideU.
   !>                 The normal use case is strideU >= ldu*min(m,n) if left_svect is set to
   !>                 singular,
   !>                 or strideU >= ldu*m when left_svect is equal to all.
-  !>     @param[out]
-  !>     V           pointer to type. Array on the GPU (the size depends on the value of strideV).
+  !>     @param[out] V - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideV).
   !>                 The matrices V_l of right singular vectors stored as rows (transposed /
   !>                 conjugate-transposed).
   !>                 Not referenced if right_svect is set to none.
-  !>     @param[in]
-  !>     ldv rocblas_int. ldv >= n if right_svect is set to all, and ldv >= min(m,n) if right_svect
-  !>     is
+  !>     @param[in] ldv - rocblas_int. ldv >= n if right_svect is set to all, and ldv >= min(m,n) if
+  !>     right_svect is
   !>                 set to singular, or ldv >= 1 otherwise.
   !>                 The leading dimension of V.
-  !>     @param[in]
-  !>     strideV     rocblas_stride.
+  !>     @param[in] strideV - rocblas_stride.
   !>                 Stride from the start of one matrix V_l to the next one V_(j+1).
   !>                 There is no restriction for the value of strideV.
   !>                 The normal use case is strideV >= ldv*n.
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info[l] = 0, successful exit. If info[l] = 1, the algorithm did not
   !>                 converge.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_sgesvdj_strided_batched
     function rocsolver_sgesvdj_strided_batched_(handle,left_svect,right_svect,m,n,A,lda,strideA, &
@@ -24497,98 +23297,79 @@ module hipfort_rocsolver
   !>     is,
   !>       no singular vectors.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     left_svect  `rocblas_svect`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] left_svect - `rocblas_svect`.
   !>                 Specifies if the left singular vectors are computed.
-  !>     @param[in]
-  !>     right_svect `rocblas_svect`.
+  !>     @param[in] right_svect - `rocblas_svect`.
   !>                 Specifies if the right singular vectors are computed.
-  !>     @param[in]
-  !>     srange      `rocblas_srange`.
+  !>     @param[in] srange - `rocblas_srange`.
   !>                 Specifies the type of range or interval of the singular values to be computed.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of matrix A.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of matrix A.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the matrix A.
   !>                 On exit, the contents of A are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 The leading dimension of A.
-  !>     @param[in]
-  !>     vl          real type. 0 <= vl < vu.
+  !>     @param[in] vl - real type. 0 <= vl < vu.
   !>                 The lower bound of the search interval [vl, vu). Ignored if srange indicates to
   !>                 look
   !>                 for all the singular values of A or the singular values within a set of
   !>                 indices.
-  !>     @param[in]
-  !>     vu          real type. 0 <= vl < vu.
+  !>     @param[in] vu - real type. 0 <= vl < vu.
   !>                 The upper bound of the search interval [vl, vu). Ignored if srange indicates to
   !>                 look
   !>                 for all the singular values of A or the singular values within a set of
   !>                 indices.
-  !>     @param[in]
-  !>     il          rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] il - rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the largest singular value to be computed. Ignored if srange
   !>                 indicates to look
   !>                 for all the singular values of A or the singular values in a half-open
   !>                 interval.
-  !>     @param[in]
-  !>     iu          rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] iu - rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the smallest singular value to be computed. Ignored if srange
   !>                 indicates to look
   !>                 for all the singular values of A or the singular values in a half-open
   !>                 interval.
-  !>     @param[out]
-  !>     nsv         pointer to a rocblas_int on the GPU.
+  !>     @param[out] nsv - pointer to a rocblas_int on the GPU.
   !>                 The total number of singular values found. If srange is rocblas_srange_all, nsv
   !>                 = min(m,n).
   !>                 If srange is rocblas_srange_index, nsv = iu - il + 1. Otherwise, 0 <= nsv <=
   !>                 min(m,n).
-  !>     @param[out]
-  !>     S           pointer to real type. Array on the GPU of dimension nsv.
+  !>     @param[out] S - pointer to real type. Array on the GPU of dimension nsv.
   !>                 The first nsv elements contain the computed singular values in descending
   !>                 order.
   !>                 - Note: If srange is rocblas_srange_value, then the value of nsv is not known
   !>                 in advance.
   !>                 In this case, the user should ensure that S is large enough to hold min(m,n)
   !>                 values.
-  !>     @param[out]
-  !>     U           pointer to type. Array on the GPU of dimension ldu*nsv.
+  !>     @param[out] U - pointer to type. Array on the GPU of dimension ldu*nsv.
   !>                 The matrix of left singular vectors stored as columns. Not
   !>                 referenced if left_svect is set to none.
   !>                 - Note: If srange is rocblas_srange_value, then the value of nsv is not known
   !>                 in advance.
   !>                 In this case, the user should ensure that U is large enough to hold min(m,n)
   !>                 columns.
-  !>     @param[in]
-  !>     ldu         rocblas_int. ldu >= m if left_svect singular, and ldu >= 1 otherwise.
+  !>     @param[in] ldu - rocblas_int. ldu >= m if left_svect singular, and ldu >= 1 otherwise.
   !>                 The leading dimension of U.
-  !>     @param[out]
-  !>     V           pointer to type. Array on the GPU of dimension ldv*n.
+  !>     @param[out] V - pointer to type. Array on the GPU of dimension ldv*n.
   !>                 The matrix of right singular vectors stored as rows (transposed /
   !>                 conjugate-transposed).
   !>                 Not referenced if right_svect is set to none.
-  !>     @param[in]
-  !>     ldv rocblas_int. ldv >= nsv if right_svect is set to singular, or ldv >= 1 otherwise.
+  !>     @param[in] ldv - rocblas_int. ldv >= nsv if right_svect is set to singular, or ldv >= 1
+  !>     otherwise.
   !>                 The leading dimension of V.
   !>                 Note: If srange is rocblas_srange_value, then the value of nsv is not known in
   !>                 advance.
   !>                 In this case, the user should ensure that V is large enough to hold min(m,n)
   !>                 rows.
-  !>     @param[out]
-  !>     ifail       pointer to rocblas_int. Array on the GPU of dimension min(m,n).
+  !>     @param[out] ifail - pointer to rocblas_int. Array on the GPU of dimension min(m,n).
   !>                 If info = 0, the first nsv elements of ifail are zero.
   !>                 Otherwise, contains the indices of those eigenvectors that failed
   !>                 to converge, as returned by \ref rocsolver_sbdsvdx "BDSVDX".
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info = 0, successful exit.
   !>                 If info = i > 0, i eigenvectors did not converge in \ref rocsolver_sbdsvdx
   !>                 "BDSVDX". Their
@@ -24760,67 +23541,54 @@ module hipfort_rocsolver
   !>     that is,
   !>       no singular vectors.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     left_svect  `rocblas_svect`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] left_svect - `rocblas_svect`.
   !>                 Specifies if the left singular vectors are computed.
-  !>     @param[in]
-  !>     right_svect `rocblas_svect`.
+  !>     @param[in] right_svect - `rocblas_svect`.
   !>                 Specifies if the right singular vectors are computed.
-  !>     @param[in]
-  !>     srange      `rocblas_srange`.
+  !>     @param[in] srange - `rocblas_srange`.
   !>                 Specifies the type of range or interval of the singular values to be computed.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of matrix A_l.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of matrix A_l.
-  !>     @param[inout]
-  !>     A Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - Array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the matrices A_l.
   !>                 On exit, the contents of A_l are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 The leading dimension of A_l.
-  !>     @param[in]
-  !>     vl          real type. 0 <= vl < vu.
+  !>     @param[in] vl - real type. 0 <= vl < vu.
   !>                 The lower bound of the search interval [vl, vu). Ignored if srange indicates to
   !>                 look
   !>                 for all the singular values of A_l or the singular values within a set of
   !>                 indices.
-  !>     @param[in]
-  !>     vu          real type. 0 <= vl < vu.
+  !>     @param[in] vu - real type. 0 <= vl < vu.
   !>                 The upper bound of the search interval [vl, vu). Ignored if srange indicates to
   !>                 look
   !>                 for all the singular values of A_l or the singular values within a set of
   !>                 indices.
-  !>     @param[in]
-  !>     il          rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] il - rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the largest singular value to be computed. Ignored if srange
   !>                 indicates to look
   !>                 for all the singular values of A_l or the singular values in a half-open
   !>                 interval.
-  !>     @param[in]
-  !>     iu          rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] iu - rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the smallest singular value to be computed. Ignored if srange
   !>                 indicates to look
   !>                 for all the singular values of A_l or the singular values in a half-open
   !>                 interval.
-  !>     @param[out]
-  !>     nsv         pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] nsv - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 The total number of singular values found. If srange is rocblas_srange_all,
   !>                 nsv[l] = min(m,n).
   !>                 If srange is rocblas_srange_index, nsv[l] = iu - il + 1. Otherwise, 0 <= nsv[l]
   !>                 <= min(m,n).
-  !>     @param[out]
-  !>     S pointer to real type. Array on the GPU (the size depends on the value of strideS).
+  !>     @param[out] S - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideS).
   !>                 The first nsv_l elements contain the computed singular values in descending
   !>                 order.
   !>                 (The remaining elements can be used as workspace for internal computations.)
-  !>     @param[in]
-  !>     strideS     rocblas_stride.
+  !>     @param[in] strideS - rocblas_stride.
   !>                 Stride from the start of one vector S_l to the next one S_(l+1).
   !>                 There is no restriction for the value of strideS. The normal use case is
   !>                 strideS >= nsv_l.
@@ -24828,15 +23596,13 @@ module hipfort_rocsolver
   !>                 in advance.
   !>                 In this case, the user should ensure that S_l is large enough to hold min(m,n)
   !>                 values.
-  !>     @param[out]
-  !>     U           pointer to type. Array on the GPU (the size depends on the value of strideU).
+  !>     @param[out] U - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideU).
   !>                 The matrix U_l of left singular vectors stored as columns. Not
   !>                 referenced if left_svect is set to none.
-  !>     @param[in]
-  !>     ldu         rocblas_int. ldu >= m if left_svect singular, and ldu >= 1 otherwise.
+  !>     @param[in] ldu - rocblas_int. ldu >= m if left_svect singular, and ldu >= 1 otherwise.
   !>                 The leading dimension of U_l.
-  !>     @param[in]
-  !>     strideU     rocblas_stride.
+  !>     @param[in] strideU - rocblas_stride.
   !>                 Stride from the start of one matrix U_l to the next one U_(l+1).
   !>                 There is no restriction for the value of strideU. The normal use case is
   !>                 strideU >= ldu*nsv_l.
@@ -24844,41 +23610,37 @@ module hipfort_rocsolver
   !>                 in advance.
   !>                 In this case, the user should ensure that U_l is large enough to hold min(m,n)
   !>                 columns.
-  !>     @param[out]
-  !>     V           pointer to type. Array on the GPU (the size depends on the value of strideV).
+  !>     @param[out] V - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideV).
   !>                 The matrix V_l of right singular vectors stored as rows (transposed /
   !>                 conjugate-transposed).
   !>                 Not referenced if right_svect is set to none.
-  !>     @param[in]
-  !>     ldv rocblas_int. ldv >= nsv_l if right_svect is set to singular, or ldv >= 1 otherwise.
+  !>     @param[in] ldv - rocblas_int. ldv >= nsv_l if right_svect is set to singular, or ldv >= 1
+  !>     otherwise.
   !>                 The leading dimension of V_l.
   !>                 - Note: If srange is rocblas_srange_value, then the value of nsv_l is not known
   !>                 in advance.
   !>                 In this case, the user should ensure that V_l is large enough to hold min(m,n)
   !>                 rows.
-  !>     @param[in]
-  !>     strideV     rocblas_stride.
+  !>     @param[in] strideV - rocblas_stride.
   !>                 Stride from the start of one matrix V_l to the next one V_(l+1).
   !>                 There is no restriction for the value of strideV. The normal use case is
   !>                 strideV >= ldv*n.
-  !>     @param[out]
-  !>     ifail pointer to rocblas_int. Array on the GPU (the size depends on the value of strideF).
+  !>     @param[out] ifail - pointer to rocblas_int. Array on the GPU (the size depends on the value
+  !>     of strideF).
   !>                 If info[l] = 0, the first nsv[l] elements of ifail_l are zero.
   !>                 Otherwise, contains the indices of those eigenvectors that failed
   !>                 to converge, as returned by \ref rocsolver_sbdsvdx "BDSVDX".
-  !>     @param[in]
-  !>     strideF     rocblas_stride.
+  !>     @param[in] strideF - rocblas_stride.
   !>                 Stride from the start of one vector ifail_l to the next one ifail_(l+1).
   !>                 There is no restriction for the value of strideF. The normal use case is
   !>                 strideF >= min(m,n).
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info[l] = 0, successful exit.
   !>                 If info[l] = i > 0, i eigenvectors did not converge in \ref rocsolver_sbdsvdx
   !>                 "BDSVDX". Their
   !>                 indices are stored in ifail_l.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_sgesvdx_batched
     function rocsolver_sgesvdx_batched_(handle,left_svect,right_svect,srange,m,n,A,lda,vl,vu,il, &
@@ -25067,72 +23829,58 @@ module hipfort_rocsolver
   !>     that is,
   !>       no singular vectors.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     left_svect  `rocblas_svect`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] left_svect - `rocblas_svect`.
   !>                 Specifies if the left singular vectors are computed.
-  !>     @param[in]
-  !>     right_svect `rocblas_svect`.
+  !>     @param[in] right_svect - `rocblas_svect`.
   !>                 Specifies if the right singular vectors are computed.
-  !>     @param[in]
-  !>     srange      `rocblas_srange`.
+  !>     @param[in] srange - `rocblas_srange`.
   !>                 Specifies the type of range or interval of the singular values to be computed.
-  !>     @param[in]
-  !>     m           rocblas_int. m >= 0.
+  !>     @param[in] m - rocblas_int. m >= 0.
   !>                 The number of rows of matrix A_l.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of columns of matrix A_l.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the matrices A_l.
   !>                 On exit, the contents of A_l are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= m.
+  !>     @param[in] lda - rocblas_int. lda >= m.
   !>                 The leading dimension of A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[in]
-  !>     vl          real type. 0 <= vl < vu.
+  !>     @param[in] vl - real type. 0 <= vl < vu.
   !>                 The lower bound of the search interval [vl, vu). Ignored if srange indicates to
   !>                 look
   !>                 for all the singular values of A_l or the singular values within a set of
   !>                 indices.
-  !>     @param[in]
-  !>     vu          real type. 0 <= vl < vu.
+  !>     @param[in] vu - real type. 0 <= vl < vu.
   !>                 The upper bound of the search interval [vl, vu). Ignored if srange indicates to
   !>                 look
   !>                 for all the singular values of A_l or the singular values within a set of
   !>                 indices.
-  !>     @param[in]
-  !>     il          rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] il - rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the largest singular value to be computed. Ignored if srange
   !>                 indicates to look
   !>                 for all the singular values of A_l or the singular values in a half-open
   !>                 interval.
-  !>     @param[in]
-  !>     iu          rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] iu - rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the smallest singular value to be computed. Ignored if srange
   !>                 indicates to look
   !>                 for all the singular values of A_l or the singular values in a half-open
   !>                 interval.
-  !>     @param[out]
-  !>     nsv         pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] nsv - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 The total number of singular values found. If srange is rocblas_srange_all,
   !>                 nsv[l] = min(m,n).
   !>                 If srange is rocblas_srange_index, nsv[l] = iu - il + 1. Otherwise, 0 <= nsv[l]
   !>                 <= min(m,n).
-  !>     @param[out]
-  !>     S pointer to real type. Array on the GPU (the size depends on the value of strideS).
+  !>     @param[out] S - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideS).
   !>                 The first nsv_l elements contain the computed singular values in descending
   !>                 order.
   !>                 (The remaining elements can be used as workspace for internal computations.)
-  !>     @param[in]
-  !>     strideS     rocblas_stride.
+  !>     @param[in] strideS - rocblas_stride.
   !>                 Stride from the start of one vector S_l to the next one S_(l+1).
   !>                 There is no restriction for the value of strideS. The normal use case is
   !>                 strideS >= nsv_l.
@@ -25140,15 +23888,13 @@ module hipfort_rocsolver
   !>                 in advance.
   !>                 In this case, the user should ensure that S_l is large enough to hold min(m,n)
   !>                 values.
-  !>     @param[out]
-  !>     U           pointer to type. Array on the GPU (the size depends on the value of strideU).
+  !>     @param[out] U - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideU).
   !>                 The matrix U_l of left singular vectors stored as columns. Not
   !>                 referenced if left_svect is set to none.
-  !>     @param[in]
-  !>     ldu         rocblas_int. ldu >= m if left_svect singular, and ldu >= 1 otherwise.
+  !>     @param[in] ldu - rocblas_int. ldu >= m if left_svect singular, and ldu >= 1 otherwise.
   !>                 The leading dimension of U_l.
-  !>     @param[in]
-  !>     strideU     rocblas_stride.
+  !>     @param[in] strideU - rocblas_stride.
   !>                 Stride from the start of one matrix U_l to the next one U_(l+1).
   !>                 There is no restriction for the value of strideU. The normal use case is
   !>                 strideU >= ldu*nsv_l.
@@ -25156,41 +23902,37 @@ module hipfort_rocsolver
   !>                 in advance.
   !>                 In this case, the user should ensure that U_l is large enough to hold min(m,n)
   !>                 columns.
-  !>     @param[out]
-  !>     V           pointer to type. Array on the GPU (the size depends on the value of strideV).
+  !>     @param[out] V - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideV).
   !>                 The matrix V_l of right singular vectors stored as rows (transposed /
   !>                 conjugate-transposed).
   !>                 Not referenced if right_svect is set to none.
-  !>     @param[in]
-  !>     ldv rocblas_int. ldv >= nsv_l if right_svect is set to singular, or ldv >= 1 otherwise.
+  !>     @param[in] ldv - rocblas_int. ldv >= nsv_l if right_svect is set to singular, or ldv >= 1
+  !>     otherwise.
   !>                 The leading dimension of V_l.
   !>                 - Note: If srange is rocblas_srange_value, then the value of nsv_l is not known
   !>                 in advance.
   !>                 In this case, the user should ensure that V_l is large enough to hold min(m,n)
   !>                 rows.
-  !>     @param[in]
-  !>     strideV     rocblas_stride.
+  !>     @param[in] strideV - rocblas_stride.
   !>                 Stride from the start of one matrix V_l to the next one V_(l+1).
   !>                 There is no restriction for the value of strideV. The normal use case is
   !>                 strideV >= ldv*n.
-  !>     @param[out]
-  !>     ifail pointer to rocblas_int. Array on the GPU (the size depends on the value of strideF).
+  !>     @param[out] ifail - pointer to rocblas_int. Array on the GPU (the size depends on the value
+  !>     of strideF).
   !>                 If info[l] = 0, the first nsv[l] elements of ifail_l are zero.
   !>                 Otherwise, contains the indices of those eigenvectors that failed
   !>                 to converge, as returned by \ref rocsolver_sbdsvdx "BDSVDX".
-  !>     @param[in]
-  !>     strideF     rocblas_stride.
+  !>     @param[in] strideF - rocblas_stride.
   !>                 Stride from the start of one vector ifail_l to the next one ifail_(l+1).
   !>                 There is no restriction for the value of strideF. The normal use case is
   !>                 strideF >= min(m,n).
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info[l] = 0, successful exit.
   !>                 If info[l] = i > 0, i eigenvectors did not converge in \ref rocsolver_sbdsvdx
   !>                 "BDSVDX". Their
   !>                 indices are stored in ifail_l.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_sgesvdx_strided_batched
     function rocsolver_sgesvdx_strided_batched_(handle,left_svect,right_svect,srange,m,n,A,lda, &
@@ -25381,18 +24123,14 @@ module hipfort_rocsolver
   !>     indicates ``upper``,
   !>     the last n-i elements of the Householder vector \f$v_i\f$ are zero, and \f$v_i[i] = 1\f$.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the symmetric matrix A is stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower)
   !>                 part of A is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows and columns of the matrix A.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the matrix to be factored.
   !>                 On exit, if upper, then the elements on the diagonal and superdiagonal
   !>                 contain the tridiagonal form T, and the elements above the superdiagonal
@@ -25401,17 +24139,13 @@ module hipfort_rocsolver
   !>                 If lower, then the elements on the diagonal and subdiagonal
   !>                 contain the tridiagonal form T, and the elements below the subdiagonal contain
   !>                 the last n-i-1 elements of the Householder vectors v_i stored as columns.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 The leading dimension of A.
-  !>     @param[out]
-  !>     D           pointer to type. Array on the GPU of dimension n.
+  !>     @param[out] D - pointer to type. Array on the GPU of dimension n.
   !>                 The diagonal elements of T.
-  !>     @param[out]
-  !>     E           pointer to type. Array on the GPU of dimension n-1.
+  !>     @param[out] E - pointer to type. Array on the GPU of dimension n-1.
   !>                 The off-diagonal elements of T.
-  !>     @param[out]
-  !>     tau         pointer to type. Array on the GPU of dimension n-1.
+  !>     @param[out] tau - pointer to type. Array on the GPU of dimension n-1.
   !>                 The Householder scalars.
   interface rocsolver_ssytd2
     function rocsolver_ssytd2_(handle,uplo,n,A,lda,D,E,tau) bind(c, name="rocsolver_ssytd2")
@@ -25497,18 +24231,14 @@ module hipfort_rocsolver
   !>     indicates ``upper``,
   !>     the last n-i elements of the Householder vector \f$v_i\f$ are zero, and \f$v_i[i] = 1\f$.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the Hermitian matrix A is stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower)
   !>                 part of A is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows and columns of the matrix A.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the matrix to be factored.
   !>                 On exit, if upper, then the elements on the diagonal and superdiagonal
   !>                 contain the tridiagonal form T, and the elements above the superdiagonal
@@ -25517,17 +24247,13 @@ module hipfort_rocsolver
   !>                 If lower, then the elements on the diagonal and subdiagonal
   !>                 contain the tridiagonal form T, and the elements below the subdiagonal contain
   !>                 the last n-i-1 elements of the Householder vectors v_i stored as columns.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 The leading dimension of A.
-  !>     @param[out]
-  !>     D           pointer to real type. Array on the GPU of dimension n.
+  !>     @param[out] D - pointer to real type. Array on the GPU of dimension n.
   !>                 The diagonal elements of T.
-  !>     @param[out]
-  !>     E           pointer to real type. Array on the GPU of dimension n-1.
+  !>     @param[out] E - pointer to real type. Array on the GPU of dimension n-1.
   !>                 The off-diagonal elements of T.
-  !>     @param[out]
-  !>     tau         pointer to type. Array on the GPU of dimension n-1.
+  !>     @param[out] tau - pointer to type. Array on the GPU of dimension n-1.
   !>                 The Householder scalars.
   interface rocsolver_chetd2
     function rocsolver_chetd2_(handle,uplo,n,A,lda,D,E,tau) bind(c, name="rocsolver_chetd2")
@@ -25615,19 +24341,16 @@ module hipfort_rocsolver
   !>     the last n-i elements of the Householder vector \f$v_{l_i}\f$ are zero, and \f$v_{l_i}[i] =
   !>     1\f$.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the symmetric matrix A_l is
   !>                 stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower)
   !>                 part of A_l is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows and columns of the matrices A_l.
-  !>     @param[inout]
-  !>     A array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the matrices A_l to be factored.
   !>                 On exit, if upper, then the elements on the diagonal and superdiagonal
   !>                 contain the tridiagonal form T_l, and the elements above the superdiagonal
@@ -25637,35 +24360,30 @@ module hipfort_rocsolver
   !>                 contain the tridiagonal form T_l, and the elements below the subdiagonal
   !>                 contain
   !>                 the last n-i-1 elements of the Householder vectors v_(l_i) stored as columns.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 The leading dimension of A_l.
-  !>     @param[out]
-  !>     D           pointer to type. Array on the GPU (the size depends on the value of strideD).
+  !>     @param[out] D - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideD).
   !>                 The diagonal elements of T_l.
-  !>     @param[in]
-  !>     strideD     rocblas_stride.
+  !>     @param[in] strideD - rocblas_stride.
   !>                 Stride from the start of one vector D_l to the next one D_(l+1).
   !>                 There is no restriction for the value of strideD. The normal use case is
   !>                 strideD >= n.
-  !>     @param[out]
-  !>     E           pointer to type. Array on the GPU (the size depends on the value of strideE).
+  !>     @param[out] E - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideE).
   !>                 The off-diagonal elements of T_l.
-  !>     @param[in]
-  !>     strideE     rocblas_stride.
+  !>     @param[in] strideE - rocblas_stride.
   !>                 Stride from the start of one vector E_l to the next one E_(l+1).
   !>                 There is no restriction for the value of strideE. The normal use case is
   !>                 strideE >= n-1.
-  !>     @param[out]
-  !>     tau         pointer to type. Array on the GPU (the size depends on the value of strideP).
+  !>     @param[out] tau - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideP).
   !>                 Contains the vectors tau_l of corresponding Householder scalars.
-  !>     @param[in]
-  !>     strideP     rocblas_stride.
+  !>     @param[in] strideP - rocblas_stride.
   !>                 Stride from the start of one vector tau_l to the next one tau_(l+1).
   !>                 There is no restriction for the value
   !>                 of strideP. Normal usage is strideP >= n-1.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_ssytd2_batched
     function rocsolver_ssytd2_batched_(handle,uplo,n,A,lda,D,strideD,E,strideE,tau,strideP, &
@@ -25763,19 +24481,16 @@ module hipfort_rocsolver
   !>     the last n-i elements of the Householder vector \f$v_{l_i}\f$ are zero, and \f$v_{l_i}[i] =
   !>     1\f$.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the Hermitian matrix A_l is
   !>                 stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower)
   !>                 part of A_l is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows and columns of the matrices A_l.
-  !>     @param[inout]
-  !>     A array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the matrices A_l to be factored.
   !>                 On exit, if upper, then the elements on the diagonal and superdiagonal
   !>                 contain the tridiagonal form T_l, and the elements above the superdiagonal
@@ -25785,35 +24500,30 @@ module hipfort_rocsolver
   !>                 contain the tridiagonal form T_l, and the elements below the subdiagonal
   !>                 contain
   !>                 the last n-i-1 elements of the Householder vectors v_(l_i) stored as columns.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 The leading dimension of A_l.
-  !>     @param[out]
-  !>     D pointer to real type. Array on the GPU (the size depends on the value of strideD).
+  !>     @param[out] D - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideD).
   !>                 The diagonal elements of T_l.
-  !>     @param[in]
-  !>     strideD     rocblas_stride.
+  !>     @param[in] strideD - rocblas_stride.
   !>                 Stride from the start of one vector D_l to the next one D_(l+1).
   !>                 There is no restriction for the value of strideD. The normal use case is
   !>                 strideD >= n.
-  !>     @param[out]
-  !>     E pointer to real type. Array on the GPU (the size depends on the value of strideE).
+  !>     @param[out] E - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideE).
   !>                 The off-diagonal elements of T_l.
-  !>     @param[in]
-  !>     strideE     rocblas_stride.
+  !>     @param[in] strideE - rocblas_stride.
   !>                 Stride from the start of one vector E_l to the next one E_(l+1).
   !>                 There is no restriction for the value of strideE. The normal use case is
   !>                 strideE >= n-1.
-  !>     @param[out]
-  !>     tau         pointer to type. Array on the GPU (the size depends on the value of strideP).
+  !>     @param[out] tau - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideP).
   !>                 Contains the vectors tau_l of corresponding Householder scalars.
-  !>     @param[in]
-  !>     strideP     rocblas_stride.
+  !>     @param[in] strideP - rocblas_stride.
   !>                 Stride from the start of one vector tau_l to the next one tau_(l+1).
   !>                 There is no restriction for the value
   !>                 of strideP. Normal usage is strideP >= n-1.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_chetd2_batched
     function rocsolver_chetd2_batched_(handle,uplo,n,A,lda,D,strideD,E,strideE,tau,strideP, &
@@ -25911,19 +24621,16 @@ module hipfort_rocsolver
   !>     the last n-i elements of the Householder vector \f$v_{l_i}\f$ are zero, and \f$v_{l_i}[i] =
   !>     1\f$.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the symmetric matrix A_l is
   !>                 stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower)
   !>                 part of A_l is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows and columns of the matrices A_l.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the matrices A_l to be factored.
   !>                 On exit, if upper, then the elements on the diagonal and superdiagonal
   !>                 contain the tridiagonal form T_l, and the elements above the superdiagonal
@@ -25933,40 +24640,34 @@ module hipfort_rocsolver
   !>                 contain the tridiagonal form T_l, and the elements below the subdiagonal
   !>                 contain
   !>                 the last n-i-1 elements of the Householder vectors v_(l_i) stored as columns.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 The leading dimension of A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[out]
-  !>     D           pointer to type. Array on the GPU (the size depends on the value of strideD).
+  !>     @param[out] D - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideD).
   !>                 The diagonal elements of T_l.
-  !>     @param[in]
-  !>     strideD     rocblas_stride.
+  !>     @param[in] strideD - rocblas_stride.
   !>                 Stride from the start of one vector D_l to the next one D_(l+1).
   !>                 There is no restriction for the value of strideD. The normal use case is
   !>                 strideD >= n.
-  !>     @param[out]
-  !>     E           pointer to type. Array on the GPU (the size depends on the value of strideE).
+  !>     @param[out] E - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideE).
   !>                 The off-diagonal elements of T_l.
-  !>     @param[in]
-  !>     strideE     rocblas_stride.
+  !>     @param[in] strideE - rocblas_stride.
   !>                 Stride from the start of one vector E_l to the next one E_(l+1).
   !>                 There is no restriction for the value of strideE. The normal use case is
   !>                 strideE >= n-1.
-  !>     @param[out]
-  !>     tau         pointer to type. Array on the GPU (the size depends on the value of strideP).
+  !>     @param[out] tau - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideP).
   !>                 Contains the vectors tau_l of corresponding Householder scalars.
-  !>     @param[in]
-  !>     strideP     rocblas_stride.
+  !>     @param[in] strideP - rocblas_stride.
   !>                 Stride from the start of one vector tau_l to the next one tau_(l+1).
   !>                 There is no restriction for the value
   !>                 of strideP. Normal usage is strideP >= n-1.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_ssytd2_strided_batched
     function rocsolver_ssytd2_strided_batched_(handle,uplo,n,A,lda,strideA,D,strideD,E,strideE, &
@@ -26068,19 +24769,16 @@ module hipfort_rocsolver
   !>     the last n-i elements of the Householder vector \f$v_{l_i}\f$ are zero, and \f$v_{l_i}[i] =
   !>     1\f$.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the Hermitian matrix A_l is
   !>                 stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower)
   !>                 part of A_l is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows and columns of the matrices A_l.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the matrices A_l to be factored.
   !>                 On exit, if upper, then the elements on the diagonal and superdiagonal
   !>                 contain the tridiagonal form T_l, and the elements above the superdiagonal
@@ -26090,40 +24788,34 @@ module hipfort_rocsolver
   !>                 contain the tridiagonal form T_l, and the elements below the subdiagonal
   !>                 contain
   !>                 the last n-i-1 elements of the Householder vectors v_(l_i) stored as columns.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 The leading dimension of A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[out]
-  !>     D pointer to real type. Array on the GPU (the size depends on the value of strideD).
+  !>     @param[out] D - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideD).
   !>                 The diagonal elements of T_l.
-  !>     @param[in]
-  !>     strideD     rocblas_stride.
+  !>     @param[in] strideD - rocblas_stride.
   !>                 Stride from the start of one vector D_l to the next one D_(l+1).
   !>                 There is no restriction for the value of strideD. The normal use case is
   !>                 strideD >= n.
-  !>     @param[out]
-  !>     E pointer to real type. Array on the GPU (the size depends on the value of strideE).
+  !>     @param[out] E - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideE).
   !>                 The off-diagonal elements of T_l.
-  !>     @param[in]
-  !>     strideE     rocblas_stride.
+  !>     @param[in] strideE - rocblas_stride.
   !>                 Stride from the start of one vector E_l to the next one E_(l+1).
   !>                 There is no restriction for the value of strideE. The normal use case is
   !>                 strideE >= n-1.
-  !>     @param[out]
-  !>     tau         pointer to type. Array on the GPU (the size depends on the value of strideP).
+  !>     @param[out] tau - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideP).
   !>                 Contains the vectors tau_l of corresponding Householder scalars.
-  !>     @param[in]
-  !>     strideP     rocblas_stride.
+  !>     @param[in] strideP - rocblas_stride.
   !>                 Stride from the start of one vector tau_l to the next one tau_(l+1).
   !>                 There is no restriction for the value
   !>                 of strideP. Normal usage is strideP >= n-1.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_chetd2_strided_batched
     function rocsolver_chetd2_strided_batched_(handle,uplo,n,A,lda,strideA,D,strideD,E,strideE, &
@@ -26222,18 +24914,14 @@ module hipfort_rocsolver
   !>     indicates ``upper``,
   !>     the last n-i elements of the Householder vector \f$v_i\f$ are zero, and \f$v_i[i] = 1\f$.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the symmetric matrix A is stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower)
   !>                 part of A is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows and columns of the matrix A.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the matrix to be factored.
   !>                 On exit, if upper, then the elements on the diagonal and superdiagonal
   !>                 contain the tridiagonal form T, and the elements above the superdiagonal
@@ -26242,17 +24930,13 @@ module hipfort_rocsolver
   !>                 If lower, then the elements on the diagonal and subdiagonal
   !>                 contain the tridiagonal form T, and  the elements below the subdiagonal contain
   !>                 the last n-i-1 elements of the Householder vectors v_i stored as columns.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 The leading dimension of A.
-  !>     @param[out]
-  !>     D           pointer to type. Array on the GPU of dimension n.
+  !>     @param[out] D - pointer to type. Array on the GPU of dimension n.
   !>                 The diagonal elements of T.
-  !>     @param[out]
-  !>     E           pointer to type. Array on the GPU of dimension n-1.
+  !>     @param[out] E - pointer to type. Array on the GPU of dimension n-1.
   !>                 The off-diagonal elements of T.
-  !>     @param[out]
-  !>     tau         pointer to type. Array on the GPU of dimension n-1.
+  !>     @param[out] tau - pointer to type. Array on the GPU of dimension n-1.
   !>                 The Householder scalars.
   interface rocsolver_ssytrd
     function rocsolver_ssytrd_(handle,uplo,n,A,lda,D,E,tau) bind(c, name="rocsolver_ssytrd")
@@ -26338,18 +25022,14 @@ module hipfort_rocsolver
   !>     indicates ``upper``,
   !>     the last n-i elements of the Householder vector \f$v_i\f$ are zero, and \f$v_i[i] = 1\f$.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the Hermitian matrix A is stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower)
   !>                 part of A is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows and columns of the matrix A.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the matrix to be factored.
   !>                 On exit, if upper, then the elements on the diagonal and superdiagonal
   !>                 contain the tridiagonal form T, and the elements above the superdiagonal
@@ -26358,17 +25038,13 @@ module hipfort_rocsolver
   !>                 If lower, then the elements on the diagonal and subdiagonal
   !>                 contain the tridiagonal form T, and the elements below the subdiagonal contain
   !>                 the last n-i-1 elements of the Householder vectors v_i stored as columns.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 The leading dimension of A.
-  !>     @param[out]
-  !>     D           pointer to real type. Array on the GPU of dimension n.
+  !>     @param[out] D - pointer to real type. Array on the GPU of dimension n.
   !>                 The diagonal elements of T.
-  !>     @param[out]
-  !>     E           pointer to real type. Array on the GPU of dimension n-1.
+  !>     @param[out] E - pointer to real type. Array on the GPU of dimension n-1.
   !>                 The off-diagonal elements of T.
-  !>     @param[out]
-  !>     tau         pointer to type. Array on the GPU of dimension n-1.
+  !>     @param[out] tau - pointer to type. Array on the GPU of dimension n-1.
   !>                 The Householder scalars.
   interface rocsolver_chetrd
     function rocsolver_chetrd_(handle,uplo,n,A,lda,D,E,tau) bind(c, name="rocsolver_chetrd")
@@ -26456,19 +25132,16 @@ module hipfort_rocsolver
   !>     the last n-i elements of the Householder vector \f$v_{l_i}\f$ are zero, and \f$v_{l_i}[i] =
   !>     1\f$.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the symmetric matrix A_l is
   !>                 stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower)
   !>                 part of A_l is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows and columns of the matrices A_l.
-  !>     @param[inout]
-  !>     A array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the matrices A_l to be factored.
   !>                 On exit, if upper, then the elements on the diagonal and superdiagonal
   !>                 contain the tridiagonal form T_l, and the elements above the superdiagonal
@@ -26478,35 +25151,30 @@ module hipfort_rocsolver
   !>                 contain the tridiagonal form T_l, and the elements below the subdiagonal
   !>                 contain
   !>                 the last n-i-1 elements of the Householder vectors v_(l_i) stored as columns.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 The leading dimension of A_l.
-  !>     @param[out]
-  !>     D           pointer to type. Array on the GPU (the size depends on the value of strideD).
+  !>     @param[out] D - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideD).
   !>                 The diagonal elements of T_l.
-  !>     @param[in]
-  !>     strideD     rocblas_stride.
+  !>     @param[in] strideD - rocblas_stride.
   !>                 Stride from the start of one vector D_l to the next one D_(l+1).
   !>                 There is no restriction for the value of strideD. The normal use case is
   !>                 strideD >= n.
-  !>     @param[out]
-  !>     E           pointer to type. Array on the GPU (the size depends on the value of strideE).
+  !>     @param[out] E - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideE).
   !>                 The off-diagonal elements of T_l.
-  !>     @param[in]
-  !>     strideE     rocblas_stride.
+  !>     @param[in] strideE - rocblas_stride.
   !>                 Stride from the start of one vector E_l to the next one E_(l+1).
   !>                 There is no restriction for the value of strideE. The normal use case is
   !>                 strideE >= n-1.
-  !>     @param[out]
-  !>     tau         pointer to type. Array on the GPU (the size depends on the value of strideP).
+  !>     @param[out] tau - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideP).
   !>                 Contains the vectors tau_l of corresponding Householder scalars.
-  !>     @param[in]
-  !>     strideP     rocblas_stride.
+  !>     @param[in] strideP - rocblas_stride.
   !>                 Stride from the start of one vector tau_l to the next one tau_(l+1).
   !>                 There is no restriction for the value
   !>                 of strideP. Normal usage is strideP >= n-1.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_ssytrd_batched
     function rocsolver_ssytrd_batched_(handle,uplo,n,A,lda,D,strideD,E,strideE,tau,strideP, &
@@ -26604,19 +25272,16 @@ module hipfort_rocsolver
   !>     the last n-i elements of the Householder vector \f$v_{l_i}\f$ are zero, and \f$v_{l_i}[i] =
   !>     1\f$.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the Hermitian matrix A_l is
   !>                 stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower)
   !>                 part of A_l is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows and columns of the matrices A_l.
-  !>     @param[inout]
-  !>     A array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the matrices A_l to be factored.
   !>                 On exit, if upper, then the elements on the diagonal and superdiagonal
   !>                 contain the tridiagonal form T_l, and the elements above the superdiagonal
@@ -26626,35 +25291,30 @@ module hipfort_rocsolver
   !>                 contain the tridiagonal form T_l, and the elements below the subdiagonal
   !>                 contain
   !>                 the last n-i-1 elements of the Householder vectors v_(l_i) stored as columns.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 The leading dimension of A_l.
-  !>     @param[out]
-  !>     D pointer to real type. Array on the GPU (the size depends on the value of strideD).
+  !>     @param[out] D - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideD).
   !>                 The diagonal elements of T_l.
-  !>     @param[in]
-  !>     strideD     rocblas_stride.
+  !>     @param[in] strideD - rocblas_stride.
   !>                 Stride from the start of one vector D_l to the next one D_(l+1).
   !>                 There is no restriction for the value of strideD. The normal use case is
   !>                 strideD >= n.
-  !>     @param[out]
-  !>     E pointer to real type. Array on the GPU (the size depends on the value of strideE).
+  !>     @param[out] E - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideE).
   !>                 The off-diagonal elements of T_l.
-  !>     @param[in]
-  !>     strideE     rocblas_stride.
+  !>     @param[in] strideE - rocblas_stride.
   !>                 Stride from the start of one vector E_l to the next one E_(l+1).
   !>                 There is no restriction for the value of strideE. The normal use case is
   !>                 strideE >= n-1.
-  !>     @param[out]
-  !>     tau         pointer to type. Array on the GPU (the size depends on the value of strideP).
+  !>     @param[out] tau - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideP).
   !>                 Contains the vectors tau_l of corresponding Householder scalars.
-  !>     @param[in]
-  !>     strideP     rocblas_stride.
+  !>     @param[in] strideP - rocblas_stride.
   !>                 Stride from the start of one vector tau_l to the next one tau_(l+1).
   !>                 There is no restriction for the value
   !>                 of strideP. Normal usage is strideP >= n-1.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_chetrd_batched
     function rocsolver_chetrd_batched_(handle,uplo,n,A,lda,D,strideD,E,strideE,tau,strideP, &
@@ -26752,19 +25412,16 @@ module hipfort_rocsolver
   !>     the last n-i elements of the Householder vector \f$v_{l_i}\f$ are zero, and \f$v_{l_i}[i] =
   !>     1\f$.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the symmetric matrix A_l is
   !>                 stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower)
   !>                 part of A_l is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows and columns of the matrices A_l.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the matrices A_l to be factored.
   !>                 On exit, if upper, then the elements on the diagonal and superdiagonal
   !>                 contain the tridiagonal form T_l, and the elements above the superdiagonal
@@ -26774,40 +25431,34 @@ module hipfort_rocsolver
   !>                 contain the tridiagonal form T_l, and the elements below the subdiagonal
   !>                 contain
   !>                 the last n-i-1 elements of the Householder vectors v_(l_i) stored as columns.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 The leading dimension of A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[out]
-  !>     D           pointer to type. Array on the GPU (the size depends on the value of strideD).
+  !>     @param[out] D - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideD).
   !>                 The diagonal elements of T_l.
-  !>     @param[in]
-  !>     strideD     rocblas_stride.
+  !>     @param[in] strideD - rocblas_stride.
   !>                 Stride from the start of one vector D_l to the next one D_(l+1).
   !>                 There is no restriction for the value of strideD. The normal use case is
   !>                 strideD >= n.
-  !>     @param[out]
-  !>     E           pointer to type. Array on the GPU (the size depends on the value of strideE).
+  !>     @param[out] E - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideE).
   !>                 The off-diagonal elements of T_l.
-  !>     @param[in]
-  !>     strideE     rocblas_stride.
+  !>     @param[in] strideE - rocblas_stride.
   !>                 Stride from the start of one vector E_l to the next one E_(l+1).
   !>                 There is no restriction for the value of strideE. The normal use case is
   !>                 strideE >= n-1.
-  !>     @param[out]
-  !>     tau         pointer to type. Array on the GPU (the size depends on the value of strideP).
+  !>     @param[out] tau - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideP).
   !>                 Contains the vectors tau_l of corresponding Householder scalars.
-  !>     @param[in]
-  !>     strideP     rocblas_stride.
+  !>     @param[in] strideP - rocblas_stride.
   !>                 Stride from the start of one vector tau_l to the next one tau_(l+1).
   !>                 There is no restriction for the value
   !>                 of strideP. Normal usage is strideP >= n-1.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_ssytrd_strided_batched
     function rocsolver_ssytrd_strided_batched_(handle,uplo,n,A,lda,strideA,D,strideD,E,strideE, &
@@ -26909,19 +25560,16 @@ module hipfort_rocsolver
   !>     the last n-i elements of the Householder vector \f$v_{l_i}\f$ are zero, and \f$v_{l_i}[i] =
   !>     1\f$.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the Hermitian matrix A_l is
   !>                 stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower)
   !>                 part of A_l is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows and columns of the matrices A_l.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the matrices A_l to be factored.
   !>                 On exit, if upper, then the elements on the diagonal and superdiagonal
   !>                 contain the tridiagonal form T_l, and the elements above the superdiagonal
@@ -26931,40 +25579,34 @@ module hipfort_rocsolver
   !>                 contain the tridiagonal form T_l, and the elements below the subdiagonal
   !>                 contain
   !>                 the last n-i-1 elements of the Householder vectors v_(l_i) stored as columns.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 The leading dimension of A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[out]
-  !>     D pointer to real type. Array on the GPU (the size depends on the value of strideD).
+  !>     @param[out] D - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideD).
   !>                 The diagonal elements of T_l.
-  !>     @param[in]
-  !>     strideD     rocblas_stride.
+  !>     @param[in] strideD - rocblas_stride.
   !>                 Stride from the start of one vector D_l to the next one D_(l+1).
   !>                 There is no restriction for the value of strideD. The normal use case is
   !>                 strideD >= n.
-  !>     @param[out]
-  !>     E pointer to real type. Array on the GPU (the size depends on the value of strideE).
+  !>     @param[out] E - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideE).
   !>                 The off-diagonal elements of T_l.
-  !>     @param[in]
-  !>     strideE     rocblas_stride.
+  !>     @param[in] strideE - rocblas_stride.
   !>                 Stride from the start of one vector E_l to the next one E_(l+1).
   !>                 There is no restriction for the value of strideE. The normal use case is
   !>                 strideE >= n-1.
-  !>     @param[out]
-  !>     tau         pointer to type. Array on the GPU (the size depends on the value of strideP).
+  !>     @param[out] tau - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideP).
   !>                 Contains the vectors tau_l of corresponding Householder scalars.
-  !>     @param[in]
-  !>     strideP     rocblas_stride.
+  !>     @param[in] strideP - rocblas_stride.
   !>                 Stride from the start of one vector tau_l to the next one tau_(l+1).
   !>                 There is no restriction for the value
   !>                 of strideP. Normal usage is strideP >= n-1.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_chetrd_strided_batched
     function rocsolver_chetrd_strided_batched_(handle,uplo,n,A,lda,strideA,D,strideD,E,strideE, &
@@ -27073,33 +25715,25 @@ module hipfort_rocsolver
   !>
   !>     also depending on the value of ``uplo``.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     itype       `rocblas_eform`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] itype - `rocblas_eform`.
   !>                 Specifies the form of the generalized eigenproblem.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the matrix A is stored, and
   !>                 whether the factorization applied to B was upper or lower triangular.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) parts of A and
   !>                 B are not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The matrix dimensions.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the matrix A. On exit, the transformed matrix associated with
   !>                 the equivalent standard eigenvalue problem.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of A.
-  !>     @param[out]
-  !>     B           pointer to type. Array on the GPU of dimension ldb*n.
+  !>     @param[out] B - pointer to type. Array on the GPU of dimension ldb*n.
   !>                 The triangular factor of the matrix B, as returned by \ref rocsolver_spotrf
   !>                 "POTRF".
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 Specifies the leading dimension of B.
   interface rocsolver_ssygs2
     function rocsolver_ssygs2_(handle,itype,uplo,n,A,lda,B,ldb) bind(c, name="rocsolver_ssygs2")
@@ -27193,33 +25827,25 @@ module hipfort_rocsolver
   !>
   !>     also depending on the value of ``uplo``.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     itype       `rocblas_eform`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] itype - `rocblas_eform`.
   !>                 Specifies the form of the generalized eigenproblem.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the matrix A is stored, and
   !>                 whether the factorization applied to B was upper or lower triangular.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) parts of A and
   !>                 B are not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The matrix dimensions.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the matrix A. On exit, the transformed matrix associated with
   !>                 the equivalent standard eigenvalue problem.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of A.
-  !>     @param[out]
-  !>     B           pointer to type. Array on the GPU of dimension ldb*n.
+  !>     @param[out] B - pointer to type. Array on the GPU of dimension ldb*n.
   !>                 The triangular factor of the matrix B, as returned by \ref rocsolver_spotrf
   !>                 "POTRF".
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 Specifies the leading dimension of B.
   interface rocsolver_chegs2
     function rocsolver_chegs2_(handle,itype,uplo,n,A,lda,B,ldb) bind(c, name="rocsolver_chegs2")
@@ -27315,36 +25941,29 @@ module hipfort_rocsolver
   !>
   !>     also depending on the value of ``uplo``.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     itype       `rocblas_eform`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] itype - `rocblas_eform`.
   !>                 Specifies the form of the generalized eigenproblems.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the matrices A_l are stored, and
   !>                 whether the factorization applied to B_l was upper or lower triangular.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) parts of A_l and
   !>                 B_l are not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The matrix dimensions.
-  !>     @param[inout]
-  !>     A array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the matrices A_l. On exit, the transformed matrices associated with
   !>                 the equivalent standard eigenvalue problems.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of A_l.
-  !>     @param[out]
-  !>     B array of pointers to type. Each pointer points to an array on the GPU of dimension ldb*n.
+  !>     @param[out] B - array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension ldb*n.
   !>                 The triangular factors of the matrices B_l, as returned by \ref
   !>                 rocsolver_spotrf_batched "POTRF_BATCHED".
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 Specifies the leading dimension of B_l.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_ssygs2_batched
     function rocsolver_ssygs2_batched_(handle,itype,uplo,n,A,lda,B,ldb,batch_count) &
@@ -27430,36 +26049,29 @@ module hipfort_rocsolver
   !>
   !>     also depending on the value of ``uplo``.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     itype       `rocblas_eform`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] itype - `rocblas_eform`.
   !>                 Specifies the form of the generalized eigenproblems.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the matrices A_l are stored, and
   !>                 whether the factorization applied to B_l was upper or lower triangular.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) parts of A_l and
   !>                 B_l are not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The matrix dimensions.
-  !>     @param[inout]
-  !>     A array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the matrices A_l. On exit, the transformed matrices associated with
   !>                 the equivalent standard eigenvalue problems.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of A_l.
-  !>     @param[out]
-  !>     B array of pointers to type. Each pointer points to an array on the GPU of dimension ldb*n.
+  !>     @param[out] B - array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension ldb*n.
   !>                 The triangular factors of the matrices B_l, as returned by \ref
   !>                 rocsolver_spotrf_batched "POTRF_BATCHED".
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 Specifies the leading dimension of B_l.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_chegs2_batched
     function rocsolver_chegs2_batched_(handle,itype,uplo,n,A,lda,B,ldb,batch_count) &
@@ -27545,46 +26157,37 @@ module hipfort_rocsolver
   !>
   !>     also depending on the value of ``uplo``.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     itype       `rocblas_eform`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] itype - `rocblas_eform`.
   !>                 Specifies the form of the generalized eigenproblems.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the matrices A_l are stored, and
   !>                 whether the factorization applied to B_l was upper or lower triangular.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) parts of A_l and
   !>                 B_l are not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The matrix dimensions.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the matrices A_l. On exit, the transformed matrices associated with
   !>                 the equivalent standard eigenvalue problems.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[out]
-  !>     B           pointer to type. Array on the GPU (the size depends on the value of strideB).
+  !>     @param[out] B - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideB).
   !>                 The triangular factors of the matrices B_l, as returned by \ref
   !>                 rocsolver_spotrf_strided_batched "POTRF_STRIDED_BATCHED".
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 Specifies the leading dimension of B_l.
-  !>     @param[in]
-  !>     strideB     rocblas_stride.
+  !>     @param[in] strideB - rocblas_stride.
   !>                 Stride from the start of one matrix B_l to the next one B_(l+1).
   !>                 There is no restriction for the value of strideB. The normal use case is
   !>                 strideB >= ldb*n.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_ssygs2_strided_batched
     function rocsolver_ssygs2_strided_batched_(handle,itype,uplo,n,A,lda,strideA,B,ldb,strideB, &
@@ -27689,46 +26292,37 @@ module hipfort_rocsolver
   !>
   !>     also depending on the value of ``uplo``.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     itype       `rocblas_eform`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] itype - `rocblas_eform`.
   !>                 Specifies the form of the generalized eigenproblems.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the matrices A_l are stored, and
   !>                 whether the factorization applied to B_l was upper or lower triangular.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) parts of A_l and
   !>                 B_l are not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The matrix dimensions.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the matrices A_l. On exit, the transformed matrices associated with
   !>                 the equivalent standard eigenvalue problems.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[out]
-  !>     B           pointer to type. Array on the GPU (the size depends on the value of strideB).
+  !>     @param[out] B - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideB).
   !>                 The triangular factors of the matrices B_l, as returned by \ref
   !>                 rocsolver_spotrf_strided_batched "POTRF_STRIDED_BATCHED".
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 Specifies the leading dimension of B_l.
-  !>     @param[in]
-  !>     strideB     rocblas_stride.
+  !>     @param[in] strideB - rocblas_stride.
   !>                 Stride from the start of one matrix B_l to the next one B_(l+1).
   !>                 There is no restriction for the value of strideB. The normal use case is
   !>                 strideB >= ldb*n.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_chegs2_strided_batched
     function rocsolver_chegs2_strided_batched_(handle,itype,uplo,n,A,lda,strideA,B,ldb,strideB, &
@@ -27833,33 +26427,25 @@ module hipfort_rocsolver
   !>
   !>     also depending on the value of ``uplo``.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     itype       `rocblas_eform`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] itype - `rocblas_eform`.
   !>                 Specifies the form of the generalized eigenproblem.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the matrix A is stored, and
   !>                 whether the factorization applied to B was upper or lower triangular.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) parts of A and
   !>                 B are not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The matrix dimensions.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the matrix A. On exit, the transformed matrix associated with
   !>                 the equivalent standard eigenvalue problem.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of A.
-  !>     @param[out]
-  !>     B           pointer to type. Array on the GPU of dimension ldb*n.
+  !>     @param[out] B - pointer to type. Array on the GPU of dimension ldb*n.
   !>                 The triangular factor of the matrix B, as returned by \ref rocsolver_spotrf
   !>                 "POTRF".
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 Specifies the leading dimension of B.
   interface rocsolver_ssygst
     function rocsolver_ssygst_(handle,itype,uplo,n,A,lda,B,ldb) bind(c, name="rocsolver_ssygst")
@@ -27953,33 +26539,25 @@ module hipfort_rocsolver
   !>
   !>     also depending on the value of ``uplo``.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     itype       `rocblas_eform`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] itype - `rocblas_eform`.
   !>                 Specifies the form of the generalized eigenproblem.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the matrix A is stored, and
   !>                 whether the factorization applied to B was upper or lower triangular.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) parts of A and
   !>                 B are not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The matrix dimensions.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the matrix A. On exit, the transformed matrix associated with
   !>                 the equivalent standard eigenvalue problem.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of A.
-  !>     @param[out]
-  !>     B           pointer to type. Array on the GPU of dimension ldb*n.
+  !>     @param[out] B - pointer to type. Array on the GPU of dimension ldb*n.
   !>                 The triangular factor of the matrix B, as returned by \ref rocsolver_spotrf
   !>                 "POTRF".
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 Specifies the leading dimension of B.
   interface rocsolver_chegst
     function rocsolver_chegst_(handle,itype,uplo,n,A,lda,B,ldb) bind(c, name="rocsolver_chegst")
@@ -28075,36 +26653,29 @@ module hipfort_rocsolver
   !>
   !>     also depending on the value of ``uplo``.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     itype       `rocblas_eform`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] itype - `rocblas_eform`.
   !>                 Specifies the form of the generalized eigenproblems.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the matrices A_l are stored, and
   !>                 whether the factorization applied to B_l was upper or lower triangular.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) parts of A_l and
   !>                 B_l are not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The matrix dimensions.
-  !>     @param[inout]
-  !>     A array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the matrices A_l. On exit, the transformed matrices associated with
   !>                 the equivalent standard eigenvalue problems.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of A_l.
-  !>     @param[out]
-  !>     B array of pointers to type. Each pointer points to an array on the GPU of dimension ldb*n.
+  !>     @param[out] B - array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension ldb*n.
   !>                 The triangular factors of the matrices B_l, as returned by \ref
   !>                 rocsolver_spotrf_batched "POTRF_BATCHED".
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 Specifies the leading dimension of B_l.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_ssygst_batched
     function rocsolver_ssygst_batched_(handle,itype,uplo,n,A,lda,B,ldb,batch_count) &
@@ -28190,36 +26761,29 @@ module hipfort_rocsolver
   !>
   !>     also depending on the value of ``uplo``.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     itype       `rocblas_eform`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] itype - `rocblas_eform`.
   !>                 Specifies the form of the generalized eigenproblems.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the matrices A_l are stored, and
   !>                 whether the factorization applied to B_l was upper or lower triangular.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) parts of A_l and
   !>                 B_l are not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The matrix dimensions.
-  !>     @param[inout]
-  !>     A array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the matrices A_l. On exit, the transformed matrices associated with
   !>                 the equivalent standard eigenvalue problems.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of A_l.
-  !>     @param[out]
-  !>     B array of pointers to type. Each pointer points to an array on the GPU of dimension ldb*n.
+  !>     @param[out] B - array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension ldb*n.
   !>                 The triangular factors of the matrices B_l, as returned by \ref
   !>                 rocsolver_spotrf_batched "POTRF_BATCHED".
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 Specifies the leading dimension of B_l.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_chegst_batched
     function rocsolver_chegst_batched_(handle,itype,uplo,n,A,lda,B,ldb,batch_count) &
@@ -28305,46 +26869,37 @@ module hipfort_rocsolver
   !>
   !>     also depending on the value of ``uplo``.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     itype       `rocblas_eform`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] itype - `rocblas_eform`.
   !>                 Specifies the form of the generalized eigenproblems.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the matrices A_l are stored, and
   !>                 whether the factorization applied to B_l was upper or lower triangular.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) parts of A_l and
   !>                 B_l are not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The matrix dimensions.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the matrices A_l. On exit, the transformed matrices associated with
   !>                 the equivalent standard eigenvalue problems.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[out]
-  !>     B           pointer to type. Array on the GPU (the size depends on the value of strideB).
+  !>     @param[out] B - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideB).
   !>                 The triangular factors of the matrices B_l, as returned by \ref
   !>                 rocsolver_spotrf_strided_batched "POTRF_STRIDED_BATCHED".
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 Specifies the leading dimension of B_l.
-  !>     @param[in]
-  !>     strideB     rocblas_stride.
+  !>     @param[in] strideB - rocblas_stride.
   !>                 Stride from the start of one matrix B_l to the next one B_(l+1).
   !>                 There is no restriction for the value of strideB. The normal use case is
   !>                 strideB >= ldb*n.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_ssygst_strided_batched
     function rocsolver_ssygst_strided_batched_(handle,itype,uplo,n,A,lda,strideA,B,ldb,strideB, &
@@ -28449,46 +27004,37 @@ module hipfort_rocsolver
   !>
   !>     also depending on the value of ``uplo``.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     itype       `rocblas_eform`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] itype - `rocblas_eform`.
   !>                 Specifies the form of the generalized eigenproblems.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the matrices A_l are stored, and
   !>                 whether the factorization applied to B_l was upper or lower triangular.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) parts of A_l and
   !>                 B_l are not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The matrix dimensions.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the matrices A_l. On exit, the transformed matrices associated with
   !>                 the equivalent standard eigenvalue problems.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[out]
-  !>     B           pointer to type. Array on the GPU (the size depends on the value of strideB).
+  !>     @param[out] B - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideB).
   !>                 The triangular factors of the matrices B_l, as returned by \ref
   !>                 rocsolver_spotrf_strided_batched "POTRF_STRIDED_BATCHED".
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 Specifies the leading dimension of B_l.
-  !>     @param[in]
-  !>     strideB     rocblas_stride.
+  !>     @param[in] strideB - rocblas_stride.
   !>                 Stride from the start of one matrix B_l to the next one B_(l+1).
   !>                 There is no restriction for the value of strideB. The normal use case is
   !>                 strideB >= ldb*n.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_chegst_strided_batched
     function rocsolver_chegst_strided_batched_(handle,itype,uplo,n,A,lda,strideA,B,ldb,strideB, &
@@ -28563,34 +27109,26 @@ module hipfort_rocsolver
   !>     The eigenvalues are returned in ascending order. The eigenvectors are computed depending
   !>     on the value of ``evect``. The computed eigenvectors are orthonormal.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the symmetric matrix A is stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) part of A
   !>                 is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of rows and columns of matrix A.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the matrix A. On exit, the eigenvectors of A if they were computed
   !>                 and
   !>                 the algorithm converged. Otherwise, the contents of A are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrix A.
-  !>     @param[out]
-  !>     D           pointer to type. Array on the GPU of dimension n.
+  !>     @param[out] D - pointer to type. Array on the GPU of dimension n.
   !>                 The eigenvalues of A in increasing order.
-  !>     @param[out]
-  !>     E           pointer to type. Array on the GPU of dimension n.
+  !>     @param[out] E - pointer to type. Array on the GPU of dimension n.
   !>                 This array is used to work internally with the tridiagonal matrix T associated
   !>                 with A.
   !>                 On exit, if info > 0, it contains the unconverged off-diagonal elements of T
@@ -28598,8 +27136,7 @@ module hipfort_rocsolver
   !>                 elements
   !>                 of this matrix are in D. Those that converged correspond to a subset of the
   !>                 eigenvalues of A (not necessarily ordered).
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info = 0, successful exit. If info = i > 0, the algorithm did not converge.
   !>                 i elements of E did not converge to zero.
   interface rocsolver_ssyev
@@ -28706,34 +27243,26 @@ module hipfort_rocsolver
   !>     The eigenvalues are returned in ascending order. The eigenvectors are computed depending
   !>     on the value of ``evect``. The computed eigenvectors are orthonormal.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the Hermitian matrix A is stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) part of A
   !>                 is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of rows and columns of matrix A.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the matrix A. On exit, the eigenvectors of A if they were computed
   !>                 and
   !>                 the algorithm converged. Otherwise, the contents of A are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrix A.
-  !>     @param[out]
-  !>     D           pointer to real type. Array on the GPU of dimension n.
+  !>     @param[out] D - pointer to real type. Array on the GPU of dimension n.
   !>                 The eigenvalues of A in increasing order.
-  !>     @param[out]
-  !>     E           pointer to real type. Array on the GPU of dimension n.
+  !>     @param[out] E - pointer to real type. Array on the GPU of dimension n.
   !>                 This array is used to work internally with the tridiagonal matrix T associated
   !>                 with A.
   !>                 On exit, if info > 0, it contains the unconverged off-diagonal elements of T
@@ -28741,8 +27270,7 @@ module hipfort_rocsolver
   !>                 elements
   !>                 of this matrix are in D. Those that converged correspond to a subset of the
   !>                 eigenvalues of A (not necessarily ordered).
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info = 0, successful exit. If info = i > 0, the algorithm did not converge.
   !>                 i elements of E did not converge to zero.
   interface rocsolver_cheev
@@ -28850,40 +27378,34 @@ module hipfort_rocsolver
   !>     The eigenvalues are returned in ascending order. The eigenvectors are computed depending
   !>     on the value of ``evect``. The computed eigenvectors are orthonormal.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the symmetric matrices A_l is
   !>                 stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) part of A_l
   !>                 is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of rows and columns of matrices A_l.
-  !>     @param[inout]
-  !>     A Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - Array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the matrices A_l. On exit, the eigenvectors of A_l if they were
   !>                 computed and
   !>                 the algorithm converged. Otherwise, the contents of A_l are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[out]
-  !>     D           pointer to type. Array on the GPU (the size depends on the value of strideD).
+  !>     @param[out] D - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideD).
   !>                 The eigenvalues of A_l in increasing order.
-  !>     @param[in]
-  !>     strideD     rocblas_stride.
+  !>     @param[in] strideD - rocblas_stride.
   !>                 Stride from the start of one vector D_l to the next one D_(l+1).
   !>                 There is no restriction for the value of strideD. The normal use case is
   !>                 strideD >= n.
-  !>     @param[out]
-  !>     E           pointer to type. Array on the GPU (the size depends on the value of strideE).
+  !>     @param[out] E - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideE).
   !>                 This array is used to work internally with the tridiagonal matrix T_l
   !>                 associated with A_l.
   !>                 On exit, if info[l] > 0, E_l contains the unconverged off-diagonal elements of
@@ -28892,18 +27414,15 @@ module hipfort_rocsolver
   !>                 elements
   !>                 of this matrix are in D_l. Those that converged correspond to a subset of the
   !>                 eigenvalues of A_l (not necessarily ordered).
-  !>     @param[in]
-  !>     strideE     rocblas_stride.
+  !>     @param[in] strideE - rocblas_stride.
   !>                 Stride from the start of one vector E_l to the next one E_(l+1).
   !>                 There is no restriction for the value of strideE. The normal use case is
   !>                 strideE >= n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for matrix A_l. If info[l] = i > 0, the
   !>                 algorithm did not converge.
   !>                 i elements of E_l did not converge to zero.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_ssyev_batched
     function rocsolver_ssyev_batched_(handle,evect,uplo,n,A,lda,D,strideD,E,strideE,myInfo, &
@@ -29026,40 +27545,34 @@ module hipfort_rocsolver
   !>     The eigenvalues are returned in ascending order. The eigenvectors are computed depending
   !>     on the value of ``evect``. The computed eigenvectors are orthonormal.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the Hermitian matrices A_l is
   !>                 stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) part of A_l
   !>                 is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of rows and columns of matrices A_l.
-  !>     @param[inout]
-  !>     A Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - Array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the matrices A_l. On exit, the eigenvectors of A_l if they were
   !>                 computed and
   !>                 the algorithm converged. Otherwise, the contents of A_l are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[out]
-  !>     D pointer to real type. Array on the GPU (the size depends on the value of strideD).
+  !>     @param[out] D - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideD).
   !>                 The eigenvalues of A_l in increasing order.
-  !>     @param[in]
-  !>     strideD     rocblas_stride.
+  !>     @param[in] strideD - rocblas_stride.
   !>                 Stride from the start of one vector D_l to the next one D_(l+1).
   !>                 There is no restriction for the value of strideD. The normal use case is
   !>                 strideD >= n.
-  !>     @param[out]
-  !>     E pointer to real type. Array on the GPU (the size depends on the value of strideE).
+  !>     @param[out] E - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideE).
   !>                 This array is used to work internally with the tridiagonal matrix T_l
   !>                 associated with A_l.
   !>                 On exit, if info[l] > 0, E_l contains the unconverged off-diagonal elements of
@@ -29068,18 +27581,15 @@ module hipfort_rocsolver
   !>                 elements
   !>                 of this matrix are in D_l. Those that converged correspond to a subset of the
   !>                 eigenvalues of A_l (not necessarily ordered).
-  !>     @param[in]
-  !>     strideE     rocblas_stride.
+  !>     @param[in] strideE - rocblas_stride.
   !>                 Stride from the start of one vector E_l to the next one E_(l+1).
   !>                 There is no restriction for the value of strideE. The normal use case is
   !>                 strideE >= n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for matrix A_l. If info[l] = i > 0, the
   !>                 algorithm did not converge.
   !>                 i elements of E_l did not converge to zero.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_cheev_batched
     function rocsolver_cheev_batched_(handle,evect,uplo,n,A,lda,D,strideD,E,strideE,myInfo, &
@@ -29202,45 +27712,38 @@ module hipfort_rocsolver
   !>     The eigenvalues are returned in ascending order. The eigenvectors are computed depending
   !>     on the value of ``evect``. The computed eigenvectors are orthonormal.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the symmetric matrices A_l is
   !>                 stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) part of A_l
   !>                 is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of rows and columns of matrices A_l.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the matrices A_l. On exit, the eigenvectors of A_l if they were
   !>                 computed and
   !>                 the algorithm converged. Otherwise, the contents of A_l are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[out]
-  !>     D           pointer to type. Array on the GPU (the size depends on the value of strideD).
+  !>     @param[out] D - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideD).
   !>                 The eigenvalues of A_l in increasing order.
-  !>     @param[in]
-  !>     strideD     rocblas_stride.
+  !>     @param[in] strideD - rocblas_stride.
   !>                 Stride from the start of one vector D_l to the next one D_(l+1).
   !>                 There is no restriction for the value of strideD. The normal use case is
   !>                 strideD >= n.
-  !>     @param[out]
-  !>     E           pointer to type. Array on the GPU (the size depends on the value of strideE).
+  !>     @param[out] E - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideE).
   !>                 This array is used to work internally with the tridiagonal matrix T_l
   !>                 associated with A_l.
   !>                 On exit, if info[l] > 0, E_l contains the unconverged off-diagonal elements of
@@ -29249,18 +27752,15 @@ module hipfort_rocsolver
   !>                 elements
   !>                 of this matrix are in D_l. Those that converged correspond to a subset of the
   !>                 eigenvalues of A_l (not necessarily ordered).
-  !>     @param[in]
-  !>     strideE     rocblas_stride.
+  !>     @param[in] strideE - rocblas_stride.
   !>                 Stride from the start of one vector E_l to the next one E_(l+1).
   !>                 There is no restriction for the value of strideE. The normal use case is
   !>                 strideE >= n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for matrix A_l. If info[l] = i > 0, the
   !>                 algorithm did not converge.
   !>                 i elements of E_l did not converge to zero.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_ssyev_strided_batched
     function rocsolver_ssyev_strided_batched_(handle,evect,uplo,n,A,lda,strideA,D,strideD,E, &
@@ -29389,45 +27889,38 @@ module hipfort_rocsolver
   !>     The eigenvalues are returned in ascending order. The eigenvectors are computed depending
   !>     on the value of ``evect``. The computed eigenvectors are orthonormal.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the Hermitian matrices A_l is
   !>                 stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) part of A_l
   !>                 is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of rows and columns of matrices A_l.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the matrices A_l. On exit, the eigenvectors of A_l if they were
   !>                 computed and
   !>                 the algorithm converged. Otherwise, the contents of A_l are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[out]
-  !>     D pointer to real type. Array on the GPU (the size depends on the value of strideD).
+  !>     @param[out] D - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideD).
   !>                 The eigenvalues of A_l in increasing order.
-  !>     @param[in]
-  !>     strideD     rocblas_stride.
+  !>     @param[in] strideD - rocblas_stride.
   !>                 Stride from the start of one vector D_l to the next one D_(l+1).
   !>                 There is no restriction for the value of strideD. The normal use case is
   !>                 strideD >= n.
-  !>     @param[out]
-  !>     E pointer to real type. Array on the GPU (the size depends on the value of strideE).
+  !>     @param[out] E - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideE).
   !>                 This array is used to work internally with the tridiagonal matrix T_l
   !>                 associated with A_l.
   !>                 On exit, if info[l] > 0, E_l contains the unconverged off-diagonal elements of
@@ -29436,18 +27929,15 @@ module hipfort_rocsolver
   !>                 elements
   !>                 of this matrix are in D_l. Those that converged correspond to a subset of the
   !>                 eigenvalues of A_l (not necessarily ordered).
-  !>     @param[in]
-  !>     strideE     rocblas_stride.
+  !>     @param[in] strideE - rocblas_stride.
   !>                 Stride from the start of one vector E_l to the next one E_(l+1).
   !>                 There is no restriction for the value of strideE. The normal use case is
   !>                 strideE >= n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for matrix A_l. If info[l] = i > 0, the
   !>                 algorithm did not converge.
   !>                 i elements of E_l did not converge to zero.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_cheev_strided_batched
     function rocsolver_cheev_strided_batched_(handle,evect,uplo,n,A,lda,strideA,D,strideD,E, &
@@ -29578,34 +28068,26 @@ module hipfort_rocsolver
   !>     eigenvectors
   !>     are orthonormal.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the symmetric matrix A is stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) part of A
   !>                 is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of rows and columns of matrix A.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the matrix A. On exit, the eigenvectors of A if they were computed
   !>                 and
   !>                 the algorithm converged. Otherwise, the contents of A are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrix A.
-  !>     @param[out]
-  !>     D           pointer to type. Array on the GPU of dimension n.
+  !>     @param[out] D - pointer to type. Array on the GPU of dimension n.
   !>                 The eigenvalues of A in increasing order.
-  !>     @param[out]
-  !>     E           pointer to type. Array on the GPU of dimension n.
+  !>     @param[out] E - pointer to type. Array on the GPU of dimension n.
   !>                 This array is used to work internally with the tridiagonal matrix T associated
   !>                 with A.
   !>                 On exit, if info > 0, it contains the unconverged off-diagonal elements of T
@@ -29613,8 +28095,7 @@ module hipfort_rocsolver
   !>                 elements
   !>                 of this matrix are in D. Those that converged correspond to a subset of the
   !>                 eigenvalues of A (not necessarily ordered).
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info = 0, successful exit.
   !>                 If info = i > 0 and evect is rocblas_evect_none, the algorithm did not
   !>                 converge.
@@ -29730,34 +28211,26 @@ module hipfort_rocsolver
   !>     eigenvectors
   !>     are orthonormal.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the Hermitian matrix A is stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) part of A
   !>                 is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of rows and columns of matrix A.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the matrix A. On exit, the eigenvectors of A if they were computed
   !>                 and
   !>                 the algorithm converged. Otherwise, the contents of A are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrix A.
-  !>     @param[out]
-  !>     D           pointer to real type. Array on the GPU of dimension n.
+  !>     @param[out] D - pointer to real type. Array on the GPU of dimension n.
   !>                 The eigenvalues of A in increasing order.
-  !>     @param[out]
-  !>     E           pointer to real type. Array on the GPU of dimension n.
+  !>     @param[out] E - pointer to real type. Array on the GPU of dimension n.
   !>                 This array is used to work internally with the tridiagonal matrix T associated
   !>                 with A.
   !>                 On exit, if info > 0, it contains the unconverged off-diagonal elements of T
@@ -29765,8 +28238,7 @@ module hipfort_rocsolver
   !>                 elements
   !>                 of this matrix are in D. Those that converged correspond to a subset of the
   !>                 eigenvalues of A (not necessarily ordered).
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info = 0, successful exit.
   !>                 If info = i > 0 and evect is rocblas_evect_none, the algorithm did not
   !>                 converge.
@@ -29883,40 +28355,34 @@ module hipfort_rocsolver
   !>     eigenvectors
   !>     are orthonormal.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the symmetric matrices A_l is
   !>                 stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) part of A_l
   !>                 is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of rows and columns of matrices A_l.
-  !>     @param[inout]
-  !>     A Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - Array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the matrices A_l. On exit, the eigenvectors of A_l if they were
   !>                 computed and
   !>                 the algorithm converged. Otherwise, the contents of A_l are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[out]
-  !>     D           pointer to type. Array on the GPU (the size depends on the value of strideD).
+  !>     @param[out] D - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideD).
   !>                 The eigenvalues of A_l in increasing order.
-  !>     @param[in]
-  !>     strideD     rocblas_stride.
+  !>     @param[in] strideD - rocblas_stride.
   !>                 Stride from the start of one vector D_l to the next one D_(l+1).
   !>                 There is no restriction for the value of strideD. The normal use case is
   !>                 strideD >= n.
-  !>     @param[out]
-  !>     E           pointer to type. Array on the GPU (the size depends on the value of strideE).
+  !>     @param[out] E - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideE).
   !>                 This array is used to work internally with the tridiagonal matrix T_l
   !>                 associated with A_l.
   !>                 On exit, if info[l] > 0, E_l contains the unconverged off-diagonal elements of
@@ -29925,13 +28391,11 @@ module hipfort_rocsolver
   !>                 elements
   !>                 of this matrix are in D_l. Those that converged correspond to a subset of the
   !>                 eigenvalues of A_l (not necessarily ordered).
-  !>     @param[in]
-  !>     strideE     rocblas_stride.
+  !>     @param[in] strideE - rocblas_stride.
   !>                 Stride from the start of one vector E_l to the next one E_(l+1).
   !>                 There is no restriction for the value of strideE. The normal use case is
   !>                 strideE >= n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for matrix A_l.
   !>                 If info[l] = i > 0 and evect is rocblas_evect_none, the algorithm did not
   !>                 converge.
@@ -29939,8 +28403,7 @@ module hipfort_rocsolver
   !>                 If info[l] = i > 0 and evect is rocblas_evect_original, the algorithm failed to
   !>                 compute an eigenvalue in the submatrix from [i/(n+1), i/(n+1)] to [i%(n+1),
   !>                 i%(n+1)].
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_ssyevd_batched
     function rocsolver_ssyevd_batched_(handle,evect,uplo,n,A,lda,D,strideD,E,strideE,myInfo, &
@@ -30065,40 +28528,34 @@ module hipfort_rocsolver
   !>     eigenvectors
   !>     are orthonormal.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the Hermitian matrices A_l is
   !>                 stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) part of A_l
   !>                 is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of rows and columns of matrices A_l.
-  !>     @param[inout]
-  !>     A Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - Array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the matrices A_l. On exit, the eigenvectors of A_l if they were
   !>                 computed and
   !>                 the algorithm converged. Otherwise, the contents of A_l are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[out]
-  !>     D pointer to real type. Array on the GPU (the size depends on the value of strideD).
+  !>     @param[out] D - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideD).
   !>                 The eigenvalues of A_l in increasing order.
-  !>     @param[in]
-  !>     strideD     rocblas_stride.
+  !>     @param[in] strideD - rocblas_stride.
   !>                 Stride from the start of one vector D_l to the next one D_(l+1).
   !>                 There is no restriction for the value of strideD. The normal use case is
   !>                 strideD >= n.
-  !>     @param[out]
-  !>     E pointer to real type. Array on the GPU (the size depends on the value of strideE).
+  !>     @param[out] E - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideE).
   !>                 This array is used to work internally with the tridiagonal matrix T_l
   !>                 associated with A_l.
   !>                 On exit, if info[l] > 0, E_l contains the unconverged off-diagonal elements of
@@ -30107,13 +28564,11 @@ module hipfort_rocsolver
   !>                 elements
   !>                 of this matrix are in D_l. Those that converged correspond to a subset of the
   !>                 eigenvalues of A_l (not necessarily ordered).
-  !>     @param[in]
-  !>     strideE     rocblas_stride.
+  !>     @param[in] strideE - rocblas_stride.
   !>                 Stride from the start of one vector E_l to the next one E_(l+1).
   !>                 There is no restriction for the value of strideE. The normal use case is
   !>                 strideE >= n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for matrix A_l.
   !>                 If info[l] = i > 0 and evect is rocblas_evect_none, the algorithm did not
   !>                 converge.
@@ -30121,8 +28576,7 @@ module hipfort_rocsolver
   !>                 If info[l] = i > 0 and evect is rocblas_evect_original, the algorithm failed to
   !>                 compute an eigenvalue in the submatrix from [i/(n+1), i/(n+1)] to [i%(n+1),
   !>                 i%(n+1)].
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_cheevd_batched
     function rocsolver_cheevd_batched_(handle,evect,uplo,n,A,lda,D,strideD,E,strideE,myInfo, &
@@ -30247,45 +28701,38 @@ module hipfort_rocsolver
   !>     eigenvectors
   !>     are orthonormal.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the symmetric matrices A_l is
   !>                 stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) part of A_l
   !>                 is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of rows and columns of matrices A_l.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the matrices A_l. On exit, the eigenvectors of A_l if they were
   !>                 computed and
   !>                 the algorithm converged. Otherwise, the contents of A_l are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[out]
-  !>     D           pointer to type. Array on the GPU (the size depends on the value of strideD).
+  !>     @param[out] D - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideD).
   !>                 The eigenvalues of A_l in increasing order.
-  !>     @param[in]
-  !>     strideD     rocblas_stride.
+  !>     @param[in] strideD - rocblas_stride.
   !>                 Stride from the start of one vector D_l to the next one D_(l+1).
   !>                 There is no restriction for the value of strideD. The normal use case is
   !>                 strideD >= n.
-  !>     @param[out]
-  !>     E           pointer to type. Array on the GPU (the size depends on the value of strideE).
+  !>     @param[out] E - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideE).
   !>                 This array is used to work internally with the tridiagonal matrix T_l
   !>                 associated with A_l.
   !>                 On exit, if info[l] > 0, E_l contains the unconverged off-diagonal elements of
@@ -30294,13 +28741,11 @@ module hipfort_rocsolver
   !>                 elements
   !>                 of this matrix are in D_l. Those that converged correspond to a subset of the
   !>                 eigenvalues of A_l (not necessarily ordered).
-  !>     @param[in]
-  !>     strideE     rocblas_stride.
+  !>     @param[in] strideE - rocblas_stride.
   !>                 Stride from the start of one vector E_l to the next one E_(l+1).
   !>                 There is no restriction for the value of strideE. The normal use case is
   !>                 strideE >= n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for matrix A_l.
   !>                 If info[l] = i > 0 and evect is rocblas_evect_none, the algorithm did not
   !>                 converge.
@@ -30308,8 +28753,7 @@ module hipfort_rocsolver
   !>                 If info[l] = i > 0 and evect is rocblas_evect_original, the algorithm failed to
   !>                 compute an eigenvalue in the submatrix from [i/(n+1), i/(n+1)] to [i%(n+1),
   !>                 i%(n+1)].
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_ssyevd_strided_batched
     function rocsolver_ssyevd_strided_batched_(handle,evect,uplo,n,A,lda,strideA,D,strideD,E, &
@@ -30440,45 +28884,38 @@ module hipfort_rocsolver
   !>     eigenvectors
   !>     are orthonormal.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the Hermitian matrices A_l is
   !>                 stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) part of A_l
   !>                 is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of rows and columns of matrices A_l.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the matrices A_l. On exit, the eigenvectors of A_l if they were
   !>                 computed and
   !>                 the algorithm converged. Otherwise, the contents of A_l are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[out]
-  !>     D pointer to real type. Array on the GPU (the size depends on the value of strideD).
+  !>     @param[out] D - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideD).
   !>                 The eigenvalues of A_l in increasing order.
-  !>     @param[in]
-  !>     strideD     rocblas_stride.
+  !>     @param[in] strideD - rocblas_stride.
   !>                 Stride from the start of one vector D_l to the next one D_(l+1).
   !>                 There is no restriction for the value of strideD. The normal use case is
   !>                 strideD >= n.
-  !>     @param[out]
-  !>     E pointer to real type. Array on the GPU (the size depends on the value of strideE).
+  !>     @param[out] E - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideE).
   !>                 This array is used to work internally with the tridiagonal matrix T_l
   !>                 associated with A_l.
   !>                 On exit, if info[l] > 0, E_l contains the unconverged off-diagonal elements of
@@ -30487,13 +28924,11 @@ module hipfort_rocsolver
   !>                 elements
   !>                 of this matrix are in D_l. Those that converged correspond to a subset of the
   !>                 eigenvalues of A_l (not necessarily ordered).
-  !>     @param[in]
-  !>     strideE     rocblas_stride.
+  !>     @param[in] strideE - rocblas_stride.
   !>                 Stride from the start of one vector E_l to the next one E_(l+1).
   !>                 There is no restriction for the value of strideE. The normal use case is
   !>                 strideE >= n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for matrix A_l.
   !>                 If info[l] = i > 0 and evect is rocblas_evect_none, the algorithm did not
   !>                 converge.
@@ -30501,8 +28936,7 @@ module hipfort_rocsolver
   !>                 If info[l] = i > 0 and evect is rocblas_evect_original, the algorithm failed to
   !>                 compute an eigenvalue in the submatrix from [i/(n+1), i/(n+1)] to [i%(n+1),
   !>                 i%(n+1)].
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_cheevd_strided_batched
     function rocsolver_cheevd_strided_batched_(handle,evect,uplo,n,A,lda,strideA,D,strideD,E, &
@@ -30629,34 +29063,26 @@ module hipfort_rocsolver
   !>     ``evect``.
   !>     The computed eigenvectors are orthonormal.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the symmetric matrix A is stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) part of A
   !>                 is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of rows and columns of matrix A.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the matrix A. On exit, the eigenvectors of A if they were computed
   !>                 and
   !>                 the algorithm converged. Otherwise, the contents of A are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrix A.
-  !>     @param[out]
-  !>     D           pointer to type. Array on the GPU of dimension n.
+  !>     @param[out] D - pointer to type. Array on the GPU of dimension n.
   !>                 The eigenvalues of A in increasing order.
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info = 0, successful exit. If info = 1, the algorithm did not converge.
   interface rocsolver_ssyevdj
     function rocsolver_ssyevdj_(handle,evect,uplo,n,A,lda,D,myInfo) &
@@ -30707,34 +29133,26 @@ module hipfort_rocsolver
   !>     ``evect``.
   !>     The computed eigenvectors are orthonormal.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the Hermitian matrix A is stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) part of A
   !>                 is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of rows and columns of matrix A.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the matrix A. On exit, the eigenvectors of A if they were computed
   !>                 and
   !>                 the algorithm converged. Otherwise, the contents of A are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrix A.
-  !>     @param[out]
-  !>     D           pointer to real type. Array on the GPU of dimension n.
+  !>     @param[out] D - pointer to real type. Array on the GPU of dimension n.
   !>                 The eigenvalues of A in increasing order.
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info = 0, successful exit. If info = 1, the algorithm did not converge.
   interface rocsolver_cheevdj
     function rocsolver_cheevdj_(handle,evect,uplo,n,A,lda,D,myInfo) &
@@ -30785,44 +29203,36 @@ module hipfort_rocsolver
   !>     ``evect``.
   !>     The computed eigenvectors are orthonormal.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the symmetric matrices A_l is
   !>                 stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) part of A_l
   !>                 is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of rows and columns of matrices A_l.
-  !>     @param[inout]
-  !>     A Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - Array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the matrices A_l. On exit, the eigenvectors of A_l if they were
   !>                 computed and
   !>                 the algorithm converged. Otherwise, the contents of A_l are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[out]
-  !>     D           pointer to type. Array on the GPU (the size depends on the value of strideD).
+  !>     @param[out] D - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideD).
   !>                 The eigenvalues of A_l in increasing order.
-  !>     @param[in]
-  !>     strideD     rocblas_stride.
+  !>     @param[in] strideD - rocblas_stride.
   !>                 Stride from the start of one vector D_l to the next one D_(l+1).
   !>                 There is no restriction for the value of strideD. The normal use case is
   !>                 strideD >= n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for A_l. If info[l] = 1, the algorithm did not
   !>                 converge for A_l.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_ssyevdj_batched
     function rocsolver_ssyevdj_batched_(handle,evect,uplo,n,A,lda,D,strideD,myInfo,batch_count) &
@@ -30877,44 +29287,36 @@ module hipfort_rocsolver
   !>     ``evect``.
   !>     The computed eigenvectors are orthonormal.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the Hermitian matrices A_l is
   !>                 stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) part of A_l
   !>                 is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of rows and columns of matrices A_l.
-  !>     @param[inout]
-  !>     A Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - Array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the matrices A_l. On exit, the eigenvectors of A_l if they were
   !>                 computed and
   !>                 the algorithm converged. Otherwise, the contents of A_l are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[out]
-  !>     D pointer to real type. Array on the GPU (the size depends on the value of strideD).
+  !>     @param[out] D - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideD).
   !>                 The eigenvalues of A_l in increasing order.
-  !>     @param[in]
-  !>     strideD     rocblas_stride.
+  !>     @param[in] strideD - rocblas_stride.
   !>                 Stride from the start of one vector D_l to the next one D_(l+1).
   !>                 There is no restriction for the value of strideD. The normal use case is
   !>                 strideD >= n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for A_l. If info[l] = 1, the algorithm did not
   !>                 converge for A_l.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_cheevdj_batched
     function rocsolver_cheevdj_batched_(handle,evect,uplo,n,A,lda,D,strideD,myInfo,batch_count) &
@@ -30969,49 +29371,40 @@ module hipfort_rocsolver
   !>     ``evect``.
   !>     The computed eigenvectors are orthonormal.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the symmetric matrices A_l is
   !>                 stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) part of A_l
   !>                 is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of rows and columns of matrices A_l.
-  !>     @param[inout]
-  !>     A           Pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - Pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the matrices A_l. On exit, the eigenvectors of A_l if they were
   !>                 computed and
   !>                 the algorithm converged. Otherwise, the contents of A_l are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[out]
-  !>     D           pointer to type. Array on the GPU (the size depends on the value of strideD).
+  !>     @param[out] D - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideD).
   !>                 The eigenvalues of A_l in increasing order.
-  !>     @param[in]
-  !>     strideD     rocblas_stride.
+  !>     @param[in] strideD - rocblas_stride.
   !>                 Stride from the start of one vector D_l to the next one D_(l+1).
   !>                 There is no restriction for the value of strideD. The normal use case is
   !>                 strideD >= n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for A_l. If info[l] = 1, the algorithm did not
   !>                 converge for A_l.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_ssyevdj_strided_batched
     function rocsolver_ssyevdj_strided_batched_(handle,evect,uplo,n,A,lda,strideA,D,strideD, &
@@ -31070,49 +29463,40 @@ module hipfort_rocsolver
   !>     ``evect``.
   !>     The computed eigenvectors are orthonormal.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the Hermitian matrices A_l is
   !>                 stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) part of A_l
   !>                 is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of rows and columns of matrices A_l.
-  !>     @param[inout]
-  !>     A           Pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - Pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the matrices A_l. On exit, the eigenvectors of A_l if they were
   !>                 computed and
   !>                 the algorithm converged. Otherwise, the contents of A_l are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[out]
-  !>     D pointer to real type. Array on the GPU (the size depends on the value of strideD).
+  !>     @param[out] D - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideD).
   !>                 The eigenvalues of A_l in increasing order.
-  !>     @param[in]
-  !>     strideD     rocblas_stride.
+  !>     @param[in] strideD - rocblas_stride.
   !>                 Stride from the start of one vector D_l to the next one D_(l+1).
   !>                 There is no restriction for the value of strideD. The normal use case is
   !>                 strideD >= n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for A_l. If info[l] = 1, the algorithm did not
   !>                 converge for A_l.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_cheevdj_strided_batched
     function rocsolver_cheevdj_strided_batched_(handle,evect,uplo,n,A,lda,strideA,D,strideD, &
@@ -31189,44 +29573,33 @@ module hipfort_rocsolver
   !>         \end{array}
   !>     \f]
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     itype       `rocblas_eform`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] itype - `rocblas_eform`.
   !>                 Specifies the form of the generalized eigenproblem.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower parts of the matrices A and B are stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) parts of A and B
   !>                 are not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of rows and columns of matrix A.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the matrix A. On exit, the normalized matrix Z of eigenvectors if
   !>                 they were computed
   !>                 and the algorithm converged. Otherwise, the contents of A are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrix A.
-  !>     @param[inout]
-  !>     B           pointer to type. Array on the GPU of dimension ldb*n.
+  !>     @param[inout] B - pointer to type. Array on the GPU of dimension ldb*n.
   !>                 On entry, the symmetric positive definite matrix B. On exit,
   !>                 the triangular factor of B as returned by \ref rocsolver_spotrf "POTRF".
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 Specifies the leading dimension of matrix B.
-  !>     @param[out]
-  !>     D           pointer to type. Array on the GPU of dimension n.
+  !>     @param[out] D - pointer to type. Array on the GPU of dimension n.
   !>                 The eigenvalues in increasing order.
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info = 0, successful exit. If info = 1, the algorithm did not converge.
   !>                 If info = n + i, the leading minor of order i of B is not positive definite.
   interface rocsolver_ssygvdj
@@ -31302,44 +29675,33 @@ module hipfort_rocsolver
   !>         \end{array}
   !>     \f]
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     itype       `rocblas_eform`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] itype - `rocblas_eform`.
   !>                 Specifies the form of the generalized eigenproblem.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower parts of the matrices A and B are stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) parts of A and B
   !>                 are not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of rows and columns of matrix A.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the matrix A. On exit, the normalized matrix Z of eigenvectors if
   !>                 they were computed
   !>                 and the algorithm converged. Otherwise, the contents of A are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrix A.
-  !>     @param[inout]
-  !>     B           pointer to type. Array on the GPU of dimension ldb*n.
+  !>     @param[inout] B - pointer to type. Array on the GPU of dimension ldb*n.
   !>                 On entry, the Hermitian positive definite matrix B. On exit,
   !>                 the triangular factor of B as returned by \ref rocsolver_spotrf "POTRF".
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 Specifies the leading dimension of matrix B.
-  !>     @param[out]
-  !>     D           pointer to real type. Array on the GPU of dimension n.
+  !>     @param[out] D - pointer to real type. Array on the GPU of dimension n.
   !>                 The eigenvalues in increasing order.
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info = 0, successful exit. If info = 1, the algorithm did not converge.
   !>                 If info = n + i, the leading minor of order i of B is not positive definite.
   interface rocsolver_chegvdj
@@ -31416,57 +29778,47 @@ module hipfort_rocsolver
   !>         \end{array}
   !>     \f]
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     itype       `rocblas_eform`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] itype - `rocblas_eform`.
   !>                 Specifies the form of the generalized eigenproblems.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower parts of the matrices A_l and B_l are
   !>                 stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) parts of A_l and
   !>                 B_l
   !>                 are not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of rows and columns of matrix A_l.
-  !>     @param[inout]
-  !>     A array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the matrices A_l. On exit, the normalized matrices Z_l of
   !>                 eigenvectors if they were computed
   !>                 and the algorithm converged. Otherwise, the contents of A_l are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[inout]
-  !>     B array of pointers to type. Each pointer points to an array on the GPU of dimension ldb*n.
+  !>     @param[inout] B - array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension ldb*n.
   !>                 On entry, the symmetric positive definite matrices B_l. On exit,
   !>                 the triangular factor of B_l as returned by \ref rocsolver_spotrf_batched
   !>                 "POTRF_BATCHED".
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 Specifies the leading dimension of matrices B_l.
-  !>     @param[out]
-  !>     D           pointer to type. Array on the GPU (the size depends on the value of strideD).
+  !>     @param[out] D - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideD).
   !>                 The eigenvalues in increasing order.
-  !>     @param[in]
-  !>     strideD     rocblas_stride.
+  !>     @param[in] strideD - rocblas_stride.
   !>                 Stride from the start of one vector D_l to the next one D_(l+1).
   !>                 There is no restriction for the value of strideD. Normal usage is strideD >= n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit. If info[l] = 1, the algorithm did not converge
   !>                 for matrix A_l.
   !>                 If info[l] = n + i, the leading minor of order i of B_l is not positive
   !>                 definite.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of eigenproblems in the batch.
   interface rocsolver_ssygvdj_batched
     function rocsolver_ssygvdj_batched_(handle,itype,evect,uplo,n,A,lda,B,ldb,D,strideD,myInfo, &
@@ -31548,57 +29900,47 @@ module hipfort_rocsolver
   !>         \end{array}
   !>     \f]
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     itype       `rocblas_eform`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] itype - `rocblas_eform`.
   !>                 Specifies the form of the generalized eigenproblems.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower parts of the matrices A_l and B_l are
   !>                 stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) parts of A_l and
   !>                 B_l
   !>                 are not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of rows and columns of matrix A_l.
-  !>     @param[inout]
-  !>     A array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the matrices A_l. On exit, the normalized matrices Z_l of
   !>                 eigenvectors if they were computed
   !>                 and the algorithm converged. Otherwise, the contents of A_l are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[inout]
-  !>     B array of pointers to type. Each pointer points to an array on the GPU of dimension ldb*n.
+  !>     @param[inout] B - array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension ldb*n.
   !>                 On entry, the Hermitian positive definite matrices B_l. On exit,
   !>                 the triangular factor of B_l as returned by \ref rocsolver_spotrf_batched
   !>                 "POTRF_BATCHED".
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 Specifies the leading dimension of matrices B_l.
-  !>     @param[out]
-  !>     D pointer to real type. Array on the GPU (the size depends on the value of strideD).
+  !>     @param[out] D - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideD).
   !>                 The eigenvalues in increasing order.
-  !>     @param[in]
-  !>     strideD     rocblas_stride.
+  !>     @param[in] strideD - rocblas_stride.
   !>                 Stride from the start of one vector D_l to the next one D_(l+1).
   !>                 There is no restriction for the value of strideD. Normal usage is strideD >= n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit. If info[l] = 1, the algorithm did not converge
   !>                 for matrix A_l.
   !>                 If info[l] = n + i, the leading minor of order i of B_l is not positive
   !>                 definite.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of eigenproblems in the batch.
   interface rocsolver_chegvdj_batched
     function rocsolver_chegvdj_batched_(handle,itype,evect,uplo,n,A,lda,B,ldb,D,strideD,myInfo, &
@@ -31680,67 +30022,55 @@ module hipfort_rocsolver
   !>         \end{array}
   !>     \f]
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     itype       `rocblas_eform`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] itype - `rocblas_eform`.
   !>                 Specifies the form of the generalized eigenproblems.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower parts of the matrices A_l and B_l are
   !>                 stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) parts of A_l and
   !>                 B_l
   !>                 are not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of rows and columns of matrix A_l.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the matrices A_l. On exit, the normalized matrices Z_l of
   !>                 eigenvectors if they were computed
   !>                 and the algorithm converged. Otherwise, the contents of A_l are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. Normal usage is strideA >=
   !>                 lda*n.
-  !>     @param[inout]
-  !>     B           pointer to type. Array on the GPU (the size depends on the value of strideB).
+  !>     @param[inout] B - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideB).
   !>                 On entry, the symmetric positive definite matrices B_l. On exit,
   !>                 the triangular factor of B_l as returned by \ref
   !>                 rocsolver_spotrf_strided_batched "POTRF_STRIDED_BATCHED".
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 Specifies the leading dimension of matrices B_l.
-  !>     @param[in]
-  !>     strideB     rocblas_stride.
+  !>     @param[in] strideB - rocblas_stride.
   !>                 Stride from the start of one matrix B_l to the next one B_(l+1).
   !>                 There is no restriction for the value of strideB. Normal usage is strideB >=
   !>                 ldb*n.
-  !>     @param[out]
-  !>     D           pointer to type. Array on the GPU (the size depends on the value of strideD).
+  !>     @param[out] D - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideD).
   !>                 The eigenvalues in increasing order.
-  !>     @param[in]
-  !>     strideD     rocblas_stride.
+  !>     @param[in] strideD - rocblas_stride.
   !>                 Stride from the start of one vector D_l to the next one D_(l+1).
   !>                 There is no restriction for the value of strideD. Normal usage is strideD >= n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit. If info[l] = 1, the algorithm did not converge
   !>                 for matrix A_l.
   !>                 If info[l] = n + i, the leading minor of order i of B_l is not positive
   !>                 definite.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of eigenproblems in the batch.
   interface rocsolver_ssygvdj_strided_batched
     function rocsolver_ssygvdj_strided_batched_(handle,itype,evect,uplo,n,A,lda,strideA,B,ldb, &
@@ -31826,67 +30156,55 @@ module hipfort_rocsolver
   !>         \end{array}
   !>     \f]
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     itype       `rocblas_eform`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] itype - `rocblas_eform`.
   !>                 Specifies the form of the generalized eigenproblems.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower parts of the matrices A_l and B_l are
   !>                 stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) parts of A_l and
   !>                 B_l
   !>                 are not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of rows and columns of matrix A_l.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the matrices A_l. On exit, the normalized matrices Z_l of
   !>                 eigenvectors if they were computed
   !>                 and the algorithm converged. Otherwise, the contents of A_l are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. Normal usage is strideA >=
   !>                 lda*n.
-  !>     @param[inout]
-  !>     B           pointer to type. Array on the GPU (the size depends on the value of strideB).
+  !>     @param[inout] B - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideB).
   !>                 On entry, the Hermitian positive definite matrices B_l. On exit,
   !>                 the triangular factor of B_l as returned by \ref rocsolver_spotrf_batched
   !>                 "POTRF_BATCHED".
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 Specifies the leading dimension of matrices B_l.
-  !>     @param[in]
-  !>     strideB     rocblas_stride.
+  !>     @param[in] strideB - rocblas_stride.
   !>                 Stride from the start of one matrix B_l to the next one B_(l+1).
   !>                 There is no restriction for the value of strideB. Normal usage is strideB >=
   !>                 ldb*n.
-  !>     @param[out]
-  !>     D pointer to real type. Array on the GPU (the size depends on the value of strideD).
+  !>     @param[out] D - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideD).
   !>                 The eigenvalues in increasing order.
-  !>     @param[in]
-  !>     strideD     rocblas_stride.
+  !>     @param[in] strideD - rocblas_stride.
   !>                 Stride from the start of one vector D_l to the next one D_(l+1).
   !>                 There is no restriction for the value of strideD. Normal usage is strideD >= n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit. If info[l] = 1, the algorithm did not converge
   !>                 for matrix A_l.
   !>                 If info[l] = n + i, the leading minor of order i of B_l is not positive
   !>                 definite.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of eigenproblems in the batch.
   interface rocsolver_chegvdj_strided_batched
     function rocsolver_chegvdj_strided_batched_(handle,itype,evect,uplo,n,A,lda,strideA,B,ldb, &
@@ -31971,57 +30289,44 @@ module hipfort_rocsolver
   !>     contained within the
   !>     ``rocblas_handle``.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     esort       `rocblas_esort`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] esort - `rocblas_esort`.
   !>                 Specifies the order of the returned eigenvalues. If esort is
   !>                 rocblas_esort_ascending, then the eigenvalues are sorted and returned in
   !>                 ascending order.
   !>                 If esort is rocblas_esort_none, then the order of the returned eigenvalues is
   !>                 unspecified.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the symmetric matrix A is stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) part of A
   !>                 is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of rows and columns of matrix A.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the matrix A. On exit, the eigenvectors of A if they were computed
   !>                 and
   !>                 the algorithm converged. Otherwise, the contents of A are unchanged.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrix A.
-  !>     @param[in]
-  !>     abstol      type.
+  !>     @param[in] abstol - type.
   !>                 The absolute tolerance. The algorithm is considered to have converged once
   !>                 off(A)
   !>                 is <= abstol. If abstol <= 0, then the tolerance will be set to machine
   !>                 precision.
-  !>     @param[out]
-  !>     residual    pointer to type on the GPU.
+  !>     @param[out] residual - pointer to type on the GPU.
   !>                 The Frobenius norm of the off-diagonal elements of A (that is, off(A)) at the
   !>                 final iteration.
-  !>     @param[in]
-  !>     max_sweeps  rocblas_int. max_sweeps > 0.
+  !>     @param[in] max_sweeps - rocblas_int. max_sweeps > 0.
   !>                 Maximum number of sweeps (iterations) to be used by the algorithm.
-  !>     @param[out]
-  !>     n_sweeps    pointer to a rocblas_int on the GPU.
+  !>     @param[out] n_sweeps - pointer to a rocblas_int on the GPU.
   !>                 The actual number of sweeps (iterations) used by the algorithm.
-  !>     @param[out]
-  !>     W           pointer to type. Array on the GPU of dimension n.
+  !>     @param[out] W - pointer to type. Array on the GPU of dimension n.
   !>                 The eigenvalues of A in increasing order.
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info = 0, successful exit. If info = 1, the algorithm did not converge.
   interface rocsolver_ssyevj
     function rocsolver_ssyevj_(handle,esort,evect,uplo,n,A,lda,abstol,residual,max_sweeps, &
@@ -32102,57 +30407,44 @@ module hipfort_rocsolver
   !>     contained within the
   !>     ``rocblas_handle``.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     esort       `rocblas_esort`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] esort - `rocblas_esort`.
   !>                 Specifies the order of the returned eigenvalues. If esort is
   !>                 rocblas_esort_ascending, then the eigenvalues are sorted and returned in
   !>                 ascending order.
   !>                 If esort is rocblas_esort_none, then the order of the returned eigenvalues is
   !>                 unspecified.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the Hermitian matrix A is stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) part of A
   !>                 is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of rows and columns of matrix A.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the matrix A. On exit, the eigenvectors of A if they were computed
   !>                 and
   !>                 the algorithm converged. Otherwise, the contents of A are unchanged.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrix A.
-  !>     @param[in]
-  !>     abstol      real type.
+  !>     @param[in] abstol - real type.
   !>                 The absolute tolerance. The algorithm is considered to have converged once
   !>                 off(A)
   !>                 is <= abstol. If abstol <= 0, then the tolerance will be set to machine
   !>                 precision.
-  !>     @param[out]
-  !>     residual    pointer to real type on the GPU.
+  !>     @param[out] residual - pointer to real type on the GPU.
   !>                 The Frobenius norm of the off-diagonal elements of A (that is, off(A)) at the
   !>                 final iteration.
-  !>     @param[in]
-  !>     max_sweeps  rocblas_int. max_sweeps > 0.
+  !>     @param[in] max_sweeps - rocblas_int. max_sweeps > 0.
   !>                 Maximum number of sweeps (iterations) to be used by the algorithm.
-  !>     @param[out]
-  !>     n_sweeps    pointer to a rocblas_int on the GPU.
+  !>     @param[out] n_sweeps - pointer to a rocblas_int on the GPU.
   !>                 The actual number of sweeps (iterations) used by the algorithm.
-  !>     @param[out]
-  !>     W           pointer to real type. Array on the GPU of dimension n.
+  !>     @param[out] W - pointer to real type. Array on the GPU of dimension n.
   !>                 The eigenvalues of A in increasing order.
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info = 0, successful exit. If info = 1, the algorithm did not converge.
   interface rocsolver_cheevj
     function rocsolver_cheevj_(handle,esort,evect,uplo,n,A,lda,abstol,residual,max_sweeps, &
@@ -32233,68 +30525,55 @@ module hipfort_rocsolver
   !>     contained within the
   !>     ``rocblas_handle``.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     esort       `rocblas_esort`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] esort - `rocblas_esort`.
   !>                 Specifies the order of the returned eigenvalues. If esort is
   !>                 rocblas_esort_ascending, then the eigenvalues are sorted and returned in
   !>                 ascending order.
   !>                 If esort is rocblas_esort_none, then the order of the returned eigenvalues is
   !>                 unspecified.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the symmetric matrices A_l is
   !>                 stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) part of A_l
   !>                 is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of rows and columns of matrices A_l.
-  !>     @param[inout]
-  !>     A Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - Array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the matrices A_l. On exit, the eigenvectors of A_l if they were
   !>                 computed and
   !>                 the algorithm converged. Otherwise, the contents of A_l are unchanged.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     abstol      type.
+  !>     @param[in] abstol - type.
   !>                 The absolute tolerance. The algorithm is considered to have converged once
   !>                 off(A_l)
   !>                 is <= abstol. If abstol <= 0, then the tolerance will be set to machine
   !>                 precision.
-  !>     @param[out]
-  !>     residual    pointer to type. Array of batch_count scalars on the GPU.
+  !>     @param[out] residual - pointer to type. Array of batch_count scalars on the GPU.
   !>                 The Frobenius norm of the off-diagonal elements of A_l (that is, off(A_l)) at
   !>                 the final iteration.
-  !>     @param[in]
-  !>     max_sweeps  rocblas_int. max_sweeps > 0.
+  !>     @param[in] max_sweeps - rocblas_int. max_sweeps > 0.
   !>                 Maximum number of sweeps (iterations) to be used by the algorithm.
-  !>     @param[out]
-  !>     n_sweeps    pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] n_sweeps - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 The actual number of sweeps (iterations) used by the algorithm for each batch
   !>                 instance.
-  !>     @param[out]
-  !>     W           pointer to type. Array on the GPU (the size depends on the value of strideW).
+  !>     @param[out] W - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideW).
   !>                 The eigenvalues of A_l in increasing order.
-  !>     @param[in]
-  !>     strideW     rocblas_stride.
+  !>     @param[in] strideW - rocblas_stride.
   !>                 Stride from the start of one vector W_l to the next one W_(l+1).
   !>                 There is no restriction for the value of strideW. The normal use case is
   !>                 strideW >= n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for matrix A_l. If info[l] = 1, the algorithm
   !>                 did not converge.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_ssyevj_batched
     function rocsolver_ssyevj_batched_(handle,esort,evect,uplo,n,A,lda,abstol,residual,max_sweeps, &
@@ -32379,68 +30658,55 @@ module hipfort_rocsolver
   !>     contained within the
   !>     ``rocblas_handle``.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     esort       `rocblas_esort`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] esort - `rocblas_esort`.
   !>                 Specifies the order of the returned eigenvalues. If esort is
   !>                 rocblas_esort_ascending, then the eigenvalues are sorted and returned in
   !>                 ascending order.
   !>                 If esort is rocblas_esort_none, then the order of the returned eigenvalues is
   !>                 unspecified.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the Hermitian matrices A_l is
   !>                 stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) part of A_l
   !>                 is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of rows and columns of matrices A_l.
-  !>     @param[inout]
-  !>     A Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - Array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the matrices A_l. On exit, the eigenvectors of A_l if they were
   !>                 computed and
   !>                 the algorithm converged. Otherwise, the contents of A_l are unchanged.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     abstol      real type.
+  !>     @param[in] abstol - real type.
   !>                 The absolute tolerance. The algorithm is considered to have converged once
   !>                 off(A_l)
   !>                 is <= abstol. If abstol <= 0, then the tolerance will be set to machine
   !>                 precision.
-  !>     @param[out]
-  !>     residual    pointer to real type. Array of batch_count scalars on the GPU.
+  !>     @param[out] residual - pointer to real type. Array of batch_count scalars on the GPU.
   !>                 The Frobenius norm of the off-diagonal elements of A_l (that is, off(A_l)) at
   !>                 the final iteration.
-  !>     @param[in]
-  !>     max_sweeps  rocblas_int. max_sweeps > 0.
+  !>     @param[in] max_sweeps - rocblas_int. max_sweeps > 0.
   !>                 Maximum number of sweeps (iterations) to be used by the algorithm.
-  !>     @param[out]
-  !>     n_sweeps    pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] n_sweeps - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 The actual number of sweeps (iterations) used by the algorithm for each batch
   !>                 instance.
-  !>     @param[out]
-  !>     W pointer to real type. Array on the GPU (the size depends on the value of strideW).
+  !>     @param[out] W - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideW).
   !>                 The eigenvalues of A_l in increasing order.
-  !>     @param[in]
-  !>     strideW     rocblas_stride.
+  !>     @param[in] strideW - rocblas_stride.
   !>                 Stride from the start of one vector W_l to the next one W_(l+1).
   !>                 There is no restriction for the value of strideW. The normal use case is
   !>                 strideW >= n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for matrix A_l. If info[l] = 1, the algorithm
   !>                 did not converge.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_cheevj_batched
     function rocsolver_cheevj_batched_(handle,esort,evect,uplo,n,A,lda,abstol,residual,max_sweeps, &
@@ -32525,73 +30791,59 @@ module hipfort_rocsolver
   !>     contained within the
   !>     ``rocblas_handle``.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     esort       `rocblas_esort`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] esort - `rocblas_esort`.
   !>                 Specifies the order of the returned eigenvalues. If esort is
   !>                 rocblas_esort_ascending, then the eigenvalues are sorted and returned in
   !>                 ascending order.
   !>                 If esort is rocblas_esort_none, then the order of the returned eigenvalues is
   !>                 unspecified.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the symmetric matrices A_l is
   !>                 stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) part of A_l
   !>                 is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of rows and columns of matrices A_l.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the matrices A_l. On exit, the eigenvectors of A_l if they were
   !>                 computed and
   !>                 the algorithm converged. Otherwise, the contents of A_l are unchanged.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[in]
-  !>     abstol      type.
+  !>     @param[in] abstol - type.
   !>                 The absolute tolerance. The algorithm is considered to have converged once
   !>                 off(A_l)
   !>                 is <= abstol. If abstol <= 0, then the tolerance will be set to machine
   !>                 precision.
-  !>     @param[out]
-  !>     residual    pointer to type. Array of batch_count scalars on the GPU.
+  !>     @param[out] residual - pointer to type. Array of batch_count scalars on the GPU.
   !>                 The Frobenius norm of the off-diagonal elements of A_l (that is, off(A_l)) at
   !>                 the final iteration.
-  !>     @param[in]
-  !>     max_sweeps  rocblas_int. max_sweeps > 0.
+  !>     @param[in] max_sweeps - rocblas_int. max_sweeps > 0.
   !>                 Maximum number of sweeps (iterations) to be used by the algorithm.
-  !>     @param[out]
-  !>     n_sweeps    pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] n_sweeps - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 The actual number of sweeps (iterations) used by the algorithm for each batch
   !>                 instance.
-  !>     @param[out]
-  !>     W           pointer to type. Array on the GPU (the size depends on the value of strideW).
+  !>     @param[out] W - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideW).
   !>                 The eigenvalues of A_l in increasing order.
-  !>     @param[in]
-  !>     strideW     rocblas_stride.
+  !>     @param[in] strideW - rocblas_stride.
   !>                 Stride from the start of one vector W_l to the next one W_(l+1).
   !>                 There is no restriction for the value of strideW. The normal use case is
   !>                 strideW >= n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for matrix A_l. If info[l] = 1, the algorithm
   !>                 did not converge.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_ssyevj_strided_batched
     function rocsolver_ssyevj_strided_batched_(handle,esort,evect,uplo,n,A,lda,strideA,abstol, &
@@ -32678,73 +30930,59 @@ module hipfort_rocsolver
   !>     contained within the
   !>     ``rocblas_handle``.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     esort       `rocblas_esort`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] esort - `rocblas_esort`.
   !>                 Specifies the order of the returned eigenvalues. If esort is
   !>                 rocblas_esort_ascending, then the eigenvalues are sorted and returned in
   !>                 ascending order.
   !>                 If esort is rocblas_esort_none, then the order of the returned eigenvalues is
   !>                 unspecified.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the Hermitian matrices A_l is
   !>                 stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) part of A_l
   !>                 is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of rows and columns of matrices A_l.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the matrices A_l. On exit, the eigenvectors of A_l if they were
   !>                 computed and
   !>                 the algorithm converged. Otherwise, the contents of A_l are unchanged.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[in]
-  !>     abstol      real type.
+  !>     @param[in] abstol - real type.
   !>                 The absolute tolerance. The algorithm is considered to have converged once
   !>                 off(A_l)
   !>                 is <= abstol. If abstol <= 0, then the tolerance will be set to machine
   !>                 precision.
-  !>     @param[out]
-  !>     residual    pointer to real type. Array of batch_count scalars on the GPU.
+  !>     @param[out] residual - pointer to real type. Array of batch_count scalars on the GPU.
   !>                 The Frobenius norm of the off-diagonal elements of A_l (that is, off(A_l)) at
   !>                 the final iteration.
-  !>     @param[in]
-  !>     max_sweeps  rocblas_int. max_sweeps > 0.
+  !>     @param[in] max_sweeps - rocblas_int. max_sweeps > 0.
   !>                 Maximum number of sweeps (iterations) to be used by the algorithm.
-  !>     @param[out]
-  !>     n_sweeps    pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] n_sweeps - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 The actual number of sweeps (iterations) used by the algorithm for each batch
   !>                 instance.
-  !>     @param[out]
-  !>     W pointer to real type. Array on the GPU (the size depends on the value of strideW).
+  !>     @param[out] W - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideW).
   !>                 The eigenvalues of A_l in increasing order.
-  !>     @param[in]
-  !>     strideW     rocblas_stride.
+  !>     @param[in] strideW - rocblas_stride.
   !>                 Stride from the start of one vector W_l to the next one W_(l+1).
   !>                 There is no restriction for the value of strideW. The normal use case is
   !>                 strideW >= n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for matrix A_l. If info[l] = 1, the algorithm
   !>                 did not converge.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_cheevj_strided_batched
     function rocsolver_cheevj_strided_batched_(handle,esort,evect,uplo,n,A,lda,strideA,abstol, &
@@ -32813,52 +31051,40 @@ module hipfort_rocsolver
   !>     ``evect`` is rocblas_evect_original,
   !>     the eigenvectors for these eigenvalues will be computed as well.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     erange      `rocblas_erange`.
+  !>     @param[in] erange - `rocblas_erange`.
   !>                 Specifies the type of range or interval of the eigenvalues to be computed.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the symmetric matrix A is stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) part of A
   !>                 is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of rows and columns of matrix A.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the matrix A. On exit, the contents of A are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrix A.
-  !>     @param[in]
-  !>     vl          type. vl < vu.
+  !>     @param[in] vl - type. vl < vu.
   !>                 The lower bound of the search interval (vl, vu]. Ignored if range indicates to
   !>                 look
   !>                 for all the eigenvalues of A or the eigenvalues within a set of indices.
-  !>     @param[in]
-  !>     vu          type. vl < vu.
+  !>     @param[in] vu - type. vl < vu.
   !>                 The upper bound of the search interval (vl, vu]. Ignored if range indicates to
   !>                 look
   !>                 for all the eigenvalues of A or the eigenvalues within a set of indices.
-  !>     @param[in]
-  !>     il          rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] il - rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the smallest eigenvalue to be computed. Ignored if range indicates
   !>                 to look
   !>                 for all the eigenvalues of A or the eigenvalues in a half-open interval.
-  !>     @param[in]
-  !>     iu          rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] iu - rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the largest eigenvalue to be computed. Ignored if range indicates
   !>                 to look
   !>                 for all the eigenvalues of A or the eigenvalues in a half-open interval.
-  !>     @param[in]
-  !>     abstol      type.
+  !>     @param[in] abstol - type.
   !>                 The absolute tolerance. An eigenvalue is considered to be located if it lies
   !>                 in an interval whose width is <= abstol. If abstol is negative, then
   !>                 machine-epsilon times
@@ -32866,18 +31092,15 @@ module hipfort_rocsolver
   !>                 abstol=0, then the tolerance will be set
   !>                 to twice the underflow threshold. This is the tolerance that could get the most
   !>                 accurate results.
-  !>     @param[out]
-  !>     nev         pointer to a rocblas_int on the GPU.
+  !>     @param[out] nev - pointer to a rocblas_int on the GPU.
   !>                 The total number of eigenvalues found. If erange is rocblas_erange_all, nev =
   !>                 n.
   !>                 If erange is rocblas_erange_index, nev = iu - il + 1. Otherwise, 0 <= nev <= n.
-  !>     @param[out]
-  !>     W           pointer to type. Array on the GPU of dimension n.
+  !>     @param[out] W - pointer to type. Array on the GPU of dimension n.
   !>                 The first nev elements contain the computed eigenvalues. (The remaining
   !>                 elements
   !>                 can be used as workspace for internal computations.)
-  !>     @param[out]
-  !>     Z           pointer to type. Array on the GPU of dimension ldz*nev.
+  !>     @param[out] Z - pointer to type. Array on the GPU of dimension ldz*nev.
   !>                 On exit, if evect is not rocblas_evect_none and info = 0, the first nev columns
   !>                 contain
   !>                 the eigenvectors of A corresponding to the output eigenvalues. Not referenced
@@ -32888,16 +31111,13 @@ module hipfort_rocsolver
   !>                 The user should ensure that Z is large enough to hold n columns, as all n
   !>                 columns
   !>                 can be used as workspace for internal computations.
-  !>     @param[in]
-  !>     ldz         rocblas_int. ldz >= n.
+  !>     @param[in] ldz - rocblas_int. ldz >= n.
   !>                 Specifies the leading dimension of matrix Z.
-  !>     @param[out]
-  !>     ifail       pointer to rocblas_int. Array on the GPU of dimension n.
+  !>     @param[out] ifail - pointer to rocblas_int. Array on the GPU of dimension n.
   !>                 If info = 0, the first nev elements of ifail are zero.
   !>                 Otherwise, contains the indices of those eigenvectors that failed
   !>                 to converge. Not referenced if evect is rocblas_evect_none.
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info = 0, successful exit.
   !>                 If info = i > 0, the algorithm did not converge. i columns of Z did not
   !>                 converge.
@@ -32972,52 +31192,40 @@ module hipfort_rocsolver
   !>     ``evect`` is rocblas_evect_original,
   !>     the eigenvectors for these eigenvalues will be computed as well.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     erange      `rocblas_erange`.
+  !>     @param[in] erange - `rocblas_erange`.
   !>                 Specifies the type of range or interval of the eigenvalues to be computed.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the symmetric matrix A is stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) part of A
   !>                 is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of rows and columns of matrix A.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the matrix A. On exit, the contents of A are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrix A.
-  !>     @param[in]
-  !>     vl          real type. vl < vu.
+  !>     @param[in] vl - real type. vl < vu.
   !>                 The lower bound of the search interval (vl, vu]. Ignored if range indicates to
   !>                 look
   !>                 for all the eigenvalues of A or the eigenvalues within a set of indices.
-  !>     @param[in]
-  !>     vu          real type. vl < vu.
+  !>     @param[in] vu - real type. vl < vu.
   !>                 The upper bound of the search interval (vl, vu]. Ignored if range indicates to
   !>                 look
   !>                 for all the eigenvalues of A or the eigenvalues within a set of indices.
-  !>     @param[in]
-  !>     il          rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] il - rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the smallest eigenvalue to be computed. Ignored if range indicates
   !>                 to look
   !>                 for all the eigenvalues of A or the eigenvalues in a half-open interval.
-  !>     @param[in]
-  !>     iu          rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] iu - rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the largest eigenvalue to be computed. Ignored if range indicates
   !>                 to look
   !>                 for all the eigenvalues of A or the eigenvalues in a half-open interval.
-  !>     @param[in]
-  !>     abstol      real type.
+  !>     @param[in] abstol - real type.
   !>                 The absolute tolerance. An eigenvalue is considered to be located if it lies
   !>                 in an interval whose width is <= abstol. If abstol is negative, then
   !>                 machine-epsilon times
@@ -33025,18 +31233,15 @@ module hipfort_rocsolver
   !>                 abstol=0, then the tolerance will be set
   !>                 to twice the underflow threshold. This is the tolerance that could get the most
   !>                 accurate results.
-  !>     @param[out]
-  !>     nev         pointer to a rocblas_int on the GPU.
+  !>     @param[out] nev - pointer to a rocblas_int on the GPU.
   !>                 The total number of eigenvalues found. If erange is rocblas_erange_all, nev =
   !>                 n.
   !>                 If erange is rocblas_erange_index, nev = iu - il + 1. Otherwise, 0 <= nev <= n.
-  !>     @param[out]
-  !>     W           pointer to real type. Array on the GPU of dimension n.
+  !>     @param[out] W - pointer to real type. Array on the GPU of dimension n.
   !>                 The first nev elements contain the computed eigenvalues. (The remaining
   !>                 elements
   !>                 can be used as workspace for internal computations.)
-  !>     @param[out]
-  !>     Z           pointer to type. Array on the GPU of dimension ldz*nev.
+  !>     @param[out] Z - pointer to type. Array on the GPU of dimension ldz*nev.
   !>                 On exit, if evect is not rocblas_evect_none and info = 0, the first nev columns
   !>                 contain
   !>                 the eigenvectors of A corresponding to the output eigenvalues. Not referenced
@@ -33047,16 +31252,13 @@ module hipfort_rocsolver
   !>                 The user should ensure that Z is large enough to hold n columns, as all n
   !>                 columns
   !>                 can be used as workspace for internal computations.
-  !>     @param[in]
-  !>     ldz         rocblas_int. ldz >= n.
+  !>     @param[in] ldz - rocblas_int. ldz >= n.
   !>                 Specifies the leading dimension of matrix Z.
-  !>     @param[out]
-  !>     ifail       pointer to rocblas_int. Array on the GPU of dimension n.
+  !>     @param[out] ifail - pointer to rocblas_int. Array on the GPU of dimension n.
   !>                 If info = 0, the first nev elements of ifail are zero.
   !>                 Otherwise, contains the indices of those eigenvectors that failed
   !>                 to converge. Not referenced if evect is rocblas_evect_none.
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info = 0, successful exit.
   !>                 If info = i > 0, the algorithm did not converge. i columns of Z did not
   !>                 converge.
@@ -33131,53 +31333,42 @@ module hipfort_rocsolver
   !>     ``evect`` is rocblas_evect_original,
   !>     the eigenvectors for these eigenvalues will be computed as well.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     erange      `rocblas_erange`.
+  !>     @param[in] erange - `rocblas_erange`.
   !>                 Specifies the type of range or interval of the eigenvalues to be computed.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the symmetric matrices A_l is
   !>                 stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) part of A_l
   !>                 is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of rows and columns of matrices A_l.
-  !>     @param[inout]
-  !>     A Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - Array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the matrices A_l. On exit, the contents of A_l are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     vl          type. vl < vu.
+  !>     @param[in] vl - type. vl < vu.
   !>                 The lower bound of the search interval (vl, vu]. Ignored if range indicates to
   !>                 look
   !>                 for all the eigenvalues of A_l or the eigenvalues within a set of indices.
-  !>     @param[in]
-  !>     vu          type. vl < vu.
+  !>     @param[in] vu - type. vl < vu.
   !>                 The upper bound of the search interval (vl, vu]. Ignored if range indicates to
   !>                 look
   !>                 for all the eigenvalues of A_l or the eigenvalues within a set of indices.
-  !>     @param[in]
-  !>     il          rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] il - rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the smallest eigenvalue to be computed. Ignored if range indicates
   !>                 to look
   !>                 for all the eigenvalues of A_l or the eigenvalues in a half-open interval.
-  !>     @param[in]
-  !>     iu          rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] iu - rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the largest eigenvalue to be computed. Ignored if range indicates
   !>                 to look
   !>                 for all the eigenvalues of A_l or the eigenvalues in a half-open interval.
-  !>     @param[in]
-  !>     abstol      type.
+  !>     @param[in] abstol - type.
   !>                 The absolute tolerance. An eigenvalue is considered to be located if it lies
   !>                 in an interval whose width is <= abstol. If abstol is negative, then
   !>                 machine-epsilon times
@@ -33185,25 +31376,22 @@ module hipfort_rocsolver
   !>                 abstol=0, then the tolerance will be set
   !>                 to twice the underflow threshold. This is the tolerance that could get the most
   !>                 accurate results.
-  !>     @param[out]
-  !>     nev         pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] nev - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 The total number of eigenvalues found. If erange is rocblas_erange_all, nev[l]
   !>                 = n.
   !>                 If erange is rocblas_erange_index, nev[l] = iu - il + 1. Otherwise, 0 <= nev[l]
   !>                 <= n.
-  !>     @param[out]
-  !>     W           pointer to type. Array on the GPU (the size depends on the value of strideW).
+  !>     @param[out] W - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideW).
   !>                 The first nev[l] elements contain the computed eigenvalues. (The remaining
   !>                 elements
   !>                 can be used as workspace for internal computations.)
-  !>     @param[in]
-  !>     strideW     rocblas_stride.
+  !>     @param[in] strideW - rocblas_stride.
   !>                 Stride from the start of one vector W_l to the next one W_(l+1).
   !>                 There is no restriction for the value of strideW. The normal use case is
   !>                 strideW >= n.
-  !>     @param[out]
-  !>     Z Array of pointers to type. Each pointer points to an array on the GPU of dimension
-  !>     ldz*nev[l].
+  !>     @param[out] Z - Array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension ldz*nev[l].
   !>                 On exit, if evect is not rocblas_evect_none and info[l] = 0, the first nev[l]
   !>                 columns contain
   !>                 the eigenvectors of A_l corresponding to the output eigenvalues. Not referenced
@@ -33214,26 +31402,22 @@ module hipfort_rocsolver
   !>                 The user should ensure that Z_l is large enough to hold n columns, as all n
   !>                 columns
   !>                 can be used as workspace for internal computations.
-  !>     @param[in]
-  !>     ldz         rocblas_int. ldz >= n.
+  !>     @param[in] ldz - rocblas_int. ldz >= n.
   !>                 Specifies the leading dimension of matrices Z_l.
-  !>     @param[out]
-  !>     ifail pointer to rocblas_int. Array on the GPU (the size depends on the value of strideF).
+  !>     @param[out] ifail - pointer to rocblas_int. Array on the GPU (the size depends on the value
+  !>     of strideF).
   !>                 If info[l] = 0, the first nev[l] elements of ifail_l are zero.
   !>                 Otherwise, contains the indices of those eigenvectors that failed
   !>                 to converge. Not referenced if evect is rocblas_evect_none.
-  !>     @param[in]
-  !>     strideF     rocblas_stride.
+  !>     @param[in] strideF - rocblas_stride.
   !>                 Stride from the start of one vector ifail_l to the next one ifail_(l+1).
   !>                 There is no restriction for the value of strideF. The normal use case is
   !>                 strideF >= n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for matrix A_l.
   !>                 If info[l] = i > 0, the algorithm did not converge. i columns of Z_l did not
   !>                 converge.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_ssyevx_batched
     function rocsolver_ssyevx_batched_(handle,evect,erange,uplo,n,A,lda,vl,vu,il,iu,abstol,nev,W, &
@@ -33312,53 +31496,42 @@ module hipfort_rocsolver
   !>     ``evect`` is rocblas_evect_original,
   !>     the eigenvectors for these eigenvalues will be computed as well.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     erange      `rocblas_erange`.
+  !>     @param[in] erange - `rocblas_erange`.
   !>                 Specifies the type of range or interval of the eigenvalues to be computed.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the symmetric matrices A_l is
   !>                 stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) part of A_l
   !>                 is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of rows and columns of matrices A_l.
-  !>     @param[inout]
-  !>     A Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - Array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the matrices A_l. On exit, the contents of A_l are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     vl          real type. vl < vu.
+  !>     @param[in] vl - real type. vl < vu.
   !>                 The lower bound of the search interval (vl, vu]. Ignored if range indicates to
   !>                 look
   !>                 for all the eigenvalues of A_l or the eigenvalues within a set of indices.
-  !>     @param[in]
-  !>     vu          real type. vl < vu.
+  !>     @param[in] vu - real type. vl < vu.
   !>                 The upper bound of the search interval (vl, vu]. Ignored if range indicates to
   !>                 look
   !>                 for all the eigenvalues of A_l or the eigenvalues within a set of indices.
-  !>     @param[in]
-  !>     il          rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] il - rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the smallest eigenvalue to be computed. Ignored if range indicates
   !>                 to look
   !>                 for all the eigenvalues of A_l or the eigenvalues in a half-open interval.
-  !>     @param[in]
-  !>     iu          rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] iu - rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the largest eigenvalue to be computed. Ignored if range indicates
   !>                 to look
   !>                 for all the eigenvalues of A_l or the eigenvalues in a half-open interval.
-  !>     @param[in]
-  !>     abstol      real type.
+  !>     @param[in] abstol - real type.
   !>                 The absolute tolerance. An eigenvalue is considered to be located if it lies
   !>                 in an interval whose width is <= abstol. If abstol is negative, then
   !>                 machine-epsilon times
@@ -33366,25 +31539,22 @@ module hipfort_rocsolver
   !>                 abstol=0, then the tolerance will be set
   !>                 to twice the underflow threshold. This is the tolerance that could get the most
   !>                 accurate results.
-  !>     @param[out]
-  !>     nev         pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] nev - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 The total number of eigenvalues found. If erange is rocblas_erange_all, nev[l]
   !>                 = n.
   !>                 If erange is rocblas_erange_index, nev[l] = iu - il + 1. Otherwise, 0 <= nev[l]
   !>                 <= n.
-  !>     @param[out]
-  !>     W pointer to real type. Array on the GPU (the size depends on the value of strideW).
+  !>     @param[out] W - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideW).
   !>                 The first nev[l] elements contain the computed eigenvalues. (The remaining
   !>                 elements
   !>                 can be used as workspace for internal computations.)
-  !>     @param[in]
-  !>     strideW     rocblas_stride.
+  !>     @param[in] strideW - rocblas_stride.
   !>                 Stride from the start of one vector W_l to the next one W_(l+1).
   !>                 There is no restriction for the value of strideW. The normal use case is
   !>                 strideW >= n.
-  !>     @param[out]
-  !>     Z Array of pointers to type. Each pointer points to an array on the GPU of dimension
-  !>     ldz*nev[l].
+  !>     @param[out] Z - Array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension ldz*nev[l].
   !>                 On exit, if evect is not rocblas_evect_none and info[l] = 0, the first nev[l]
   !>                 columns contain
   !>                 the eigenvectors of A_l corresponding to the output eigenvalues. Not referenced
@@ -33395,26 +31565,22 @@ module hipfort_rocsolver
   !>                 The user should ensure that Z_l is large enough to hold n columns, as all n
   !>                 columns
   !>                 can be used as workspace for internal computations.
-  !>     @param[in]
-  !>     ldz         rocblas_int. ldz >= n.
+  !>     @param[in] ldz - rocblas_int. ldz >= n.
   !>                 Specifies the leading dimension of matrices Z_l.
-  !>     @param[out]
-  !>     ifail pointer to rocblas_int. Array on the GPU (the size depends on the value of strideF).
+  !>     @param[out] ifail - pointer to rocblas_int. Array on the GPU (the size depends on the value
+  !>     of strideF).
   !>                 If info[l] = 0, the first nev[l] elements of ifail_l are zero.
   !>                 Otherwise, contains the indices of those eigenvectors that failed
   !>                 to converge. Not referenced if evect is rocblas_evect_none.
-  !>     @param[in]
-  !>     strideF     rocblas_stride.
+  !>     @param[in] strideF - rocblas_stride.
   !>                 Stride from the start of one vector ifail_l to the next one ifail_(l+1).
   !>                 There is no restriction for the value of strideF. The normal use case is
   !>                 strideF >= n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for matrix A_l.
   !>                 If info[l] = i > 0, the algorithm did not converge. i columns of Z_l did not
   !>                 converge.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_cheevx_batched
     function rocsolver_cheevx_batched_(handle,evect,erange,uplo,n,A,lda,vl,vu,il,iu,abstol,nev,W, &
@@ -33493,58 +31659,46 @@ module hipfort_rocsolver
   !>     ``evect`` is rocblas_evect_original,
   !>     the eigenvectors for these eigenvalues will be computed as well.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     erange      `rocblas_erange`.
+  !>     @param[in] erange - `rocblas_erange`.
   !>                 Specifies the type of range or interval of the eigenvalues to be computed.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the symmetric matrices A_l is
   !>                 stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) part of A_l
   !>                 is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of rows and columns of matrices A_l.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the matrices A_l. On exit, the contents of A_l are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[in]
-  !>     vl          type. vl < vu.
+  !>     @param[in] vl - type. vl < vu.
   !>                 The lower bound of the search interval (vl, vu]. Ignored if range indicates to
   !>                 look
   !>                 for all the eigenvalues of A_l or the eigenvalues within a set of indices.
-  !>     @param[in]
-  !>     vu          type. vl < vu.
+  !>     @param[in] vu - type. vl < vu.
   !>                 The upper bound of the search interval (vl, vu]. Ignored if range indicates to
   !>                 look
   !>                 for all the eigenvalues of A_l or the eigenvalues within a set of indices.
-  !>     @param[in]
-  !>     il          rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] il - rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the smallest eigenvalue to be computed. Ignored if range indicates
   !>                 to look
   !>                 for all the eigenvalues of A_l or the eigenvalues in a half-open interval.
-  !>     @param[in]
-  !>     iu          rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] iu - rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the largest eigenvalue to be computed. Ignored if range indicates
   !>                 to look
   !>                 for all the eigenvalues of A_l or the eigenvalues in a half-open interval.
-  !>     @param[in]
-  !>     abstol      type.
+  !>     @param[in] abstol - type.
   !>                 The absolute tolerance. An eigenvalue is considered to be located if it lies
   !>                 in an interval whose width is <= abstol. If abstol is negative, then
   !>                 machine-epsilon times
@@ -33552,34 +31706,30 @@ module hipfort_rocsolver
   !>                 abstol=0, then the tolerance will be set
   !>                 to twice the underflow threshold. This is the tolerance that could get the most
   !>                 accurate results.
-  !>     @param[out]
-  !>     nev         pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] nev - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 The total number of eigenvalues found. If erange is rocblas_erange_all, nev[l]
   !>                 = n.
   !>                 If erange is rocblas_erange_index, nev[l] = iu - il + 1. Otherwise, 0 <= nev[l]
   !>                 <= n.
-  !>     @param[out]
-  !>     W           pointer to type. Array on the GPU (the size depends on the value of strideW).
+  !>     @param[out] W - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideW).
   !>                 The first nev[l] elements contain the computed eigenvalues. (The remaining
   !>                 elements
   !>                 can be used as workspace for internal computations.)
-  !>     @param[in]
-  !>     strideW     rocblas_stride.
+  !>     @param[in] strideW - rocblas_stride.
   !>                 Stride from the start of one vector W_l to the next one W_(l+1).
   !>                 There is no restriction for the value of strideW. The normal use case is
   !>                 strideW >= n.
-  !>     @param[out]
-  !>     Z           pointer to type. Array on the GPU (the size depends on the value of strideZ).
+  !>     @param[out] Z - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideZ).
   !>                 On exit, if evect is not rocblas_evect_none and info[l] = 0, the first nev[l]
   !>                 columns contain
   !>                 the eigenvectors of A_l corresponding to the output eigenvalues. Not referenced
   !>                 if
   !>                 evect is rocblas_evect_none.
-  !>     @param[in]
-  !>     ldz         rocblas_int. ldz >= n.
+  !>     @param[in] ldz - rocblas_int. ldz >= n.
   !>                 Specifies the leading dimension of matrices Z_l.
-  !>     @param[in]
-  !>     strideZ     rocblas_stride.
+  !>     @param[in] strideZ - rocblas_stride.
   !>                 Stride from the start of one matrix Z_l to the next one Z_(l+1).
   !>                 There is no restriction for the value of strideZ. The normal use case is
   !>                 strideZ >= ldz*nev[l].
@@ -33588,23 +31738,20 @@ module hipfort_rocsolver
   !>                 The user should ensure that Z_l is large enough to hold n columns, as all n
   !>                 columns
   !>                 can be used as workspace for internal computations.
-  !>     @param[out]
-  !>     ifail pointer to rocblas_int. Array on the GPU (the size depends on the value of strideF).
+  !>     @param[out] ifail - pointer to rocblas_int. Array on the GPU (the size depends on the value
+  !>     of strideF).
   !>                 If info[l] = 0, the first nev[l] elements of ifail_l are zero.
   !>                 Otherwise, contains the indices of those eigenvectors that failed
   !>                 to converge. Not referenced if evect is rocblas_evect_none.
-  !>     @param[in]
-  !>     strideF     rocblas_stride.
+  !>     @param[in] strideF - rocblas_stride.
   !>                 Stride from the start of one vector ifail_l to the next one ifail_(l+1).
   !>                 There is no restriction for the value of strideF. The normal use case is
   !>                 strideF >= n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for matrix A_l.
   !>                 If info[l] = i > 0, the algorithm did not converge. i columns of Z_l did not
   !>                 converge.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_ssyevx_strided_batched
     function rocsolver_ssyevx_strided_batched_(handle,evect,erange,uplo,n,A,lda,strideA,vl,vu,il, &
@@ -33687,58 +31834,46 @@ module hipfort_rocsolver
   !>     ``evect`` is rocblas_evect_original,
   !>     the eigenvectors for these eigenvalues will be computed as well.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     erange      `rocblas_erange`.
+  !>     @param[in] erange - `rocblas_erange`.
   !>                 Specifies the type of range or interval of the eigenvalues to be computed.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the symmetric matrices A_l is
   !>                 stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) part of A_l
   !>                 is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of rows and columns of matrices A_l.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the matrices A_l. On exit, the contents of A_l are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[in]
-  !>     vl          real type. vl < vu.
+  !>     @param[in] vl - real type. vl < vu.
   !>                 The lower bound of the search interval (vl, vu]. Ignored if range indicates to
   !>                 look
   !>                 for all the eigenvalues of A_l or the eigenvalues within a set of indices.
-  !>     @param[in]
-  !>     vu          real type. vl < vu.
+  !>     @param[in] vu - real type. vl < vu.
   !>                 The upper bound of the search interval (vl, vu]. Ignored if range indicates to
   !>                 look
   !>                 for all the eigenvalues of A_l or the eigenvalues within a set of indices.
-  !>     @param[in]
-  !>     il          rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] il - rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the smallest eigenvalue to be computed. Ignored if range indicates
   !>                 to look
   !>                 for all the eigenvalues of A_l or the eigenvalues in a half-open interval.
-  !>     @param[in]
-  !>     iu          rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] iu - rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the largest eigenvalue to be computed. Ignored if range indicates
   !>                 to look
   !>                 for all the eigenvalues of A_l or the eigenvalues in a half-open interval.
-  !>     @param[in]
-  !>     abstol      real type.
+  !>     @param[in] abstol - real type.
   !>                 The absolute tolerance. An eigenvalue is considered to be located if it lies
   !>                 in an interval whose width is <= abstol. If abstol is negative, then
   !>                 machine-epsilon times
@@ -33746,34 +31881,30 @@ module hipfort_rocsolver
   !>                 abstol=0, then the tolerance will be set
   !>                 to twice the underflow threshold. This is the tolerance that could get the most
   !>                 accurate results.
-  !>     @param[out]
-  !>     nev         pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] nev - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 The total number of eigenvalues found. If erange is rocblas_erange_all, nev[l]
   !>                 = n.
   !>                 If erange is rocblas_erange_index, nev[l] = iu - il + 1. Otherwise, 0 <= nev[l]
   !>                 <= n.
-  !>     @param[out]
-  !>     W pointer to real type. Array on the GPU (the size depends on the value of strideW).
+  !>     @param[out] W - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideW).
   !>                 The first nev[l] elements contain the computed eigenvalues. (The remaining
   !>                 elements
   !>                 can be used as workspace for internal computations.)
-  !>     @param[in]
-  !>     strideW     rocblas_stride.
+  !>     @param[in] strideW - rocblas_stride.
   !>                 Stride from the start of one vector W_l to the next one W_(l+1).
   !>                 There is no restriction for the value of strideW. The normal use case is
   !>                 strideW >= n.
-  !>     @param[out]
-  !>     Z           pointer to type. Array on the GPU (the size depends on the value of strideZ).
+  !>     @param[out] Z - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideZ).
   !>                 On exit, if evect is not rocblas_evect_none and info[l] = 0, the first nev[l]
   !>                 columns contain
   !>                 the eigenvectors of A_l corresponding to the output eigenvalues. Not referenced
   !>                 if
   !>                 evect is rocblas_evect_none.
-  !>     @param[in]
-  !>     ldz         rocblas_int. ldz >= n.
+  !>     @param[in] ldz - rocblas_int. ldz >= n.
   !>                 Specifies the leading dimension of matrices Z_l.
-  !>     @param[in]
-  !>     strideZ     rocblas_stride.
+  !>     @param[in] strideZ - rocblas_stride.
   !>                 Stride from the start of one matrix Z_l to the next one Z_(l+1).
   !>                 There is no restriction for the value of strideZ. The normal use case is
   !>                 strideZ >= ldz*nev[l].
@@ -33782,23 +31913,20 @@ module hipfort_rocsolver
   !>                 The user should ensure that Z_l is large enough to hold n columns, as all n
   !>                 columns
   !>                 can be used as workspace for internal computations.
-  !>     @param[out]
-  !>     ifail pointer to rocblas_int. Array on the GPU (the size depends on the value of strideF).
+  !>     @param[out] ifail - pointer to rocblas_int. Array on the GPU (the size depends on the value
+  !>     of strideF).
   !>                 If info[l] = 0, the first nev[l] elements of ifail_l are zero.
   !>                 Otherwise, contains the indices of those eigenvectors that failed
   !>                 to converge. Not referenced if evect is rocblas_evect_none.
-  !>     @param[in]
-  !>     strideF     rocblas_stride.
+  !>     @param[in] strideF - rocblas_stride.
   !>                 Stride from the start of one vector ifail_l to the next one ifail_(l+1).
   !>                 There is no restriction for the value of strideF. The normal use case is
   !>                 strideF >= n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for matrix A_l.
   !>                 If info[l] = i > 0, the algorithm did not converge. i columns of Z_l did not
   !>                 converge.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_cheevx_strided_batched
     function rocsolver_cheevx_strided_batched_(handle,evect,erange,uplo,n,A,lda,strideA,vl,vu,il, &
@@ -33896,46 +32024,35 @@ module hipfort_rocsolver
   !>         \end{array}
   !>     \f]
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     itype       `rocblas_eform`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] itype - `rocblas_eform`.
   !>                 Specifies the form of the generalized eigenproblem.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower parts of the matrices
   !>                 A and B are stored. If uplo indicates lower (or upper),
   !>                 then the upper (or lower) parts of A and B are not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The matrix dimensions.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the symmetric matrix A. On exit, if evect is original,
   !>                 the normalized matrix Z of eigenvectors. If evect is none, then the upper or
   !>                 lower triangular
   !>                 part of the matrix A (including the diagonal) is destroyed,
   !>                 depending on the value of uplo.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of A.
-  !>     @param[out]
-  !>     B           pointer to type. Array on the GPU of dimension ldb*n.
+  !>     @param[out] B - pointer to type. Array on the GPU of dimension ldb*n.
   !>                 On entry, the symmetric positive definite matrix B. On exit, the
   !>                 triangular factor of B as returned by \ref rocsolver_spotrf "POTRF".
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 Specifies the leading dimension of B.
-  !>     @param[out]
-  !>     D           pointer to type. Array on the GPU of dimension n.
+  !>     @param[out] D - pointer to type. Array on the GPU of dimension n.
   !>                 On exit, the eigenvalues in increasing order.
-  !>     @param[out]
-  !>     E           pointer to type. Array on the GPU of dimension n.
+  !>     @param[out] E - pointer to type. Array on the GPU of dimension n.
   !>                 This array is used to work internally with the tridiagonal matrix T associated
   !>                 with
   !>                 the reduced eigenvalue problem.
@@ -33945,8 +32062,7 @@ module hipfort_rocsolver
   !>                 elements
   !>                 of this matrix are in D. Those that converged correspond to a subset of the
   !>                 eigenvalues (not necessarily ordered).
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info = 0, successful exit.
   !>                 If info = i <= n, i off-diagonal elements of an intermediate
   !>                 tridiagonal form did not converge to zero.
@@ -34038,46 +32154,35 @@ module hipfort_rocsolver
   !>         \end{array}
   !>     \f]
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     itype       `rocblas_eform`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] itype - `rocblas_eform`.
   !>                 Specifies the form of the generalized eigenproblem.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower parts of the matrices
   !>                 A and B are stored. If uplo indicates lower (or upper),
   !>                 then the upper (or lower) parts of A and B are not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The matrix dimensions.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the Hermitian matrix A. On exit, if evect is original,
   !>                 the normalized matrix Z of eigenvectors. If evect is none, then the upper or
   !>                 lower triangular
   !>                 part of the matrix A (including the diagonal) is destroyed,
   !>                 depending on the value of uplo.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of A.
-  !>     @param[out]
-  !>     B           pointer to type. Array on the GPU of dimension ldb*n.
+  !>     @param[out] B - pointer to type. Array on the GPU of dimension ldb*n.
   !>                 On entry, the Hermitian positive definite matrix B. On exit, the
   !>                 triangular factor of B as returned by \ref rocsolver_spotrf "POTRF".
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 Specifies the leading dimension of B.
-  !>     @param[out]
-  !>     D           pointer to real type. Array on the GPU of dimension n.
+  !>     @param[out] D - pointer to real type. Array on the GPU of dimension n.
   !>                 On exit, the eigenvalues in increasing order.
-  !>     @param[out]
-  !>     E           pointer to real type. Array on the GPU of dimension n.
+  !>     @param[out] E - pointer to real type. Array on the GPU of dimension n.
   !>                 This array is used to work internally with the tridiagonal matrix T associated
   !>                 with
   !>                 the reduced eigenvalue problem.
@@ -34087,8 +32192,7 @@ module hipfort_rocsolver
   !>                 elements
   !>                 of this matrix are in D. Those that converged correspond to a subset of the
   !>                 eigenvalues (not necessarily ordered).
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info = 0, successful exit.
   !>                 If info = i <= n, i off-diagonal elements of an intermediate
   !>                 tridiagonal form did not converge to zero.
@@ -34180,51 +32284,43 @@ module hipfort_rocsolver
   !>         \end{array}
   !>     \f]
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     itype       `rocblas_eform`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] itype - `rocblas_eform`.
   !>                 Specifies the form of the generalized eigenproblems.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower parts of the matrices
   !>                 A_l and B_l are stored. If uplo indicates lower (or upper),
   !>                 then the upper (or lower) parts of A_l and B_l are not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The matrix dimensions.
-  !>     @param[inout]
-  !>     A array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the symmetric matrices A_l. On exit, if evect is original,
   !>                 the normalized matrix Z_l of eigenvectors. If evect is none, then the upper or
   !>                 lower triangular
   !>                 part of the matrices A_l (including the diagonal) are destroyed,
   !>                 depending on the value of uplo.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of A_l.
-  !>     @param[out]
-  !>     B array of pointers to type. Each pointer points to an array on the GPU of dimension ldb*n.
+  !>     @param[out] B - array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension ldb*n.
   !>                 On entry, the symmetric positive definite matrices B_l. On exit, the
   !>                 triangular factor of B_l as returned by \ref rocsolver_spotrf_batched
   !>                 "POTRF_BATCHED".
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 Specifies the leading dimension of B_l.
-  !>     @param[out]
-  !>     D           pointer to type. Array on the GPU (the size depends on the value of strideD).
+  !>     @param[out] D - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideD).
   !>                 On exit, the eigenvalues in increasing order.
-  !>     @param[in]
-  !>     strideD     rocblas_stride.
+  !>     @param[in] strideD - rocblas_stride.
   !>                 Stride from the start of one vector D_l to the next one D_(l+1).
   !>                 There is no restriction for the value of strideD. Normal usage is strideD >= n.
-  !>     @param[out]
-  !>     E           pointer to type. Array on the GPU (the size depends on the value of strideE).
+  !>     @param[out] E - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideE).
   !>                 This array is used to work internally with the tridiagonal matrix T_l
   !>                 associated with
   !>                 the l-th reduced eigenvalue problem.
@@ -34234,19 +32330,16 @@ module hipfort_rocsolver
   !>                 elements
   !>                 of this matrix are in D_l. Those that converged correspond to a subset of the
   !>                 eigenvalues (not necessarily ordered).
-  !>     @param[in]
-  !>     strideE     rocblas_stride.
+  !>     @param[in] strideE - rocblas_stride.
   !>                 Stride from the start of one vector E_l to the next one E_(l+1).
   !>                 There is no restriction for the value of strideE. Normal usage is strideE >= n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit of batch instance l.
   !>                 If info[l] = i <= n, i off-diagonal elements of an intermediate
   !>                 tridiagonal form did not converge to zero.
   !>                 If info[l] = n + i, the leading minor of order i of B_l is not
   !>                 positive definite.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_ssygv_batched
     function rocsolver_ssygv_batched_(handle,itype,evect,uplo,n,A,lda,B,ldb,D,strideD,E,strideE, &
@@ -34340,51 +32433,43 @@ module hipfort_rocsolver
   !>         \end{array}
   !>     \f]
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     itype       `rocblas_eform`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] itype - `rocblas_eform`.
   !>                 Specifies the form of the generalized eigenproblems.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower parts of the matrices
   !>                 A_l and B_l are stored. If uplo indicates lower (or upper),
   !>                 then the upper (or lower) parts of A_l and B_l are not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The matrix dimensions.
-  !>     @param[inout]
-  !>     A array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the Hermitian matrices A_l. On exit, if evect is original,
   !>                 the normalized matrix Z_l of eigenvectors. If evect is none, then the upper or
   !>                 lower triangular
   !>                 part of the matrices A_l (including the diagonal) are destroyed,
   !>                 depending on the value of uplo.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of A_l.
-  !>     @param[out]
-  !>     B array of pointers to type. Each pointer points to an array on the GPU of dimension ldb*n.
+  !>     @param[out] B - array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension ldb*n.
   !>                 On entry, the Hermitian positive definite matrices B_l. On exit, the
   !>                 triangular factor of B_l as returned by \ref rocsolver_spotrf_batched
   !>                 "POTRF_BATCHED".
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 Specifies the leading dimension of B_l.
-  !>     @param[out]
-  !>     D pointer to real type. Array on the GPU (the size depends on the value of strideD).
+  !>     @param[out] D - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideD).
   !>                 On exit, the eigenvalues in increasing order.
-  !>     @param[in]
-  !>     strideD     rocblas_stride.
+  !>     @param[in] strideD - rocblas_stride.
   !>                 Stride from the start of one vector D_l to the next one D_(l+1).
   !>                 There is no restriction for the value of strideD. Normal usage is strideD >= n.
-  !>     @param[out]
-  !>     E pointer to real type. Array on the GPU (the size depends on the value of strideE).
+  !>     @param[out] E - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideE).
   !>                 This array is used to work internally with the tridiagonal matrix T_l
   !>                 associated with
   !>                 the l-th reduced eigenvalue problem.
@@ -34394,19 +32479,16 @@ module hipfort_rocsolver
   !>                 elements
   !>                 of this matrix are in D_l. Those that converged correspond to a subset of the
   !>                 eigenvalues (not necessarily ordered).
-  !>     @param[in]
-  !>     strideE     rocblas_stride.
+  !>     @param[in] strideE - rocblas_stride.
   !>                 Stride from the start of one vector E_l to the next one E_(l+1).
   !>                 There is no restriction for the value of strideE. Normal usage is strideE >= n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit of batch l.
   !>                 If info[l] = i <= n, i off-diagonal elements of an intermediate
   !>                 tridiagonal form did not converge to zero.
   !>                 If info[l] = n + i, the leading minor of order i of B_l is not
   !>                 positive definite.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_chegv_batched
     function rocsolver_chegv_batched_(handle,itype,evect,uplo,n,A,lda,B,ldb,D,strideD,E,strideE, &
@@ -34500,61 +32582,51 @@ module hipfort_rocsolver
   !>         \end{array}
   !>     \f]
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     itype       `rocblas_eform`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] itype - `rocblas_eform`.
   !>                 Specifies the form of the generalized eigenproblems.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower parts of the matrices
   !>                 A_l and B_l are stored. If uplo indicates lower (or upper),
   !>                 then the upper (or lower) parts of A_l and B_l are not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The matrix dimensions.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the symmetric matrices A_l. On exit, if evect is original,
   !>                 the normalized matrix Z_l of eigenvectors. If evect is none, then the upper or
   !>                 lower triangular
   !>                 part of the matrices A_l (including the diagonal) are destroyed,
   !>                 depending on the value of uplo.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. Normal usage is strideA >=
   !>                 lda*n.
-  !>     @param[out]
-  !>     B           pointer to type. Array on the GPU (the size depends on the value of strideB).
+  !>     @param[out] B - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideB).
   !>                 On entry, the symmetric positive definite matrices B_l. On exit, the
   !>                 triangular factor of B_l as returned by \ref rocsolver_spotrf_strided_batched
   !>                 "POTRF_STRIDED_BATCHED".
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 Specifies the leading dimension of B_l.
-  !>     @param[in]
-  !>     strideB     rocblas_stride.
+  !>     @param[in] strideB - rocblas_stride.
   !>                 Stride from the start of one matrix B_l to the next one B_(l+1).
   !>                 There is no restriction for the value of strideB. Normal usage is strideB >=
   !>                 ldb*n.
-  !>     @param[out]
-  !>     D           pointer to type. Array on the GPU (the size depends on the value of strideD).
+  !>     @param[out] D - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideD).
   !>                 On exit, the eigenvalues in increasing order.
-  !>     @param[in]
-  !>     strideD     rocblas_stride.
+  !>     @param[in] strideD - rocblas_stride.
   !>                 Stride from the start of one vector D_l to the next one D_(l+1).
   !>                 There is no restriction for the value of strideD. Normal usage is strideD >= n.
-  !>     @param[out]
-  !>     E           pointer to type. Array on the GPU (the size depends on the value of strideE).
+  !>     @param[out] E - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideE).
   !>                 This array is used to work internally with the tridiagonal matrix T_l
   !>                 associated with
   !>                 the l-th reduced eigenvalue problem.
@@ -34564,19 +32636,16 @@ module hipfort_rocsolver
   !>                 elements
   !>                 of this matrix are in D_l. Those that converged correspond to a subset of the
   !>                 eigenvalues (not necessarily ordered).
-  !>     @param[in]
-  !>     strideE     rocblas_stride.
+  !>     @param[in] strideE - rocblas_stride.
   !>                 Stride from the start of one vector E_l to the next one E_(l+1).
   !>                 There is no restriction for the value of strideE. Normal usage is strideE >= n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit of batch j.
   !>                 If info[l] = i <= n, i off-diagonal elements of an intermediate
   !>                 tridiagonal form did not converge to zero.
   !>                 If info[l] = n + i, the leading minor of order i of B_l is not
   !>                 positive definite.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_ssygv_strided_batched
     function rocsolver_ssygv_strided_batched_(handle,itype,evect,uplo,n,A,lda,strideA,B,ldb, &
@@ -34676,61 +32745,51 @@ module hipfort_rocsolver
   !>         \end{array}
   !>     \f]
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     itype       `rocblas_eform`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] itype - `rocblas_eform`.
   !>                 Specifies the form of the generalized eigenproblems.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower parts of the matrices
   !>                 A_l and B_l are stored. If uplo indicates lower (or upper),
   !>                 then the upper (or lower) parts of A_l and B_l are not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The matrix dimensions.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the Hermitian matrices A_l. On exit, if evect is original,
   !>                 the normalized matrix Z_l of eigenvectors. If evect is none, then the upper or
   !>                 lower triangular
   !>                 part of the matrices A_l (including the diagonal) are destroyed,
   !>                 depending on the value of uplo.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. Normal usage is strideA >=
   !>                 lda*n.
-  !>     @param[out]
-  !>     B           pointer to type. Array on the GPU (the size depends on the value of strideB).
+  !>     @param[out] B - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideB).
   !>                 On entry, the Hermitian positive definite matrices B_l. On exit, the
   !>                 triangular factor of B_l as returned by \ref rocsolver_spotrf_strided_batched
   !>                 "POTRF_STRIDED_BATCHED".
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 Specifies the leading dimension of B_l.
-  !>     @param[in]
-  !>     strideB     rocblas_stride.
+  !>     @param[in] strideB - rocblas_stride.
   !>                 Stride from the start of one matrix B_l to the next one B_(l+1).
   !>                 There is no restriction for the value of strideB. Normal usage is strideB >=
   !>                 ldb*n.
-  !>     @param[out]
-  !>     D pointer to real type. Array on the GPU (the size depends on the value of strideD).
+  !>     @param[out] D - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideD).
   !>                 On exit, the eigenvalues in increasing order.
-  !>     @param[in]
-  !>     strideD     rocblas_stride.
+  !>     @param[in] strideD - rocblas_stride.
   !>                 Stride from the start of one vector D_l to the next one D_(l+1).
   !>                 There is no restriction for the value of strideD. Normal usage is strideD >= n.
-  !>     @param[out]
-  !>     E pointer to real type. Array on the GPU (the size depends on the value of strideE).
+  !>     @param[out] E - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideE).
   !>                 This array is used to work internally with the tridiagonal matrix T_l
   !>                 associated with
   !>                 the l-th reduced eigenvalue problem.
@@ -34740,19 +32799,16 @@ module hipfort_rocsolver
   !>                 elements
   !>                 of this matrix are in D_l. Those that converged correspond to a subset of the
   !>                 eigenvalues (not necessarily ordered).
-  !>     @param[in]
-  !>     strideE     rocblas_stride.
+  !>     @param[in] strideE - rocblas_stride.
   !>                 Stride from the start of one vector E_l to the next one E_(l+1).
   !>                 There is no restriction for the value of strideE. Normal usage is strideE >= n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit of batch l.
   !>                 If info[l] = i <= n, i off-diagonal elements of an intermediate
   !>                 tridiagonal form did not converge to zero.
   !>                 If info[l] = n + i, the leading minor of order i of B_l is not
   !>                 positive definite.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_chegv_strided_batched
     function rocsolver_chegv_strided_batched_(handle,itype,evect,uplo,n,A,lda,strideA,B,ldb, &
@@ -34853,46 +32909,35 @@ module hipfort_rocsolver
   !>         \end{array}
   !>     \f]
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     itype       `rocblas_eform`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] itype - `rocblas_eform`.
   !>                 Specifies the form of the generalized eigenproblem.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower parts of the matrices
   !>                 A and B are stored. If uplo indicates lower (or upper),
   !>                 then the upper (or lower) parts of A and B are not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The matrix dimensions.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the symmetric matrix A. On exit, if evect is original,
   !>                 the normalized matrix Z of eigenvectors. If evect is none, then the upper or
   !>                 lower triangular
   !>                 part of the matrix A (including the diagonal) is destroyed,
   !>                 depending on the value of uplo.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of A.
-  !>     @param[out]
-  !>     B           pointer to type. Array on the GPU of dimension ldb*n.
+  !>     @param[out] B - pointer to type. Array on the GPU of dimension ldb*n.
   !>                 On entry, the symmetric positive definite matrix B. On exit, the
   !>                 triangular factor of B, as returned by \ref rocsolver_spotrf "POTRF".
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 Specifies the leading dimension of B.
-  !>     @param[out]
-  !>     D           pointer to type. Array on the GPU of dimension n.
+  !>     @param[out] D - pointer to type. Array on the GPU of dimension n.
   !>                 On exit, the eigenvalues in increasing order.
-  !>     @param[out]
-  !>     E           pointer to type. Array on the GPU of dimension n.
+  !>     @param[out] E - pointer to type. Array on the GPU of dimension n.
   !>                 This array is used to work internally with the tridiagonal matrix T associated
   !>                 with
   !>                 the reduced eigenvalue problem.
@@ -34902,8 +32947,7 @@ module hipfort_rocsolver
   !>                 elements
   !>                 of this matrix are in D. Those that converged correspond to a subset of the
   !>                 eigenvalues (not necessarily ordered).
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 - If info = 0, successful exit.
   !>                 - If info = i <= n and evect is rocblas_evect_none, i off-diagonal elements of
   !>                 an
@@ -35000,46 +33044,35 @@ module hipfort_rocsolver
   !>         \end{array}
   !>     \f]
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     itype       `rocblas_eform`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] itype - `rocblas_eform`.
   !>                 Specifies the form of the generalized eigenproblem.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower parts of the matrices
   !>                 A and B are stored. If uplo indicates lower (or upper),
   !>                 then the upper (or lower) parts of A and B are not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The matrix dimensions.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the Hermitian matrix A. On exit, if evect is original,
   !>                 the normalized matrix Z of eigenvectors. If evect is none, then the upper or
   !>                 lower triangular
   !>                 part of the matrix A (including the diagonal) is destroyed,
   !>                 depending on the value of uplo.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of A.
-  !>     @param[out]
-  !>     B           pointer to type. Array on the GPU of dimension ldb*n.
+  !>     @param[out] B - pointer to type. Array on the GPU of dimension ldb*n.
   !>                 On entry, the Hermitian positive definite matrix B. On exit, the
   !>                 triangular factor of B as returned by \ref rocsolver_spotrf "POTRF".
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 Specifies the leading dimension of B.
-  !>     @param[out]
-  !>     D           pointer to real type. Array on the GPU of dimension n.
+  !>     @param[out] D - pointer to real type. Array on the GPU of dimension n.
   !>                 On exit, the eigenvalues in increasing order.
-  !>     @param[out]
-  !>     E           pointer to real type. Array on the GPU of dimension n.
+  !>     @param[out] E - pointer to real type. Array on the GPU of dimension n.
   !>                 This array is used to work internally with the tridiagonal matrix T associated
   !>                 with
   !>                 the reduced eigenvalue problem.
@@ -35049,8 +33082,7 @@ module hipfort_rocsolver
   !>                 elements
   !>                 of this matrix are in D. Those that converged correspond to a subset of the
   !>                 eigenvalues (not necessarily ordered).
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 - If info = 0, successful exit.
   !>                 - If info = i <= n and evect is rocblas_evect_none, i off-diagonal elements of
   !>                 an
@@ -35152,51 +33184,43 @@ module hipfort_rocsolver
   !>     contained within the
   !>     ``rocblas_handle``.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     itype       `rocblas_eform`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] itype - `rocblas_eform`.
   !>                 Specifies the form of the generalized eigenproblems.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower parts of the matrices
   !>                 A_l and B_l are stored. If uplo indicates lower (or upper),
   !>                 then the upper (or lower) parts of A_l and B_l are not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The matrix dimensions.
-  !>     @param[inout]
-  !>     A array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the symmetric matrices A_l. On exit, if evect is original,
   !>                 the normalized matrix Z_l of eigenvectors. If evect is none, then the upper or
   !>                 lower triangular
   !>                 part of the matrices A_l (including the diagonal) are destroyed,
   !>                 depending on the value of uplo.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of A_l.
-  !>     @param[out]
-  !>     B array of pointers to type. Each pointer points to an array on the GPU of dimension ldb*n.
+  !>     @param[out] B - array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension ldb*n.
   !>                 On entry, the symmetric positive definite matrices B_l. On exit, the
   !>                 triangular factor of B_l, as returned by \ref rocsolver_spotrf_batched
   !>                 "POTRF_BATCHED".
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 Specifies the leading dimension of B_l.
-  !>     @param[out]
-  !>     D           pointer to type. Array on the GPU (the size depends on the value of strideD).
+  !>     @param[out] D - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideD).
   !>                 On exit, the eigenvalues in increasing order.
-  !>     @param[in]
-  !>     strideD     rocblas_stride.
+  !>     @param[in] strideD - rocblas_stride.
   !>                 Stride from the start of one vector D_l to the next one D_(l+1).
   !>                 There is no restriction for the value of strideD. Normal usage is strideD >= n.
-  !>     @param[out]
-  !>     E           pointer to type. Array on the GPU (the size depends on the value of strideE).
+  !>     @param[out] E - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideE).
   !>                 This array is used to work internally with the tridiagonal matrix T_l
   !>                 associated with
   !>                 the l-th reduced eigenvalue problem.
@@ -35206,12 +33230,10 @@ module hipfort_rocsolver
   !>                 elements
   !>                 of this matrix are in D_l. Those that converged correspond to a subset of the
   !>                 eigenvalues (not necessarily ordered).
-  !>     @param[in]
-  !>     strideE     rocblas_stride.
+  !>     @param[in] strideE - rocblas_stride.
   !>                 Stride from the start of one vector E_l to the next one E_(l+1).
   !>                 There is no restriction for the value of strideE. Normal usage is strideE >= n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 - If info[l] = 0, successful exit of batch l.
   !>                 - If info[l] = i <= n and evect is rocblas_evect_none, i off-diagonal elements
   !>                 of an
@@ -35222,8 +33244,7 @@ module hipfort_rocsolver
   !>                 i%(n+1)].
   !>                 - If info[l] = n + i, the leading minor of order i of B_l is not
   !>                 positive definite.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_ssygvd_batched
     function rocsolver_ssygvd_batched_(handle,itype,evect,uplo,n,A,lda,B,ldb,D,strideD,E,strideE, &
@@ -35323,51 +33344,43 @@ module hipfort_rocsolver
   !>     contained within the
   !>     ``rocblas_handle``.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     itype       `rocblas_eform`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] itype - `rocblas_eform`.
   !>                 Specifies the form of the generalized eigenproblems.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower parts of the matrices
   !>                 A_l and B_l are stored. If uplo indicates lower (or upper),
   !>                 then the upper (or lower) parts of A_l and B_l are not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The matrix dimensions.
-  !>     @param[inout]
-  !>     A array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the Hermitian matrices A_l. On exit, if evect is original,
   !>                 the normalized matrix Z_l of eigenvectors. If evect is none, then the upper or
   !>                 lower triangular
   !>                 part of the matrices A_l (including the diagonal) are destroyed,
   !>                 depending on the value of uplo.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of A_l.
-  !>     @param[out]
-  !>     B array of pointers to type. Each pointer points to an array on the GPU of dimension ldb*n.
+  !>     @param[out] B - array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension ldb*n.
   !>                 On entry, the Hermitian positive definite matrices B_l. On exit, the
   !>                 triangular factor of B_l as returned by \ref rocsolver_spotrf_batched
   !>                 "POTRF_BATCHED".
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 Specifies the leading dimension of B_l.
-  !>     @param[out]
-  !>     D pointer to real type. Array on the GPU (the size depends on the value of strideD).
+  !>     @param[out] D - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideD).
   !>                 On exit, the eigenvalues in increasing order.
-  !>     @param[in]
-  !>     strideD     rocblas_stride.
+  !>     @param[in] strideD - rocblas_stride.
   !>                 Stride from the start of one vector D_l to the next one D_(l+1).
   !>                 There is no restriction for the value of strideD. Normal usage is strideD >= n.
-  !>     @param[out]
-  !>     E pointer to real type. Array on the GPU (the size depends on the value of strideE).
+  !>     @param[out] E - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideE).
   !>                 This array is used to work internally with the tridiagonal matrix T_l
   !>                 associated with
   !>                 the l-th reduced eigenvalue problem.
@@ -35377,12 +33390,10 @@ module hipfort_rocsolver
   !>                 elements
   !>                 of this matrix are in D_l. Those that converged correspond to a subset of the
   !>                 eigenvalues (not necessarily ordered).
-  !>     @param[in]
-  !>     strideE     rocblas_stride.
+  !>     @param[in] strideE - rocblas_stride.
   !>                 Stride from the start of one vector E_l to the next one E_(l+1).
   !>                 There is no restriction for the value of strideE. Normal usage is strideE >= n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 - If info[l] = 0, successful exit of batch l.
   !>                 - If info[l] = i <= n and evect is rocblas_evect_none, i off-diagonal elements
   !>                 of an
@@ -35393,8 +33404,7 @@ module hipfort_rocsolver
   !>                 i%(n+1)].
   !>                 - If info[l] = n + i, the leading minor of order i of B_l is not
   !>                 positive definite.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_chegvd_batched
     function rocsolver_chegvd_batched_(handle,itype,evect,uplo,n,A,lda,B,ldb,D,strideD,E,strideE, &
@@ -35494,61 +33504,51 @@ module hipfort_rocsolver
   !>     contained within the
   !>     ``rocblas_handle``.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     itype       `rocblas_eform`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] itype - `rocblas_eform`.
   !>                 Specifies the form of the generalized eigenproblems.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower parts of the matrices
   !>                 A_l and B_l are stored. If uplo indicates lower (or upper),
   !>                 then the upper (or lower) parts of A_l and B_l are not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The matrix dimensions.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the symmetric matrices A_l. On exit, if evect is original,
   !>                 the normalized matrix Z_l of eigenvectors. If evect is none, then the upper or
   !>                 lower triangular
   !>                 part of the matrices A_l (including the diagonal) are destroyed,
   !>                 depending on the value of uplo.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. Normal usage is strideA >=
   !>                 lda*n.
-  !>     @param[out]
-  !>     B           pointer to type. Array on the GPU (the size depends on the value of strideB).
+  !>     @param[out] B - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideB).
   !>                 On entry, the symmetric positive definite matrices B_l. On exit, the
   !>                 triangular factor of B_l as returned by \ref rocsolver_spotrf_strided_batched
   !>                 "POTRF_STRIDED_BATCHED".
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 Specifies the leading dimension of B_l.
-  !>     @param[in]
-  !>     strideB     rocblas_stride.
+  !>     @param[in] strideB - rocblas_stride.
   !>                 Stride from the start of one matrix B_l to the next one B_(l+1).
   !>                 There is no restriction for the value of strideB. Normal usage is strideB >=
   !>                 ldb*n.
-  !>     @param[out]
-  !>     D           pointer to type. Array on the GPU (the size depends on the value of strideD).
+  !>     @param[out] D - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideD).
   !>                 On exit, the eigenvalues in increasing order.
-  !>     @param[in]
-  !>     strideD     rocblas_stride.
+  !>     @param[in] strideD - rocblas_stride.
   !>                 Stride from the start of one vector D_l to the next one D_(l+1).
   !>                 There is no restriction for the value of strideD. Normal usage is strideD >= n.
-  !>     @param[out]
-  !>     E           pointer to type. Array on the GPU (the size depends on the value of strideE).
+  !>     @param[out] E - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideE).
   !>                 This array is used to work internally with the tridiagonal matrix T_l
   !>                 associated with
   !>                 the l-th reduced eigenvalue problem.
@@ -35558,12 +33558,10 @@ module hipfort_rocsolver
   !>                 elements
   !>                 of this matrix are in D_l. Those that converged correspond to a subset of the
   !>                 eigenvalues (not necessarily ordered).
-  !>     @param[in]
-  !>     strideE     rocblas_stride.
+  !>     @param[in] strideE - rocblas_stride.
   !>                 Stride from the start of one vector E_l to the next one E_(l+1).
   !>                 There is no restriction for the value of strideE. Normal usage is strideE >= n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 - If info[l] = 0, successful exit of batch l.
   !>                 - If info[l] = i <= n and evect is rocblas_evect_none, i off-diagonal elements
   !>                 of an
@@ -35574,8 +33572,7 @@ module hipfort_rocsolver
   !>                 i%(n+1)].
   !>                 - If info[l] = n + i, the leading minor of order i of B_l is not
   !>                 positive definite.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_ssygvd_strided_batched
     function rocsolver_ssygvd_strided_batched_(handle,itype,evect,uplo,n,A,lda,strideA,B,ldb, &
@@ -35681,61 +33678,51 @@ module hipfort_rocsolver
   !>     contained within the
   !>     ``rocblas_handle``.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     itype       `rocblas_eform`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] itype - `rocblas_eform`.
   !>                 Specifies the form of the generalized eigenproblems.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower parts of the matrices
   !>                 A_l and B_l are stored. If uplo indicates lower (or upper),
   !>                 then the upper (or lower) parts of A_l and B_l are not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The matrix dimensions.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the Hermitian matrices A_l. On exit, if evect is original,
   !>                 the normalized matrix Z_l of eigenvectors. If evect is none, then the upper or
   !>                 lower triangular
   !>                 part of the matrices A_l (including the diagonal) are destroyed,
   !>                 depending on the value of uplo.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. Normal usage is strideA >=
   !>                 lda*n.
-  !>     @param[out]
-  !>     B           pointer to type. Array on the GPU (the size depends on the value of strideB).
+  !>     @param[out] B - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideB).
   !>                 On entry, the Hermitian positive definite matrices B_l. On exit, the
   !>                 triangular factor of B_l as returned by \ref rocsolver_spotrf_strided_batched
   !>                 "POTRF_STRIDED_BATCHED".
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 Specifies the leading dimension of B_l.
-  !>     @param[in]
-  !>     strideB     rocblas_stride.
+  !>     @param[in] strideB - rocblas_stride.
   !>                 Stride from the start of one matrix B_l to the next one B_(l+1).
   !>                 There is no restriction for the value of strideB. Normal usage is strideB >=
   !>                 ldb*n.
-  !>     @param[out]
-  !>     D pointer to real type. Array on the GPU (the size depends on the value of strideD).
+  !>     @param[out] D - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideD).
   !>                 On exit, the eigenvalues in increasing order.
-  !>     @param[in]
-  !>     strideD     rocblas_stride.
+  !>     @param[in] strideD - rocblas_stride.
   !>                 Stride from the start of one vector D_l to the next one D_(l+1).
   !>                 There is no restriction for the value of strideD. Normal usage is strideD >= n.
-  !>     @param[out]
-  !>     E pointer to real type. Array on the GPU (the size depends on the value of strideE).
+  !>     @param[out] E - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideE).
   !>                 This array is used to work internally with the tridiagonal matrix T_l
   !>                 associated with
   !>                 the l-th reduced eigenvalue problem.
@@ -35745,12 +33732,10 @@ module hipfort_rocsolver
   !>                 elements
   !>                 of this matrix are in D_l. Those that converged correspond to a subset of the
   !>                 eigenvalues (not necessarily ordered).
-  !>     @param[in]
-  !>     strideE     rocblas_stride.
+  !>     @param[in] strideE - rocblas_stride.
   !>                 Stride from the start of one vector E_l to the next one E_(l+1).
   !>                 There is no restriction for the value of strideE. Normal usage is strideE >= n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 - If info[l] = 0, successful exit of batch l.
   !>                 - If info[l] = i <= n and evect is rocblas_evect_none, i off-diagonal elements
   !>                 of an
@@ -35761,8 +33746,7 @@ module hipfort_rocsolver
   !>                 i%(n+1)].
   !>                 - If info[l] = n + i, the leading minor of order i of B_l is not
   !>                 positive definite.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_chegvd_strided_batched
     function rocsolver_chegvd_strided_batched_(handle,itype,evect,uplo,n,A,lda,strideA,B,ldb, &
@@ -35868,61 +33852,46 @@ module hipfort_rocsolver
   !>     contained within the
   !>     ``rocblas_handle``.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     itype       `rocblas_eform`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] itype - `rocblas_eform`.
   !>                 Specifies the form of the generalized eigenproblem.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower parts of the matrices
   !>                 A and B are stored. If uplo indicates lower (or upper),
   !>                 then the upper (or lower) parts of A and B are not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The matrix dimensions.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the symmetric matrix A. On exit, if evect is original,
   !>                 the normalized matrix Z of eigenvectors. If evect is none, then the upper or
   !>                 lower triangular
   !>                 part of the matrix A (including the diagonal) is destroyed,
   !>                 depending on the value of uplo.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of A.
-  !>     @param[out]
-  !>     B           pointer to type. Array on the GPU of dimension ldb*n.
+  !>     @param[out] B - pointer to type. Array on the GPU of dimension ldb*n.
   !>                 On entry, the symmetric positive definite matrix B. On exit, the
   !>                 triangular factor of B, as returned by \ref rocsolver_spotrf "POTRF".
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 Specifies the leading dimension of B.
-  !>     @param[in]
-  !>     abstol      type.
+  !>     @param[in] abstol - type.
   !>                 The absolute tolerance. The algorithm is considered to have converged once the
   !>                 residual
   !>                 is <= abstol. If abstol <= 0, then the tolerance will be set to machine
   !>                 precision.
-  !>     @param[out]
-  !>     residual    pointer to type on the GPU.
+  !>     @param[out] residual - pointer to type on the GPU.
   !>                 The Frobenius norm of the off-diagonal elements at the final iteration.
-  !>     @param[in]
-  !>     max_sweeps  rocblas_int. max_sweeps > 0.
+  !>     @param[in] max_sweeps - rocblas_int. max_sweeps > 0.
   !>                 Maximum number of sweeps (iterations) to be used by the algorithm.
-  !>     @param[out]
-  !>     n_sweeps    pointer to a rocblas_int on the GPU.
+  !>     @param[out] n_sweeps - pointer to a rocblas_int on the GPU.
   !>                 The actual number of sweeps (iterations) used by the algorithm.
-  !>     @param[out]
-  !>     W           pointer to type. Array on the GPU of dimension n.
+  !>     @param[out] W - pointer to type. Array on the GPU of dimension n.
   !>                 On exit, the eigenvalues in increasing order.
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info = 0, successful exit.
   !>                 If info = 1, the algorithm did not converge.
   !>                 If info = n + i, the leading minor of order i of B is not
@@ -36013,61 +33982,46 @@ module hipfort_rocsolver
   !>     contained within the
   !>     ``rocblas_handle``.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     itype       `rocblas_eform`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] itype - `rocblas_eform`.
   !>                 Specifies the form of the generalized eigenproblem.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower parts of the matrices
   !>                 A and B are stored. If uplo indicates lower (or upper),
   !>                 then the upper (or lower) parts of A and B are not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The matrix dimensions.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the Hermitian matrix A. On exit, if evect is original,
   !>                 the normalized matrix Z of eigenvectors. If evect is none, then the upper or
   !>                 lower triangular
   !>                 part of the matrix A (including the diagonal) is destroyed,
   !>                 depending on the value of uplo.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of A.
-  !>     @param[out]
-  !>     B           pointer to type. Array on the GPU of dimension ldb*n.
+  !>     @param[out] B - pointer to type. Array on the GPU of dimension ldb*n.
   !>                 On entry, the Hermitian positive definite matrix B. On exit, the
   !>                 triangular factor of B, as returned by \ref rocsolver_spotrf "POTRF".
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 Specifies the leading dimension of B.
-  !>     @param[in]
-  !>     abstol      real type.
+  !>     @param[in] abstol - real type.
   !>                 The absolute tolerance. The algorithm is considered to have converged once the
   !>                 residual
   !>                 is <= abstol. If abstol <= 0, then the tolerance will be set to machine
   !>                 precision.
-  !>     @param[out]
-  !>     residual    pointer to real type on the GPU.
+  !>     @param[out] residual - pointer to real type on the GPU.
   !>                 The Frobenius norm of the off-diagonal elements at the final iteration.
-  !>     @param[in]
-  !>     max_sweeps  rocblas_int. max_sweeps > 0.
+  !>     @param[in] max_sweeps - rocblas_int. max_sweeps > 0.
   !>                 Maximum number of sweeps (iterations) to be used by the algorithm.
-  !>     @param[out]
-  !>     n_sweeps    pointer to a rocblas_int on the GPU.
+  !>     @param[out] n_sweeps - pointer to a rocblas_int on the GPU.
   !>                 The actual number of sweeps (iterations) used by the algorithm.
-  !>     @param[out]
-  !>     W           pointer to real type. Array on the GPU of dimension n.
+  !>     @param[out] W - pointer to real type. Array on the GPU of dimension n.
   !>                 On exit, the eigenvalues in increasing order.
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info = 0, successful exit.
   !>                 If info = 1, the algorithm did not converge.
   !>                 If info = n + i, the leading minor of order i of B is not
@@ -36153,74 +34107,60 @@ module hipfort_rocsolver
   !>         \end{array}
   !>     \f]
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     itype       `rocblas_eform`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] itype - `rocblas_eform`.
   !>                 Specifies the form of the generalized eigenproblems.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower parts of the matrices
   !>                 A_l and B_l are stored. If uplo indicates lower (or upper),
   !>                 then the upper (or lower) parts of A_l and B_l are not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The matrix dimensions.
-  !>     @param[inout]
-  !>     A array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the symmetric matrices A_l. On exit, if evect is original,
   !>                 the normalized matrix Z_l of eigenvectors. If evect is none, then the upper or
   !>                 lower triangular
   !>                 part of the matrices A_l (including the diagonal) are destroyed,
   !>                 depending on the value of uplo.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of A_l.
-  !>     @param[out]
-  !>     B array of pointers to type. Each pointer points to an array on the GPU of dimension ldb*n.
+  !>     @param[out] B - array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension ldb*n.
   !>                 On entry, the symmetric positive definite matrices B_l. On exit, the
   !>                 triangular factor of B_l, as returned by \ref rocsolver_spotrf_batched
   !>                 "POTRF_BATCHED".
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 Specifies the leading dimension of B_l.
-  !>     @param[in]
-  !>     abstol      type.
+  !>     @param[in] abstol - type.
   !>                 The absolute tolerance. The algorithm is considered to have converged once the
   !>                 residual
   !>                 is <= abstol. If abstol <= 0, then the tolerance will be set to machine
   !>                 precision.
-  !>     @param[out]
-  !>     residual    pointer to type. Array of batch_count scalars on the GPU.
+  !>     @param[out] residual - pointer to type. Array of batch_count scalars on the GPU.
   !>                 The Frobenius norm of the off-diagonal elements at the final iteration for each
   !>                 batch instance.
-  !>     @param[in]
-  !>     max_sweeps  rocblas_int. max_sweeps > 0.
+  !>     @param[in] max_sweeps - rocblas_int. max_sweeps > 0.
   !>                 Maximum number of sweeps (iterations) to be used by the algorithm.
-  !>     @param[out]
-  !>     n_sweeps    pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] n_sweeps - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 The actual number of sweeps (iterations) used by the algorithm for each batch
   !>                 instance.
-  !>     @param[out]
-  !>     W           pointer to type. Array on the GPU (the size depends on the value of strideW).
+  !>     @param[out] W - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideW).
   !>                 On exit, the eigenvalues in increasing order.
-  !>     @param[in]
-  !>     strideW     rocblas_stride.
+  !>     @param[in] strideW - rocblas_stride.
   !>                 Stride from the start of one vector W_l to the next one W_(l+1).
   !>                 There is no restriction for the value of strideW. Normal usage is strideW >= n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit of batch instance l.
   !>                 If info[l] = 1, the algorithm did not converge.
   !>                 If info[l] = n + i, the leading minor of order i of B_l is not
   !>                 positive definite.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_ssygvj_batched
     function rocsolver_ssygvj_batched_(handle,itype,evect,uplo,n,A,lda,B,ldb,abstol,residual, &
@@ -36307,74 +34247,60 @@ module hipfort_rocsolver
   !>         \end{array}
   !>     \f]
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     itype       `rocblas_eform`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] itype - `rocblas_eform`.
   !>                 Specifies the form of the generalized eigenproblems.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower parts of the matrices
   !>                 A_l and B_l are stored. If uplo indicates lower (or upper),
   !>                 then the upper (or lower) parts of A_l and B_l are not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The matrix dimensions.
-  !>     @param[inout]
-  !>     A array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the Hermitian matrices A_l. On exit, if evect is original,
   !>                 the normalized matrix Z_l of eigenvectors. If evect is none, then the upper or
   !>                 lower triangular
   !>                 part of the matrices A_l (including the diagonal) are destroyed,
   !>                 depending on the value of uplo.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of A_l.
-  !>     @param[out]
-  !>     B array of pointers to type. Each pointer points to an array on the GPU of dimension ldb*n.
+  !>     @param[out] B - array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension ldb*n.
   !>                 On entry, the Hermitian positive definite matrices B_l. On exit, the
   !>                 triangular factor of B_l, as returned by \ref rocsolver_spotrf_batched
   !>                 "POTRF_BATCHED".
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 Specifies the leading dimension of B_l.
-  !>     @param[in]
-  !>     abstol      real type.
+  !>     @param[in] abstol - real type.
   !>                 The absolute tolerance. The algorithm is considered to have converged once the
   !>                 residual
   !>                 is <= abstol. If abstol <= 0, then the tolerance will be set to machine
   !>                 precision.
-  !>     @param[out]
-  !>     residual    pointer to real type. Array of batch_count scalars on the GPU.
+  !>     @param[out] residual - pointer to real type. Array of batch_count scalars on the GPU.
   !>                 The Frobenius norm of the off-diagonal elements at the final iteration for each
   !>                 batch instance.
-  !>     @param[in]
-  !>     max_sweeps  rocblas_int. max_sweeps > 0.
+  !>     @param[in] max_sweeps - rocblas_int. max_sweeps > 0.
   !>                 Maximum number of sweeps (iterations) to be used by the algorithm.
-  !>     @param[out]
-  !>     n_sweeps    pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] n_sweeps - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 The actual number of sweeps (iterations) used by the algorithm for each batch
   !>                 instance.
-  !>     @param[out]
-  !>     W pointer to real type. Array on the GPU (the size depends on the value of strideW).
+  !>     @param[out] W - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideW).
   !>                 On exit, the eigenvalues in increasing order.
-  !>     @param[in]
-  !>     strideW     rocblas_stride.
+  !>     @param[in] strideW - rocblas_stride.
   !>                 Stride from the start of one vector W_l to the next one W_(l+1).
   !>                 There is no restriction for the value of strideW. Normal usage is strideW >= n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit of batch l.
   !>                 If info[l] = 1, the algorithm did not converge.
   !>                 If info[l] = n + i, the leading minor of order i of B_l is not
   !>                 positive definite.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_chegvj_batched
     function rocsolver_chegvj_batched_(handle,itype,evect,uplo,n,A,lda,B,ldb,abstol,residual, &
@@ -36461,84 +34387,68 @@ module hipfort_rocsolver
   !>         \end{array}
   !>     \f]
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     itype       `rocblas_eform`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] itype - `rocblas_eform`.
   !>                 Specifies the form of the generalized eigenproblems.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower parts of the matrices
   !>                 A_l and B_l are stored. If uplo indicates lower (or upper),
   !>                 then the upper (or lower) parts of A_l and B_l are not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The matrix dimensions.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the symmetric matrices A_l. On exit, if evect is original,
   !>                 the normalized matrix Z_l of eigenvectors. If evect is none, then the upper or
   !>                 lower triangular
   !>                 part of the matrices A_l (including the diagonal) are destroyed,
   !>                 depending on the value of uplo.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. Normal use is strideA >=
   !>                 lda*n.
-  !>     @param[out]
-  !>     B           pointer to type. Array on the GPU (the size depends on the value of strideB).
+  !>     @param[out] B - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideB).
   !>                 On entry, the symmetric positive definite matrices B_l. On exit, the
   !>                 triangular factor of B_l, as returned by \ref rocsolver_spotrf_strided_batched
   !>                 "POTRF_STRIDED_BATCHED".
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 Specifies the leading dimension of B_l.
-  !>     @param[in]
-  !>     strideB     rocblas_stride.
+  !>     @param[in] strideB - rocblas_stride.
   !>                 Stride from the start of one matrix B_l to the next one B_(l+1).
   !>                 There is no restriction for the value of strideB. Normal usage is strideB >=
   !>                 ldb*n.
-  !>     @param[in]
-  !>     abstol      type.
+  !>     @param[in] abstol - type.
   !>                 The absolute tolerance. The algorithm is considered to have converged once the
   !>                 residual
   !>                 is <= abstol. If abstol <= 0, then the tolerance will be set to machine
   !>                 precision.
-  !>     @param[out]
-  !>     residual    pointer to type. Array of batch_count scalars on the GPU.
+  !>     @param[out] residual - pointer to type. Array of batch_count scalars on the GPU.
   !>                 The Frobenius norm of the off-diagonal elements at the final iteration for each
   !>                 batch instance.
-  !>     @param[in]
-  !>     max_sweeps  rocblas_int. max_sweeps > 0.
+  !>     @param[in] max_sweeps - rocblas_int. max_sweeps > 0.
   !>                 Maximum number of sweeps (iterations) to be used by the algorithm.
-  !>     @param[out]
-  !>     n_sweeps    pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] n_sweeps - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 The actual number of sweeps (iterations) used by the algorithm for each batch
   !>                 instance.
-  !>     @param[out]
-  !>     W           pointer to type. Array on the GPU (the size depends on the value of strideW).
+  !>     @param[out] W - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideW).
   !>                 On exit, the eigenvalues in increasing order.
-  !>     @param[in]
-  !>     strideW     rocblas_stride.
+  !>     @param[in] strideW - rocblas_stride.
   !>                 Stride from the start of one vector W_l to the next one W_(l+1).
   !>                 There is no restriction for the value of strideW. Normal usage is strideW >= n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit of batch l.
   !>                 If info[l] = 1, the algorithm did not converge.
   !>                 If info[l] = n + i, the leading minor of order i of B_l is not
   !>                 positive definite.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_ssygvj_strided_batched
     function rocsolver_ssygvj_strided_batched_(handle,itype,evect,uplo,n,A,lda,strideA,B,ldb, &
@@ -36629,84 +34539,68 @@ module hipfort_rocsolver
   !>         \end{array}
   !>     \f]
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     itype       `rocblas_eform`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] itype - `rocblas_eform`.
   !>                 Specifies the form of the generalized eigenproblems.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower parts of the matrices
   !>                 A_l and B_l are stored. If uplo indicates lower (or upper),
   !>                 then the upper (or lower) parts of A_l and B_l are not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The matrix dimensions.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the Hermitian matrices A_l. On exit, if evect is original,
   !>                 the normalized matrix Z_l of eigenvectors. If evect is none, then the upper or
   !>                 lower triangular
   !>                 part of the matrices A_l (including the diagonal) are destroyed,
   !>                 depending on the value of uplo.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. Normal usage is strideA >=
   !>                 lda*n.
-  !>     @param[out]
-  !>     B           pointer to type. Array on the GPU (the size depends on the value of strideB).
+  !>     @param[out] B - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideB).
   !>                 On entry, the Hermitian positive definite matrices B_l. On exit, the
   !>                 triangular factor of B_l, as returned by \ref rocsolver_spotrf_strided_batched
   !>                 "POTRF_STRIDED_BATCHED".
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 Specifies the leading dimension of B_l.
-  !>     @param[in]
-  !>     strideB     rocblas_stride.
+  !>     @param[in] strideB - rocblas_stride.
   !>                 Stride from the start of one matrix B_l to the next one B_(l+1).
   !>                 There is no restriction for the value of strideB. Normal usage is strideB >=
   !>                 ldb*n.
-  !>     @param[in]
-  !>     abstol      real type.
+  !>     @param[in] abstol - real type.
   !>                 The absolute tolerance. The algorithm is considered to have converged once the
   !>                 residual
   !>                 is <= abstol. If abstol <= 0, then the tolerance will be set to machine
   !>                 precision.
-  !>     @param[out]
-  !>     residual    pointer to real type. Array of batch_count scalars on the GPU.
+  !>     @param[out] residual - pointer to real type. Array of batch_count scalars on the GPU.
   !>                 The Frobenius norm of the off-diagonal elements at the final iteration for each
   !>                 batch instance.
-  !>     @param[in]
-  !>     max_sweeps  rocblas_int. max_sweeps > 0.
+  !>     @param[in] max_sweeps - rocblas_int. max_sweeps > 0.
   !>                 Maximum number of sweeps (iterations) to be used by the algorithm.
-  !>     @param[out]
-  !>     n_sweeps    pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] n_sweeps - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 The actual number of sweeps (iterations) used by the algorithm for each batch
   !>                 instance.
-  !>     @param[out]
-  !>     W pointer to real type. Array on the GPU (the size depends on the value of strideW).
+  !>     @param[out] W - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideW).
   !>                 On exit, the eigenvalues in increasing order.
-  !>     @param[in]
-  !>     strideW     rocblas_stride.
+  !>     @param[in] strideW - rocblas_stride.
   !>                 Stride from the start of one vector W_l to the next one W_(l+1).
   !>                 There is no restriction for the value of strideW. Normal usage is strideW >= n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit of batch l.
   !>                 If info[l] = 1, the algorithm did not converge.
   !>                 If info[l] = n + i, the leading minor of order i of B_l is not
   !>                 positive definite.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_chegvj_strided_batched
     function rocsolver_chegvj_strided_batched_(handle,itype,evect,uplo,n,A,lda,strideA,B,ldb, &
@@ -36803,62 +34697,47 @@ module hipfort_rocsolver
   !>     ``evect`` is ``rocblas_evect_original``,
   !>     the eigenvectors for these eigenvalues will be computed as well.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     itype       `rocblas_eform`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] itype - `rocblas_eform`.
   !>                 Specifies the form of the generalized eigenproblem.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     erange      `rocblas_erange`.
+  !>     @param[in] erange - `rocblas_erange`.
   !>                 Specifies the type of range or interval of the eigenvalues to be computed.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower parts of the matrices
   !>                 A and B are stored. If uplo indicates lower (or upper),
   !>                 then the upper (or lower) parts of A and B are not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The matrix dimensions.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the matrix A. On exit, the contents of A are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrix A.
-  !>     @param[out]
-  !>     B           pointer to type. Array on the GPU of dimension ldb*n.
+  !>     @param[out] B - pointer to type. Array on the GPU of dimension ldb*n.
   !>                 On entry, the symmetric positive definite matrix B. On exit, the
   !>                 triangular factor of B as returned by \ref rocsolver_spotrf "POTRF".
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 Specifies the leading dimension of B.
-  !>     @param[in]
-  !>     vl          type. vl < vu.
+  !>     @param[in] vl - type. vl < vu.
   !>                 The lower bound of the search interval (vl, vu]. Ignored if range indicates to
   !>                 look
   !>                 for all the eigenvalues of A or the eigenvalues within a set of indices.
-  !>     @param[in]
-  !>     vu          type. vl < vu.
+  !>     @param[in] vu - type. vl < vu.
   !>                 The upper bound of the search interval (vl, vu]. Ignored if range indicates to
   !>                 look
   !>                 for all the eigenvalues of A or the eigenvalues within a set of indices.
-  !>     @param[in]
-  !>     il          rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] il - rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the smallest eigenvalue to be computed. Ignored if range indicates
   !>                 to look
   !>                 for all the eigenvalues of A or the eigenvalues in a half-open interval.
-  !>     @param[in]
-  !>     iu          rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] iu - rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the largest eigenvalue to be computed. Ignored if range indicates
   !>                 to look
   !>                 for all the eigenvalues of A or the eigenvalues in a half-open interval.
-  !>     @param[in]
-  !>     abstol      type.
+  !>     @param[in] abstol - type.
   !>                 The absolute tolerance. An eigenvalue is considered to be located if it lies
   !>                 in an interval whose width is <= abstol. If abstol is negative, then
   !>                 machine-epsilon times
@@ -36866,18 +34745,15 @@ module hipfort_rocsolver
   !>                 abstol=0, then the tolerance will be set
   !>                 to twice the underflow threshold. This is the tolerance that could get the most
   !>                 accurate results.
-  !>     @param[out]
-  !>     nev         pointer to a rocblas_int on the GPU.
+  !>     @param[out] nev - pointer to a rocblas_int on the GPU.
   !>                 The total number of eigenvalues found. If erange is rocblas_erange_all, nev =
   !>                 n.
   !>                 If erange is rocblas_erange_index, nev = iu - il + 1. Otherwise, 0 <= nev <= n.
-  !>     @param[out]
-  !>     W           pointer to type. Array on the GPU of dimension n.
+  !>     @param[out] W - pointer to type. Array on the GPU of dimension n.
   !>                 The first nev elements contain the computed eigenvalues. (The remaining
   !>                 elements
   !>                 can be used as workspace for internal computations.)
-  !>     @param[out]
-  !>     Z           pointer to type. Array on the GPU of dimension ldz*nev.
+  !>     @param[out] Z - pointer to type. Array on the GPU of dimension ldz*nev.
   !>                 On exit, if evect is not rocblas_evect_none and info = 0, the first nev columns
   !>                 contain
   !>                 the eigenvectors of A corresponding to the output eigenvalues. Not referenced
@@ -36888,17 +34764,14 @@ module hipfort_rocsolver
   !>                 The user should ensure that Z is large enough to hold n columns, as all n
   !>                 columns
   !>                 can be used as workspace for internal computations.
-  !>     @param[in]
-  !>     ldz         rocblas_int. ldz >= n.
+  !>     @param[in] ldz - rocblas_int. ldz >= n.
   !>                 Specifies the leading dimension of matrix Z.
-  !>     @param[out]
-  !>     ifail       pointer to rocblas_int. Array on the GPU of dimension n.
+  !>     @param[out] ifail - pointer to rocblas_int. Array on the GPU of dimension n.
   !>                 If info = 0, the first nev elements of ifail are zero.
   !>                 If info = i <= n, ifail contains the indices of the i eigenvectors that failed
   !>                 to converge.
   !>                 Not referenced if evect is rocblas_evect_none.
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info = 0, successful exit.
   !>                 If info = i <= n, i columns of Z did not converge.
   !>                 If info = n + i, the leading minor of order i of B is not
@@ -37002,62 +34875,47 @@ module hipfort_rocsolver
   !>     ``evect`` is ``rocblas_evect_original``,
   !>     the eigenvectors for these eigenvalues will be computed as well.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     itype       `rocblas_eform`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] itype - `rocblas_eform`.
   !>                 Specifies the form of the generalized eigenproblem.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     erange      `rocblas_erange`.
+  !>     @param[in] erange - `rocblas_erange`.
   !>                 Specifies the type of range or interval of the eigenvalues to be computed.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower parts of the matrices
   !>                 A and B are stored. If uplo indicates lower (or upper),
   !>                 then the upper (or lower) parts of A and B are not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The matrix dimensions.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the matrix A. On exit, the contents of A are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrix A.
-  !>     @param[out]
-  !>     B           pointer to type. Array on the GPU of dimension ldb*n.
+  !>     @param[out] B - pointer to type. Array on the GPU of dimension ldb*n.
   !>                 On entry, the Hermitian positive definite matrix B. On exit, the
   !>                 triangular factor of B, as returned by \ref rocsolver_spotrf "POTRF".
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 Specifies the leading dimension of B.
-  !>     @param[in]
-  !>     vl          real type. vl < vu.
+  !>     @param[in] vl - real type. vl < vu.
   !>                 The lower bound of the search interval (vl, vu]. Ignored if range indicates to
   !>                 look
   !>                 for all the eigenvalues of A or the eigenvalues within a set of indices.
-  !>     @param[in]
-  !>     vu          real type. vl < vu.
+  !>     @param[in] vu - real type. vl < vu.
   !>                 The upper bound of the search interval (vl, vu]. Ignored if range indicates to
   !>                 look
   !>                 for all the eigenvalues of A or the eigenvalues within a set of indices.
-  !>     @param[in]
-  !>     il          rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] il - rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the smallest eigenvalue to be computed. Ignored if range indicates
   !>                 to look
   !>                 for all the eigenvalues of A or the eigenvalues in a half-open interval.
-  !>     @param[in]
-  !>     iu          rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] iu - rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the largest eigenvalue to be computed. Ignored if range indicates
   !>                 to look
   !>                 for all the eigenvalues of A or the eigenvalues in a half-open interval.
-  !>     @param[in]
-  !>     abstol      real type.
+  !>     @param[in] abstol - real type.
   !>                 The absolute tolerance. An eigenvalue is considered to be located if it lies
   !>                 in an interval whose width is <= abstol. If abstol is negative, then
   !>                 machine-epsilon times
@@ -37065,18 +34923,15 @@ module hipfort_rocsolver
   !>                 abstol=0, then the tolerance will be set
   !>                 to twice the underflow threshold. This is the tolerance that could get the most
   !>                 accurate results.
-  !>     @param[out]
-  !>     nev         pointer to a rocblas_int on the GPU.
+  !>     @param[out] nev - pointer to a rocblas_int on the GPU.
   !>                 The total number of eigenvalues found. If erange is rocblas_erange_all, nev =
   !>                 n.
   !>                 If erange is rocblas_erange_index, nev = iu - il + 1. Otherwise, 0 <= nev <= n.
-  !>     @param[out]
-  !>     W           pointer to real type. Array on the GPU of dimension n.
+  !>     @param[out] W - pointer to real type. Array on the GPU of dimension n.
   !>                 The first nev elements contain the computed eigenvalues. (The remaining
   !>                 elements
   !>                 can be used as workspace for internal computations.)
-  !>     @param[out]
-  !>     Z           pointer to type. Array on the GPU of dimension ldz*nev.
+  !>     @param[out] Z - pointer to type. Array on the GPU of dimension ldz*nev.
   !>                 On exit, if evect is not rocblas_evect_none and info = 0, the first nev columns
   !>                 contain
   !>                 the eigenvectors of A corresponding to the output eigenvalues. Not referenced
@@ -37087,17 +34942,14 @@ module hipfort_rocsolver
   !>                 The user should ensure that Z is large enough to hold n columns, as all n
   !>                 columns
   !>                 can be used as workspace for internal computations.
-  !>     @param[in]
-  !>     ldz         rocblas_int. ldz >= n.
+  !>     @param[in] ldz - rocblas_int. ldz >= n.
   !>                 Specifies the leading dimension of matrix Z.
-  !>     @param[out]
-  !>     ifail       pointer to rocblas_int. Array on the GPU of dimension n.
+  !>     @param[out] ifail - pointer to rocblas_int. Array on the GPU of dimension n.
   !>                 If info = 0, the first nev elements of ifail are zero.
   !>                 If info = i <= n, ifail contains the indices of the i eigenvectors that failed
   !>                 to converge.
   !>                 Not referenced if evect is rocblas_evect_none.
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info = 0, successful exit.
   !>                 If info = i <= n, i columns of Z did not converge.
   !>                 If info = n + i, the leading minor of order i of B is not
@@ -37201,63 +35053,50 @@ module hipfort_rocsolver
   !>     ``evect`` is ``rocblas_evect_original``,
   !>     the eigenvectors for these eigenvalues will be computed as well.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     itype       `rocblas_eform`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] itype - `rocblas_eform`.
   !>                 Specifies the form of the generalized eigenproblems.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     erange      `rocblas_erange`.
+  !>     @param[in] erange - `rocblas_erange`.
   !>                 Specifies the type of range or interval of the eigenvalues to be computed.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower parts of the matrices
   !>                 A_l and B_l are stored. If uplo indicates lower (or upper),
   !>                 then the upper (or lower) parts of A_l and B_l are not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The matrix dimensions.
-  !>     @param[inout]
-  !>     A Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - Array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the matrices A_l. On exit, the contents of A_l are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[out]
-  !>     B Array of pointers to type. Each pointer points to an array on the GPU of dimension ldb*n.
+  !>     @param[out] B - Array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension ldb*n.
   !>                 On entry, the symmetric positive definite matrices B_l. On exit, the
   !>                 triangular factor of B_l as returned by \ref rocsolver_spotrf_batched
   !>                 "POTRF_BATCHED".
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 Specifies the leading dimension of B_l.
-  !>     @param[in]
-  !>     vl          type. vl < vu.
+  !>     @param[in] vl - type. vl < vu.
   !>                 The lower bound of the search interval (vl, vu]. Ignored if range indicates to
   !>                 look
   !>                 for all the eigenvalues of A_l or the eigenvalues within a set of indices.
-  !>     @param[in]
-  !>     vu          type. vl < vu.
+  !>     @param[in] vu - type. vl < vu.
   !>                 The upper bound of the search interval (vl, vu]. Ignored if range indicates to
   !>                 look
   !>                 for all the eigenvalues of A_l or the eigenvalues within a set of indices.
-  !>     @param[in]
-  !>     il          rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] il - rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the smallest eigenvalue to be computed. Ignored if range indicates
   !>                 to look
   !>                 for all the eigenvalues of A_l or the eigenvalues in a half-open interval.
-  !>     @param[in]
-  !>     iu          rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] iu - rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the largest eigenvalue to be computed. Ignored if range indicates
   !>                 to look
   !>                 for all the eigenvalues of A_l or the eigenvalues in a half-open interval.
-  !>     @param[in]
-  !>     abstol      type.
+  !>     @param[in] abstol - type.
   !>                 The absolute tolerance. An eigenvalue is considered to be located if it lies
   !>                 in an interval whose width is <= abstol. If abstol is negative, then
   !>                 machine-epsilon times
@@ -37265,25 +35104,22 @@ module hipfort_rocsolver
   !>                 abstol=0, then the tolerance will be set
   !>                 to twice the underflow threshold. This is the tolerance that could get the most
   !>                 accurate results.
-  !>     @param[out]
-  !>     nev         pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] nev - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 The total number of eigenvalues found. If erange is rocblas_erange_all, nev[l]
   !>                 = n.
   !>                 If erange is rocblas_erange_index, nev[l] = iu - il + 1. Otherwise, 0 <= nev[l]
   !>                 <= n.
-  !>     @param[out]
-  !>     W           pointer to type. Array on the GPU (the size depends on the value of strideW).
+  !>     @param[out] W - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideW).
   !>                 The first nev[l] elements contain the computed eigenvalues. (The remaining
   !>                 elements
   !>                 can be used as workspace for internal computations.)
-  !>     @param[in]
-  !>     strideW     rocblas_stride.
+  !>     @param[in] strideW - rocblas_stride.
   !>                 Stride from the start of one vector W_l to the next one W_(l+1).
   !>                 There is no restriction for the value of strideW. The normal use case is
   !>                 strideW >= n.
-  !>     @param[out]
-  !>     Z Array of pointers to type. Each pointer points to an array on the GPU of dimension
-  !>     ldz*nev[l].
+  !>     @param[out] Z - Array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension ldz*nev[l].
   !>                 On exit, if evect is not rocblas_evect_none and info[l] = 0, the first nev[l]
   !>                 columns contain
   !>                 the eigenvectors of A_l corresponding to the output eigenvalues. Not referenced
@@ -37294,29 +35130,25 @@ module hipfort_rocsolver
   !>                 The user should ensure that Z_l is large enough to hold n columns, as all n
   !>                 columns
   !>                 can be used as workspace for internal computations.
-  !>     @param[in]
-  !>     ldz         rocblas_int. ldz >= n.
+  !>     @param[in] ldz - rocblas_int. ldz >= n.
   !>                 Specifies the leading dimension of matrices Z_l.
-  !>     @param[out]
-  !>     ifail pointer to rocblas_int. Array on the GPU (the size depends on the value of strideF).
+  !>     @param[out] ifail - pointer to rocblas_int. Array on the GPU (the size depends on the value
+  !>     of strideF).
   !>                 If info[l] = 0, the first nev[l] elements of ifail_l are zero.
   !>                 If info[l] = i <= n, ifail_l contains the indices of the i eigenvectors that
   !>                 failed
   !>                 to converge.
   !>                 Not referenced if evect is rocblas_evect_none.
-  !>     @param[in]
-  !>     strideF     rocblas_stride.
+  !>     @param[in] strideF - rocblas_stride.
   !>                 Stride from the start of one vector ifail_l to the next one ifail_(l+1).
   !>                 There is no restriction for the value of strideF. The normal use case is
   !>                 strideF >= n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit of batch instance l.
   !>                 If info[l] = i <= n, i columns of Z_l did not converge.
   !>                 If info[l] = n + i, the leading minor of order i of B_l is not
   !>                 positive definite.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_ssygvx_batched
     function rocsolver_ssygvx_batched_(handle,itype,evect,erange,uplo,n,A,lda,B,ldb,vl,vu,il,iu, &
@@ -37423,63 +35255,50 @@ module hipfort_rocsolver
   !>     ``evect`` is ``rocblas_evect_original``,
   !>     the eigenvectors for these eigenvalues will be computed as well.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     itype       `rocblas_eform`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] itype - `rocblas_eform`.
   !>                 Specifies the form of the generalized eigenproblems.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     erange      `rocblas_erange`.
+  !>     @param[in] erange - `rocblas_erange`.
   !>                 Specifies the type of range or interval of the eigenvalues to be computed.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower parts of the matrices
   !>                 A_l and B_l are stored. If uplo indicates lower (or upper),
   !>                 then the upper (or lower) parts of A_l and B_l are not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The matrix dimensions.
-  !>     @param[inout]
-  !>     A Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - Array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the matrices A_l. On exit, the contents of A_l are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[out]
-  !>     B Array of pointers to type. Each pointer points to an array on the GPU of dimension ldb*n.
+  !>     @param[out] B - Array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension ldb*n.
   !>                 On entry, the Hermitian positive definite matrices B_l. On exit, the
   !>                 triangular factor of B_l as returned by \ref rocsolver_spotrf_batched
   !>                 "POTRF_BATCHED".
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 Specifies the leading dimension of B_l.
-  !>     @param[in]
-  !>     vl          real type. vl < vu.
+  !>     @param[in] vl - real type. vl < vu.
   !>                 The lower bound of the search interval (vl, vu]. Ignored if range indicates to
   !>                 look
   !>                 for all the eigenvalues of A_l or the eigenvalues within a set of indices.
-  !>     @param[in]
-  !>     vu          real type. vl < vu.
+  !>     @param[in] vu - real type. vl < vu.
   !>                 The upper bound of the search interval (vl, vu]. Ignored if range indicates to
   !>                 look
   !>                 for all the eigenvalues of A_l or the eigenvalues within a set of indices.
-  !>     @param[in]
-  !>     il          rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] il - rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the smallest eigenvalue to be computed. Ignored if range indicates
   !>                 to look
   !>                 for all the eigenvalues of A_l or the eigenvalues in a half-open interval.
-  !>     @param[in]
-  !>     iu          rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] iu - rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the largest eigenvalue to be computed. Ignored if range indicates
   !>                 to look
   !>                 for all the eigenvalues of A_l or the eigenvalues in a half-open interval.
-  !>     @param[in]
-  !>     abstol      real type.
+  !>     @param[in] abstol - real type.
   !>                 The absolute tolerance. An eigenvalue is considered to be located if it lies
   !>                 in an interval whose width is <= abstol. If abstol is negative, then
   !>                 machine-epsilon times
@@ -37487,25 +35306,22 @@ module hipfort_rocsolver
   !>                 abstol=0, then the tolerance will be set
   !>                 to twice the underflow threshold. This is the tolerance that could get the most
   !>                 accurate results.
-  !>     @param[out]
-  !>     nev         pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] nev - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 The total number of eigenvalues found. If erange is rocblas_erange_all, nev[l]
   !>                 = n.
   !>                 If erange is rocblas_erange_index, nev[l] = iu - il + 1. Otherwise, 0 <= nev[l]
   !>                 <= n.
-  !>     @param[out]
-  !>     W pointer to real type. Array on the GPU (the size depends on the value of strideW).
+  !>     @param[out] W - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideW).
   !>                 The first nev[l] elements contain the computed eigenvalues. (The remaining
   !>                 elements
   !>                 can be used as workspace for internal computations.)
-  !>     @param[in]
-  !>     strideW     rocblas_stride.
+  !>     @param[in] strideW - rocblas_stride.
   !>                 Stride from the start of one vector W_l to the next one W_(l+1).
   !>                 There is no restriction for the value of strideW. The normal use case is
   !>                 strideW >= n.
-  !>     @param[out]
-  !>     Z Array of pointers to type. Each pointer points to an array on the GPU of dimension
-  !>     ldz*nev[l].
+  !>     @param[out] Z - Array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension ldz*nev[l].
   !>                 On exit, if evect is not rocblas_evect_none and info[l] = 0, the first nev[l]
   !>                 columns contain
   !>                 the eigenvectors of A_l corresponding to the output eigenvalues. Not referenced
@@ -37516,29 +35332,25 @@ module hipfort_rocsolver
   !>                 The user should ensure that Z_l is large enough to hold n columns, as all n
   !>                 columns
   !>                 can be used as workspace for internal computations.
-  !>     @param[in]
-  !>     ldz         rocblas_int. ldz >= n.
+  !>     @param[in] ldz - rocblas_int. ldz >= n.
   !>                 Specifies the leading dimension of matrices Z_l.
-  !>     @param[out]
-  !>     ifail pointer to rocblas_int. Array on the GPU (the size depends on the value of strideF).
+  !>     @param[out] ifail - pointer to rocblas_int. Array on the GPU (the size depends on the value
+  !>     of strideF).
   !>                 If info[l] = 0, the first nev[l] elements of ifail_l are zero.
   !>                 If info[l] = i <= n, ifail_l contains the indices of the i eigenvectors that
   !>                 failed
   !>                 to converge.
   !>                 Not referenced if evect is rocblas_evect_none.
-  !>     @param[in]
-  !>     strideF     rocblas_stride.
+  !>     @param[in] strideF - rocblas_stride.
   !>                 Stride from the start of one vector ifail_l to the next one ifail_(l+1).
   !>                 There is no restriction for the value of strideF. The normal use case is
   !>                 strideF >= n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit of batch instance l.
   !>                 If info[l] = i <= n, i columns of Z_l did not converge.
   !>                 If info[l] = n + i, the leading minor of order i of B_l is not
   !>                 positive definite.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_chegvx_batched
     function rocsolver_chegvx_batched_(handle,itype,evect,erange,uplo,n,A,lda,B,ldb,vl,vu,il,iu, &
@@ -37645,73 +35457,58 @@ module hipfort_rocsolver
   !>     ``evect`` is ``rocblas_evect_original``,
   !>     the eigenvectors for these eigenvalues will be computed as well.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     itype       `rocblas_eform`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] itype - `rocblas_eform`.
   !>                 Specifies the form of the generalized eigenproblems.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     erange      `rocblas_erange`.
+  !>     @param[in] erange - `rocblas_erange`.
   !>                 Specifies the type of range or interval of the eigenvalues to be computed.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower parts of the matrices
   !>                 A_l and B_l are stored. If uplo indicates lower (or upper),
   !>                 then the upper (or lower) parts of A_l and B_l are not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The matrix dimensions.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the matrices A_l. On exit, the contents of A_l are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[out]
-  !>     B           pointer to type. Array on the GPU (the size depends on the value of strideB).
+  !>     @param[out] B - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideB).
   !>                 On entry, the symmetric positive definite matrices B_l. On exit, the
   !>                 triangular factor of B_l as returned by \ref rocsolver_spotrf_strided_batched
   !>                 "POTRF_STRIDED_BATCHED".
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 Specifies the leading dimension of B_l.
-  !>     @param[in]
-  !>     strideB     rocblas_stride.
+  !>     @param[in] strideB - rocblas_stride.
   !>                 Stride from the start of one matrix B_l to the next one B_(l+1).
   !>                 There is no restriction for the value of strideB. The normal use case is
   !>                 strideB >= ldb*n.
-  !>     @param[in]
-  !>     vl          type. vl < vu.
+  !>     @param[in] vl - type. vl < vu.
   !>                 The lower bound of the search interval (vl, vu]. Ignored if range indicates to
   !>                 look
   !>                 for all the eigenvalues of A_l or the eigenvalues within a set of indices.
-  !>     @param[in]
-  !>     vu          type. vl < vu.
+  !>     @param[in] vu - type. vl < vu.
   !>                 The upper bound of the search interval (vl, vu]. Ignored if range indicates to
   !>                 look
   !>                 for all the eigenvalues of A_l or the eigenvalues within a set of indices.
-  !>     @param[in]
-  !>     il          rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] il - rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the smallest eigenvalue to be computed. Ignored if range indicates
   !>                 to look
   !>                 for all the eigenvalues of A_l or the eigenvalues in a half-open interval.
-  !>     @param[in]
-  !>     iu          rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] iu - rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the largest eigenvalue to be computed. Ignored if range indicates
   !>                 to look
   !>                 for all the eigenvalues of A_l or the eigenvalues in a half-open interval.
-  !>     @param[in]
-  !>     abstol      type.
+  !>     @param[in] abstol - type.
   !>                 The absolute tolerance. An eigenvalue is considered to be located if it lies
   !>                 in an interval whose width is <= abstol. If abstol is negative, then
   !>                 machine-epsilon times
@@ -37719,34 +35516,30 @@ module hipfort_rocsolver
   !>                 abstol=0, then the tolerance will be set
   !>                 to twice the underflow threshold. This is the tolerance that could get the most
   !>                 accurate results.
-  !>     @param[out]
-  !>     nev         pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] nev - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 The total number of eigenvalues found. If erange is rocblas_erange_all, nev[l]
   !>                 = n.
   !>                 If erange is rocblas_erange_index, nev[l] = iu - il + 1. Otherwise, 0 <= nev[l]
   !>                 <= n.
-  !>     @param[out]
-  !>     W           pointer to type. Array on the GPU (the size depends on the value of strideW).
+  !>     @param[out] W - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideW).
   !>                 The first nev[l] elements contain the computed eigenvalues. (The remaining
   !>                 elements
   !>                 can be used as workspace for internal computations.)
-  !>     @param[in]
-  !>     strideW     rocblas_stride.
+  !>     @param[in] strideW - rocblas_stride.
   !>                 Stride from the start of one vector W_l to the next one W_(l+1).
   !>                 There is no restriction for the value of strideW. The normal use case is
   !>                 strideW >= n.
-  !>     @param[out]
-  !>     Z           pointer to type. Array on the GPU (the size depends on the value of strideZ).
+  !>     @param[out] Z - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideZ).
   !>                 On exit, if evect is not rocblas_evect_none and info[l] = 0, the first nev[l]
   !>                 columns contain
   !>                 the eigenvectors of A_l corresponding to the output eigenvalues. Not referenced
   !>                 if
   !>                 evect is rocblas_evect_none.
-  !>     @param[in]
-  !>     ldz         rocblas_int. ldz >= n.
+  !>     @param[in] ldz - rocblas_int. ldz >= n.
   !>                 Specifies the leading dimension of matrices Z_l.
-  !>     @param[in]
-  !>     strideZ     rocblas_stride.
+  !>     @param[in] strideZ - rocblas_stride.
   !>                 Stride from the start of one matrix Z_l to the next one Z_(l+1).
   !>                 There is no restriction for the value of strideZ. The normal use case is
   !>                 strideZ >= ldz*nev[l].
@@ -37755,26 +35548,23 @@ module hipfort_rocsolver
   !>                 The user should ensure that Z_l is large enough to hold n columns, as all n
   !>                 columns
   !>                 can be used as workspace for internal computations.
-  !>     @param[out]
-  !>     ifail pointer to rocblas_int. Array on the GPU (the size depends on the value of strideF).
+  !>     @param[out] ifail - pointer to rocblas_int. Array on the GPU (the size depends on the value
+  !>     of strideF).
   !>                 If info[l] = 0, the first nev[l] elements of ifail_l are zero.
   !>                 If info[l] = i <= n, ifail_l contains the indices of the i eigenvectors that
   !>                 failed
   !>                 to converge.
   !>                 Not referenced if evect is rocblas_evect_none.
-  !>     @param[in]
-  !>     strideF     rocblas_stride.
+  !>     @param[in] strideF - rocblas_stride.
   !>                 Stride from the start of one vector ifail_l to the next one ifail_(l+1).
   !>                 There is no restriction for the value of strideF. The normal use case is
   !>                 strideF >= n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit of batch l.
   !>                 If info[l] = i <= n, i columns of Z_l did not converge.
   !>                 If info[l] = n + i, the leading minor of order i of B_l is not
   !>                 positive definite.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_ssygvx_strided_batched
     function rocsolver_ssygvx_strided_batched_(handle,itype,evect,erange,uplo,n,A,lda,strideA,B, &
@@ -37889,73 +35679,58 @@ module hipfort_rocsolver
   !>     ``evect`` is ``rocblas_evect_original``,
   !>     the eigenvectors for these eigenvalues will be computed as well.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     itype       `rocblas_eform`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] itype - `rocblas_eform`.
   !>                 Specifies the form of the generalized eigenproblems.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     erange      `rocblas_erange`.
+  !>     @param[in] erange - `rocblas_erange`.
   !>                 Specifies the type of range or interval of the eigenvalues to be computed.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower parts of the matrices
   !>                 A_l and B_l are stored. If uplo indicates lower (or upper),
   !>                 then the upper (or lower) parts of A_l and B_l are not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The matrix dimensions.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the matrices A_l. On exit, the contents of A_l are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[out]
-  !>     B           pointer to type. Array on the GPU (the size depends on the value of strideB).
+  !>     @param[out] B - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideB).
   !>                 On entry, the Hermitian positive definite matrices B_l. On exit, the
   !>                 triangular factor of B_l as returned by \ref rocsolver_spotrf_strided_batched
   !>                 "POTRF_STRIDED_BATCHED".
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 Specifies the leading dimension of B_l.
-  !>     @param[in]
-  !>     strideB     rocblas_stride.
+  !>     @param[in] strideB - rocblas_stride.
   !>                 Stride from the start of one matrix B_l to the next one B_(l+1).
   !>                 There is no restriction for the value of strideB. The normal use case is
   !>                 strideB >= ldb*n.
-  !>     @param[in]
-  !>     vl          real type. vl < vu.
+  !>     @param[in] vl - real type. vl < vu.
   !>                 The lower bound of the search interval (vl, vu]. Ignored if range indicates to
   !>                 look
   !>                 for all the eigenvalues of A_l or the eigenvalues within a set of indices.
-  !>     @param[in]
-  !>     vu          real type. vl < vu.
+  !>     @param[in] vu - real type. vl < vu.
   !>                 The upper bound of the search interval (vl, vu]. Ignored if range indicates to
   !>                 look
   !>                 for all the eigenvalues of A_l or the eigenvalues within a set of indices.
-  !>     @param[in]
-  !>     il          rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] il - rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the smallest eigenvalue to be computed. Ignored if range indicates
   !>                 to look
   !>                 for all the eigenvalues of A_l or the eigenvalues in a half-open interval.
-  !>     @param[in]
-  !>     iu          rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] iu - rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the largest eigenvalue to be computed. Ignored if range indicates
   !>                 to look
   !>                 for all the eigenvalues of A_l or the eigenvalues in a half-open interval.
-  !>     @param[in]
-  !>     abstol      real type.
+  !>     @param[in] abstol - real type.
   !>                 The absolute tolerance. An eigenvalue is considered to be located if it lies
   !>                 in an interval whose width is <= abstol. If abstol is negative, then
   !>                 machine-epsilon times
@@ -37963,34 +35738,30 @@ module hipfort_rocsolver
   !>                 abstol=0, then the tolerance will be set
   !>                 to twice the underflow threshold. This is the tolerance that could get the most
   !>                 accurate results.
-  !>     @param[out]
-  !>     nev         pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] nev - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 The total number of eigenvalues found. If erange is rocblas_erange_all, nev[l]
   !>                 = n.
   !>                 If erange is rocblas_erange_index, nev[l] = iu - il + 1. Otherwise, 0 <= nev[l]
   !>                 <= n.
-  !>     @param[out]
-  !>     W pointer to real type. Array on the GPU (the size depends on the value of strideW).
+  !>     @param[out] W - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideW).
   !>                 The first nev[l] elements contain the computed eigenvalues. (The remaining
   !>                 elements
   !>                 can be used as workspace for internal computations.)
-  !>     @param[in]
-  !>     strideW     rocblas_stride.
+  !>     @param[in] strideW - rocblas_stride.
   !>                 Stride from the start of one vector W_l to the next one W_(l+1).
   !>                 There is no restriction for the value of strideW. The normal use case is
   !>                 strideW >= n.
-  !>     @param[out]
-  !>     Z           pointer to type. Array on the GPU (the size depends on the value of strideZ).
+  !>     @param[out] Z - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideZ).
   !>                 On exit, if evect is not rocblas_evect_none and info[l] = 0, the first nev[l]
   !>                 columns contain
   !>                 the eigenvectors of A_l corresponding to the output eigenvalues. Not referenced
   !>                 if
   !>                 evect is rocblas_evect_none.
-  !>     @param[in]
-  !>     ldz         rocblas_int. ldz >= n.
+  !>     @param[in] ldz - rocblas_int. ldz >= n.
   !>                 Specifies the leading dimension of matrices Z_l.
-  !>     @param[in]
-  !>     strideZ     rocblas_stride.
+  !>     @param[in] strideZ - rocblas_stride.
   !>                 Stride from the start of one matrix Z_l to the next one Z_(l+1).
   !>                 There is no restriction for the value of strideZ. The normal use case is
   !>                 strideZ >= ldz*nev[l].
@@ -37999,26 +35770,23 @@ module hipfort_rocsolver
   !>                 The user should ensure that Z_l is large enough to hold n columns, as all n
   !>                 columns
   !>                 can be used as workspace for internal computations.
-  !>     @param[out]
-  !>     ifail pointer to rocblas_int. Array on the GPU (the size depends on the value of strideF).
+  !>     @param[out] ifail - pointer to rocblas_int. Array on the GPU (the size depends on the value
+  !>     of strideF).
   !>                 If info[l] = 0, the first nev[l] elements of ifail_l are zero.
   !>                 If info[l] = i <= n, ifail_l contains the indices of the i eigenvectors that
   !>                 failed
   !>                 to converge.
   !>                 Not referenced if evect is rocblas_evect_none.
-  !>     @param[in]
-  !>     strideF     rocblas_stride.
+  !>     @param[in] strideF - rocblas_stride.
   !>                 Stride from the start of one vector ifail_l to the next one ifail_(l+1).
   !>                 There is no restriction for the value of strideF. The normal use case is
   !>                 strideF >= n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit of batch l.
   !>                 If info[l] = i <= n, i columns of Z_l did not converge.
   !>                 If info[l] = n + i, the leading minor of order i of B_l is not
   !>                 positive definite.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_chegvx_strided_batched
     function rocsolver_chegvx_strided_batched_(handle,itype,evect,erange,uplo,n,A,lda,strideA,B, &
@@ -38113,29 +35881,21 @@ module hipfort_rocsolver
   !>     where I is the identity matrix, and ``A`` is factorized as \f$A = PLU\f$, as given by \ref
   !>     rocsolver_sgetrf "GETRF".
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows and columns of the matrix A.
-  !>     @param[in]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[in] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 The factors L and U of the factorization \f$A = PLU\f$ returned by \ref
   !>                 rocsolver_sgetrf "GETRF".
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of A.
-  !>     @param[in]
-  !>     ipiv        pointer to rocblas_int. Array on the GPU of dimension n.
+  !>     @param[in] ipiv - pointer to rocblas_int. Array on the GPU of dimension n.
   !>                 The pivot indices returned by \ref rocsolver_sgetrf "GETRF".
-  !>     @param[out]
-  !>     C           pointer to type. Array on the GPU of dimension ldc*n.
+  !>     @param[out] C - pointer to type. Array on the GPU of dimension ldc*n.
   !>                 If info = 0, the inverse of A, and otherwise undefined.
-  !>     @param[in]
-  !>     ldc         rocblas_int. ldc >= n.
+  !>     @param[in] ldc - rocblas_int. ldc >= n.
   !>                 Specifies the leading dimension of C.
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info = 0, successful exit.
   !>                 If info = i > 0, U is singular. U[i,i] is the first zero pivot.
   interface rocsolver_sgetri_outofplace
@@ -38255,38 +36015,31 @@ module hipfort_rocsolver
   !>     where I is the identity matrix, and \f$A_l\f$ is factorized as \f$A_l = P_l L_l U_l\f$, as
   !>     given by \ref rocsolver_sgetrf_batched "GETRF_BATCHED".
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows and columns of all matrices A_l in the batch.
-  !>     @param[in]
-  !>     A array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[in] A - array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 The factors L_l and U_l of the factorization A_l = P_l*L_l*U_l returned by \ref
   !>                 rocsolver_sgetrf_batched "GETRF_BATCHED".
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     ipiv pointer to rocblas_int. Array on the GPU (the size depends on the value of strideP).
+  !>     @param[in] ipiv - pointer to rocblas_int. Array on the GPU (the size depends on the value
+  !>     of strideP).
   !>                 The pivot indices returned by \ref rocsolver_sgetrf_batched "GETRF_BATCHED".
-  !>     @param[in]
-  !>     strideP     rocblas_stride.
+  !>     @param[in] strideP - rocblas_stride.
   !>                 Stride from the start of one vector ipiv_l to the next one ipiv_(l+1).
   !>                 There is no restriction for the value of strideP. The normal use case is
   !>                 strideP >= n.
-  !>     @param[out]
-  !>     C array of pointers to type. Each pointer points to an array on the GPU of dimension ldc*n.
+  !>     @param[out] C - array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension ldc*n.
   !>                 If info[l] = 0, the inverse of matrices A_l, and otherwise undefined.
-  !>     @param[in]
-  !>     ldc         rocblas_int. ldc >= n.
+  !>     @param[in] ldc - rocblas_int. ldc >= n.
   !>                 Specifies the leading dimension of C_l.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for inversion of A_l.
   !>                 If info[l] = i > 0, U_l is singular. U_l[i,i] is the first zero pivot.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_sgetri_outofplace_batched
     function rocsolver_sgetri_outofplace_batched_(handle,n,A,lda,ipiv,strideP,C,ldc,myInfo, &
@@ -38413,49 +36166,40 @@ module hipfort_rocsolver
   !>     where I is the identity matrix, and \f$A_l\f$ is factorized as \f$A_l = P_l L_l U_l\f$, as
   !>     given by \ref rocsolver_sgetrf_strided_batched "GETRF_STRIDED_BATCHED".
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows and columns of all matrices A_l in the batch.
-  !>     @param[in]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[in] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 The factors L_l and U_l of the factorization A_l = P_l*L_l*U_l returned by
   !>                 \ref rocsolver_sgetrf_strided_batched "GETRF_STRIDED_BATCHED".
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[in]
-  !>     ipiv pointer to rocblas_int. Array on the GPU (the size depends on the value of strideP).
+  !>     @param[in] ipiv - pointer to rocblas_int. Array on the GPU (the size depends on the value
+  !>     of strideP).
   !>                 The pivot indices returned by \ref rocsolver_sgetrf_strided_batched
   !>                 "GETRF_STRIDED_BATCHED".
-  !>     @param[in]
-  !>     strideP     rocblas_stride.
+  !>     @param[in] strideP - rocblas_stride.
   !>                 Stride from the start of one vector ipiv_l to the next one ipiv_(l+1).
   !>                 There is no restriction for the value of strideP. The normal use case is
   !>                 strideP >= n.
-  !>     @param[out]
-  !>     C           pointer to type. Array on the GPU (the size depends on the value of strideC).
+  !>     @param[out] C - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideC).
   !>                 If info[l] = 0, the inverse of matrices A_l, and otherwise undefined.
-  !>     @param[in]
-  !>     ldc         rocblas_int. ldc >= n.
+  !>     @param[in] ldc - rocblas_int. ldc >= n.
   !>                 Specifies the leading dimension of C_l.
-  !>     @param[in]
-  !>     strideC     rocblas_stride.
+  !>     @param[in] strideC - rocblas_stride.
   !>                 Stride from the start of one matrix C_l to the next one C_(l+1).
   !>                 There is no restriction for the value of strideC. The normal use case is
   !>                 strideC >= ldc*n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for inversion of A_l.
   !>                 If info[l] = i > 0, U_l is singular. U_l[i,i] is the first zero pivot.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_sgetri_outofplace_strided_batched
     function rocsolver_sgetri_outofplace_strided_batched_(handle,n,A,lda,strideA,ipiv,strideP,C, &
@@ -38594,26 +36338,19 @@ module hipfort_rocsolver
   !>     where I is the identity matrix, and ``A`` is factorized as \f$A = LU\f$, as given by \ref
   !>     rocsolver_sgetrf_npvt "GETRF_NPVT".
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows and columns of the matrix A.
-  !>     @param[in]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[in] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 The factors L and U of the factorization \f$A = LU\f$ returned by \ref
   !>                 rocsolver_sgetrf_npvt "GETRF_NPVT".
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of A.
-  !>     @param[out]
-  !>     C           pointer to type. Array on the GPU of dimension ldc*n.
+  !>     @param[out] C - pointer to type. Array on the GPU of dimension ldc*n.
   !>                 If info = 0, the inverse of A, and otherwise undefined.
-  !>     @param[in]
-  !>     ldc         rocblas_int. ldc >= n.
+  !>     @param[in] ldc - rocblas_int. ldc >= n.
   !>                 Specifies the leading dimension of C.
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info = 0, successful exit.
   !>                 If info = i > 0, U is singular. U[i,i] is the first zero pivot.
   interface rocsolver_sgetri_npvt_outofplace
@@ -38730,30 +36467,24 @@ module hipfort_rocsolver
   !>     where I is the identity matrix, and \f$A_l\f$ is factorized as \f$A_l = L_l U_l\f$, as
   !>     given by \ref rocsolver_sgetrf_npvt_batched "GETRF_NPVT_BATCHED".
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows and columns of all matrices A_l in the batch.
-  !>     @param[in]
-  !>     A array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[in] A - array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 The factors L_l and U_l of the factorization A_l = L_l*U_l returned by \ref
   !>                 rocsolver_sgetrf_npvt_batched "GETRF_NPVT_BATCHED".
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[out]
-  !>     C array of pointers to type. Each pointer points to an array on the GPU of dimension ldc*n.
+  !>     @param[out] C - array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension ldc*n.
   !>                 If info[l] = 0, the inverse of matrices A_l, and otherwise undefined.
-  !>     @param[in]
-  !>     ldc         rocblas_int. ldc >= n.
+  !>     @param[in] ldc - rocblas_int. ldc >= n.
   !>                 Specifies the leading dimension of C_l.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for inversion of A_l.
   !>                 If info[l] = i > 0, U_l is singular. U_l[i,i] is the first zero pivot.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_sgetri_npvt_outofplace_batched
     function rocsolver_sgetri_npvt_outofplace_batched_(handle,n,A,lda,C,ldc,myInfo,batch_count) &
@@ -38845,40 +36576,32 @@ module hipfort_rocsolver
   !>     where I is the identity matrix, and \f$A_l\f$ is factorized as \f$A_l = L_l U_l\f$, as
   !>     given by \ref rocsolver_sgetrf_npvt_strided_batched "GETRF_NPVT_STRIDED_BATCHED".
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows and columns of all matrices A_l in the batch.
-  !>     @param[in]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[in] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 The factors L_l and U_l of the factorization A_l = L_l*U_l returned by
   !>                 \ref rocsolver_sgetrf_npvt_strided_batched "GETRF_NPVT_STRIDED_BATCHED".
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[out]
-  !>     C           pointer to type. Array on the GPU (the size depends on the value of strideC).
+  !>     @param[out] C - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideC).
   !>                 If info[l] = 0, the inverse of matrices A_l, and otherwise undefined.
-  !>     @param[in]
-  !>     ldc         rocblas_int. ldc >= n.
+  !>     @param[in] ldc - rocblas_int. ldc >= n.
   !>                 Specifies the leading dimension of C_l.
-  !>     @param[in]
-  !>     strideC     rocblas_stride.
+  !>     @param[in] strideC - rocblas_stride.
   !>                 Stride from the start of one matrix C_l to the next one C_(l+1).
   !>                 There is no restriction for the value of strideC. The normal use case is
   !>                 strideC >= ldc*n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for inversion of A_l.
   !>                 If info[l] = i > 0, U_l is singular. U_l[i,i] is the first zero pivot.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_sgetri_npvt_outofplace_strided_batched
     function rocsolver_sgetri_npvt_outofplace_strided_batched_(handle,n,A,lda,strideA,C,ldc, &
@@ -39003,29 +36726,22 @@ module hipfort_rocsolver
   !>     non-unit
   !>     triangular, depending on the value of ``diag``.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the matrix A is stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower)
   !>                 part of A is not used.
-  !>     @param[in]
-  !>     diag        rocblas_diagonal.
+  !>     @param[in] diag - rocblas_diagonal.
   !>                 If diag indicates unit, then the diagonal elements of A are not referenced and
   !>                 assumed to equal one.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows and columns of the matrix A.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the triangular matrix.
   !>                 On exit, the inverse of A if info = 0.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of A.
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info = 0, successful exit.
   !>                 If info = i > 0, A is singular. A[i,i] is the first zero element in the
   !>                 diagonal.
@@ -39133,35 +36849,28 @@ module hipfort_rocsolver
   !>     non-unit
   !>     triangular, depending on the value of ``diag``.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the matrices A_l are stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower)
   !>                 part of A_l is not used.
-  !>     @param[in]
-  !>     diag        rocblas_diagonal.
+  !>     @param[in] diag - rocblas_diagonal.
   !>                 If diag indicates unit, then the diagonal elements of matrices A_l are not
   !>                 referenced and
   !>                 assumed to equal one.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows and columns of all matrices A_l in the batch.
-  !>     @param[inout]
-  !>     A array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the triangular matrices A_l.
   !>                 On exit, the inverses of A_l if info[l] = 0.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for inversion of A_l.
   !>                 If info[l] = i > 0, A_l is singular. A_l[i,i] is the first zero element in the
   !>                 diagonal.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_strtri_batched
     function rocsolver_strtri_batched_(handle,uplo,diag,n,A,lda,myInfo,batch_count) &
@@ -39247,40 +36956,32 @@ module hipfort_rocsolver
   !>     non-unit
   !>     triangular, depending on the value of ``diag``.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the matrices A_l are stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower)
   !>                 part of A_l is not used.
-  !>     @param[in]
-  !>     diag        rocblas_diagonal.
+  !>     @param[in] diag - rocblas_diagonal.
   !>                 If diag indicates unit, then the diagonal elements of matrices A_l are not
   !>                 referenced and
   !>                 assumed to equal one.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows and columns of all matrices A_l in the batch.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the triangular matrices A_l.
   !>                 On exit, the inverses of A_l if info[l] = 0.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for inversion of A_l.
   !>                 If info[l] = i > 0, A_l is singular. A_l[i,i] is the first zero element in the
   !>                 diagonal.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_strtri_strided_batched
     function rocsolver_strtri_strided_batched_(handle,uplo,diag,n,A,lda,strideA,myInfo, &
@@ -39459,26 +37160,20 @@ module hipfort_rocsolver
   !>     and \f$A[k+1,k+1]\f$, and \f$v\f$ is stored in the lower parts of columns \f$k\f$ and
   !>     \f$k+1\f$ of \f$A\f$.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the matrix A is stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower)
   !>                 part of A is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows and columns of the matrix A.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the symmetric matrix A to be factored.
   !>                 On exit, the block diagonal matrix D and the multipliers needed to
   !>                 compute U or L.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of A.
-  !>     @param[out]
-  !>     ipiv        pointer to rocblas_int. Array on the GPU of dimension n.
+  !>     @param[out] ipiv - pointer to rocblas_int. Array on the GPU of dimension n.
   !>                 The vector of pivot indices. Elements of ipiv are 1-based indices.
   !>                 For 1 <= k <= n, if ipiv[k] > 0, then rows and columns k and ipiv[k]
   !>                 were interchanged, and D[k,k] is a 1-by-1 diagonal block.
@@ -39487,8 +37182,7 @@ module hipfort_rocsolver
   !>                 -ipiv[k] (or rows and columns k+1 and -ipiv[k]) were interchanged,
   !>                 and D[k-1,k-1] to D[k,k] (or D[k,k] to D[k+1,k+1]) is a 2-by-2
   !>                 diagonal block.
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info = 0, successful exit.
   !>                 If info = i > 0, D is singular. D[i,i] is the first diagonal zero.
   interface rocsolver_ssytf2
@@ -39652,26 +37346,21 @@ module hipfort_rocsolver
   !>     and \f$A_l[k+1,k+1]\f$, and \f$v\f$ is stored in the lower parts of columns \f$k\f$ and
   !>     \f$k+1\f$ of \f$A_l\f$.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the matrices A_l are stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower)
   !>                 part of A_l is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows and columns of all matrices A_l in the batch.
-  !>     @param[inout]
-  !>     A array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the symmetric matrices A_l to be factored.
   !>                 On exit, the block diagonal matrices D_l and the multipliers needed to
   !>                 compute U_l or L_l.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[out]
-  !>     ipiv        pointer to rocblas_int. Array on the GPU of dimension n.
+  !>     @param[out] ipiv - pointer to rocblas_int. Array on the GPU of dimension n.
   !>                 The vector of pivot indices. Elements of ipiv are 1-based indices.
   !>                 For 1 <= k <= n, if ipiv_l[k] > 0, then rows and columns k and ipiv_l[k]
   !>                 were interchanged, and D_l[k,k] is a 1-by-1 diagonal block.
@@ -39680,17 +37369,14 @@ module hipfort_rocsolver
   !>                 -ipiv_l[k] (or rows and columns k+1 and -ipiv_l[k]) were interchanged,
   !>                 and D_l[k-1,k-1] to D_l[k,k] (or D_l[k,k] to D_l[k+1,k+1]) is a 2-by-2
   !>                 diagonal block.
-  !>     @param[in]
-  !>     strideP     rocblas_stride.
+  !>     @param[in] strideP - rocblas_stride.
   !>                 Stride from the start of one vector ipiv_l to the next one ipiv_(l+1).
   !>                 There is no restriction for the value of strideP. The normal use case is
   !>                 strideP >= n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for factorization of A_l.
   !>                 If info[l] = i > 0, D_l is singular. D_l[i,i] is the first diagonal zero.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_ssytf2_batched
     function rocsolver_ssytf2_batched_(handle,uplo,n,A,lda,ipiv,strideP,myInfo,batch_count) &
@@ -39861,31 +37547,25 @@ module hipfort_rocsolver
   !>     and \f$A_l[k+1,k+1]\f$, and \f$v\f$ is stored in the lower parts of columns \f$k\f$ and
   !>     \f$k+1\f$ of \f$A_l\f$.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the matrices A_l are stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower)
   !>                 part of A_l is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows and columns of all matrices A_l in the batch.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the symmetric matrices A_l to be factored.
   !>                 On exit, the block diagonal matrices D_l and the multipliers needed to
   !>                 compute U_l or L_l.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n
-  !>     @param[out]
-  !>     ipiv        pointer to rocblas_int. Array on the GPU of dimension n.
+  !>     @param[out] ipiv - pointer to rocblas_int. Array on the GPU of dimension n.
   !>                 The vector of pivot indices. Elements of ipiv are 1-based indices.
   !>                 For 1 <= k <= n, if ipiv_l[k] > 0, then rows and columns k and ipiv_l[k]
   !>                 were interchanged, and D_l[k,k] is a 1-by-1 diagonal block.
@@ -39894,17 +37574,14 @@ module hipfort_rocsolver
   !>                 -ipiv_l[k] (or rows and columns k+1 and -ipiv_l[k]) were interchanged,
   !>                 and D_l[k-1,k-1] to D_l[k,k] (or D_l[k,k] to D_l[k+1,k+1]) is a 2-by-2
   !>                 diagonal block.
-  !>     @param[in]
-  !>     strideP     rocblas_stride.
+  !>     @param[in] strideP - rocblas_stride.
   !>                 Stride from the start of one vector ipiv_l to the next one ipiv_(l+1).
   !>                 There is no restriction for the value of strideP. The normal use case is
   !>                 strideP >= n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for factorization of A_l.
   !>                 If info[l] = i > 0, D_l is singular. D_l[i,i] is the first diagonal zero.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_ssytf2_strided_batched
     function rocsolver_ssytf2_strided_batched_(handle,uplo,n,A,lda,strideA,ipiv,strideP,myInfo, &
@@ -40087,26 +37764,20 @@ module hipfort_rocsolver
   !>     and \f$A[k+1,k+1]\f$, and \f$v\f$ is stored in the lower parts of columns \f$k\f$ and
   !>     \f$k+1\f$ of \f$A\f$.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the matrix A is stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower)
   !>                 part of A is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows and columns of the matrix A.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the symmetric matrix A to be factored.
   !>                 On exit, the block diagonal matrix D and the multipliers needed to
   !>                 compute U or L.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of A.
-  !>     @param[out]
-  !>     ipiv        pointer to rocblas_int. Array on the GPU of dimension n.
+  !>     @param[out] ipiv - pointer to rocblas_int. Array on the GPU of dimension n.
   !>                 The vector of pivot indices. Elements of ipiv are 1-based indices.
   !>                 For 1 <= k <= n, if ipiv[k] > 0, then rows and columns k and ipiv[k]
   !>                 were interchanged, and D[k,k] is a 1-by-1 diagonal block.
@@ -40115,8 +37786,7 @@ module hipfort_rocsolver
   !>                 -ipiv[k] (or rows and columns k+1 and -ipiv[k]) were interchanged,
   !>                 and D[k-1,k-1] to D[k,k] (or D[k,k] to D[k+1,k+1]) is a 2-by-2
   !>                 diagonal block.
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info = 0, successful exit.
   !>                 If info = i > 0, D is singular. D[i,i] is the first diagonal zero.
   interface rocsolver_ssytrf
@@ -40280,26 +37950,21 @@ module hipfort_rocsolver
   !>     and \f$A_l[k+1,k+1]\f$, and \f$v\f$ is stored in the lower parts of columns \f$k\f$ and
   !>     \f$k+1\f$ of \f$A_l\f$.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the matrices A_l are stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower)
   !>                 part of A_l is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows and columns of all matrices A_l in the batch.
-  !>     @param[inout]
-  !>     A array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the symmetric matrices A_l to be factored.
   !>                 On exit, the block diagonal matrices D_l and the multipliers needed to
   !>                 compute U_l or L_l.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[out]
-  !>     ipiv        pointer to rocblas_int. Array on the GPU of dimension n.
+  !>     @param[out] ipiv - pointer to rocblas_int. Array on the GPU of dimension n.
   !>                 The vector of pivot indices. Elements of ipiv are 1-based indices.
   !>                 For 1 <= k <= n, if ipiv_l[k] > 0, then rows and columns k and ipiv_l[k]
   !>                 were interchanged, and D_l[k,k] is a 1-by-1 diagonal block.
@@ -40308,17 +37973,14 @@ module hipfort_rocsolver
   !>                 -ipiv_l[k] (or rows and columns k+1 and -ipiv_l[k]) were interchanged,
   !>                 and D_l[k-1,k-1] to D_l[k,k] (or D_l[k,k] to D_l[k+1,k+1]) is a 2-by-2
   !>                 diagonal block.
-  !>     @param[in]
-  !>     strideP     rocblas_stride.
+  !>     @param[in] strideP - rocblas_stride.
   !>                 Stride from the start of one vector ipiv_l to the next one ipiv_(l+1).
   !>                 There is no restriction for the value of strideP. The normal use case is
   !>                 strideP >= n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for factorization of A_l.
   !>                 If info[l] = i > 0, D_l is singular. D_l[i,i] is the first diagonal zero.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_ssytrf_batched
     function rocsolver_ssytrf_batched_(handle,uplo,n,A,lda,ipiv,strideP,myInfo,batch_count) &
@@ -40489,31 +38151,25 @@ module hipfort_rocsolver
   !>     and \f$A_l[k+1,k+1]\f$, and \f$v\f$ is stored in the lower parts of columns \f$k\f$ and
   !>     \f$k+1\f$ of \f$A_l\f$.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the matrices A_l are stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower)
   !>                 part of A_l is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows and columns of all matrices A_l in the batch.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the symmetric matrices A_l to be factored.
   !>                 On exit, the block diagonal matrices D_l and the multipliers needed to
   !>                 compute U_l or L_l.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[out]
-  !>     ipiv        pointer to rocblas_int. Array on the GPU of dimension n.
+  !>     @param[out] ipiv - pointer to rocblas_int. Array on the GPU of dimension n.
   !>                 The vector of pivot indices. Elements of ipiv are 1-based indices.
   !>                 For 1 <= k <= n, if ipiv_l[k] > 0, then rows and columns k and ipiv_l[k]
   !>                 were interchanged, and D_l[k,k] is a 1-by-1 diagonal block.
@@ -40522,17 +38178,14 @@ module hipfort_rocsolver
   !>                 -ipiv_l[k] (or rows and columns k+1 and -ipiv_l[k]) were interchanged,
   !>                 and D_l[k-1,k-1] to D_l[k,k] (or D_l[k,k] to D_l[k+1,k+1]) is a 2-by-2
   !>                 diagonal block.
-  !>     @param[in]
-  !>     strideP     rocblas_stride.
+  !>     @param[in] strideP - rocblas_stride.
   !>                 Stride from the start of one vector ipiv_l to the next one ipiv_(l+1).
   !>                 There is no restriction for the value of strideP. The normal use case is
   !>                 strideP >= n.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for factorization of A_l.
   !>                 If info[l] = i > 0, D_l is singular. D_l[i,i] is the first diagonal zero.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_ssytrf_strided_batched
     function rocsolver_ssytrf_strided_batched_(handle,uplo,n,A,lda,strideA,ipiv,strideP,myInfo, &
@@ -40689,38 +38342,28 @@ module hipfort_rocsolver
   !>     strictly lower triangular
   !>     and \f$U_i\f$ is upper triangular.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     nb          rocblas_int. nb >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] nb - rocblas_int. nb >= 0.
   !>                 The number of rows and columns of each block.
-  !>     @param[in]
-  !>     nblocks     rocblas_int. nblocks >= 0.
+  !>     @param[in] nblocks - rocblas_int. nblocks >= 0.
   !>                 The number of blocks along the diagonal of the matrix.
-  !>     @param[in]
-  !>     A           pointer to type. Array on the GPU of dimension lda*nb*(nblocks-1).
+  !>     @param[in] A - pointer to type. Array on the GPU of dimension lda*nb*(nblocks-1).
   !>                 Contains the blocks A_i, arranged one after the other.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= nb.
+  !>     @param[in] lda - rocblas_int. lda >= nb.
   !>                 Specifies the leading dimension of blocks A_i.
-  !>     @param[inout]
-  !>     B           pointer to type. Array on the GPU of dimension ldb*nb*nblocks.
+  !>     @param[inout] B - pointer to type. Array on the GPU of dimension ldb*nb*nblocks.
   !>                 On entry, contains the blocks B_i, arranged one after the other.
   !>                 On exit, it is overwritten by L_i + U_i, where L_i and U_i are the factors of
   !>                 E_i as returned by
   !>                 \ref rocsolver_sgetrf_npvt "GETRF_NPVT".
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= nb.
+  !>     @param[in] ldb - rocblas_int. ldb >= nb.
   !>                 Specifies the leading dimension of blocks B_i.
-  !>     @param[inout]
-  !>     C           pointer to type. Array on the GPU of dimension ldc*nb*(nblocks-1).
+  !>     @param[inout] C - pointer to type. Array on the GPU of dimension ldc*nb*(nblocks-1).
   !>                 On entry, contains the blocks C_i, arranged one after the other.
   !>                 On exit, it is overwritten by blocks F_i.
-  !>     @param[in]
-  !>     ldc         rocblas_int. ldc >= nb.
+  !>     @param[in] ldc - rocblas_int. ldc >= nb.
   !>                 Specifies the leading dimension of blocks C_i.
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info = 0, successful exit.
   !>                 If info = i > 0, the matrix is singular.
   interface rocsolver_sgeblttrf_npvt
@@ -40845,45 +38488,37 @@ module hipfort_rocsolver
   !>     \f$L_{li}\f$ is strictly lower triangular
   !>     and \f$U_{li}\f$ is upper triangular.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     nb          rocblas_int. nb >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] nb - rocblas_int. nb >= 0.
   !>                 The number of rows and columns of each block.
-  !>     @param[in]
-  !>     nblocks     rocblas_int. nblocks >= 0.
+  !>     @param[in] nblocks - rocblas_int. nblocks >= 0.
   !>                 The number of blocks along the diagonal of each matrix in the batch.
-  !>     @param[in]
-  !>     A array of pointers to type. Each pointer points to an array on the GPU of dimension
+  !>     @param[in] A - array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension
   !>                 lda*nb*(nblocks-1).
   !>                 Contains the blocks A_{li}, arranged one after the other.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= nb.
+  !>     @param[in] lda - rocblas_int. lda >= nb.
   !>                 Specifies the leading dimension of blocks A_{li}.
-  !>     @param[inout]
-  !>     B array of pointers to type. Each pointer points to an array on the GPU of dimension
+  !>     @param[inout] B - array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension
   !>                 ldb*nb*nblocks.
   !>                 On entry, contains the blocks B_{li}, arranged one after the other.
   !>                 On exit, it is overwritten by L_{li} + U_{li}, where L_{li} and U_{li} are the
   !>                 factors of E_{li} as returned by
   !>                 \ref rocsolver_sgetrf_npvt "GETRF_NPVT".
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= nb.
+  !>     @param[in] ldb - rocblas_int. ldb >= nb.
   !>                 Specifies the leading dimension of blocks B_{li}.
-  !>     @param[inout]
-  !>     C array of pointers to type. Each pointer points to an array on the GPU of dimension
+  !>     @param[inout] C - array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension
   !>                 ldc*nb*(nblocks-1).
   !>                 On entry, contains the blocks C_{li}, arranged one after the other.
   !>                 On exit, it is overwritten by blocks F_{li}.
-  !>     @param[in]
-  !>     ldc         rocblas_int. ldc >= nb.
+  !>     @param[in] ldc - rocblas_int. ldc >= nb.
   !>                 Specifies the leading dimension of blocks C_{li}.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for factorization of l-th batch instance.
   !>                 If info[l] = i > 0, the l-th batch instance is singular.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_sgeblttrf_npvt_batched
     function rocsolver_sgeblttrf_npvt_batched_(handle,nb,nblocks,A,lda,B,ldb,C,ldc,myInfo, &
@@ -41015,63 +38650,52 @@ module hipfort_rocsolver
   !>     \f$L_{li}\f$ is strictly lower triangular
   !>     and \f$U_{li}\f$ is upper triangular.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     nb          rocblas_int. nb >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] nb - rocblas_int. nb >= 0.
   !>                 The number of rows and columns of each block.
-  !>     @param[in]
-  !>     nblocks     rocblas_int. nblocks >= 0.
+  !>     @param[in] nblocks - rocblas_int. nblocks >= 0.
   !>                 The number of blocks along the diagonal of each matrix in the batch.
-  !>     @param[in]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[in] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 Contains the blocks A_{li}, arranged one after the other.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= nb.
+  !>     @param[in] lda - rocblas_int. lda >= nb.
   !>                 Specifies the leading dimension of blocks A_{li}.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one block A_{li} to the same block in the next batch
   !>                 instance A_{(l+1)i}.
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >=
   !>                 lda*nb*(nblocks-1).
-  !>     @param[inout]
-  !>     B           pointer to type. Array on the GPU (the size depends on the value of strideB).
+  !>     @param[inout] B - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideB).
   !>                 On entry, contains the blocks B_{li}, arranged one after the other.
   !>                 On exit, it is overwritten by L_{li} + U_{li}, where L_{li} and U_{li} are the
   !>                 factors of E_{li} as returned by
   !>                 \ref rocsolver_sgetrf_npvt "GETRF_NPVT".
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= nb.
+  !>     @param[in] ldb - rocblas_int. ldb >= nb.
   !>                 Specifies the leading dimension of matrix blocks B_{li}.
-  !>     @param[in]
-  !>     strideB     rocblas_stride.
+  !>     @param[in] strideB - rocblas_stride.
   !>                 Stride from the start of one block B_{li} to the same block in the next batch
   !>                 instance B_{(l+1)i}.
   !>                 There is no restriction for the value of strideB. The normal use case is
   !>                 strideB >=
   !>                 ldb*nb*nblocks.
-  !>     @param[inout]
-  !>     C           pointer to type. Array on the GPU (the size depends on the value of strideC).
+  !>     @param[inout] C - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideC).
   !>                 On entry, contains the blocks C_{li}, arranged one after the other.
   !>                 On exit, it is overwritten by blocks F_{li}.
-  !>     @param[in]
-  !>     ldc         rocblas_int. ldc >= nb.
+  !>     @param[in] ldc - rocblas_int. ldc >= nb.
   !>                 Specifies the leading dimension of matrix blocks C_{li}.
-  !>     @param[in]
-  !>     strideC     rocblas_stride.
+  !>     @param[in] strideC - rocblas_stride.
   !>                 Stride from the start of one block C_{li} to the same block in the next batch
   !>                 instance C_{(l+1)i}.
   !>                 There is no restriction for the value of strideC. The normal use case is
   !>                 strideC >=
   !>                 ldc*nb*(nblocks-1).
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for factorization of l-th batch instance.
   !>                 If info[l] = i > 0, the l-th batch instance is singular.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_sgeblttrf_npvt_strided_batched
     function rocsolver_sgeblttrf_npvt_strided_batched_(handle,nb,nblocks,A,lda,strideA,B,ldb, &
@@ -41215,90 +38839,76 @@ module hipfort_rocsolver
   !>     \f$L_{li}\f$ is strictly lower triangular
   !>     and \f$U_{li}\f$ is upper triangular.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     nb          rocblas_int. nb >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] nb - rocblas_int. nb >= 0.
   !>                 The number of rows and columns of each block.
-  !>     @param[in]
-  !>     nblocks     rocblas_int. nblocks >= 0.
+  !>     @param[in] nblocks - rocblas_int. nblocks >= 0.
   !>                 The number of blocks along the diagonal of each matrix in the batch.
-  !>     @param[in]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[in] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 Contains the blocks A_{li}, arranged one after the other.
-  !>     @param[in]
-  !>     inca        rocblas_int. inca > 0.
+  !>     @param[in] inca - rocblas_int. inca > 0.
   !>                 Stride from the start of one row of A_{li} to the next. The normal use cases
   !>                 are
   !>                 inca = 1 (equivalent to the strided batched case) or inca = batch_count (for an
   !>                 interleaved batched case).
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= inca * nb.
+  !>     @param[in] lda - rocblas_int. lda >= inca * nb.
   !>                 Specifies the leading dimension of blocks A_{li}, that is, the stride from the
   !>                 start
   !>                 of one column of A_{li} to the next.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one block A_{li} to the same block in the next batch
   !>                 instance A_{(l+1)i}.
   !>                 There is no restriction for the value of strideA. The normal use cases are
   !>                 strideA >=
   !>                 lda*nb*(nblocks-1) (equivalent to the strided batched case) or strideA = 1 (for
   !>                 an interleaved batched case).
-  !>     @param[inout]
-  !>     B           pointer to type. Array on the GPU (the size depends on the value of strideB).
+  !>     @param[inout] B - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideB).
   !>                 On entry, contains the blocks B_{li}, arranged one after the other.
   !>                 On exit, it is overwritten by L_{li} + U_{li}, where L_{li} and U_{li} are the
   !>                 factors of E_{li} as returned by
   !>                 \ref rocsolver_sgetrf_npvt "GETRF_NPVT".
-  !>     @param[in]
-  !>     incb        rocblas_int. incb > 0.
+  !>     @param[in] incb - rocblas_int. incb > 0.
   !>                 Stride from the start of one row of B_{li} to the next. The normal use cases
   !>                 are
   !>                 incb = 1 (equivalent to the strided batched case) or incb = batch_count (for an
   !>                 interleaved batched case).
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= incb * nb.
+  !>     @param[in] ldb - rocblas_int. ldb >= incb * nb.
   !>                 Specifies the leading dimension of blocks B_{li}, that is, the stride from the
   !>                 start
   !>                 of one column of B_{li} to the next.
-  !>     @param[in]
-  !>     strideB     rocblas_stride.
+  !>     @param[in] strideB - rocblas_stride.
   !>                 Stride from the start of one block B_{li} to the same block in the next batch
   !>                 instance B_{(l+1)i}.
   !>                 There is no restriction for the value of strideB. The normal use cases are
   !>                 strideB >=
   !>                 ldb*nb*nblocks (equivalent to the strided batched case) or strideB = 1 (for an
   !>                 interleaved batched case).
-  !>     @param[inout]
-  !>     C           pointer to type. Array on the GPU (the size depends on the value of strideC).
+  !>     @param[inout] C - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideC).
   !>                 On entry, contains the blocks C_{li}, arranged one after the other.
   !>                 On exit, it is overwritten by blocks F_{li}.
-  !>     @param[in]
-  !>     incc        rocblas_int. incc > 0.
+  !>     @param[in] incc - rocblas_int. incc > 0.
   !>                 Stride from the start of one row of C_{li} to the next. The normal use cases
   !>                 are
   !>                 incc = 1 (equivalent to the strided batched case) or incc = batch_count (for an
   !>                 interleaved batched case).
-  !>     @param[in]
-  !>     ldc         rocblas_int. ldc >= incc * nb.
+  !>     @param[in] ldc - rocblas_int. ldc >= incc * nb.
   !>                 Specifies the leading dimension of blocks C_{li}, that is, the stride from the
   !>                 start
   !>                 of one column of C_{li} to the next.
-  !>     @param[in]
-  !>     strideC     rocblas_stride.
+  !>     @param[in] strideC - rocblas_stride.
   !>                 Stride from the start of one block C_{li} to the same block in the next batch
   !>                 instance C_{(l+1)i}.
   !>                 There is no restriction for the value of strideC. The normal use cases are
   !>                 strideC >=
   !>                 ldc*nb*(nblocks-1) (equivalent to the strided batched case) or strideC = 1 (for
   !>                 an interleaved batched case).
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for factorization of l-th batch instance.
   !>                 If info[l] = i > 0, the l-th batch instance is singular.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_sgeblttrf_npvt_interleaved_batched
     function rocsolver_sgeblttrf_npvt_interleaved_batched_(handle,nb,nblocks,A,inca,lda,strideA,B, &
@@ -41450,45 +39060,33 @@ module hipfort_rocsolver
   !>     should be in
   !>     the factorized form, as returned by \ref rocsolver_sgeblttrf_npvt "GEBLTTRF_NPVT".
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     nb          rocblas_int. nb >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] nb - rocblas_int. nb >= 0.
   !>                 The number of rows and columns of each block.
-  !>     @param[in]
-  !>     nblocks     rocblas_int. nblocks >= 0.
+  !>     @param[in] nblocks - rocblas_int. nblocks >= 0.
   !>                 The number of blocks along the diagonal of the matrix.
-  !>     @param[in]
-  !>     nrhs        rocblas_int. nrhs >= 0.
+  !>     @param[in] nrhs - rocblas_int. nrhs >= 0.
   !>                 The number of right hand sides, that is, the number of columns of blocks R_i.
-  !>     @param[in]
-  !>     A           pointer to type. Array on the GPU of dimension lda*nb*(nblocks-1).
+  !>     @param[in] A - pointer to type. Array on the GPU of dimension lda*nb*(nblocks-1).
   !>                 Contains the blocks A_i, as returned by \ref rocsolver_sgeblttrf_npvt
   !>                 "GEBLTTRF_NPVT".
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= nb.
+  !>     @param[in] lda - rocblas_int. lda >= nb.
   !>                 Specifies the leading dimension of blocks A_i.
-  !>     @param[in]
-  !>     B           pointer to type. Array on the GPU of dimension ldb*nb*nblocks.
+  !>     @param[in] B - pointer to type. Array on the GPU of dimension ldb*nb*nblocks.
   !>                 Contains the blocks B_i, as returned by \ref rocsolver_sgeblttrf_npvt
   !>                 "GEBLTTRF_NPVT".
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= nb.
+  !>     @param[in] ldb - rocblas_int. ldb >= nb.
   !>                 Specifies the leading dimension of blocks B_i.
-  !>     @param[in]
-  !>     C           pointer to type. Array on the GPU of dimension ldc*nb*(nblocks-1).
+  !>     @param[in] C - pointer to type. Array on the GPU of dimension ldc*nb*(nblocks-1).
   !>                 Contains the blocks C_i, as returned by \ref rocsolver_sgeblttrf_npvt
   !>                 "GEBLTTRF_NPVT".
-  !>     @param[in]
-  !>     ldc         rocblas_int. ldc >= nb.
+  !>     @param[in] ldc - rocblas_int. ldc >= nb.
   !>                 Specifies the leading dimension of blocks C_i.
-  !>     @param[inout]
-  !>     X           pointer to type. Array on the GPU of dimension ldx*nblocks*nrhs.
+  !>     @param[inout] X - pointer to type. Array on the GPU of dimension ldx*nblocks*nrhs.
   !>                 On entry, X contains the right-hand-side blocks R_i. It is overwritten by
   !>                 solution
   !>                 vectors X_i on exit.
-  !>     @param[in]
-  !>     ldx         rocblas_int. ldx >= nb.
+  !>     @param[in] ldx - rocblas_int. ldx >= nb.
   !>                 Specifies the leading dimension of blocks X_i.
   interface rocsolver_sgeblttrs_npvt
     function rocsolver_sgeblttrs_npvt_(handle,nb,nblocks,nrhs,A,lda,B,ldb,C,ldc,X,ldx) &
@@ -41617,53 +39215,44 @@ module hipfort_rocsolver
   !>     the factorized form, as returned by \ref rocsolver_sgeblttrf_npvt_batched
   !>     "GEBLTTRF_NPVT_BATCHED".
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     nb          rocblas_int. nb >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] nb - rocblas_int. nb >= 0.
   !>                 The number of rows and columns of each block.
-  !>     @param[in]
-  !>     nblocks     rocblas_int. nblocks >= 0.
+  !>     @param[in] nblocks - rocblas_int. nblocks >= 0.
   !>                 The number of blocks along the diagonal of each matrix in the batch.
-  !>     @param[in]
-  !>     nrhs        rocblas_int. nrhs >= 0.
+  !>     @param[in] nrhs - rocblas_int. nrhs >= 0.
   !>                 The number of right hand sides, that is, the number of columns of blocks
   !>                 R_{li}.
-  !>     @param[in]
-  !>     A array of pointers to type. Each pointer points to an array on the GPU of dimension
+  !>     @param[in] A - array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension
   !>                 lda*nb*(nblocks-1).
   !>                 Contains the blocks A_{li}, as returned by \ref
   !>                 rocsolver_sgeblttrf_npvt_batched "GEBLTTRF_NPVT_BATCHED".
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= nb.
+  !>     @param[in] lda - rocblas_int. lda >= nb.
   !>                 Specifies the leading dimension of blocks A_{li}.
-  !>     @param[in]
-  !>     B array of pointers to type. Each pointer points to an array on the GPU of dimension
+  !>     @param[in] B - array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension
   !>                 lda*nb*nblocks.
   !>                 Contains the blocks B_{li}, as returned by \ref
   !>                 rocsolver_sgeblttrf_npvt_batched "GEBLTTRF_NPVT_BATCHED".
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= nb.
+  !>     @param[in] ldb - rocblas_int. ldb >= nb.
   !>                 Specifies the leading dimension of blocks B_{li}.
-  !>     @param[in]
-  !>     C array of pointers to type. Each pointer points to an array on the GPU of dimension
+  !>     @param[in] C - array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension
   !>                 ldc*nb*(nblocks-1).
   !>                 Contains the blocks C_{li}, as returned by \ref
   !>                 rocsolver_sgeblttrf_npvt_batched "GEBLTTRF_NPVT_BATCHED".
-  !>     @param[in]
-  !>     ldc         rocblas_int. ldc >= nb.
+  !>     @param[in] ldc - rocblas_int. ldc >= nb.
   !>                 Specifies the leading dimension of blocks C_{li}.
-  !>     @param[inout]
-  !>     X array of pointers to type. Each pointer points to an array on the GPU of dimension
+  !>     @param[inout] X - array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension
   !>                 ldx*nblocks*nrhs.
   !>                 On entry, X contains the right-hand-side blocks R_{li}. It is overwritten by
   !>                 solution
   !>                 vectors X_{li} on exit.
-  !>     @param[in]
-  !>     ldx         rocblas_int. ldx >= nb.
+  !>     @param[in] ldx - rocblas_int. ldx >= nb.
   !>                 Specifies the leading dimension of blocks X_{li}.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_sgeblttrs_npvt_batched
     function rocsolver_sgeblttrs_npvt_batched_(handle,nb,nblocks,nrhs,A,lda,B,ldb,C,ldc,X,ldx, &
@@ -41800,77 +39389,64 @@ module hipfort_rocsolver
   !>     the factorized form, as returned by \ref rocsolver_sgeblttrf_npvt_strided_batched
   !>     "GEBLTTRF_NPVT_STRIDED_BATCHED".
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     nb          rocblas_int. nb >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] nb - rocblas_int. nb >= 0.
   !>                 The number of rows and columns of each block.
-  !>     @param[in]
-  !>     nblocks     rocblas_int. nblocks >= 0.
+  !>     @param[in] nblocks - rocblas_int. nblocks >= 0.
   !>                 The number of blocks along the diagonal of each matrix in the batch.
-  !>     @param[in]
-  !>     nrhs        rocblas_int. nrhs >= 0.
+  !>     @param[in] nrhs - rocblas_int. nrhs >= 0.
   !>                 The number of right hand sides, that is, the number of columns of blocks
   !>                 R_{li}.
-  !>     @param[in]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[in] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 Contains the blocks A_{li}, as returned by \ref
   !>                 rocsolver_sgeblttrf_npvt_strided_batched "GEBLTTRF_NPVT_STRIDED_BATCHED".
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= nb.
+  !>     @param[in] lda - rocblas_int. lda >= nb.
   !>                 Specifies the leading dimension of blocks A_{li}.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one block A_{li} to the same block in the next batch
   !>                 instance A_{(l+1)i}.
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >=
   !>                 lda*nb*(nblocks-1).
-  !>     @param[in]
-  !>     B           pointer to type. Array on the GPU (the size depends on the value of strideB).
+  !>     @param[in] B - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideB).
   !>                 Contains the blocks B_{li}, as returned by \ref
   !>                 rocsolver_sgeblttrf_npvt_strided_batched "GEBLTTRF_NPVT_STRIDED_BATCHED".
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= nb.
+  !>     @param[in] ldb - rocblas_int. ldb >= nb.
   !>                 Specifies the leading dimension of blocks B_{li}.
-  !>     @param[in]
-  !>     strideB     rocblas_stride.
+  !>     @param[in] strideB - rocblas_stride.
   !>                 Stride from the start of one block B_{li} to the same block in the next batch
   !>                 instance B_{(l+1)i}.
   !>                 There is no restriction for the value of strideB. The normal use case is
   !>                 strideB >=
   !>                 ldb*nb*nblocks.
-  !>     @param[in]
-  !>     C           pointer to type. Array on the GPU (the size depends on the value of strideC).
+  !>     @param[in] C - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideC).
   !>                 Contains the blocks C_{li}, as returned by \ref
   !>                 rocsolver_sgeblttrf_npvt_strided_batched "GEBLTTRF_NPVT_STRIDED_BATCHED".
-  !>     @param[in]
-  !>     ldc         rocblas_int. ldc >= nb.
+  !>     @param[in] ldc - rocblas_int. ldc >= nb.
   !>                 Specifies the leading dimension of blocks C_{li}.
-  !>     @param[in]
-  !>     strideC     rocblas_stride.
+  !>     @param[in] strideC - rocblas_stride.
   !>                 Stride from the start of one block C_{li} to the same block in the next batch
   !>                 instance C_{(l+1)i}.
   !>                 There is no restriction for the value of strideC. The normal use case is
   !>                 strideC >=
   !>                 ldc*nb*(nblocks-1).
-  !>     @param[inout]
-  !>     X           pointer to type. Array on the GPU (the size depends on the value of strideX).
+  !>     @param[inout] X - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideX).
   !>                 On entry, X contains the right-hand-side blocks R_{li}. It is overwritten by
   !>                 solution
   !>                 vectors X_{li} on exit.
-  !>     @param[in]
-  !>     ldx         rocblas_int. ldx >= nb.
+  !>     @param[in] ldx - rocblas_int. ldx >= nb.
   !>                 Specifies the leading dimension of blocks X_{li}.
-  !>     @param[in]
-  !>     strideX     rocblas_stride.
+  !>     @param[in] strideX - rocblas_stride.
   !>                 Stride from the start of one block X_{li} to the same block in the next batch
   !>                 instance X_{(l+1)i}.
   !>                 There is no restriction for the value of strideX. The normal use case is
   !>                 strideX >=
   !>                 ldx*nblocks*nrhs.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_sgeblttrs_npvt_strided_batched
     function rocsolver_sgeblttrs_npvt_strided_batched_(handle,nb,nblocks,nrhs,A,lda,strideA,B,ldb, &
@@ -42023,116 +39599,99 @@ module hipfort_rocsolver
   !>     the factorized form, as returned by \ref rocsolver_sgeblttrf_npvt_interleaved_batched
   !>     "GEBLTTRF_NPVT_INTERLEAVED_BATCHED".
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     nb          rocblas_int. nb >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] nb - rocblas_int. nb >= 0.
   !>                 The number of rows and columns of each block.
-  !>     @param[in]
-  !>     nblocks     rocblas_int. nblocks >= 0.
+  !>     @param[in] nblocks - rocblas_int. nblocks >= 0.
   !>                 The number of blocks along the diagonal of each matrix in the batch.
-  !>     @param[in]
-  !>     nrhs        rocblas_int. nrhs >= 0.
+  !>     @param[in] nrhs - rocblas_int. nrhs >= 0.
   !>                 The number of right hand sides, that is, the number of columns of blocks
   !>                 R_{li}.
-  !>     @param[in]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[in] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 Contains the blocks A_{li}, as returned by \ref
   !>                 rocsolver_sgeblttrf_npvt_interleaved_batched
   !>                 "GEBLTTRF_NPVT_INTERLEAVED_BATCHED".
-  !>     @param[in]
-  !>     inca        rocblas_int. inca > 0.
+  !>     @param[in] inca - rocblas_int. inca > 0.
   !>                 Stride from the start of one row of A_{li} to the next. The normal use cases
   !>                 are
   !>                 inca = 1 (equivalent to the strided batched case) or inca = batch_count (for an
   !>                 interleaved batched case).
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= inca * nb.
+  !>     @param[in] lda - rocblas_int. lda >= inca * nb.
   !>                 Specifies the leading dimension of blocks A_{li}, that is, the stride from the
   !>                 start
   !>                 of one column of A_{li} to the next.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one block A_{li} to the same block in the next batch
   !>                 instance A_{(l+1)i}.
   !>                 There is no restriction for the value of strideA. The normal use cases are
   !>                 strideA >=
   !>                 lda*nb*(nblocks-1) (equivalent to the strided batched case) or strideA = 1 (for
   !>                 an interleaved batched case).
-  !>     @param[in]
-  !>     B           pointer to type. Array on the GPU (the size depends on the value of strideB).
+  !>     @param[in] B - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideB).
   !>                 Contains the blocks B_{li}, as returned by \ref
   !>                 rocsolver_sgeblttrf_npvt_interleaved_batched
   !>                 "GEBLTTRF_NPVT_INTERLEAVED_BATCHED".
-  !>     @param[in]
-  !>     incb        rocblas_int. incb > 0.
+  !>     @param[in] incb - rocblas_int. incb > 0.
   !>                 Stride from the start of one row of B_{li} to the next. The normal use cases
   !>                 are
   !>                 incb = 1 (equivalent to the strided batched case) or incb = batch_count (for an
   !>                 interleaved batched case).
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= incb * nb.
+  !>     @param[in] ldb - rocblas_int. ldb >= incb * nb.
   !>                 Specifies the leading dimension of blocks B_{li}, that is, the stride from the
   !>                 start
   !>                 of one column of B_{li} to the next.
-  !>     @param[in]
-  !>     strideB     rocblas_stride.
+  !>     @param[in] strideB - rocblas_stride.
   !>                 Stride from the start of one block B_{li} to the same block in the next batch
   !>                 instance B_{(l+1)i}.
   !>                 There is no restriction for the value of strideB. The normal use cases are
   !>                 strideB >=
   !>                 ldb*nb*nblocks (equivalent to the strided batched case) or strideB = 1 (for an
   !>                 interleaved batched case).
-  !>     @param[in]
-  !>     C           pointer to type. Array on the GPU (the size depends on the value of strideC).
+  !>     @param[in] C - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideC).
   !>                 Contains the blocks C_{li}, as returned by \ref
   !>                 rocsolver_sgeblttrf_npvt_interleaved_batched
   !>                 "GEBLTTRF_NPVT_INTERLEAVED_BATCHED".
-  !>     @param[in]
-  !>     incc        rocblas_int. incc > 0.
+  !>     @param[in] incc - rocblas_int. incc > 0.
   !>                 Stride from the start of one row of C_{li} to the next. The normal use cases
   !>                 are
   !>                 incc = 1 (equivalent to the strided batched case) or incc = batch_count (for an
   !>                 interleaved batched case).
-  !>     @param[in]
-  !>     ldc         rocblas_int. ldc >= incc * nb.
+  !>     @param[in] ldc - rocblas_int. ldc >= incc * nb.
   !>                 Specifies the leading dimension of blocks C_{li}, that is, the stride from the
   !>                 start
   !>                 of one column of C_{li} to the next.
-  !>     @param[in]
-  !>     strideC     rocblas_stride.
+  !>     @param[in] strideC - rocblas_stride.
   !>                 Stride from the start of one block C_{li} to the same block in the next batch
   !>                 instance C_{(l+1)i}.
   !>                 There is no restriction for the value of strideC. The normal use cases are
   !>                 strideC >=
   !>                 ldc*nb*(nblocks-1) (equivalent to the strided batched case) or strideC = 1 (for
   !>                 an interleaved batched case).
-  !>     @param[inout]
-  !>     X           pointer to type. Array on the GPU (the size depends on the value of strideX).
+  !>     @param[inout] X - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideX).
   !>                 On entry, X contains the right-hand-side blocks R_{li}. It is overwritten by
   !>                 solution
   !>                 vectors X_{li} on exit.
-  !>     @param[in]
-  !>     incx        rocblas_int. incx > 0.
+  !>     @param[in] incx - rocblas_int. incx > 0.
   !>                 Stride from the start of one row of X_{li} to the next. The normal use cases
   !>                 are
   !>                 incx = 1 (equivalent to the strided batched case) or incx = batch_count (for an
   !>                 interleaved batched case).
-  !>     @param[in]
-  !>     ldx         rocblas_int. ldx >= incx * nb.
+  !>     @param[in] ldx - rocblas_int. ldx >= incx * nb.
   !>                 Specifies the leading dimension of blocks X_{li}, that is, the stride from the
   !>                 start
   !>                 of one column of X_{li} to the next.
-  !>     @param[in]
-  !>     strideX     rocblas_stride.
+  !>     @param[in] strideX - rocblas_stride.
   !>                 Stride from the start of one block X_{li} to the same block in the next batch
   !>                 instance X_{(l+1)i}.
   !>                 There is no restriction for the value of strideX. The normal use cases are
   !>                 strideX >=
   !>                 ldx*nrhs*nblocks (equivalent to the strided batched case) or strideX = 1 (for
   !>                 an interleaved batched case).
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_sgeblttrs_npvt_interleaved_batched
     function rocsolver_sgeblttrs_npvt_interleaved_batched_(handle,nb,nblocks,nrhs,A,inca,lda, &
@@ -42274,11 +39833,9 @@ module hipfort_rocsolver
   !>     by the direct solver \ref rocsolver_scsrrf_solve "CSRRF_SOLVE".
   !>
   !>     \details
-  !>     @param[out]
-  !>     rfinfo      `rocsolver_rfinfo`.
+  !>     @param[out] rfinfo - `rocsolver_rfinfo`.
   !>                 The pointer to the rfinfo struct to be initialized.
-  !>     @param[in]
-  !>     handle      rocblas_handle.
+  !>     @param[in] handle - rocblas_handle.
   interface rocsolver_create_rfinfo
     function rocsolver_create_rfinfo_(rfinfo,handle) bind(c, name="rocsolver_create_rfinfo")
       use iso_c_binding
@@ -42298,8 +39855,7 @@ module hipfort_rocsolver
   !>     by the direct solver \ref rocsolver_scsrrf_solve "CSRRF_SOLVE".
   !>
   !>     \details
-  !>     @param[in]
-  !>     rfinfo      `rocsolver_rfinfo`.
+  !>     @param[in] rfinfo - `rocsolver_rfinfo`.
   !>                 The rfinfo struct to be destroyed.
   interface rocsolver_destroy_rfinfo
     function rocsolver_destroy_rfinfo_(rfinfo) bind(c, name="rocsolver_destroy_rfinfo")
@@ -42319,11 +39875,9 @@ module hipfort_rocsolver
   !>     by the direct solver \ref rocsolver_scsrrf_solve "CSRRF_SOLVE".
   !>
   !>     \details
-  !>     @param[in]
-  !>     rfinfo      `rocsolver_rfinfo`.
+  !>     @param[in] rfinfo - `rocsolver_rfinfo`.
   !>                 The rfinfo struct to be set up.
-  !>     @param[in]
-  !>     mode        `rocsolver_rfinfo_mode`.
+  !>     @param[in] mode - `rocsolver_rfinfo_mode`.
   !>                 Use rocsolver_rfinfo_mode_cholesky when the Cholesky factorization is required.
   interface rocsolver_set_rfinfo_mode
     function rocsolver_set_rfinfo_mode_(rfinfo,mode) bind(c, name="rocsolver_set_rfinfo_mode")
@@ -42344,11 +39898,9 @@ module hipfort_rocsolver
   !>     by the direct solver \ref rocsolver_scsrrf_solve "CSRRF_SOLVE".
   !>
   !>     \details
-  !>     @param[in]
-  !>     rfinfo      `rocsolver_rfinfo`.
+  !>     @param[in] rfinfo - `rocsolver_rfinfo`.
   !>                 The referenced rfinfo struct.
-  !>     @param[out]
-  !>     mode        `rocsolver_rfinfo_mode`.
+  !>     @param[out] mode - `rocsolver_rfinfo_mode`.
   !>                 The queried mode.
   interface rocsolver_get_rfinfo_mode
     function rocsolver_get_rfinfo_mode_(rfinfo,mode) bind(c, name="rocsolver_get_rfinfo_mode")
@@ -42374,49 +39926,36 @@ module hipfort_rocsolver
   !>     elements of T, ``nnzT``, is given by ``nnzT`` = ``nnzL`` - ``n`` + ``nnzU``.
   !>
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows (and columns) of matrix A.
-  !>     @param[in]
-  !>     nnzL        rocblas_int. nnzL >= n.
+  !>     @param[in] nnzL - rocblas_int. nnzL >= n.
   !>                 The number of non-zero elements in L.
-  !>     @param[in]
-  !>     ptrL        pointer to rocblas_int. Array on the GPU of dimension n+1.
+  !>     @param[in] ptrL - pointer to rocblas_int. Array on the GPU of dimension n+1.
   !>                 It contains the positions of the beginning of each row in indL and valL.
   !>                 The last element of ptrL is equal to nnzL.
-  !>     @param[in]
-  !>     indL        pointer to rocblas_int. Array on the GPU of dimension nnzL.
+  !>     @param[in] indL - pointer to rocblas_int. Array on the GPU of dimension nnzL.
   !>                 It contains the column indices of the non-zero elements of L. Indices are
   !>                 sorted by row and by column within each row.
-  !>     @param[in]
-  !>     valL        pointer to type. Array on the GPU of dimension nnzL.
+  !>     @param[in] valL - pointer to type. Array on the GPU of dimension nnzL.
   !>                 The values of the non-zero elements of L.
-  !>     @param[in]
-  !>     nnzU        rocblas_int. nnzU >= 0.
+  !>     @param[in] nnzU - rocblas_int. nnzU >= 0.
   !>                 The number of non-zero elements in U.
-  !>     @param[in]
-  !>     ptrU        pointer to rocblas_int. Array on the GPU of dimension n+1.
+  !>     @param[in] ptrU - pointer to rocblas_int. Array on the GPU of dimension n+1.
   !>                 It contains the positions of the beginning of each row in indU and valU.
   !>                 The last element of ptrU is equal to nnzU.
-  !>     @param[in]
-  !>     indU        pointer to rocblas_int. Array on the GPU of dimension nnzU.
+  !>     @param[in] indU - pointer to rocblas_int. Array on the GPU of dimension nnzU.
   !>                 It contains the column indices of the non-zero elements of U. Indices are
   !>                 sorted by row and by column within each row.
-  !>     @param[in]
-  !>     valU        pointer to type. Array on the GPU of dimension nnzU.
+  !>     @param[in] valU - pointer to type. Array on the GPU of dimension nnzU.
   !>                 The values of the non-zero elements of U.
-  !>     @param[out]
-  !>     ptrT        pointer to rocblas_int. Array on the GPU of dimension n+1.
+  !>     @param[out] ptrT - pointer to rocblas_int. Array on the GPU of dimension n+1.
   !>                 It contains the positions of the beginning of each row in indT and valT.
   !>                 The last element of ptrT is equal to nnzT.
-  !>     @param[out]
-  !>     indT        pointer to rocblas_int. Array on the GPU of dimension nnzT.
+  !>     @param[out] indT - pointer to rocblas_int. Array on the GPU of dimension nnzT.
   !>                 It contains the column indices of the non-zero elements of T. Indices are
   !>                 sorted by row and by column within each row.
-  !>     @param[out]
-  !>     valT        pointer to type. Array on the GPU of dimension nnzT.
+  !>     @param[out] valT - pointer to type. Array on the GPU of dimension nnzT.
   !>                 The values of the non-zero elements of T.
   interface rocsolver_scsrrf_sumlu
     function rocsolver_scsrrf_sumlu_(handle,n,nnzL,ptrL,indL,valL,nnzU,ptrU,indU,valU,ptrT,indT, &
@@ -42480,49 +40019,37 @@ module hipfort_rocsolver
   !>     strictly
   !>     lower part of \f$T\f$.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows (and columns) of matrix A.
-  !>     @param[in]
-  !>     nnzT        rocblas_int. nnzT >= 0.
+  !>     @param[in] nnzT - rocblas_int. nnzT >= 0.
   !>                 The number of non-zero elements in T.
-  !>     @param[in]
-  !>     ptrT        pointer to rocblas_int. Array on the GPU of dimension n+1.
+  !>     @param[in] ptrT - pointer to rocblas_int. Array on the GPU of dimension n+1.
   !>                 It contains the positions of the beginning of each row in indT and valT.
   !>                 The last element of ptrT is equal to nnzT.
-  !>     @param[in]
-  !>     indT        pointer to rocblas_int. Array on the GPU of dimension nnzT.
+  !>     @param[in] indT - pointer to rocblas_int. Array on the GPU of dimension nnzT.
   !>                 It contains the column indices of the non-zero elements of T. Indices are
   !>                 sorted by row and by column within each row.
-  !>     @param[in]
-  !>     valT        pointer to type. Array on the GPU of dimension nnzT.
+  !>     @param[in] valT - pointer to type. Array on the GPU of dimension nnzT.
   !>                 The values of the non-zero elements of T.
-  !>     @param[out]
-  !>     ptrL        pointer to rocblas_int. Array on the GPU of dimension n+1.
+  !>     @param[out] ptrL - pointer to rocblas_int. Array on the GPU of dimension n+1.
   !>                 It contains the positions of the beginning of each row in indL and valL.
   !>                 The last element of ptrL is equal to nnzL.
-  !>     @param[out]
-  !>     indL        pointer to rocblas_int. Array on the GPU of dimension nnzL.
+  !>     @param[out] indL - pointer to rocblas_int. Array on the GPU of dimension nnzL.
   !>                 It contains the column indices of the non-zero elements of L. Indices are
   !>                 sorted by row and by column within each row. (If nnzL is not known in advance,
   !>                 the size of this array could be set to nnzT + n as an upper bound.)
-  !>     @param[out]
-  !>     valL        pointer to type. Array on the GPU of dimension nnzL.
+  !>     @param[out] valL - pointer to type. Array on the GPU of dimension nnzL.
   !>                 The values of the non-zero elements of L. (If nnzL is not known in advance,
   !>                 the size of this array could be set to nnzT + n as an upper bound.)
-  !>     @param[out]
-  !>     ptrU        pointer to rocblas_int. Array on the GPU of dimension n+1.
+  !>     @param[out] ptrU - pointer to rocblas_int. Array on the GPU of dimension n+1.
   !>                 It contains the positions of the beginning of each row in indU and valU.
   !>                 The last element of ptrU is equal to nnzU.
-  !>     @param[out]
-  !>     indU        pointer to rocblas_int. Array on the GPU of dimension nnzU.
+  !>     @param[out] indU - pointer to rocblas_int. Array on the GPU of dimension nnzU.
   !>                 It contains the column indices of the non-zero elements of U. Indices are
   !>                 sorted by row and by column within each row. (If nnzU is not known in advance,
   !>                 the size of this array could be set to nnzT as an upper bound.)
-  !>     @param[out]
-  !>     valU        pointer to type. Array on the GPU of dimension nnzU.
+  !>     @param[out] valU - pointer to type. Array on the GPU of dimension nnzU.
   !>                 The values of the non-zero elements of U. (If nnzU is not known in advance,
   !>                 the size of this array could be set to nnzT as an upper bound.)
   interface rocsolver_scsrrf_splitlu
@@ -42640,67 +40167,51 @@ module hipfort_rocsolver
   !>     can be set to zero
   !>     and ``B`` can be null.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows (and columns) of matrix M.
-  !>     @param[in]
-  !>     nrhs        rocblas_int. nrhs >= 0.
+  !>     @param[in] nrhs - rocblas_int. nrhs >= 0.
   !>                 The number of right-hand-sides (columns of matrix B). Set nrhs to zero when
   !>                 only the
   !>                 refactorization is needed.
-  !>     @param[in]
-  !>     nnzM        rocblas_int. nnzM >= 0.
+  !>     @param[in] nnzM - rocblas_int. nnzM >= 0.
   !>                 The number of non-zero elements in M.
-  !>     @param[in]
-  !>     ptrM        pointer to rocblas_int. Array on the GPU of dimension n+1.
+  !>     @param[in] ptrM - pointer to rocblas_int. Array on the GPU of dimension n+1.
   !>                 It contains the positions of the beginning of each row in indM and valM.
   !>                 The last element of ptrM is equal to nnzM.
-  !>     @param[in]
-  !>     indM        pointer to rocblas_int. Array on the GPU of dimension nnzM.
+  !>     @param[in] indM - pointer to rocblas_int. Array on the GPU of dimension nnzM.
   !>                 It contains the column indices of the non-zero elements of M. Indices are
   !>                 sorted by row and by column within each row.
-  !>     @param[in]
-  !>     valM        pointer to type. Array on the GPU of dimension nnzM.
+  !>     @param[in] valM - pointer to type. Array on the GPU of dimension nnzM.
   !>                 The values of the non-zero elements of M. The strictly upper triangular entries
   !>                 are
   !>                 not referenced when working in Cholesky mode.
-  !>     @param[in]
-  !>     nnzT        rocblas_int. nnzT >= 0.
+  !>     @param[in] nnzT - rocblas_int. nnzT >= 0.
   !>                 The number of non-zero elements in T.
-  !>     @param[in]
-  !>     ptrT        pointer to rocblas_int. Array on the GPU of dimension n+1.
+  !>     @param[in] ptrT - pointer to rocblas_int. Array on the GPU of dimension n+1.
   !>                 It contains the positions of the beginning of each row in indT and valT.
   !>                 The last element of ptrT is equal to nnzT.
-  !>     @param[in]
-  !>     indT        pointer to rocblas_int. Array on the GPU of dimension nnzT.
+  !>     @param[in] indT - pointer to rocblas_int. Array on the GPU of dimension nnzT.
   !>                 It contains the column indices of the non-zero elements of T. Indices are
   !>                 sorted by row and by column within each row.
-  !>     @param[in]
-  !>     valT        pointer to type. Array on the GPU of dimension nnzT.
+  !>     @param[in] valT - pointer to type. Array on the GPU of dimension nnzT.
   !>                 The values of the non-zero elements of T. The strictly upper triangular entries
   !>                 are
   !>                 not referenced when working in Cholesky mode.
-  !>     @param[in]
-  !>     pivP        pointer to rocblas_int. Array on the GPU of dimension n.
+  !>     @param[in] pivP - pointer to rocblas_int. Array on the GPU of dimension n.
   !>                 Contains the pivot indices representing the permutation matrix P, that is, the
   !>                 order in which the rows of matrix M were rearranged. When working in Cholesky
   !>                 mode,
   !>                 this array is not referenced and can be null.
-  !>     @param[in]
-  !>     pivQ        pointer to rocblas_int. Array on the GPU of dimension n.
+  !>     @param[in] pivQ - pointer to rocblas_int. Array on the GPU of dimension n.
   !>                 Contains the pivot indices representing the permutation matrix Q, that is, the
   !>                 order in which the columns of matrix M were rearranged.
-  !>     @param[in]
-  !>     B           pointer to type. Array on the GPU of dimension ldb*nrhs.
+  !>     @param[in] B - pointer to type. Array on the GPU of dimension ldb*nrhs.
   !>                 The right hand side matrix B. It can be null if only the refactorization is
   !>                 needed.
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 The leading dimension of B.
-  !>     @param[out]
-  !>     rfinfo      rocsolver_rfinfo.
+  !>     @param[out] rfinfo - rocsolver_rfinfo.
   !>                 Structure that holds the meta data generated in the analysis phase.
   interface rocsolver_scsrrf_analysis
     function rocsolver_scsrrf_analysis_(handle,n,nrhs,nnzM,ptrM,indM,valM,nnzT,ptrT,indT,valT, &
@@ -42790,49 +40301,36 @@ module hipfort_rocsolver
   !>     mode), otherwise, the workflow will
   !>     result in an error.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows (and columns) of matrix A.
-  !>     @param[in]
-  !>     nnzA        rocblas_int. nnzA >= 0.
+  !>     @param[in] nnzA - rocblas_int. nnzA >= 0.
   !>                 The number of non-zero elements in A.
-  !>     @param[in]
-  !>     ptrA        pointer to rocblas_int. Array on the GPU of dimension n+1.
+  !>     @param[in] ptrA - pointer to rocblas_int. Array on the GPU of dimension n+1.
   !>                 It contains the positions of the beginning of each row in indA and valA.
   !>                 The last element of ptrM is equal to nnzA.
-  !>     @param[in]
-  !>     indA        pointer to rocblas_int. Array on the GPU of dimension nnzA.
+  !>     @param[in] indA - pointer to rocblas_int. Array on the GPU of dimension nnzA.
   !>                 It contains the column indices of the non-zero elements of M. Indices are
   !>                 sorted by row and by column within each row.
-  !>     @param[in]
-  !>     valA        pointer to type. Array on the GPU of dimension nnzA.
+  !>     @param[in] valA - pointer to type. Array on the GPU of dimension nnzA.
   !>                 The values of the non-zero elements of A.
-  !>     @param[in]
-  !>     nnzT        rocblas_int. nnzT >= 0.
+  !>     @param[in] nnzT - rocblas_int. nnzT >= 0.
   !>                 The number of non-zero elements in T.
-  !>     @param[in]
-  !>     ptrT        pointer to rocblas_int. Array on the GPU of dimension n+1.
+  !>     @param[in] ptrT - pointer to rocblas_int. Array on the GPU of dimension n+1.
   !>                 It contains the positions of the beginning of each row in indT and valT.
   !>                 The last element of ptrT is equal to nnzT.
-  !>     @param[in]
-  !>     indT        pointer to rocblas_int. Array on the GPU of dimension nnzT.
+  !>     @param[in] indT - pointer to rocblas_int. Array on the GPU of dimension nnzT.
   !>                 It contains the column indices of the non-zero elements of T. Indices are
   !>                 sorted by row and by column within each row.
-  !>     @param[out]
-  !>     valT        pointer to type. Array on the GPU of dimension nnzT.
+  !>     @param[out] valT - pointer to type. Array on the GPU of dimension nnzT.
   !>                 The values of the non-zero elements of the new bundle matrix (L_A - I) + U_A.
-  !>     @param[in]
-  !>     pivP        pointer to rocblas_int. Array on the GPU of dimension n.
+  !>     @param[in] pivP - pointer to rocblas_int. Array on the GPU of dimension n.
   !>                 Contains the pivot indices representing the permutation matrix P, that is, the
   !>                 order in which the rows of matrix M were rearranged.
-  !>     @param[in]
-  !>     pivQ        pointer to rocblas_int. Array on the GPU of dimension n.
+  !>     @param[in] pivQ - pointer to rocblas_int. Array on the GPU of dimension n.
   !>                 Contains the pivot indices representing the permutation matrix Q, that is, the
   !>                 order in which the columns of matrix M were rearranged.
-  !>     @param[in]
-  !>     rfinfo      rocsolver_rfinfo.
+  !>     @param[in] rfinfo - rocsolver_rfinfo.
   !>                 Structure that holds the meta data generated in the analysis phase.
   interface rocsolver_scsrrf_refactlu
     function rocsolver_scsrrf_refactlu_(handle,n,nnzA,ptrA,indA,valA,nnzT,ptrT,indT,valT,pivP, &
@@ -42914,48 +40412,36 @@ module hipfort_rocsolver
   !>     otherwise, the workflow will
   !>     result in an error.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows (and columns) of matrix A.
-  !>     @param[in]
-  !>     nnzA        rocblas_int. nnzA >= 0.
+  !>     @param[in] nnzA - rocblas_int. nnzA >= 0.
   !>                 The number of non-zero elements in A.
-  !>     @param[in]
-  !>     ptrA        pointer to rocblas_int. Array on the GPU of dimension n+1.
+  !>     @param[in] ptrA - pointer to rocblas_int. Array on the GPU of dimension n+1.
   !>                 It contains the positions of the beginning of each row in indA and valA.
   !>                 The last element of ptrM is equal to nnzA.
-  !>     @param[in]
-  !>     indA        pointer to rocblas_int. Array on the GPU of dimension nnzA.
+  !>     @param[in] indA - pointer to rocblas_int. Array on the GPU of dimension nnzA.
   !>                 It contains the column indices of the non-zero elements of M. Indices are
   !>                 sorted by row and by column within each row.
-  !>     @param[in]
-  !>     valA        pointer to type. Array on the GPU of dimension nnzA.
+  !>     @param[in] valA - pointer to type. Array on the GPU of dimension nnzA.
   !>                 The values of the non-zero elements of A. The strictly upper triangular entries
   !>                 are
   !>                 not referenced.
-  !>     @param[in]
-  !>     nnzT        rocblas_int. nnzT >= 0.
+  !>     @param[in] nnzT - rocblas_int. nnzT >= 0.
   !>                 The number of non-zero elements in T.
-  !>     @param[in]
-  !>     ptrT        pointer to rocblas_int. Array on the GPU of dimension n+1.
+  !>     @param[in] ptrT - pointer to rocblas_int. Array on the GPU of dimension n+1.
   !>                 It contains the positions of the beginning of each row in indT and valT.
   !>                 The last element of ptrT is equal to nnzT.
-  !>     @param[in]
-  !>     indT        pointer to rocblas_int. Array on the GPU of dimension nnzT.
+  !>     @param[in] indT - pointer to rocblas_int. Array on the GPU of dimension nnzT.
   !>                 It contains the column indices of the non-zero elements of T. Indices are
   !>                 sorted by row and by column within each row.
-  !>     @param[out]
-  !>     valT        pointer to type. Array on the GPU of dimension nnzT.
+  !>     @param[out] valT - pointer to type. Array on the GPU of dimension nnzT.
   !>                 The values of the non-zero elements of the new Cholesky factor L_A.
   !>                 The strictly upper triangular entries of this array are not referenced.
-  !>     @param[in]
-  !>     pivQ        pointer to rocblas_int. Array on the GPU of dimension n.
+  !>     @param[in] pivQ - pointer to rocblas_int. Array on the GPU of dimension n.
   !>                 Contains the pivot indices representing the permutation matrix Q, that is, the
   !>                 order in which the columns of matrix M were rearranged.
-  !>     @param[in]
-  !>     rfinfo      `rocsolver_rfinfo`.
+  !>     @param[in] rfinfo - `rocsolver_rfinfo`.
   !>                 Structure that holds the meta data generated in the analysis phase.
   interface rocsolver_scsrrf_refactchol
     function rocsolver_scsrrf_refactchol_(handle,n,nnzA,ptrA,indA,valA,nnzT,ptrT,indT,valT,pivQ, &
@@ -43046,48 +40532,36 @@ module hipfort_rocsolver
   !>     strictly upper triangular
   !>     part of \f$T\f$ will be ignored.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The number of rows (and columns) of matrix A.
-  !>     @param[in]
-  !>     nrhs        rocblas_int. nrhs >= 0.
+  !>     @param[in] nrhs - rocblas_int. nrhs >= 0.
   !>                 The number of right hand sides, that is, the number of columns of matrix B.
-  !>     @param[in]
-  !>     nnzT        rocblas_int. nnzT >= 0.
+  !>     @param[in] nnzT - rocblas_int. nnzT >= 0.
   !>                 The number of non-zero elements in T.
-  !>     @param[in]
-  !>     ptrT        pointer to rocblas_int. Array on the GPU of dimension n+1.
+  !>     @param[in] ptrT - pointer to rocblas_int. Array on the GPU of dimension n+1.
   !>                 It contains the positions of the beginning of each row in indT and valT.
   !>                 The last element of ptrT is equal to nnzT.
-  !>     @param[in]
-  !>     indT        pointer to rocblas_int. Array on the GPU of dimension nnzT.
+  !>     @param[in] indT - pointer to rocblas_int. Array on the GPU of dimension nnzT.
   !>                 It contains the column indices of the non-zero elements of T. Indices are
   !>                 sorted by row and by column within each row.
-  !>     @param[in]
-  !>     valT        pointer to type. Array on the GPU of dimension nnzT.
+  !>     @param[in] valT - pointer to type. Array on the GPU of dimension nnzT.
   !>                 The values of the non-zero elements of T. The strictly upper triangular entries
   !>                 are
   !>                 not referenced when working in Cholesky mode.
-  !>     @param[in]
-  !>     pivP        pointer to rocblas_int. Array on the GPU of dimension n.
+  !>     @param[in] pivP - pointer to rocblas_int. Array on the GPU of dimension n.
   !>                 Contains the pivot indices representing the permutation matrix P, that is, the
   !>                 order in which the rows of matrix A were rearranged. When working in Cholesky
   !>                 mode,
   !>                 this array is not referenced and can be null.
-  !>     @param[in]
-  !>     pivQ        pointer to rocblas_int. Array on the GPU of dimension n.
+  !>     @param[in] pivQ - pointer to rocblas_int. Array on the GPU of dimension n.
   !>                 Contains the pivot indices representing the permutation matrix Q, that is, the
   !>                 order in which the columns of matrix A were rearranged.
-  !>     @param[inout]
-  !>     B           pointer to type. Array on the GPU of dimension ldb*nrhs.
+  !>     @param[inout] B - pointer to type. Array on the GPU of dimension ldb*nrhs.
   !>                 On entry the right hand side matrix B. On exit, the solution matrix X.
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 The leading dimension of B.
-  !>     @param[in]
-  !>     rfinfo      rocsolver_rfinfo.
+  !>     @param[in] rfinfo - rocsolver_rfinfo.
   !>                 Structure that holds the metadata generated in the analysis phase.
   interface rocsolver_scsrrf_solve
     function rocsolver_scsrrf_solve_(handle,n,nrhs,nnzT,ptrT,indT,valT,pivP,pivQ,B,ldb,rfinfo) &
@@ -43148,62 +40622,48 @@ module hipfort_rocsolver
   !>     computed using a
   !>     divide-and-conquer approach.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     erange      `rocblas_erange`.
+  !>     @param[in] erange - `rocblas_erange`.
   !>                 Specifies the type of range or interval of the eigenvalues to be computed.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the symmetric matrix A is stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) part of A
   !>                 is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of rows and columns of matrix A.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the matrix A. On exit, the contents of A are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrix A.
-  !>     @param[in]
-  !>     vl          type. vl < vu.
+  !>     @param[in] vl - type. vl < vu.
   !>                 The lower bound of the search interval (vl, vu]. Ignored if range indicates to
   !>                 look
   !>                 for all the eigenvalues of A or the eigenvalues within a set of indices.
-  !>     @param[in]
-  !>     vu          type. vl < vu.
+  !>     @param[in] vu - type. vl < vu.
   !>                 The upper bound of the search interval (vl, vu]. Ignored if range indicates to
   !>                 look
   !>                 for all the eigenvalues of A or the eigenvalues within a set of indices.
-  !>     @param[in]
-  !>     il          rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] il - rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the smallest eigenvalue to be computed. Ignored if range indicates
   !>                 to look
   !>                 for all the eigenvalues of A or the eigenvalues in a half-open interval.
-  !>     @param[in]
-  !>     iu          rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise..
+  !>     @param[in] iu - rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise..
   !>                 The index of the largest eigenvalue to be computed. Ignored if range indicates
   !>                 to look
   !>                 for all the eigenvalues of A or the eigenvalues in a half-open interval.
-  !>     @param[out]
-  !>     nev         pointer to a rocblas_int on the GPU.
+  !>     @param[out] nev - pointer to a rocblas_int on the GPU.
   !>                 The total number of eigenvalues found. If erange is rocblas_erange_all, nev =
   !>                 n.
   !>                 If erange is rocblas_erange_index, nev = iu - il + 1. Otherwise, 0 <= nev <= n.
-  !>     @param[out]
-  !>     W           pointer to type. Array on the GPU of dimension n.
+  !>     @param[out] W - pointer to type. Array on the GPU of dimension n.
   !>                 The first nev elements contain the computed eigenvalues. (The remaining
   !>                 elements
   !>                 can be used as workspace for internal computations.)
-  !>     @param[out]
-  !>     Z           pointer to type. Array on the GPU of dimension ldz*nev.
+  !>     @param[out] Z - pointer to type. Array on the GPU of dimension ldz*nev.
   !>                 On exit, if evect is not rocblas_evect_none and info = 0, the first nev columns
   !>                 contain
   !>                 the eigenvectors of A corresponding to the output eigenvalues. Not referenced
@@ -43214,11 +40674,9 @@ module hipfort_rocsolver
   !>                 The user should ensure that Z is large enough to hold n columns, because all n
   !>                 columns
   !>                 can be used as workspace for internal computations.
-  !>     @param[in]
-  !>     ldz         rocblas_int. ldz >= n.
+  !>     @param[in] ldz - rocblas_int. ldz >= n.
   !>                 Specifies the leading dimension of matrix Z.
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info = 0, successful exit.
   !>                 If info = i > 0, the algorithm did not converge. i columns of Z did not
   !>                 converge.
@@ -43289,62 +40747,48 @@ module hipfort_rocsolver
   !>     computed using a
   !>     divide-and-conquer approach.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     erange      `rocblas_erange`.
+  !>     @param[in] erange - `rocblas_erange`.
   !>                 Specifies the type of range or interval of the eigenvalues to be computed.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the symmetric matrix A is stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) part of A
   !>                 is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of rows and columns of matrix A.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the matrix A. On exit, the contents of A are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrix A.
-  !>     @param[in]
-  !>     vl          real type. vl < vu.
+  !>     @param[in] vl - real type. vl < vu.
   !>                 The lower bound of the search interval (vl, vu]. Ignored if range indicates to
   !>                 look
   !>                 for all the eigenvalues of A or the eigenvalues within a set of indices.
-  !>     @param[in]
-  !>     vu          real type. vl < vu.
+  !>     @param[in] vu - real type. vl < vu.
   !>                 The upper bound of the search interval (vl, vu]. Ignored if range indicates to
   !>                 look
   !>                 for all the eigenvalues of A or the eigenvalues within a set of indices.
-  !>     @param[in]
-  !>     il          rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] il - rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the smallest eigenvalue to be computed. Ignored if range indicates
   !>                 to look
   !>                 for all the eigenvalues of A or the eigenvalues in a half-open interval.
-  !>     @param[in]
-  !>     iu          rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] iu - rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the largest eigenvalue to be computed. Ignored if range indicates
   !>                 to look
   !>                 for all the eigenvalues of A or the eigenvalues in a half-open interval.
-  !>     @param[out]
-  !>     nev         pointer to a rocblas_int on the GPU.
+  !>     @param[out] nev - pointer to a rocblas_int on the GPU.
   !>                 The total number of eigenvalues found. If erange is rocblas_erange_all, nev =
   !>                 n.
   !>                 If erange is rocblas_erange_index, nev = iu - il + 1. Otherwise, 0 <= nev <= n.
-  !>     @param[out]
-  !>     W           pointer to real type. Array on the GPU of dimension n.
+  !>     @param[out] W - pointer to real type. Array on the GPU of dimension n.
   !>                 The first nev elements contain the computed eigenvalues. (The remaining
   !>                 elements
   !>                 can be used as workspace for internal computations.)
-  !>     @param[out]
-  !>     Z           pointer to type. Array on the GPU of dimension ldz*nev.
+  !>     @param[out] Z - pointer to type. Array on the GPU of dimension ldz*nev.
   !>                 On exit, if evect is not rocblas_evect_none and info = 0, the first nev columns
   !>                 contain
   !>                 the eigenvectors of A corresponding to the output eigenvalues. Not referenced
@@ -43355,11 +40799,9 @@ module hipfort_rocsolver
   !>                 The user should ensure that Z is large enough to hold n columns, because all n
   !>                 columns
   !>                 can be used as workspace for internal computations.
-  !>     @param[in]
-  !>     ldz         rocblas_int. ldz >= n.
+  !>     @param[in] ldz - rocblas_int. ldz >= n.
   !>                 Specifies the leading dimension of matrix Z.
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info = 0, successful exit.
   !>                 If info = i > 0, the algorithm did not converge. i columns of Z did not
   !>                 converge.
@@ -43430,70 +40872,57 @@ module hipfort_rocsolver
   !>     computed using a
   !>     divide-and-conquer approach.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     erange      `rocblas_erange`.
+  !>     @param[in] erange - `rocblas_erange`.
   !>                 Specifies the type of range or interval of the eigenvalues to be computed.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the symmetric matrices A_l is
   !>                 stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) part of A_l
   !>                 is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of rows and columns of matrices A_l.
-  !>     @param[inout]
-  !>     A Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - Array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the matrices A_l. On exit, the contents of A_l are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     vl          type. vl < vu.
+  !>     @param[in] vl - type. vl < vu.
   !>                 The lower bound of the search interval (vl, vu]. Ignored if range indicates to
   !>                 look
   !>                 for all the eigenvalues of A_l or the eigenvalues within a set of indices.
-  !>     @param[in]
-  !>     vu          type. vl < vu.
+  !>     @param[in] vu - type. vl < vu.
   !>                 The upper bound of the search interval (vl, vu]. Ignored if range indicates to
   !>                 look
   !>                 for all the eigenvalues of A_l or the eigenvalues within a set of indices.
-  !>     @param[in]
-  !>     il          rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] il - rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the smallest eigenvalue to be computed. Ignored if range indicates
   !>                 to look
   !>                 for all the eigenvalues of A_l or the eigenvalues in a half-open interval.
-  !>     @param[in]
-  !>     iu          rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] iu - rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the largest eigenvalue to be computed. Ignored if range indicates
   !>                 to look
   !>                 for all the eigenvalues of A_l or the eigenvalues in a half-open interval.
-  !>     @param[out]
-  !>     nev         pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] nev - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 The total number of eigenvalues found. If erange is rocblas_erange_all, nev[l]
   !>                 = n.
   !>                 If erange is rocblas_erange_index, nev[l] = iu - il + 1. Otherwise, 0 <= nev[l]
   !>                 <= n.
-  !>     @param[out]
-  !>     W           pointer to type. Array on the GPU (the size depends on the value of strideW).
+  !>     @param[out] W - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideW).
   !>                 The first nev[l] elements contain the computed eigenvalues. (The remaining
   !>                 elements
   !>                 can be used as workspace for internal computations.)
-  !>     @param[in]
-  !>     strideW     rocblas_stride.
+  !>     @param[in] strideW - rocblas_stride.
   !>                 Stride from the start of one vector W_l to the next one W_(l+1).
   !>                 There is no restriction for the value of strideW. The normal use case is
   !>                 strideW >= n.
-  !>     @param[out]
-  !>     Z Array of pointers to type. Each pointer points to an array on the GPU of dimension
-  !>     ldz*nev[l].
+  !>     @param[out] Z - Array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension ldz*nev[l].
   !>                 On exit, if evect is not rocblas_evect_none and info[l] = 0, the first nev[l]
   !>                 columns contain
   !>                 the eigenvectors of A_l corresponding to the output eigenvalues. Not referenced
@@ -43504,16 +40933,13 @@ module hipfort_rocsolver
   !>                 The user should ensure that Z_l is large enough to hold n columns, because all
   !>                 n columns
   !>                 can be used as workspace for internal computations.
-  !>     @param[in]
-  !>     ldz         rocblas_int. ldz >= n.
+  !>     @param[in] ldz - rocblas_int. ldz >= n.
   !>                 Specifies the leading dimension of matrices Z_l.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for matrix A_l.
   !>                 If info[l] = i > 0, the algorithm did not converge. i columns of Z_l did not
   !>                 converge.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_ssyevdx_batched
     function rocsolver_ssyevdx_batched_(handle,evect,erange,uplo,n,A,lda,vl,vu,il,iu,nev,W, &
@@ -43588,70 +41014,57 @@ module hipfort_rocsolver
   !>     computed using a
   !>     divide-and-conquer approach.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     erange      `rocblas_erange`.
+  !>     @param[in] erange - `rocblas_erange`.
   !>                 Specifies the type of range or interval of the eigenvalues to be computed.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the symmetric matrices A_l is
   !>                 stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) part of A_l
   !>                 is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of rows and columns of matrices A_l.
-  !>     @param[inout]
-  !>     A Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - Array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the matrices A_l. On exit, the contents of A_l are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     vl          real type. vl < vu.
+  !>     @param[in] vl - real type. vl < vu.
   !>                 The lower bound of the search interval (vl, vu]. Ignored if range indicates to
   !>                 look
   !>                 for all the eigenvalues of A_l or the eigenvalues within a set of indices.
-  !>     @param[in]
-  !>     vu          real type. vl < vu.
+  !>     @param[in] vu - real type. vl < vu.
   !>                 The upper bound of the search interval (vl, vu]. Ignored if range indicates to
   !>                 look
   !>                 for all the eigenvalues of A_l or the eigenvalues within a set of indices.
-  !>     @param[in]
-  !>     il          rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] il - rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the smallest eigenvalue to be computed. Ignored if range indicates
   !>                 to look
   !>                 for all the eigenvalues of A_l or the eigenvalues in a half-open interval.
-  !>     @param[in]
-  !>     iu          rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] iu - rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the largest eigenvalue to be computed. Ignored if range indicates
   !>                 to look
   !>                 for all the eigenvalues of A_l or the eigenvalues in a half-open interval.
-  !>     @param[out]
-  !>     nev         pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] nev - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 The total number of eigenvalues found. If erange is rocblas_erange_all, nev[l]
   !>                 = n.
   !>                 If erange is rocblas_erange_index, nev[l] = iu - il + 1. Otherwise, 0 <= nev[l]
   !>                 <= n.
-  !>     @param[out]
-  !>     W pointer to real type. Array on the GPU (the size depends on the value of strideW).
+  !>     @param[out] W - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideW).
   !>                 The first nev[l] elements contain the computed eigenvalues. (The remaining
   !>                 elements
   !>                 can be used as workspace for internal computations.)
-  !>     @param[in]
-  !>     strideW     rocblas_stride.
+  !>     @param[in] strideW - rocblas_stride.
   !>                 Stride from the start of one vector W_l to the next one W_(l+1).
   !>                 There is no restriction for the value of strideW. The normal use case is
   !>                 strideW >= n.
-  !>     @param[out]
-  !>     Z Array of pointers to type. Each pointer points to an array on the GPU of dimension
-  !>     ldz*nev[l].
+  !>     @param[out] Z - Array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension ldz*nev[l].
   !>                 On exit, if evect is not rocblas_evect_none and info[l] = 0, the first nev[l]
   !>                 columns contain
   !>                 the eigenvectors of A_l corresponding to the output eigenvalues. Not referenced
@@ -43662,16 +41075,13 @@ module hipfort_rocsolver
   !>                 The user should ensure that Z_l is large enough to hold n columns, because all
   !>                 n columns
   !>                 can be used as workspace for internal computations.
-  !>     @param[in]
-  !>     ldz         rocblas_int. ldz >= n.
+  !>     @param[in] ldz - rocblas_int. ldz >= n.
   !>                 Specifies the leading dimension of matrices Z_l.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for matrix A_l.
   !>                 If info[l] = i > 0, the algorithm did not converge. i columns of Z_l did not
   !>                 converge.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_cheevdx_batched
     function rocsolver_cheevdx_batched_(handle,evect,erange,uplo,n,A,lda,vl,vu,il,iu,nev,W, &
@@ -43746,84 +41156,69 @@ module hipfort_rocsolver
   !>     computed using a
   !>     divide-and-conquer approach.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     erange      `rocblas_erange`.
+  !>     @param[in] erange - `rocblas_erange`.
   !>                 Specifies the type of range or interval of the eigenvalues to be computed.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the symmetric matrices A_l is
   !>                 stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) part of A_l
   !>                 is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of rows and columns of matrices A_l.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the matrices A_l. On exit, the contents of A_l are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[in]
-  !>     vl          type. vl < vu.
+  !>     @param[in] vl - type. vl < vu.
   !>                 The lower bound of the search interval (vl, vu]. Ignored if range indicates to
   !>                 look
   !>                 for all the eigenvalues of A_l or the eigenvalues within a set of indices.
-  !>     @param[in]
-  !>     vu          type. vl < vu.
+  !>     @param[in] vu - type. vl < vu.
   !>                 The upper bound of the search interval (vl, vu]. Ignored if range indicates to
   !>                 look
   !>                 for all the eigenvalues of A_l or the eigenvalues within a set of indices.
-  !>     @param[in]
-  !>     il          rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] il - rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the smallest eigenvalue to be computed. Ignored if range indicates
   !>                 to look
   !>                 for all the eigenvalues of A_l or the eigenvalues in a half-open interval.
-  !>     @param[in]
-  !>     iu          rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] iu - rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the largest eigenvalue to be computed. Ignored if range indicates
   !>                 to look
   !>                 for all the eigenvalues of A_l or the eigenvalues in a half-open interval.
-  !>     @param[out]
-  !>     nev         pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] nev - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 The total number of eigenvalues found. If erange is rocblas_erange_all, nev[l]
   !>                 = n.
   !>                 If erange is rocblas_erange_index, nev[l] = iu - il + 1. Otherwise, 0 <= nev[l]
   !>                 <= n.
-  !>     @param[out]
-  !>     W           pointer to type. Array on the GPU (the size depends on the value of strideW).
+  !>     @param[out] W - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideW).
   !>                 The first nev[l] elements contain the computed eigenvalues. (The remaining
   !>                 elements
   !>                 can be used as workspace for internal computations.)
-  !>     @param[in]
-  !>     strideW     rocblas_stride.
+  !>     @param[in] strideW - rocblas_stride.
   !>                 Stride from the start of one vector W_l to the next one W_(l+1).
   !>                 There is no restriction for the value of strideW. The normal use case is
   !>                 strideW >= n.
-  !>     @param[out]
-  !>     Z           pointer to type. Array on the GPU (the size depends on the value of strideZ).
+  !>     @param[out] Z - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideZ).
   !>                 On exit, if evect is not rocblas_evect_none and info[l] = 0, the first nev[l]
   !>                 columns contain
   !>                 the eigenvectors of A_l corresponding to the output eigenvalues. Not referenced
   !>                 if
   !>                 evect is rocblas_evect_none.
-  !>     @param[in]
-  !>     ldz         rocblas_int. ldz >= n.
+  !>     @param[in] ldz - rocblas_int. ldz >= n.
   !>                 Specifies the leading dimension of matrices Z_l.
-  !>     @param[in]
-  !>     strideZ     rocblas_stride.
+  !>     @param[in] strideZ - rocblas_stride.
   !>                 Stride from the start of one matrix Z_l to the next one Z_(l+1).
   !>                 There is no restriction for the value of strideZ. The normal use case is
   !>                 strideZ >= ldz*nev[l].
@@ -43832,13 +41227,11 @@ module hipfort_rocsolver
   !>                 The user should ensure that Z_l is large enough to hold n columns, because all
   !>                 n columns
   !>                 can be used as workspace for internal computations.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for matrix A_l.
   !>                 If info[l] = i > 0, the algorithm did not converge. i columns of Z_l did not
   !>                 converge.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_ssyevdx_strided_batched
     function rocsolver_ssyevdx_strided_batched_(handle,evect,erange,uplo,n,A,lda,strideA,vl,vu,il, &
@@ -43917,84 +41310,69 @@ module hipfort_rocsolver
   !>     computed using a
   !>     divide-and-conquer approach.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     erange      `rocblas_erange`.
+  !>     @param[in] erange - `rocblas_erange`.
   !>                 Specifies the type of range or interval of the eigenvalues to be computed.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower part of the symmetric matrices A_l is
   !>                 stored.
   !>                 If uplo indicates lower (or upper), then the upper (or lower) part of A_l
   !>                 is not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 Number of rows and columns of matrices A_l.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the matrices A_l. On exit, the contents of A_l are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[in]
-  !>     vl          real type. vl < vu.
+  !>     @param[in] vl - real type. vl < vu.
   !>                 The lower bound of the search interval (vl, vu]. Ignored if range indicates to
   !>                 look
   !>                 for all the eigenvalues of A_l or the eigenvalues within a set of indices.
-  !>     @param[in]
-  !>     vu          real type. vl < vu.
+  !>     @param[in] vu - real type. vl < vu.
   !>                 The upper bound of the search interval (vl, vu]. Ignored if range indicates to
   !>                 look
   !>                 for all the eigenvalues of A_l or the eigenvalues within a set of indices.
-  !>     @param[in]
-  !>     il          rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] il - rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the smallest eigenvalue to be computed. Ignored if range indicates
   !>                 to look
   !>                 for all the eigenvalues of A_l or the eigenvalues in a half-open interval.
-  !>     @param[in]
-  !>     iu          rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] iu - rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the largest eigenvalue to be computed. Ignored if range indicates
   !>                 to look
   !>                 for all the eigenvalues of A_l or the eigenvalues in a half-open interval.
-  !>     @param[out]
-  !>     nev         pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] nev - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 The total number of eigenvalues found. If erange is rocblas_erange_all, nev[l]
   !>                 = n.
   !>                 If erange is rocblas_erange_index, nev[l] = iu - il + 1. Otherwise, 0 <= nev[l]
   !>                 <= n.
-  !>     @param[out]
-  !>     W pointer to real type. Array on the GPU (the size depends on the value of strideW).
+  !>     @param[out] W - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideW).
   !>                 The first nev[l] elements contain the computed eigenvalues. (The remaining
   !>                 elements
   !>                 can be used as workspace for internal computations.)
-  !>     @param[in]
-  !>     strideW     rocblas_stride.
+  !>     @param[in] strideW - rocblas_stride.
   !>                 Stride from the start of one vector W_l to the next one W_(l+1).
   !>                 There is no restriction for the value of strideW. The normal use case is
   !>                 strideW >= n.
-  !>     @param[out]
-  !>     Z           pointer to type. Array on the GPU (the size depends on the value of strideZ).
+  !>     @param[out] Z - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideZ).
   !>                 On exit, if evect is not rocblas_evect_none and info[l] = 0, the first nev[l]
   !>                 columns contain
   !>                 the eigenvectors of A_l corresponding to the output eigenvalues. Not referenced
   !>                 if
   !>                 evect is rocblas_evect_none.
-  !>     @param[in]
-  !>     ldz         rocblas_int. ldz >= n.
+  !>     @param[in] ldz - rocblas_int. ldz >= n.
   !>                 Specifies the leading dimension of matrices Z_l.
-  !>     @param[in]
-  !>     strideZ     rocblas_stride.
+  !>     @param[in] strideZ - rocblas_stride.
   !>                 Stride from the start of one matrix Z_l to the next one Z_(l+1).
   !>                 There is no restriction for the value of strideZ. The normal use case is
   !>                 strideZ >= ldz*nev[l].
@@ -44003,13 +41381,11 @@ module hipfort_rocsolver
   !>                 The user should ensure that Z_l is large enough to hold n columns, because all
   !>                 n columns
   !>                 can be used as workspace for internal computations.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit for matrix A_l.
   !>                 If info[l] = i > 0, the algorithm did not converge. i columns of Z_l did not
   !>                 converge.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_cheevdx_strided_batched
     function rocsolver_cheevdx_strided_batched_(handle,evect,erange,uplo,n,A,lda,strideA,vl,vu,il, &
@@ -44110,72 +41486,55 @@ module hipfort_rocsolver
   !>     computed using a
   !>     divide-and-conquer approach.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     itype       `rocblas_eform`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] itype - `rocblas_eform`.
   !>                 Specifies the form of the generalized eigenproblem.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     erange      `rocblas_erange`.
+  !>     @param[in] erange - `rocblas_erange`.
   !>                 Specifies the type of range or interval of the eigenvalues to be computed.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower parts of the matrices
   !>                 A and B are stored. If uplo indicates lower (or upper),
   !>                 then the upper (or lower) parts of A and B are not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The matrix dimensions.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the matrix A. On exit, the contents of A are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrix A.
-  !>     @param[out]
-  !>     B           pointer to type. Array on the GPU of dimension ldb*n.
+  !>     @param[out] B - pointer to type. Array on the GPU of dimension ldb*n.
   !>                 On entry, the symmetric positive definite matrix B. On exit, the
   !>                 triangular factor of B as returned by \ref rocsolver_spotrf "POTRF".
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 Specifies the leading dimension of B.
-  !>     @param[in]
-  !>     vl          type. vl < vu.
+  !>     @param[in] vl - type. vl < vu.
   !>                 The lower bound of the search interval (vl, vu]. Ignored if range indicates to
   !>                 look
   !>                 for all the eigenvalues of A or the eigenvalues within a set of indices.
-  !>     @param[in]
-  !>     vu          type. vl < vu.
+  !>     @param[in] vu - type. vl < vu.
   !>                 The upper bound of the search interval (vl, vu]. Ignored if range indicates to
   !>                 look
   !>                 for all the eigenvalues of A or the eigenvalues within a set of indices.
-  !>     @param[in]
-  !>     il          rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] il - rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the smallest eigenvalue to be computed. Ignored if range indicates
   !>                 to look
   !>                 for all the eigenvalues of A or the eigenvalues in a half-open interval.
-  !>     @param[in]
-  !>     iu          rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] iu - rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the largest eigenvalue to be computed. Ignored if range indicates
   !>                 to look
   !>                 for all the eigenvalues of A or the eigenvalues in a half-open interval.
-  !>     @param[out]
-  !>     nev         pointer to a rocblas_int on the GPU.
+  !>     @param[out] nev - pointer to a rocblas_int on the GPU.
   !>                 The total number of eigenvalues found. If erange is rocblas_erange_all, nev =
   !>                 n.
   !>                 If erange is rocblas_erange_index, nev = iu - il + 1. Otherwise, 0 <= nev <= n.
-  !>     @param[out]
-  !>     W           pointer to type. Array on the GPU of dimension n.
+  !>     @param[out] W - pointer to type. Array on the GPU of dimension n.
   !>                 The first nev elements contain the computed eigenvalues. (The remaining
   !>                 elements
   !>                 can be used as workspace for internal computations.)
-  !>     @param[out]
-  !>     Z           pointer to type. Array on the GPU of dimension ldz*nev.
+  !>     @param[out] Z - pointer to type. Array on the GPU of dimension ldz*nev.
   !>                 On exit, if evect is not rocblas_evect_none and info = 0, the first nev columns
   !>                 contain
   !>                 the eigenvectors of A corresponding to the output eigenvalues. Not referenced
@@ -44186,11 +41545,9 @@ module hipfort_rocsolver
   !>                 The user should ensure that Z is large enough to hold n columns, because all n
   !>                 columns
   !>                 can be used as workspace for internal computations.
-  !>     @param[in]
-  !>     ldz         rocblas_int. ldz >= n.
+  !>     @param[in] ldz - rocblas_int. ldz >= n.
   !>                 Specifies the leading dimension of matrix Z.
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info = 0, successful exit.
   !>                 If info = i <= n, i columns of Z did not converge.
   !>                 If info = n + i, the leading minor of order i of B is not
@@ -44292,72 +41649,55 @@ module hipfort_rocsolver
   !>     computed using a
   !>     divide-and-conquer approach.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     itype       `rocblas_eform`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] itype - `rocblas_eform`.
   !>                 Specifies the form of the generalized eigenproblem.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     erange      `rocblas_erange`.
+  !>     @param[in] erange - `rocblas_erange`.
   !>                 Specifies the type of range or interval of the eigenvalues to be computed.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower parts of the matrices
   !>                 A and B are stored. If uplo indicates lower (or upper),
   !>                 then the upper (or lower) parts of A and B are not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The matrix dimensions.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU of dimension lda*n.
+  !>     @param[inout] A - pointer to type. Array on the GPU of dimension lda*n.
   !>                 On entry, the matrix A. On exit, the contents of A are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrix A.
-  !>     @param[out]
-  !>     B           pointer to type. Array on the GPU of dimension ldb*n.
+  !>     @param[out] B - pointer to type. Array on the GPU of dimension ldb*n.
   !>                 On entry, the Hermitian positive definite matrix B. On exit, the
   !>                 triangular factor of B as returned by \ref rocsolver_spotrf "POTRF".
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 Specifies the leading dimension of B.
-  !>     @param[in]
-  !>     vl          real type. vl < vu.
+  !>     @param[in] vl - real type. vl < vu.
   !>                 The lower bound of the search interval (vl, vu]. Ignored if range indicates to
   !>                 look
   !>                 for all the eigenvalues of A or the eigenvalues within a set of indices.
-  !>     @param[in]
-  !>     vu          real type. vl < vu.
+  !>     @param[in] vu - real type. vl < vu.
   !>                 The upper bound of the search interval (vl, vu]. Ignored if range indicates to
   !>                 look
   !>                 for all the eigenvalues of A or the eigenvalues within a set of indices.
-  !>     @param[in]
-  !>     il          rocblas_int. il = 1 if n = 0, and  1 <= il <= iu otherwise.
+  !>     @param[in] il - rocblas_int. il = 1 if n = 0, and  1 <= il <= iu otherwise.
   !>                 The index of the smallest eigenvalue to be computed. Ignored if range indicates
   !>                 to look
   !>                 for all the eigenvalues of A or the eigenvalues in a half-open interval.
-  !>     @param[in]
-  !>     iu          rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] iu - rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the largest eigenvalue to be computed. Ignored if range indicates
   !>                 to look
   !>                 for all the eigenvalues of A or the eigenvalues in a half-open interval.
-  !>     @param[out]
-  !>     nev         pointer to a rocblas_int on the GPU.
+  !>     @param[out] nev - pointer to a rocblas_int on the GPU.
   !>                 The total number of eigenvalues found. If erange is rocblas_erange_all, nev =
   !>                 n.
   !>                 If erange is rocblas_erange_index, nev = iu - il + 1. Otherwise, 0 <= nev <= n.
-  !>     @param[out]
-  !>     W           pointer to real type. Array on the GPU of dimension n.
+  !>     @param[out] W - pointer to real type. Array on the GPU of dimension n.
   !>                 The first nev elements contain the computed eigenvalues. (The remaining
   !>                 elements
   !>                 can be used as workspace for internal computations.)
-  !>     @param[out]
-  !>     Z           pointer to type. Array on the GPU of dimension ldz*nev.
+  !>     @param[out] Z - pointer to type. Array on the GPU of dimension ldz*nev.
   !>                 On exit, if evect is not rocblas_evect_none and info = 0, the first nev columns
   !>                 contain
   !>                 the eigenvectors of A corresponding to the output eigenvalues. Not referenced
@@ -44368,11 +41708,9 @@ module hipfort_rocsolver
   !>                 The user should ensure that Z is large enough to hold n columns, because all n
   !>                 columns
   !>                 can be used as workspace for internal computations.
-  !>     @param[in]
-  !>     ldz         rocblas_int. ldz >= n.
+  !>     @param[in] ldz - rocblas_int. ldz >= n.
   !>                 Specifies the leading dimension of matrix Z.
-  !>     @param[out]
-  !>     info        pointer to a rocblas_int on the GPU.
+  !>     @param[out] myInfo - pointer to a rocblas_int on the GPU.
   !>                 If info = 0, successful exit.
   !>                 If info = i <= n, i columns of Z did not converge.
   !>                 If info = n + i, the leading minor of order i of B is not
@@ -44488,80 +41826,65 @@ module hipfort_rocsolver
   !>     computed using a
   !>     divide-and-conquer approach.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     itype       `rocblas_eform`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] itype - `rocblas_eform`.
   !>                 Specifies the form of the generalized eigenproblems.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     erange      `rocblas_erange`.
+  !>     @param[in] erange - `rocblas_erange`.
   !>                 Specifies the type of range or interval of the eigenvalues to be computed.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower parts of the matrices
   !>                 A_l and B_l are stored. If uplo indicates lower (or upper),
   !>                 then the upper (or lower) parts of A_l and B_l are not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The matrix dimensions.
-  !>     @param[inout]
-  !>     A Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - Array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the matrices A_l. On exit, the contents of A_l are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[out]
-  !>     B Array of pointers to type. Each pointer points to an array on the GPU of dimension ldb*n.
+  !>     @param[out] B - Array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension ldb*n.
   !>                 On entry, the symmetric positive definite matrices B_l. On exit, the
   !>                 triangular factor of B_l as returned by \ref rocsolver_spotrf_batched
   !>                 "POTRF_BATCHED".
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 Specifies the leading dimension of B_l.
-  !>     @param[in]
-  !>     vl          type. vl < vu.
+  !>     @param[in] vl - type. vl < vu.
   !>                 The lower bound of the search interval (vl, vu]. Ignored if range indicates to
   !>                 look
   !>                 for all the eigenvalues of A_l or the eigenvalues within a set of indices.
-  !>     @param[in]
-  !>     vu          type. vl < vu.
+  !>     @param[in] vu - type. vl < vu.
   !>                 The upper bound of the search interval (vl, vu]. Ignored if range indicates to
   !>                 look
   !>                 for all the eigenvalues of A_l or the eigenvalues within a set of indices.
-  !>     @param[in]
-  !>     il          rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] il - rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the smallest eigenvalue to be computed. Ignored if range indicates
   !>                 to look
   !>                 for all the eigenvalues of A_l or the eigenvalues in a half-open interval.
-  !>     @param[in]
-  !>     iu          rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] iu - rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the largest eigenvalue to be computed. Ignored if range indicates
   !>                 to look
   !>                 for all the eigenvalues of A_l or the eigenvalues in a half-open interval.
-  !>     @param[out]
-  !>     nev         pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] nev - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 The total number of eigenvalues found. If erange is rocblas_erange_all, nev[l]
   !>                 = n.
   !>                 If erange is rocblas_erange_index, nev[l] = iu - il + 1. Otherwise, 0 <= nev[l]
   !>                 <= n.
-  !>     @param[out]
-  !>     W           pointer to type. Array on the GPU (the size depends on the value of strideW).
+  !>     @param[out] W - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideW).
   !>                 The first nev[l] elements contain the computed eigenvalues. (The remaining
   !>                 elements
   !>                 can be used as workspace for internal computations.)
-  !>     @param[in]
-  !>     strideW     rocblas_stride.
+  !>     @param[in] strideW - rocblas_stride.
   !>                 Stride from the start of one vector W_l to the next one W_(l+1).
   !>                 There is no restriction for the value of strideW. The normal use case is
   !>                 strideW >= n.
-  !>     @param[out]
-  !>     Z Array of pointers to type. Each pointer points to an array on the GPU of dimension
-  !>     ldz*nev[l].
+  !>     @param[out] Z - Array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension ldz*nev[l].
   !>                 On exit, if evect is not rocblas_evect_none and info[l] = 0, the first nev[l]
   !>                 columns contain
   !>                 the eigenvectors of A_l corresponding to the output eigenvalues. Not referenced
@@ -44572,17 +41895,14 @@ module hipfort_rocsolver
   !>                 The user should ensure that Z_l is large enough to hold n columns, because all
   !>                 n columns
   !>                 can be used as workspace for internal computations.
-  !>     @param[in]
-  !>     ldz         rocblas_int. ldz >= n.
+  !>     @param[in] ldz - rocblas_int. ldz >= n.
   !>                 Specifies the leading dimension of matrices Z_l.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit of batch instance l.
   !>                 If info[l] = i <= n, i columns of Z_l did not converge.
   !>                 If info[l] = n + i, the leading minor of order i of B_l is not
   !>                 positive definite.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_ssygvdx_batched
     function rocsolver_ssygvdx_batched_(handle,itype,evect,erange,uplo,n,A,lda,B,ldb,vl,vu,il,iu, &
@@ -44685,80 +42005,65 @@ module hipfort_rocsolver
   !>     computed using a
   !>     divide-and-conquer approach.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     itype       `rocblas_eform`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] itype - `rocblas_eform`.
   !>                 Specifies the form of the generalized eigenproblems.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     erange      `rocblas_erange`.
+  !>     @param[in] erange - `rocblas_erange`.
   !>                 Specifies the type of range or interval of the eigenvalues to be computed.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower parts of the matrices
   !>                 A_l and B_l are stored. If uplo indicates lower (or upper),
   !>                 then the upper (or lower) parts of A_l and B_l are not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The matrix dimensions.
-  !>     @param[inout]
-  !>     A Array of pointers to type. Each pointer points to an array on the GPU of dimension lda*n.
+  !>     @param[inout] A - Array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension lda*n.
   !>                 On entry, the matrices A_l. On exit, the contents of A_l are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[out]
-  !>     B Array of pointers to type. Each pointer points to an array on the GPU of dimension ldb*n.
+  !>     @param[out] B - Array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension ldb*n.
   !>                 On entry, the Hermitian positive definite matrices B_l. On exit, the
   !>                 triangular factor of B_l as returned by \ref rocsolver_spotrf_batched
   !>                 "POTRF_BATCHED".
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 Specifies the leading dimension of B_l.
-  !>     @param[in]
-  !>     vl          real type. vl < vu.
+  !>     @param[in] vl - real type. vl < vu.
   !>                 The lower bound of the search interval (vl, vu]. Ignored if range indicates to
   !>                 look
   !>                 for all the eigenvalues of A_l or the eigenvalues within a set of indices.
-  !>     @param[in]
-  !>     vu          real type. vl < vu.
+  !>     @param[in] vu - real type. vl < vu.
   !>                 The upper bound of the search interval (vl, vu]. Ignored if range indicates to
   !>                 look
   !>                 for all the eigenvalues of A_l or the eigenvalues within a set of indices.
-  !>     @param[in]
-  !>     il          rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] il - rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the smallest eigenvalue to be computed. Ignored if range indicates
   !>                 to look
   !>                 for all the eigenvalues of A_l or the eigenvalues in a half-open interval.
-  !>     @param[in]
-  !>     iu          rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] iu - rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the largest eigenvalue to be computed. Ignored if range indicates
   !>                 to look
   !>                 for all the eigenvalues of A_l or the eigenvalues in a half-open interval.
-  !>     @param[out]
-  !>     nev         pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] nev - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 The total number of eigenvalues found. If erange is rocblas_erange_all, nev[l]
   !>                 = n.
   !>                 If erange is rocblas_erange_index, nev[l] = iu - il + 1. Otherwise, 0 <= nev[l]
   !>                 <= n.
-  !>     @param[out]
-  !>     W pointer to real type. Array on the GPU (the size depends on the value of strideW).
+  !>     @param[out] W - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideW).
   !>                 The first nev[l] elements contain the computed eigenvalues. (The remaining
   !>                 elements
   !>                 can be used as workspace for internal computations.)
-  !>     @param[in]
-  !>     strideW     rocblas_stride.
+  !>     @param[in] strideW - rocblas_stride.
   !>                 Stride from the start of one vector W_l to the next one W_(l+1).
   !>                 There is no restriction for the value of strideW. The normal use case is
   !>                 strideW >= n.
-  !>     @param[out]
-  !>     Z Array of pointers to type. Each pointer points to an array on the GPU of dimension
-  !>     ldz*nev[l].
+  !>     @param[out] Z - Array of pointers to type. Each pointer points to an array on the GPU of
+  !>     dimension ldz*nev[l].
   !>                 On exit, if evect is not rocblas_evect_none and info[l] = 0, the first nev[l]
   !>                 columns contain
   !>                 the eigenvectors of A_l corresponding to the output eigenvalues. Not referenced
@@ -44769,17 +42074,14 @@ module hipfort_rocsolver
   !>                 The user should ensure that Z_l is large enough to hold n columns, because all
   !>                 n columns
   !>                 can be used as workspace for internal computations.
-  !>     @param[in]
-  !>     ldz         rocblas_int. ldz >= n.
+  !>     @param[in] ldz - rocblas_int. ldz >= n.
   !>                 Specifies the leading dimension of matrices Z_l.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit of batch instance l.
   !>                 If info[l] = i <= n, i columns of Z_l did not converge.
   !>                 If info[l] = n + i, the leading minor of order i of B_l is not
   !>                 positive definite.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_chegvdx_batched
     function rocsolver_chegvdx_batched_(handle,itype,evect,erange,uplo,n,A,lda,B,ldb,vl,vu,il,iu, &
@@ -44882,99 +42184,81 @@ module hipfort_rocsolver
   !>     computed using a
   !>     divide-and-conquer approach.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     itype       `rocblas_eform`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] itype - `rocblas_eform`.
   !>                 Specifies the form of the generalized eigenproblems.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     erange      `rocblas_erange`.
+  !>     @param[in] erange - `rocblas_erange`.
   !>                 Specifies the type of range or interval of the eigenvalues to be computed.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower parts of the matrices
   !>                 A_l and B_l are stored. If uplo indicates lower (or upper),
   !>                 then the upper (or lower) parts of A_l and B_l are not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The matrix dimensions.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the matrices A_l. On exit, the contents of A_l are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[out]
-  !>     B           pointer to type. Array on the GPU (the size depends on the value of strideB).
+  !>     @param[out] B - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideB).
   !>                 On entry, the symmetric positive definite matrices B_l. On exit, the
   !>                 triangular factor of B_l, as returned by \ref rocsolver_spotrf_strided_batched
   !>                 "POTRF_STRIDED_BATCHED".
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 Specifies the leading dimension of B_l.
-  !>     @param[in]
-  !>     strideB     rocblas_stride.
+  !>     @param[in] strideB - rocblas_stride.
   !>                 Stride from the start of one matrix B_l to the next one B_(l+1).
   !>                 There is no restriction for the value of strideB. The normal use is strideB >=
   !>                 ldb*n.
-  !>     @param[in]
-  !>     vl          type. vl < vu.
+  !>     @param[in] vl - type. vl < vu.
   !>                 The lower bound of the search interval (vl, vu]. Ignored if range indicates to
   !>                 look
   !>                 for all the eigenvalues of A_l or the eigenvalues within a set of indices.
-  !>     @param[in]
-  !>     vu          type. vl < vu.
+  !>     @param[in] vu - type. vl < vu.
   !>                 The upper bound of the search interval (vl, vu]. Ignored if range indicates to
   !>                 look
   !>                 for all the eigenvalues of A_l or the eigenvalues within a set of indices.
-  !>     @param[in]
-  !>     il          rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] il - rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the smallest eigenvalue to be computed. Ignored if range indicates
   !>                 to look
   !>                 for all the eigenvalues of A_l or the eigenvalues in a half-open interval.
-  !>     @param[in]
-  !>     iu          rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] iu - rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the largest eigenvalue to be computed. Ignored if range indicates
   !>                 to look
   !>                 for all the eigenvalues of A_l or the eigenvalues in a half-open interval.
-  !>     @param[out]
-  !>     nev         pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] nev - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 The total number of eigenvalues found. If erange is rocblas_erange_all, nev[l]
   !>                 = n.
   !>                 If erange is rocblas_erange_index, nev[l] = iu - il + 1. Otherwise, 0 <= nev[l]
   !>                 <= n.
-  !>     @param[out]
-  !>     W           pointer to type. Array on the GPU (the size depends on the value of strideW).
+  !>     @param[out] W - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideW).
   !>                 The first nev[l] elements contain the computed eigenvalues. (The remaining
   !>                 elements
   !>                 can be used as workspace for internal computations.)
-  !>     @param[in]
-  !>     strideW     rocblas_stride.
+  !>     @param[in] strideW - rocblas_stride.
   !>                 Stride from the start of one vector W_l to the next one W_(l+1).
   !>                 There is no restriction for the value of strideW. The normal use case is
   !>                 strideW >= n.
-  !>     @param[out]
-  !>     Z           pointer to type. Array on the GPU (the size depends on the value of strideZ).
+  !>     @param[out] Z - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideZ).
   !>                 On exit, if evect is not rocblas_evect_none and info[l] = 0, the first nev[l]
   !>                 columns contain
   !>                 the eigenvectors of A_l corresponding to the output eigenvalues. Not referenced
   !>                 if
   !>                 evect is rocblas_evect_none.
-  !>     @param[in]
-  !>     ldz         rocblas_int. ldz >= n.
+  !>     @param[in] ldz - rocblas_int. ldz >= n.
   !>                 Specifies the leading dimension of matrices Z_l.
-  !>     @param[in]
-  !>     strideZ     rocblas_stride.
+  !>     @param[in] strideZ - rocblas_stride.
   !>                 Stride from the start of one matrix Z_l to the next one Z_(l+1).
   !>                 There is no restriction for the value of strideZ. The normal use case is
   !>                 strideZ >= ldz*nev[l].
@@ -44983,14 +42267,12 @@ module hipfort_rocsolver
   !>                 The user should ensure that Z_l is large enough to hold n columns, because all
   !>                 n columns
   !>                 can be used as workspace for internal computations.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit of batch l.
   !>                 If info[l] = i <= n, i columns of Z_l did not converge.
   !>                 If info[l] = n + i, the leading minor of order i of B_l is not
   !>                 positive definite.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_ssygvdx_strided_batched
     function rocsolver_ssygvdx_strided_batched_(handle,itype,evect,erange,uplo,n,A,lda,strideA,B, &
@@ -45099,99 +42381,81 @@ module hipfort_rocsolver
   !>     computed using a
   !>     divide-and-conquer approach.
   !>
-  !>     @param[in]
-  !>     handle      rocblas_handle.
-  !>     @param[in]
-  !>     itype       `rocblas_eform`.
+  !>     @param[in] handle - rocblas_handle.
+  !>     @param[in] itype - `rocblas_eform`.
   !>                 Specifies the form of the generalized eigenproblems.
-  !>     @param[in]
-  !>     evect       `rocblas_evect`.
+  !>     @param[in] evect - `rocblas_evect`.
   !>                 Specifies whether the eigenvectors are to be computed.
   !>                 If evect is rocblas_evect_original, then the eigenvectors are computed.
   !>                 rocblas_evect_tridiagonal is not supported.
-  !>     @param[in]
-  !>     erange      `rocblas_erange`.
+  !>     @param[in] erange - `rocblas_erange`.
   !>                 Specifies the type of range or interval of the eigenvalues to be computed.
-  !>     @param[in]
-  !>     uplo        rocblas_fill.
+  !>     @param[in] uplo - rocblas_fill.
   !>                 Specifies whether the upper or lower parts of the matrices
   !>                 A_l and B_l are stored. If uplo indicates lower (or upper),
   !>                 then the upper (or lower) parts of A_l and B_l are not used.
-  !>     @param[in]
-  !>     n           rocblas_int. n >= 0.
+  !>     @param[in] n - rocblas_int. n >= 0.
   !>                 The matrix dimensions.
-  !>     @param[inout]
-  !>     A           pointer to type. Array on the GPU (the size depends on the value of strideA).
+  !>     @param[inout] A - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideA).
   !>                 On entry, the matrices A_l. On exit, the contents of A_l are destroyed.
-  !>     @param[in]
-  !>     lda         rocblas_int. lda >= n.
+  !>     @param[in] lda - rocblas_int. lda >= n.
   !>                 Specifies the leading dimension of matrices A_l.
-  !>     @param[in]
-  !>     strideA     rocblas_stride.
+  !>     @param[in] strideA - rocblas_stride.
   !>                 Stride from the start of one matrix A_l to the next one A_(l+1).
   !>                 There is no restriction for the value of strideA. The normal use case is
   !>                 strideA >= lda*n.
-  !>     @param[out]
-  !>     B           pointer to type. Array on the GPU (the size depends on the value of strideB).
+  !>     @param[out] B - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideB).
   !>                 On entry, the Hermitian positive definite matrices B_l. On exit, the
   !>                 triangular factor of B_l as returned by \ref rocsolver_spotrf_strided_batched
   !>                 "POTRF_STRIDED_BATCHED".
-  !>     @param[in]
-  !>     ldb         rocblas_int. ldb >= n.
+  !>     @param[in] ldb - rocblas_int. ldb >= n.
   !>                 Specifies the leading dimension of B_l.
-  !>     @param[in]
-  !>     strideB     rocblas_stride.
+  !>     @param[in] strideB - rocblas_stride.
   !>                 Stride from the start of one matrix B_l to the next one B_(l+1).
   !>                 There is no restriction for the value of strideB. The normal use is strideB >=
   !>                 ldb*n.
-  !>     @param[in]
-  !>     vl          real type. vl < vu.
+  !>     @param[in] vl - real type. vl < vu.
   !>                 The lower bound of the search interval (vl, vu]. Ignored if range indicates to
   !>                 look
   !>                 for all the eigenvalues of A_l or the eigenvalues within a set of indices.
-  !>     @param[in]
-  !>     vu          real type. vl < vu.
+  !>     @param[in] vu - real type. vl < vu.
   !>                 The upper bound of the search interval (vl, vu]. Ignored if range indicates to
   !>                 look
   !>                 for all the eigenvalues of A_l or the eigenvalues within a set of indices.
-  !>     @param[in]
-  !>     il          rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] il - rocblas_int. il = 1 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the smallest eigenvalue to be computed. Ignored if range indicates
   !>                 to look
   !>                 for all the eigenvalues of A_l or the eigenvalues in a half-open interval.
-  !>     @param[in]
-  !>     iu          rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
+  !>     @param[in] iu - rocblas_int. iu = 0 if n = 0, and 1 <= il <= iu otherwise.
   !>                 The index of the largest eigenvalue to be computed. Ignored if range indicates
   !>                 to look
   !>                 for all the eigenvalues of A_l or the eigenvalues in a half-open interval.
-  !>     @param[out]
-  !>     nev         pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] nev - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 The total number of eigenvalues found. If erange is rocblas_erange_all, nev[l]
   !>                 = n.
   !>                 If erange is rocblas_erange_index, nev[l] = iu - il + 1. Otherwise, 0 <= nev[l]
   !>                 <= n.
-  !>     @param[out]
-  !>     W pointer to real type. Array on the GPU (the size depends on the value of strideW).
+  !>     @param[out] W - pointer to real type. Array on the GPU (the size depends on the value of
+  !>     strideW).
   !>                 The first nev[l] elements contain the computed eigenvalues. (The remaining
   !>                 elements
   !>                 can be used as workspace for internal computations.)
-  !>     @param[in]
-  !>     strideW     rocblas_stride.
+  !>     @param[in] strideW - rocblas_stride.
   !>                 Stride from the start of one vector W_l to the next one W_(l+1).
   !>                 There is no restriction for the value of strideW. The normal use case is
   !>                 strideW >= n.
-  !>     @param[out]
-  !>     Z           pointer to type. Array on the GPU (the size depends on the value of strideZ).
+  !>     @param[out] Z - pointer to type. Array on the GPU (the size depends on the value of
+  !>     strideZ).
   !>                 On exit, if evect is not rocblas_evect_none and info[l] = 0, the first nev[l]
   !>                 columns contain
   !>                 the eigenvectors of A_l corresponding to the output eigenvalues. Not referenced
   !>                 if
   !>                 evect is rocblas_evect_none.
-  !>     @param[in]
-  !>     ldz         rocblas_int. ldz >= n.
+  !>     @param[in] ldz - rocblas_int. ldz >= n.
   !>                 Specifies the leading dimension of matrices Z_l.
-  !>     @param[in]
-  !>     strideZ     rocblas_stride.
+  !>     @param[in] strideZ - rocblas_stride.
   !>                 Stride from the start of one matrix Z_l to the next one Z_(l+1).
   !>                 There is no restriction for the value of strideZ. The normal use case is
   !>                 strideZ >= ldz*nev[l].
@@ -45200,14 +42464,12 @@ module hipfort_rocsolver
   !>                 The user should ensure that Z_l is large enough to hold n columns, because all
   !>                 n columns
   !>                 can be used as workspace for internal computations.
-  !>     @param[out]
-  !>     info        pointer to rocblas_int. Array of batch_count integers on the GPU.
+  !>     @param[out] myInfo - pointer to rocblas_int. Array of batch_count integers on the GPU.
   !>                 If info[l] = 0, successful exit of batch l.
   !>                 If info[l] = i <= n, i columns of Z_l did not converge.
   !>                 If info[l] = n + i, the leading minor of order i of B_l is not
   !>                 positive definite.
-  !>     @param[in]
-  !>     batch_count rocblas_int. batch_count >= 0.
+  !>     @param[in] batch_count - rocblas_int. batch_count >= 0.
   !>                 Number of matrices in the batch.
   interface rocsolver_chegvdx_strided_batched
     function rocsolver_chegvdx_strided_batched_(handle,itype,evect,erange,uplo,n,A,lda,strideA,B, &

--- a/lib/hipfort/hipfort_rocsparse.F90
+++ b/lib/hipfort/hipfort_rocsparse.F90
@@ -37,8 +37,7 @@ module hipfort_rocsparse
   !>   all subsequent library function calls. The handle should be destroyed at the end
   !>   using rocsparse_destroy_handle().
   !>
-  !>   @param[out]
-  !>   handle  the pointer to the handle to the rocSPARSE library context.
+  !>   @param[out] handle - the pointer to the handle to the rocSPARSE library context.
   !>
   !>   \retval rocsparse_status_success the initialization succeeded.
   !>   \retval rocsparse_status_invalid_handle \p handle pointer is invalid.
@@ -60,8 +59,7 @@ module hipfort_rocsparse
   !>   \p rocsparse_destroy_handle destroys the rocSPARSE library context and releases all
   !>   resources used by the rocSPARSE library.
   !>
-  !>   @param[in]
-  !>   handle  the handle to the rocSPARSE library context.
+  !>   @param[in] handle - the handle to the rocSPARSE library context.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_handle \p handle is invalid.
@@ -82,8 +80,8 @@ module hipfort_rocsparse
   !>   \details
   !>   \p rocsparse_destroy_error destroys the rocSPARSE error descriptor.
   !>
-  !>   @param[in]
-  !>   error  the pointer to the rocSPARSE error descriptor, which can be a null pointer.
+  !>   @param[in] error - the pointer to the rocSPARSE error descriptor, which can be a null
+  !>   pointer.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_internal_error an internal error occurred.
@@ -103,8 +101,7 @@ module hipfort_rocsparse
   !>   \details
   !>   \p rocsparse_error_message returns a C-style string that provides details for the error.
   !>
-  !>   @param[in]
-  !>   error  the error to the rocSPARSE error descriptor.
+  !>   @param[in] error - the error to the rocSPARSE error descriptor.
   !>
   !>   @return an error message from a rocSPARSE error descriptor.
   !>   \retval rocsparse_status_success the operation completed successfully.
@@ -127,8 +124,7 @@ module hipfort_rocsparse
   !>   representation of this status.
   !>   If the status is not recognized, the function returns "Unrecognized status code".
   !>
-  !>   @param[in]
-  !>   status  a rocSPARSE status.
+  !>   @param[in] status - a rocSPARSE status.
   !>
   !>   \retval pointer to null-terminated string.
   interface rocsparse_get_status_name
@@ -149,8 +145,7 @@ module hipfort_rocsparse
   !>   description as a string.
   !>   If the status is not recognized, the function returns "Unrecognized status code"
   !>
-  !>   @param[in]
-  !>   status  a rocSPARSE status.
+  !>   @param[in] status - a rocSPARSE status.
   !>
   !>   \retval pointer to null-terminated string.
   interface rocsparse_get_status_description
@@ -171,10 +166,8 @@ module hipfort_rocsparse
   !>   \p rocsparse_set_stream specifies the stream to be used by the rocSPARSE library
   !>   context and all subsequent function calls.
   !>
-  !>   @param[inout]
-  !>   handle  the handle to the rocSPARSE library context.
-  !>   @param[in]
-  !>   stream  the stream to be used by the rocSPARSE library context.
+  !>   @param[inout] handle - the handle to the rocSPARSE library context.
+  !>   @param[in] stream - the stream to be used by the rocSPARSE library context.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_handle \p handle is invalid.
@@ -218,10 +211,8 @@ module hipfort_rocsparse
   !>   \p rocsparse_get_stream gets the rocSPARSE library context stream which will
   !>   be used for all subsequent function calls.
   !>
-  !>   @param[in]
-  !>   handle the handle to the rocSPARSE library context.
-  !>   @param[out]
-  !>   stream the stream currently used by the rocSPARSE library context.
+  !>   @param[in] handle - the handle to the rocSPARSE library context.
+  !>   @param[out] stream - the stream currently used by the rocSPARSE library context.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_handle \p handle is invalid.
@@ -248,10 +239,8 @@ module hipfort_rocsparse
   !>   using host pointer mode. Valid pointer modes are `rocsparse_pointer_mode_host`
   !>   or `rocsparse_pointer_mode_device`.
   !>
-  !>   @param[in]
-  !>   handle          the handle to the rocSPARSE library context.
-  !>   @param[in]
-  !>   pointer_mode    the pointer mode to be used by the rocSPARSE library context.
+  !>   @param[in] handle - the handle to the rocSPARSE library context.
+  !>   @param[in] pointer_mode - the pointer mode to be used by the rocSPARSE library context.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_handle \p handle is invalid.
@@ -274,10 +263,8 @@ module hipfort_rocsparse
   !>   \p rocsparse_get_pointer_mode gets the rocSPARSE library context pointer mode which
   !>   will be used for all subsequent function calls.
   !>
-  !>   @param[in]
-  !>   handle          the handle to the rocSPARSE library context.
-  !>   @param[out]
-  !>   pointer_mode    the pointer mode that is currently used by the rocSPARSE library
+  !>   @param[in] handle - the handle to the rocSPARSE library context.
+  !>   @param[out] pointer_mode - the pointer mode that is currently used by the rocSPARSE library
   !>                   context.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
@@ -303,10 +290,8 @@ module hipfort_rocsparse
   !>   - minor = version / 100 % 1000
   !>   - major = version / 100000
   !>
-  !>   @param[in]
-  !>   handle  the handle to the rocSPARSE library context.
-  !>   @param[out]
-  !>   version the version number of the rocSPARSE library.
+  !>   @param[in] handle - the handle to the rocSPARSE library context.
+  !>   @param[out] version - the version number of the rocSPARSE library.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_handle \p handle is invalid.
@@ -334,10 +319,8 @@ module hipfort_rocsparse
   !>   \details
   !>   \p rocsparse_get_git_rev gets the rocSPARSE library git commit revision (SHA-1).
   !>
-  !>   @param[in]
-  !>   handle  the handle to the rocSPARSE library context.
-  !>   @param[out]
-  !>   rev     the git commit revision (SHA-1).
+  !>   @param[in] handle - the handle to the rocSPARSE library context.
+  !>   @param[out] rev - the git commit revision (SHA-1).
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_handle \p handle is invalid.
@@ -373,8 +356,7 @@ module hipfort_rocsparse
   !>   \ref rocsparse_set_mat_type, \ref rocsparse_set_mat_fill_mode, `rocsparse_set_mat_diag_type`,
   !>   \ref rocsparse_set_mat_index_base, and \ref rocsparse_set_mat_storage_mode APIs respectively.
   !>
-  !>   @param[out]
-  !>   descr   the pointer to the matrix descriptor.
+  !>   @param[out] descr - the pointer to the matrix descriptor.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer \p descr pointer is invalid.
@@ -394,10 +376,8 @@ module hipfort_rocsparse
   !>   \p rocsparse_copy_mat_descr copies a matrix descriptor. Both source and destination
   !>   matrix descriptors must be initialized prior to calling \p rocsparse_copy_mat_descr.
   !>
-  !>   @param[out]
-  !>   dest    the pointer to the destination matrix descriptor.
-  !>   @param[in]
-  !>   src     the pointer to the source matrix descriptor.
+  !>   @param[out] dest - the pointer to the destination matrix descriptor.
+  !>   @param[in] src - the pointer to the source matrix descriptor.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer \p src or \p dest pointer is invalid.
@@ -419,8 +399,7 @@ module hipfort_rocsparse
   !>   \p rocsparse_destroy_mat_descr destroys a matrix descriptor and releases all
   !>   resources used by the descriptor.
   !>
-  !>   @param[in]
-  !>   descr   the matrix descriptor.
+  !>   @param[in] descr - the matrix descriptor.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer \p descr is invalid.
@@ -441,10 +420,8 @@ module hipfort_rocsparse
   !>   \p rocsparse_set_mat_index_base sets the index base of a matrix descriptor. Valid
   !>   options are `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
   !>
-  !>   @param[inout]
-  !>   descr   the matrix descriptor.
-  !>   @param[in]
-  !>   base    `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
+  !>   @param[inout] descr - the matrix descriptor.
+  !>   @param[in] base - `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer \p descr pointer is invalid.
@@ -466,8 +443,7 @@ module hipfort_rocsparse
   !>   \details
   !>   \p rocsparse_get_mat_index_base returns the index base of a matrix descriptor.
   !>
-  !>   @param[in]
-  !>   descr   the matrix descriptor.
+  !>   @param[in] descr - the matrix descriptor.
   !>
   !>   \returns `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
   interface rocsparse_get_mat_index_base
@@ -489,10 +465,8 @@ module hipfort_rocsparse
   !>   `rocsparse_matrix_type_symmetric`, `rocsparse_matrix_type_hermitian`, or
   !>   `rocsparse_matrix_type_triangular`.
   !>
-  !>   @param[inout]
-  !>   descr   the matrix descriptor.
-  !>   @param[in]
-  !>   type    `rocsparse_matrix_type_general`, `rocsparse_matrix_type_symmetric`,
+  !>   @param[inout] descr - the matrix descriptor.
+  !>   @param[in] myType - `rocsparse_matrix_type_general`, `rocsparse_matrix_type_symmetric`,
   !>           `rocsparse_matrix_type_hermitian`, or
   !>           `rocsparse_matrix_type_triangular`.
   !>
@@ -516,8 +490,7 @@ module hipfort_rocsparse
   !>   \details
   !>   \p rocsparse_get_mat_type returns the matrix type of a matrix descriptor.
   !>
-  !>   @param[in]
-  !>   descr   the matrix descriptor.
+  !>   @param[in] descr - the matrix descriptor.
   !>
   !>   \returns    `rocsparse_matrix_type_general`, `rocsparse_matrix_type_symmetric`,
   !>               `rocsparse_matrix_type_hermitian`, or
@@ -540,10 +513,8 @@ module hipfort_rocsparse
   !>   Valid fill modes are `rocsparse_fill_mode_lower` or
   !>   `rocsparse_fill_mode_upper`.
   !>
-  !>   @param[inout]
-  !>   descr       the matrix descriptor.
-  !>   @param[in]
-  !>   fill_mode   `rocsparse_fill_mode_lower` or `rocsparse_fill_mode_upper`.
+  !>   @param[inout] descr - the matrix descriptor.
+  !>   @param[in] fill_mode - `rocsparse_fill_mode_lower` or `rocsparse_fill_mode_upper`.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer \p descr pointer is invalid.
@@ -566,8 +537,7 @@ module hipfort_rocsparse
   !>   \details
   !>   \p rocsparse_get_mat_fill_mode returns the matrix fill mode of a matrix descriptor.
   !>
-  !>   @param[in]
-  !>   descr   the matrix descriptor.
+  !>   @param[in] descr - the matrix descriptor.
   !>
   !>   \returns    `rocsparse_fill_mode_lower` or `rocsparse_fill_mode_upper`.
   interface rocsparse_get_mat_fill_mode
@@ -588,10 +558,8 @@ module hipfort_rocsparse
   !>   descriptor. Valid diagonal types are `rocsparse_diag_type_unit` or
   !>   `rocsparse_diag_type_non_unit`.
   !>
-  !>   @param[inout]
-  !>   descr       the matrix descriptor.
-  !>   @param[in]
-  !>   diag_type   `rocsparse_diag_type_unit` or `rocsparse_diag_type_non_unit`.
+  !>   @param[inout] descr - the matrix descriptor.
+  !>   @param[in] diag_type - `rocsparse_diag_type_unit` or `rocsparse_diag_type_non_unit`.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer \p descr pointer is invalid.
@@ -615,8 +583,7 @@ module hipfort_rocsparse
   !>   \p rocsparse_get_mat_diag_type returns the matrix diagonal type of a matrix
   !>   descriptor.
   !>
-  !>   @param[in]
-  !>   descr   the matrix descriptor.
+  !>   @param[in] descr - the matrix descriptor.
   !>
   !>   \returns `rocsparse_diag_type_unit` or `rocsparse_diag_type_non_unit`.
   interface rocsparse_get_mat_diag_type
@@ -637,10 +604,8 @@ module hipfort_rocsparse
   !>   Valid fill modes are `rocsparse_storage_mode_sorted` or
   !>   `rocsparse_storage_mode_unsorted`.
   !>
-  !>   @param[inout]
-  !>   descr           the matrix descriptor.
-  !>   @param[in]
-  !>   storage_mode    `rocsparse_storage_mode_sorted` or
+  !>   @param[inout] descr - the matrix descriptor.
+  !>   @param[in] storage_mode - `rocsparse_storage_mode_sorted` or
   !>                   `rocsparse_storage_mode_unsorted`.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
@@ -664,8 +629,7 @@ module hipfort_rocsparse
   !>   \details
   !>   \p rocsparse_get_mat_storage_mode returns the matrix storage mode of a matrix descriptor.
   !>
-  !>   @param[in]
-  !>   descr   the matrix descriptor.
+  !>   @param[in] descr - the matrix descriptor.
   !>
   !>   \returns    `rocsparse_storage_mode_sorted` or `rocsparse_storage_mode_unsorted`.
   interface rocsparse_get_mat_storage_mode
@@ -685,8 +649,7 @@ module hipfort_rocsparse
   !>   \p rocsparse_create_hyb_mat creates a structure that holds the matrix in \p HYB
   !>   storage format. It should be destroyed at the end using rocsparse_destroy_hyb_mat().
   !>
-  !>   @param[inout]
-  !>   hyb the pointer to the hybrid matrix.
+  !>   @param[inout] hyb - the pointer to the hybrid matrix.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer \p hyb pointer is invalid.
@@ -707,10 +670,8 @@ module hipfort_rocsparse
   !>   \p rocsparse_copy_hyb_mat copies a matrix info structure. Both source and destination
   !>   matrix info structure must be initialized prior to calling \p rocsparse_copy_hyb_mat.
   !>
-  !>   @param[out]
-  !>   dest    the pointer to the destination matrix info structure.
-  !>   @param[in]
-  !>   src     the pointer to the source matrix info structure.
+  !>   @param[out] dest - the pointer to the destination matrix info structure.
+  !>   @param[in] src - the pointer to the source matrix info structure.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer \p hyb pointer is invalid.
@@ -731,8 +692,7 @@ module hipfort_rocsparse
   !>   \details
   !>   \p rocsparse_destroy_hyb_mat destroys a \p HYB structure.
   !>
-  !>   @param[in]
-  !>   hyb the hybrid matrix structure.
+  !>   @param[in] hyb - the hybrid matrix structure.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer \p hyb pointer is invalid.
@@ -755,8 +715,7 @@ module hipfort_rocsparse
   !>   that is gathered during the analysis routines available. It should be destroyed
   !>   at the end using `rocsparse_destroy_mat_info()`.
   !>
-  !>   @param[inout]
-  !>   info    the pointer to the info structure.
+  !>   @param[inout] myInfo - the pointer to the info structure.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer \p info pointer is invalid.
@@ -776,10 +735,8 @@ module hipfort_rocsparse
   !>   \p rocsparse_copy_mat_info copies a matrix info structure. Both source and destination
   !>   matrix info structure must be initialized prior to calling \p rocsparse_copy_mat_info.
   !>
-  !>   @param[out]
-  !>   dest    the pointer to the destination matrix info structure.
-  !>   @param[in]
-  !>   src     the pointer to the source matrix info structure.
+  !>   @param[out] dest - the pointer to the destination matrix info structure.
+  !>   @param[in] src - the pointer to the source matrix info structure.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer \p src or \p dest pointer is invalid.
@@ -800,8 +757,7 @@ module hipfort_rocsparse
   !>   \details
   !>   \p rocsparse_destroy_mat_info destroys a matrix info structure.
   !>
-  !>   @param[in]
-  !>   info    the info structure.
+  !>   @param[in] myInfo - the info structure.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer \p info pointer is invalid.
@@ -824,8 +780,7 @@ module hipfort_rocsparse
   !>   that is gathered during the analysis routines. It should be destroyed
   !>   at the end using rocsparse_destroy_color_info().
   !>
-  !>   @param[inout]
-  !>   info    the pointer to the info structure.
+  !>   @param[inout] myInfo - the pointer to the info structure.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer \p info pointer is invalid.
@@ -845,10 +800,8 @@ module hipfort_rocsparse
   !>   \p rocsparse_copy_color_info copies a color info structure. Both source and destination
   !>   color info structure must be initialized prior to calling \p rocsparse_copy_color_info.
   !>
-  !>   @param[out]
-  !>   dest    the pointer to the destination color info structure.
-  !>   @param[in]
-  !>   src     the pointer to the source color info structure.
+  !>   @param[out] dest - the pointer to the destination color info structure.
+  !>   @param[in] src - the pointer to the source color info structure.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer \p src or \p dest pointer is invalid.
@@ -869,8 +822,7 @@ module hipfort_rocsparse
   !>   \details
   !>   \p rocsparse_destroy_color_info destroys a color info structure.
   !>
-  !>   @param[in]
-  !>   info    the info structure.
+  !>   @param[in] myInfo - the info structure.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer \p info pointer is invalid.
@@ -891,23 +843,15 @@ module hipfort_rocsparse
   !>   \p rocsparse_create_spvec_descr creates a sparse vector descriptor. It should be
   !>   destroyed at the end using `rocsparse_destroy_mat_descr()`.
   !>
-  !>   @param[out]
-  !>   descr   the pointer to the sparse vector descriptor.
-  !>   @param[in]
-  !>   size   size of the sparse vector.
-  !>   @param[in]
-  !>   nnz   number of non-zeros in sparse vector.
-  !>   @param[in]
-  !>   indices indices of the sparse vector where non-zeros occur. Must be an array of length \p
-  !>   nnz.
-  !>   @param[in]
-  !>   values   non-zero values in the sparse vector. Must be an array of length \p nnz.
-  !>   @param[in]
-  !>   idx_type   `rocsparse_indextype_i32` or `rocsparse_indextype_i64`.
-  !>   @param[in]
-  !>   idx_base   `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
-  !>   @param[in]
-  !>   data_type   `rocsparse_datatype_f32_r`, `rocsparse_datatype_f64_r`,
+  !>   @param[out] descr - the pointer to the sparse vector descriptor.
+  !>   @param[in] mySize - size of the sparse vector.
+  !>   @param[in] nnz - number of non-zeros in sparse vector.
+  !>   @param[in] indices - indices of the sparse vector where non-zeros occur. Must be an array of
+  !>   length \p nnz.
+  !>   @param[in] values - non-zero values in the sparse vector. Must be an array of length \p nnz.
+  !>   @param[in] idx_type - `rocsparse_indextype_i32` or `rocsparse_indextype_i64`.
+  !>   @param[in] idx_base - `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
+  !>   @param[in] data_type - `rocsparse_datatype_f32_r`, `rocsparse_datatype_f64_r`,
   !>               `rocsparse_datatype_f32_c`, or `rocsparse_datatype_f64_c`.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
@@ -960,8 +904,7 @@ module hipfort_rocsparse
   !>   \p rocsparse_destroy_spvec_descr destroys a sparse vector descriptor and releases all
   !>   resources used by the descriptor.
   !>
-  !>   @param[in]
-  !>   descr   the matrix descriptor.
+  !>   @param[in] descr - the matrix descriptor.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer \p descr is invalid.
@@ -980,23 +923,15 @@ module hipfort_rocsparse
   !>   \details
   !>   \p rocsparse_spvec_get gets the fields of the sparse vector descriptor.
   !>
-  !>   @param[in]
-  !>   descr   the pointer to the sparse vector descriptor.
-  !>   @param[out]
-  !>   size   size of the sparse vector.
-  !>   @param[out]
-  !>   nnz   number of non-zeros in sparse vector.
-  !>   @param[out]
-  !>   indices indices of the sparse vector where non-zeros occur. Must be an array of length \p
-  !>   nnz.
-  !>   @param[out]
-  !>   values   non-zero values in the sparse vector. Must be an array of length \p nnz.
-  !>   @param[out]
-  !>   idx_type   `rocsparse_indextype_i32` or `rocsparse_indextype_i64`.
-  !>   @param[out]
-  !>   idx_base   `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
-  !>   @param[out]
-  !>   data_type   `rocsparse_datatype_f32_r`, `rocsparse_datatype_f64_r`,
+  !>   @param[in] descr - the pointer to the sparse vector descriptor.
+  !>   @param[out] mySize - size of the sparse vector.
+  !>   @param[out] nnz - number of non-zeros in sparse vector.
+  !>   @param[out] indices - indices of the sparse vector where non-zeros occur. Must be an array of
+  !>   length \p nnz.
+  !>   @param[out] values - non-zero values in the sparse vector. Must be an array of length \p nnz.
+  !>   @param[out] idx_type - `rocsparse_indextype_i32` or `rocsparse_indextype_i64`.
+  !>   @param[out] idx_base - `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
+  !>   @param[out] data_type - `rocsparse_datatype_f32_r`, `rocsparse_datatype_f64_r`,
   !>               `rocsparse_datatype_f32_c`, or `rocsparse_datatype_f64_c`.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
@@ -1044,10 +979,8 @@ module hipfort_rocsparse
   !>  \ingroup aux_module
   !>   \brief Get the index base stored in the sparse vector descriptor.
   !>
-  !>   @param[in]
-  !>   descr   the pointer to the sparse vector descriptor.
-  !>   @param[out]
-  !>   idx_base   `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
+  !>   @param[in] descr - the pointer to the sparse vector descriptor.
+  !>   @param[out] idx_base - `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer if \p descr is invalid.
@@ -1067,10 +1000,8 @@ module hipfort_rocsparse
   !>  \ingroup aux_module
   !>   \brief Get the values array stored in the sparse vector descriptor
   !>
-  !>   @param[in]
-  !>   descr   the pointer to the sparse vector descriptor.
-  !>   @param[out]
-  !>   values   non-zero values in the sparse vector. Must be an array of length \p nnz.
+  !>   @param[in] descr - the pointer to the sparse vector descriptor.
+  !>   @param[out] values - non-zero values in the sparse vector. Must be an array of length \p nnz.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer if \p descr or \p values is invalid.
@@ -1100,10 +1031,8 @@ module hipfort_rocsparse
   !>  \ingroup aux_module
   !>   \brief Set the values array in the sparse vector descriptor.
   !>
-  !>   @param[inout]
-  !>   descr   the pointer to the sparse vector descriptor.
-  !>   @param[in]
-  !>   values   non-zero values in the sparse vector. Must be an array of length \p nnz.
+  !>   @param[inout] descr - the pointer to the sparse vector descriptor.
+  !>   @param[in] values - non-zero values in the sparse vector. Must be an array of length \p nnz.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer if \p descr or \p values is invalid.
@@ -1124,26 +1053,16 @@ module hipfort_rocsparse
   !>   \p rocsparse_create_coo_descr creates a sparse COO matrix descriptor. It should be
   !>   destroyed at the end using \p rocsparse_destroy_spmat_descr.
   !>
-  !>   @param[out]
-  !>   descr       the pointer to the sparse COO matrix descriptor.
-  !>   @param[in]
-  !>   rows        number of rows in the COO matrix.
-  !>   @param[in]
-  !>   cols        number of columns in the COO matrix
-  !>   @param[in]
-  !>   nnz         number of non-zeros in the COO matrix.
-  !>   @param[in]
-  !>   coo_row_ind row indices of the COO matrix. Must be an array of length \p nnz.
-  !>   @param[in]
-  !>   coo_col_ind column indices of the COO matrix. Must be an array of length \p nnz.
-  !>   @param[in]
-  !>   coo_val     values of the COO matrix. Must be an array of length \p nnz.
-  !>   @param[in]
-  !>   idx_type    `rocsparse_indextype_i32` or `rocsparse_indextype_i64`.
-  !>   @param[in]
-  !>   idx_base    `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
-  !>   @param[in]
-  !>   data_type   `rocsparse_datatype_f32_r`, `rocsparse_datatype_f64_r`,
+  !>   @param[out] descr - the pointer to the sparse COO matrix descriptor.
+  !>   @param[in] rows - number of rows in the COO matrix.
+  !>   @param[in] cols - number of columns in the COO matrix
+  !>   @param[in] nnz - number of non-zeros in the COO matrix.
+  !>   @param[in] coo_row_ind - row indices of the COO matrix. Must be an array of length \p nnz.
+  !>   @param[in] coo_col_ind - column indices of the COO matrix. Must be an array of length \p nnz.
+  !>   @param[in] coo_val - values of the COO matrix. Must be an array of length \p nnz.
+  !>   @param[in] idx_type - `rocsparse_indextype_i32` or `rocsparse_indextype_i64`.
+  !>   @param[in] idx_base - `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
+  !>   @param[in] data_type - `rocsparse_datatype_f32_r`, `rocsparse_datatype_f64_r`,
   !>               `rocsparse_datatype_f32_c`, or `rocsparse_datatype_f64_c`.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
@@ -1200,24 +1119,16 @@ module hipfort_rocsparse
   !>   \p rocsparse_create_coo_aos_descr creates a sparse COO AoS matrix descriptor. It should be
   !>   destroyed at the end using \p rocsparse_destroy_spmat_descr.
   !>
-  !>   @param[out]
-  !>   descr       the pointer to the sparse COO AoS matrix descriptor.
-  !>   @param[in]
-  !>   rows        number of rows in the COO AoS matrix.
-  !>   @param[in]
-  !>   cols        number of columns in the COO AoS matrix
-  !>   @param[in]
-  !>   nnz         number of non-zeros in the COO AoS matrix.
-  !>   @param[in]
-  !>   coo_ind     <row, column> indices of the COO AoS matrix. Must be an array of length \p nnz.
-  !>   @param[in]
-  !>   coo_val     values of the COO AoS matrix. Must be an array of length \p nnz.
-  !>   @param[in]
-  !>   idx_type    `rocsparse_indextype_i32` or `rocsparse_indextype_i64`.
-  !>   @param[in]
-  !>   idx_base    `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
-  !>   @param[in]
-  !>   data_type   `rocsparse_datatype_f32_r`, `rocsparse_datatype_f64_r`,
+  !>   @param[out] descr - the pointer to the sparse COO AoS matrix descriptor.
+  !>   @param[in] rows - number of rows in the COO AoS matrix.
+  !>   @param[in] cols - number of columns in the COO AoS matrix
+  !>   @param[in] nnz - number of non-zeros in the COO AoS matrix.
+  !>   @param[in] coo_ind - <row, column> indices of the COO AoS matrix. Must be an array of length
+  !>   \p nnz.
+  !>   @param[in] coo_val - values of the COO AoS matrix. Must be an array of length \p nnz.
+  !>   @param[in] idx_type - `rocsparse_indextype_i32` or `rocsparse_indextype_i64`.
+  !>   @param[in] idx_base - `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
+  !>   @param[in] data_type - `rocsparse_datatype_f32_r`, `rocsparse_datatype_f64_r`,
   !>               `rocsparse_datatype_f32_c`, or `rocsparse_datatype_f64_c`.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
@@ -1251,33 +1162,20 @@ module hipfort_rocsparse
   !>   \p rocsparse_create_bsr_descr creates a sparse BSR matrix descriptor. It should be
   !>   destroyed at the end using \p rocsparse_destroy_spmat_descr.
   !>
-  !>   @param[out]
-  !>   descr        the pointer to the sparse BSR matrix descriptor.
-  !>   @param[in]
-  !>   brows        number of block rows in the BSR matrix.
-  !>   @param[in]
-  !>   bcols        number of block columns in the BSR matrix.
-  !>   @param[in]
-  !>   bnnz         number of non-zero blocks in the BSR matrix.
-  !>   @param[in]
-  !>   block_dir    direction of the internal block storage.
-  !>   @param[in]
-  !>   block_dim    dimension of the blocks.
-  !>   @param[in]
-  !>   bsr_row_ptr  row offsets of the BSR matrix (must be array of length \p brows+1 ).
-  !>   @param[in]
-  !>   bsr_col_ind  column indices of the BSR matrix (must be array of length \p bnnz ).
-  !>   @param[in]
-  !>   bsr_val values of the BSR matrix (must be array of length \p bnnz * \p block_dim * \p
-  !>   block_dim ).
-  !>   @param[in]
-  !>   row_ptr_type `rocsparse_indextype_i32` or `rocsparse_indextype_i64`.
-  !>   @param[in]
-  !>   col_ind_type `rocsparse_indextype_i32` or `rocsparse_indextype_i64`.
-  !>   @param[in]
-  !>   idx_base     `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
-  !>   @param[in]
-  !>   data_type    `rocsparse_datatype_f32_r`, `rocsparse_datatype_f64_r`,
+  !>   @param[out] descr - the pointer to the sparse BSR matrix descriptor.
+  !>   @param[in] brows - number of block rows in the BSR matrix.
+  !>   @param[in] bcols - number of block columns in the BSR matrix.
+  !>   @param[in] bnnz - number of non-zero blocks in the BSR matrix.
+  !>   @param[in] block_dir - direction of the internal block storage.
+  !>   @param[in] block_dim - dimension of the blocks.
+  !>   @param[in] bsr_row_ptr - row offsets of the BSR matrix (must be array of length \p brows+1 ).
+  !>   @param[in] bsr_col_ind - column indices of the BSR matrix (must be array of length \p bnnz ).
+  !>   @param[in] bsr_val - values of the BSR matrix (must be array of length \p bnnz * \p block_dim
+  !>   * \p block_dim ).
+  !>   @param[in] row_ptr_type - `rocsparse_indextype_i32` or `rocsparse_indextype_i64`.
+  !>   @param[in] col_ind_type - `rocsparse_indextype_i32` or `rocsparse_indextype_i64`.
+  !>   @param[in] idx_base - `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
+  !>   @param[in] data_type - `rocsparse_datatype_f32_r`, `rocsparse_datatype_f64_r`,
   !>                `rocsparse_datatype_f32_c`, or `rocsparse_datatype_f64_c`.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
@@ -1341,28 +1239,17 @@ module hipfort_rocsparse
   !>   \p rocsparse_create_csr_descr creates a sparse CSR matrix descriptor. It should be
   !>   destroyed at the end using \p rocsparse_destroy_spmat_descr.
   !>
-  !>   @param[out]
-  !>   descr        the pointer to the sparse CSR matrix descriptor.
-  !>   @param[in]
-  !>   rows         number of rows in the CSR matrix.
-  !>   @param[in]
-  !>   cols         number of columns in the CSR matrix
-  !>   @param[in]
-  !>   nnz          number of non-zeros in the CSR matrix.
-  !>   @param[in]
-  !>   csr_row_ptr  row offsets of the CSR matrix. Must be an array of length \p rows+1.
-  !>   @param[in]
-  !>   csr_col_ind  column indices of the CSR matrix. Must be an array of length \p nnz.
-  !>   @param[in]
-  !>   csr_val      values of the CSR matrix. Must be an array of length \p nnz.
-  !>   @param[in]
-  !>   row_ptr_type `rocsparse_indextype_i32` or `rocsparse_indextype_i64`.
-  !>   @param[in]
-  !>   col_ind_type `rocsparse_indextype_i32` or `rocsparse_indextype_i64`.
-  !>   @param[in]
-  !>   idx_base     `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
-  !>   @param[in]
-  !>   data_type    `rocsparse_datatype_f32_r`, `rocsparse_datatype_f64_r`,
+  !>   @param[out] descr - the pointer to the sparse CSR matrix descriptor.
+  !>   @param[in] rows - number of rows in the CSR matrix.
+  !>   @param[in] cols - number of columns in the CSR matrix
+  !>   @param[in] nnz - number of non-zeros in the CSR matrix.
+  !>   @param[in] csr_row_ptr - row offsets of the CSR matrix. Must be an array of length \p rows+1.
+  !>   @param[in] csr_col_ind - column indices of the CSR matrix. Must be an array of length \p nnz.
+  !>   @param[in] csr_val - values of the CSR matrix. Must be an array of length \p nnz.
+  !>   @param[in] row_ptr_type - `rocsparse_indextype_i32` or `rocsparse_indextype_i64`.
+  !>   @param[in] col_ind_type - `rocsparse_indextype_i32` or `rocsparse_indextype_i64`.
+  !>   @param[in] idx_base - `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
+  !>   @param[in] data_type - `rocsparse_datatype_f32_r`, `rocsparse_datatype_f64_r`,
   !>                `rocsparse_datatype_f32_c`, or `rocsparse_datatype_f64_c`.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
@@ -1421,28 +1308,18 @@ module hipfort_rocsparse
   !>   \p rocsparse_create_csc_descr creates a sparse CSC matrix descriptor. It should be
   !>   destroyed at the end using \p rocsparse_destroy_spmat_descr.
   !>
-  !>   @param[out]
-  !>   descr       the pointer to the sparse CSC matrix descriptor.
-  !>   @param[in]
-  !>   rows         number of rows in the CSC matrix.
-  !>   @param[in]
-  !>   cols         number of columns in the CSC matrix.
-  !>   @param[in]
-  !>   nnz          number of non-zeros in the CSC matrix.
-  !>   @param[in]
-  !>   csc_col_ptr  column offsets of the CSC matrix. Must be an array of length \p cols+1.
-  !>   @param[in]
-  !>   csc_row_ind  row indices of the CSC matrix. Must be an array of length \p nnz.
-  !>   @param[in]
-  !>   csc_val      values of the CSC matrix. Must be an array of length \p nnz.
-  !>   @param[in]
-  !>   col_ptr_type `rocsparse_indextype_i32` or `rocsparse_indextype_i64`.
-  !>   @param[in]
-  !>   row_ind_type `rocsparse_indextype_i32` or `rocsparse_indextype_i64`.
-  !>   @param[in]
-  !>   idx_base     `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
-  !>   @param[in]
-  !>   data_type    `rocsparse_datatype_f32_r`, `rocsparse_datatype_f64_r`,
+  !>   @param[out] descr - the pointer to the sparse CSC matrix descriptor.
+  !>   @param[in] rows - number of rows in the CSC matrix.
+  !>   @param[in] cols - number of columns in the CSC matrix.
+  !>   @param[in] nnz - number of non-zeros in the CSC matrix.
+  !>   @param[in] csc_col_ptr - column offsets of the CSC matrix. Must be an array of length \p
+  !>   cols+1.
+  !>   @param[in] csc_row_ind - row indices of the CSC matrix. Must be an array of length \p nnz.
+  !>   @param[in] csc_val - values of the CSC matrix. Must be an array of length \p nnz.
+  !>   @param[in] col_ptr_type - `rocsparse_indextype_i32` or `rocsparse_indextype_i64`.
+  !>   @param[in] row_ind_type - `rocsparse_indextype_i32` or `rocsparse_indextype_i64`.
+  !>   @param[in] idx_base - `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
+  !>   @param[in] data_type - `rocsparse_datatype_f32_r`, `rocsparse_datatype_f64_r`,
   !>                `rocsparse_datatype_f32_c`, or `rocsparse_datatype_f64_c`.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
@@ -1501,24 +1378,16 @@ module hipfort_rocsparse
   !>   \p rocsparse_create_ell_descr creates a sparse ELL matrix descriptor. It should be
   !>   destroyed at the end using \p rocsparse_destroy_spmat_descr.
   !>
-  !>   @param[out]
-  !>   descr       the pointer to the sparse ELL matrix descriptor.
-  !>   @param[in]
-  !>   rows        number of rows in the ELL matrix.
-  !>   @param[in]
-  !>   cols        number of columns in the ELL matrix.
-  !>   @param[in]
-  !>   ell_col_ind column indices of the ELL matrix. Must be an array of length \p rows*ell_width.
-  !>   @param[in]
-  !>   ell_val     values of the ELL matrix. Must be an array of length \p rows*ell_width.
-  !>   @param[in]
-  !>   ell_width   width of the ELL matrix.
-  !>   @param[in]
-  !>   idx_type    `rocsparse_indextype_i32` or `rocsparse_indextype_i64`.
-  !>   @param[in]
-  !>   idx_base    `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
-  !>   @param[in]
-  !>   data_type   `rocsparse_datatype_f32_r`, `rocsparse_datatype_f64_r`,
+  !>   @param[out] descr - the pointer to the sparse ELL matrix descriptor.
+  !>   @param[in] rows - number of rows in the ELL matrix.
+  !>   @param[in] cols - number of columns in the ELL matrix.
+  !>   @param[in] ell_col_ind - column indices of the ELL matrix. Must be an array of length \p
+  !>   rows*ell_width.
+  !>   @param[in] ell_val - values of the ELL matrix. Must be an array of length \p rows*ell_width.
+  !>   @param[in] ell_width - width of the ELL matrix.
+  !>   @param[in] idx_type - `rocsparse_indextype_i32` or `rocsparse_indextype_i64`.
+  !>   @param[in] idx_base - `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
+  !>   @param[in] data_type - `rocsparse_datatype_f32_r`, `rocsparse_datatype_f64_r`,
   !>               `rocsparse_datatype_f32_c`, or `rocsparse_datatype_f64_c`.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
@@ -1555,30 +1424,20 @@ module hipfort_rocsparse
   !>
   !>   Currently the only routine that supports the Blocked ELL format is \ref rocsparse_spmm.
   !>
-  !>   @param[out]
-  !>   descr         the pointer to the sparse blocked ELL matrix descriptor.
-  !>   @param[in]
-  !>   rows          number of rows in the blocked ELL matrix.
-  !>   @param[in]
-  !>   cols          number of columns in the blocked ELL matrix
-  !>   @param[in]
-  !>   ell_block_dir `rocsparse_direction_row` or `rocsparse_direction_column`.
-  !>   @param[in]
-  !>   ell_block_dim block dimension of the sparse blocked ELL matrix.
-  !>   @param[in]
-  !>   ell_cols column indices of the blocked ELL matrix. Must be an array of length \p
+  !>   @param[out] descr - the pointer to the sparse blocked ELL matrix descriptor.
+  !>   @param[in] rows - number of rows in the blocked ELL matrix.
+  !>   @param[in] cols - number of columns in the blocked ELL matrix
+  !>   @param[in] ell_block_dir - `rocsparse_direction_row` or `rocsparse_direction_column`.
+  !>   @param[in] ell_block_dim - block dimension of the sparse blocked ELL matrix.
+  !>   @param[in] ell_cols - column indices of the blocked ELL matrix. Must be an array of length \p
   !>   rows*ell_width.
-  !>   @param[in]
-  !>   ell_col_ind column indices of the blocked ELL matrix. Must be an array of length \p
+  !>   @param[in] ell_col_ind - column indices of the blocked ELL matrix. Must be an array of length
+  !>   \p rows*ell_width.
+  !>   @param[in] ell_val - values of the blocked ELL matrix. Must be an array of length \p
   !>   rows*ell_width.
-  !>   @param[in]
-  !>   ell_val       values of the blocked ELL matrix. Must be an array of length \p rows*ell_width.
-  !>   @param[in]
-  !>   idx_type      `rocsparse_indextype_i32` or `rocsparse_indextype_i64`.
-  !>   @param[in]
-  !>   idx_base      `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
-  !>   @param[in]
-  !>   data_type     `rocsparse_datatype_f32_r`, `rocsparse_datatype_f64_r`,
+  !>   @param[in] idx_type - `rocsparse_indextype_i32` or `rocsparse_indextype_i64`.
+  !>   @param[in] idx_base - `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
+  !>   @param[in] data_type - `rocsparse_datatype_f32_r`, `rocsparse_datatype_f64_r`,
   !>                 `rocsparse_datatype_f32_c`, or `rocsparse_datatype_f64_c`.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
@@ -1639,34 +1498,22 @@ module hipfort_rocsparse
   !>
   !>   Currently the only routine that supports the sliced ELL format is \ref rocsparse_spmv.
   !>
-  !>   @param[out]
-  !>   descr                   the pointer to the sparse sliced ELL matrix descriptor.
-  !>   @param[in]
-  !>   rows                    number of rows in the sliced ELL matrix.
-  !>   @param[in]
-  !>   cols                    number of columns in the sliced ELL matrix.
-  !>   @param[in]
-  !>   nnz                     number of non-zeros in the sliced ELL matrix.
-  !>   @param[in]
-  !>   sell_slice_size         slice size in the sliced ELL matrix.
-  !>   @param[in]
-  !>   sell_colval_size        size of the column and value arrays in the sliced ELL matrix.
-  !>   @param[in]
-  !>   sell_slice_offsets slice offsets into column and value matrix. Must be an array of length \p
-  !>   nslices+1 where \p nslice=m/sell_slice_size.
-  !>   @param[in]
-  !>   sell_col_ind column indices of the sliced ELL matrix. Must be an array of length \p
+  !>   @param[out] descr - the pointer to the sparse sliced ELL matrix descriptor.
+  !>   @param[in] rows - number of rows in the sliced ELL matrix.
+  !>   @param[in] cols - number of columns in the sliced ELL matrix.
+  !>   @param[in] nnz - number of non-zeros in the sliced ELL matrix.
+  !>   @param[in] sell_slice_size - slice size in the sliced ELL matrix.
+  !>   @param[in] sell_colval_size - size of the column and value arrays in the sliced ELL matrix.
+  !>   @param[in] sell_slice_offsets - slice offsets into column and value matrix. Must be an array
+  !>   of length \p nslices+1 where \p nslice=m/sell_slice_size.
+  !>   @param[in] sell_col_ind - column indices of the sliced ELL matrix. Must be an array of length
+  !>   \p sell_colval_size.
+  !>   @param[in] sell_val - values of the sliced ELL matrix. Must be an array of length \p
   !>   sell_colval_size.
-  !>   @param[in]
-  !>   sell_val values of the sliced ELL matrix. Must be an array of length \p sell_colval_size.
-  !>   @param[in]
-  !>   sell_slice_offsets_type `rocsparse_indextype_i32` or `rocsparse_indextype_i64`.
-  !>   @param[in]
-  !>   sell_col_ind_type       `rocsparse_indextype_i32` or `rocsparse_indextype_i64`.
-  !>   @param[in]
-  !>   idx_base                `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
-  !>   @param[in]
-  !>   data_type               `rocsparse_datatype_f32_r`, `rocsparse_datatype_f64_r`,
+  !>   @param[in] sell_slice_offsets_type - `rocsparse_indextype_i32` or `rocsparse_indextype_i64`.
+  !>   @param[in] sell_col_ind_type - `rocsparse_indextype_i32` or `rocsparse_indextype_i64`.
+  !>   @param[in] idx_base - `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
+  !>   @param[in] data_type - `rocsparse_datatype_f32_r`, `rocsparse_datatype_f64_r`,
   !>                           `rocsparse_datatype_f32_c`, or `rocsparse_datatype_f64_c`.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
@@ -1735,8 +1582,7 @@ module hipfort_rocsparse
   !>
   !>   Currently the only routine that supports the Blocked ELL format is \ref rocsparse_spmm.
   !>
-  !>   @param[in]
-  !>   descr   the matrix descriptor.
+  !>   @param[in] descr - the matrix descriptor.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer \p descr is invalid.
@@ -1757,14 +1603,10 @@ module hipfort_rocsparse
   !>   \p rocsparse_create_sparse_to_sparse_descr creates the descriptor of the sparse_to_sparse
   !>   algorithm.
   !>
-  !>   @param[out]
-  !>   descr        pointer to the descriptor of the sparse_to_sparse algorithm.
-  !>   @param[in]
-  !>   source       source sparse matrix descriptor.
-  !>   @param[in]
-  !>   target       target sparse matrix descriptor.
-  !>   @param[in]
-  !>   alg          algorithm for the sparse_to_sparse computation.
+  !>   @param[out] descr - pointer to the descriptor of the sparse_to_sparse algorithm.
+  !>   @param[in] source - source sparse matrix descriptor.
+  !>   @param[in] target - target sparse matrix descriptor.
+  !>   @param[in] alg - algorithm for the sparse_to_sparse computation.
   !>
   !>   \retval      rocsparse_status_success the operation completed successfully.
   !>   \retval      rocsparse_status_invalid_value if any required enumeration is invalid.
@@ -1791,8 +1633,7 @@ module hipfort_rocsparse
   !>   \p rocsparse_sparse_to_sparse_permissive allows the routine to allocate an intermediate
   !>   sparse matrix
   !>   to perform the conversion. By default, the routine is not permissive.
-  !>   @param[in]
-  !>   descr        descriptor of the sparse_to_sparse algorithm.
+  !>   @param[in] descr - descriptor of the sparse_to_sparse algorithm.
   !>   \retval      rocsparse_status_success the operation completed successfully.
   interface rocsparse_sparse_to_sparse_permissive
     function rocsparse_sparse_to_sparse_permissive_(descr) &
@@ -1812,8 +1653,7 @@ module hipfort_rocsparse
   !>   \p rocsparse_destroy_sparse_to_sparse_descr destroys the descriptor of the sparse_to_sparse
   !>   algorithm.
   !>
-  !>   @param[in]
-  !>   descr        descriptor of the sparse_to_sparse algorithm.
+  !>   @param[in] descr - descriptor of the sparse_to_sparse algorithm.
   !>   \retval      rocsparse_status_success the operation completed successfully.
   interface rocsparse_destroy_sparse_to_sparse_descr
     function rocsparse_destroy_sparse_to_sparse_descr_(descr) &
@@ -1832,14 +1672,10 @@ module hipfort_rocsparse
   !>   \details
   !>   \p rocsparse_create_extract_descr creates the descriptor of the extract algorithm.
   !>
-  !>   @param[out]
-  !>   descr        pointer to the descriptor of the extract algorithm.
-  !>   @param[in]
-  !>   source       source sparse matrix descriptor.
-  !>   @param[in]
-  !>   target       target sparse matrix descriptor.
-  !>   @param[in]
-  !>   alg          algorithm for the extract computation.
+  !>   @param[out] descr - pointer to the descriptor of the extract algorithm.
+  !>   @param[in] source - source sparse matrix descriptor.
+  !>   @param[in] target - target sparse matrix descriptor.
+  !>   @param[in] alg - algorithm for the extract computation.
   !>
   !>   \retval      rocsparse_status_success the operation completed successfully.
   !>   \retval      rocsparse_status_invalid_value if any required enumeration is invalid.
@@ -1866,8 +1702,7 @@ module hipfort_rocsparse
   !>   \p rocsparse_destroy_extract_descr destroys the descriptor of the \ref rocsparse_extract
   !>   routine.
   !>
-  !>   @param[in]
-  !>   descr        descriptor of the extract routine.
+  !>   @param[in] descr - descriptor of the extract routine.
   !>   \retval      rocsparse_status_success the operation completed successfully.
   interface rocsparse_destroy_extract_descr
     function rocsparse_destroy_extract_descr_(descr) bind(c, name="rocsparse_destroy_extract_descr")
@@ -1887,8 +1722,7 @@ module hipfort_rocsparse
   !>   rocsparse_spgeam_buffer_size and
   !>   `rocsparse_spgeam` routines.
   !>
-  !>   @param[out]
-  !>   descr        pointer to the descriptor of the SpGEAM routine.
+  !>   @param[out] descr - pointer to the descriptor of the SpGEAM routine.
   !>
   !>   \retval      rocsparse_status_success the operation completed successfully.
   !>   \retval      rocsparse_status_invalid_pointer \p descr pointer is invalid.
@@ -1910,8 +1744,7 @@ module hipfort_rocsparse
   !>   rocsparse_spgeam_buffer_size and
   !>   `rocsparse_spgeam` routines.
   !>
-  !>   @param[in]
-  !>   descr        descriptor of the SpGEAM routine.
+  !>   @param[in] descr - descriptor of the SpGEAM routine.
   !>   \retval      rocsparse_status_success the operation completed successfully.
   interface rocsparse_destroy_spgeam_descr
     function rocsparse_destroy_spgeam_descr_(descr) bind(c, name="rocsparse_destroy_spgeam_descr")
@@ -1926,19 +1759,14 @@ module hipfort_rocsparse
   !>  \ingroup aux_module
   !>   \brief Set the requested `rocsparse_spgeam_input` data in the SpGEAM descriptor.
   !>
-  !>   @param[in]
-  !>   handle      the pointer to the handle to the rocSPARSE library context.
-  !>   @param[inout]
-  !>   descr       the pointer to the SpGEAM descriptor.
-  !>   @param[in]
-  !>   input       one of the values from `rocsparse_spgeam_input`.
-  !>   @param[in]
-  !>   data        input data.
-  !>   @param[in]
-  !>   data_size_in_bytes   input data size.
-  !>   @param[out]
-  !>   p_error error descriptor created if the returned status is not `rocsparse_status_success`. A
-  !>   null pointer can be passed if an error descriptor is not required.
+  !>   @param[in] handle - the pointer to the handle to the rocSPARSE library context.
+  !>   @param[inout] descr - the pointer to the SpGEAM descriptor.
+  !>   @param[in] input - one of the values from `rocsparse_spgeam_input`.
+  !>   @param[in] myData - input data.
+  !>   @param[in] data_size_in_bytes - input data size.
+  !>   @param[out] p_error - error descriptor created if the returned status is not
+  !>   `rocsparse_status_success`. A null pointer can be passed if an error descriptor is not
+  !>   required.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer if \p descr or \p data is invalid.
@@ -1963,19 +1791,14 @@ module hipfort_rocsparse
   !>  \ingroup aux_module
   !>   \brief Get the requested `rocsparse_spgeam_output` data from the SpGEAM descriptor.
   !>
-  !>   @param[in]
-  !>   handle      the pointer to the handle to the rocSPARSE library context.
-  !>   @param[inout]
-  !>   descr       the pointer to the SpGEAM descriptor.
-  !>   @param[in]
-  !>   output      `rocsparse_spgeam_output_nnz`.
-  !>   @param[in]
-  !>   data        output data.
-  !>   @param[in]
-  !>   data_size_in_bytes   output data size.
-  !>   @param[out]
-  !>   error error descriptor created if the returned status is not `rocsparse_status_success`. A
-  !>   null pointer can be passed if an error descriptor is not required.
+  !>   @param[in] handle - the pointer to the handle to the rocSPARSE library context.
+  !>   @param[inout] descr - the pointer to the SpGEAM descriptor.
+  !>   @param[in] output - `rocsparse_spgeam_output_nnz`.
+  !>   @param[in] myData - output data.
+  !>   @param[in] data_size_in_bytes - output data size.
+  !>   @param[out] error - error descriptor created if the returned status is not
+  !>   `rocsparse_status_success`. A null pointer can be passed if an error descriptor is not
+  !>   required.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer if \p descr or \p data is invalid.
@@ -2005,8 +1828,7 @@ module hipfort_rocsparse
   !>   rocsparse_v2_spmv_buffer_size and
   !>   `rocsparse_v2_spmv` routines.
   !>
-  !>   @param[out]
-  !>   descr        pointer to the descriptor of the SpMV routine.
+  !>   @param[out] descr - pointer to the descriptor of the SpMV routine.
   !>
   !>   \retval      rocsparse_status_success the operation completed successfully.
   !>   \retval      rocsparse_status_invalid_pointer \p descr pointer is invalid.
@@ -2028,8 +1850,7 @@ module hipfort_rocsparse
   !>   rocsparse_v2_spmv_buffer_size and
   !>   `rocsparse_v2_spmv` routines.
   !>
-  !>   @param[in]
-  !>   descr        descriptor of the v2_spmv routine.
+  !>   @param[in] descr - descriptor of the v2_spmv routine.
   !>   \retval      rocsparse_status_success the operation completed successfully.
   interface rocsparse_destroy_spmv_descr
     function rocsparse_destroy_spmv_descr_(descr) bind(c, name="rocsparse_destroy_spmv_descr")
@@ -2044,19 +1865,14 @@ module hipfort_rocsparse
   !>  \ingroup aux_module
   !>   \brief Set the requested `rocsparse_spmv_input` data in the SpMV descriptor.
   !>
-  !>   @param[in]
-  !>   handle      the pointer to the handle to the rocSPARSE library context.
-  !>   @param[inout]
-  !>   descr       the pointer to the SpMV descriptor.
-  !>   @param[in]
-  !>   input       one possible value of `rocsparse_spmv_input`.
-  !>   @param[in]
-  !>   in          input value.
-  !>   @param[in]
-  !>   size_in_bytes input value size in bytes.
-  !>   @param[out]
-  !>   error error descriptor created if the returned status is not `rocsparse_status_success`. A
-  !>   null pointer can be passed if an error descriptor is not required.
+  !>   @param[in] handle - the pointer to the handle to the rocSPARSE library context.
+  !>   @param[inout] descr - the pointer to the SpMV descriptor.
+  !>   @param[in] input - one possible value of `rocsparse_spmv_input`.
+  !>   @param[in] in - input value.
+  !>   @param[in] size_in_bytes - input value size in bytes.
+  !>   @param[out] error - error descriptor created if the returned status is not
+  !>   `rocsparse_status_success`. A null pointer can be passed if an error descriptor is not
+  !>   required.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer if \p descr or \p in is invalid.
@@ -2086,13 +1902,11 @@ module hipfort_rocsparse
   !>   rocsparse_sptrsv_buffer_size and
   !>   `rocsparse_sptrsv` routines.
   !>
-  !>   @param[in]
-  !>   handle  the handle to the rocSPARSE library context.
-  !>   @param[out]
-  !>   p_sptrsv_descr        pointer to the descriptor of the sptrsv routine.
-  !>   @param[out]
-  !>   p_error error descriptor created if the returned status is not `rocsparse_status_success`. A
-  !>   null pointer can be passed if an error descriptor is not required.
+  !>   @param[in] handle - the handle to the rocSPARSE library context.
+  !>   @param[out] p_sptrsv_descr - pointer to the descriptor of the sptrsv routine.
+  !>   @param[out] p_error - error descriptor created if the returned status is not
+  !>   `rocsparse_status_success`. A null pointer can be passed if an error descriptor is not
+  !>   required.
   !>
   !>   \retval      rocsparse_status_invalid_handle \p handle pointer is invalid.
   !>   \retval      rocsparse_status_success the operation completed successfully.
@@ -2118,13 +1932,11 @@ module hipfort_rocsparse
   !>   rocsparse_sptrsv_buffer_size and
   !>   `rocsparse_sptrsv` routines.
   !>
-  !>   @param[in]
-  !>   handle  the handle to the rocSPARSE library context.
-  !>   @param[in]
-  !>   sptrsv_descr        descriptor of the sptrsv routine.
-  !>   @param[out]
-  !>   p_error error descriptor created if the returned status is not `rocsparse_status_success`. A
-  !>   null pointer can be passed if an error descriptor is not required.
+  !>   @param[in] handle - the handle to the rocSPARSE library context.
+  !>   @param[in] sptrsv_descr - descriptor of the sptrsv routine.
+  !>   @param[out] p_error - error descriptor created if the returned status is not
+  !>   `rocsparse_status_success`. A null pointer can be passed if an error descriptor is not
+  !>   required.
   !>
   !>   \retval      rocsparse_status_invalid_handle \p handle pointer is invalid.
   !>   \retval      rocsparse_status_success the operation completed successfully.
@@ -2149,8 +1961,7 @@ module hipfort_rocsparse
   !>   rocsparse_sptrsv_buffer_size and
   !>   `rocsparse_sptrsv` routines.
   !>
-  !>   @param[out]
-  !>   descr        pointer to the descriptor of the sptrsv routine.
+  !>   @param[out] descr - pointer to the descriptor of the sptrsv routine.
   !>
   !>   \retval      rocsparse_status_success the operation completed successfully.
   !>   \retval      rocsparse_status_invalid_pointer \p descr pointer is invalid.
@@ -2172,8 +1983,7 @@ module hipfort_rocsparse
   !>   rocsparse_sptrsv_buffer_size and
   !>   `rocsparse_sptrsv` routines.
   !>
-  !>   @param[in]
-  !>   descr        descriptor of the sptrsv routine.
+  !>   @param[in] descr - descriptor of the sptrsv routine.
   !>   \retval      rocsparse_status_success the operation completed successfully.
   interface rocsparse_destroy_sptrsv_descr
     function rocsparse_destroy_sptrsv_descr_(descr) bind(c, name="rocsparse_destroy_sptrsv_descr")
@@ -2188,19 +1998,14 @@ module hipfort_rocsparse
   !>  \ingroup aux_module
   !>   \brief Set the requested `rocsparse_sptrsv_input` data in the sptrsv descriptor.
   !>
-  !>   @param[in]
-  !>   handle      the pointer to the handle to the rocSPARSE library context.
-  !>   @param[inout]
-  !>   descr       the pointer to the sptrsv descriptor.
-  !>   @param[in]
-  !>   input       value of `rocsparse_sptrsv_input`.
-  !>   @param[in]
-  !>   data        input data.
-  !>   @param[in]
-  !>   data_size_in_bytes   input data size in bytes.
-  !>   @param[out]
-  !>   p_error error descriptor created if the returned status is not `rocsparse_status_success`. A
-  !>   null pointer can be passed if an error descriptor is not required.
+  !>   @param[in] handle - the pointer to the handle to the rocSPARSE library context.
+  !>   @param[inout] descr - the pointer to the sptrsv descriptor.
+  !>   @param[in] input - value of `rocsparse_sptrsv_input`.
+  !>   @param[in] myData - input data.
+  !>   @param[in] data_size_in_bytes - input data size in bytes.
+  !>   @param[out] p_error - error descriptor created if the returned status is not
+  !>   `rocsparse_status_success`. A null pointer can be passed if an error descriptor is not
+  !>   required.
   !>
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
@@ -2226,19 +2031,14 @@ module hipfort_rocsparse
   !>  \ingroup aux_module
   !>   \brief Get the requested `rocsparse_sptrsv_output` data from the sptrsv descriptor.
   !>
-  !>   @param[in]
-  !>   handle      the pointer to the handle to the rocSPARSE library context.
-  !>   @param[inout]
-  !>   descr       the pointer to the sptrsv descriptor.
-  !>   @param[in]
-  !>   output      value of `rocsparse_sptrsv_output`.
-  !>   @param[out]
-  !>   data        output data.
-  !>   @param[in]
-  !>   data_size_in_bytes   output data size in bytes.
-  !>   @param[out]
-  !>   p_error error descriptor created if the returned status is not `rocsparse_status_success`. A
-  !>   null pointer can be passed if an error descriptor is not required.
+  !>   @param[in] handle - the pointer to the handle to the rocSPARSE library context.
+  !>   @param[inout] descr - the pointer to the sptrsv descriptor.
+  !>   @param[in] output - value of `rocsparse_sptrsv_output`.
+  !>   @param[out] myData - output data.
+  !>   @param[in] data_size_in_bytes - output data size in bytes.
+  !>   @param[out] p_error - error descriptor created if the returned status is not
+  !>   `rocsparse_status_success`. A null pointer can be passed if an error descriptor is not
+  !>   required.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer if \p descr or \p data is invalid.
@@ -2268,8 +2068,7 @@ module hipfort_rocsparse
   !>   rocsparse_sptrsm_buffer_size and
   !>   `rocsparse_sptrsm` routines.
   !>
-  !>   @param[out]
-  !>   descr        pointer to the descriptor of the sptrsm routine.
+  !>   @param[out] descr - pointer to the descriptor of the sptrsm routine.
   !>
   !>   \retval      rocsparse_status_success the operation completed successfully.
   !>   \retval      rocsparse_status_invalid_pointer \p descr pointer is invalid.
@@ -2291,8 +2090,7 @@ module hipfort_rocsparse
   !>   rocsparse_sptrsm_buffer_size and
   !>   `rocsparse_sptrsm` routines.
   !>
-  !>   @param[in]
-  !>   descr        descriptor of the sptrsm routine.
+  !>   @param[in] descr - descriptor of the sptrsm routine.
   !>   \retval      rocsparse_status_success the operation completed successfully.
   interface rocsparse_destroy_sptrsm_descr
     function rocsparse_destroy_sptrsm_descr_(descr) bind(c, name="rocsparse_destroy_sptrsm_descr")
@@ -2307,19 +2105,14 @@ module hipfort_rocsparse
   !>  \ingroup aux_module
   !>   \brief Set the requested `rocsparse_sptrsm_input` data in the sptrsm descriptor.
   !>
-  !>   @param[in]
-  !>   handle      the pointer to the handle to the rocSPARSE library context.
-  !>   @param[inout]
-  !>   descr       the pointer to the sptrsm descriptor.
-  !>   @param[in]
-  !>   input      value of `rocsparse_sptrsm_input`.
-  !>   @param[in]
-  !>   data        input data.
-  !>   @param[in]
-  !>   data_size   input data size.
-  !>   @param[out]
-  !>   p_error error descriptor created if the returned status is not `rocsparse_status_success`. A
-  !>   null pointer can be passed if an error descriptor is not required.
+  !>   @param[in] handle - the pointer to the handle to the rocSPARSE library context.
+  !>   @param[inout] descr - the pointer to the sptrsm descriptor.
+  !>   @param[in] input - value of `rocsparse_sptrsm_input`.
+  !>   @param[in] myData - input data.
+  !>   @param[in] data_size - input data size.
+  !>   @param[out] p_error - error descriptor created if the returned status is not
+  !>   `rocsparse_status_success`. A null pointer can be passed if an error descriptor is not
+  !>   required.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer if \p descr or \p data is invalid.
@@ -2344,19 +2137,14 @@ module hipfort_rocsparse
   !>  \ingroup aux_module
   !>   \brief Get the requested `rocsparse_sptrsm_output` data from the sptrsm descriptor.
   !>
-  !>   @param[in]
-  !>   handle      the pointer to the handle to the rocSPARSE library context.
-  !>   @param[inout]
-  !>   descr       the pointer to the sptrsm descriptor.
-  !>   @param[in]
-  !>   output      value of `rocsparse_sptrsm_output`.
-  !>   @param[out]
-  !>   data        output data.
-  !>   @param[in]
-  !>   data_size_in_bytes   output data size in bytes.
-  !>   @param[out]
-  !>   p_error error descriptor created if the returned status is not `rocsparse_status_success`. A
-  !>   null pointer can be passed if an error descriptor is not required.
+  !>   @param[in] handle - the pointer to the handle to the rocSPARSE library context.
+  !>   @param[inout] descr - the pointer to the sptrsm descriptor.
+  !>   @param[in] output - value of `rocsparse_sptrsm_output`.
+  !>   @param[out] myData - output data.
+  !>   @param[in] data_size_in_bytes - output data size in bytes.
+  !>   @param[out] p_error - error descriptor created if the returned status is not
+  !>   `rocsparse_status_success`. A null pointer can be passed if an error descriptor is not
+  !>   required.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer if \p descr or \p data is invalid.
@@ -2384,13 +2172,11 @@ module hipfort_rocsparse
   !>   \details
   !>   \p rocsparse_spic0_descr_create creates the descriptor of the configuration of the sparse
   !>   Incomplete Cholesky of level 0.
-  !>   @param[in]
-  !>   handle  the handle to the rocSPARSE library context.
-  !>   @param[out]
-  !>   p_spic0_descr        pointer to the descriptor of the Spic0 routine.
-  !>   @param[out]
-  !>   p_error error descriptor created if the returned status is not `rocsparse_status_success`. A
-  !>   null pointer can be passed if an error descriptor is not required.
+  !>   @param[in] handle - the handle to the rocSPARSE library context.
+  !>   @param[out] p_spic0_descr - pointer to the descriptor of the Spic0 routine.
+  !>   @param[out] p_error - error descriptor created if the returned status is not
+  !>   `rocsparse_status_success`. A null pointer can be passed if an error descriptor is not
+  !>   required.
   !>
   !>   \retval      rocsparse_status_invalid_handle \p handle pointer is invalid.
   !>   \retval      rocsparse_status_success the operation completed successfully.
@@ -2415,13 +2201,11 @@ module hipfort_rocsparse
   !>   \p rocsparse_spic0_descr_destroy destroys the descriptor of the configuration of the sparse
   !>   Incomplete Cholesky of level 0.
   !>
-  !>   @param[in]
-  !>   handle  the handle to the rocSPARSE library context.
-  !>   @param[in]
-  !>   spic0_descr        descriptor of the spic0 routine.
-  !>   @param[out]
-  !>   p_error error descriptor created if the returned status is not `rocsparse_status_success`. A
-  !>   null pointer can be passed if an error descriptor is not required.
+  !>   @param[in] handle - the handle to the rocSPARSE library context.
+  !>   @param[in] spic0_descr - descriptor of the spic0 routine.
+  !>   @param[out] p_error - error descriptor created if the returned status is not
+  !>   `rocsparse_status_success`. A null pointer can be passed if an error descriptor is not
+  !>   required.
   !>   \retval      rocsparse_status_invalid_handle \p handle pointer is invalid.
   !>   \retval      rocsparse_status_success the operation completed successfully.
   interface rocsparse_spic0_descr_destroy
@@ -2455,19 +2239,14 @@ module hipfort_rocsparse
   !>   - `rocsparse_spic0_input_boost_tolerance` is a double pointer. Its device mode is determined
   !>   from the `rocsparse_handle`.
   !>
-  !>   @param[in]
-  !>   handle      the pointer to the handle to the rocSPARSE library context.
-  !>   @param[inout]
-  !>   spic0_descr       the pointer to the SpIC0 descriptor.
-  !>   @param[in]
-  !>   spic0_input       value of `rocsparse_spic0_input`.
-  !>   @param[in]
-  !>   input        input data.
-  !>   @param[in]
-  !>   input_size_in_bytes   input data size in bytes.
-  !>   @param[out]
-  !>   p_error error descriptor created if the returned status is not `rocsparse_status_success`. A
-  !>   null pointer can be passed if an error descriptor is not required.
+  !>   @param[in] handle - the pointer to the handle to the rocSPARSE library context.
+  !>   @param[inout] spic0_descr - the pointer to the SpIC0 descriptor.
+  !>   @param[in] spic0_input - value of `rocsparse_spic0_input`.
+  !>   @param[in] input - input data.
+  !>   @param[in] input_size_in_bytes - input data size in bytes.
+  !>   @param[out] p_error - error descriptor created if the returned status is not
+  !>   `rocsparse_status_success`. A null pointer can be passed if an error descriptor is not
+  !>   required.
   !>
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
@@ -2498,19 +2277,14 @@ module hipfort_rocsparse
   !>   an array of size \p batch_count.
   !>   - `rocsparse_spic0_output_singularity_position` is \p int64_t. It will be considered as an
   !>   array of size \p batch_count.
-  !>   @param[in]
-  !>   handle      the pointer to the handle to the rocSPARSE library context.
-  !>   @param[inout]
-  !>   spic0_descr       the pointer to the SpIC0 descriptor.
-  !>   @param[in]
-  !>   spic0_output      value of `rocsparse_spic0_output`.
-  !>   @param[out]
-  !>   output        output data
-  !>   @param[in]
-  !>   output_size_in_bytes   output data size in bytes.
-  !>   @param[out]
-  !>   p_error error descriptor created if the returned status is not `rocsparse_status_success`. A
-  !>   null pointer can be passed if an error descriptor is not required.
+  !>   @param[in] handle - the pointer to the handle to the rocSPARSE library context.
+  !>   @param[inout] spic0_descr - the pointer to the SpIC0 descriptor.
+  !>   @param[in] spic0_output - value of `rocsparse_spic0_output`.
+  !>   @param[out] output - output data
+  !>   @param[in] output_size_in_bytes - output data size in bytes.
+  !>   @param[out] p_error - error descriptor created if the returned status is not
+  !>   `rocsparse_status_success`. A null pointer can be passed if an error descriptor is not
+  !>   required.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer if \p descr or \p data is invalid.
@@ -2540,13 +2314,11 @@ module hipfort_rocsparse
   !>   \p rocsparse_spilu0_descr_create creates the descriptor of the configuration of the sparse
   !>   Incomplete LU of level 0.
   !>
-  !>   @param[in]
-  !>   handle  the handle to the rocSPARSE library context.
-  !>   @param[out]
-  !>   p_spilu0_descr        pointer to the descriptor of the Spilu0 routine.
-  !>   @param[out]
-  !>   p_error error descriptor created if the returned status is not `rocsparse_status_success`. A
-  !>   null pointer can be passed if an error descriptor is not required.
+  !>   @param[in] handle - the handle to the rocSPARSE library context.
+  !>   @param[out] p_spilu0_descr - pointer to the descriptor of the Spilu0 routine.
+  !>   @param[out] p_error - error descriptor created if the returned status is not
+  !>   `rocsparse_status_success`. A null pointer can be passed if an error descriptor is not
+  !>   required.
   !>
   !>   \retval      rocsparse_status_invalid_handle \p handle pointer is invalid.
   !>   \retval      rocsparse_status_success the operation completed successfully.
@@ -2571,13 +2343,11 @@ module hipfort_rocsparse
   !>   \p rocsparse_spilu0_descr_destroy destroys the descriptor of the configuration of the sparse
   !>   Incomplete LU of level 0.
   !>
-  !>   @param[in]
-  !>   handle  the handle to the rocSPARSE library context.
-  !>   @param[in]
-  !>   spilu0_descr        descriptor of the spilu0 routine.
-  !>   @param[out]
-  !>   p_error error descriptor created if the returned status is not `rocsparse_status_success`. A
-  !>   null pointer can be passed if an error descriptor is not required.
+  !>   @param[in] handle - the handle to the rocSPARSE library context.
+  !>   @param[in] spilu0_descr - descriptor of the spilu0 routine.
+  !>   @param[out] p_error - error descriptor created if the returned status is not
+  !>   `rocsparse_status_success`. A null pointer can be passed if an error descriptor is not
+  !>   required.
   !>   \retval      rocsparse_status_invalid_handle \p handle pointer is invalid.
   !>   \retval      rocsparse_status_success the operation completed successfully.
   interface rocsparse_spilu0_descr_destroy
@@ -2613,19 +2383,14 @@ module hipfort_rocsparse
   !>   - `rocsparse_spilu0_input_boost_tolerance` is a double pointer. Its device mode is determined
   !>   from the `rocsparse_handle`. No batched boost tolerances can be specified.
   !>
-  !>   @param[in]
-  !>   handle      the pointer to the handle to the rocSPARSE library context.
-  !>   @param[inout]
-  !>   spilu0_descr       the pointer to the SpILU0 descriptor.
-  !>   @param[in]
-  !>   spilu0_input       value of `rocsparse_spilu0_input`.
-  !>   @param[in]
-  !>   input        input data.
-  !>   @param[in]
-  !>   input_size_in_bytes   input data size in bytes.
-  !>   @param[out]
-  !>   p_error error descriptor created if the returned status is not `rocsparse_status_success`. A
-  !>   null pointer can be passed if an error descriptor is not required.
+  !>   @param[in] handle - the pointer to the handle to the rocSPARSE library context.
+  !>   @param[inout] spilu0_descr - the pointer to the SpILU0 descriptor.
+  !>   @param[in] spilu0_input - value of `rocsparse_spilu0_input`.
+  !>   @param[in] input - input data.
+  !>   @param[in] input_size_in_bytes - input data size in bytes.
+  !>   @param[out] p_error - error descriptor created if the returned status is not
+  !>   `rocsparse_status_success`. A null pointer can be passed if an error descriptor is not
+  !>   required.
   !>
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
@@ -2656,19 +2421,14 @@ module hipfort_rocsparse
   !>   an array of size \p batch_count.
   !>   - `rocsparse_spilu0_output_singularity_position` is int64_t. It will be considered as an
   !>   array of size \p batch_count.
-  !>   @param[in]
-  !>   handle      the pointer to the handle to the rocSPARSE library context.
-  !>   @param[inout]
-  !>   spilu0_descr       the pointer to the SpILU0 descriptor.
-  !>   @param[in]
-  !>   spilu0_output      value of `rocsparse_spilu0_output`.
-  !>   @param[out]
-  !>   output        output data.
-  !>   @param[in]
-  !>   output_size_in_bytes   output data size in bytes.
-  !>   @param[out]
-  !>   p_error error descriptor created if the returned status is not `rocsparse_status_success`. A
-  !>   null pointer can be passed if an error descriptor is not required.
+  !>   @param[in] handle - the pointer to the handle to the rocSPARSE library context.
+  !>   @param[inout] spilu0_descr - the pointer to the SpILU0 descriptor.
+  !>   @param[in] spilu0_output - value of `rocsparse_spilu0_output`.
+  !>   @param[out] output - output data.
+  !>   @param[in] output_size_in_bytes - output data size in bytes.
+  !>   @param[out] p_error - error descriptor created if the returned status is not
+  !>   `rocsparse_status_success`. A null pointer can be passed if an error descriptor is not
+  !>   required.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer if \p descr or \p data is invalid.
@@ -2696,26 +2456,17 @@ module hipfort_rocsparse
   !>   \details
   !>   \p rocsparse_coo_get gets the fields of the sparse COO matrix descriptor.
   !>
-  !>   @param[in]
-  !>   descr       the pointer to the sparse COO matrix descriptor.
-  !>   @param[out]
-  !>   rows        number of rows in the sparse COO matrix.
-  !>   @param[out]
-  !>   cols        number of columns in the sparse COO matrix.
-  !>   @param[out]
-  !>   nnz         number of non-zeros in sparse COO matrix.
-  !>   @param[out]
-  !>   coo_row_ind row indices of the COO matrix. Must be an array of length \p nnz.
-  !>   @param[out]
-  !>   coo_col_ind column indices of the COO matrix. Must be an array of length \p nnz.
-  !>   @param[out]
-  !>   coo_val     values of the COO matrix. Must be an array of length \p nnz.
-  !>   @param[out]
-  !>   idx_type    `rocsparse_indextype_i32` or `rocsparse_indextype_i64`.
-  !>   @param[out]
-  !>   idx_base    `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
-  !>   @param[out]
-  !>   data_type   `rocsparse_datatype_f32_r`, `rocsparse_datatype_f64_r`,
+  !>   @param[in] descr - the pointer to the sparse COO matrix descriptor.
+  !>   @param[out] rows - number of rows in the sparse COO matrix.
+  !>   @param[out] cols - number of columns in the sparse COO matrix.
+  !>   @param[out] nnz - number of non-zeros in sparse COO matrix.
+  !>   @param[out] coo_row_ind - row indices of the COO matrix. Must be an array of length \p nnz.
+  !>   @param[out] coo_col_ind - column indices of the COO matrix. Must be an array of length \p
+  !>   nnz.
+  !>   @param[out] coo_val - values of the COO matrix. Must be an array of length \p nnz.
+  !>   @param[out] idx_type - `rocsparse_indextype_i32` or `rocsparse_indextype_i64`.
+  !>   @param[out] idx_base - `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
+  !>   @param[out] data_type - `rocsparse_datatype_f32_r`, `rocsparse_datatype_f64_r`,
   !>               `rocsparse_datatype_f32_c`, or `rocsparse_datatype_f64_c`.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
@@ -2771,24 +2522,16 @@ module hipfort_rocsparse
   !>   \details
   !>   \p rocsparse_coo_aos_get gets the fields of the sparse COO AoS matrix descriptor.
   !>
-  !>   @param[in]
-  !>   descr       the pointer to the sparse COO AoS matrix descriptor.
-  !>   @param[out]
-  !>   rows        number of rows in the sparse COO AoS matrix.
-  !>   @param[out]
-  !>   cols        number of columns in the sparse COO AoS matrix.
-  !>   @param[out]
-  !>   nnz         number of non-zeros in the sparse COO AoS matrix.
-  !>   @param[out]
-  !>   coo_ind     <row, columns> indices of the COO AoS matrix. Must be an array of length \p nnz.
-  !>   @param[out]
-  !>   coo_val     values of the COO AoS matrix. Must be an array of length \p nnz.
-  !>   @param[out]
-  !>   idx_type    `rocsparse_indextype_i32` or `rocsparse_indextype_i64`.
-  !>   @param[out]
-  !>   idx_base    `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
-  !>   @param[out]
-  !>   data_type   `rocsparse_datatype_f32_r`, `rocsparse_datatype_f64_r`,
+  !>   @param[in] descr - the pointer to the sparse COO AoS matrix descriptor.
+  !>   @param[out] rows - number of rows in the sparse COO AoS matrix.
+  !>   @param[out] cols - number of columns in the sparse COO AoS matrix.
+  !>   @param[out] nnz - number of non-zeros in the sparse COO AoS matrix.
+  !>   @param[out] coo_ind - <row, columns> indices of the COO AoS matrix. Must be an array of
+  !>   length \p nnz.
+  !>   @param[out] coo_val - values of the COO AoS matrix. Must be an array of length \p nnz.
+  !>   @param[out] idx_type - `rocsparse_indextype_i32` or `rocsparse_indextype_i64`.
+  !>   @param[out] idx_base - `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
+  !>   @param[out] data_type - `rocsparse_datatype_f32_r`, `rocsparse_datatype_f64_r`,
   !>               `rocsparse_datatype_f32_c`, or `rocsparse_datatype_f64_c`.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
@@ -2841,28 +2584,19 @@ module hipfort_rocsparse
   !>   \details
   !>   \p rocsparse_csr_get gets the fields of the sparse CSR matrix descriptor.
   !>
-  !>   @param[in]
-  !>   descr        the pointer to the sparse CSR matrix descriptor.
-  !>   @param[out]
-  !>   rows         number of rows in the CSR matrix.
-  !>   @param[out]
-  !>   cols         number of columns in the CSR matrix.
-  !>   @param[out]
-  !>   nnz          number of non-zeros in the CSR matrix.
-  !>   @param[out]
-  !>   csr_row_ptr  row offsets of the CSR matrix. Must be an array of length \p rows+1.
-  !>   @param[out]
-  !>   csr_col_ind  column indices of the CSR matrix. Must be an array of length \p nnz.
-  !>   @param[out]
-  !>   csr_val      values of the CSR matrix. Must be an array of length \p nnz.
-  !>   @param[out]
-  !>   row_ptr_type `rocsparse_indextype_i32` or `rocsparse_indextype_i64`.
-  !>   @param[out]
-  !>   col_ind_type `rocsparse_indextype_i32` or `rocsparse_indextype_i64`.
-  !>   @param[out]
-  !>   idx_base     `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
-  !>   @param[out]
-  !>   data_type    `rocsparse_datatype_f32_r`, `rocsparse_datatype_f64_r`,
+  !>   @param[in] descr - the pointer to the sparse CSR matrix descriptor.
+  !>   @param[out] rows - number of rows in the CSR matrix.
+  !>   @param[out] cols - number of columns in the CSR matrix.
+  !>   @param[out] nnz - number of non-zeros in the CSR matrix.
+  !>   @param[out] csr_row_ptr - row offsets of the CSR matrix. Must be an array of length \p
+  !>   rows+1.
+  !>   @param[out] csr_col_ind - column indices of the CSR matrix. Must be an array of length \p
+  !>   nnz.
+  !>   @param[out] csr_val - values of the CSR matrix. Must be an array of length \p nnz.
+  !>   @param[out] row_ptr_type - `rocsparse_indextype_i32` or `rocsparse_indextype_i64`.
+  !>   @param[out] col_ind_type - `rocsparse_indextype_i32` or `rocsparse_indextype_i64`.
+  !>   @param[out] idx_base - `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
+  !>   @param[out] data_type - `rocsparse_datatype_f32_r`, `rocsparse_datatype_f64_r`,
   !>                `rocsparse_datatype_f32_c`, or `rocsparse_datatype_f64_c`.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
@@ -2920,28 +2654,18 @@ module hipfort_rocsparse
   !>   \details
   !>   \p rocsparse_csc_get gets the fields of the sparse CSC matrix descriptor.
   !>
-  !>   @param[in]
-  !>   descr        the pointer to the sparse CSC matrix descriptor.
-  !>   @param[out]
-  !>   rows         number of rows in the CSC matrix.
-  !>   @param[out]
-  !>   cols         number of columns in the CSC matrix
-  !>   @param[out]
-  !>   nnz          number of non-zeros in the CSC matrix.
-  !>   @param[out]
-  !>   csc_col_ptr  column offsets of the CSC matrix. Must be an array of length \p cols+1.
-  !>   @param[out]
-  !>   csc_row_ind  row indices of the CSC matrix. Must be an array of length \p nnz.
-  !>   @param[out]
-  !>   csc_val      values of the CSC matrix. Must be an array of length \p nnz.
-  !>   @param[out]
-  !>   col_ptr_type `rocsparse_indextype_i32` or `rocsparse_indextype_i64`.
-  !>   @param[out]
-  !>   row_ind_type `rocsparse_indextype_i32` or `rocsparse_indextype_i64`.
-  !>   @param[out]
-  !>   idx_base     `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
-  !>   @param[out]
-  !>   data_type    `rocsparse_datatype_f32_r`, `rocsparse_datatype_f64_r`,
+  !>   @param[in] descr - the pointer to the sparse CSC matrix descriptor.
+  !>   @param[out] rows - number of rows in the CSC matrix.
+  !>   @param[out] cols - number of columns in the CSC matrix
+  !>   @param[out] nnz - number of non-zeros in the CSC matrix.
+  !>   @param[out] csc_col_ptr - column offsets of the CSC matrix. Must be an array of length \p
+  !>   cols+1.
+  !>   @param[out] csc_row_ind - row indices of the CSC matrix. Must be an array of length \p nnz.
+  !>   @param[out] csc_val - values of the CSC matrix. Must be an array of length \p nnz.
+  !>   @param[out] col_ptr_type - `rocsparse_indextype_i32` or `rocsparse_indextype_i64`.
+  !>   @param[out] row_ind_type - `rocsparse_indextype_i32` or `rocsparse_indextype_i64`.
+  !>   @param[out] idx_base - `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
+  !>   @param[out] data_type - `rocsparse_datatype_f32_r`, `rocsparse_datatype_f64_r`,
   !>                `rocsparse_datatype_f32_c`, or `rocsparse_datatype_f64_c`.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
@@ -2999,24 +2723,16 @@ module hipfort_rocsparse
   !>   \details
   !>   \p rocsparse_ell_get gets the fields of the sparse ELL matrix descriptor.
   !>
-  !>   @param[in]
-  !>   descr       the pointer to the sparse ELL matrix descriptor.
-  !>   @param[out]
-  !>   rows        number of rows in the ELL matrix.
-  !>   @param[out]
-  !>   cols        number of columns in the ELL matrix.
-  !>   @param[out]
-  !>   ell_col_ind column indices of the ELL matrix. Must be an array of length \p rows*ell_width.
-  !>   @param[out]
-  !>   ell_val     values of the ELL matrix. Must be an array of length \p rows*ell_width.
-  !>   @param[out]
-  !>   ell_width   width of the ELL matrix.
-  !>   @param[out]
-  !>   idx_type    `rocsparse_indextype_i32` or `rocsparse_indextype_i64`.
-  !>   @param[out]
-  !>   idx_base    `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
-  !>   @param[out]
-  !>   data_type   `rocsparse_datatype_f32_r`, `rocsparse_datatype_f64_r`,
+  !>   @param[in] descr - the pointer to the sparse ELL matrix descriptor.
+  !>   @param[out] rows - number of rows in the ELL matrix.
+  !>   @param[out] cols - number of columns in the ELL matrix.
+  !>   @param[out] ell_col_ind - column indices of the ELL matrix. Must be an array of length \p
+  !>   rows*ell_width.
+  !>   @param[out] ell_val - values of the ELL matrix. Must be an array of length \p rows*ell_width.
+  !>   @param[out] ell_width - width of the ELL matrix.
+  !>   @param[out] idx_type - `rocsparse_indextype_i32` or `rocsparse_indextype_i64`.
+  !>   @param[out] idx_base - `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
+  !>   @param[out] data_type - `rocsparse_datatype_f32_r`, `rocsparse_datatype_f64_r`,
   !>               `rocsparse_datatype_f32_c`, or `rocsparse_datatype_f64_c`.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
@@ -3070,30 +2786,20 @@ module hipfort_rocsparse
   !>   \details
   !>   \p rocsparse_bell_get gets the fields of the sparse blocked ELL matrix descriptor.
   !>
-  !>   @param[in]
-  !>   descr         the pointer to the sparse blocked ELL matrix descriptor.
-  !>   @param[out]
-  !>   rows          number of rows in the blocked ELL matrix.
-  !>   @param[out]
-  !>   cols          number of columns in the blocked ELL matrix.
-  !>   @param[out]
-  !>   ell_block_dir `rocsparse_direction_row` or `rocsparse_direction_column`.
-  !>   @param[out]
-  !>   ell_block_dim block dimension of the sparse blocked ELL matrix.
-  !>   @param[out]
-  !>   ell_cols column indices of the blocked ELL matrix. Must be an array of length \p
+  !>   @param[in] descr - the pointer to the sparse blocked ELL matrix descriptor.
+  !>   @param[out] rows - number of rows in the blocked ELL matrix.
+  !>   @param[out] cols - number of columns in the blocked ELL matrix.
+  !>   @param[out] ell_block_dir - `rocsparse_direction_row` or `rocsparse_direction_column`.
+  !>   @param[out] ell_block_dim - block dimension of the sparse blocked ELL matrix.
+  !>   @param[out] ell_cols - column indices of the blocked ELL matrix. Must be an array of length
+  !>   \p rows*ell_width.
+  !>   @param[out] ell_col_ind - column indices of the blocked ELL matrix. Must be an array of
+  !>   length \p rows*ell_width.
+  !>   @param[out] ell_val - values of the blocked ELL matrix. Must be an array of length \p
   !>   rows*ell_width.
-  !>   @param[out]
-  !>   ell_col_ind column indices of the blocked ELL matrix. Must be an array of length \p
-  !>   rows*ell_width.
-  !>   @param[out]
-  !>   ell_val       values of the blocked ELL matrix. Must be an array of length \p rows*ell_width.
-  !>   @param[out]
-  !>   idx_type      `rocsparse_indextype_i32` or `rocsparse_indextype_i64`.
-  !>   @param[out]
-  !>   idx_base      `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
-  !>   @param[out]
-  !>   data_type     `rocsparse_datatype_f32_r`, `rocsparse_datatype_f64_r`,
+  !>   @param[out] idx_type - `rocsparse_indextype_i32` or `rocsparse_indextype_i64`.
+  !>   @param[out] idx_base - `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
+  !>   @param[out] data_type - `rocsparse_datatype_f32_r`, `rocsparse_datatype_f64_r`,
   !>                 `rocsparse_datatype_f32_c`, or `rocsparse_datatype_f64_c`.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
@@ -3151,35 +2857,23 @@ module hipfort_rocsparse
   !>   \details
   !>   \p rocsparse_sell_get gets the fields of the sparse sliced ELL matrix descriptor.
   !>
-  !>   @param[in]
-  !>   descr                  the pointer to the sparse sliced ELL matrix descriptor.
-  !>   @param[out]
-  !>   rows                   number of rows in the sliced ELL matrix.
-  !>   @param[out]
-  !>   cols                   number of columns in the sliced ELL matrix.
-  !>   @param[out]
-  !>   nnz                    number of non-zeros in the sliced ELL matrix.
-  !>   @param[out]
-  !>   sell_slice_size        slice size in the sliced ELL matrix.
-  !>   @param[out]
-  !>   sell_colval_size       actual number of elements stored in the sliced ELL matrix.
-  !>   @param[out]
-  !>   sell_slice_offsets slice offsets array in the sliced ELL matrix. Must be an array of length
-  !>   \p nslices + 1
+  !>   @param[in] descr - the pointer to the sparse sliced ELL matrix descriptor.
+  !>   @param[out] rows - number of rows in the sliced ELL matrix.
+  !>   @param[out] cols - number of columns in the sliced ELL matrix.
+  !>   @param[out] nnz - number of non-zeros in the sliced ELL matrix.
+  !>   @param[out] sell_slice_size - slice size in the sliced ELL matrix.
+  !>   @param[out] sell_colval_size - actual number of elements stored in the sliced ELL matrix.
+  !>   @param[out] sell_slice_offsets - slice offsets array in the sliced ELL matrix. Must be an
+  !>   array of length \p nslices + 1
   !>                          where \p nslices=(rows-1)/sell_slice_size+1.
-  !>   @param[out]
-  !>   sell_col_ind column indices of the sliced ELL matrix. Must be an array of length \p
+  !>   @param[out] sell_col_ind - column indices of the sliced ELL matrix. Must be an array of
+  !>   length \p sell_colval_size.
+  !>   @param[out] sell_val - values of the sliced ELL matrix. Must be an array of length \p
   !>   sell_colval_size.
-  !>   @param[out]
-  !>   sell_val values of the sliced ELL matrix. Must be an array of length \p sell_colval_size.
-  !>   @param[out]
-  !>   sell_slice_offsets_type `rocsparse_indextype_i32` or `rocsparse_indextype_i64`.
-  !>   @param[out]
-  !>   sell_col_ind_type       `rocsparse_indextype_i32` or `rocsparse_indextype_i64`.
-  !>   @param[out]
-  !>   idx_base                `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
-  !>   @param[out]
-  !>   data_type               `rocsparse_datatype_f32_r`, `rocsparse_datatype_f64_r`,
+  !>   @param[out] sell_slice_offsets_type - `rocsparse_indextype_i32` or `rocsparse_indextype_i64`.
+  !>   @param[out] sell_col_ind_type - `rocsparse_indextype_i32` or `rocsparse_indextype_i64`.
+  !>   @param[out] idx_base - `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
+  !>   @param[out] data_type - `rocsparse_datatype_f32_r`, `rocsparse_datatype_f64_r`,
   !>                           `rocsparse_datatype_f32_c`, or `rocsparse_datatype_f64_c`.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
@@ -3244,33 +2938,22 @@ module hipfort_rocsparse
   !>   \details
   !>   \p rocsparse_bsr_get gets the fields of the sparse BSR matrix descriptor.
   !>
-  !>   @param[in]
-  !>   descr        the pointer to the sparse BSR matrix descriptor.
-  !>   @param[out]
-  !>   brows        number of block rows in the BSR matrix.
-  !>   @param[out]
-  !>   bcols        number of block columns in the BSR matrix.
-  !>   @param[out]
-  !>   bnnz         number of non-zero blocks in the BSR matrix.
-  !>   @param[out]
-  !>   block_dir    storage layout of the dense block matrices.
-  !>   @param[out]
-  !>   block_dim    block dimension.
-  !>   @param[out]
-  !>   bsr_row_ptr  row offsets of the BSR matrix. Must be an array of length \p brows+1.
-  !>   @param[out]
-  !>   bsr_col_ind  column indices of the BSR matrix. Must be an array of length \p bnnz.
-  !>   @param[out]
-  !>   bsr_val values of the BSR matrix (must be array of length \p bnnz * \p block_dim * \p
-  !>   block_dim ).
-  !>   @param[out]
-  !>   row_ptr_type `rocsparse_indextype_i32` or `rocsparse_indextype_i64`.
-  !>   @param[out]
-  !>   col_ind_type `rocsparse_indextype_i32` or `rocsparse_indextype_i64`.
-  !>   @param[out]
-  !>   idx_base     `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
-  !>   @param[out]
-  !>   data_type    `rocsparse_datatype_f32_r`, `rocsparse_datatype_f64_r`,
+  !>   @param[in] descr - the pointer to the sparse BSR matrix descriptor.
+  !>   @param[out] brows - number of block rows in the BSR matrix.
+  !>   @param[out] bcols - number of block columns in the BSR matrix.
+  !>   @param[out] bnnz - number of non-zero blocks in the BSR matrix.
+  !>   @param[out] block_dir - storage layout of the dense block matrices.
+  !>   @param[out] block_dim - block dimension.
+  !>   @param[out] bsr_row_ptr - row offsets of the BSR matrix. Must be an array of length \p
+  !>   brows+1.
+  !>   @param[out] bsr_col_ind - column indices of the BSR matrix. Must be an array of length \p
+  !>   bnnz.
+  !>   @param[out] bsr_val - values of the BSR matrix (must be array of length \p bnnz * \p
+  !>   block_dim * \p block_dim ).
+  !>   @param[out] row_ptr_type - `rocsparse_indextype_i32` or `rocsparse_indextype_i64`.
+  !>   @param[out] col_ind_type - `rocsparse_indextype_i32` or `rocsparse_indextype_i64`.
+  !>   @param[out] idx_base - `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
+  !>   @param[out] data_type - `rocsparse_datatype_f32_r`, `rocsparse_datatype_f64_r`,
   !>                `rocsparse_datatype_f32_c`, or `rocsparse_datatype_f64_c`.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
@@ -3330,14 +3013,10 @@ module hipfort_rocsparse
   !>   \brief Set the row indices, column indices, and values array in the sparse COO matrix
   !>   descriptor.
   !>
-  !>   @param[inout]
-  !>   descr   the pointer to the sparse matrix descriptor.
-  !>   @param[in]
-  !>   coo_row_ind row indices of the COO matrix. Must be an array of length \p nnz.
-  !>   @param[in]
-  !>   coo_col_ind column indices of the COO matrix. Must be an array of length \p nnz.
-  !>   @param[in]
-  !>   coo_val     values of the COO matrix. Must be an array of length \p nnz.
+  !>   @param[inout] descr - the pointer to the sparse matrix descriptor.
+  !>   @param[in] coo_row_ind - row indices of the COO matrix. Must be an array of length \p nnz.
+  !>   @param[in] coo_col_ind - column indices of the COO matrix. Must be an array of length \p nnz.
+  !>   @param[in] coo_val - values of the COO matrix. Must be an array of length \p nnz.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer if \p descr, \p coo_row_ind, \p coo_col_ind, or \p
@@ -3360,12 +3039,10 @@ module hipfort_rocsparse
   !>   \brief Set the <row, column> indices and values array in the sparse COO AoS matrix
   !>   descriptor.
   !>
-  !>   @param[inout]
-  !>   descr   the pointer to the sparse matrix descriptor.
-  !>   @param[in]
-  !>   coo_ind <row, column> indices of the COO matrix. Must be an array of length \p nnz.
-  !>   @param[in]
-  !>   coo_val values of the COO matrix. Must be an array of length \p nnz.
+  !>   @param[inout] descr - the pointer to the sparse matrix descriptor.
+  !>   @param[in] coo_ind - <row, column> indices of the COO matrix. Must be an array of length \p
+  !>   nnz.
+  !>   @param[in] coo_val - values of the COO matrix. Must be an array of length \p nnz.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer if \p descr, \p coo_ind, or \p coo_val is invalid.
@@ -3386,14 +3063,10 @@ module hipfort_rocsparse
   !>   \brief Set the row offsets, column indices, and values array in the sparse CSR matrix
   !>   descriptor.
   !>
-  !>   @param[inout]
-  !>   descr   the pointer to the sparse matrix descriptor.
-  !>   @param[in]
-  !>   csr_row_ptr  row offsets of the CSR matrix. Must be an array of length \p rows+1.
-  !>   @param[in]
-  !>   csr_col_ind  column indices of the CSR matrix. Must be an array of length \p nnz.
-  !>   @param[in]
-  !>   csr_val      values of the CSR matrix. Must be an array of length \p nnz.
+  !>   @param[inout] descr - the pointer to the sparse matrix descriptor.
+  !>   @param[in] csr_row_ptr - row offsets of the CSR matrix. Must be an array of length \p rows+1.
+  !>   @param[in] csr_col_ind - column indices of the CSR matrix. Must be an array of length \p nnz.
+  !>   @param[in] csr_val - values of the CSR matrix. Must be an array of length \p nnz.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer if \p descr, \p coo_ind, or \p coo_val is invalid.
@@ -3415,14 +3088,11 @@ module hipfort_rocsparse
   !>   \brief Set the column offsets, row indices, and values array in the sparse CSC matrix
   !>   descriptor.
   !>
-  !>   @param[inout]
-  !>   descr       the pointer to the sparse matrix descriptor.
-  !>   @param[in]
-  !>   csc_col_ptr column offsets of the CSC matrix. Must be an array of length \p cols+1.
-  !>   @param[in]
-  !>   csc_row_ind row indices of the CSC matrix. Must be an array of length \p nnz.
-  !>   @param[in]
-  !>   csc_val     values of the CSC matrix. Must be an array of length \p nnz.
+  !>   @param[inout] descr - the pointer to the sparse matrix descriptor.
+  !>   @param[in] csc_col_ptr - column offsets of the CSC matrix. Must be an array of length \p
+  !>   cols+1.
+  !>   @param[in] csc_row_ind - row indices of the CSC matrix. Must be an array of length \p nnz.
+  !>   @param[in] csc_val - values of the CSC matrix. Must be an array of length \p nnz.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer if \p descr, \p csc_col_ptr, \p csc_row_ind, or \p
@@ -3444,12 +3114,10 @@ module hipfort_rocsparse
   !>  \ingroup aux_module
   !>   \brief Set the column indices and values array in the sparse ELL matrix descriptor.
   !>
-  !>   @param[inout]
-  !>   descr       the pointer to the sparse matrix descriptor.
-  !>   @param[in]
-  !>   ell_col_ind column indices of the ELL matrix. Must be an array of length \p rows*ell_width.
-  !>   @param[in]
-  !>   ell_val     values of the ELL matrix. Must be an array of length \p rows*ell_width.
+  !>   @param[inout] descr - the pointer to the sparse matrix descriptor.
+  !>   @param[in] ell_col_ind - column indices of the ELL matrix. Must be an array of length \p
+  !>   rows*ell_width.
+  !>   @param[in] ell_val - values of the ELL matrix. Must be an array of length \p rows*ell_width.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer if \p descr, \p ell_col_ind, or \p ell_val is
@@ -3471,14 +3139,12 @@ module hipfort_rocsparse
   !>   \brief Set the row offsets, column indices, and values array in the sparse BSR matrix
   !>   descriptor
   !>
-  !>   @param[inout]
-  !>   descr   the pointer to the sparse matrix descriptor.
-  !>   @param[in]
-  !>   bsr_row_ptr  row offsets of the BSR matrix. Must be an array of length \p rows+1.
-  !>   @param[in]
-  !>   bsr_col_ind  column indices of the BSR matrix. Must be an array of length \p nnzb.
-  !>   @param[in]
-  !>   bsr_val values of the BSR matrix. Must be an array of length \p nnzb*block_dim*block_dim.
+  !>   @param[inout] descr - the pointer to the sparse matrix descriptor.
+  !>   @param[in] bsr_row_ptr - row offsets of the BSR matrix. Must be an array of length \p rows+1.
+  !>   @param[in] bsr_col_ind - column indices of the BSR matrix. Must be an array of length \p
+  !>   nnzb.
+  !>   @param[in] bsr_val - values of the BSR matrix. Must be an array of length \p
+  !>   nnzb*block_dim*block_dim.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer if \p descr, \p bsr_row_ptr, \p bsr_col_ind, or \p
@@ -3500,13 +3166,11 @@ module hipfort_rocsparse
   !>  \ingroup aux_module
   !>   \brief Set the column indices and values array in the sparse Blocked ELL matrix descriptor
   !>
-  !>   @param[inout]
-  !>   descr   the pointer to the sparse matrix descriptor.
-  !>   @param[in]
-  !>   bell_col_ind column indices of the Blocked ELL matrix. Must be an array of length \p
-  !>   mb*ell_cols/ell_block_size.
-  !>   @param[in]
-  !>   bell_val      values of the Blocked ELL matrix. Must be an array of length \p m*ell_cols.
+  !>   @param[inout] descr - the pointer to the sparse matrix descriptor.
+  !>   @param[in] bell_col_ind - column indices of the Blocked ELL matrix. Must be an array of
+  !>   length \p mb*ell_cols/ell_block_size.
+  !>   @param[in] bell_val - values of the Blocked ELL matrix. Must be an array of length \p
+  !>   m*ell_cols.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer if \p descr, \p bell_col_ind, or \p bell_val is
@@ -3527,14 +3191,10 @@ module hipfort_rocsparse
   !>  \ingroup aux_module
   !>   \brief Get the number of rows, columns, and non-zeros from the sparse matrix descriptor.
   !>
-  !>   @param[in]
-  !>   descr       the pointer to the sparse matrix descriptor.
-  !>   @param[out]
-  !>   rows        number of rows in the sparse matrix.
-  !>   @param[out]
-  !>   cols        number of columns in the sparse matrix.
-  !>   @param[out]
-  !>   nnz         number of non-zeros in sparse matrix.
+  !>   @param[in] descr - the pointer to the sparse matrix descriptor.
+  !>   @param[out] rows - number of rows in the sparse matrix.
+  !>   @param[out] cols - number of columns in the sparse matrix.
+  !>   @param[out] nnz - number of non-zeros in sparse matrix.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer if \p descr is invalid.
@@ -3555,10 +3215,8 @@ module hipfort_rocsparse
   !>  \ingroup aux_module
   !>   \brief Get the sparse matrix format from the sparse matrix descriptor.
   !>
-  !>   @param[in]
-  !>   descr       the pointer to the sparse matrix descriptor.
-  !>   @param[out]
-  !>   format      `rocsparse_format_coo`, `rocsparse_format_coo_aos`,
+  !>   @param[in] descr - the pointer to the sparse matrix descriptor.
+  !>   @param[out] myFormat - `rocsparse_format_coo`, `rocsparse_format_coo_aos`,
   !>               `rocsparse_format_csr`, `rocsparse_format_csc`, or
   !>               `rocsparse_format_ell`
   !>
@@ -3579,10 +3237,8 @@ module hipfort_rocsparse
   !>  \ingroup aux_module
   !>   \brief Get the sparse matrix index base from the sparse matrix descriptor.
   !>
-  !>   @param[in]
-  !>   descr       the pointer to the sparse matrix descriptor.
-  !>   @param[out]
-  !>   idx_base    `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
+  !>   @param[in] descr - the pointer to the sparse matrix descriptor.
+  !>   @param[out] idx_base - `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer if \p descr is invalid.
@@ -3602,10 +3258,8 @@ module hipfort_rocsparse
   !>  \ingroup aux_module
   !>   \brief Get the values array from the sparse matrix descriptor.
   !>
-  !>   @param[in]
-  !>   descr     the pointer to the sparse matrix descriptor.
-  !>   @param[out]
-  !>   values    values array of the sparse matrix.
+  !>   @param[in] descr - the pointer to the sparse matrix descriptor.
+  !>   @param[out] values - values array of the sparse matrix.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer if \p descr or \p values is invalid.
@@ -3635,10 +3289,8 @@ module hipfort_rocsparse
   !>  \ingroup aux_module
   !>   \brief Set the values array in the sparse matrix descriptor.
   !>
-  !>   @param[inout]
-  !>   descr     the pointer to the sparse matrix descriptor.
-  !>   @param[in]
-  !>   values    values array of the sparse matrix.
+  !>   @param[inout] descr - the pointer to the sparse matrix descriptor.
+  !>   @param[in] values - values array of the sparse matrix.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer if \p descr or \p values is invalid.
@@ -3659,10 +3311,8 @@ module hipfort_rocsparse
   !>   \note The returned number of non-zeros is the number of elements of the array of values of
   !>   the sparse matrix.
   !>
-  !>   @param[in]
-  !>   descr       the pointer to the sparse matrix descriptor.
-  !>   @param[out]
-  !>   nnz the number of non-zeros of the sparse matrix.
+  !>   @param[in] descr - the pointer to the sparse matrix descriptor.
+  !>   @param[out] nnz - the number of non-zeros of the sparse matrix.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer if \p descr or \p nnz is invalid.
@@ -3687,10 +3337,8 @@ module hipfort_rocsparse
   !>   \note In the case of a sparse matrix with the format `rocsparse_format_bell`, the operation
   !>   will return an error.
   !>
-  !>   @param[in]
-  !>   descr       the pointer to the sparse matrix descriptor.
-  !>   @param[in]
-  !>   nnz         number of non-zeros of the sparse matrix.
+  !>   @param[in] descr - the pointer to the sparse matrix descriptor.
+  !>   @param[in] nnz - number of non-zeros of the sparse matrix.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer if \p descr is invalid.
@@ -3709,10 +3357,8 @@ module hipfort_rocsparse
   !>  \ingroup aux_module
   !>   \brief Get the strided batch count from the sparse matrix descriptor.
   !>
-  !>   @param[in]
-  !>   descr       the pointer to the sparse matrix descriptor.
-  !>   @param[out]
-  !>   batch_count batch_count of the sparse matrix.
+  !>   @param[in] descr - the pointer to the sparse matrix descriptor.
+  !>   @param[out] batch_count - batch_count of the sparse matrix.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer if \p descr is invalid.
@@ -3732,10 +3378,8 @@ module hipfort_rocsparse
   !>  \ingroup aux_module
   !>   \brief Set the strided batch count in the sparse matrix descriptor.
   !>
-  !>   @param[in]
-  !>   descr       the pointer to the sparse matrix descriptor.
-  !>   @param[in]
-  !>   batch_count batch_count of the sparse matrix.
+  !>   @param[in] descr - the pointer to the sparse matrix descriptor.
+  !>   @param[in] batch_count - batch_count of the sparse matrix.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer if \p descr is invalid.
@@ -3755,12 +3399,9 @@ module hipfort_rocsparse
   !>  \ingroup aux_module
   !>   \brief Set the batch count and batch stride in the sparse COO matrix descriptor
   !>
-  !>   @param[inout]
-  !>   descr        the pointer to the sparse COO matrix descriptor.
-  !>   @param[in]
-  !>   batch_count  batch_count of the sparse COO matrix.
-  !>   @param[in]
-  !>   batch_stride batch stride of the sparse COO matrix.
+  !>   @param[inout] descr - the pointer to the sparse COO matrix descriptor.
+  !>   @param[in] batch_count - batch_count of the sparse COO matrix.
+  !>   @param[in] batch_stride - batch stride of the sparse COO matrix.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer if \p descr is invalid.
@@ -3782,14 +3423,11 @@ module hipfort_rocsparse
   !>   \brief Set the batch count, row offset batch stride, and the column indices batch stride in
   !>   the sparse CSR matrix descriptor.
   !>
-  !>   @param[inout]
-  !>   descr                       the pointer to the sparse CSR matrix descriptor.
-  !>   @param[in]
-  !>   batch_count                 batch_count of the sparse CSR matrix.
-  !>   @param[in]
-  !>   offsets_batch_stride        row offset batch stride of the sparse CSR matrix.
-  !>   @param[in]
-  !>   columns_values_batch_stride column indices batch stride of the sparse CSR matrix.
+  !>   @param[inout] descr - the pointer to the sparse CSR matrix descriptor.
+  !>   @param[in] batch_count - batch_count of the sparse CSR matrix.
+  !>   @param[in] offsets_batch_stride - row offset batch stride of the sparse CSR matrix.
+  !>   @param[in] columns_values_batch_stride - column indices batch stride of the sparse CSR
+  !>   matrix.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer if \p descr is invalid.
@@ -3814,14 +3452,10 @@ module hipfort_rocsparse
   !>   \brief Set the batch count, column offset batch stride, and the row indices batch stride in
   !>   the sparse CSC matrix descriptor.
   !>
-  !>   @param[inout]
-  !>   descr                       the pointer to the sparse CSC matrix descriptor.
-  !>   @param[in]
-  !>   batch_count                 batch_count of the sparse CSC matrix.
-  !>   @param[in]
-  !>   offsets_batch_stride        column offset batch stride of the sparse CSC matrix.
-  !>   @param[in]
-  !>   rows_values_batch_stride    row indices batch stride of the sparse CSC matrix.
+  !>   @param[inout] descr - the pointer to the sparse CSC matrix descriptor.
+  !>   @param[in] batch_count - batch_count of the sparse CSC matrix.
+  !>   @param[in] offsets_batch_stride - column offset batch stride of the sparse CSC matrix.
+  !>   @param[in] rows_values_batch_stride - row indices batch stride of the sparse CSC matrix.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer if \p descr is invalid.
@@ -3845,15 +3479,11 @@ module hipfort_rocsparse
   !>  \ingroup aux_module
   !>   \brief Get the requested attribute data from the sparse matrix descriptor.
   !>
-  !>   @param[in]
-  !>   descr       the pointer to the sparse matrix descriptor.
-  !>   @param[in]
-  !>   attribute `rocsparse_spmat_fill_mode`, `rocsparse_spmat_diag_type`,
+  !>   @param[in] descr - the pointer to the sparse matrix descriptor.
+  !>   @param[in] attribute - `rocsparse_spmat_fill_mode`, `rocsparse_spmat_diag_type`,
   !>             `rocsparse_spmat_matrix_type`, or `rocsparse_spmat_storage_mode`.
-  !>   @param[out]
-  !>   data      attribute data.
-  !>   @param[in]
-  !>   data_size attribute data size.
+  !>   @param[out] myData - attribute data.
+  !>   @param[in] data_size - attribute data size.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer if \p descr or \p data is invalid.
@@ -3876,15 +3506,11 @@ module hipfort_rocsparse
   !>  \ingroup aux_module
   !>   \brief Set the requested attribute data in the sparse matrix descriptor.
   !>
-  !>   @param[inout]
-  !>   descr       the pointer to the sparse matrix descriptor.
-  !>   @param[in]
-  !>   attribute `rocsparse_spmat_fill_mode`, `rocsparse_spmat_diag_type`,
+  !>   @param[inout] descr - the pointer to the sparse matrix descriptor.
+  !>   @param[in] attribute - `rocsparse_spmat_fill_mode`, `rocsparse_spmat_diag_type`,
   !>             `rocsparse_spmat_matrix_type`, or `rocsparse_spmat_storage_mode`.
-  !>   @param[in]
-  !>   data      attribute data.
-  !>   @param[in]
-  !>   data_size attribute data size.
+  !>   @param[in] myData - attribute data.
+  !>   @param[in] data_size - attribute data size.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer if \p descr or \p data is invalid.
@@ -3910,14 +3536,10 @@ module hipfort_rocsparse
   !>   \p rocsparse_create_dnvec_descr creates a dense vector descriptor. It should be
   !>   destroyed at the end using rocsparse_destroy_dnvec_descr().
   !>
-  !>   @param[out]
-  !>   descr   the pointer to the dense vector descriptor.
-  !>   @param[in]
-  !>   size   size of the dense vector.
-  !>   @param[in]
-  !>   values   non-zero values in the dense vector. Must be an array of length \p size.
-  !>   @param[in]
-  !>   data_type   `rocsparse_datatype_f32_r`, `rocsparse_datatype_f64_r`,
+  !>   @param[out] descr - the pointer to the dense vector descriptor.
+  !>   @param[in] mySize - size of the dense vector.
+  !>   @param[in] values - non-zero values in the dense vector. Must be an array of length \p size.
+  !>   @param[in] data_type - `rocsparse_datatype_f32_r`, `rocsparse_datatype_f64_r`,
   !>               `rocsparse_datatype_f32_c`, or `rocsparse_datatype_f64_c`.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
@@ -3959,8 +3581,7 @@ module hipfort_rocsparse
   !>   \p rocsparse_destroy_dnvec_descr destroys a dense vector descriptor and releases all
   !>   resources used by the descriptor.
   !>
-  !>   @param[in]
-  !>   descr   the matrix descriptor.
+  !>   @param[in] descr - the matrix descriptor.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer \p descr is invalid.
@@ -3979,14 +3600,10 @@ module hipfort_rocsparse
   !>   \details
   !>   \p rocsparse_dnvec_get gets the fields of the dense vector descriptor.
   !>
-  !>   @param[in]
-  !>   descr   the pointer to the dense vector descriptor.
-  !>   @param[out]
-  !>   size   size of the dense vector.
-  !>   @param[out]
-  !>   values   non-zero values in the dense vector. Must be an array of length \p size.
-  !>   @param[out]
-  !>   data_type   `rocsparse_datatype_f32_r`, `rocsparse_datatype_f64_r`,
+  !>   @param[in] descr - the pointer to the dense vector descriptor.
+  !>   @param[out] mySize - size of the dense vector.
+  !>   @param[out] values - non-zero values in the dense vector. Must be an array of length \p size.
+  !>   @param[out] data_type - `rocsparse_datatype_f32_r`, `rocsparse_datatype_f64_r`,
   !>               `rocsparse_datatype_f32_c`, or `rocsparse_datatype_f64_c`.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
@@ -4023,10 +3640,8 @@ module hipfort_rocsparse
   !>  \ingroup aux_module
   !>   \brief Get the values array from a dense vector descriptor.
   !>
-  !>   @param[in]
-  !>   descr   the matrix descriptor.
-  !>   @param[out]
-  !>   values   non-zero values in the dense vector. Must be an array of length \p size.
+  !>   @param[in] descr - the matrix descriptor.
+  !>   @param[out] values - non-zero values in the dense vector. Must be an array of length \p size.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer \p descr or \p values is invalid.
@@ -4056,10 +3671,8 @@ module hipfort_rocsparse
   !>  \ingroup aux_module
   !>   \brief Set the values array in a dense vector descriptor.
   !>
-  !>   @param[inout]
-  !>   descr   the matrix descriptor.
-  !>   @param[in]
-  !>   values   non-zero values in the dense vector. Must be an array of length \p size.
+  !>   @param[inout] descr - the matrix descriptor.
+  !>   @param[in] values - non-zero values in the dense vector. Must be an array of length \p size.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer \p descr or \p values is invalid.
@@ -4080,23 +3693,16 @@ module hipfort_rocsparse
   !>   \p rocsparse_create_dnmat_descr creates a dense matrix descriptor. It should be
   !>   destroyed at the end using rocsparse_destroy_dnmat_descr().
   !>
-  !>   @param[out]
-  !>   descr     the pointer to the dense matrix descriptor.
-  !>   @param[in]
-  !>   rows      number of rows in the dense matrix.
-  !>   @param[in]
-  !>   cols      number of columns in the dense matrix.
-  !>   @param[in]
-  !>   ld        leading dimension of the dense matrix.
-  !>   @param[in]
-  !>   values    non-zero values in the dense vector. Must be an array of length
+  !>   @param[out] descr - the pointer to the dense matrix descriptor.
+  !>   @param[in] rows - number of rows in the dense matrix.
+  !>   @param[in] cols - number of columns in the dense matrix.
+  !>   @param[in] ld - leading dimension of the dense matrix.
+  !>   @param[in] values - non-zero values in the dense vector. Must be an array of length
   !>             \p ld*rows if \p order=rocsparse_order_column or \p ld*cols if \p
   !>             order=rocsparse_order_row.
-  !>   @param[in]
-  !>   data_type `rocsparse_datatype_f32_r`, `rocsparse_datatype_f64_r`,
+  !>   @param[in] data_type - `rocsparse_datatype_f32_r`, `rocsparse_datatype_f64_r`,
   !>             `rocsparse_datatype_f32_c`, or `rocsparse_datatype_f64_c`.
-  !>   @param[in]
-  !>   order     `rocsparse_order_row` or `rocsparse_order_column`.
+  !>   @param[in] order - `rocsparse_order_row` or `rocsparse_order_column`.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer if \p descr or \p values is invalid.
@@ -4143,8 +3749,7 @@ module hipfort_rocsparse
   !>   \p rocsparse_destroy_dnmat_descr destroys a dense matrix descriptor and releases all
   !>   resources used by the descriptor.
   !>
-  !>   @param[in]
-  !>   descr   the matrix descriptor.
+  !>   @param[in] descr - the matrix descriptor.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer \p descr is invalid.
@@ -4161,23 +3766,16 @@ module hipfort_rocsparse
   !>  \ingroup aux_module
   !>   \brief Get the fields of the dense matrix descriptor.
   !>
-  !>   @param[in]
-  !>   descr   the pointer to the dense matrix descriptor.
-  !>   @param[out]
-  !>   rows   number of rows in the dense matrix.
-  !>   @param[out]
-  !>   cols   number of columns in the dense matrix.
-  !>   @param[out]
-  !>   ld        leading dimension of the dense matrix.
-  !>   @param[out]
-  !>   values    non-zero values in the dense matrix. Must be an array of length
+  !>   @param[in] descr - the pointer to the dense matrix descriptor.
+  !>   @param[out] rows - number of rows in the dense matrix.
+  !>   @param[out] cols - number of columns in the dense matrix.
+  !>   @param[out] ld - leading dimension of the dense matrix.
+  !>   @param[out] values - non-zero values in the dense matrix. Must be an array of length
   !>             \p ld*rows if \p order=rocsparse_order_column or \p ld*cols if \p
   !>             order=rocsparse_order_row.
-  !>   @param[out]
-  !>   data_type   `rocsparse_datatype_f32_r`, `rocsparse_datatype_f64_r`,
+  !>   @param[out] data_type - `rocsparse_datatype_f32_r`, `rocsparse_datatype_f64_r`,
   !>               `rocsparse_datatype_f32_c`, or `rocsparse_datatype_f64_c`.
-  !>   @param[out]
-  !>   order     `rocsparse_order_row` or `rocsparse_order_column`.
+  !>   @param[out] order - `rocsparse_order_row` or `rocsparse_order_column`.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer if \p descr or \p values is invalid.
@@ -4220,10 +3818,8 @@ module hipfort_rocsparse
   !>  \ingroup aux_module
   !>   \brief Get the values array from the dense matrix descriptor.
   !>
-  !>   @param[in]
-  !>   descr   the pointer to the dense matrix descriptor.
-  !>   @param[out]
-  !>   values    non-zero values in the dense matrix. Must be an array of length
+  !>   @param[in] descr - the pointer to the dense matrix descriptor.
+  !>   @param[out] values - non-zero values in the dense matrix. Must be an array of length
   !>             \p ld*rows if \p order=rocsparse_order_column or \p ld*cols if \p
   !>             order=rocsparse_order_row.
   !>
@@ -4255,10 +3851,8 @@ module hipfort_rocsparse
   !>  \ingroup aux_module
   !>   \brief Set the values array in a dense matrix descriptor.
   !>
-  !>   @param[inout]
-  !>   descr   the matrix descriptor.
-  !>   @param[in]
-  !>   values    non-zero values in the dense matrix. Must be an array of length
+  !>   @param[inout] descr - the matrix descriptor.
+  !>   @param[in] values - non-zero values in the dense matrix. Must be an array of length
   !>             \p ld*rows if \p order=rocsparse_order_column or \p ld*cols if \p
   !>             order=rocsparse_order_row.
   !>
@@ -4278,12 +3872,9 @@ module hipfort_rocsparse
   !>  \ingroup aux_module
   !>   \brief Get the batch count and batch stride from the dense matrix descriptor.
   !>
-  !>   @param[in]
-  !>   descr        the pointer to the dense matrix descriptor.
-  !>   @param[out]
-  !>   batch_count  the batch count in the dense matrix.
-  !>   @param[out]
-  !>   batch_stride the batch stride in the dense matrix.
+  !>   @param[in] descr - the pointer to the dense matrix descriptor.
+  !>   @param[out] batch_count - the batch count in the dense matrix.
+  !>   @param[out] batch_stride - the batch stride in the dense matrix.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer if \p descr is invalid.
@@ -4304,12 +3895,9 @@ module hipfort_rocsparse
   !>  \ingroup aux_module
   !>   \brief Set the batch count and batch stride in the dense matrix descriptor.
   !>
-  !>   @param[inout]
-  !>   descr        the pointer to the dense matrix descriptor.
-  !>   @param[in]
-  !>   batch_count  the batch count in the dense matrix.
-  !>   @param[in]
-  !>   batch_stride the batch stride in the dense matrix.
+  !>   @param[inout] descr - the pointer to the dense matrix descriptor.
+  !>   @param[in] batch_count - the batch count in the dense matrix.
+  !>   @param[in] batch_stride - the batch stride in the dense matrix.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer if \p descr is invalid.
@@ -4330,12 +3918,9 @@ module hipfort_rocsparse
   !>  \ingroup aux_module
   !>   \brief Get the batch count and batch stride from the dense vector descriptor.
   !>
-  !>   @param[in]
-  !>   descr        the pointer to the dense vector descriptor.
-  !>   @param[out]
-  !>   batch_count  the batch count in the dense vector.
-  !>   @param[out]
-  !>   batch_stride the batch stride in the dense vector.
+  !>   @param[in] descr - the pointer to the dense vector descriptor.
+  !>   @param[out] batch_count - the batch count in the dense vector.
+  !>   @param[out] batch_stride - the batch stride in the dense vector.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer if \p descr is invalid.
@@ -4356,12 +3941,9 @@ module hipfort_rocsparse
   !>  \ingroup aux_module
   !>   \brief Set the batch count and batch stride in the dense vector descriptor.
   !>
-  !>   @param[inout]
-  !>   descr        the pointer to the dense vector descriptor.
-  !>   @param[in]
-  !>   batch_count  the batch count in the dense vector.
-  !>   @param[in]
-  !>   batch_stride the batch stride in the dense vector.
+  !>   @param[inout] descr - the pointer to the dense vector descriptor.
+  !>   @param[in] batch_count - the batch count in the dense vector.
+  !>   @param[in] batch_stride - the batch stride in the dense vector.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_pointer if \p descr is invalid.
@@ -4672,41 +4254,30 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   dir the storage format of the blocks, `rocsparse_direction_row` or
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] dir - the storage format of the blocks, `rocsparse_direction_row` or
   !>   `rocsparse_direction_column`.
-  !>   @param[in]
-  !>   mb          number of block rows in the sparse BSR matrix.
-  !>   @param[in]
-  !>   nb          number of block columns in the sparse BSR matrix.
-  !>   @param[in]
-  !>   bsr_descr   descriptor of the sparse BSR matrix. Currently, only
+  !>   @param[in] mb - number of block rows in the sparse BSR matrix.
+  !>   @param[in] nb - number of block columns in the sparse BSR matrix.
+  !>   @param[in] bsr_descr - descriptor of the sparse BSR matrix. Currently, only
   !>               `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   bsr_val array of \p nnzb*block_dim*block_dim containing the values of the sparse BSR matrix.
-  !>   @param[in]
-  !>   bsr_row_ptr array of \p mb+1 elements that point to the start of every block row of the
+  !>   @param[in] bsr_val - array of \p nnzb*block_dim*block_dim containing the values of the sparse
+  !>   BSR matrix.
+  !>   @param[in] bsr_row_ptr - array of \p mb+1 elements that point to the start of every block row
+  !>   of the
   !>               sparse BSR matrix.
-  !>   @param[in]
-  !>   bsr_col_ind array of \p nnzb elements containing the block column indices of the sparse BSR
-  !>   matrix.
-  !>   @param[in]
-  !>   block_dim   size of the blocks in the sparse BSR matrix.
-  !>   @param[in]
-  !>   csr_descr   descriptor of the sparse CSR matrix. Currently, only
+  !>   @param[in] bsr_col_ind - array of \p nnzb elements containing the block column indices of the
+  !>   sparse BSR matrix.
+  !>   @param[in] block_dim - size of the blocks in the sparse BSR matrix.
+  !>   @param[in] csr_descr - descriptor of the sparse CSR matrix. Currently, only
   !>               `rocsparse_matrix_type_general` is supported.
-  !>   @param[out]
-  !>   csr_val array of \p nnzb*block_dim*block_dim elements containing the values of the sparse CSR
-  !>   matrix.
-  !>   @param[out]
-  !>   csr_row_ptr array of \p m+1 where \p m=mb*block_dim elements that point to the start of every
-  !>   row of the
-  !>               sparse CSR matrix.
-  !>   @param[out]
-  !>   csr_col_ind array of \p nnzb*block_dim*block_dim elements containing the column indices of
+  !>   @param[out] csr_val - array of \p nnzb*block_dim*block_dim elements containing the values of
   !>   the sparse CSR matrix.
+  !>   @param[out] csr_row_ptr - array of \p m+1 where \p m=mb*block_dim elements that point to the
+  !>   start of every row of the
+  !>               sparse CSR matrix.
+  !>   @param[out] csr_col_ind - array of \p nnzb*block_dim*block_dim elements containing the column
+  !>   indices of the sparse CSR matrix.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -4857,29 +4428,21 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m           number of rows of the sparse BSR matrix.
-  !>   @param[in]
-  !>   mb          number of block rows of the sparse BSR matrix.
-  !>   @param[in]
-  !>   nnzb        number of non-zero blocks of the sparse BSR matrix.
-  !>   @param[in]
-  !>   block_dim   block dimension of the sparse BSR matrix.
-  !>   @param[in]
-  !>   value scalar value that is set on the diagonal of the last block when the matrix expands
-  !>   outside of \p m x \p m.
-  !>   @param[in]
-  !>   bsr_descr   descriptor of the sparse BSR matrix. Currently, only
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse BSR matrix.
+  !>   @param[in] mb - number of block rows of the sparse BSR matrix.
+  !>   @param[in] nnzb - number of non-zero blocks of the sparse BSR matrix.
+  !>   @param[in] block_dim - block dimension of the sparse BSR matrix.
+  !>   @param[in] myValue - scalar value that is set on the diagonal of the last block when the
+  !>   matrix expands outside of \p m x \p m.
+  !>   @param[in] bsr_descr - descriptor of the sparse BSR matrix. Currently, only
   !>               `rocsparse_matrix_type_general` is supported.
-  !>   @param[inout]
-  !>   bsr_val     array of \p nnzb blocks of the sparse BSR matrix.
-  !>   @param[in]
-  !>   bsr_row_ptr array of \p mb+1 elements that point to the start of every block row of
+  !>   @param[inout] bsr_val - array of \p nnzb blocks of the sparse BSR matrix.
+  !>   @param[in] bsr_row_ptr - array of \p mb+1 elements that point to the start of every block row
+  !>   of
   !>               the sparse BSR matrix.
-  !>   @param[in]
-  !>   bsr_col_ind array of \p nnzb elements containing the block column indices of the sparse
+  !>   @param[in] bsr_col_ind - array of \p nnzb elements containing the block column indices of the
+  !>   sparse
   !>               BSR matrix.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
@@ -4991,20 +4554,16 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   coo_row_ind array of \p nnz elements containing the row indices of the sparse COO
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] coo_row_ind - array of \p nnz elements containing the row indices of the sparse
+  !>   COO
   !>               matrix.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of the sparse CSR matrix.
-  !>   @param[in]
-  !>   m           number of rows of the sparse CSR matrix.
-  !>   @param[out]
-  !>   csr_row_ptr array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix.
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
+  !>   @param[out] csr_row_ptr - array of \p m+1 elements that point to the start of every row of
+  !>   the
   !>               sparse CSR matrix.
-  !>   @param[in]
-  !>   idx_base    `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
+  !>   @param[in] idx_base - `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -5047,29 +4606,22 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m           number of rows of the column-oriented dense matrix \p A.
-  !>   @param[in]
-  !>   n           number of columns of the column-oriented dense matrix \p A.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of the sparse COO matrix.
-  !>   @param[in]
-  !>   descr the descriptor of the column-oriented dense matrix \p A. The supported matrix type is
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - number of rows of the column-oriented dense matrix \p A.
+  !>   @param[in] n - number of columns of the column-oriented dense matrix \p A.
+  !>   @param[in] nnz - number of non-zero entries of the sparse COO matrix.
+  !>   @param[in] descr - the descriptor of the column-oriented dense matrix \p A. The supported
+  !>   matrix type is
   !>               `rocsparse_matrix_type_general` and also any valid value of the
   !>               `rocsparse_index_base`.
-  !>   @param[in]
-  !>   coo_val     array of \p nnz non-zero elements of matrix \p A.
-  !>   @param[in]
-  !>   coo_row_ind integer array of \p nnz row indices of the non-zero elements of matrix \p A.
-  !>   @param[in]
-  !>   coo_col_ind integer array of \p nnz column indices of the non-zero elements of matrix \p A.
-  !>   @param[out]
-  !>   A           array of dimensions (\p ld, \p n).
+  !>   @param[in] coo_val - array of \p nnz non-zero elements of matrix \p A.
+  !>   @param[in] coo_row_ind - integer array of \p nnz row indices of the non-zero elements of
+  !>   matrix \p A.
+  !>   @param[in] coo_col_ind - integer array of \p nnz column indices of the non-zero elements of
+  !>   matrix \p A.
+  !>   @param[out] A - array of dimensions (\p ld, \p n).
   !>
-  !>   @param[out]
-  !>   ld          leading dimension of column-oriented dense matrix \p A.
+  !>   @param[out] ld - leading dimension of column-oriented dense matrix \p A.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -5199,22 +4751,15 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle          handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m               number of rows of the sparse COO matrix.
-  !>   @param[in]
-  !>   n               number of columns of the sparse COO matrix.
-  !>   @param[in]
-  !>   nnz             number of non-zero entries of the sparse COO matrix.
-  !>   @param[in]
-  !>   coo_row_ind     array of \p nnz elements containing the row indices of the sparse
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse COO matrix.
+  !>   @param[in] n - number of columns of the sparse COO matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse COO matrix.
+  !>   @param[in] coo_row_ind - array of \p nnz elements containing the row indices of the sparse
   !>                   COO matrix.
-  !>   @param[in]
-  !>   coo_col_ind     array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] coo_col_ind - array of \p nnz elements containing the column indices of the sparse
   !>                   COO matrix.
-  !>   @param[out]
-  !>   buffer_size     number of bytes of the temporary storage buffer required by
+  !>   @param[out] buffer_size - number of bytes of the temporary storage buffer required by
   !>                   `rocsparse_coosort_by_row`() and `rocsparse_coosort_by_column`().
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
@@ -5269,25 +4814,20 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle          handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m               number of rows of the sparse COO matrix.
-  !>   @param[in]
-  !>   n               number of columns of the sparse COO matrix.
-  !>   @param[in]
-  !>   nnz             number of non-zero entries of the sparse COO matrix.
-  !>   @param[inout]
-  !>   coo_row_ind     array of \p nnz elements containing the row indices of the sparse
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse COO matrix.
+  !>   @param[in] n - number of columns of the sparse COO matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse COO matrix.
+  !>   @param[inout] coo_row_ind - array of \p nnz elements containing the row indices of the sparse
   !>                   COO matrix.
-  !>   @param[inout]
-  !>   coo_col_ind     array of \p nnz elements containing the column indices of the sparse
+  !>   @param[inout] coo_col_ind - array of \p nnz elements containing the column indices of the
+  !>   sparse
   !>                   COO matrix.
-  !>   @param[inout]
-  !>   perm            array of \p nnz integers containing the unsorted map indices, which can be
+  !>   @param[inout] perm - array of \p nnz integers containing the unsorted map indices, which can
+  !>   be
   !>                   \p NULL.
-  !>   @param[in]
-  !>   temp_buffer     temporary storage buffer allocated by the user. The size is returned by
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user. The size is returned
+  !>   by
   !>                   `rocsparse_coosort_buffer_size`().
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
@@ -5346,25 +4886,20 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle          handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m               number of rows of the sparse COO matrix.
-  !>   @param[in]
-  !>   n               number of columns of the sparse COO matrix.
-  !>   @param[in]
-  !>   nnz             number of non-zero entries of the sparse COO matrix.
-  !>   @param[inout]
-  !>   coo_row_ind     array of \p nnz elements containing the row indices of the sparse
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse COO matrix.
+  !>   @param[in] n - number of columns of the sparse COO matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse COO matrix.
+  !>   @param[inout] coo_row_ind - array of \p nnz elements containing the row indices of the sparse
   !>                   COO matrix.
-  !>   @param[inout]
-  !>   coo_col_ind     array of \p nnz elements containing the column indices of the sparse
+  !>   @param[inout] coo_col_ind - array of \p nnz elements containing the column indices of the
+  !>   sparse
   !>                   COO matrix.
-  !>   @param[inout]
-  !>   perm            array of \p nnz integers containing the unsorted map indices, which can be
+  !>   @param[inout] perm - array of \p nnz integers containing the unsorted map indices, which can
+  !>   be
   !>                   \p NULL.
-  !>   @param[in]
-  !>   temp_buffer     temporary storage buffer allocated by the user. The size is returned by
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user. The size is returned
+  !>   by
   !>                   `rocsparse_coosort_buffer_size`().
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
@@ -5411,31 +4946,23 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m           number of rows of the column-oriented dense matrix \p A.
-  !>   @param[in]
-  !>   n           number of columns of the column-oriented dense matrix \p A.
-  !>   @param[in]
-  !>   descr the descriptor of the column-oriented dense matrix \p A. The supported matrix type is
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - number of rows of the column-oriented dense matrix \p A.
+  !>   @param[in] n - number of columns of the column-oriented dense matrix \p A.
+  !>   @param[in] descr - the descriptor of the column-oriented dense matrix \p A. The supported
+  !>   matrix type is
   !>               `rocsparse_matrix_type_general` and also any valid value of the
   !>               `rocsparse_index_base`.
-  !>   @param[in]
-  !>   csc_val array of nnz ( = \p csc_col_ptr[n] - \p csc_col_ptr[0] ) non-zero elements of matrix
-  !>   \p A.
-  !>   @param[in]
-  !>   csc_col_ptr integer array of \p n+1 elements that contains the start of every column and the
-  !>   end of the last
+  !>   @param[in] csc_val - array of nnz ( = \p csc_col_ptr[n] - \p csc_col_ptr[0] ) non-zero
+  !>   elements of matrix \p A.
+  !>   @param[in] csc_col_ptr - integer array of \p n+1 elements that contains the start of every
+  !>   column and the end of the last
   !>               column plus one.
-  !>   @param[in]
-  !>   csc_row_ind integer array of nnz ( = \p csc_col_ptr[n] - \p csc_col_ptr[0] ) column indices
-  !>   of the non-zero
+  !>   @param[in] csc_row_ind - integer array of nnz ( = \p csc_col_ptr[n] - \p csc_col_ptr[0] )
+  !>   column indices of the non-zero
   !>               elements of matrix \p A.
-  !>   @param[out]
-  !>   A           array of dimensions (\p ld, \p n).
-  !>   @param[out]
-  !>   ld          leading dimension of column-oriented dense matrix \p A.
+  !>   @param[out] A - array of dimensions (\p ld, \p n).
+  !>   @param[out] ld - leading dimension of column-oriented dense matrix \p A.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -5561,22 +5088,15 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle          handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m               number of rows of the sparse CSC matrix.
-  !>   @param[in]
-  !>   n               number of columns of the sparse CSC matrix.
-  !>   @param[in]
-  !>   nnz             number of non-zero entries of the sparse CSC matrix.
-  !>   @param[in]
-  !>   csc_col_ptr     array of \p n+1 elements that point to the start of every column of
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse CSC matrix.
+  !>   @param[in] n - number of columns of the sparse CSC matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSC matrix.
+  !>   @param[in] csc_col_ptr - array of \p n+1 elements that point to the start of every column of
   !>                   the sparse CSC matrix.
-  !>   @param[in]
-  !>   csc_row_ind     array of \p nnz elements containing the row indices of the sparse
+  !>   @param[in] csc_row_ind - array of \p nnz elements containing the row indices of the sparse
   !>                   CSC matrix.
-  !>   @param[out]
-  !>   buffer_size     number of bytes of the temporary storage buffer required by
+  !>   @param[out] buffer_size - number of bytes of the temporary storage buffer required by
   !>                   `rocsparse_cscsort`().
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
@@ -5629,28 +5149,21 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle          handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m               number of rows of the sparse CSC matrix.
-  !>   @param[in]
-  !>   n               number of columns of the sparse CSC matrix.
-  !>   @param[in]
-  !>   nnz             number of non-zero entries of the sparse CSC matrix.
-  !>   @param[in]
-  !>   descr           descriptor of the sparse CSC matrix. Currently, only
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse CSC matrix.
+  !>   @param[in] n - number of columns of the sparse CSC matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSC matrix.
+  !>   @param[in] descr - descriptor of the sparse CSC matrix. Currently, only
   !>                   `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   csc_col_ptr     array of \p n+1 elements that point to the start of every column of
+  !>   @param[in] csc_col_ptr - array of \p n+1 elements that point to the start of every column of
   !>                   the sparse CSC matrix.
-  !>   @param[inout]
-  !>   csc_row_ind     array of \p nnz elements containing the row indices of the sparse
+  !>   @param[inout] csc_row_ind - array of \p nnz elements containing the row indices of the sparse
   !>                   CSC matrix.
-  !>   @param[inout]
-  !>   perm            array of \p nnz integers containing the unsorted map indices, which can be
+  !>   @param[inout] perm - array of \p nnz integers containing the unsorted map indices, which can
+  !>   be
   !>                   \p NULL.
-  !>   @param[in]
-  !>   temp_buffer     temporary storage buffer allocated by the user. The size is returned by
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user. The size is returned
+  !>   by
   !>                   `rocsparse_cscsort_buffer_size`().
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
@@ -5705,42 +5218,32 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
   !>
-  !>   @param[in]
-  !>   dir direction that specifies whether to count non-zero elements by `rocsparse_direction_row`
-  !>   or by
+  !>   @param[in] dir - direction that specifies whether to count non-zero elements by
+  !>   `rocsparse_direction_row` or by
   !>               `rocsparse_direction_column`.
   !>
-  !>   @param[in]
-  !>   m           number of rows of the sparse CSR matrix.
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
   !>
-  !>   @param[in]
-  !>   n           number of columns of the sparse CSR matrix.
+  !>   @param[in] n - number of columns of the sparse CSR matrix.
   !>
-  !>   @param[in]
-  !>   csr_descr    descriptor of the sparse CSR matrix. Currently, only
+  !>   @param[in] csr_descr - descriptor of the sparse CSR matrix. Currently, only
   !>                `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   csr_row_ptr integer array containing \p m+1 elements that point to the start of each row of
-  !>   the CSR matrix.
+  !>   @param[in] csr_row_ptr - integer array containing \p m+1 elements that point to the start of
+  !>   each row of the CSR matrix.
   !>
-  !>   @param[in]
-  !>   csr_col_ind integer array of the column indices for each non-zero element in the CSR matrix.
+  !>   @param[in] csr_col_ind - integer array of the column indices for each non-zero element in the
+  !>   CSR matrix.
   !>
-  !>   @param[in]
-  !>   block_dim   the block dimension of the BSR matrix. Between 1 and min(m, n).
+  !>   @param[in] block_dim - the block dimension of the BSR matrix. Between 1 and min(m, n).
   !>
-  !>   @param[in]
-  !>   bsr_descr    descriptor of the sparse BSR matrix. Currently, only
+  !>   @param[in] bsr_descr - descriptor of the sparse BSR matrix. Currently, only
   !>                `rocsparse_matrix_type_general` is supported.
-  !>   @param[out]
-  !>   bsr_row_ptr integer array containing \p mb+1 elements that point to the start of each block
-  !>   row of the BSR matrix.
+  !>   @param[out] bsr_row_ptr - integer array containing \p mb+1 elements that point to the start
+  !>   of each block row of the BSR matrix.
   !>
-  !>   @param[out]
-  !>   bsr_nnz     total number of non-zero elements in device or host memory.
+  !>   @param[out] bsr_nnz - total number of non-zero elements in device or host memory.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -5809,38 +5312,28 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle       handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   dir the storage format of the blocks, `rocsparse_direction_row` or
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] dir - the storage format of the blocks, `rocsparse_direction_row` or
   !>   `rocsparse_direction_column`.
-  !>   @param[in]
-  !>   m            number of rows in the sparse CSR matrix.
-  !>   @param[in]
-  !>   n            number of columns in the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_descr    descriptor of the sparse CSR matrix. Currently, only
+  !>   @param[in] m - number of rows in the sparse CSR matrix.
+  !>   @param[in] n - number of columns in the sparse CSR matrix.
+  !>   @param[in] csr_descr - descriptor of the sparse CSR matrix. Currently, only
   !>                `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   csr_val      array of \p nnz elements containing the values of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_row_ptr  array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] csr_val - array of \p nnz elements containing the values of the sparse CSR matrix.
+  !>   @param[in] csr_row_ptr - array of \p m+1 elements that point to the start of every row of the
   !>                sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_col_ind  array of \p nnz elements containing the column indices of the sparse CSR matrix.
-  !>   @param[in]
-  !>   block_dim    size of the blocks in the sparse BSR matrix.
-  !>   @param[in]
-  !>   bsr_descr    descriptor of the sparse BSR matrix. Currently, only
+  !>   @param[in] csr_col_ind - array of \p nnz elements containing the column indices of the sparse
+  !>   CSR matrix.
+  !>   @param[in] block_dim - size of the blocks in the sparse BSR matrix.
+  !>   @param[in] bsr_descr - descriptor of the sparse BSR matrix. Currently, only
   !>                `rocsparse_matrix_type_general` is supported.
-  !>   @param[out]
-  !>   bsr_val array of \p nnzb*block_dim*block_dim containing the values of the sparse BSR matrix.
-  !>   @param[out]
-  !>   bsr_row_ptr  array of \p mb+1 elements that point to the start of every block row of the
+  !>   @param[out] bsr_val - array of \p nnzb*block_dim*block_dim containing the values of the
+  !>   sparse BSR matrix.
+  !>   @param[out] bsr_row_ptr - array of \p mb+1 elements that point to the start of every block
+  !>   row of the
   !>                sparse BSR matrix.
-  !>   @param[out]
-  !>   bsr_col_ind array of \p nnzb elements containing the block column indices of the sparse BSR
-  !>   matrix.
+  !>   @param[out] bsr_col_ind - array of \p nnzb elements containing the block column indices of
+  !>   the sparse BSR matrix.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -5988,20 +5481,15 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   csr_row_ptr array of \p m+1 elements that point to the start of every row
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] csr_row_ptr - array of \p m+1 elements that point to the start of every row
   !>               of the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of the sparse CSR matrix.
-  !>   @param[in]
-  !>   m           number of rows of the sparse CSR matrix.
-  !>   @param[out]
-  !>   coo_row_ind array of \p nnz elements containing the row indices of the sparse COO
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix.
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
+  !>   @param[out] coo_row_ind - array of \p nnz elements containing the row indices of the sparse
+  !>   COO
   !>               matrix.
-  !>   @param[in]
-  !>   idx_base    `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
+  !>   @param[in] idx_base - `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -6046,24 +5534,16 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m           number of rows of the sparse CSR matrix.
-  !>   @param[in]
-  !>   n           number of columns of the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_row_ptr array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
+  !>   @param[in] n - number of columns of the sparse CSR matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix.
+  !>   @param[in] csr_row_ptr - array of \p m+1 elements that point to the start of every row of the
   !>               sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_col_ind array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] csr_col_ind - array of \p nnz elements containing the column indices of the sparse
   !>               CSR matrix.
-  !>   @param[in]
-  !>   copy_values `rocsparse_action_symbolic` or `rocsparse_action_numeric`.
-  !>   @param[out]
-  !>   buffer_size number of bytes of the temporary storage buffer required by
+  !>   @param[in] copy_values - `rocsparse_action_symbolic` or `rocsparse_action_numeric`.
+  !>   @param[out] buffer_size - number of bytes of the temporary storage buffer required by
   !>               \ref rocsparse_scsr2csc "rocsparse_Xcsr2csc()".
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
@@ -6128,36 +5608,26 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m           number of rows of the sparse CSR matrix.
-  !>   @param[in]
-  !>   n           number of columns of the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_val     array of \p nnz elements of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_row_ptr array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
+  !>   @param[in] n - number of columns of the sparse CSR matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix.
+  !>   @param[in] csr_val - array of \p nnz elements of the sparse CSR matrix.
+  !>   @param[in] csr_row_ptr - array of \p m+1 elements that point to the start of every row of the
   !>               sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_col_ind array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] csr_col_ind - array of \p nnz elements containing the column indices of the sparse
   !>               CSR matrix.
-  !>   @param[out]
-  !>   csc_val     array of \p nnz elements of the sparse CSC matrix.
-  !>   @param[out]
-  !>   csc_row_ind array of \p nnz elements containing the row indices of the sparse CSC
+  !>   @param[out] csc_val - array of \p nnz elements of the sparse CSC matrix.
+  !>   @param[out] csc_row_ind - array of \p nnz elements containing the row indices of the sparse
+  !>   CSC
   !>               matrix.
-  !>   @param[out]
-  !>   csc_col_ptr array of \p n+1 elements that point to the start of every column of the
+  !>   @param[out] csc_col_ptr - array of \p n+1 elements that point to the start of every column of
+  !>   the
   !>               sparse CSC matrix.
-  !>   @param[in]
-  !>   copy_values `rocsparse_action_symbolic` or `rocsparse_action_numeric`.
-  !>   @param[in]
-  !>   idx_base    `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
-  !>   @param[in]
-  !>   temp_buffer temporary storage buffer allocated by the user. The size is returned by
+  !>   @param[in] copy_values - `rocsparse_action_symbolic` or `rocsparse_action_numeric`.
+  !>   @param[in] idx_base - `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user. The size is returned
+  !>   by
   !>               rocsparse_csr2csc_buffer_size().
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
@@ -6371,41 +5841,32 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle        handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m             number of rows of the sparse CSR matrix.
-  !>   @param[in]
-  !>   n             number of columns of the sparse CSR matrix.
-  !>   @param[in]
-  !>   descr_A       matrix descriptor for the CSR matrix.
-  !>   @param[in]
-  !>   csr_val_A     array of \p nnz_A elements of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_row_ptr_A array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
+  !>   @param[in] n - number of columns of the sparse CSR matrix.
+  !>   @param[in] descr_A - matrix descriptor for the CSR matrix.
+  !>   @param[in] csr_val_A - array of \p nnz_A elements of the sparse CSR matrix.
+  !>   @param[in] csr_row_ptr_A - array of \p m+1 elements that point to the start of every row of
+  !>   the
   !>                 uncompressed sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_col_ind_A array of \p nnz_A elements containing the column indices of the uncompressed
+  !>   @param[in] csr_col_ind_A - array of \p nnz_A elements containing the column indices of the
+  !>   uncompressed
   !>                 sparse CSR matrix.
-  !>   @param[in]
-  !>   nnz_A         number of elements in the column indices and values arrays of the uncompressed
+  !>   @param[in] nnz_A - number of elements in the column indices and values arrays of the
+  !>   uncompressed
   !>                 sparse CSR matrix.
-  !>   @param[in]
-  !>   nnz_per_row array of length \p m containing the number of entries that will be kept per row
-  !>   in
+  !>   @param[in] nnz_per_row - array of length \p m containing the number of entries that will be
+  !>   kept per row in
   !>                 the final compressed CSR matrix.
-  !>   @param[out]
-  !>   csr_val_C     array of \p nnz_C elements of the compressed sparse CSC matrix.
-  !>   @param[out]
-  !>   csr_row_ptr_C array of \p m+1 elements that point to the start of every column of the
+  !>   @param[out] csr_val_C - array of \p nnz_C elements of the compressed sparse CSC matrix.
+  !>   @param[out] csr_row_ptr_C - array of \p m+1 elements that point to the start of every column
+  !>   of the compressed
+  !>                 sparse CSR matrix.
+  !>   @param[out] csr_col_ind_C - array of \p nnz_C elements containing the row indices of the
   !>   compressed
   !>                 sparse CSR matrix.
-  !>   @param[out]
-  !>   csr_col_ind_C array of \p nnz_C elements containing the row indices of the compressed
-  !>                 sparse CSR matrix.
-  !>   @param[in]
-  !>   tol the non-negative tolerance used for compression. If \p tol is complex, then only the
-  !>   magnitude
+  !>   @param[in] tol - the non-negative tolerance used for compression. If \p tol is complex, then
+  !>   only the magnitude
   !>                 of the real part is used. Entries in the input uncompressed CSR array that are
   !>                 below the tolerance
   !>                 are removed in the output-compressed CSR matrix.
@@ -6551,31 +6012,23 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m           number of rows of the column-oriented dense matrix \p A.
-  !>   @param[in]
-  !>   n           number of columns of the column-oriented dense matrix \p A.
-  !>   @param[in]
-  !>   descr the descriptor of the column-oriented dense matrix \p A. The supported matrix type is
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - number of rows of the column-oriented dense matrix \p A.
+  !>   @param[in] n - number of columns of the column-oriented dense matrix \p A.
+  !>   @param[in] descr - the descriptor of the column-oriented dense matrix \p A. The supported
+  !>   matrix type is
   !>               `rocsparse_matrix_type_general` and also any valid value of the
   !>               `rocsparse_index_base`.
-  !>   @param[in]
-  !>   csr_val array of nnz ( = \p csr_row_ptr[m] - \p csr_row_ptr[0] ) non-zero elements of matrix
-  !>   \p A.
-  !>   @param[in]
-  !>   csr_row_ptr integer array of \p m+1 elements that contains the start of every row and the end
-  !>   of the last
+  !>   @param[in] csr_val - array of nnz ( = \p csr_row_ptr[m] - \p csr_row_ptr[0] ) non-zero
+  !>   elements of matrix \p A.
+  !>   @param[in] csr_row_ptr - integer array of \p m+1 elements that contains the start of every
+  !>   row and the end of the last
   !>               row plus one.
-  !>   @param[in]
-  !>   csr_col_ind integer array of nnz ( = \p csr_row_ptr[m] - \p csr_row_ptr[0] ) column indices
-  !>   of the non-zero
+  !>   @param[in] csr_col_ind - integer array of nnz ( = \p csr_row_ptr[m] - \p csr_row_ptr[0] )
+  !>   column indices of the non-zero
   !>               elements of matrix \p A.
-  !>   @param[out]
-  !>   A           array of dimensions (\p ld, \p n).
-  !>   @param[out]
-  !>   ld          leading dimension of column-oriented dense matrix \p A.
+  !>   @param[out] A - array of dimensions (\p ld, \p n).
+  !>   @param[out] ld - leading dimension of column-oriented dense matrix \p A.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -6700,21 +6153,15 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m           number of rows of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_descr   descriptor of the sparse CSR matrix. Currently, only
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
+  !>   @param[in] csr_descr - descriptor of the sparse CSR matrix. Currently, only
   !>               `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   csr_row_ptr array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] csr_row_ptr - array of \p m+1 elements that point to the start of every row of the
   !>               sparse CSR matrix.
-  !>   @param[in]
-  !>   ell_descr   descriptor of the sparse ELL matrix. Currently, only
+  !>   @param[in] ell_descr - descriptor of the sparse ELL matrix. Currently, only
   !>               `rocsparse_matrix_type_general` is supported.
-  !>   @param[out]
-  !>   ell_width   pointer to the number of non-zero elements per row in ELL storage
+  !>   @param[out] ell_width - pointer to the number of non-zero elements per row in ELL storage
   !>               format.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
@@ -6764,29 +6211,20 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m           number of rows of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_descr   descriptor of the sparse CSR matrix. Currently, only
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
+  !>   @param[in] csr_descr - descriptor of the sparse CSR matrix. Currently, only
   !>               `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   csr_val     array containing the values of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_row_ptr array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] csr_val - array containing the values of the sparse CSR matrix.
+  !>   @param[in] csr_row_ptr - array of \p m+1 elements that point to the start of every row of the
   !>               sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_col_ind array containing the column indices of the sparse CSR matrix.
-  !>   @param[in]
-  !>   ell_descr   descriptor of the sparse ELL matrix. Currently, only
+  !>   @param[in] csr_col_ind - array containing the column indices of the sparse CSR matrix.
+  !>   @param[in] ell_descr - descriptor of the sparse ELL matrix. Currently, only
   !>               `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   ell_width   number of non-zero elements per row in ELL storage format.
-  !>   @param[out]
-  !>   ell_val     array of \p m times \p ell_width elements of the sparse ELL matrix.
-  !>   @param[out]
-  !>   ell_col_ind array of \p m times \p ell_width elements containing the column indices
+  !>   @param[in] ell_width - number of non-zero elements per row in ELL storage format.
+  !>   @param[out] ell_val - array of \p m times \p ell_width elements of the sparse ELL matrix.
+  !>   @param[out] ell_col_ind - array of \p m times \p ell_width elements containing the column
+  !>   indices
   !>               of the sparse ELL matrix.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
@@ -6921,42 +6359,34 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
   !>
-  !>   @param[in]
-  !>   dir direction that specifies whether to count non-zero elements by `rocsparse_direction_row`
-  !>   or by
+  !>   @param[in] dir - direction that specifies whether to count non-zero elements by
+  !>   `rocsparse_direction_row` or by
   !>               `rocsparse_direction_column`.
   !>
-  !>   @param[in]
-  !>   m           number of rows of the sparse CSR matrix.
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
   !>
-  !>   @param[in]
-  !>   n           number of columns of the sparse CSR matrix.
+  !>   @param[in] n - number of columns of the sparse CSR matrix.
   !>
-  !>   @param[in]
-  !>   csr_descr    descriptor of the sparse CSR matrix. Currently, only
+  !>   @param[in] csr_descr - descriptor of the sparse CSR matrix. Currently, only
   !>                `rocsparse_matrix_type_general` is supported.
   !>
-  !>   @param[in]
-  !>   csr_val      array of \p nnz elements containing the values of the sparse CSR matrix.
+  !>   @param[in] csr_val - array of \p nnz elements containing the values of the sparse CSR matrix.
   !>
-  !>   @param[in]
-  !>   csr_row_ptr integer array containing \p m+1 elements that point to the start of each row of
-  !>   the CSR matrix.
+  !>   @param[in] csr_row_ptr - integer array containing \p m+1 elements that point to the start of
+  !>   each row of the CSR matrix.
   !>
-  !>   @param[in]
-  !>   csr_col_ind  integer array of the column indices for each non-zero element in the CSR matrix.
+  !>   @param[in] csr_col_ind - integer array of the column indices for each non-zero element in the
+  !>   CSR matrix.
   !>
-  !>   @param[in]
-  !>   row_block_dim   the row block dimension of the general BSR matrix. Between 1 and \p m.
+  !>   @param[in] row_block_dim - the row block dimension of the general BSR matrix. Between 1 and
+  !>   \p m.
   !>
-  !>   @param[in]
-  !>   col_block_dim   the col block dimension of the general BSR matrix. Between 1 and \p n.
+  !>   @param[in] col_block_dim - the col block dimension of the general BSR matrix. Between 1 and
+  !>   \p n.
   !>
-  !>   @param[out]
-  !>   buffer_size number of bytes of the temporary storage buffer required by \ref
+  !>   @param[out] buffer_size - number of bytes of the temporary storage buffer required by \ref
   !>   rocsparse_csr2gebsr_nnz
   !>                and \ref rocsparse_scsr2gebsr "rocsparse_Xcsr2gebsr()".
   !>
@@ -7100,43 +6530,31 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle           handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   dir direction that specifies whether to count non-zero elements by `rocsparse_direction_row`
-  !>   or by
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] dir - direction that specifies whether to count non-zero elements by
+  !>   `rocsparse_direction_row` or by
   !>                    `rocsparse_direction_column`.
-  !>   @param[in]
-  !>   m                number of rows of the sparse CSR matrix.
-  !>   @param[in]
-  !>   n                number of columns of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_descr        descriptor of the sparse CSR matrix. Currently, only
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
+  !>   @param[in] n - number of columns of the sparse CSR matrix.
+  !>   @param[in] csr_descr - descriptor of the sparse CSR matrix. Currently, only
   !>                    `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   csr_row_ptr integer array containing \p m+1 elements that point to the start of each row of
-  !>   the CSR matrix.
+  !>   @param[in] csr_row_ptr - integer array containing \p m+1 elements that point to the start of
+  !>   each row of the CSR matrix.
   !>
-  !>   @param[in]
-  !>   csr_col_ind integer array of the column indices for each non-zero element in the CSR matrix.
+  !>   @param[in] csr_col_ind - integer array of the column indices for each non-zero element in the
+  !>   CSR matrix.
   !>
-  !>   @param[in]
-  !>   bsr_descr        descriptor of the sparse general BSR matrix. Currently, only
+  !>   @param[in] bsr_descr - descriptor of the sparse general BSR matrix. Currently, only
   !>                    `rocsparse_matrix_type_general` is supported.
-  !>   @param[out]
-  !>   bsr_row_ptr integer array containing \p mb+1 elements that point to the start of each block
-  !>   row of the
+  !>   @param[out] bsr_row_ptr - integer array containing \p mb+1 elements that point to the start
+  !>   of each block row of the
   !>                    general BSR matrix.
-  !>   @param[in]
-  !>   row_block_dim the row block dimension of the general BSR matrix. Between \f$1\f$ and
-  !>   \f$\min(m, n)\f$.
-  !>   @param[in]
-  !>   col_block_dim the col block dimension of the general BSR matrix. Between \f$1\f$ and
-  !>   \f$\min(m, n)\f$.
-  !>   @param[out]
-  !>   bsr_nnz_devhost  total number of non-zero elements in device or host memory.
-  !>   @param[in]
-  !>   temp_buffer      buffer allocated by the user. Its size is determined by calling
+  !>   @param[in] row_block_dim - the row block dimension of the general BSR matrix. Between \f$1\f$
+  !>   and \f$\min(m, n)\f$.
+  !>   @param[in] col_block_dim - the col block dimension of the general BSR matrix. Between \f$1\f$
+  !>   and \f$\min(m, n)\f$.
+  !>   @param[out] bsr_nnz_devhost - total number of non-zero elements in device or host memory.
+  !>   @param[in] temp_buffer - buffer allocated by the user. Its size is determined by calling
   !>                    \ref rocsparse_scsr2gebsr_buffer_size "rocsparse_Xcsr2gebsr_buffer_size()".
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
@@ -7211,43 +6629,30 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle         handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   dir the storage format of the blocks, `rocsparse_direction_row` or
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] dir - the storage format of the blocks, `rocsparse_direction_row` or
   !>   `rocsparse_direction_column`.
-  !>   @param[in]
-  !>   m              number of rows in the sparse CSR matrix.
-  !>   @param[in]
-  !>   n              number of columns in the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_descr      descriptor of the sparse CSR matrix. Currently, only
+  !>   @param[in] m - number of rows in the sparse CSR matrix.
+  !>   @param[in] n - number of columns in the sparse CSR matrix.
+  !>   @param[in] csr_descr - descriptor of the sparse CSR matrix. Currently, only
   !>                  `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   csr_val        array of \p nnz elements containing the values of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_row_ptr    array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] csr_val - array of \p nnz elements containing the values of the sparse CSR matrix.
+  !>   @param[in] csr_row_ptr - array of \p m+1 elements that point to the start of every row of the
   !>                  sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_col_ind array of \p nnz elements containing the column indices of the sparse CSR matrix.
-  !>   @param[in]
-  !>   bsr_descr      descriptor of the sparse BSR matrix. Currently, only
+  !>   @param[in] csr_col_ind - array of \p nnz elements containing the column indices of the sparse
+  !>   CSR matrix.
+  !>   @param[in] bsr_descr - descriptor of the sparse BSR matrix. Currently, only
   !>                  `rocsparse_matrix_type_general` is supported.
-  !>   @param[out]
-  !>   bsr_val array of \p nnzb* \p row_block_dim* \p col_block_dim containing the values of the
-  !>   sparse BSR matrix.
-  !>   @param[out]
-  !>   bsr_row_ptr    array of \p mb+1 elements that point to the start of every block row of the
+  !>   @param[out] bsr_val - array of \p nnzb* \p row_block_dim* \p col_block_dim containing the
+  !>   values of the sparse BSR matrix.
+  !>   @param[out] bsr_row_ptr - array of \p mb+1 elements that point to the start of every block
+  !>   row of the
   !>                  sparse BSR matrix.
-  !>   @param[out]
-  !>   bsr_col_ind array of \p nnzb elements containing the block column indices of the sparse BSR
-  !>   matrix.
-  !>   @param[in]
-  !>   row_block_dim  row size of the blocks in the sparse general BSR matrix.
-  !>   @param[in]
-  !>   col_block_dim  col size of the blocks in the sparse general BSR matrix.
-  !>   @param[in]
-  !>   temp_buffer    buffer allocated by the user. Its size is determined by calling
+  !>   @param[out] bsr_col_ind - array of \p nnzb elements containing the block column indices of
+  !>   the sparse BSR matrix.
+  !>   @param[in] row_block_dim - row size of the blocks in the sparse general BSR matrix.
+  !>   @param[in] col_block_dim - col size of the blocks in the sparse general BSR matrix.
+  !>   @param[in] temp_buffer - buffer allocated by the user. Its size is determined by calling
   !>                  \ref rocsparse_scsr2gebsr_buffer_size "rocsparse_Xcsr2gebsr_buffer_size()".
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
@@ -7405,29 +6810,19 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle          handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m               number of rows of the sparse CSR matrix.
-  !>   @param[in]
-  !>   n               number of columns of the sparse CSR matrix.
-  !>   @param[in]
-  !>   descr           descriptor of the sparse CSR matrix. Currently, only
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
+  !>   @param[in] n - number of columns of the sparse CSR matrix.
+  !>   @param[in] descr - descriptor of the sparse CSR matrix. Currently, only
   !>                   `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   csr_val         array containing the values of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_row_ptr     array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] csr_val - array containing the values of the sparse CSR matrix.
+  !>   @param[in] csr_row_ptr - array of \p m+1 elements that point to the start of every row of the
   !>                   sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_col_ind     array containing the column indices of the sparse CSR matrix.
-  !>   @param[out]
-  !>   hyb             sparse matrix in HYB format.
-  !>   @param[in]
-  !>   user_ell_width  width of the ELL part of the HYB matrix (only required if
+  !>   @param[in] csr_col_ind - array containing the column indices of the sparse CSR matrix.
+  !>   @param[out] hyb - sparse matrix in HYB format.
+  !>   @param[in] user_ell_width - width of the ELL part of the HYB matrix (only required if
   !>                   \p partition_type == `rocsparse_hyb_partition_user`).
-  !>   @param[in]
-  !>   partition_type  `rocsparse_hyb_partition_auto` (recommended),
+  !>   @param[in] partition_type - `rocsparse_hyb_partition_auto` (recommended),
   !>                   `rocsparse_hyb_partition_user`, or
   !>                   `rocsparse_hyb_partition_max`.
   !>
@@ -7566,22 +6961,15 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle          handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m               number of rows of the sparse CSR matrix.
-  !>   @param[in]
-  !>   n               number of columns of the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnz             number of non-zero entries of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_row_ptr     array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
+  !>   @param[in] n - number of columns of the sparse CSR matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix.
+  !>   @param[in] csr_row_ptr - array of \p m+1 elements that point to the start of every row of the
   !>                   sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_col_ind     array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] csr_col_ind - array of \p nnz elements containing the column indices of the sparse
   !>                   CSR matrix.
-  !>   @param[out]
-  !>   buffer_size     number of bytes of the temporary storage buffer required by
+  !>   @param[out] buffer_size - number of bytes of the temporary storage buffer required by
   !>                   `rocsparse_csrsort`().
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
@@ -7634,28 +7022,22 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle          handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m               number of rows of the sparse CSR matrix.
-  !>   @param[in]
-  !>   n               number of columns of the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnz             number of non-zero entries of the sparse CSR matrix.
-  !>   @param[in]
-  !>   descr           descriptor of the sparse CSR matrix. Currently, only
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
+  !>   @param[in] n - number of columns of the sparse CSR matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix.
+  !>   @param[in] descr - descriptor of the sparse CSR matrix. Currently, only
   !>                   `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   csr_row_ptr     array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] csr_row_ptr - array of \p m+1 elements that point to the start of every row of the
   !>                   sparse CSR matrix.
-  !>   @param[inout]
-  !>   csr_col_ind     array of \p nnz elements containing the column indices of the sparse
+  !>   @param[inout] csr_col_ind - array of \p nnz elements containing the column indices of the
+  !>   sparse
   !>                   CSR matrix.
-  !>   @param[inout]
-  !>   perm            array of \p nnz integers containing the unsorted map indices, which can be
+  !>   @param[inout] perm - array of \p nnz integers containing the unsorted map indices, which can
+  !>   be
   !>                   \p NULL.
-  !>   @param[in]
-  !>   temp_buffer     temporary storage buffer allocated by the user. The size is returned by
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user. The size is returned
+  !>   by
   !>                   `rocsparse_csrsort_buffer_size`().
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
@@ -7708,29 +7090,23 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle       handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m            number of rows of the column-oriented dense matrix \p A.
-  !>   @param[in]
-  !>   n            number of columns of the column-oriented dense matrix \p A.
-  !>   @param[in]
-  !>   descr the descriptor of the column-oriented dense matrix \p A. The supported matrix type is
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - number of rows of the column-oriented dense matrix \p A.
+  !>   @param[in] n - number of columns of the column-oriented dense matrix \p A.
+  !>   @param[in] descr - the descriptor of the column-oriented dense matrix \p A. The supported
+  !>   matrix type is
   !>                `rocsparse_matrix_type_general` and also any valid value of the
   !>                `rocsparse_index_base`.
-  !>   @param[in]
-  !>   A            column-oriented dense matrix of dimensions (\p ld, \p n).
-  !>   @param[in]
-  !>   ld           leading dimension of column-oriented dense matrix \p A.
-  !>   @param[in]
-  !>   nnz_per_rows array of size \p n containing the number of non-zero elements per row.
-  !>   @param[out]
-  !>   coo_val
+  !>   @param[in] A - column-oriented dense matrix of dimensions (\p ld, \p n).
+  !>   @param[in] ld - leading dimension of column-oriented dense matrix \p A.
+  !>   @param[in] nnz_per_rows - array of size \p n containing the number of non-zero elements per
+  !>   row.
+  !>   @param[out] coo_val
   !>                array of nnz nonzero elements of matrix \p A.
-  !>   @param[out]
-  !>   coo_row_ind  integer array of nnz row indices of the non-zero elements of matrix \p A.
-  !>   @param[out]
-  !>   coo_col_ind  integer array of nnz column indices of the non-zero elements of matrix \p A.
+  !>   @param[out] coo_row_ind - integer array of nnz row indices of the non-zero elements of matrix
+  !>   \p A.
+  !>   @param[out] coo_col_ind - integer array of nnz column indices of the non-zero elements of
+  !>   matrix \p A.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -7867,32 +7243,24 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle           handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m                number of rows of the column-oriented dense matrix \p A.
-  !>   @param[in]
-  !>   n                number of columns of the column-oriented dense matrix \p A.
-  !>   @param[in]
-  !>   descr the descriptor of the column-oriented dense matrix \p A. The supported matrix type is
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - number of rows of the column-oriented dense matrix \p A.
+  !>   @param[in] n - number of columns of the column-oriented dense matrix \p A.
+  !>   @param[in] descr - the descriptor of the column-oriented dense matrix \p A. The supported
+  !>   matrix type is
   !>                    `rocsparse_matrix_type_general` and also any valid value of the
   !>                    `rocsparse_index_base`.
-  !>   @param[in]
-  !>   A                column-oriented dense matrix of dimensions (\p ld, \p n).
-  !>   @param[in]
-  !>   ld               leading dimension of the column-oriented dense matrix \p A.
-  !>   @param[in]
-  !>   nnz_per_columns  array of size \p n containing the number of non-zero elements per column.
-  !>   @param[out]
-  !>   csc_val array of nnz ( = \p csc_col_ptr[n] - \p csc_col_ptr[0] ) non-zero elements of matrix
-  !>   \p A.
-  !>   @param[out]
-  !>   csc_col_ptr integer array of \p n+1 elements that contains the start of every column and the
-  !>   end of the last column
+  !>   @param[in] A - column-oriented dense matrix of dimensions (\p ld, \p n).
+  !>   @param[in] ld - leading dimension of the column-oriented dense matrix \p A.
+  !>   @param[in] nnz_per_columns - array of size \p n containing the number of non-zero elements
+  !>   per column.
+  !>   @param[out] csc_val - array of nnz ( = \p csc_col_ptr[n] - \p csc_col_ptr[0] ) non-zero
+  !>   elements of matrix \p A.
+  !>   @param[out] csc_col_ptr - integer array of \p n+1 elements that contains the start of every
+  !>   column and the end of the last column
   !>                    plus one.
-  !>   @param[out]
-  !>   csc_row_ind integer array of nnz ( = \p csc_col_ptr[n] - \p csc_col_ptr[0] ) column indices
-  !>   of the non-zero elements
+  !>   @param[out] csc_row_ind - integer array of nnz ( = \p csc_col_ptr[n] - \p csc_col_ptr[0] )
+  !>   column indices of the non-zero elements
   !>                    of matrix \p A.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
@@ -8028,31 +7396,23 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle        handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m             number of rows of the column-oriented dense matrix \p A.
-  !>   @param[in]
-  !>   n             number of columns of the column-oriented dense dense matrix \p A.
-  !>   @param[in]
-  !>   descr the descriptor of the column-oriented dense matrix \p A. The supported matrix type is
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - number of rows of the column-oriented dense matrix \p A.
+  !>   @param[in] n - number of columns of the column-oriented dense dense matrix \p A.
+  !>   @param[in] descr - the descriptor of the column-oriented dense matrix \p A. The supported
+  !>   matrix type is
   !>                 `rocsparse_matrix_type_general` and also any valid value of the
   !>                 `rocsparse_index_base`.
-  !>   @param[in]
-  !>   A             column-oriented dense matrix of dimensions (\p ld, \p n).
-  !>   @param[in]
-  !>   ld            leading dimension of column-oriented dense matrix \p A.
-  !>   @param[in]
-  !>   nnz_per_rows  array of size \p n containing the number of non-zero elements per row.
-  !>   @param[out]
-  !>   csr_val array of nnz ( = \p csr_row_ptr[m] - \p csr_row_ptr[0] ) non-zero elements of matrix
-  !>   \p A.
-  !>   @param[out]
-  !>   csr_row_ptr integer array of \p m+1 elements that contains the start of every row and the end
-  !>   of the last row plus one.
-  !>   @param[out]
-  !>   csr_col_ind integer array of nnz ( = \p csr_row_ptr[m] - \p csr_row_ptr[0] ) column indices
-  !>   of the non-zero elements of
+  !>   @param[in] A - column-oriented dense matrix of dimensions (\p ld, \p n).
+  !>   @param[in] ld - leading dimension of column-oriented dense matrix \p A.
+  !>   @param[in] nnz_per_rows - array of size \p n containing the number of non-zero elements per
+  !>   row.
+  !>   @param[out] csr_val - array of nnz ( = \p csr_row_ptr[m] - \p csr_row_ptr[0] ) non-zero
+  !>   elements of matrix \p A.
+  !>   @param[out] csr_row_ptr - integer array of \p m+1 elements that contains the start of every
+  !>   row and the end of the last row plus one.
+  !>   @param[out] csr_col_ind - integer array of nnz ( = \p csr_row_ptr[m] - \p csr_row_ptr[0] )
+  !>   column indices of the non-zero elements of
   !>                 matrix \p A.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
@@ -8193,28 +7553,21 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m           number of rows of the sparse ELL matrix.
-  !>   @param[in]
-  !>   n           number of columns of the sparse ELL matrix.
-  !>   @param[in]
-  !>   ell_descr   descriptor of the sparse ELL matrix. Currently, only
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse ELL matrix.
+  !>   @param[in] n - number of columns of the sparse ELL matrix.
+  !>   @param[in] ell_descr - descriptor of the sparse ELL matrix. Currently, only
   !>               `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   ell_width   number of non-zero elements per row in ELL storage format.
-  !>   @param[in]
-  !>   ell_col_ind array of \p m times \p ell_width elements containing the column indices
+  !>   @param[in] ell_width - number of non-zero elements per row in ELL storage format.
+  !>   @param[in] ell_col_ind - array of \p m times \p ell_width elements containing the column
+  !>   indices
   !>               of the sparse ELL matrix.
-  !>   @param[in]
-  !>   csr_descr   descriptor of the sparse CSR matrix. Currently, only
+  !>   @param[in] csr_descr - descriptor of the sparse CSR matrix. Currently, only
   !>               `rocsparse_matrix_type_general` is supported.
-  !>   @param[out]
-  !>   csr_row_ptr array of \p m+1 elements that point to the start of every row of the
+  !>   @param[out] csr_row_ptr - array of \p m+1 elements that point to the start of every row of
+  !>   the
   !>               sparse CSR matrix.
-  !>   @param[out]
-  !>   csr_nnz     pointer to the total number of non-zero elements in CSR storage
+  !>   @param[out] csr_nnz - pointer to the total number of non-zero elements in CSR storage
   !>               format.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
@@ -8267,32 +7620,22 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m           number of rows of the sparse ELL matrix.
-  !>   @param[in]
-  !>   n           number of columns of the sparse ELL matrix.
-  !>   @param[in]
-  !>   ell_descr   descriptor of the sparse ELL matrix. Currently, only
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse ELL matrix.
+  !>   @param[in] n - number of columns of the sparse ELL matrix.
+  !>   @param[in] ell_descr - descriptor of the sparse ELL matrix. Currently, only
   !>               `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   ell_width   number of non-zero elements per row in ELL storage format.
-  !>   @param[in]
-  !>   ell_val     array of \p m times \p ell_width elements of the sparse ELL matrix.
-  !>   @param[in]
-  !>   ell_col_ind array of \p m times \p ell_width elements containing the column indices
+  !>   @param[in] ell_width - number of non-zero elements per row in ELL storage format.
+  !>   @param[in] ell_val - array of \p m times \p ell_width elements of the sparse ELL matrix.
+  !>   @param[in] ell_col_ind - array of \p m times \p ell_width elements containing the column
+  !>   indices
   !>               of the sparse ELL matrix.
-  !>   @param[in]
-  !>   csr_descr   descriptor of the sparse CSR matrix. Currently, only
+  !>   @param[in] csr_descr - descriptor of the sparse CSR matrix. Currently, only
   !>               `rocsparse_matrix_type_general` is supported.
-  !>   @param[out]
-  !>   csr_val     array containing the values of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_row_ptr array of \p m+1 elements that point to the start of every row of the
+  !>   @param[out] csr_val - array containing the values of the sparse CSR matrix.
+  !>   @param[in] csr_row_ptr - array of \p m+1 elements that point to the start of every row of the
   !>               sparse CSR matrix.
-  !>   @param[out]
-  !>   csr_col_ind array containing the column indices of the sparse CSR matrix.
+  !>   @param[out] csr_col_ind - array containing the column indices of the sparse CSR matrix.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -8441,44 +7784,31 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   dir the storage format of the blocks, `rocsparse_direction_row` or
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] dir - the storage format of the blocks, `rocsparse_direction_row` or
   !>   `rocsparse_direction_column`.
-  !>   @param[in]
-  !>   mb          number of block rows in the sparse general BSR matrix.
-  !>   @param[in]
-  !>   nb          number of block columns in the sparse general BSR matrix.
-  !>   @param[in]
-  !>   bsr_descr   descriptor of the sparse general BSR matrix. Currently, only
+  !>   @param[in] mb - number of block rows in the sparse general BSR matrix.
+  !>   @param[in] nb - number of block columns in the sparse general BSR matrix.
+  !>   @param[in] bsr_descr - descriptor of the sparse general BSR matrix. Currently, only
   !>               `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   bsr_val array of \p nnzb*row_block_dim*col_block_dim containing the values of the sparse BSR
-  !>   matrix.
-  !>   @param[in]
-  !>   bsr_row_ptr array of \p mb+1 elements that point to the start of every block row of the
+  !>   @param[in] bsr_val - array of \p nnzb*row_block_dim*col_block_dim containing the values of
+  !>   the sparse BSR matrix.
+  !>   @param[in] bsr_row_ptr - array of \p mb+1 elements that point to the start of every block row
+  !>   of the
   !>               sparse BSR matrix.
-  !>   @param[in]
-  !>   bsr_col_ind array of \p nnzb elements containing the block column indices of the sparse BSR
-  !>   matrix.
-  !>   @param[in]
-  !>   row_block_dim   row size of the blocks in the sparse general BSR matrix.
-  !>   @param[in]
-  !>   col_block_dim   column size of the blocks in the sparse general BSR matrix.
-  !>   @param[in]
-  !>   csr_descr   descriptor of the sparse CSR matrix. Currently, only
+  !>   @param[in] bsr_col_ind - array of \p nnzb elements containing the block column indices of the
+  !>   sparse BSR matrix.
+  !>   @param[in] row_block_dim - row size of the blocks in the sparse general BSR matrix.
+  !>   @param[in] col_block_dim - column size of the blocks in the sparse general BSR matrix.
+  !>   @param[in] csr_descr - descriptor of the sparse CSR matrix. Currently, only
   !>               `rocsparse_matrix_type_general` is supported.
-  !>   @param[out]
-  !>   csr_val array of \p nnzb*row_block_dim*col_block_dim elements containing the values of the
-  !>   sparse CSR matrix.
-  !>   @param[out]
-  !>   csr_row_ptr array of \p m+1 where \p m=mb*row_block_dim elements that point to the start of
-  !>   every row of the
+  !>   @param[out] csr_val - array of \p nnzb*row_block_dim*col_block_dim elements containing the
+  !>   values of the sparse CSR matrix.
+  !>   @param[out] csr_row_ptr - array of \p m+1 where \p m=mb*row_block_dim elements that point to
+  !>   the start of every row of the
   !>               sparse CSR matrix.
-  !>   @param[out]
-  !>   csr_col_ind array of \p nnzb*block_dim*block_dim elements containing the column indices of
-  !>   the sparse CSR matrix.
+  !>   @param[out] csr_col_ind - array of \p nnzb*block_dim*block_dim elements containing the column
+  !>   indices of the sparse CSR matrix.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -8626,29 +7956,21 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   mb           number of rows of the sparse general BSR matrix.
-  !>   @param[in]
-  !>   nb           number of columns of the sparse general BSR matrix.
-  !>   @param[in]
-  !>   nnzb         number of non-zero entries of the sparse general BSR matrix.
-  !>   @param[in]
-  !>   bsr_val array of \p nnzb*row_block_dim*col_block_dim containing the values of the sparse
-  !>   general BSR matrix.
-  !>   @param[in]
-  !>   bsr_row_ptr array of \p mb+1 elements that point to the start of every row of the
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] mb - number of rows of the sparse general BSR matrix.
+  !>   @param[in] nb - number of columns of the sparse general BSR matrix.
+  !>   @param[in] nnzb - number of non-zero entries of the sparse general BSR matrix.
+  !>   @param[in] bsr_val - array of \p nnzb*row_block_dim*col_block_dim containing the values of
+  !>   the sparse general BSR matrix.
+  !>   @param[in] bsr_row_ptr - array of \p mb+1 elements that point to the start of every row of
+  !>   the
   !>               sparse general BSR matrix.
-  !>   @param[in]
-  !>   bsr_col_ind array of \p nnzb elements containing the column indices of the sparse
+  !>   @param[in] bsr_col_ind - array of \p nnzb elements containing the column indices of the
+  !>   sparse
   !>               general BSR matrix.
-  !>   @param[in]
-  !>   row_block_dim   row size of the blocks in the sparse general BSR matrix.
-  !>   @param[in]
-  !>   col_block_dim   col size of the blocks in the sparse general BSR matrix.
-  !>   @param[out]
-  !>   p_buffer_size number of bytes of the temporary storage buffer required by
+  !>   @param[in] row_block_dim - row size of the blocks in the sparse general BSR matrix.
+  !>   @param[in] col_block_dim - col size of the blocks in the sparse general BSR matrix.
+  !>   @param[out] p_buffer_size - number of bytes of the temporary storage buffer required by
   !>               rocsparse_sgebsr2gebsc(), rocsparse_dgebsr2gebsc(), rocsparse_cgebsr2gebsc(), and
   !>               rocsparse_zgebsr2gebsc().
   !>
@@ -8803,41 +8125,30 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle         handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   mb             number of rows of the sparse general BSR matrix.
-  !>   @param[in]
-  !>   nb             number of columns of the sparse general BSR matrix.
-  !>   @param[in]
-  !>   nnzb           number of non-zero entries of the sparse general BSR matrix.
-  !>   @param[in]
-  !>   bsr_val array of \p nnzb * \p row_block_dim * \p col_block_dim elements of the sparse general
-  !>   BSR matrix.
-  !>   @param[in]
-  !>   bsr_row_ptr    array of \p mb+1 elements that point to the start of every row of the
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] mb - number of rows of the sparse general BSR matrix.
+  !>   @param[in] nb - number of columns of the sparse general BSR matrix.
+  !>   @param[in] nnzb - number of non-zero entries of the sparse general BSR matrix.
+  !>   @param[in] bsr_val - array of \p nnzb * \p row_block_dim * \p col_block_dim elements of the
+  !>   sparse general BSR matrix.
+  !>   @param[in] bsr_row_ptr - array of \p mb+1 elements that point to the start of every row of
+  !>   the
   !>                  sparse general BSR matrix.
-  !>   @param[in]
-  !>   bsr_col_ind    array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] bsr_col_ind - array of \p nnz elements containing the column indices of the sparse
   !>                  general BSR matrix.
-  !>   @param[in]
-  !>   row_block_dim  row size of the blocks in the sparse general BSR matrix.
-  !>   @param[in]
-  !>   col_block_dim  col size of the blocks in the sparse general BSR matrix.
-  !>   @param[out]
-  !>   bsc_val        array of \p nnz elements of the sparse BSC matrix.
-  !>   @param[out]
-  !>   bsc_row_ind    array of \p nnz elements containing the row indices of the sparse BSC
+  !>   @param[in] row_block_dim - row size of the blocks in the sparse general BSR matrix.
+  !>   @param[in] col_block_dim - col size of the blocks in the sparse general BSR matrix.
+  !>   @param[out] bsc_val - array of \p nnz elements of the sparse BSC matrix.
+  !>   @param[out] bsc_row_ind - array of \p nnz elements containing the row indices of the sparse
+  !>   BSC
   !>                  matrix.
-  !>   @param[out]
-  !>   bsc_col_ptr    array of \p nb+1 elements that point to the start of every column of the
+  !>   @param[out] bsc_col_ptr - array of \p nb+1 elements that point to the start of every column
+  !>   of the
   !>                  sparse BSC matrix.
-  !>   @param[in]
-  !>   copy_values    `rocsparse_action_symbolic` or `rocsparse_action_numeric`.
-  !>   @param[in]
-  !>   idx_base       `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
-  !>   @param[in]
-  !>   temp_buffer    temporary storage buffer allocated by the user. The size is returned by
+  !>   @param[in] copy_values - `rocsparse_action_symbolic` or `rocsparse_action_numeric`.
+  !>   @param[in] idx_base - `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user. The size is returned
+  !>   by
   !>                  \ref rocsparse_sgebsr2gebsc_buffer_size
   !>                  "rocsparse_Xgebsr2gebsc_buffer_size()".
   !>
@@ -8999,41 +8310,31 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle           handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   dir the storage format of the blocks, `rocsparse_direction_row` or
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] dir - the storage format of the blocks, `rocsparse_direction_row` or
   !>   `rocsparse_direction_column`.
-  !>   @param[in]
-  !>   mb               number of block rows of the general BSR sparse matrix \f$A\f$.
-  !>   @param[in]
-  !>   nb               number of block columns of the general BSR sparse matrix \f$A\f$.
-  !>   @param[in]
-  !>   nnzb             number of blocks in the general BSR sparse matrix \f$A\f$.
-  !>   @param[in]
-  !>   descr_A the descriptor of the general BSR sparse matrix \f$A\f$. The supported matrix type is
+  !>   @param[in] mb - number of block rows of the general BSR sparse matrix \f$A\f$.
+  !>   @param[in] nb - number of block columns of the general BSR sparse matrix \f$A\f$.
+  !>   @param[in] nnzb - number of blocks in the general BSR sparse matrix \f$A\f$.
+  !>   @param[in] descr_A - the descriptor of the general BSR sparse matrix \f$A\f$. The supported
+  !>   matrix type is
   !>                    `rocsparse_matrix_type_general` and also any valid value of the
   !>                    `rocsparse_index_base`.
-  !>   @param[in]
-  !>   bsr_val_A array of \p nnzb*row_block_dim_A*col_block_dim_A containing the values of the
-  !>   sparse general BSR
+  !>   @param[in] bsr_val_A - array of \p nnzb*row_block_dim_A*col_block_dim_A containing the values
+  !>   of the sparse general BSR
   !>                    matrix \f$A\f$.
-  !>   @param[in]
-  !>   bsr_row_ptr_A    array of \p mb+1 elements that point to the start of every block row of the
+  !>   @param[in] bsr_row_ptr_A - array of \p mb+1 elements that point to the start of every block
+  !>   row of the
   !>                    sparse general BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   bsr_col_ind_A array of \p nnzb elements containing the block column indices of the sparse
-  !>   general BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   row_block_dim_A  row size of the blocks in the sparse general BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   col_block_dim_A  column size of the blocks in the sparse general BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   row_block_dim_C  row size of the blocks in the sparse general BSR matrix \f$C\f$.
-  !>   @param[in]
-  !>   col_block_dim_C  column size of the blocks in the sparse general BSR matrix \f$C\f$.
-  !>   @param[out]
-  !>   buffer_size number of bytes of the temporary storage buffer required by
+  !>   @param[in] bsr_col_ind_A - array of \p nnzb elements containing the block column indices of
+  !>   the sparse general BSR matrix \f$A\f$.
+  !>   @param[in] row_block_dim_A - row size of the blocks in the sparse general BSR matrix \f$A\f$.
+  !>   @param[in] col_block_dim_A - column size of the blocks in the sparse general BSR matrix
+  !>   \f$A\f$.
+  !>   @param[in] row_block_dim_C - row size of the blocks in the sparse general BSR matrix \f$C\f$.
+  !>   @param[in] col_block_dim_C - column size of the blocks in the sparse general BSR matrix
+  !>   \f$C\f$.
+  !>   @param[out] buffer_size - number of bytes of the temporary storage buffer required by
   !>   `rocsparse_gebsr2gebsr_nnz` () and
   !>                    \ref rocsparse_sgebsr2gebsr "rocsparse_Xgebsr2gebsr()".
   !>
@@ -9170,48 +8471,38 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle                  handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   dir the storage format of the blocks, `rocsparse_direction_row` or
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] dir - the storage format of the blocks, `rocsparse_direction_row` or
   !>   `rocsparse_direction_column`.
-  !>   @param[in]
-  !>   mb                      number of block rows of the general BSR sparse matrix \f$A\f$.
-  !>   @param[in]
-  !>   nb                      number of block columns of the general BSR sparse matrix \f$A\f$.
-  !>   @param[in]
-  !>   nnzb                    number of blocks in the general BSR sparse matrix \f$A\f$.
-  !>   @param[in]
-  !>   descr_A the descriptor of the general BSR sparse matrix \f$A\f$. The supported matrix type is
+  !>   @param[in] mb - number of block rows of the general BSR sparse matrix \f$A\f$.
+  !>   @param[in] nb - number of block columns of the general BSR sparse matrix \f$A\f$.
+  !>   @param[in] nnzb - number of blocks in the general BSR sparse matrix \f$A\f$.
+  !>   @param[in] descr_A - the descriptor of the general BSR sparse matrix \f$A\f$. The supported
+  !>   matrix type is
   !>                           `rocsparse_matrix_type_general` and also any valid value of the
   !>                           `rocsparse_index_base`.
-  !>   @param[in]
-  !>   bsr_row_ptr_A array of \p mb+1 elements that point to the start of every block row of the
+  !>   @param[in] bsr_row_ptr_A - array of \p mb+1 elements that point to the start of every block
+  !>   row of the
   !>                           sparse general BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   bsr_col_ind_A array of \p nnzb elements containing the block column indices of the sparse
-  !>   general BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   row_block_dim_A         row size of the blocks in the sparse general BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   col_block_dim_A         column size of the blocks in the sparse general BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   descr_C the descriptor of the general BSR sparse matrix \f$C\f$. The supported matrix type is
+  !>   @param[in] bsr_col_ind_A - array of \p nnzb elements containing the block column indices of
+  !>   the sparse general BSR matrix \f$A\f$.
+  !>   @param[in] row_block_dim_A - row size of the blocks in the sparse general BSR matrix \f$A\f$.
+  !>   @param[in] col_block_dim_A - column size of the blocks in the sparse general BSR matrix
+  !>   \f$A\f$.
+  !>   @param[in] descr_C - the descriptor of the general BSR sparse matrix \f$C\f$. The supported
+  !>   matrix type is
   !>                           `rocsparse_matrix_type_general` and also any valid value of the
   !>                           `rocsparse_index_base`.
-  !>   @param[in]
-  !>   bsr_row_ptr_C array of \p mb_C+1 elements that point to the start of every block row of the
+  !>   @param[in] bsr_row_ptr_C - array of \p mb_C+1 elements that point to the start of every block
+  !>   row of the
   !>                           sparse general BSR matrix \f$C\f$ where \p
   !>                           mb_C=(m+row_block_dim_C-1)/row_block_dim_C.
-  !>   @param[in]
-  !>   row_block_dim_C         row size of the blocks in the sparse general BSR matrix \f$C\f$.
-  !>   @param[in]
-  !>   col_block_dim_C         column size of the blocks in the sparse general BSR matrix \f$C\f$.
-  !>   @param[out]
-  !>   nnz_total_dev_host_ptr total number of non-zero blocks in general BSR sparse matrix \f$C\f$
-  !>   stored using device or host memory.
-  !>   @param[out]
-  !>   temp_buffer             buffer allocated by the user whose size is determined by calling
+  !>   @param[in] row_block_dim_C - row size of the blocks in the sparse general BSR matrix \f$C\f$.
+  !>   @param[in] col_block_dim_C - column size of the blocks in the sparse general BSR matrix
+  !>   \f$C\f$.
+  !>   @param[out] nnz_total_dev_host_ptr - total number of non-zero blocks in general BSR sparse
+  !>   matrix \f$C\f$ stored using device or host memory.
+  !>   @param[out] temp_buffer - buffer allocated by the user whose size is determined by calling
   !>                           \ref rocsparse_sgebsr2gebsr_buffer_size
   !>                           "rocsparse_Xgebsr2gebsr_buffer_size()".
   !>
@@ -9301,53 +8592,41 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle           handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   dir the storage format of the blocks, `rocsparse_direction_row` or
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] dir - the storage format of the blocks, `rocsparse_direction_row` or
   !>   `rocsparse_direction_column`.
-  !>   @param[in]
-  !>   mb               number of block rows of the general BSR sparse matrix \f$A\f$.
-  !>   @param[in]
-  !>   nb               number of block columns of the general BSR sparse matrix \f$A\f$.
-  !>   @param[in]
-  !>   nnzb             number of blocks in the general BSR sparse matrix \f$A\f$.
-  !>   @param[in]
-  !>   descr_A the descriptor of the general BSR sparse matrix \f$A\f$. The supported matrix type is
+  !>   @param[in] mb - number of block rows of the general BSR sparse matrix \f$A\f$.
+  !>   @param[in] nb - number of block columns of the general BSR sparse matrix \f$A\f$.
+  !>   @param[in] nnzb - number of blocks in the general BSR sparse matrix \f$A\f$.
+  !>   @param[in] descr_A - the descriptor of the general BSR sparse matrix \f$A\f$. The supported
+  !>   matrix type is
   !>                    `rocsparse_matrix_type_general` and also any valid value of the
   !>                    `rocsparse_index_base`.
-  !>   @param[in]
-  !>   bsr_val_A array of \p nnzb*row_block_dim_A*col_block_dim_A containing the values of the
-  !>   sparse general BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   bsr_row_ptr_A    array of \p mb+1 elements that point to the start of every block row of the
+  !>   @param[in] bsr_val_A - array of \p nnzb*row_block_dim_A*col_block_dim_A containing the values
+  !>   of the sparse general BSR matrix \f$A\f$.
+  !>   @param[in] bsr_row_ptr_A - array of \p mb+1 elements that point to the start of every block
+  !>   row of the
   !>                    sparse general BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   bsr_col_ind_A array of \p nnzb elements containing the block column indices of the sparse
-  !>   general BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   row_block_dim_A  row size of the blocks in the sparse general BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   col_block_dim_A  column size of the blocks in the sparse general BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   descr_C the descriptor of the general BSR sparse matrix \f$C\f$. The supported matrix type is
+  !>   @param[in] bsr_col_ind_A - array of \p nnzb elements containing the block column indices of
+  !>   the sparse general BSR matrix \f$A\f$.
+  !>   @param[in] row_block_dim_A - row size of the blocks in the sparse general BSR matrix \f$A\f$.
+  !>   @param[in] col_block_dim_A - column size of the blocks in the sparse general BSR matrix
+  !>   \f$A\f$.
+  !>   @param[in] descr_C - the descriptor of the general BSR sparse matrix \f$C\f$. The supported
+  !>   matrix type is
   !>                    `rocsparse_matrix_type_general` and also any valid value of the
   !>                    `rocsparse_index_base`.
-  !>   @param[in]
-  !>   bsr_val_C array of \p nnzb_C*row_block_dim_C*col_block_dim_C containing the values of the
-  !>   sparse general BSR matrix \f$C\f$.
-  !>   @param[in]
-  !>   bsr_row_ptr_C array of \p mb_C+1 elements that point to the start of every block row of the
+  !>   @param[in] bsr_val_C - array of \p nnzb_C*row_block_dim_C*col_block_dim_C containing the
+  !>   values of the sparse general BSR matrix \f$C\f$.
+  !>   @param[in] bsr_row_ptr_C - array of \p mb_C+1 elements that point to the start of every block
+  !>   row of the
   !>                    sparse general BSR matrix \f$C\f$.
-  !>   @param[in]
-  !>   bsr_col_ind_C array of \p nnzb_C elements containing the block column indices of the sparse
-  !>   general BSR matrix \f$C\f$.
-  !>   @param[in]
-  !>   row_block_dim_C  row size of the blocks in the sparse general BSR matrix \f$C\f$.
-  !>   @param[in]
-  !>   col_block_dim_C  column size of the blocks in the sparse general BSR matrix \f$C\f$.
-  !>   @param[out]
-  !>   temp_buffer      buffer allocated by the user. Its size is determined by calling
+  !>   @param[in] bsr_col_ind_C - array of \p nnzb_C elements containing the block column indices of
+  !>   the sparse general BSR matrix \f$C\f$.
+  !>   @param[in] row_block_dim_C - row size of the blocks in the sparse general BSR matrix \f$C\f$.
+  !>   @param[in] col_block_dim_C - column size of the blocks in the sparse general BSR matrix
+  !>   \f$C\f$.
+  !>   @param[out] temp_buffer - buffer allocated by the user. Its size is determined by calling
   !>                    \ref rocsparse_sgebsr2gebsr_buffer_size
   !>                    "rocsparse_Xgebsr2gebsr_buffer_size()".
   !>
@@ -9494,18 +8773,13 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle          handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   descr           descriptor of the sparse HYB matrix. Currently, only
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] descr - descriptor of the sparse HYB matrix. Currently, only
   !>                   `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   hyb             sparse matrix in HYB format.
-  !>   @param[in]
-  !>   csr_row_ptr     array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] hyb - sparse matrix in HYB format.
+  !>   @param[in] csr_row_ptr - array of \p m+1 elements that point to the start of every row of the
   !>                   sparse CSR matrix.
-  !>   @param[out]
-  !>   buffer_size     number of bytes of the temporary storage buffer required by
+  !>   @param[out] buffer_size - number of bytes of the temporary storage buffer required by
   !>                   \ref rocsparse_shyb2csr "rocsparse_Xhyb2csr()".
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
@@ -9559,22 +8833,17 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle          handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   descr           descriptor of the sparse HYB matrix. Currently, only
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] descr - descriptor of the sparse HYB matrix. Currently, only
   !>                   `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   hyb             sparse matrix in HYB format.
-  !>   @param[out]
-  !>   csr_val         array containing the values of the sparse CSR matrix.
-  !>   @param[out]
-  !>   csr_row_ptr     array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] hyb - sparse matrix in HYB format.
+  !>   @param[out] csr_val - array containing the values of the sparse CSR matrix.
+  !>   @param[out] csr_row_ptr - array of \p m+1 elements that point to the start of every row of
+  !>   the
   !>                   sparse CSR matrix.
-  !>   @param[out]
-  !>   csr_col_ind     array containing the column indices of the sparse CSR matrix.
-  !>   @param[in]
-  !>   temp_buffer     temporary storage buffer allocated by the user. The size is returned by
+  !>   @param[out] csr_col_ind - array containing the column indices of the sparse CSR matrix.
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user. The size is returned
+  !>   by
   !>                   `rocsparse_hyb2csr_buffer_size`().
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
@@ -9700,12 +8969,9 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   n           size of the map \p p.
-  !>   @param[out]
-  !>   p           array of \p n integers containing the map.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] n - size of the map \p p.
+  !>   @param[out] p - array of \p n integers containing the map.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -9753,16 +9019,11 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   n           size of the permutation vector \p p.
-  !>   @param[in]
-  !>   p           array of \p n integers containing the permutation vector to inverse.
-  !>   @param[out]
-  !>   q           array of \p n integers containing the invsrse of the permutation vector.
-  !>   @param[in]
-  !>   base        `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] n - size of the permutation vector \p p.
+  !>   @param[in] p - array of \p n integers containing the permutation vector to inverse.
+  !>   @param[out] q - array of \p n integers containing the invsrse of the permutation vector.
+  !>   @param[in] base - `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -9805,14 +9066,10 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   n           size of the map \p p.
-  !>   @param[out]
-  !>   p           array of \p n integers containing the map.
-  !>   @param[in]
-  !>   indextype the integer type of \p p. Can be \p rocsparse_indextype_i32 or \p
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] n - size of the map \p p.
+  !>   @param[out] p - array of \p n integers containing the map.
+  !>   @param[in] indextype - the integer type of \p p. Can be \p rocsparse_indextype_i32 or \p
   !>   rocsparse_indextype_i64.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
@@ -9859,27 +9116,19 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle                  handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   dir direction that specifies whether to count non-zero elements by `rocsparse_direction_row`
-  !>   or by
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] dir - direction that specifies whether to count non-zero elements by
+  !>   `rocsparse_direction_row` or by
   !>                           `rocsparse_direction_column`.
-  !>   @param[in]
-  !>   m                       number of rows of the dense matrix \p A.
-  !>   @param[in]
-  !>   n                       number of columns of the dense matrix \p A.
-  !>   @param[in]
-  !>   descr                   the descriptor of the dense matrix \p A.
-  !>   @param[in]
-  !>   A                       array of dimensions (\p ld, \p n).
-  !>   @param[in]
-  !>   ld                      leading dimension of dense array \p A.
-  !>   @param[out]
-  !>   nnz_per_row_columns array of size \p m or \p n containing the number of non-zero elements per
-  !>   row or column, respectively.
-  !>   @param[out]
-  !>   nnz_total_dev_host_ptr  total number of non-zero elements in device or host memory.
+  !>   @param[in] m - number of rows of the dense matrix \p A.
+  !>   @param[in] n - number of columns of the dense matrix \p A.
+  !>   @param[in] descr - the descriptor of the dense matrix \p A.
+  !>   @param[in] A - array of dimensions (\p ld, \p n).
+  !>   @param[in] ld - leading dimension of dense array \p A.
+  !>   @param[out] nnz_per_row_columns - array of size \p m or \p n containing the number of
+  !>   non-zero elements per row or column, respectively.
+  !>   @param[out] nnz_total_dev_host_ptr - total number of non-zero elements in device or host
+  !>   memory.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -10006,30 +9255,24 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle        handle to the rocSPARSE library context queue.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
   !>
-  !>   @param[in]
-  !>   m             number of rows of the sparse CSR matrix.
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
   !>
-  !>   @param[in]
-  !>   descr_A       the descriptor of the sparse CSR matrix.
+  !>   @param[in] descr_A - the descriptor of the sparse CSR matrix.
   !>
-  !>   @param[in]
-  !>   csr_val_A     array of \p nnz_A elements of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_row_ptr_A array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] csr_val_A - array of \p nnz_A elements of the sparse CSR matrix.
+  !>   @param[in] csr_row_ptr_A - array of \p m+1 elements that point to the start of every row of
+  !>   the
   !>                 uncompressed sparse CSR matrix.
-  !>   @param[out]
-  !>   nnz_per_row array of length \p m containing the number of entries that will be kept per row
-  !>   in
+  !>   @param[out] nnz_per_row - array of length \p m containing the number of entries that will be
+  !>   kept per row in
   !>                 the final compressed CSR matrix.
-  !>   @param[out]
-  !>   nnz_C         number of elements in the column indices and values arrays of the compressed
+  !>   @param[out] nnz_C - number of elements in the column indices and values arrays of the
+  !>   compressed
   !>                 sparse CSR matrix. It can be either a host or device pointer.
-  !>   @param[in]
-  !>   tol the non-negative tolerance used for compression. If \p tol is complex, then only the
-  !>   magnitude
+  !>   @param[in] tol - the non-negative tolerance used for compression. If \p tol is complex, then
+  !>   only the magnitude
   !>                 of the real part is used. Entries in the input uncompressed CSR array that are
   !>                 below the tolerance
   !>                 are removed in the output compressed CSR matrix.
@@ -10157,41 +9400,31 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle        handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m             number of rows in the sparse CSR matrix.
-  !>   @param[in]
-  !>   n             number of columns in the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnz_A         number of non-zeros in the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csr_descr_A   descriptor of the sparse CSR matrix \f$A\f$. Currently, only
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - number of rows in the sparse CSR matrix.
+  !>   @param[in] n - number of columns in the sparse CSR matrix.
+  !>   @param[in] nnz_A - number of non-zeros in the sparse CSR matrix \f$A\f$.
+  !>   @param[in] csr_descr_A - descriptor of the sparse CSR matrix \f$A\f$. Currently, only
   !>                 `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   csr_val_A array of \p nnz_A elements containing the values of the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csr_row_ptr_A array of \p m+1 elements that point to the start of every row of the
-  !>                 sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csr_col_ind_A array of \p nnz_A elements containing the column indices of the sparse CSR
+  !>   @param[in] csr_val_A - array of \p nnz_A elements containing the values of the sparse CSR
   !>   matrix \f$A\f$.
-  !>   @param[in]
-  !>   threshold pointer to the non-negative pruning threshold, which can exist in either host or
-  !>   device memory.
-  !>   @param[in]
-  !>   csr_descr_C   descriptor of the sparse CSR matrix \f$C\f$. Currently, only
+  !>   @param[in] csr_row_ptr_A - array of \p m+1 elements that point to the start of every row of
+  !>   the
+  !>                 sparse CSR matrix \f$A\f$.
+  !>   @param[in] csr_col_ind_A - array of \p nnz_A elements containing the column indices of the
+  !>   sparse CSR matrix \f$A\f$.
+  !>   @param[in] threshold - pointer to the non-negative pruning threshold, which can exist in
+  !>   either host or device memory.
+  !>   @param[in] csr_descr_C - descriptor of the sparse CSR matrix \f$C\f$. Currently, only
   !>                 `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   csr_val_C array of \p nnz_C elements containing the values of the sparse CSR matrix \f$C\f$.
-  !>   @param[in]
-  !>   csr_row_ptr_C array of \p m+1 elements that point to the start of every row of the
-  !>                 sparse CSR matrix \f$C\f$.
-  !>   @param[in]
-  !>   csr_col_ind_C array of \p nnz_C elements containing the column indices of the sparse CSR
+  !>   @param[in] csr_val_C - array of \p nnz_C elements containing the values of the sparse CSR
   !>   matrix \f$C\f$.
-  !>   @param[out]
-  !>   buffer_size   number of bytes of the temporary storage buffer required by
+  !>   @param[in] csr_row_ptr_C - array of \p m+1 elements that point to the start of every row of
+  !>   the
+  !>                 sparse CSR matrix \f$C\f$.
+  !>   @param[in] csr_col_ind_C - array of \p nnz_C elements containing the column indices of the
+  !>   sparse CSR matrix \f$C\f$.
+  !>   @param[out] buffer_size - number of bytes of the temporary storage buffer required by
   !>                 \ref rocsparse_sprune_csr2csr_nnz "rocsparse_Xprune_csr2csr_nnz()" and
   !>                 \ref rocsparse_sprune_csr2csr "rocsparse_Xprune_csr2csr()".
   !>
@@ -10274,38 +9507,29 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle                 handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m                      number of rows in the sparse CSR matrix.
-  !>   @param[in]
-  !>   n                      number of columns in the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnz_A                  number of non-zeros in the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csr_descr_A            descriptor of the sparse CSR matrix \f$A\f$. Currently, only
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - number of rows in the sparse CSR matrix.
+  !>   @param[in] n - number of columns in the sparse CSR matrix.
+  !>   @param[in] nnz_A - number of non-zeros in the sparse CSR matrix \f$A\f$.
+  !>   @param[in] csr_descr_A - descriptor of the sparse CSR matrix \f$A\f$. Currently, only
   !>                          `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   csr_val_A array of \p nnz_A elements containing the values of the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csr_row_ptr_A          array of \p m+1 elements that point to the start of every row of the
-  !>                          sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csr_col_ind_A array of \p nnz_A elements containing the column indices of the sparse CSR
+  !>   @param[in] csr_val_A - array of \p nnz_A elements containing the values of the sparse CSR
   !>   matrix \f$A\f$.
-  !>   @param[in]
-  !>   threshold pointer to the non-negative pruning threshold which can exist in either host or
-  !>   device memory.
-  !>   @param[in]
-  !>   csr_descr_C            descriptor of the sparse CSR matrix \f$C\f$. Currently, only
+  !>   @param[in] csr_row_ptr_A - array of \p m+1 elements that point to the start of every row of
+  !>   the
+  !>                          sparse CSR matrix \f$A\f$.
+  !>   @param[in] csr_col_ind_A - array of \p nnz_A elements containing the column indices of the
+  !>   sparse CSR matrix \f$A\f$.
+  !>   @param[in] threshold - pointer to the non-negative pruning threshold which can exist in
+  !>   either host or device memory.
+  !>   @param[in] csr_descr_C - descriptor of the sparse CSR matrix \f$C\f$. Currently, only
   !>                          `rocsparse_matrix_type_general` is supported.
-  !>   @param[out]
-  !>   csr_row_ptr_C          array of \p m+1 elements that point to the start of every row of the
+  !>   @param[out] csr_row_ptr_C - array of \p m+1 elements that point to the start of every row of
+  !>   the
   !>                          sparse CSR matrix \f$C\f$.
-  !>   @param[out]
-  !>   nnz_total_dev_host_ptr total number of non-zero elements in device or host memory.
-  !>   @param[out]
-  !>   temp_buffer            buffer allocated by the user. Its size is determined by calling
+  !>   @param[out] nnz_total_dev_host_ptr - total number of non-zero elements in device or host
+  !>   memory.
+  !>   @param[out] temp_buffer - buffer allocated by the user. Its size is determined by calling
   !>                          \ref rocsparse_sprune_csr2csr_buffer_size
   !>                          "rocsparse_Xprune_csr2csr_buffer_size()".
   !>
@@ -10405,41 +9629,31 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle        handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m             number of rows in the sparse CSR matrix.
-  !>   @param[in]
-  !>   n             number of columns in the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnz_A         number of non-zeros in the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csr_descr_A   descriptor of the sparse CSR matrix \f$A\f$. Currently, only
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - number of rows in the sparse CSR matrix.
+  !>   @param[in] n - number of columns in the sparse CSR matrix.
+  !>   @param[in] nnz_A - number of non-zeros in the sparse CSR matrix \f$A\f$.
+  !>   @param[in] csr_descr_A - descriptor of the sparse CSR matrix \f$A\f$. Currently, only
   !>                 `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   csr_val_A array of \p nnz_A elements containing the values of the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csr_row_ptr_A array of \p m+1 elements that point to the start of every row of the
-  !>                 sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csr_col_ind_A array of \p nnz_A elements containing the column indices of the sparse CSR
+  !>   @param[in] csr_val_A - array of \p nnz_A elements containing the values of the sparse CSR
   !>   matrix \f$A\f$.
-  !>   @param[in]
-  !>   threshold pointer to the non-negative pruning threshold, which can exist in either host or
-  !>   device memory.
-  !>   @param[in]
-  !>   csr_descr_C   descriptor of the sparse CSR matrix \f$C\f$. Currently, only
+  !>   @param[in] csr_row_ptr_A - array of \p m+1 elements that point to the start of every row of
+  !>   the
+  !>                 sparse CSR matrix \f$A\f$.
+  !>   @param[in] csr_col_ind_A - array of \p nnz_A elements containing the column indices of the
+  !>   sparse CSR matrix \f$A\f$.
+  !>   @param[in] threshold - pointer to the non-negative pruning threshold, which can exist in
+  !>   either host or device memory.
+  !>   @param[in] csr_descr_C - descriptor of the sparse CSR matrix \f$C\f$. Currently, only
   !>                 `rocsparse_matrix_type_general` is supported.
-  !>   @param[out]
-  !>   csr_val_C array of \p nnz_C elements containing the values of the sparse CSR matrix \f$C\f$.
-  !>   @param[in]
-  !>   csr_row_ptr_C array of \p m+1 elements that point to the start of every row of the
-  !>                 sparse CSR matrix \f$C\f$.
-  !>   @param[out]
-  !>   csr_col_ind_C array of \p nnz_C elements containing the column indices of the sparse CSR
+  !>   @param[out] csr_val_C - array of \p nnz_C elements containing the values of the sparse CSR
   !>   matrix \f$C\f$.
-  !>   @param[in]
-  !>   temp_buffer   buffer allocated by the user. Its size is determined by calling
+  !>   @param[in] csr_row_ptr_C - array of \p m+1 elements that point to the start of every row of
+  !>   the
+  !>                 sparse CSR matrix \f$C\f$.
+  !>   @param[out] csr_col_ind_C - array of \p nnz_C elements containing the column indices of the
+  !>   sparse CSR matrix \f$C\f$.
+  !>   @param[in] temp_buffer - buffer allocated by the user. Its size is determined by calling
   !>                 \ref rocsparse_sprune_csr2csr_buffer_size
   !>                 "rocsparse_Xprune_csr2csr_buffer_size()".
   !>
@@ -10532,42 +9746,31 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle        handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m             number of rows in the sparse CSR matrix.
-  !>   @param[in]
-  !>   n             number of columns in the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnz_A         number of non-zeros in the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csr_descr_A   descriptor of the sparse CSR matrix \f$A\f$. Currently, only
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - number of rows in the sparse CSR matrix.
+  !>   @param[in] n - number of columns in the sparse CSR matrix.
+  !>   @param[in] nnz_A - number of non-zeros in the sparse CSR matrix \f$A\f$.
+  !>   @param[in] csr_descr_A - descriptor of the sparse CSR matrix \f$A\f$. Currently, only
   !>                 `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   csr_val_A array of \p nnz_A elements containing the values of the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csr_row_ptr_A array of \p m+1 elements that point to the start of every row of the
-  !>                 sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csr_col_ind_A array of \p nnz_A elements containing the column indices of the sparse CSR
+  !>   @param[in] csr_val_A - array of \p nnz_A elements containing the values of the sparse CSR
   !>   matrix \f$A\f$.
-  !>   @param[in]
-  !>   percentage    \p percentage>=0 and \p percentage<=100.
-  !>   @param[in]
-  !>   csr_descr_C   descriptor of the sparse CSR matrix \f$C\f$. Currently, only
+  !>   @param[in] csr_row_ptr_A - array of \p m+1 elements that point to the start of every row of
+  !>   the
+  !>                 sparse CSR matrix \f$A\f$.
+  !>   @param[in] csr_col_ind_A - array of \p nnz_A elements containing the column indices of the
+  !>   sparse CSR matrix \f$A\f$.
+  !>   @param[in] percentage - \p percentage>=0 and \p percentage<=100.
+  !>   @param[in] csr_descr_C - descriptor of the sparse CSR matrix \f$C\f$. Currently, only
   !>                 `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   csr_val_C array of \p nnz_C elements containing the values of the sparse CSR matrix \f$C\f$.
-  !>   @param[in]
-  !>   csr_row_ptr_C array of \p m+1 elements that point to the start of every row of the
-  !>                 sparse CSR matrix \f$C\f$.
-  !>   @param[in]
-  !>   csr_col_ind_C array of \p nnz_C elements containing the column indices of the sparse CSR
+  !>   @param[in] csr_val_C - array of \p nnz_C elements containing the values of the sparse CSR
   !>   matrix \f$C\f$.
-  !>   @param[in]
-  !>   info          prune info structure.
-  !>   @param[out]
-  !>   buffer_size   number of bytes of the temporary storage buffer required by
+  !>   @param[in] csr_row_ptr_C - array of \p m+1 elements that point to the start of every row of
+  !>   the
+  !>                 sparse CSR matrix \f$C\f$.
+  !>   @param[in] csr_col_ind_C - array of \p nnz_C elements containing the column indices of the
+  !>   sparse CSR matrix \f$C\f$.
+  !>   @param[in] myInfo - prune info structure.
+  !>   @param[out] buffer_size - number of bytes of the temporary storage buffer required by
   !>                 \ref rocsparse_sprune_csr2csr_nnz_by_percentage
   !>                 "rocsparse_Xprune_csr2csr_nnz_by_percentage()" and
   !>                 \ref rocsparse_sprune_csr2csr_by_percentage
@@ -10659,39 +9862,29 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle                 handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m                      number of rows in the sparse CSR matrix.
-  !>   @param[in]
-  !>   n                      number of columns in the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnz_A                  number of non-zeros in the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csr_descr_A            descriptor of the sparse CSR matrix \f$A\f$. Currently, only
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - number of rows in the sparse CSR matrix.
+  !>   @param[in] n - number of columns in the sparse CSR matrix.
+  !>   @param[in] nnz_A - number of non-zeros in the sparse CSR matrix \f$A\f$.
+  !>   @param[in] csr_descr_A - descriptor of the sparse CSR matrix \f$A\f$. Currently, only
   !>                          `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   csr_val_A array of \p nnz_A elements containing the values of the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csr_row_ptr_A          array of \p m+1 elements that point to the start of every row of the
-  !>                          sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csr_col_ind_A array of \p nnz_A elements containing the column indices of the sparse CSR
+  !>   @param[in] csr_val_A - array of \p nnz_A elements containing the values of the sparse CSR
   !>   matrix \f$A\f$.
-  !>   @param[in]
-  !>   percentage             \p percentage>=0 and \p percentage<=100.
-  !>   @param[in]
-  !>   csr_descr_C            descriptor of the sparse CSR matrix \f$C\f$. Currently, only
+  !>   @param[in] csr_row_ptr_A - array of \p m+1 elements that point to the start of every row of
+  !>   the
+  !>                          sparse CSR matrix \f$A\f$.
+  !>   @param[in] csr_col_ind_A - array of \p nnz_A elements containing the column indices of the
+  !>   sparse CSR matrix \f$A\f$.
+  !>   @param[in] percentage - \p percentage>=0 and \p percentage<=100.
+  !>   @param[in] csr_descr_C - descriptor of the sparse CSR matrix \f$C\f$. Currently, only
   !>                          `rocsparse_matrix_type_general` is supported.
-  !>   @param[out]
-  !>   csr_row_ptr_C          array of \p m+1 elements that point to the start of every row of the
+  !>   @param[out] csr_row_ptr_C - array of \p m+1 elements that point to the start of every row of
+  !>   the
   !>                          sparse CSR matrix \f$C\f$.
-  !>   @param[out]
-  !>   nnz_total_dev_host_ptr total number of non-zero elements in device or host memory.
-  !>   @param[in]
-  !>   info                   prune info structure.
-  !>   @param[out]
-  !>   temp_buffer            buffer allocated by the user. Its size is determined by calling
+  !>   @param[out] nnz_total_dev_host_ptr - total number of non-zero elements in device or host
+  !>   memory.
+  !>   @param[in] myInfo - prune info structure.
+  !>   @param[out] temp_buffer - buffer allocated by the user. Its size is determined by calling
   !>                          \ref rocsparse_sprune_csr2csr_by_percentage_buffer_size
   !>                          "rocsparse_Xprune_csr2csr_by_percentage_buffer_size()".
   !>
@@ -10816,42 +10009,31 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle        handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m             number of rows in the sparse CSR matrix.
-  !>   @param[in]
-  !>   n             number of columns in the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnz_A         number of non-zeros in the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csr_descr_A   descriptor of the sparse CSR matrix \f$A\f$. Currently, only
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - number of rows in the sparse CSR matrix.
+  !>   @param[in] n - number of columns in the sparse CSR matrix.
+  !>   @param[in] nnz_A - number of non-zeros in the sparse CSR matrix \f$A\f$.
+  !>   @param[in] csr_descr_A - descriptor of the sparse CSR matrix \f$A\f$. Currently, only
   !>                 `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   csr_val_A array of \p nnz_A elements containing the values of the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csr_row_ptr_A array of \p m+1 elements that point to the start of every row of the
-  !>                 sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csr_col_ind_A array of \p nnz_A elements containing the column indices of the sparse CSR
+  !>   @param[in] csr_val_A - array of \p nnz_A elements containing the values of the sparse CSR
   !>   matrix \f$A\f$.
-  !>   @param[in]
-  !>   percentage    \p percentage>=0 and \p percentage<=100.
-  !>   @param[in]
-  !>   csr_descr_C   descriptor of the sparse CSR matrix \f$C\f$. Currently, only
+  !>   @param[in] csr_row_ptr_A - array of \p m+1 elements that point to the start of every row of
+  !>   the
+  !>                 sparse CSR matrix \f$A\f$.
+  !>   @param[in] csr_col_ind_A - array of \p nnz_A elements containing the column indices of the
+  !>   sparse CSR matrix \f$A\f$.
+  !>   @param[in] percentage - \p percentage>=0 and \p percentage<=100.
+  !>   @param[in] csr_descr_C - descriptor of the sparse CSR matrix \f$C\f$. Currently, only
   !>                 `rocsparse_matrix_type_general` is supported.
-  !>   @param[out]
-  !>   csr_val_C array of \p nnz_C elements containing the values of the sparse CSR matrix \f$C\f$.
-  !>   @param[in]
-  !>   csr_row_ptr_C array of \p m+1 elements that point to the start of every row of the
-  !>                 sparse CSR matrix \f$C\f$.
-  !>   @param[out]
-  !>   csr_col_ind_C array of \p nnz_C elements containing the column indices of the sparse CSR
+  !>   @param[out] csr_val_C - array of \p nnz_C elements containing the values of the sparse CSR
   !>   matrix \f$C\f$.
-  !>   @param[in]
-  !>   info          prune info structure.
-  !>   @param[in]
-  !>   temp_buffer   buffer allocated by the user. Its size is determined by calling
+  !>   @param[in] csr_row_ptr_C - array of \p m+1 elements that point to the start of every row of
+  !>   the
+  !>                 sparse CSR matrix \f$C\f$.
+  !>   @param[out] csr_col_ind_C - array of \p nnz_C elements containing the column indices of the
+  !>   sparse CSR matrix \f$C\f$.
+  !>   @param[in] myInfo - prune info structure.
+  !>   @param[in] temp_buffer - buffer allocated by the user. Its size is determined by calling
   !>                 \ref rocsparse_sprune_csr2csr_buffer_size
   !>                 "rocsparse_Xprune_csr2csr_buffer_size()".
   !>
@@ -10945,34 +10127,23 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m           number of rows of the dense matrix \p A.
-  !>   @param[in]
-  !>   n           number of columns of the dense matrix \p A.
-  !>   @param[in]
-  !>   A           array of dimensions (\p lda, \p n).
-  !>   @param[in]
-  !>   lda         leading dimension of dense array \p A.
-  !>   @param[in]
-  !>   threshold pointer to the pruning non-negative threshold which can exist in either host or
-  !>   device memory.
-  !>   @param[in]
-  !>   descr the descriptor of the dense matrix \p A, the supported matrix type is
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - number of rows of the dense matrix \p A.
+  !>   @param[in] n - number of columns of the dense matrix \p A.
+  !>   @param[in] A - array of dimensions (\p lda, \p n).
+  !>   @param[in] lda - leading dimension of dense array \p A.
+  !>   @param[in] threshold - pointer to the pruning non-negative threshold which can exist in
+  !>   either host or device memory.
+  !>   @param[in] descr - the descriptor of the dense matrix \p A, the supported matrix type is
   !>   `rocsparse_matrix_type_general` and
   !>               also any valid value of the `rocsparse_index_base`.
-  !>   @param[in]
-  !>   csr_val array of nnz ( = \p csr_row_ptr[m] - \p csr_row_ptr[0] ) non-zero elements of matrix
-  !>   \p A.
-  !>   @param[in]
-  !>   csr_row_ptr integer array of \p m+1 elements that contains the start of every row and the end
-  !>   of the last row plus one.
-  !>   @param[in]
-  !>   csr_col_ind integer array of nnz ( = \p csr_row_ptr[m] - \p csr_row_ptr[0] ) column indices
-  !>   of the non-zero elements of matrix \p A.
-  !>   @param[out]
-  !>   buffer_size number of bytes of the temporary storage buffer required by
+  !>   @param[in] csr_val - array of nnz ( = \p csr_row_ptr[m] - \p csr_row_ptr[0] ) non-zero
+  !>   elements of matrix \p A.
+  !>   @param[in] csr_row_ptr - integer array of \p m+1 elements that contains the start of every
+  !>   row and the end of the last row plus one.
+  !>   @param[in] csr_col_ind - integer array of nnz ( = \p csr_row_ptr[m] - \p csr_row_ptr[0] )
+  !>   column indices of the non-zero elements of matrix \p A.
+  !>   @param[out] buffer_size - number of bytes of the temporary storage buffer required by
   !>               \ref rocsparse_sprune_dense2csr_nnz "rocsparse_Xprune_dense2csr_nnz()" and
   !>               \ref rocsparse_sprune_dense2csr "rocsparse_Xprune_dense2csr()".
   !>
@@ -11051,28 +10222,19 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle                 handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m                      number of rows of the dense matrix \p A.
-  !>   @param[in]
-  !>   n                      number of columns of the dense matrix \p A.
-  !>   @param[in]
-  !>   A                      array of dimensions (\p lda, \p n).
-  !>   @param[in]
-  !>   lda                    leading dimension of dense array \p A.
-  !>   @param[in]
-  !>   threshold pointer to the pruning non-negative threshold which can exist in either host or
-  !>   device memory.
-  !>   @param[in]
-  !>   descr                  the descriptor of the dense matrix \p A.
-  !>   @param[out]
-  !>   csr_row_ptr integer array of \p m+1 elements that contains the start of every row and the end
-  !>   of the last row plus one.
-  !>   @param[out]
-  !>   nnz_total_dev_host_ptr total number of non-zero elements in device or host memory.
-  !>   @param[out]
-  !>   temp_buffer            buffer allocated by the user. Its size is determined by calling
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - number of rows of the dense matrix \p A.
+  !>   @param[in] n - number of columns of the dense matrix \p A.
+  !>   @param[in] A - array of dimensions (\p lda, \p n).
+  !>   @param[in] lda - leading dimension of dense array \p A.
+  !>   @param[in] threshold - pointer to the pruning non-negative threshold which can exist in
+  !>   either host or device memory.
+  !>   @param[in] descr - the descriptor of the dense matrix \p A.
+  !>   @param[out] csr_row_ptr - integer array of \p m+1 elements that contains the start of every
+  !>   row and the end of the last row plus one.
+  !>   @param[out] nnz_total_dev_host_ptr - total number of non-zero elements in device or host
+  !>   memory.
+  !>   @param[out] temp_buffer - buffer allocated by the user. Its size is determined by calling
   !>                          \ref rocsparse_sprune_dense2csr_buffer_size
   !>                          "rocsparse_Xprune_dense2csr_buffer_size()".
   !>
@@ -11166,34 +10328,24 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m           number of rows of the dense matrix \p A.
-  !>   @param[in]
-  !>   n           number of columns of the dense matrix \p A.
-  !>   @param[in]
-  !>   A           array of dimensions (\p lda, \p n).
-  !>   @param[in]
-  !>   lda         leading dimension of dense array \p A.
-  !>   @param[in]
-  !>   threshold pointer to the non-negative pruning threshold, which can exist in either host or
-  !>   device memory.
-  !>   @param[in]
-  !>   descr the descriptor of the dense matrix \p A. The supported matrix type is
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - number of rows of the dense matrix \p A.
+  !>   @param[in] n - number of columns of the dense matrix \p A.
+  !>   @param[in] A - array of dimensions (\p lda, \p n).
+  !>   @param[in] lda - leading dimension of dense array \p A.
+  !>   @param[in] threshold - pointer to the non-negative pruning threshold, which can exist in
+  !>   either host or device memory.
+  !>   @param[in] descr - the descriptor of the dense matrix \p A. The supported matrix type is
   !>   `rocsparse_matrix_type_general` and
   !>               also any valid value of the `rocsparse_index_base`.
-  !>   @param[out]
-  !>   csr_val array of nnz ( = \p csr_row_ptr[m] - \p csr_row_ptr[0] ) non-zero elements of matrix
-  !>   \p A.
-  !>   @param[in]
-  !>   csr_row_ptr integer array of \p m+1 elements that contains the start of every row and the end
-  !>   of the last row plus one.
-  !>   @param[out]
-  !>   csr_col_ind integer array of nnz ( = \p csr_row_ptr[m] - \p csr_row_ptr[0] ) column indices
-  !>   of the non-zero elements of matrix \p A.
-  !>   @param[in]
-  !>   temp_buffer temporary storage buffer allocated by the user. The size is returned by
+  !>   @param[out] csr_val - array of nnz ( = \p csr_row_ptr[m] - \p csr_row_ptr[0] ) non-zero
+  !>   elements of matrix \p A.
+  !>   @param[in] csr_row_ptr - integer array of \p m+1 elements that contains the start of every
+  !>   row and the end of the last row plus one.
+  !>   @param[out] csr_col_ind - integer array of nnz ( = \p csr_row_ptr[m] - \p csr_row_ptr[0] )
+  !>   column indices of the non-zero elements of matrix \p A.
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user. The size is returned
+  !>   by
   !>               \ref rocsparse_sprune_dense2csr_buffer_size
   !>               "rocsparse_Xprune_dense2csr_buffer_size()".
   !>
@@ -11279,35 +10431,23 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m           number of rows of the dense matrix \p A.
-  !>   @param[in]
-  !>   n           number of columns of the dense matrix \p A.
-  !>   @param[in]
-  !>   A           array of dimensions (\p lda, \p n).
-  !>   @param[in]
-  !>   lda         leading dimension of dense array \p A.
-  !>   @param[in]
-  !>   percentage  \p percentage>=0 and \p percentage<=100.
-  !>   @param[in]
-  !>   descr the descriptor of the dense matrix \p A. The supported matrix type is
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - number of rows of the dense matrix \p A.
+  !>   @param[in] n - number of columns of the dense matrix \p A.
+  !>   @param[in] A - array of dimensions (\p lda, \p n).
+  !>   @param[in] lda - leading dimension of dense array \p A.
+  !>   @param[in] percentage - \p percentage>=0 and \p percentage<=100.
+  !>   @param[in] descr - the descriptor of the dense matrix \p A. The supported matrix type is
   !>   `rocsparse_matrix_type_general`
   !>               and also any valid value of the `rocsparse_index_base`.
-  !>   @param[in]
-  !>   csr_val array of nnz ( = \p csr_row_ptr[m] - \p csr_row_ptr[0] ) non-zero elements of matrix
-  !>   \p A.
-  !>   @param[in]
-  !>   csr_row_ptr integer array of \p m+1 elements that contains the start of every row and the end
-  !>   of the last row plus one.
-  !>   @param[in]
-  !>   csr_col_ind integer array of nnz ( = \p csr_row_ptr[m] - \p csr_row_ptr[0] ) column indices
-  !>   of the non-zero elements of matrix \p A.
-  !>   @param[in]
-  !>   info prune  information structure.
-  !>   @param[out]
-  !>   buffer_size number of bytes of the temporary storage buffer required by
+  !>   @param[in] csr_val - array of nnz ( = \p csr_row_ptr[m] - \p csr_row_ptr[0] ) non-zero
+  !>   elements of matrix \p A.
+  !>   @param[in] csr_row_ptr - integer array of \p m+1 elements that contains the start of every
+  !>   row and the end of the last row plus one.
+  !>   @param[in] csr_col_ind - integer array of nnz ( = \p csr_row_ptr[m] - \p csr_row_ptr[0] )
+  !>   column indices of the non-zero elements of matrix \p A.
+  !>   @param[in] myInfo - prune  information structure.
+  !>   @param[out] buffer_size - number of bytes of the temporary storage buffer required by
   !>               \ref rocsparse_sprune_dense2csr_nnz_by_percentage
   !>               "rocsparse_Xprune_dense2csr_nnz_by_percentage()" and
   !>               \ref rocsparse_sprune_dense2csr_by_percentage
@@ -11394,29 +10534,19 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle                 handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m                      number of rows of the dense matrix \p A.
-  !>   @param[in]
-  !>   n                      number of columns of the dense matrix \p A.
-  !>   @param[in]
-  !>   A                      array of dimensions (\p lda, \p n).
-  !>   @param[in]
-  !>   lda                    leading dimension of dense array \p A.
-  !>   @param[in]
-  !>   percentage             \p percentage>=0 and \p percentage<=100.
-  !>   @param[in]
-  !>   descr                  the descriptor of the dense matrix \p A.
-  !>   @param[out]
-  !>   csr_row_ptr integer array of \p m+1 elements that contains the start of every row and the end
-  !>   of the last row plus one.
-  !>   @param[out]
-  !>   nnz_total_dev_host_ptr total number of non-zero elements in device or host memory.
-  !>   @param[in]
-  !>   info prune             information structure.
-  !>   @param[out]
-  !>   temp_buffer            buffer allocated by the user. Its size is determined by calling
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - number of rows of the dense matrix \p A.
+  !>   @param[in] n - number of columns of the dense matrix \p A.
+  !>   @param[in] A - array of dimensions (\p lda, \p n).
+  !>   @param[in] lda - leading dimension of dense array \p A.
+  !>   @param[in] percentage - \p percentage>=0 and \p percentage<=100.
+  !>   @param[in] descr - the descriptor of the dense matrix \p A.
+  !>   @param[out] csr_row_ptr - integer array of \p m+1 elements that contains the start of every
+  !>   row and the end of the last row plus one.
+  !>   @param[out] nnz_total_dev_host_ptr - total number of non-zero elements in device or host
+  !>   memory.
+  !>   @param[in] myInfo - prune             information structure.
+  !>   @param[out] temp_buffer - buffer allocated by the user. Its size is determined by calling
   !>                          \ref rocsparse_sprune_dense2csr_by_percentage_buffer_size
   !>                          "rocsparse_Xprune_dense2csr_by_percentage_buffer_size()".
   !>
@@ -11535,35 +10665,24 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m           number of rows of the dense matrix \p A.
-  !>   @param[in]
-  !>   n           number of columns of the dense matrix \p A.
-  !>   @param[in]
-  !>   A           array of dimensions (\p lda, \p n).
-  !>   @param[in]
-  !>   lda         leading dimension of dense array \p A.
-  !>   @param[in]
-  !>   percentage  \p percentage>=0 and \p percentage<=100.
-  !>   @param[in]
-  !>   descr the descriptor of the dense matrix \p A. The supported matrix type is
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - number of rows of the dense matrix \p A.
+  !>   @param[in] n - number of columns of the dense matrix \p A.
+  !>   @param[in] A - array of dimensions (\p lda, \p n).
+  !>   @param[in] lda - leading dimension of dense array \p A.
+  !>   @param[in] percentage - \p percentage>=0 and \p percentage<=100.
+  !>   @param[in] descr - the descriptor of the dense matrix \p A. The supported matrix type is
   !>   `rocsparse_matrix_type_general` and
   !>               also any valid value of the `rocsparse_index_base`.
-  !>   @param[out]
-  !>   csr_val array of nnz ( = \p csr_row_ptr[m] - \p csr_row_ptr[0] ) non-zero elements of matrix
-  !>   \p A.
-  !>   @param[in]
-  !>   csr_row_ptr integer array of \p m+1 elements that contains the start of every row and the end
-  !>   of the last row plus one.
-  !>   @param[out]
-  !>   csr_col_ind integer array of nnz ( = \p csr_row_ptr[m] - \p csr_row_ptr[0] ) column indices
-  !>   of the non-zero elements of matrix \p A.
-  !>   @param[in]
-  !>   info prune  information structure.
-  !>   @param[in]
-  !>   temp_buffer temporary storage buffer allocated by the user. The size is returned by
+  !>   @param[out] csr_val - array of nnz ( = \p csr_row_ptr[m] - \p csr_row_ptr[0] ) non-zero
+  !>   elements of matrix \p A.
+  !>   @param[in] csr_row_ptr - integer array of \p m+1 elements that contains the start of every
+  !>   row and the end of the last row plus one.
+  !>   @param[out] csr_col_ind - integer array of nnz ( = \p csr_row_ptr[m] - \p csr_row_ptr[0] )
+  !>   column indices of the non-zero elements of matrix \p A.
+  !>   @param[in] myInfo - prune  information structure.
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user. The size is returned
+  !>   by
   !>               \ref rocsparse_sprune_dense2csr_by_percentage_buffer_size
   !>               "rocsparse_Xprune_dense2csr_by_percentage_buffer_size()".
   !>
@@ -11650,51 +10769,39 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle          handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   dir direction that specifies whether to count non-zero elements by `rocsparse_direction_row`
-  !>   or by
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] dir - direction that specifies whether to count non-zero elements by
+  !>   `rocsparse_direction_row` or by
   !>                   `rocsparse_direction_column` in the BSR matrices \f$A\f$, \f$B\f$, and
   !>                   \f$C\f$.
-  !>   @param[in]
-  !>   mb              number of block rows in the sparse BSR matrix \f$op(A)\f$ and \f$C\f$.
-  !>   @param[in]
-  !>   nb              number of block columns of the sparse BSR matrix \f$op(B)\f$ and
+  !>   @param[in] mb - number of block rows in the sparse BSR matrix \f$op(A)\f$ and \f$C\f$.
+  !>   @param[in] nb - number of block columns of the sparse BSR matrix \f$op(B)\f$ and
   !>                   \f$C\f$.
-  !>   @param[in]
-  !>   block_dim the block dimension of the BSR matrix \f$A\f$. Between 1 and m where \p
-  !>   m=mb*block_dim.
-  !>   @param[in]
-  !>   descr_A         descriptor of the sparse BSR matrix \f$A\f$. Currently, only
+  !>   @param[in] block_dim - the block dimension of the BSR matrix \f$A\f$. Between 1 and m where
+  !>   \p m=mb*block_dim.
+  !>   @param[in] descr_A - descriptor of the sparse BSR matrix \f$A\f$. Currently, only
   !>                   `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   nnzb_A          number of non-zero block entries of the sparse BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   bsr_row_ptr_A   array of \p mb+1 elements that point to the start of every block row of the
+  !>   @param[in] nnzb_A - number of non-zero block entries of the sparse BSR matrix \f$A\f$.
+  !>   @param[in] bsr_row_ptr_A - array of \p mb+1 elements that point to the start of every block
+  !>   row of the
   !>                   sparse BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   bsr_col_ind_A   array of \p nnzb_A elements containing the column indices of the
+  !>   @param[in] bsr_col_ind_A - array of \p nnzb_A elements containing the column indices of the
   !>                   sparse BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   descr_B         descriptor of the sparse BSR matrix \f$B\f$. Currently, only
+  !>   @param[in] descr_B - descriptor of the sparse BSR matrix \f$B\f$. Currently, only
   !>                   `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   nnzb_B          number of non-zero block entries of the sparse BSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   bsr_row_ptr_B   array of \p mb+1 elements that point to the start of every block row of the
+  !>   @param[in] nnzb_B - number of non-zero block entries of the sparse BSR matrix \f$B\f$.
+  !>   @param[in] bsr_row_ptr_B - array of \p mb+1 elements that point to the start of every block
+  !>   row of the
   !>                   sparse BSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   bsr_col_ind_B   array of \p nnzb_B elements containing the block column indices of the
+  !>   @param[in] bsr_col_ind_B - array of \p nnzb_B elements containing the block column indices of
+  !>   the
   !>                   sparse BSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   descr_C         descriptor of the sparse BSR matrix \f$C\f$. Currently, only
+  !>   @param[in] descr_C - descriptor of the sparse BSR matrix \f$C\f$. Currently, only
   !>                   `rocsparse_matrix_type_general` is supported.
-  !>   @param[out]
-  !>   bsr_row_ptr_C   array of \p mb+1 elements that point to the start of every block row of the
+  !>   @param[out] bsr_row_ptr_C - array of \p mb+1 elements that point to the start of every block
+  !>   row of the
   !>                   sparse BSR matrix \f$C\f$.
-  !>   @param[out]
-  !>   nnzb_C          pointer to the number of non-zero block entries of the sparse BSR
+  !>   @param[out] nnzb_C - pointer to the number of non-zero block entries of the sparse BSR
   !>                   matrix \f$C\f$. \p nnzb_C can be a host or device pointer.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
@@ -11761,63 +10868,45 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle          handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   dir direction that specifies whether to count non-zero elements by `rocsparse_direction_row`
-  !>   or by
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] dir - direction that specifies whether to count non-zero elements by
+  !>   `rocsparse_direction_row` or by
   !>                   `rocsparse_direction_column` in the BSR matrices \f$A\f$, \f$B\f$, and
   !>                   \f$C\f$.
-  !>   @param[in]
-  !>   mb               number of rows of the sparse BSR matrix \f$A\f$, \f$B\f$, and \f$C\f$.
-  !>   @param[in]
-  !>   nb               number of columns of the sparse BSR matrix \f$A\f$, \f$B\f$, and \f$C\f$.
-  !>   @param[in]
-  !>   block_dim the block dimension of the BSR matrix \f$A\f$. Between 1 and m where \p
-  !>   m=mb*block_dim.
-  !>   @param[in]
-  !>   alpha           scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   descr_A         descriptor of the sparse CSR matrix \f$A\f$. Currently, only
+  !>   @param[in] mb - number of rows of the sparse BSR matrix \f$A\f$, \f$B\f$, and \f$C\f$.
+  !>   @param[in] nb - number of columns of the sparse BSR matrix \f$A\f$, \f$B\f$, and \f$C\f$.
+  !>   @param[in] block_dim - the block dimension of the BSR matrix \f$A\f$. Between 1 and m where
+  !>   \p m=mb*block_dim.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] descr_A - descriptor of the sparse CSR matrix \f$A\f$. Currently, only
   !>                   `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   nnzb_A           number of non-zero block entries of the sparse BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   bsr_val_A       array of \p nnzb_A block elements of the sparse BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   bsr_row_ptr_A array of \p mb+1 block elements that point to the start of every block row of
-  !>   the
+  !>   @param[in] nnzb_A - number of non-zero block entries of the sparse BSR matrix \f$A\f$.
+  !>   @param[in] bsr_val_A - array of \p nnzb_A block elements of the sparse BSR matrix \f$A\f$.
+  !>   @param[in] bsr_row_ptr_A - array of \p mb+1 block elements that point to the start of every
+  !>   block row of the
   !>                   sparse BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   bsr_col_ind_A   array of \p nnzb_A block elements containing the block column indices of the
+  !>   @param[in] bsr_col_ind_A - array of \p nnzb_A block elements containing the block column
+  !>   indices of the
   !>                   sparse BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   beta            scalar \f$\beta\f$.
-  !>   @param[in]
-  !>   descr_B         descriptor of the sparse BSR matrix \f$B\f$. Currently, only
+  !>   @param[in] beta - scalar \f$\beta\f$.
+  !>   @param[in] descr_B - descriptor of the sparse BSR matrix \f$B\f$. Currently, only
   !>                   `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   nnzb_B          number of non-zero block entries of the sparse BSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   bsr_val_B       array of \p nnzb_B block elements of the sparse BSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   bsr_row_ptr_B array of \p mb+1 block elements that point to the start of every block row of
-  !>   the
+  !>   @param[in] nnzb_B - number of non-zero block entries of the sparse BSR matrix \f$B\f$.
+  !>   @param[in] bsr_val_B - array of \p nnzb_B block elements of the sparse BSR matrix \f$B\f$.
+  !>   @param[in] bsr_row_ptr_B - array of \p mb+1 block elements that point to the start of every
+  !>   block row of the
   !>                   sparse BSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   bsr_col_ind_B   array of \p nnzb_B block elements containing the block column indices of the
+  !>   @param[in] bsr_col_ind_B - array of \p nnzb_B block elements containing the block column
+  !>   indices of the
   !>                   sparse BSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   descr_C         descriptor of the sparse BSR matrix \f$C\f$. Currently, only
+  !>   @param[in] descr_C - descriptor of the sparse BSR matrix \f$C\f$. Currently, only
   !>                   `rocsparse_matrix_type_general` is supported.
-  !>   @param[out]
-  !>   bsr_val_C       array of block elements of the sparse BSR matrix \f$C\f$.
-  !>   @param[in]
-  !>   bsr_row_ptr_C array of \p mb+1 block elements that point to the start of every block row of
-  !>   the
+  !>   @param[out] bsr_val_C - array of block elements of the sparse BSR matrix \f$C\f$.
+  !>   @param[in] bsr_row_ptr_C - array of \p mb+1 block elements that point to the start of every
+  !>   block row of the
   !>                   sparse BSR matrix \f$C\f$.
-  !>   @param[out]
-  !>   bsr_col_ind_C   array of block elements containing the block column indices of the
+  !>   @param[out] bsr_col_ind_C - array of block elements containing the block column indices of
+  !>   the
   !>                   sparse BSR matrix \f$C\f$.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
@@ -11981,70 +11070,51 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle          handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   dir direction that specifies whether to count non-zero elements by `rocsparse_direction_row`
-  !>   or by
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] dir - direction that specifies whether to count non-zero elements by
+  !>   `rocsparse_direction_row` or by
   !>                   `rocsparse_direction_column` in the BSR matrices \f$A\f$, \f$B\f$, \f$C\f$,
   !>                   and \f$D\f$.
-  !>   @param[in]
-  !>   trans_A         matrix \f$A\f$ operation type.
-  !>   @param[in]
-  !>   trans_B         matrix \f$B\f$ operation type.
-  !>   @param[in]
-  !>   mb              number of block rows in the sparse BSR matrix \f$op(A)\f$ and \f$C\f$.
-  !>   @param[in]
-  !>   nb              number of block columns of the sparse BSR matrix \f$op(B)\f$ and
+  !>   @param[in] trans_A - matrix \f$A\f$ operation type.
+  !>   @param[in] trans_B - matrix \f$B\f$ operation type.
+  !>   @param[in] mb - number of block rows in the sparse BSR matrix \f$op(A)\f$ and \f$C\f$.
+  !>   @param[in] nb - number of block columns of the sparse BSR matrix \f$op(B)\f$ and
   !>                   \f$C\f$.
-  !>   @param[in]
-  !>   kb              number of block columns of the sparse BSR matrix \f$op(A)\f$ and number of
+  !>   @param[in] kb - number of block columns of the sparse BSR matrix \f$op(A)\f$ and number of
   !>                   rows of the sparse BSR matrix \f$op(B)\f$.
-  !>   @param[in]
-  !>   block_dim       the block dimension of the BSR matrix \f$A\f$, \f$B\f$, \f$C\f$, and \f$D\f$.
-  !>   @param[in]
-  !>   alpha           scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   descr_A         descriptor of the sparse BSR matrix \f$A\f$. Currently, only
+  !>   @param[in] block_dim - the block dimension of the BSR matrix \f$A\f$, \f$B\f$, \f$C\f$, and
+  !>   \f$D\f$.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] descr_A - descriptor of the sparse BSR matrix \f$A\f$. Currently, only
   !>                   `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   nnzb_A          number of non-zero block entries of the sparse BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   bsr_row_ptr_A   array of \p mb+1 elements (\f$op(A) == A\f$, \p kb+1 otherwise)
+  !>   @param[in] nnzb_A - number of non-zero block entries of the sparse BSR matrix \f$A\f$.
+  !>   @param[in] bsr_row_ptr_A - array of \p mb+1 elements (\f$op(A) == A\f$, \p kb+1 otherwise)
   !>                   that point to the start of every block row of the sparse BSR matrix
   !>                   \f$op(A)\f$.
-  !>   @param[in]
-  !>   bsr_col_ind_A   array of \p nnzb_A elements containing the block column indices of the
+  !>   @param[in] bsr_col_ind_A - array of \p nnzb_A elements containing the block column indices of
+  !>   the
   !>                   sparse BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   descr_B         descriptor of the sparse BSR matrix \f$B\f$. Currently, only
+  !>   @param[in] descr_B - descriptor of the sparse BSR matrix \f$B\f$. Currently, only
   !>                   `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   nnzb_B          number of non-zero block entries of the sparse BSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   bsr_row_ptr_B   array of \p kb+1 elements (\f$op(B) == B\f$, \p mb+1 otherwise)
+  !>   @param[in] nnzb_B - number of non-zero block entries of the sparse BSR matrix \f$B\f$.
+  !>   @param[in] bsr_row_ptr_B - array of \p kb+1 elements (\f$op(B) == B\f$, \p mb+1 otherwise)
   !>                   that point to the start of every block row of the sparse BSR matrix
   !>                   \f$op(B)\f$.
-  !>   @param[in]
-  !>   bsr_col_ind_B   array of \p nnzb_B elements containing the block column indices of the
+  !>   @param[in] bsr_col_ind_B - array of \p nnzb_B elements containing the block column indices of
+  !>   the
   !>                   sparse BSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   beta            scalar \f$\beta\f$.
-  !>   @param[in]
-  !>   descr_D         descriptor of the sparse BSR matrix \f$D\f$. Currently, only
+  !>   @param[in] beta - scalar \f$\beta\f$.
+  !>   @param[in] descr_D - descriptor of the sparse BSR matrix \f$D\f$. Currently, only
   !>                   `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   nnzb_D          number of non-zero block entries of the sparse BSR matrix \f$D\f$.
-  !>   @param[in]
-  !>   bsr_row_ptr_D   array of \p mb+1 elements that point to the start of every block row of the
+  !>   @param[in] nnzb_D - number of non-zero block entries of the sparse BSR matrix \f$D\f$.
+  !>   @param[in] bsr_row_ptr_D - array of \p mb+1 elements that point to the start of every block
+  !>   row of the
   !>                   sparse BSR matrix \f$D\f$.
-  !>   @param[in]
-  !>   bsr_col_ind_D   array of \p nnzb_D elements containing the block column indices of the sparse
+  !>   @param[in] bsr_col_ind_D - array of \p nnzb_D elements containing the block column indices of
+  !>   the sparse
   !>                   BSR matrix \f$D\f$.
-  !>   @param[inout]
-  !>   info_C          structure that holds metadata for the sparse BSR matrix \f$C\f$.
-  !>   @param[out]
-  !>   buffer_size     number of bytes of the temporary storage buffer required by
+  !>   @param[inout] info_C - structure that holds metadata for the sparse BSR matrix \f$C\f$.
+  !>   @param[out] buffer_size - number of bytes of the temporary storage buffer required by
   !>                   `rocsparse_bsrgemm_nnzb()`, rocsparse_sbsrgemm(), rocsparse_dbsrgemm(),
   !>                   rocsparse_cbsrgemm(), and rocsparse_zbsrgemm().
   !>
@@ -12226,78 +11296,58 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle          handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   dir direction that specifies whether to count non-zero elements by `rocsparse_direction_row`
-  !>   or by
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] dir - direction that specifies whether to count non-zero elements by
+  !>   `rocsparse_direction_row` or by
   !>                   `rocsparse_direction_column` in the BSR matrices \f$A\f$, \f$B\f$, \f$C\f$,
   !>                   and \f$D\f$.
-  !>   @param[in]
-  !>   trans_A         matrix \f$A\f$ operation type.
-  !>   @param[in]
-  !>   trans_B         matrix \f$B\f$ operation type.
-  !>   @param[in]
-  !>   mb              number of block rows in the sparse BSR matrix \f$op(A)\f$ and \f$C\f$.
-  !>   @param[in]
-  !>   nb              number of block columns of the sparse BSR matrix \f$op(B)\f$ and
+  !>   @param[in] trans_A - matrix \f$A\f$ operation type.
+  !>   @param[in] trans_B - matrix \f$B\f$ operation type.
+  !>   @param[in] mb - number of block rows in the sparse BSR matrix \f$op(A)\f$ and \f$C\f$.
+  !>   @param[in] nb - number of block columns of the sparse BSR matrix \f$op(B)\f$ and
   !>                   \f$C\f$.
-  !>   @param[in]
-  !>   kb              number of block columns of the sparse BSR matrix \f$op(A)\f$ and number of
+  !>   @param[in] kb - number of block columns of the sparse BSR matrix \f$op(A)\f$ and number of
   !>                   rows of the sparse BSR matrix \f$op(B)\f$.
-  !>   @param[in]
-  !>   block_dim       the block dimension of the BSR matrix \f$A\f$, \f$B\f$, \f$C\f$, and \f$D\f$.
-  !>   @param[in]
-  !>   descr_A         descriptor of the sparse BSR matrix \f$A\f$. Currently, only
+  !>   @param[in] block_dim - the block dimension of the BSR matrix \f$A\f$, \f$B\f$, \f$C\f$, and
+  !>   \f$D\f$.
+  !>   @param[in] descr_A - descriptor of the sparse BSR matrix \f$A\f$. Currently, only
   !>                   `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   nnzb_A          number of non-zero block entries of the sparse BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   bsr_row_ptr_A   array of \p mb+1 block elements (\f$op(A) == A\f$, \p kb+1 otherwise)
+  !>   @param[in] nnzb_A - number of non-zero block entries of the sparse BSR matrix \f$A\f$.
+  !>   @param[in] bsr_row_ptr_A - array of \p mb+1 block elements (\f$op(A) == A\f$, \p kb+1
+  !>   otherwise)
   !>                   that point to the start of every row of the sparse BSR matrix
   !>                   \f$op(A)\f$.
-  !>   @param[in]
-  !>   bsr_col_ind_A   array of \p nnzb_A block elements containing the block column indices of the
+  !>   @param[in] bsr_col_ind_A - array of \p nnzb_A block elements containing the block column
+  !>   indices of the
   !>                   sparse BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   descr_B         descriptor of the sparse BSR matrix \f$B\f$. Currently, only
+  !>   @param[in] descr_B - descriptor of the sparse BSR matrix \f$B\f$. Currently, only
   !>                   `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   nnzb_B          number of non-zero block entries of the sparse BSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   bsr_row_ptr_B   array of \p kb+1 block elements (\f$op(B) == B\f$, \p mb+1 otherwise)
+  !>   @param[in] nnzb_B - number of non-zero block entries of the sparse BSR matrix \f$B\f$.
+  !>   @param[in] bsr_row_ptr_B - array of \p kb+1 block elements (\f$op(B) == B\f$, \p mb+1
+  !>   otherwise)
   !>                   that point to the start of every block row of the sparse BSR matrix
   !>                   \f$op(B)\f$.
-  !>   @param[in]
-  !>   bsr_col_ind_B   array of \p nnzb_B block elements containing the block column indices of the
+  !>   @param[in] bsr_col_ind_B - array of \p nnzb_B block elements containing the block column
+  !>   indices of the
   !>                   sparse BSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   descr_D         descriptor of the sparse BSR matrix \f$D\f$. Currently, only
+  !>   @param[in] descr_D - descriptor of the sparse BSR matrix \f$D\f$. Currently, only
   !>                   `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   nnzb_D          number of non-zero block entries of the sparse BSR matrix \f$D\f$.
-  !>   @param[in]
-  !>   bsr_row_ptr_D array of \p mb+1 block elements that point to the start of every block row of
-  !>   the
+  !>   @param[in] nnzb_D - number of non-zero block entries of the sparse BSR matrix \f$D\f$.
+  !>   @param[in] bsr_row_ptr_D - array of \p mb+1 block elements that point to the start of every
+  !>   block row of the
   !>                   sparse BSR matrix \f$D\f$.
-  !>   @param[in]
-  !>   bsr_col_ind_D array of \p nnzb_D block elements containing the block column indices of the
-  !>   sparse
+  !>   @param[in] bsr_col_ind_D - array of \p nnzb_D block elements containing the block column
+  !>   indices of the sparse
   !>                   BSR matrix \f$D\f$.
-  !>   @param[in]
-  !>   descr_C         descriptor of the sparse BSR matrix \f$C\f$. Currently, only
+  !>   @param[in] descr_C - descriptor of the sparse BSR matrix \f$C\f$. Currently, only
   !>                   `rocsparse_matrix_type_general` is supported.
-  !>   @param[out]
-  !>   bsr_row_ptr_C array of \p mb+1 block elements that point to the start of every block row of
-  !>   the
+  !>   @param[out] bsr_row_ptr_C - array of \p mb+1 block elements that point to the start of every
+  !>   block row of the
   !>                   sparse BSR matrix \f$C\f$.
-  !>   @param[out]
-  !>   nnzb_C          pointer to the number of non-zero block entries of the sparse BSR
+  !>   @param[out] nnzb_C - pointer to the number of non-zero block entries of the sparse BSR
   !>                   matrix \f$C\f$.
-  !>   @param[in]
-  !>   info_C          structure that holds metadata for the sparse BSR matrix \f$C\f$.
-  !>   @param[in]
-  !>   temp_buffer     temporary storage buffer allocated by the user. The size is returned
+  !>   @param[in] info_C - structure that holds metadata for the sparse BSR matrix \f$C\f$.
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user. The size is returned
   !>                   by rocsparse_sbsrgemm_buffer_size(),
   !>                   rocsparse_dbsrgemm_buffer_size(), rocsparse_cbsrgemm_buffer_size(), or
   !>                   rocsparse_zbsrgemm_buffer_size().
@@ -12409,89 +11459,65 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle          handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   dir direction that specifies whether to count non-zero elements by `rocsparse_direction_row`
-  !>   or by
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] dir - direction that specifies whether to count non-zero elements by
+  !>   `rocsparse_direction_row` or by
   !>                   `rocsparse_direction_column` in the BSR matrices \f$A\f$, \f$B\f$, \f$C\f$,
   !>                   and \f$D\f$.
-  !>   @param[in]
-  !>   trans_A         matrix \f$A\f$ operation type.
-  !>   @param[in]
-  !>   trans_B         matrix \f$B\f$ operation type.
-  !>   @param[in]
-  !>   mb              number of block rows of the sparse BSR matrix \f$op(A)\f$ and \f$C\f$.
-  !>   @param[in]
-  !>   nb              number of block columns of the sparse BSR matrix \f$op(B)\f$ and
+  !>   @param[in] trans_A - matrix \f$A\f$ operation type.
+  !>   @param[in] trans_B - matrix \f$B\f$ operation type.
+  !>   @param[in] mb - number of block rows of the sparse BSR matrix \f$op(A)\f$ and \f$C\f$.
+  !>   @param[in] nb - number of block columns of the sparse BSR matrix \f$op(B)\f$ and
   !>                   \f$C\f$.
-  !>   @param[in]
-  !>   kb              number of block columns of the sparse BSR matrix \f$op(A)\f$ and number of
+  !>   @param[in] kb - number of block columns of the sparse BSR matrix \f$op(A)\f$ and number of
   !>                   block rows of the sparse BSR matrix \f$op(B)\f$.
-  !>   @param[in]
-  !>   block_dim       the block dimension of the BSR matrix \f$A\f$, \f$B\f$, \f$C\f$, and \f$D\f$.
-  !>   @param[in]
-  !>   alpha           scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   descr_A         descriptor of the sparse BSR matrix \f$A\f$. Currently, only
+  !>   @param[in] block_dim - the block dimension of the BSR matrix \f$A\f$, \f$B\f$, \f$C\f$, and
+  !>   \f$D\f$.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] descr_A - descriptor of the sparse BSR matrix \f$A\f$. Currently, only
   !>                   `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   nnzb_A          number of non-zero block entries of the sparse BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   bsr_val_A       array of \p nnzb_A block elements of the sparse BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   bsr_row_ptr_A   array of \p mb+1 block elements (\f$op(A) == A\f$, \p kb+1 otherwise)
+  !>   @param[in] nnzb_A - number of non-zero block entries of the sparse BSR matrix \f$A\f$.
+  !>   @param[in] bsr_val_A - array of \p nnzb_A block elements of the sparse BSR matrix \f$A\f$.
+  !>   @param[in] bsr_row_ptr_A - array of \p mb+1 block elements (\f$op(A) == A\f$, \p kb+1
+  !>   otherwise)
   !>                   that point to the start of every block row of the sparse BSR matrix
   !>                   \f$op(A)\f$.
-  !>   @param[in]
-  !>   bsr_col_ind_A   array of \p nnzb_A block elements containing the block column indices of the
+  !>   @param[in] bsr_col_ind_A - array of \p nnzb_A block elements containing the block column
+  !>   indices of the
   !>                   sparse BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   descr_B         descriptor of the sparse BSR matrix \f$B\f$. Currently, only
+  !>   @param[in] descr_B - descriptor of the sparse BSR matrix \f$B\f$. Currently, only
   !>                   `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   nnzb_B          number of non-zero block entries of the sparse BSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   bsr_val_B       array of \p nnzb_B block elements of the sparse BSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   bsr_row_ptr_B   array of \p kb+1 block elements (\f$op(B) == B\f$, \p mb+1 otherwise)
+  !>   @param[in] nnzb_B - number of non-zero block entries of the sparse BSR matrix \f$B\f$.
+  !>   @param[in] bsr_val_B - array of \p nnzb_B block elements of the sparse BSR matrix \f$B\f$.
+  !>   @param[in] bsr_row_ptr_B - array of \p kb+1 block elements (\f$op(B) == B\f$, \p mb+1
+  !>   otherwise)
   !>                   that point to the start of every block row of the sparse BSR matrix
   !>                   \f$op(B)\f$.
-  !>   @param[in]
-  !>   bsr_col_ind_B   array of \p nnzb_B block elements containing the block column indices of the
+  !>   @param[in] bsr_col_ind_B - array of \p nnzb_B block elements containing the block column
+  !>   indices of the
   !>                   sparse BSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   beta            scalar \f$\beta\f$.
-  !>   @param[in]
-  !>   descr_D         descriptor of the sparse BSR matrix \f$D\f$. Currently, only
+  !>   @param[in] beta - scalar \f$\beta\f$.
+  !>   @param[in] descr_D - descriptor of the sparse BSR matrix \f$D\f$. Currently, only
   !>                   `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   nnzb_D          number of non-zero block entries of the sparse BSR matrix \f$D\f$.
-  !>   @param[in]
-  !>   bsr_val_D       array of \p nnzb_D block elements of the sparse BSR matrix \f$D\f$.
-  !>   @param[in]
-  !>   bsr_row_ptr_D array of \p mb+1 block elements that point to the start of every block row of
-  !>   the
+  !>   @param[in] nnzb_D - number of non-zero block entries of the sparse BSR matrix \f$D\f$.
+  !>   @param[in] bsr_val_D - array of \p nnzb_D block elements of the sparse BSR matrix \f$D\f$.
+  !>   @param[in] bsr_row_ptr_D - array of \p mb+1 block elements that point to the start of every
+  !>   block row of the
   !>                   sparse BSR matrix \f$D\f$.
-  !>   @param[in]
-  !>   bsr_col_ind_D   array of \p nnzb_D block elements containing the block column indices of the
+  !>   @param[in] bsr_col_ind_D - array of \p nnzb_D block elements containing the block column
+  !>   indices of the
   !>                   sparse BSR matrix \f$D\f$.
-  !>   @param[in]
-  !>   descr_C         descriptor of the sparse BSR matrix \f$C\f$. Currently, only
+  !>   @param[in] descr_C - descriptor of the sparse BSR matrix \f$C\f$. Currently, only
   !>                   `rocsparse_matrix_type_general` is supported.
-  !>   @param[out]
-  !>   bsr_val_C       array of \p nnzb_C elements of the sparse BSR matrix \f$C\f$.
-  !>   @param[in]
-  !>   bsr_row_ptr_C array of \p mb+1 block elements that point to the start of every block row of
-  !>   the
+  !>   @param[out] bsr_val_C - array of \p nnzb_C elements of the sparse BSR matrix \f$C\f$.
+  !>   @param[in] bsr_row_ptr_C - array of \p mb+1 block elements that point to the start of every
+  !>   block row of the
   !>                   sparse BSR matrix \f$C\f$.
-  !>   @param[out]
-  !>   bsr_col_ind_C   array of \p nnzb_C block elements containing the block column indices of the
+  !>   @param[out] bsr_col_ind_C - array of \p nnzb_C block elements containing the block column
+  !>   indices of the
   !>                   sparse BSR matrix \f$C\f$.
-  !>   @param[in]
-  !>   info_C          structure that holds metadata for the sparse BSR matrix \f$C\f$.
-  !>   @param[in]
-  !>   temp_buffer     temporary storage buffer allocated by the user. The size is returned
+  !>   @param[in] info_C - structure that holds metadata for the sparse BSR matrix \f$C\f$.
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user. The size is returned
   !>                   by rocsparse_sbsrgemm_buffer_size(),
   !>                   rocsparse_dbsrgemm_buffer_size(), rocsparse_cbsrgemm_buffer_size(), or
   !>                   rocsparse_zbsrgemm_buffer_size().
@@ -12709,42 +11735,31 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle          handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m               number of rows of the sparse CSR matrix \f$A\f$, \f$B\f$, and \f$C\f$.
-  !>   @param[in]
-  !>   n               number of columns of the sparse CSR matrix \f$A\f$, \f$B\f$, and \f$C\f$.
-  !>   @param[in]
-  !>   descr_A         descriptor of the sparse CSR matrix \f$A\f$. Currently, only
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse CSR matrix \f$A\f$, \f$B\f$, and \f$C\f$.
+  !>   @param[in] n - number of columns of the sparse CSR matrix \f$A\f$, \f$B\f$, and \f$C\f$.
+  !>   @param[in] descr_A - descriptor of the sparse CSR matrix \f$A\f$. Currently, only
   !>                   `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   nnz_A           number of non-zero entries of the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csr_row_ptr_A   array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] nnz_A - number of non-zero entries of the sparse CSR matrix \f$A\f$.
+  !>   @param[in] csr_row_ptr_A - array of \p m+1 elements that point to the start of every row of
+  !>   the
   !>                   sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csr_col_ind_A   array of \p nnz_A elements containing the column indices of the
+  !>   @param[in] csr_col_ind_A - array of \p nnz_A elements containing the column indices of the
   !>                   sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   descr_B         descriptor of the sparse CSR matrix \f$B\f$. Currently, only
+  !>   @param[in] descr_B - descriptor of the sparse CSR matrix \f$B\f$. Currently, only
   !>                   `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   nnz_B           number of non-zero entries of the sparse CSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   csr_row_ptr_B   array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] nnz_B - number of non-zero entries of the sparse CSR matrix \f$B\f$.
+  !>   @param[in] csr_row_ptr_B - array of \p m+1 elements that point to the start of every row of
+  !>   the
   !>                   sparse CSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   csr_col_ind_B   array of \p nnz_B elements containing the column indices of the
+  !>   @param[in] csr_col_ind_B - array of \p nnz_B elements containing the column indices of the
   !>                   sparse CSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   descr_C         descriptor of the sparse CSR matrix \f$C\f$. Currently, only
+  !>   @param[in] descr_C - descriptor of the sparse CSR matrix \f$C\f$. Currently, only
   !>                   `rocsparse_matrix_type_general` is supported.
-  !>   @param[out]
-  !>   csr_row_ptr_C   array of \p m+1 elements that point to the start of every row of the
+  !>   @param[out] csr_row_ptr_C - array of \p m+1 elements that point to the start of every row of
+  !>   the
   !>                   sparse CSR matrix \f$C\f$.
-  !>   @param[out]
-  !>   nnz_C           pointer to the number of non-zero entries of the sparse CSR
+  !>   @param[out] nnz_C - pointer to the number of non-zero entries of the sparse CSR
   !>                   matrix \f$C\f$. \p nnz_C can be a host or device pointer.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
@@ -12814,52 +11829,36 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle          handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m               number of rows of the sparse CSR matrix \f$A\f$, \f$B\f$, and \f$C\f$.
-  !>   @param[in]
-  !>   n               number of columns of the sparse CSR matrix \f$A\f$, \f$B\f$, and \f$C\f$.
-  !>   @param[in]
-  !>   alpha           scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   descr_A         descriptor of the sparse CSR matrix \f$A\f$. Currently, only
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse CSR matrix \f$A\f$, \f$B\f$, and \f$C\f$.
+  !>   @param[in] n - number of columns of the sparse CSR matrix \f$A\f$, \f$B\f$, and \f$C\f$.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] descr_A - descriptor of the sparse CSR matrix \f$A\f$. Currently, only
   !>                   `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   nnz_A           number of non-zero entries of the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csr_val_A       array of \p nnz_A elements of the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csr_row_ptr_A   array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] nnz_A - number of non-zero entries of the sparse CSR matrix \f$A\f$.
+  !>   @param[in] csr_val_A - array of \p nnz_A elements of the sparse CSR matrix \f$A\f$.
+  !>   @param[in] csr_row_ptr_A - array of \p m+1 elements that point to the start of every row of
+  !>   the
   !>                   sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csr_col_ind_A   array of \p nnz_A elements containing the column indices of the
+  !>   @param[in] csr_col_ind_A - array of \p nnz_A elements containing the column indices of the
   !>                   sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   beta            scalar \f$\beta\f$.
-  !>   @param[in]
-  !>   descr_B         descriptor of the sparse CSR matrix \f$B\f$. Currently, only
+  !>   @param[in] beta - scalar \f$\beta\f$.
+  !>   @param[in] descr_B - descriptor of the sparse CSR matrix \f$B\f$. Currently, only
   !>                   `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   nnz_B           number of non-zero entries of the sparse CSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   csr_val_B       array of \p nnz_B elements of the sparse CSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   csr_row_ptr_B   array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] nnz_B - number of non-zero entries of the sparse CSR matrix \f$B\f$.
+  !>   @param[in] csr_val_B - array of \p nnz_B elements of the sparse CSR matrix \f$B\f$.
+  !>   @param[in] csr_row_ptr_B - array of \p m+1 elements that point to the start of every row of
+  !>   the
   !>                   sparse CSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   csr_col_ind_B   array of \p nnz_B elements containing the column indices of the
+  !>   @param[in] csr_col_ind_B - array of \p nnz_B elements containing the column indices of the
   !>                   sparse CSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   descr_C         descriptor of the sparse CSR matrix \f$C\f$. Currently, only
+  !>   @param[in] descr_C - descriptor of the sparse CSR matrix \f$C\f$. Currently, only
   !>                   `rocsparse_matrix_type_general` is supported.
-  !>   @param[out]
-  !>   csr_val_C       array of elements of the sparse CSR matrix \f$C\f$.
-  !>   @param[in]
-  !>   csr_row_ptr_C   array of \p m+1 elements that point to the start of every row of the
+  !>   @param[out] csr_val_C - array of elements of the sparse CSR matrix \f$C\f$.
+  !>   @param[in] csr_row_ptr_C - array of \p m+1 elements that point to the start of every row of
+  !>   the
   !>                   sparse CSR matrix \f$C\f$.
-  !>   @param[out]
-  !>   csr_col_ind_C   array of elements containing the column indices of the
+  !>   @param[out] csr_col_ind_C - array of elements containing the column indices of the
   !>                   sparse CSR matrix \f$C\f$.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
@@ -13043,63 +12042,43 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle          handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   trans_A         matrix \f$A\f$ operation type.
-  !>   @param[in]
-  !>   trans_B         matrix \f$B\f$ operation type.
-  !>   @param[in]
-  !>   m               number of rows of the sparse CSR matrix \f$op(A)\f$ and \f$C\f$.
-  !>   @param[in]
-  !>   n               number of columns of the sparse CSR matrix \f$op(B)\f$ and
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] trans_A - matrix \f$A\f$ operation type.
+  !>   @param[in] trans_B - matrix \f$B\f$ operation type.
+  !>   @param[in] m - number of rows of the sparse CSR matrix \f$op(A)\f$ and \f$C\f$.
+  !>   @param[in] n - number of columns of the sparse CSR matrix \f$op(B)\f$ and
   !>                   \f$C\f$.
-  !>   @param[in]
-  !>   k               number of columns of the sparse CSR matrix \f$op(A)\f$ and number of
+  !>   @param[in] k - number of columns of the sparse CSR matrix \f$op(A)\f$ and number of
   !>                   rows of the sparse CSR matrix \f$op(B)\f$.
-  !>   @param[in]
-  !>   alpha           scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   descr_A         descriptor of the sparse CSR matrix \f$A\f$. Currently, only
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] descr_A - descriptor of the sparse CSR matrix \f$A\f$. Currently, only
   !>                   `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   nnz_A           number of non-zero entries of the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csr_row_ptr_A   array of \p m+1 elements (\f$op(A) == A\f$, \p k+1 otherwise)
+  !>   @param[in] nnz_A - number of non-zero entries of the sparse CSR matrix \f$A\f$.
+  !>   @param[in] csr_row_ptr_A - array of \p m+1 elements (\f$op(A) == A\f$, \p k+1 otherwise)
   !>                   that point to the start of every row of the sparse CSR matrix
   !>                   \f$op(A)\f$.
-  !>   @param[in]
-  !>   csr_col_ind_A   array of \p nnz_A elements containing the column indices of the
+  !>   @param[in] csr_col_ind_A - array of \p nnz_A elements containing the column indices of the
   !>                   sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   descr_B         descriptor of the sparse CSR matrix \f$B\f$. Currently, only
+  !>   @param[in] descr_B - descriptor of the sparse CSR matrix \f$B\f$. Currently, only
   !>                   `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   nnz_B           number of non-zero entries of the sparse CSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   csr_row_ptr_B   array of \p k+1 elements (\f$op(B) == B\f$, \p m+1 otherwise)
+  !>   @param[in] nnz_B - number of non-zero entries of the sparse CSR matrix \f$B\f$.
+  !>   @param[in] csr_row_ptr_B - array of \p k+1 elements (\f$op(B) == B\f$, \p m+1 otherwise)
   !>                   that point to the start of every row of the sparse CSR matrix
   !>                   \f$op(B)\f$.
-  !>   @param[in]
-  !>   csr_col_ind_B   array of \p nnz_B elements containing the column indices of the
+  !>   @param[in] csr_col_ind_B - array of \p nnz_B elements containing the column indices of the
   !>                   sparse CSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   beta            scalar \f$\beta\f$.
-  !>   @param[in]
-  !>   descr_D         descriptor of the sparse CSR matrix \f$D\f$. Currently, only
+  !>   @param[in] beta - scalar \f$\beta\f$.
+  !>   @param[in] descr_D - descriptor of the sparse CSR matrix \f$D\f$. Currently, only
   !>                   `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   nnz_D           number of non-zero entries of the sparse CSR matrix \f$D\f$.
-  !>   @param[in]
-  !>   csr_row_ptr_D   array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] nnz_D - number of non-zero entries of the sparse CSR matrix \f$D\f$.
+  !>   @param[in] csr_row_ptr_D - array of \p m+1 elements that point to the start of every row of
+  !>   the
   !>                   sparse CSR matrix \f$D\f$.
-  !>   @param[in]
-  !>   csr_col_ind_D   array of \p nnz_D elements containing the column indices of the sparse
+  !>   @param[in] csr_col_ind_D - array of \p nnz_D elements containing the column indices of the
+  !>   sparse
   !>                   CSR matrix \f$D\f$.
-  !>   @param[inout]
-  !>   info_C          structure that holds metadata for the sparse CSR matrix \f$C\f$.
-  !>   @param[out]
-  !>   buffer_size     number of bytes of the temporary storage buffer required by
+  !>   @param[inout] info_C - structure that holds metadata for the sparse CSR matrix \f$C\f$.
+  !>   @param[out] buffer_size - number of bytes of the temporary storage buffer required by
   !>                   `rocsparse_csrgemm_nnz`() and \ref rocsparse_scsrgemm "rocsparse_Xcsrgemm()".
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
@@ -13305,68 +12284,48 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle          handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   trans_A         matrix \f$A\f$ operation type.
-  !>   @param[in]
-  !>   trans_B         matrix \f$B\f$ operation type.
-  !>   @param[in]
-  !>   m               number of rows of the sparse CSR matrix \f$op(A)\f$ and \f$C\f$.
-  !>   @param[in]
-  !>   n               number of columns of the sparse CSR matrix \f$op(B)\f$ and
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] trans_A - matrix \f$A\f$ operation type.
+  !>   @param[in] trans_B - matrix \f$B\f$ operation type.
+  !>   @param[in] m - number of rows of the sparse CSR matrix \f$op(A)\f$ and \f$C\f$.
+  !>   @param[in] n - number of columns of the sparse CSR matrix \f$op(B)\f$ and
   !>                   \f$C\f$.
-  !>   @param[in]
-  !>   k               number of columns of the sparse CSR matrix \f$op(A)\f$ and number of
+  !>   @param[in] k - number of columns of the sparse CSR matrix \f$op(A)\f$ and number of
   !>                   rows of the sparse CSR matrix \f$op(B)\f$.
-  !>   @param[in]
-  !>   descr_A         descriptor of the sparse CSR matrix \f$A\f$. Currently, only
+  !>   @param[in] descr_A - descriptor of the sparse CSR matrix \f$A\f$. Currently, only
   !>                   `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   nnz_A           number of non-zero entries of the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csr_row_ptr_A   array of \p m+1 elements (\f$op(A) == A\f$, \p k+1 otherwise)
+  !>   @param[in] nnz_A - number of non-zero entries of the sparse CSR matrix \f$A\f$.
+  !>   @param[in] csr_row_ptr_A - array of \p m+1 elements (\f$op(A) == A\f$, \p k+1 otherwise)
   !>                   that point to the start of every row of the sparse CSR matrix
   !>                   \f$op(A)\f$.
-  !>   @param[in]
-  !>   csr_col_ind_A   array of \p nnz_A elements containing the column indices of the
+  !>   @param[in] csr_col_ind_A - array of \p nnz_A elements containing the column indices of the
   !>                   sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   descr_B         descriptor of the sparse CSR matrix \f$B\f$. Currently, only
+  !>   @param[in] descr_B - descriptor of the sparse CSR matrix \f$B\f$. Currently, only
   !>                   `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   nnz_B           number of non-zero entries of the sparse CSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   csr_row_ptr_B   array of \p k+1 elements (\f$op(B) == B\f$, \p m+1 otherwise)
+  !>   @param[in] nnz_B - number of non-zero entries of the sparse CSR matrix \f$B\f$.
+  !>   @param[in] csr_row_ptr_B - array of \p k+1 elements (\f$op(B) == B\f$, \p m+1 otherwise)
   !>                   that point to the start of every row of the sparse CSR matrix
   !>                   \f$op(B)\f$.
-  !>   @param[in]
-  !>   csr_col_ind_B   array of \p nnz_B elements containing the column indices of the
+  !>   @param[in] csr_col_ind_B - array of \p nnz_B elements containing the column indices of the
   !>                   sparse CSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   descr_D         descriptor of the sparse CSR matrix \f$D\f$. Currently, only
+  !>   @param[in] descr_D - descriptor of the sparse CSR matrix \f$D\f$. Currently, only
   !>                   `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   nnz_D           number of non-zero entries of the sparse CSR matrix \f$D\f$.
-  !>   @param[in]
-  !>   csr_row_ptr_D   array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] nnz_D - number of non-zero entries of the sparse CSR matrix \f$D\f$.
+  !>   @param[in] csr_row_ptr_D - array of \p m+1 elements that point to the start of every row of
+  !>   the
   !>                   sparse CSR matrix \f$D\f$.
-  !>   @param[in]
-  !>   csr_col_ind_D   array of \p nnz_D elements containing the column indices of the sparse
+  !>   @param[in] csr_col_ind_D - array of \p nnz_D elements containing the column indices of the
+  !>   sparse
   !>                   CSR matrix \f$D\f$.
-  !>   @param[in]
-  !>   descr_C         descriptor of the sparse CSR matrix \f$C\f$. Currently, only
+  !>   @param[in] descr_C - descriptor of the sparse CSR matrix \f$C\f$. Currently, only
   !>                   `rocsparse_matrix_type_general` is supported.
-  !>   @param[out]
-  !>   csr_row_ptr_C   array of \p m+1 elements that point to the start of every row of the
+  !>   @param[out] csr_row_ptr_C - array of \p m+1 elements that point to the start of every row of
+  !>   the
   !>                   sparse CSR matrix \f$C\f$.
-  !>   @param[out]
-  !>   nnz_C           pointer to the number of non-zero entries of the sparse CSR
+  !>   @param[out] nnz_C - pointer to the number of non-zero entries of the sparse CSR
   !>                   matrix \f$C\f$.
-  !>   @param[in]
-  !>   info_C          structure that holds meta data for the sparse CSR matrix \f$C\f$.
-  !>   @param[in]
-  !>   temp_buffer     temporary storage buffer allocated by the user, size is returned
+  !>   @param[in] info_C - structure that holds meta data for the sparse CSR matrix \f$C\f$.
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user, size is returned
   !>                   by rocsparse_scsrgemm_buffer_size(),
   !>                   rocsparse_dcsrgemm_buffer_size(), rocsparse_ccsrgemm_buffer_size(), or
   !>                   rocsparse_zcsrgemm_buffer_size().
@@ -13490,80 +12449,53 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle          handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   trans_A         matrix \f$A\f$ operation type.
-  !>   @param[in]
-  !>   trans_B         matrix \f$B\f$ operation type.
-  !>   @param[in]
-  !>   m               number of rows of the sparse CSR matrix \f$op(A)\f$ and \f$C\f$.
-  !>   @param[in]
-  !>   n               number of columns of the sparse CSR matrix \f$op(B)\f$ and
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] trans_A - matrix \f$A\f$ operation type.
+  !>   @param[in] trans_B - matrix \f$B\f$ operation type.
+  !>   @param[in] m - number of rows of the sparse CSR matrix \f$op(A)\f$ and \f$C\f$.
+  !>   @param[in] n - number of columns of the sparse CSR matrix \f$op(B)\f$ and
   !>                   \f$C\f$.
-  !>   @param[in]
-  !>   k               number of columns of the sparse CSR matrix \f$op(A)\f$ and number of
+  !>   @param[in] k - number of columns of the sparse CSR matrix \f$op(A)\f$ and number of
   !>                   rows of the sparse CSR matrix \f$op(B)\f$.
-  !>   @param[in]
-  !>   alpha           scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   descr_A         descriptor of the sparse CSR matrix \f$A\f$. Currently, only
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] descr_A - descriptor of the sparse CSR matrix \f$A\f$. Currently, only
   !>                   `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   nnz_A           number of non-zero entries of the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csr_val_A       array of \p nnz_A elements of the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csr_row_ptr_A   array of \p m+1 elements (\f$op(A) == A\f$, \p k+1 otherwise)
+  !>   @param[in] nnz_A - number of non-zero entries of the sparse CSR matrix \f$A\f$.
+  !>   @param[in] csr_val_A - array of \p nnz_A elements of the sparse CSR matrix \f$A\f$.
+  !>   @param[in] csr_row_ptr_A - array of \p m+1 elements (\f$op(A) == A\f$, \p k+1 otherwise)
   !>                   that point to the start of every row of the sparse CSR matrix
   !>                   \f$op(A)\f$.
-  !>   @param[in]
-  !>   csr_col_ind_A   array of \p nnz_A elements containing the column indices of the
+  !>   @param[in] csr_col_ind_A - array of \p nnz_A elements containing the column indices of the
   !>                   sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   descr_B         descriptor of the sparse CSR matrix \f$B\f$. Currently, only
+  !>   @param[in] descr_B - descriptor of the sparse CSR matrix \f$B\f$. Currently, only
   !>                   `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   nnz_B           number of non-zero entries of the sparse CSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   csr_val_B       array of \p nnz_B elements of the sparse CSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   csr_row_ptr_B   array of \p k+1 elements (\f$op(B) == B\f$, \p m+1 otherwise)
+  !>   @param[in] nnz_B - number of non-zero entries of the sparse CSR matrix \f$B\f$.
+  !>   @param[in] csr_val_B - array of \p nnz_B elements of the sparse CSR matrix \f$B\f$.
+  !>   @param[in] csr_row_ptr_B - array of \p k+1 elements (\f$op(B) == B\f$, \p m+1 otherwise)
   !>                   that point to the start of every row of the sparse CSR matrix
   !>                   \f$op(B)\f$.
-  !>   @param[in]
-  !>   csr_col_ind_B   array of \p nnz_B elements containing the column indices of the
+  !>   @param[in] csr_col_ind_B - array of \p nnz_B elements containing the column indices of the
   !>                   sparse CSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   beta            scalar \f$\beta\f$.
-  !>   @param[in]
-  !>   descr_D         descriptor of the sparse CSR matrix \f$D\f$. Currently, only
+  !>   @param[in] beta - scalar \f$\beta\f$.
+  !>   @param[in] descr_D - descriptor of the sparse CSR matrix \f$D\f$. Currently, only
   !>                   `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   nnz_D           number of non-zero entries of the sparse CSR matrix \f$D\f$.
-  !>   @param[in]
-  !>   csr_val_D       array of \p nnz_D elements of the sparse CSR matrix \f$D\f$.
-  !>   @param[in]
-  !>   csr_row_ptr_D   array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] nnz_D - number of non-zero entries of the sparse CSR matrix \f$D\f$.
+  !>   @param[in] csr_val_D - array of \p nnz_D elements of the sparse CSR matrix \f$D\f$.
+  !>   @param[in] csr_row_ptr_D - array of \p m+1 elements that point to the start of every row of
+  !>   the
   !>                   sparse CSR matrix \f$D\f$.
-  !>   @param[in]
-  !>   csr_col_ind_D   array of \p nnz_D elements containing the column indices of the
+  !>   @param[in] csr_col_ind_D - array of \p nnz_D elements containing the column indices of the
   !>                   sparse CSR matrix \f$D\f$.
-  !>   @param[in]
-  !>   descr_C         descriptor of the sparse CSR matrix \f$C\f$. Currently, only
+  !>   @param[in] descr_C - descriptor of the sparse CSR matrix \f$C\f$. Currently, only
   !>                   `rocsparse_matrix_type_general` is supported.
-  !>   @param[out]
-  !>   csr_val_C       array of \p nnz_C elements of the sparse CSR matrix \f$C\f$.
-  !>   @param[in]
-  !>   csr_row_ptr_C   array of \p m+1 elements that point to the start of every row of the
+  !>   @param[out] csr_val_C - array of \p nnz_C elements of the sparse CSR matrix \f$C\f$.
+  !>   @param[in] csr_row_ptr_C - array of \p m+1 elements that point to the start of every row of
+  !>   the
   !>                   sparse CSR matrix \f$C\f$.
-  !>   @param[out]
-  !>   csr_col_ind_C   array of \p nnz_C elements containing the column indices of the
+  !>   @param[out] csr_col_ind_C - array of \p nnz_C elements containing the column indices of the
   !>                   sparse CSR matrix \f$C\f$.
-  !>   @param[in]
-  !>   info_C          structure that holds meta data for the sparse CSR matrix \f$C\f$.
-  !>   @param[in]
-  !>   temp_buffer     temporary storage buffer allocated by the user, size is returned
+  !>   @param[in] info_C - structure that holds meta data for the sparse CSR matrix \f$C\f$.
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user, size is returned
   !>                   by rocsparse_scsrgemm_buffer_size(),
   !>                   rocsparse_dcsrgemm_buffer_size(), rocsparse_ccsrgemm_buffer_size(), or
   !>                   rocsparse_zcsrgemm_buffer_size().
@@ -13948,70 +12880,48 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle          handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   trans_A         matrix \f$A\f$ operation type.
-  !>   @param[in]
-  !>   trans_B         matrix \f$B\f$ operation type.
-  !>   @param[in]
-  !>   m               number of rows of the sparse CSR matrix \f$op(A)\f$ and \f$C\f$.
-  !>   @param[in]
-  !>   n               number of columns of the sparse CSR matrix \f$op(B)\f$ and
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] trans_A - matrix \f$A\f$ operation type.
+  !>   @param[in] trans_B - matrix \f$B\f$ operation type.
+  !>   @param[in] m - number of rows of the sparse CSR matrix \f$op(A)\f$ and \f$C\f$.
+  !>   @param[in] n - number of columns of the sparse CSR matrix \f$op(B)\f$ and
   !>                   \f$C\f$.
-  !>   @param[in]
-  !>   k               number of columns of the sparse CSR matrix \f$op(A)\f$ and number of
+  !>   @param[in] k - number of columns of the sparse CSR matrix \f$op(A)\f$ and number of
   !>                   rows of the sparse CSR matrix \f$op(B)\f$.
-  !>   @param[in]
-  !>   descr_A         descriptor of the sparse CSR matrix \f$A\f$. Currently, only
+  !>   @param[in] descr_A - descriptor of the sparse CSR matrix \f$A\f$. Currently, only
   !>                   `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   nnz_A           number of non-zero entries of the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csr_row_ptr_A   array of \p m+1 elements (\f$op(A) == A\f$, \p k+1 otherwise)
+  !>   @param[in] nnz_A - number of non-zero entries of the sparse CSR matrix \f$A\f$.
+  !>   @param[in] csr_row_ptr_A - array of \p m+1 elements (\f$op(A) == A\f$, \p k+1 otherwise)
   !>                   that point to the start of every row of the sparse CSR matrix
   !>                   \f$op(A)\f$.
-  !>   @param[in]
-  !>   csr_col_ind_A   array of \p nnz_A elements containing the column indices of the
+  !>   @param[in] csr_col_ind_A - array of \p nnz_A elements containing the column indices of the
   !>                   sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   descr_B         descriptor of the sparse CSR matrix \f$B\f$. Currently, only
+  !>   @param[in] descr_B - descriptor of the sparse CSR matrix \f$B\f$. Currently, only
   !>                   `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   nnz_B           number of non-zero entries of the sparse CSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   csr_row_ptr_B   array of \p k+1 elements (\f$op(B) == B\f$, \p m+1 otherwise)
+  !>   @param[in] nnz_B - number of non-zero entries of the sparse CSR matrix \f$B\f$.
+  !>   @param[in] csr_row_ptr_B - array of \p k+1 elements (\f$op(B) == B\f$, \p m+1 otherwise)
   !>                   that point to the start of every row of the sparse CSR matrix
   !>                   \f$op(B)\f$.
-  !>   @param[in]
-  !>   csr_col_ind_B   array of \p nnz_B elements containing the column indices of the
+  !>   @param[in] csr_col_ind_B - array of \p nnz_B elements containing the column indices of the
   !>                   sparse CSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   descr_D         descriptor of the sparse CSR matrix \f$D\f$. Currently, only
+  !>   @param[in] descr_D - descriptor of the sparse CSR matrix \f$D\f$. Currently, only
   !>                   `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   nnz_D           number of non-zero entries of the sparse CSR matrix \f$D\f$.
-  !>   @param[in]
-  !>   csr_row_ptr_D   array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] nnz_D - number of non-zero entries of the sparse CSR matrix \f$D\f$.
+  !>   @param[in] csr_row_ptr_D - array of \p m+1 elements that point to the start of every row of
+  !>   the
   !>                   sparse CSR matrix \f$D\f$.
-  !>   @param[in]
-  !>   csr_col_ind_D   array of \p nnz_D elements containing the column indices of the
+  !>   @param[in] csr_col_ind_D - array of \p nnz_D elements containing the column indices of the
   !>                   sparse CSR matrix \f$D\f$.
-  !>   @param[in]
-  !>   descr_C         descriptor of the sparse CSR matrix \f$C\f$. Currently, only
+  !>   @param[in] descr_C - descriptor of the sparse CSR matrix \f$C\f$. Currently, only
   !>                   `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   nnz_C           number of non-zero entries of the sparse CSR matrix \f$C\f$.
-  !>   @param[in]
-  !>   csr_row_ptr_C   array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] nnz_C - number of non-zero entries of the sparse CSR matrix \f$C\f$.
+  !>   @param[in] csr_row_ptr_C - array of \p m+1 elements that point to the start of every row of
+  !>   the
   !>                   sparse CSR matrix \f$C\f$.
-  !>   @param[out]
-  !>   csr_col_ind_C   array of \p nnz_C elements containing the column indices of the
+  !>   @param[out] csr_col_ind_C - array of \p nnz_C elements containing the column indices of the
   !>                   sparse CSR matrix \f$C\f$.
-  !>   @param[in]
-  !>   info_C          structure that holds metadata for the sparse CSR matrix \f$C\f$.
-  !>   @param[in]
-  !>   temp_buffer     temporary storage buffer allocated by the user. The size is returned
+  !>   @param[in] info_C - structure that holds metadata for the sparse CSR matrix \f$C\f$.
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user. The size is returned
   !>                   by rocsparse_scsrgemm_buffer_size(),
   !>                   rocsparse_dcsrgemm_buffer_size(), rocsparse_ccsrgemm_buffer_size(), or
   !>                   rocsparse_zcsrgemm_buffer_size().
@@ -14239,82 +13149,54 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle          handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   trans_A         matrix \f$A\f$ operation type.
-  !>   @param[in]
-  !>   trans_B         matrix \f$B\f$ operation type.
-  !>   @param[in]
-  !>   m               number of rows of the sparse CSR matrix \f$op(A)\f$ and \f$C\f$.
-  !>   @param[in]
-  !>   n               number of columns of the sparse CSR matrix \f$op(B)\f$ and
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] trans_A - matrix \f$A\f$ operation type.
+  !>   @param[in] trans_B - matrix \f$B\f$ operation type.
+  !>   @param[in] m - number of rows of the sparse CSR matrix \f$op(A)\f$ and \f$C\f$.
+  !>   @param[in] n - number of columns of the sparse CSR matrix \f$op(B)\f$ and
   !>                   \f$C\f$.
-  !>   @param[in]
-  !>   k               number of columns of the sparse CSR matrix \f$op(A)\f$ and number of
+  !>   @param[in] k - number of columns of the sparse CSR matrix \f$op(A)\f$ and number of
   !>                   rows of the sparse CSR matrix \f$op(B)\f$.
-  !>   @param[in]
-  !>   alpha           scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   descr_A         descriptor of the sparse CSR matrix \f$A\f$. Currently, only
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] descr_A - descriptor of the sparse CSR matrix \f$A\f$. Currently, only
   !>                   `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   nnz_A           number of non-zero entries of the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csr_val_A       array of \p nnz_A elements of the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csr_row_ptr_A   array of \p m+1 elements (\f$op(A) == A\f$, \p k+1 otherwise)
+  !>   @param[in] nnz_A - number of non-zero entries of the sparse CSR matrix \f$A\f$.
+  !>   @param[in] csr_val_A - array of \p nnz_A elements of the sparse CSR matrix \f$A\f$.
+  !>   @param[in] csr_row_ptr_A - array of \p m+1 elements (\f$op(A) == A\f$, \p k+1 otherwise)
   !>                   that point to the start of every row of the sparse CSR matrix
   !>                   \f$op(A)\f$.
-  !>   @param[in]
-  !>   csr_col_ind_A   array of \p nnz_A elements containing the column indices of the
+  !>   @param[in] csr_col_ind_A - array of \p nnz_A elements containing the column indices of the
   !>                   sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   descr_B         descriptor of the sparse CSR matrix \f$B\f$. Currently, only
+  !>   @param[in] descr_B - descriptor of the sparse CSR matrix \f$B\f$. Currently, only
   !>                   `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   nnz_B           number of non-zero entries of the sparse CSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   csr_val_B       array of \p nnz_B elements of the sparse CSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   csr_row_ptr_B   array of \p k+1 elements (\f$op(B) == B\f$, \p m+1 otherwise)
+  !>   @param[in] nnz_B - number of non-zero entries of the sparse CSR matrix \f$B\f$.
+  !>   @param[in] csr_val_B - array of \p nnz_B elements of the sparse CSR matrix \f$B\f$.
+  !>   @param[in] csr_row_ptr_B - array of \p k+1 elements (\f$op(B) == B\f$, \p m+1 otherwise)
   !>                   that point to the start of every row of the sparse CSR matrix
   !>                   \f$op(B)\f$.
-  !>   @param[in]
-  !>   csr_col_ind_B   array of \p nnz_B elements containing the column indices of the
+  !>   @param[in] csr_col_ind_B - array of \p nnz_B elements containing the column indices of the
   !>                   sparse CSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   beta            scalar \f$\beta\f$.
-  !>   @param[in]
-  !>   descr_D         descriptor of the sparse CSR matrix \f$D\f$. Currently, only
+  !>   @param[in] beta - scalar \f$\beta\f$.
+  !>   @param[in] descr_D - descriptor of the sparse CSR matrix \f$D\f$. Currently, only
   !>                   `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   nnz_D           number of non-zero entries of the sparse CSR matrix \f$D\f$.
-  !>   @param[in]
-  !>   csr_val_D       array of \p nnz_D elements of the sparse CSR matrix \f$D\f$.
-  !>   @param[in]
-  !>   csr_row_ptr_D   array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] nnz_D - number of non-zero entries of the sparse CSR matrix \f$D\f$.
+  !>   @param[in] csr_val_D - array of \p nnz_D elements of the sparse CSR matrix \f$D\f$.
+  !>   @param[in] csr_row_ptr_D - array of \p m+1 elements that point to the start of every row of
+  !>   the
   !>                   sparse CSR matrix \f$D\f$.
-  !>   @param[in]
-  !>   csr_col_ind_D   array of \p nnz_D elements containing the column indices of the
+  !>   @param[in] csr_col_ind_D - array of \p nnz_D elements containing the column indices of the
   !>                   sparse CSR matrix \f$D\f$.
-  !>   @param[in]
-  !>   descr_C         descriptor of the sparse CSR matrix \f$C\f$. Currently, only
+  !>   @param[in] descr_C - descriptor of the sparse CSR matrix \f$C\f$. Currently, only
   !>                   `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   nnz_C           number of non-zero entries of the sparse CSR matrix \f$C\f$.
-  !>   @param[out]
-  !>   csr_val_C       array of \p nnz_C elements of the sparse CSR matrix \f$C\f$.
-  !>   @param[in]
-  !>   csr_row_ptr_C   array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] nnz_C - number of non-zero entries of the sparse CSR matrix \f$C\f$.
+  !>   @param[out] csr_val_C - array of \p nnz_C elements of the sparse CSR matrix \f$C\f$.
+  !>   @param[in] csr_row_ptr_C - array of \p m+1 elements that point to the start of every row of
+  !>   the
   !>                   sparse CSR matrix \f$C\f$.
-  !>   @param[in]
-  !>   csr_col_ind_C   array of \p nnz_C elements containing the column indices of the
+  !>   @param[in] csr_col_ind_C - array of \p nnz_C elements containing the column indices of the
   !>                   sparse CSR matrix \f$C\f$.
-  !>   @param[in]
-  !>   info_C          structure that holds metadata for the sparse CSR matrix \f$C\f$.
-  !>   @param[in]
-  !>   temp_buffer     temporary storage buffer allocated by the user. The size is returned
+  !>   @param[in] info_C - structure that holds metadata for the sparse CSR matrix \f$C\f$.
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user. The size is returned
   !>                   by rocsparse_scsrgemm_buffer_size(),
   !>                   rocsparse_dcsrgemm_buffer_size(), rocsparse_ccsrgemm_buffer_size(), or
   !>                   rocsparse_zcsrgemm_buffer_size().
@@ -14706,16 +13588,11 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support batched computation.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   alpha       scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   x           sparse matrix descriptor.
-  !>   @param[in]
-  !>   beta        scalar \f$\beta\f$.
-  !>   @param[inout]
-  !>   y           dense matrix descriptor.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] x - sparse matrix descriptor.
+  !>   @param[in] beta - scalar \f$\beta\f$.
+  !>   @param[inout] y - dense matrix descriptor.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_handle the library context was not initialized.
@@ -14786,19 +13663,15 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support batched computation.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   mat         matrix descriptor.
-  !>   @param[out]
-  !>   data_status modified to indicate the status of the data.
-  !>   @param[in]
-  !>   stage       check_matrix stage for the matrix computation.
-  !>   @param[out]
-  !>   buffer_size number of bytes of the temporary storage buffer. buffer_size is set when
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] mat - matrix descriptor.
+  !>   @param[out] data_status - modified to indicate the status of the data.
+  !>   @param[in] stage - check_matrix stage for the matrix computation.
+  !>   @param[out] buffer_size - number of bytes of the temporary storage buffer. buffer_size is set
+  !>   when
   !>               \p temp_buffer is nullptr.
-  !>   @param[in]
-  !>   temp_buffer temporary storage buffer allocated by the user. When a nullptr is passed,
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user. When a nullptr is
+  !>   passed,
   !>               the required allocation size (in bytes) is written to \p buffer_size and
   !>               function returns without performing the checking operation.
   !>
@@ -14920,19 +13793,15 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support batched computation.
   !>
-  !>   @param[in]
-  !>   handle       handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   mat_A        dense matrix descriptor.
-  !>   @param[in]
-  !>   mat_B        sparse matrix descriptor.
-  !>   @param[in]
-  !>   alg          algorithm for the dense to sparse computation.
-  !>   @param[out]
-  !>   buffer_size  number of bytes of the temporary storage buffer. buffer_size is set when
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] mat_A - dense matrix descriptor.
+  !>   @param[in] mat_B - sparse matrix descriptor.
+  !>   @param[in] alg - algorithm for the dense to sparse computation.
+  !>   @param[out] buffer_size - number of bytes of the temporary storage buffer. buffer_size is set
+  !>   when
   !>                \p temp_buffer is nullptr.
-  !>   @param[in]
-  !>   temp_buffer  temporary storage buffer allocated by the user. When a nullptr is passed,
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user. When a nullptr is
+  !>   passed,
   !>                the required allocation size (in bytes) is written to \p buffer_size and the
   !>                function returns without performing the dense to sparse operation.
   !>
@@ -14976,18 +13845,12 @@ module hipfort_rocsparse
   !>   This routine does not support batched computation.
   !>
   !>
-  !>   @param[in]
-  !>   handle       handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   descr        descriptor of the extract algorithm.
-  !>   @param[in]
-  !>   source       source sparse matrix descriptor.
-  !>   @param[in]
-  !>   target       target sparse matrix descriptor.
-  !>   @param[in]
-  !>   stage        stage of the extract computation.
-  !>   @param[out]
-  !>   buffer_size_in_bytes  size in bytes of the buffer.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] descr - descriptor of the extract algorithm.
+  !>   @param[in] source - source sparse matrix descriptor.
+  !>   @param[in] target - target sparse matrix descriptor.
+  !>   @param[in] stage - stage of the extract computation.
+  !>   @param[out] buffer_size_in_bytes - size in bytes of the buffer.
   !>
   !>   \retval      rocsparse_status_success the operation completed successfully.
   !>   \retval      rocsparse_status_invalid_handle the library context was not initialized.
@@ -15027,12 +13890,9 @@ module hipfort_rocsparse
   !>   This routine is asynchronous with respect to the host.
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle       handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   descr        descriptor of the extract algorithm.
-  !>   @param[out]
-  !>   nnz          the number of non-zeros.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] descr - descriptor of the extract algorithm.
+  !>   @param[out] nnz - the number of non-zeros.
   !>
   !>   \retval      rocsparse_status_success the operation completed successfully.
   !>   \retval      rocsparse_status_invalid_handle the library context was not initialized.
@@ -15182,20 +14042,13 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support batched computation.
   !>
-  !>   @param[in]
-  !>   handle       handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   descr        descriptor of the extract algorithm.
-  !>   @param[in]
-  !>   source       sparse matrix descriptor.
-  !>   @param[in]
-  !>   target       sparse matrix descriptor.
-  !>   @param[in]
-  !>   stage        stage of the extract computation.
-  !>   @param[in]
-  !>   buffer_size_in_bytes  size in bytes of the \p buffer.
-  !>   @param[in]
-  !>   buffer  temporary storage buffer allocated by the user.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] descr - descriptor of the extract algorithm.
+  !>   @param[in] source - sparse matrix descriptor.
+  !>   @param[in] target - sparse matrix descriptor.
+  !>   @param[in] stage - stage of the extract computation.
+  !>   @param[in] buffer_size_in_bytes - size in bytes of the \p buffer.
+  !>   @param[in] buffer - temporary storage buffer allocated by the user.
   !>
   !>   \retval      rocsparse_status_success the operation completed successfully.
   !>   \retval      rocsparse_status_invalid_handle the library context was not initialized.
@@ -15262,12 +14115,9 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support batched computation.
   !>
-  !>   @param[in]
-  !>   handle       handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   y            dense vector \f$y\f$.
-  !>   @param[out]
-  !>   x            sparse vector \f$x\f$.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] y - dense vector \f$y\f$.
+  !>   @param[out] x - sparse vector \f$x\f$.
   !>
   !>   \retval      rocsparse_status_success the operation completed successfully.
   !>   \retval      rocsparse_status_invalid_handle the library context was not initialized.
@@ -15331,16 +14181,11 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support batched computation.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   c           pointer to the cosine element of \f$G\f$, which can be on host or device.
-  !>   @param[in]
-  !>   s           pointer to the sine element of \f$G\f$, which can be on host or device.
-  !>   @param[inout]
-  !>   x           sparse vector \f$x\f$.
-  !>   @param[inout]
-  !>   y           dense vector \f$y\f$.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] c - pointer to the cosine element of \f$G\f$, which can be on host or device.
+  !>   @param[in] s - pointer to the sine element of \f$G\f$, which can be on host or device.
+  !>   @param[inout] x - sparse vector \f$x\f$.
+  !>   @param[inout] y - dense vector \f$y\f$.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -15402,12 +14247,9 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support batched computation.
   !>
-  !>   @param[in]
-  !>   handle       handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   x            sparse vector \f$x\f$.
-  !>   @param[out]
-  !>   y            dense vector \f$y\f$.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] x - sparse vector \f$x\f$.
+  !>   @param[out] y - dense vector \f$y\f$.
   !>
   !>   \retval      rocsparse_status_success the operation completed successfully.
   !>   \retval      rocsparse_status_invalid_handle the library context was not initialized.
@@ -15436,28 +14278,17 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle       handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   opA          dense matrix \f$A\f$ operation type.
-  !>   @param[in]
-  !>   opB          dense matrix \f$B\f$ operation type.
-  !>   @param[in]
-  !>   alpha        scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   mat_A        dense matrix \f$A\f$ descriptor.
-  !>   @param[in]
-  !>   mat_B        dense matrix \f$B\f$ descriptor.
-  !>   @param[in]
-  !>   beta         scalar \f$\beta\f$.
-  !>   @param[inout]
-  !>   mat_C        sparse matrix \f$C\f$ descriptor.
-  !>   @param[in]
-  !>   compute_type floating point precision for the SDDMM computation.
-  !>   @param[in]
-  !>   alg specification of the algorithm to use.
-  !>   @param[out]
-  !>   buffer_size  number of bytes of the temporary storage buffer.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] opA - dense matrix \f$A\f$ operation type.
+  !>   @param[in] opB - dense matrix \f$B\f$ operation type.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] mat_A - dense matrix \f$A\f$ descriptor.
+  !>   @param[in] mat_B - dense matrix \f$B\f$ descriptor.
+  !>   @param[in] beta - scalar \f$\beta\f$.
+  !>   @param[inout] mat_C - sparse matrix \f$C\f$ descriptor.
+  !>   @param[in] compute_type - floating point precision for the SDDMM computation.
+  !>   @param[in] alg - specification of the algorithm to use.
+  !>   @param[out] buffer_size - number of bytes of the temporary storage buffer.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_value the value of \p opA or \p opB is incorrect.
@@ -15498,28 +14329,17 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle       handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   opA          dense matrix \f$A\f$ operation type.
-  !>   @param[in]
-  !>   opB          dense matrix \f$B\f$ operation type.
-  !>   @param[in]
-  !>   alpha        scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   mat_A        dense matrix \f$A\f$ descriptor.
-  !>   @param[in]
-  !>   mat_B        dense matrix \f$B\f$ descriptor.
-  !>   @param[in]
-  !>   beta         scalar \f$\beta\f$.
-  !>   @param[inout]
-  !>   mat_C        sparse matrix \f$C\f$ descriptor.
-  !>   @param[in]
-  !>   compute_type floating point precision for the SDDMM computation.
-  !>   @param[in]
-  !>   alg specification of the algorithm to use.
-  !>   @param[in]
-  !>   temp_buffer  temporary storage buffer allocated by the user.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] opA - dense matrix \f$A\f$ operation type.
+  !>   @param[in] opB - dense matrix \f$B\f$ operation type.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] mat_A - dense matrix \f$A\f$ descriptor.
+  !>   @param[in] mat_B - dense matrix \f$B\f$ descriptor.
+  !>   @param[in] beta - scalar \f$\beta\f$.
+  !>   @param[inout] mat_C - sparse matrix \f$C\f$ descriptor.
+  !>   @param[in] compute_type - floating point precision for the SDDMM computation.
+  !>   @param[in] alg - specification of the algorithm to use.
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user.
   !>   The size must be greater or equal to the size obtained with \ref rocsparse_sddmm_buffer_size.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
@@ -15654,28 +14474,17 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support batched computation.
   !>
-  !>   @param[in]
-  !>   handle       handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   opA          dense matrix \f$A\f$ operation type.
-  !>   @param[in]
-  !>   opB          dense matrix \f$B\f$ operation type.
-  !>   @param[in]
-  !>   alpha        scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   mat_A        dense matrix \f$A\f$ descriptor.
-  !>   @param[in]
-  !>   mat_B        dense matrix \f$B\f$ descriptor.
-  !>   @param[in]
-  !>   beta         scalar \f$\beta\f$.
-  !>   @param[inout]
-  !>   mat_C        sparse matrix \f$C\f$ descriptor.
-  !>   @param[in]
-  !>   compute_type floating point precision for the SDDMM computation.
-  !>   @param[in]
-  !>   alg specification of the algorithm to use.
-  !>   @param[in]
-  !>   temp_buffer  temporary storage buffer allocated by the user.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] opA - dense matrix \f$A\f$ operation type.
+  !>   @param[in] opB - dense matrix \f$B\f$ operation type.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] mat_A - dense matrix \f$A\f$ descriptor.
+  !>   @param[in] mat_B - dense matrix \f$B\f$ descriptor.
+  !>   @param[in] beta - scalar \f$\beta\f$.
+  !>   @param[inout] mat_C - sparse matrix \f$C\f$ descriptor.
+  !>   @param[in] compute_type - floating point precision for the SDDMM computation.
+  !>   @param[in] alg - specification of the algorithm to use.
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user.
   !>   The size must be greater or equal to the size obtained with \ref rocsparse_sddmm_buffer_size.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
@@ -15787,19 +14596,15 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support batched computation.
   !>
-  !>   @param[in]
-  !>   handle       handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   mat_A        sparse matrix descriptor.
-  !>   @param[in]
-  !>   mat_B        dense matrix descriptor.
-  !>   @param[in]
-  !>   alg          algorithm for the sparse to dense computation.
-  !>   @param[out]
-  !>   buffer_size  number of bytes of the temporary storage buffer. buffer_size is set when
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] mat_A - sparse matrix descriptor.
+  !>   @param[in] mat_B - dense matrix descriptor.
+  !>   @param[in] alg - algorithm for the sparse to dense computation.
+  !>   @param[out] buffer_size - number of bytes of the temporary storage buffer. buffer_size is set
+  !>   when
   !>                \p temp_buffer is nullptr.
-  !>   @param[in]
-  !>   temp_buffer  temporary storage buffer allocated by the user. When a nullptr is passed,
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user. When a nullptr is
+  !>   passed,
   !>                the required allocation size (in bytes) is written to \p buffer_size and the
   !>                function returns without performing the sparse to dense operation.
   !>
@@ -15830,18 +14635,12 @@ module hipfort_rocsparse
   !>   \p rocsparse_sparse_to_sparse_buffer_size calculates the required buffer size in bytes for a
   !>   given stage \p stage.
   !>
-  !>   @param[in]
-  !>   handle       handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   descr        descriptor of the sparse_to_sparse algorithm.
-  !>   @param[in]
-  !>   source       source sparse matrix descriptor.
-  !>   @param[in]
-  !>   target       target sparse matrix descriptor.
-  !>   @param[in]
-  !>   stage        stage of the sparse_to_sparse computation.
-  !>   @param[out]
-  !>   buffer_size_in_bytes  size in bytes of the \p buffer
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] descr - descriptor of the sparse_to_sparse algorithm.
+  !>   @param[in] source - source sparse matrix descriptor.
+  !>   @param[in] target - target sparse matrix descriptor.
+  !>   @param[in] stage - stage of the sparse_to_sparse computation.
+  !>   @param[out] buffer_size_in_bytes - size in bytes of the \p buffer
   !>
   !>   \note
   !>   This routine does not support batched computation.
@@ -15885,20 +14684,13 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support batched computation.
   !>
-  !>   @param[in]
-  !>   handle       handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   descr        descriptor of the sparse_to_sparse algorithm.
-  !>   @param[in]
-  !>   source       sparse matrix descriptor.
-  !>   @param[in]
-  !>   target       sparse matrix descriptor.
-  !>   @param[in]
-  !>   stage        stage of the sparse_to_sparse computation.
-  !>   @param[in]
-  !>   buffer_size_in_bytes  size in bytes of the \p buffer.
-  !>   @param[in]
-  !>   buffer  temporary storage buffer allocated by the user.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] descr - descriptor of the sparse_to_sparse algorithm.
+  !>   @param[in] source - sparse matrix descriptor.
+  !>   @param[in] target - sparse matrix descriptor.
+  !>   @param[in] stage - stage of the sparse_to_sparse computation.
+  !>   @param[in] buffer_size_in_bytes - size in bytes of the \p buffer.
+  !>   @param[in] buffer - temporary storage buffer allocated by the user.
   !>
   !>   \retval      rocsparse_status_success the operation completed successfully.
   !>   \par Example
@@ -15931,23 +14723,16 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle       handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   descr        SpGEAM descriptor.
-  !>   @param[in]
-  !>   mat_A        sparse matrix \f$A\f$ descriptor.
-  !>   @param[in]
-  !>   mat_B        sparse matrix \f$B\f$ descriptor.
-  !>   @param[in]
-  !>   mat_C        sparse matrix \f$C\f$ descriptor.
-  !>   @param[in]
-  !>   stage        SpGEAM stage for the SpGEAM computation.
-  !>   @param[out]
-  !>   buffer_size  number of bytes of the temporary storage buffer.
-  !>   @param[out]
-  !>   error error descriptor created if the returned status is not `rocsparse_status_success`. A
-  !>   null pointer can be passed if an error descriptor is not required.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] descr - SpGEAM descriptor.
+  !>   @param[in] mat_A - sparse matrix \f$A\f$ descriptor.
+  !>   @param[in] mat_B - sparse matrix \f$B\f$ descriptor.
+  !>   @param[in] mat_C - sparse matrix \f$C\f$ descriptor.
+  !>   @param[in] stage - SpGEAM stage for the SpGEAM computation.
+  !>   @param[out] buffer_size - number of bytes of the temporary storage buffer.
+  !>   @param[out] error - error descriptor created if the returned status is not
+  !>   `rocsparse_status_success`. A null pointer can be passed if an error descriptor is not
+  !>   required.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_handle the library context was not initialized.
@@ -16114,26 +14899,18 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle       handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   descr        SpGEAM descriptor.
-  !>   @param[in]
-  !>   mat_A        sparse matrix \f$A\f$ descriptor.
-  !>   @param[in]
-  !>   mat_B        sparse matrix \f$B\f$ descriptor.
-  !>   @param[out]
-  !>   mat_C        sparse matrix \f$C\f$ descriptor.
-  !>   @param[in]
-  !>   stage        SpGEAM stage for the SpGEAM computation.
-  !>   @param[out]
-  !>   buffer_size  number of bytes of the temporary storage buffer. \p buffer_size is
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] descr - SpGEAM descriptor.
+  !>   @param[in] mat_A - sparse matrix \f$A\f$ descriptor.
+  !>   @param[in] mat_B - sparse matrix \f$B\f$ descriptor.
+  !>   @param[out] mat_C - sparse matrix \f$C\f$ descriptor.
+  !>   @param[in] stage - SpGEAM stage for the SpGEAM computation.
+  !>   @param[out] buffer_size - number of bytes of the temporary storage buffer. \p buffer_size is
   !>                determined by calling \ref rocsparse_spgeam_buffer_size.
-  !>   @param[in]
-  !>   temp_buffer  temporary storage buffer allocated by the user.
-  !>   @param[out]
-  !>   error error descriptor created if the returned status is not `rocsparse_status_success`. A
-  !>   null pointer can be passed if an error descriptor is not required.
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user.
+  !>   @param[out] error - error descriptor created if the returned status is not
+  !>   `rocsparse_status_success`. A null pointer can be passed if an error descriptor is not
+  !>   required.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_handle the library context was not initialized.
@@ -16300,35 +15077,23 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support batched computation.
   !>
-  !>   @param[in]
-  !>   handle       handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   trans_A      sparse matrix \f$A\f$ operation type.
-  !>   @param[in]
-  !>   trans_B      sparse matrix \f$B\f$ operation type.
-  !>   @param[in]
-  !>   alpha        scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   A            sparse matrix \f$A\f$ descriptor.
-  !>   @param[in]
-  !>   B            sparse matrix \f$B\f$ descriptor.
-  !>   @param[in]
-  !>   beta         scalar \f$\beta\f$.
-  !>   @param[in]
-  !>   D            sparse matrix \f$D\f$ descriptor.
-  !>   @param[out]
-  !>   C            sparse matrix \f$C\f$ descriptor.
-  !>   @param[in]
-  !>   compute_type floating point precision for the SpGEMM computation.
-  !>   @param[in]
-  !>   alg          SpGEMM algorithm for the SpGEMM computation.
-  !>   @param[in]
-  !>   stage        SpGEMM stage for the SpGEMM computation.
-  !>   @param[out]
-  !>   buffer_size  number of bytes of the temporary storage buffer. buffer_size is set when
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] trans_A - sparse matrix \f$A\f$ operation type.
+  !>   @param[in] trans_B - sparse matrix \f$B\f$ operation type.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] A - sparse matrix \f$A\f$ descriptor.
+  !>   @param[in] B - sparse matrix \f$B\f$ descriptor.
+  !>   @param[in] beta - scalar \f$\beta\f$.
+  !>   @param[in] D - sparse matrix \f$D\f$ descriptor.
+  !>   @param[out] C - sparse matrix \f$C\f$ descriptor.
+  !>   @param[in] compute_type - floating point precision for the SpGEMM computation.
+  !>   @param[in] alg - SpGEMM algorithm for the SpGEMM computation.
+  !>   @param[in] stage - SpGEMM stage for the SpGEMM computation.
+  !>   @param[out] buffer_size - number of bytes of the temporary storage buffer. buffer_size is set
+  !>   when
   !>                \p temp_buffer is nullptr.
-  !>   @param[in]
-  !>   temp_buffer  temporary storage buffer allocated by the user. When a nullptr is passed,
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user. When a nullptr is
+  !>   passed,
   !>                the required allocation size (in bytes) is written to \p buffer_size and the
   !>                function returns without performing the SpGEMM operation.
   !>
@@ -16388,21 +15153,14 @@ module hipfort_rocsparse
   !>   \note
   !>   Supported formats are `rocsparse_format_csr` and `rocsparse_format_bsr`.
   !>
-  !>   @param[in]
-  !>   handle       handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   spic0_descr Spic0 descriptor.
-  !>   @param[in]
-  !>   A            descriptor of the matrix to factorize.
-  !>   @param[in]
-  !>   P            descriptor of the factorization. In-place \p P = \p A is allowed.
-  !>   @param[in]
-  !>   spic0_stage stage for the Spic0 computation.
-  !>   @param[out]
-  !>   p_buffer_size_in_bytes  number of bytes of the buffer.
-  !>   @param[out]
-  !>   p_error error descriptor created if the returned status is not `rocsparse_status_success`. A
-  !>   null pointer can be passed if error descriptor is not required.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] spic0_descr - Spic0 descriptor.
+  !>   @param[in] A - descriptor of the matrix to factorize.
+  !>   @param[in] P - descriptor of the factorization. In-place \p P = \p A is allowed.
+  !>   @param[in] spic0_stage - stage for the Spic0 computation.
+  !>   @param[out] p_buffer_size_in_bytes - number of bytes of the buffer.
+  !>   @param[out] p_error - error descriptor created if the returned status is not
+  !>   `rocsparse_status_success`. A null pointer can be passed if error descriptor is not required.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_handle the library context was not initialized.
@@ -16481,23 +15239,16 @@ module hipfort_rocsparse
   !>   This routine only supports uniform strided batched computation, that is, the same sparsity
   !>   pattern but strided batched values of the matrices.
   !>
-  !>   @param[in]
-  !>   handle       handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   spic0_descr Spic0 descriptor
-  !>   @param[in]
-  !>   A            descriptor of the matrix to factorize.
-  !>   @param[out]
-  !>   P            descriptor of the factorization. In-place \p P = \p A is allowed.
-  !>   @param[in]
-  !>   spic0_stage stage for the Spic0 computation.
-  !>   @param[in]
-  !>   buffer_size_in_bytes  number of bytes of the buffer.
-  !>   @param[in]
-  !>   buffer       buffer allocated by the user.
-  !>   @param[out]
-  !>   p_error error descriptor created if the returned status is not `rocsparse_status_success`. A
-  !>   null pointer can be passed if an error descriptor is not required.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] spic0_descr - Spic0 descriptor
+  !>   @param[in] A - descriptor of the matrix to factorize.
+  !>   @param[out] P - descriptor of the factorization. In-place \p P = \p A is allowed.
+  !>   @param[in] spic0_stage - stage for the Spic0 computation.
+  !>   @param[in] buffer_size_in_bytes - number of bytes of the buffer.
+  !>   @param[in] buffer - buffer allocated by the user.
+  !>   @param[out] p_error - error descriptor created if the returned status is not
+  !>   `rocsparse_status_success`. A null pointer can be passed if an error descriptor is not
+  !>   required.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_handle the library context was not initialized.
@@ -16543,21 +15294,15 @@ module hipfort_rocsparse
   !>   \note
   !>   Supported formats are `rocsparse_format_csr` and `rocsparse_format_bsr`.
   !>
-  !>   @param[in]
-  !>   handle       handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   spilu0_descr Spilu0 descriptor.
-  !>   @param[in]
-  !>   A            descriptor of the matrix to factorize.
-  !>   @param[in]
-  !>   P            descriptor of the factorization.
-  !>   @param[in]
-  !>   spilu0_stage stage for the Spilu0 computation.
-  !>   @param[out]
-  !>   p_buffer_size_in_bytes  number of bytes of the buffer.
-  !>   @param[out]
-  !>   p_error error descriptor created if the returned status is not `rocsparse_status_success`. A
-  !>   null pointer can be passed if the user is not interested in obtaining an error descriptor.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] spilu0_descr - Spilu0 descriptor.
+  !>   @param[in] A - descriptor of the matrix to factorize.
+  !>   @param[in] P - descriptor of the factorization.
+  !>   @param[in] spilu0_stage - stage for the Spilu0 computation.
+  !>   @param[out] p_buffer_size_in_bytes - number of bytes of the buffer.
+  !>   @param[out] p_error - error descriptor created if the returned status is not
+  !>   `rocsparse_status_success`. A null pointer can be passed if the user is not interested in
+  !>   obtaining an error descriptor.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_handle the library context was not initialized.
@@ -16635,23 +15380,16 @@ module hipfort_rocsparse
   !>   This routine only supports uniform batched computation, that is, same sparsity pattern but
   !>   batched values of the matrices.
   !>
-  !>   @param[in]
-  !>   handle       handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   spilu0_descr Spilu0 descriptor.
-  !>   @param[in]
-  !>   A            descriptor of the matrix to factorize.
-  !>   @param[out]
-  !>   P            descriptor of the factorization.
-  !>   @param[in]
-  !>   spilu0_stage stage for the Spilu0 computation.
-  !>   @param[in]
-  !>   buffer_size_in_bytes  number of bytes of the buffer.
-  !>   @param[in]
-  !>   buffer       buffer allocated by the user.
-  !>   @param[out]
-  !>   p_error error descriptor created if the returned status is not `rocsparse_status_success`. A
-  !>   null pointer can be passed if an error descriptor is not required.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] spilu0_descr - Spilu0 descriptor.
+  !>   @param[in] A - descriptor of the matrix to factorize.
+  !>   @param[out] P - descriptor of the factorization.
+  !>   @param[in] spilu0_stage - stage for the Spilu0 computation.
+  !>   @param[in] buffer_size_in_bytes - number of bytes of the buffer.
+  !>   @param[in] buffer - buffer allocated by the user.
+  !>   @param[out] p_error - error descriptor created if the returned status is not
+  !>   `rocsparse_status_success`. A null pointer can be passed if an error descriptor is not
+  !>   required.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_handle the library context was not initialized.
@@ -16759,40 +15497,27 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support batched computation.
   !>
-  !>   @param[in]
-  !>   handle        handle to the rocSPARSE library context queue.
-  !>   @param[inout]
-  !>   host_nmaxiter maximum number of iteration on input and number of iteration on output. If the
-  !>   output number of iterations is strictly less than the input maximum number of iterations,
-  !>   then the algorithm converged.
-  !>   @param[in]
-  !>   host_tol if the pointer is null, then the loop will execute \p nmaxiter[0] iterations. The
-  !>   precision is float for f32-based calculations (including the complex case) and double for
-  !>   f64-based calculations (including the complex case).
-  !>   @param[out]
-  !>   host_history Optional array to record the norm of the residual before each iteration. The
-  !>   precision is float for f32-based calculations (including the complex case) and double for
-  !>   f64-based calculations (including the complex case).
-  !>   @param[in]
-  !>   trans         matrix operation type.
-  !>   @param[in]
-  !>   alpha         scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   mat           matrix descriptor.
-  !>   @param[in]
-  !>   x             vector descriptor.
-  !>   @param[inout]
-  !>   y             vector descriptor.
-  !>   @param[in]
-  !>   compute_type  floating point precision for the SpITSV computation.
-  !>   @param[in]
-  !>   alg           SpITSV algorithm for the SpITSV computation.
-  !>   @param[in]
-  !>   stage         SpITSV stage for the SpITSV computation.
-  !>   @param[out]
-  !>   buffer_size   number of bytes of the temporary storage buffer.
-  !>   @param[in]
-  !>   temp_buffer   temporary storage buffer allocated by the user. When a nullptr is passed,
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[inout] host_nmaxiter - maximum number of iteration on input and number of iteration on
+  !>   output. If the output number of iterations is strictly less than the input maximum number of
+  !>   iterations, then the algorithm converged.
+  !>   @param[in] host_tol - if the pointer is null, then the loop will execute \p nmaxiter[0]
+  !>   iterations. The precision is float for f32-based calculations (including the complex case)
+  !>   and double for f64-based calculations (including the complex case).
+  !>   @param[out] host_history - Optional array to record the norm of the residual before each
+  !>   iteration. The precision is float for f32-based calculations (including the complex case) and
+  !>   double for f64-based calculations (including the complex case).
+  !>   @param[in] trans - matrix operation type.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] mat - matrix descriptor.
+  !>   @param[in] x - vector descriptor.
+  !>   @param[inout] y - vector descriptor.
+  !>   @param[in] compute_type - floating point precision for the SpITSV computation.
+  !>   @param[in] alg - SpITSV algorithm for the SpITSV computation.
+  !>   @param[in] stage - SpITSV stage for the SpITSV computation.
+  !>   @param[out] buffer_size - number of bytes of the temporary storage buffer.
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user. When a nullptr is
+  !>   passed,
   !>                 the required allocation size (in bytes) is written to \p buffer_size and
   !>                 function returns without performing the SpITSV operation.
   !>
@@ -17058,32 +15783,19 @@ module hipfort_rocsparse
   !>   \note
   !>   Currently, only CSR, CSC, COO, BSR, and blocked ELL sparse formats are supported.
   !>
-  !>   @param[in]
-  !>   handle       handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   trans_A      matrix operation type.
-  !>   @param[in]
-  !>   trans_B      matrix operation type.
-  !>   @param[in]
-  !>   alpha        scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   mat_A        matrix descriptor.
-  !>   @param[in]
-  !>   mat_B        matrix descriptor.
-  !>   @param[in]
-  !>   beta         scalar \f$\beta\f$.
-  !>   @param[in]
-  !>   mat_C        matrix descriptor.
-  !>   @param[in]
-  !>   compute_type floating point precision for the SpMM computation.
-  !>   @param[in]
-  !>   alg          SpMM algorithm for the SpMM computation.
-  !>   @param[in]
-  !>   stage        SpMM stage for the SpMM computation.
-  !>   @param[out]
-  !>   buffer_size  number of bytes of the temporary storage buffer.
-  !>   @param[in]
-  !>   temp_buffer  temporary storage buffer allocated by the user. When the
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] trans_A - matrix operation type.
+  !>   @param[in] trans_B - matrix operation type.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] mat_A - matrix descriptor.
+  !>   @param[in] mat_B - matrix descriptor.
+  !>   @param[in] beta - scalar \f$\beta\f$.
+  !>   @param[in] mat_C - matrix descriptor.
+  !>   @param[in] compute_type - floating point precision for the SpMM computation.
+  !>   @param[in] alg - SpMM algorithm for the SpMM computation.
+  !>   @param[in] stage - SpMM stage for the SpMM computation.
+  !>   @param[out] buffer_size - number of bytes of the temporary storage buffer.
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user. When the
   !>                `rocsparse_spmm_stage_buffer_size` stage is passed in, the required
   !>                allocation size (in bytes) is written to \p buffer_size and function
   !>                returns without performing the SpMM operation.
@@ -17289,31 +16001,20 @@ module hipfort_rocsparse
   !>   support execution in a hipGraph context. The `rocsparse_spmv_stage_preprocess` stage does not
   !>   support hipGraph.
   !>
-  !>   @param[in]
-  !>   handle       handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   trans        matrix operation type.
-  !>   @param[in]
-  !>   alpha        scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   mat          matrix descriptor.
-  !>   @param[in]
-  !>   x            vector descriptor.
-  !>   @param[in]
-  !>   beta         scalar \f$\beta\f$.
-  !>   @param[inout]
-  !>   y            vector descriptor.
-  !>   @param[in]
-  !>   compute_type floating point precision for the SpMV computation.
-  !>   @param[in]
-  !>   alg          SpMV algorithm for the SpMV computation.
-  !>   @param[in]
-  !>   stage        SpMV stage for the SpMV computation.
-  !>   @param[out]
-  !>   buffer_size  number of bytes of the temporary storage buffer. buffer_size is set when
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] trans - matrix operation type.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] mat - matrix descriptor.
+  !>   @param[in] x - vector descriptor.
+  !>   @param[in] beta - scalar \f$\beta\f$.
+  !>   @param[inout] y - vector descriptor.
+  !>   @param[in] compute_type - floating point precision for the SpMV computation.
+  !>   @param[in] alg - SpMV algorithm for the SpMV computation.
+  !>   @param[in] stage - SpMV stage for the SpMV computation.
+  !>   @param[out] buffer_size - number of bytes of the temporary storage buffer. buffer_size is set
+  !>   when
   !>                \p temp_buffer is nullptr.
-  !>   @param[in]
-  !>   temp_buffer  temporary storage buffer allocated by the user. When the
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user. When the
   !>                `rocsparse_spmv_stage_buffer_size` stage is passed,
   !>                the required allocation size (in bytes) is written to \p buffer_size and
   !>                function returns without performing the SpMV operation.
@@ -17457,30 +16158,18 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support batched computation.
   !>
-  !>   @param[in]
-  !>   handle       handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   trans_A      matrix operation type for the sparse matrix \f$op(A)\f$.
-  !>   @param[in]
-  !>   trans_B      matrix operation type for the dense matrix \f$op(B)\f$.
-  !>   @param[in]
-  !>   alpha        scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   matA         sparse matrix descriptor.
-  !>   @param[in]
-  !>   matB         dense matrix descriptor.
-  !>   @param[inout]
-  !>   matC         dense matrix descriptor.
-  !>   @param[in]
-  !>   compute_type floating point precision for the SpSM computation.
-  !>   @param[in]
-  !>   alg          SpSM algorithm for the SpSM computation.
-  !>   @param[in]
-  !>   stage        SpSM stage for the SpSM computation.
-  !>   @param[out]
-  !>   buffer_size  number of bytes of the temporary storage buffer.
-  !>   @param[in]
-  !>   temp_buffer  temporary storage buffer allocated by the user. When the
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] trans_A - matrix operation type for the sparse matrix \f$op(A)\f$.
+  !>   @param[in] trans_B - matrix operation type for the dense matrix \f$op(B)\f$.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] matA - sparse matrix descriptor.
+  !>   @param[in] matB - dense matrix descriptor.
+  !>   @param[inout] matC - dense matrix descriptor.
+  !>   @param[in] compute_type - floating point precision for the SpSM computation.
+  !>   @param[in] alg - SpSM algorithm for the SpSM computation.
+  !>   @param[in] stage - SpSM stage for the SpSM computation.
+  !>   @param[out] buffer_size - number of bytes of the temporary storage buffer.
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user. When the
   !>                `rocsparse_spsm_stage_buffer_size` stage is passed in,
   !>                the required allocation size (in bytes) is written to \p buffer_size, and the
   !>                function returns without performing the SpSM operation.
@@ -17593,28 +16282,17 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support batched computation.
   !>
-  !>   @param[in]
-  !>   handle       handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   trans        matrix operation type.
-  !>   @param[in]
-  !>   alpha        scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   mat          matrix descriptor.
-  !>   @param[in]
-  !>   x            vector descriptor.
-  !>   @param[inout]
-  !>   y            vector descriptor.
-  !>   @param[in]
-  !>   compute_type floating point precision for the SpSV computation.
-  !>   @param[in]
-  !>   alg          SpSV algorithm for the SpSV computation.
-  !>   @param[in]
-  !>   stage        SpSV stage for the SpSV computation.
-  !>   @param[out]
-  !>   buffer_size  number of bytes of the temporary storage buffer.
-  !>   @param[in]
-  !>   temp_buffer  temporary storage buffer allocated by the user. When the
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] trans - matrix operation type.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] mat - matrix descriptor.
+  !>   @param[in] x - vector descriptor.
+  !>   @param[inout] y - vector descriptor.
+  !>   @param[in] compute_type - floating point precision for the SpSV computation.
+  !>   @param[in] alg - SpSV algorithm for the SpSV computation.
+  !>   @param[in] stage - SpSV stage for the SpSV computation.
+  !>   @param[out] buffer_size - number of bytes of the temporary storage buffer.
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user. When the
   !>                `rocsparse_spsv_stage_buffer_size` stage is passed,
   !>                the required allocation size (in bytes) is written to \p buffer_size and the
   !>                function returns without performing the SpSV operation.
@@ -17666,23 +16344,16 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support batched execution.
   !>
-  !>   @param[in]
-  !>   handle       handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   sptrsm_descr SpTrSM descriptor.
-  !>   @param[in]
-  !>   A  sparse matrix descriptor.
-  !>   @param[in]
-  !>   X            dense matrix descriptor.
-  !>   @param[in]
-  !>   Y            dense matrix descriptor.
-  !>   @param[in]
-  !>   sptrsm_stage stage for the SpTrSM computation.
-  !>   @param[out]
-  !>   buffer_size_in_bytes  number of bytes of the buffer.
-  !>   @param[out]
-  !>   p_error error descriptor created if the returned status is not `rocsparse_status_success`. A
-  !>   null pointer can be passed if an error descriptor is not required.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] sptrsm_descr - SpTrSM descriptor.
+  !>   @param[in] A - sparse matrix descriptor.
+  !>   @param[in] X - dense matrix descriptor.
+  !>   @param[in] Y - dense matrix descriptor.
+  !>   @param[in] sptrsm_stage - stage for the SpTrSM computation.
+  !>   @param[out] buffer_size_in_bytes - number of bytes of the buffer.
+  !>   @param[out] p_error - error descriptor created if the returned status is not
+  !>   `rocsparse_status_success`. A null pointer can be passed if an error descriptor is not
+  !>   required.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_handle the library context was not initialized.
@@ -17805,25 +16476,17 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support batched execution.
   !>
-  !>   @param[in]
-  !>   handle       handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   sptrsm_descr           SpTrSM routine descriptor.
-  !>   @param[in]
-  !>   A           sparse matrix descriptor.
-  !>   @param[in]
-  !>   X           dense matrix descriptor.
-  !>   @param[inout]
-  !>   Y           dense matrix descriptor.
-  !>   @param[in]
-  !>   sptrsm_stage SpTrSM stage for the SpTrSM computation.
-  !>   @param[out]
-  !>   buffer_size_in_bytes  number of bytes of the temporary storage buffer.
-  !>   @param[in]
-  !>   buffer  temporary storage buffer allocated by the user.
-  !>   @param[out]
-  !>   p_error error descriptor created if the returned status is not `rocsparse_status_success`. A
-  !>   null pointer can be passed if an error descriptor is not required.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] sptrsm_descr - SpTrSM routine descriptor.
+  !>   @param[in] A - sparse matrix descriptor.
+  !>   @param[in] X - dense matrix descriptor.
+  !>   @param[inout] Y - dense matrix descriptor.
+  !>   @param[in] sptrsm_stage - SpTrSM stage for the SpTrSM computation.
+  !>   @param[out] buffer_size_in_bytes - number of bytes of the temporary storage buffer.
+  !>   @param[in] buffer - temporary storage buffer allocated by the user.
+  !>   @param[out] p_error - error descriptor created if the returned status is not
+  !>   `rocsparse_status_success`. A null pointer can be passed if an error descriptor is not
+  !>   required.
   !>
   !>   \retval      rocsparse_status_success the operation completed successfully.
   !>   \retval      rocsparse_status_invalid_handle the library context was not initialized.
@@ -17866,23 +16529,16 @@ module hipfort_rocsparse
   !>   This routine does not support batched computation.
   !>
   !>
-  !>   @param[in]
-  !>   handle       handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   sptrsv_descr SpTrSV descriptor.
-  !>   @param[in]
-  !>   spmat_descr  sparse matrix descriptor.
-  !>   @param[in]
-  !>   x            dense vector descriptor.
-  !>   @param[in]
-  !>   y            dense vector descriptor.
-  !>   @param[in]
-  !>   sptrsv_stage stage for the SpTrSV computation.
-  !>   @param[out]
-  !>   buffer_size_in_bytes  number of bytes of the buffer.
-  !>   @param[out]
-  !>   p_error error descriptor created if the returned status is not `rocsparse_status_success`. A
-  !>   null pointer can be passed if an error descriptor is not required.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] sptrsv_descr - SpTrSV descriptor.
+  !>   @param[in] spmat_descr - sparse matrix descriptor.
+  !>   @param[in] x - dense vector descriptor.
+  !>   @param[in] y - dense vector descriptor.
+  !>   @param[in] sptrsv_stage - stage for the SpTrSV computation.
+  !>   @param[out] buffer_size_in_bytes - number of bytes of the buffer.
+  !>   @param[out] p_error - error descriptor created if the returned status is not
+  !>   `rocsparse_status_success`. A null pointer can be passed if an error descriptor is not
+  !>   required.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_handle the library context was not initialized.
@@ -17973,25 +16629,17 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support batched computation.
   !>
-  !>   @param[in]
-  !>   handle       handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   sptrsv_descr descriptor of the routine.
-  !>   @param[in]
-  !>   A            matrix descriptor.
-  !>   @param[in]
-  !>   x            vector descriptor.
-  !>   @param[inout]
-  !>   y            vector descriptor.
-  !>   @param[in]
-  !>   sptrsv_stage stage for the SpTRSV computation.
-  !>   @param[in]
-  !>   buffer_size_in_bytes  number of bytes of the buffer.
-  !>   @param[in]
-  !>   buffer       buffer allocated by the user.
-  !>   @param[out]
-  !>   p_error error descriptor created if the returned status is not `rocsparse_status_success`. A
-  !>   null pointer can be passed if the user is not interested in obtaining an error descriptor.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] sptrsv_descr - descriptor of the routine.
+  !>   @param[in] A - matrix descriptor.
+  !>   @param[in] x - vector descriptor.
+  !>   @param[inout] y - vector descriptor.
+  !>   @param[in] sptrsv_stage - stage for the SpTRSV computation.
+  !>   @param[in] buffer_size_in_bytes - number of bytes of the buffer.
+  !>   @param[in] buffer - buffer allocated by the user.
+  !>   @param[out] p_error - error descriptor created if the returned status is not
+  !>   `rocsparse_status_success`. A null pointer can be passed if the user is not interested in
+  !>   obtaining an error descriptor.
   !>
   !>   \retval      rocsparse_status_success the operation completed successfully.
   !>   \retval      rocsparse_status_invalid_handle the library context was not initialized.
@@ -18094,23 +16742,17 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support batched computation.
   !>
-  !>   @param[in]
-  !>   handle       handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   trans        sparse vector operation type.
-  !>   @param[in]
-  !>   x            sparse vector descriptor.
-  !>   @param[in]
-  !>   y            dense vector descriptor.
-  !>   @param[out]
-  !>   result       pointer to the result, which can be in host or device memory.
-  !>   @param[in]
-  !>   compute_type floating point precision for the SpVV computation.
-  !>   @param[out]
-  !>   buffer_size  number of bytes of the temporary storage buffer. buffer_size is set when
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] trans - sparse vector operation type.
+  !>   @param[in] x - sparse vector descriptor.
+  !>   @param[in] y - dense vector descriptor.
+  !>   @param[out] myResult - pointer to the result, which can be in host or device memory.
+  !>   @param[in] compute_type - floating point precision for the SpVV computation.
+  !>   @param[out] buffer_size - number of bytes of the temporary storage buffer. buffer_size is set
+  !>   when
   !>                \p temp_buffer is nullptr.
-  !>   @param[in]
-  !>   temp_buffer  temporary storage buffer allocated by the user. When a nullptr is passed,
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user. When a nullptr is
+  !>   passed,
   !>                the required allocation size (in bytes) is written to \p buffer_size and the
   !>                function returns without performing the SpVV operation.
   !>
@@ -18150,23 +16792,16 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle       handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   descr        SpMV descriptor.
-  !>   @param[in]
-  !>   mat          sparse matrix descriptor.
-  !>   @param[in]
-  !>   x            dense vector descriptor.
-  !>   @param[in]
-  !>   y            dense vector descriptor.
-  !>   @param[in]
-  !>   stage        Version 2 SpMV stage for the SpMV computation.
-  !>   @param[out]
-  !>   buffer_size_in_bytes  number of bytes of the buffer.
-  !>   @param[out]
-  !>   error error descriptor created if the returned status is not `rocsparse_status_success`. A
-  !>   null pointer can be passed if an error descriptor is not required.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] descr - SpMV descriptor.
+  !>   @param[in] mat - sparse matrix descriptor.
+  !>   @param[in] x - dense vector descriptor.
+  !>   @param[in] y - dense vector descriptor.
+  !>   @param[in] stage - Version 2 SpMV stage for the SpMV computation.
+  !>   @param[out] buffer_size_in_bytes - number of bytes of the buffer.
+  !>   @param[out] error - error descriptor created if the returned status is not
+  !>   `rocsparse_status_success`. A null pointer can be passed if an error descriptor is not
+  !>   required.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_handle the library context was not initialized.
@@ -18355,30 +16990,20 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support batched computation.
   !>
-  !>   @param[in]
-  !>   handle       handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   descr        SpMV descriptor.
-  !>   @param[in]
-  !>   alpha        scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   mat          matrix descriptor.
-  !>   @param[in]
-  !>   x            vector descriptor.
-  !>   @param[in]
-  !>   beta         scalar \f$\beta\f$.
-  !>   @param[inout]
-  !>   y            vector descriptor.
-  !>   @param[in]
-  !>   stage        SpMV stage of the SpMV algorithm.
-  !>   @param[in]
-  !>   buffer_size_in_bytes size in bytes of the buffer, which must be greater or equal to the
-  !>   buffer size obtained from \ref rocsparse_v2_spmv_buffer_size.
-  !>   @param[in]
-  !>   buffer       temporary buffer allocated by the user.
-  !>   @param[out]
-  !>   error error descriptor created if the returned status is not `rocsparse_status_success`. A
-  !>   null pointer can be passed if an error descriptor is not required.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] descr - SpMV descriptor.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] mat - matrix descriptor.
+  !>   @param[in] x - vector descriptor.
+  !>   @param[in] beta - scalar \f$\beta\f$.
+  !>   @param[inout] y - vector descriptor.
+  !>   @param[in] stage - SpMV stage of the SpMV algorithm.
+  !>   @param[in] buffer_size_in_bytes - size in bytes of the buffer, which must be greater or equal
+  !>   to the buffer size obtained from \ref rocsparse_v2_spmv_buffer_size.
+  !>   @param[in] buffer - temporary buffer allocated by the user.
+  !>   @param[out] error - error descriptor created if the returned status is not
+  !>   `rocsparse_status_success`. A null pointer can be passed if an error descriptor is not
+  !>   required.
   !>
   !>   \retval      rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_handle the library context \p handle was not initialized.
@@ -18434,21 +17059,17 @@ module hipfort_rocsparse
   !>   - Both scalar and compute data types must be set on the descriptor before calling this
   !>   function.
   !>
-  !>   @param[in]
-  !>   handle          handle to the rocSPARSE library context queue.
-  !>   @param[inout]
-  !>   descr           SpMV descriptor.
-  !>   @param[in]
-  !>   num_extras      number of extra terms (gamma/z pairs).
-  !>   @param[in]
-  !>   gamma_vec dense vector descriptor containing gamma scalars. Must have a data type matching
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[inout] descr - SpMV descriptor.
+  !>   @param[in] num_extras - number of extra terms (gamma/z pairs).
+  !>   @param[in] gamma_vec - dense vector descriptor containing gamma scalars. Must have a data
+  !>   type matching
   !>                   the scalar datatype and a size equal to \p num_extras.
-  !>   @param[in]
-  !>   z_vecs          array of dense vector descriptors for z vectors. All vectors must have a
+  !>   @param[in] z_vecs - array of dense vector descriptors for z vectors. All vectors must have a
   !>                   data type matching the compute data type and have the same size.
-  !>   @param[out]
-  !>   p_error error descriptor created if the returned status is not `rocsparse_status_success`. A
-  !>   null pointer can be passed if an error descriptor is not required.
+  !>   @param[out] p_error - error descriptor created if the returned status is not
+  !>   `rocsparse_status_success`. A null pointer can be passed if an error descriptor is not
+  !>   required.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_handle the library context was not initialized.
@@ -18482,13 +17103,11 @@ module hipfort_rocsparse
   !>   \p rocsparse_spmv_clear_extra clears the extra parameters set by
   !>   \ref rocsparse_spmv_set_extra.
   !>
-  !>   @param[in]
-  !>   handle          handle to the rocSPARSE library context queue.
-  !>   @param[inout]
-  !>   descr           SpMV descriptor.
-  !>   @param[out]
-  !>   p_error error descriptor created if the returned status is not `rocsparse_status_success`. A
-  !>   null pointer can be passed if an error descriptor is not required.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[inout] descr - SpMV descriptor.
+  !>   @param[out] p_error - error descriptor created if the returned status is not
+  !>   `rocsparse_status_success`. A null pointer can be passed if an error descriptor is not
+  !>   required.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_handle the library context was not initialized.
@@ -18531,21 +17150,14 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of vector \f$x\f$.
-  !>   @param[in]
-  !>   alpha       scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   x_val       array of \p nnz elements containing the values of \f$x\f$.
-  !>   @param[in]
-  !>   x_ind       array of \p nnz elements containing the indices of the non-zero
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] nnz - number of non-zero entries of vector \f$x\f$.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] x_val - array of \p nnz elements containing the values of \f$x\f$.
+  !>   @param[in] x_ind - array of \p nnz elements containing the indices of the non-zero
   !>               values of \f$x\f$.
-  !>   @param[inout]
-  !>   y           array of values in dense format.
-  !>   @param[in]
-  !>   idx_base    `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
+  !>   @param[inout] y - array of values in dense format.
+  !>   @param[in] idx_base - `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_handle the library context was not initialized.
@@ -18673,21 +17285,14 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of vector \f$x\f$.
-  !>   @param[in]
-  !>   x_val       array of \p nnz values.
-  !>   @param[in]
-  !>   x_ind       array of \p nnz elements containing the indices of the non-zero
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] nnz - number of non-zero entries of vector \f$x\f$.
+  !>   @param[in] x_val - array of \p nnz values.
+  !>   @param[in] x_ind - array of \p nnz elements containing the indices of the non-zero
   !>               values of \f$x\f$.
-  !>   @param[in]
-  !>   y           array of values in dense format.
-  !>   @param[out]
-  !>   result      pointer to the result, which can be in host or device memory.
-  !>   @param[in]
-  !>   idx_base    `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
+  !>   @param[in] y - array of values in dense format.
+  !>   @param[out] myResult - pointer to the result, which can be in host or device memory.
+  !>   @param[in] idx_base - `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_handle the library context was not initialized.
@@ -18769,21 +17374,14 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of vector \f$x\f$.
-  !>   @param[in]
-  !>   x_val       array of \p nnz values.
-  !>   @param[in]
-  !>   x_ind       array of \p nnz elements containing the indices of the non-zero
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] nnz - number of non-zero entries of vector \f$x\f$.
+  !>   @param[in] x_val - array of \p nnz values.
+  !>   @param[in] x_ind - array of \p nnz elements containing the indices of the non-zero
   !>               values of \f$x\f$.
-  !>   @param[in]
-  !>   y           array of values in dense format.
-  !>   @param[out]
-  !>   result      pointer to the result, which can be in host or device memory.
-  !>   @param[in]
-  !>   idx_base    `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
+  !>   @param[in] y - array of values in dense format.
+  !>   @param[out] myResult - pointer to the result, which can be in host or device memory.
+  !>   @param[in] idx_base - `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_handle the library context was not initialized.
@@ -18909,19 +17507,13 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of \f$x\f$.
-  !>   @param[in]
-  !>   y           array of values in dense format.
-  !>   @param[out]
-  !>   x_val       array of \p nnz elements containing the values of \f$x\f$.
-  !>   @param[in]
-  !>   x_ind       array of \p nnz elements containing the indices of the non-zero
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] nnz - number of non-zero entries of \f$x\f$.
+  !>   @param[in] y - array of values in dense format.
+  !>   @param[out] x_val - array of \p nnz elements containing the values of \f$x\f$.
+  !>   @param[in] x_ind - array of \p nnz elements containing the indices of the non-zero
   !>               values of \f$x\f$.
-  !>   @param[in]
-  !>   idx_base    `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
+  !>   @param[in] idx_base - `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -19039,19 +17631,13 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of \f$x\f$.
-  !>   @param[inout]
-  !>   y           array of values in dense format.
-  !>   @param[out]
-  !>   x_val       array of \p nnz elements containing the non-zero values of \f$x\f$.
-  !>   @param[in]
-  !>   x_ind       array of \p nnz elements containing the indices of the non-zero
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] nnz - number of non-zero entries of \f$x\f$.
+  !>   @param[inout] y - array of values in dense format.
+  !>   @param[out] x_val - array of \p nnz elements containing the non-zero values of \f$x\f$.
+  !>   @param[in] x_ind - array of \p nnz elements containing the indices of the non-zero
   !>               values of \f$x\f$.
-  !>   @param[in]
-  !>   idx_base    `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
+  !>   @param[in] idx_base - `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -19171,23 +17757,15 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of \f$x\f$.
-  !>   @param[inout]
-  !>   x_val       array of \p nnz elements containing the non-zero values of \f$x\f$.
-  !>   @param[in]
-  !>   x_ind       array of \p nnz elements containing the indices of the non-zero
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] nnz - number of non-zero entries of \f$x\f$.
+  !>   @param[inout] x_val - array of \p nnz elements containing the non-zero values of \f$x\f$.
+  !>   @param[in] x_ind - array of \p nnz elements containing the indices of the non-zero
   !>               values of \f$x\f$.
-  !>   @param[inout]
-  !>   y           array of values in dense format.
-  !>   @param[in]
-  !>   c           pointer to the cosine element of \f$G\f$, can be on the host or device.
-  !>   @param[in]
-  !>   s           pointer to the sine element of \f$G\f$, can be on the host or device.
-  !>   @param[in]
-  !>   idx_base    `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
+  !>   @param[inout] y - array of values in dense format.
+  !>   @param[in] c - pointer to the cosine element of \f$G\f$, can be on the host or device.
+  !>   @param[in] s - pointer to the sine element of \f$G\f$, can be on the host or device.
+  !>   @param[in] idx_base - `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -19265,19 +17843,13 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of \f$x\f$.
-  !>   @param[in]
-  !>   x_val       array of \p nnz elements containing the non-zero values of \f$x\f$.
-  !>   @param[in]
-  !>   x_ind       array of \p nnz elements containing the indices of the non-zero
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] nnz - number of non-zero entries of \f$x\f$.
+  !>   @param[in] x_val - array of \p nnz elements containing the non-zero values of \f$x\f$.
+  !>   @param[in] x_ind - array of \p nnz elements containing the indices of the non-zero
   !>               values of x.
-  !>   @param[inout]
-  !>   y           array of values in dense format.
-  !>   @param[in]
-  !>   idx_base    `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
+  !>   @param[inout] y - array of values in dense format.
+  !>   @param[in] idx_base - `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -19416,33 +17988,23 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   dir         matrix storage of BSR blocks.
-  !>   @param[in]
-  !>   trans       matrix operation type.
-  !>   @param[in]
-  !>   mb          number of block rows of the sparse BSR matrix.
-  !>   @param[in]
-  !>   nb          number of block columns of the sparse BSR matrix.
-  !>   @param[in]
-  !>   nnzb        number of non-zero blocks of the sparse BSR matrix.
-  !>   @param[in]
-  !>   descr       descriptor of the sparse BSR matrix. Currently, only
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] dir - matrix storage of BSR blocks.
+  !>   @param[in] trans - matrix operation type.
+  !>   @param[in] mb - number of block rows of the sparse BSR matrix.
+  !>   @param[in] nb - number of block columns of the sparse BSR matrix.
+  !>   @param[in] nnzb - number of non-zero blocks of the sparse BSR matrix.
+  !>   @param[in] descr - descriptor of the sparse BSR matrix. Currently, only
   !>               `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   bsr_val     array of \p nnzb blocks of the sparse BSR matrix.
-  !>   @param[in]
-  !>   bsr_row_ptr array of \p mb+1 elements that point to the start of every block row of
+  !>   @param[in] bsr_val - array of \p nnzb blocks of the sparse BSR matrix.
+  !>   @param[in] bsr_row_ptr - array of \p mb+1 elements that point to the start of every block row
+  !>   of
   !>               the sparse BSR matrix.
-  !>   @param[in]
-  !>   bsr_col_ind array of \p nnzb elements containing the block column indices of the sparse
+  !>   @param[in] bsr_col_ind - array of \p nnzb elements containing the block column indices of the
+  !>   sparse
   !>               BSR matrix.
-  !>   @param[in]
-  !>   block_dim     block dimension of the sparse BSR matrix.
-  !>   @param[out]
-  !>   info        structure that holds the information collected during the analysis step.
+  !>   @param[in] block_dim - block dimension of the sparse BSR matrix.
+  !>   @param[out] myInfo - structure that holds the information collected during the analysis step.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -19612,43 +18174,29 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   dir         matrix storage of BSR blocks.
-  !>   @param[in]
-  !>   trans       matrix operation type.
-  !>   @param[in]
-  !>   mb          number of block rows of the sparse BSR matrix.
-  !>   @param[in]
-  !>   nb          number of block columns of the sparse BSR matrix.
-  !>   @param[in]
-  !>   nnzb        number of non-zero blocks of the sparse BSR matrix.
-  !>   @param[in]
-  !>   alpha       scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   descr       descriptor of the sparse BSR matrix. Currently, only
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] dir - matrix storage of BSR blocks.
+  !>   @param[in] trans - matrix operation type.
+  !>   @param[in] mb - number of block rows of the sparse BSR matrix.
+  !>   @param[in] nb - number of block columns of the sparse BSR matrix.
+  !>   @param[in] nnzb - number of non-zero blocks of the sparse BSR matrix.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] descr - descriptor of the sparse BSR matrix. Currently, only
   !>               `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   bsr_val     array of \p nnzb blocks of the sparse BSR matrix.
-  !>   @param[in]
-  !>   bsr_row_ptr array of \p mb+1 elements that point to the start of every block row of
+  !>   @param[in] bsr_val - array of \p nnzb blocks of the sparse BSR matrix.
+  !>   @param[in] bsr_row_ptr - array of \p mb+1 elements that point to the start of every block row
+  !>   of
   !>               the sparse BSR matrix.
-  !>   @param[in]
-  !>   bsr_col_ind array of \p nnzb elements containing the block column indices of the sparse
+  !>   @param[in] bsr_col_ind - array of \p nnzb elements containing the block column indices of the
+  !>   sparse
   !>               BSR matrix.
-  !>   @param[in]
-  !>   block_dim     block dimension of the sparse BSR matrix.
-  !>   @param[in]
-  !>   x           array of \p nb*block_dim elements (\f$op(A) = A\f$) or \p mb*block_dim
+  !>   @param[in] block_dim - block dimension of the sparse BSR matrix.
+  !>   @param[in] x - array of \p nb*block_dim elements (\f$op(A) = A\f$) or \p mb*block_dim
   !>               elements (\f$op(A) = A^T\f$ or \f$op(A) = A^H\f$).
-  !>   @param[in]
-  !>   beta        scalar \f$\beta\f$.
-  !>   @param[inout]
-  !>   y           array of \p mb*block_dim elements (\f$op(A) = A\f$) or \p nb*block_dim
+  !>   @param[in] beta - scalar \f$\beta\f$.
+  !>   @param[inout] y - array of \p mb*block_dim elements (\f$op(A) = A\f$) or \p nb*block_dim
   !>               elements (\f$op(A) = A^T\f$ or \f$op(A) = A^H\f$).
-  !>   @param[out]
-  !>   info        structure that holds the information collected during the analysis step.
+  !>   @param[out] myInfo - structure that holds the information collected during the analysis step.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -19809,10 +18357,8 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[inout]
-  !>   info        structure that holds the information collected during analysis step.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[inout] myInfo - structure that holds the information collected during analysis step.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -19848,12 +18394,10 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   info        structure that holds the information collected during the analysis step.
-  !>   @param[inout]
-  !>   position    pointer to zero pivot \f$j\f$, which can be in host or device memory.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[inout] position - pointer to zero pivot \f$j\f$, which can be in host or device
+  !>   memory.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -19888,32 +18432,21 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   dir         matrix storage of BSR blocks.
-  !>   @param[in]
-  !>   trans       matrix operation type.
-  !>   @param[in]
-  !>   mb          number of block rows of the sparse BSR matrix.
-  !>   @param[in]
-  !>   nnzb        number of non-zero blocks of the sparse BSR matrix.
-  !>   @param[in]
-  !>   descr       descriptor of the sparse BSR matrix.
-  !>   @param[in]
-  !>   bsr_val     array of \p nnzb blocks of the sparse BSR matrix.
-  !>   @param[in]
-  !>   bsr_row_ptr array of \p mb+1 elements that point to the start of every block row of
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] dir - matrix storage of BSR blocks.
+  !>   @param[in] trans - matrix operation type.
+  !>   @param[in] mb - number of block rows of the sparse BSR matrix.
+  !>   @param[in] nnzb - number of non-zero blocks of the sparse BSR matrix.
+  !>   @param[in] descr - descriptor of the sparse BSR matrix.
+  !>   @param[in] bsr_val - array of \p nnzb blocks of the sparse BSR matrix.
+  !>   @param[in] bsr_row_ptr - array of \p mb+1 elements that point to the start of every block row
+  !>   of
   !>               the sparse BSR matrix.
-  !>   @param[in]
-  !>   bsr_col_ind array of \p nnz containing the block column indices of the sparse
+  !>   @param[in] bsr_col_ind - array of \p nnz containing the block column indices of the sparse
   !>               BSR matrix.
-  !>   @param[in]
-  !>   block_dim     block dimension of the sparse BSR matrix.
-  !>   @param[out]
-  !>   info        structure that holds the information collected during the analysis step.
-  !>   @param[out]
-  !>   buffer_size number of bytes of the temporary storage buffer required by
+  !>   @param[in] block_dim - block dimension of the sparse BSR matrix.
+  !>   @param[out] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[out] buffer_size - number of bytes of the temporary storage buffer required by
   !>               rocsparse_sbsrsv_analysis(), rocsparse_dbsrsv_analysis(),
   !>               rocsparse_cbsrsv_analysis(), rocsparse_zbsrsv_analysis(),
   !>               rocsparse_sbsrsv_solve(), rocsparse_dbsrsv_solve(),
@@ -20070,38 +18603,25 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   dir         matrix storage of BSR blocks.
-  !>   @param[in]
-  !>   trans       matrix operation type.
-  !>   @param[in]
-  !>   mb          number of block rows of the sparse BSR matrix.
-  !>   @param[in]
-  !>   nnzb        number of non-zero blocks of the sparse BSR matrix.
-  !>   @param[in]
-  !>   descr       descriptor of the sparse BSR matrix.
-  !>   @param[in]
-  !>   bsr_val     array of \p nnzb blocks of the sparse BSR matrix.
-  !>   @param[in]
-  !>   bsr_row_ptr array of \p mb+1 elements that point to the start of every block row of
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] dir - matrix storage of BSR blocks.
+  !>   @param[in] trans - matrix operation type.
+  !>   @param[in] mb - number of block rows of the sparse BSR matrix.
+  !>   @param[in] nnzb - number of non-zero blocks of the sparse BSR matrix.
+  !>   @param[in] descr - descriptor of the sparse BSR matrix.
+  !>   @param[in] bsr_val - array of \p nnzb blocks of the sparse BSR matrix.
+  !>   @param[in] bsr_row_ptr - array of \p mb+1 elements that point to the start of every block row
+  !>   of
   !>               the sparse BSR matrix.
-  !>   @param[in]
-  !>   bsr_col_ind array of \p nnz containing the block column indices of the sparse
+  !>   @param[in] bsr_col_ind - array of \p nnz containing the block column indices of the sparse
   !>               BSR matrix.
-  !>   @param[in]
-  !>   block_dim     block dimension of the sparse BSR matrix.
-  !>   @param[out]
-  !>   info        structure that holds the information collected during
+  !>   @param[in] block_dim - block dimension of the sparse BSR matrix.
+  !>   @param[out] myInfo - structure that holds the information collected during
   !>               the analysis step.
-  !>   @param[in]
-  !>   analysis    `rocsparse_analysis_policy_reuse` or
+  !>   @param[in] analysis - `rocsparse_analysis_policy_reuse` or
   !>               `rocsparse_analysis_policy_force`.
-  !>   @param[in]
-  !>   solve       `rocsparse_solve_policy_auto`.
-  !>   @param[in]
-  !>   temp_buffer temporary storage buffer allocated by the user.
+  !>   @param[in] solve - `rocsparse_solve_policy_auto`.
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -20249,10 +18769,9 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[inout]
-  !>   info        structure that holds the information collected during the analysis step.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[inout] myInfo - structure that holds the information collected during the analysis
+  !>   step.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -20347,40 +18866,25 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   dir         matrix storage of BSR blocks.
-  !>   @param[in]
-  !>   trans       matrix operation type.
-  !>   @param[in]
-  !>   mb          number of block rows of the sparse BSR matrix.
-  !>   @param[in]
-  !>   nnzb        number of non-zero blocks of the sparse BSR matrix.
-  !>   @param[in]
-  !>   alpha       scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   descr       descriptor of the sparse BSR matrix.
-  !>   @param[in]
-  !>   bsr_val     array of \p nnzb blocks of the sparse BSR matrix.
-  !>   @param[in]
-  !>   bsr_row_ptr array of \p mb+1 elements that point to the start of every block row of
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] dir - matrix storage of BSR blocks.
+  !>   @param[in] trans - matrix operation type.
+  !>   @param[in] mb - number of block rows of the sparse BSR matrix.
+  !>   @param[in] nnzb - number of non-zero blocks of the sparse BSR matrix.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] descr - descriptor of the sparse BSR matrix.
+  !>   @param[in] bsr_val - array of \p nnzb blocks of the sparse BSR matrix.
+  !>   @param[in] bsr_row_ptr - array of \p mb+1 elements that point to the start of every block row
+  !>   of
   !>               the sparse BSR matrix.
-  !>   @param[in]
-  !>   bsr_col_ind array of \p nnz containing the block column indices of the sparse
+  !>   @param[in] bsr_col_ind - array of \p nnz containing the block column indices of the sparse
   !>               BSR matrix.
-  !>   @param[in]
-  !>   block_dim     block dimension of the sparse BSR matrix.
-  !>   @param[in]
-  !>   info        structure that holds the information collected during the analysis step.
-  !>   @param[in]
-  !>   x           array of \p m elements, holding the right-hand side.
-  !>   @param[out]
-  !>   y           array of \p m elements, holding the solution.
-  !>   @param[in]
-  !>   policy      `rocsparse_solve_policy_auto`.
-  !>   @param[in]
-  !>   temp_buffer temporary storage buffer allocated by the user.
+  !>   @param[in] block_dim - block dimension of the sparse BSR matrix.
+  !>   @param[in] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[in] x - array of \p m elements, holding the right-hand side.
+  !>   @param[out] y - array of \p m elements, holding the solution.
+  !>   @param[in] policy - `rocsparse_solve_policy_auto`.
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -20566,50 +19070,34 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   dir         matrix storage of BSR blocks.
-  !>   @param[in]
-  !>   trans       matrix operation type.
-  !>   @param[in]
-  !>   size_of_mask number of updated block rows of the array \p y.
-  !>   @param[in]
-  !>   mb          number of block rows of the sparse BSR matrix.
-  !>   @param[in]
-  !>   nb          number of block columns of the sparse BSR matrix.
-  !>   @param[in]
-  !>   nnzb        number of non-zero blocks of the sparse BSR matrix.
-  !>   @param[in]
-  !>   alpha       scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   descr       descriptor of the sparse BSR matrix. Currently, only
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] dir - matrix storage of BSR blocks.
+  !>   @param[in] trans - matrix operation type.
+  !>   @param[in] size_of_mask - number of updated block rows of the array \p y.
+  !>   @param[in] mb - number of block rows of the sparse BSR matrix.
+  !>   @param[in] nb - number of block columns of the sparse BSR matrix.
+  !>   @param[in] nnzb - number of non-zero blocks of the sparse BSR matrix.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] descr - descriptor of the sparse BSR matrix. Currently, only
   !>               `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   bsr_val     array of \p nnzb blocks of the sparse BSR matrix.
+  !>   @param[in] bsr_val - array of \p nnzb blocks of the sparse BSR matrix.
   !>
-  !>   @param[in]
-  !>   bsr_mask_ptr array of \p size_of_mask elements that give the indices of the updated block
-  !>   rows.
+  !>   @param[in] bsr_mask_ptr - array of \p size_of_mask elements that give the indices of the
+  !>   updated block rows.
   !>
-  !>   @param[in]
-  !>   bsr_row_ptr array of \p mb elements that point to the start of every block row of
+  !>   @param[in] bsr_row_ptr - array of \p mb elements that point to the start of every block row
+  !>   of
   !>               the sparse BSR matrix.
-  !>   @param[in]
-  !>   bsr_end_ptr array of \p mb elements that point to the end of every block row of
+  !>   @param[in] bsr_end_ptr - array of \p mb elements that point to the end of every block row of
   !>               the sparse BSR matrix.
-  !>   @param[in]
-  !>   bsr_col_ind array of \p nnzb elements containing the block column indices of the sparse
+  !>   @param[in] bsr_col_ind - array of \p nnzb elements containing the block column indices of the
+  !>   sparse
   !>               BSR matrix.
-  !>   @param[in]
-  !>   block_dim     block dimension of the sparse BSR matrix.
-  !>   @param[in]
-  !>   x           array of \p nb*block_dim elements (\f$op(A) = A\f$) or \p mb*block_dim
+  !>   @param[in] block_dim - block dimension of the sparse BSR matrix.
+  !>   @param[in] x - array of \p nb*block_dim elements (\f$op(A) = A\f$) or \p mb*block_dim
   !>               elements (\f$op(A) = A^T\f$ or \f$op(A) = A^H\f$).
-  !>   @param[in]
-  !>   beta        scalar \f$\beta\f$.
-  !>   @param[inout]
-  !>   y           array of \p mb*block_dim elements (\f$op(A) = A\f$) or \p nb*block_dim
+  !>   @param[in] beta - scalar \f$\beta\f$.
+  !>   @param[inout] y - array of \p mb*block_dim elements (\f$op(A) = A\f$) or \p nb*block_dim
   !>               elements (\f$op(A) = A^T\f$ or \f$op(A) = A^H\f$).
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
@@ -20811,36 +19299,24 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   trans       matrix operation type.
-  !>   @param[in]
-  !>   m           number of rows of the sparse COO matrix.
-  !>   @param[in]
-  !>   n           number of columns of the sparse COO matrix.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of the sparse COO matrix.
-  !>   @param[in]
-  !>   alpha       scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   descr       descriptor of the sparse COO matrix. Currently, only
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] trans - matrix operation type.
+  !>   @param[in] m - number of rows of the sparse COO matrix.
+  !>   @param[in] n - number of columns of the sparse COO matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse COO matrix.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] descr - descriptor of the sparse COO matrix. Currently, only
   !>               `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   coo_val     array of \p nnz elements of the sparse COO matrix.
-  !>   @param[in]
-  !>   coo_row_ind array of \p nnz elements containing the row indices of the sparse COO
+  !>   @param[in] coo_val - array of \p nnz elements of the sparse COO matrix.
+  !>   @param[in] coo_row_ind - array of \p nnz elements containing the row indices of the sparse
+  !>   COO
   !>               matrix.
-  !>   @param[in]
-  !>   coo_col_ind array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] coo_col_ind - array of \p nnz elements containing the column indices of the sparse
   !>               COO matrix.
-  !>   @param[in]
-  !>   x           array of \p n elements (\f$op(A) = A\f$) or \p m elements
+  !>   @param[in] x - array of \p n elements (\f$op(A) = A\f$) or \p m elements
   !>               (\f$op(A) = A^T\f$ or \f$op(A) = A^H\f$).
-  !>   @param[in]
-  !>   beta        scalar \f$\beta\f$.
-  !>   @param[inout]
-  !>   y           array of \p m elements (\f$op(A) = A\f$) or \p n elements
+  !>   @param[in] beta - scalar \f$\beta\f$.
+  !>   @param[inout] y - array of \p m elements (\f$op(A) = A\f$) or \p n elements
   !>               (\f$op(A) = A^T\f$ or \f$op(A) = A^H\f$).
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
@@ -20992,14 +19468,11 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   descr       descriptor of the sparse CSR matrix.
-  !>   @param[in]
-  !>   info        structure that holds the information collected during the analysis step.
-  !>   @param[inout]
-  !>   position    pointer to zero pivot \f$j\f$, which can be in host or device memory.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] descr - descriptor of the sparse CSR matrix.
+  !>   @param[in] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[inout] position - pointer to zero pivot \f$j\f$, which can be in host or device
+  !>   memory.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -21031,28 +19504,18 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   trans       matrix operation type.
-  !>   @param[in]
-  !>   m           number of rows of the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of the sparse CSR matrix.
-  !>   @param[in]
-  !>   descr       descriptor of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_val     array of \p nnz elements of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_row_ptr array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] trans - matrix operation type.
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix.
+  !>   @param[in] descr - descriptor of the sparse CSR matrix.
+  !>   @param[in] csr_val - array of \p nnz elements of the sparse CSR matrix.
+  !>   @param[in] csr_row_ptr - array of \p m+1 elements that point to the start of every row of the
   !>               sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_col_ind array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] csr_col_ind - array of \p nnz elements containing the column indices of the sparse
   !>               CSR matrix.
-  !>   @param[out]
-  !>   info        structure that holds the information collected during the analysis step.
-  !>   @param[out]
-  !>   buffer_size number of bytes of the temporary storage buffer required by
+  !>   @param[out] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[out] buffer_size - number of bytes of the temporary storage buffer required by
   !>               \ref rocsparse_scsritsv_analysis "rocsparse_Xcsritsv_analysis()" and
   !>               \ref rocsparse_scsritsv_solve "rocsparse_Xcsritsv_solve()".
   !>
@@ -21172,34 +19635,22 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   trans       matrix operation type.
-  !>   @param[in]
-  !>   m           number of rows of the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of the sparse CSR matrix.
-  !>   @param[in]
-  !>   descr       descriptor of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_val     array of \p nnz elements of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_row_ptr array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] trans - matrix operation type.
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix.
+  !>   @param[in] descr - descriptor of the sparse CSR matrix.
+  !>   @param[in] csr_val - array of \p nnz elements of the sparse CSR matrix.
+  !>   @param[in] csr_row_ptr - array of \p m+1 elements that point to the start of every row of the
   !>               sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_col_ind array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] csr_col_ind - array of \p nnz elements containing the column indices of the sparse
   !>               CSR matrix.
-  !>   @param[out]
-  !>   info        structure that holds the information collected during
+  !>   @param[out] myInfo - structure that holds the information collected during
   !>               the analysis step.
-  !>   @param[in]
-  !>   analysis    `rocsparse_analysis_policy_reuse` or
+  !>   @param[in] analysis - `rocsparse_analysis_policy_reuse` or
   !>               `rocsparse_analysis_policy_force`.
-  !>   @param[in]
-  !>   solve       `rocsparse_solve_policy_auto`.
-  !>   @param[in]
-  !>   temp_buffer temporary storage buffer allocated by the user.
+  !>   @param[in] solve - `rocsparse_solve_policy_auto`.
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -21315,12 +19766,10 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   descr       descriptor of the sparse CSR matrix.
-  !>   @param[inout]
-  !>   info        structure that holds the information collected during the analysis step.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] descr - descriptor of the sparse CSR matrix.
+  !>   @param[inout] myInfo - structure that holds the information collected during the analysis
+  !>   step.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -21403,44 +19852,29 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle         handle to the rocSPARSE library context queue.
-  !>   @param[inout]
-  !>   host_nmaxiter maximum number of iterations on input and number of iterations on output. If
-  !>   the output number of iterations is strictly less than the input maximum number of iterations,
-  !>   then the algorithm converged.
-  !>   @param[in]
-  !>   host_tol       if the pointer is null then loop will execute \p nmaxiter[0] iterations.
-  !>   @param[out]
-  !>   host_history   optional array to record the norm of the residual before each iteration.
-  !>   @param[in]
-  !>   trans          matrix operation type.
-  !>   @param[in]
-  !>   m              number of rows of the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnz            number of non-zero entries of the sparse CSR matrix.
-  !>   @param[in]
-  !>   alpha          scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   descr          descriptor of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_val        array of \p nnz elements of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_row_ptr    array of \p m+1 elements that point to the start
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[inout] host_nmaxiter - maximum number of iterations on input and number of iterations
+  !>   on output. If the output number of iterations is strictly less than the input maximum number
+  !>   of iterations, then the algorithm converged.
+  !>   @param[in] host_tol - if the pointer is null then loop will execute \p nmaxiter[0]
+  !>   iterations.
+  !>   @param[out] host_history - optional array to record the norm of the residual before each
+  !>   iteration.
+  !>   @param[in] trans - matrix operation type.
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] descr - descriptor of the sparse CSR matrix.
+  !>   @param[in] csr_val - array of \p nnz elements of the sparse CSR matrix.
+  !>   @param[in] csr_row_ptr - array of \p m+1 elements that point to the start
   !>                  of every row of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_col_ind    array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] csr_col_ind - array of \p nnz elements containing the column indices of the sparse
   !>                  CSR matrix.
-  !>   @param[in]
-  !>   info           structure that holds the information collected during the analysis step.
-  !>   @param[in]
-  !>   x              array of \p m elements, holding the right-hand side.
-  !>   @param[inout]
-  !>   y              array of \p m elements, holding the solution.
-  !>   @param[in]
-  !>   policy         `rocsparse_solve_policy_auto`.
-  !>   @param[in]
-  !>   temp_buffer    temporary storage buffer allocated by the user.
+  !>   @param[in] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[in] x - array of \p m elements, holding the right-hand side.
+  !>   @param[inout] y - array of \p m elements, holding the solution.
+  !>   @param[in] policy - `rocsparse_solve_policy_auto`.
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -21733,47 +20167,32 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[inout]
-  !>   host_nmaxiter maximum number of iterations on input and number of iterations on output. If
-  !>   the output number of iterations is strictly less than the input maximum number of iterations,
-  !>   then the algorithm converged.
-  !>   @param[in]
-  !>   host_nfreeiter number of free iterations, that is, the number of iterations performed without
-  !>   stopping criteria evaluation between two iterations with stopping criteria evaluation.
-  !>   @param[in]
-  !>   host_tol          if the pointer is null, then loop will execute \p nmaxiter[0] iterations.
-  !>   @param[out]
-  !>   host_history      optional array to record the norm of the residual before each iteration.
-  !>   @param[in]
-  !>   trans       matrix operation type.
-  !>   @param[in]
-  !>   m           number of rows of the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of the sparse CSR matrix.
-  !>   @param[in]
-  !>   alpha       scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   descr       descriptor of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_val     array of \p nnz elements of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_row_ptr array of \p m+1 elements that point to the start
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[inout] host_nmaxiter - maximum number of iterations on input and number of iterations
+  !>   on output. If the output number of iterations is strictly less than the input maximum number
+  !>   of iterations, then the algorithm converged.
+  !>   @param[in] host_nfreeiter - number of free iterations, that is, the number of iterations
+  !>   performed without stopping criteria evaluation between two iterations with stopping criteria
+  !>   evaluation.
+  !>   @param[in] host_tol - if the pointer is null, then loop will execute \p nmaxiter[0]
+  !>   iterations.
+  !>   @param[out] host_history - optional array to record the norm of the residual before each
+  !>   iteration.
+  !>   @param[in] trans - matrix operation type.
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] descr - descriptor of the sparse CSR matrix.
+  !>   @param[in] csr_val - array of \p nnz elements of the sparse CSR matrix.
+  !>   @param[in] csr_row_ptr - array of \p m+1 elements that point to the start
   !>               of every row of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_col_ind array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] csr_col_ind - array of \p nnz elements containing the column indices of the sparse
   !>               CSR matrix.
-  !>   @param[in]
-  !>   info        structure that holds the information collected during the analysis step.
-  !>   @param[in]
-  !>   x           array of \p m elements, holding the right-hand side.
-  !>   @param[inout]
-  !>   y           array of \p m elements, holding the solution.
-  !>   @param[in]
-  !>   policy      `rocsparse_solve_policy_auto`.
-  !>   @param[in]
-  !>   temp_buffer temporary storage buffer allocated by the user.
+  !>   @param[in] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[in] x - array of \p m elements, holding the right-hand side.
+  !>   @param[inout] y - array of \p m elements, holding the solution.
+  !>   @param[in] policy - `rocsparse_solve_policy_auto`.
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -22028,28 +20447,18 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   trans       matrix operation type.
-  !>   @param[in]
-  !>   m           number of rows of the sparse CSR matrix.
-  !>   @param[in]
-  !>   n           number of columns of the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of the sparse CSR matrix.
-  !>   @param[in]
-  !>   descr       descriptor of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_val     array of \p nnz elements of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_row_ptr array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] trans - matrix operation type.
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
+  !>   @param[in] n - number of columns of the sparse CSR matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix.
+  !>   @param[in] descr - descriptor of the sparse CSR matrix.
+  !>   @param[in] csr_val - array of \p nnz elements of the sparse CSR matrix.
+  !>   @param[in] csr_row_ptr - array of \p m+1 elements that point to the start of every row of the
   !>               sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_col_ind array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] csr_col_ind - array of \p nnz elements containing the column indices of the sparse
   !>               CSR matrix.
-  !>   @param[out]
-  !>   info        structure that holds the information collected during the analysis step.
+  !>   @param[out] myInfo - structure that holds the information collected during the analysis step.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -22185,10 +20594,9 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[inout]
-  !>   info        structure that holds the information collected during the analysis step.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[inout] myInfo - structure that holds the information collected during the analysis
+  !>   step.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -22282,39 +20690,26 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   trans       matrix operation type.
-  !>   @param[in]
-  !>   m           number of rows of the sparse CSR matrix.
-  !>   @param[in]
-  !>   n           number of columns of the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of the sparse CSR matrix.
-  !>   @param[in]
-  !>   alpha       scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   descr       descriptor of the sparse CSR matrix. Currently, only
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] trans - matrix operation type.
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
+  !>   @param[in] n - number of columns of the sparse CSR matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] descr - descriptor of the sparse CSR matrix. Currently, only
   !>               `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   csr_val     array of \p nnz elements of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_row_ptr array of \p m+1 elements that point to the start
+  !>   @param[in] csr_val - array of \p nnz elements of the sparse CSR matrix.
+  !>   @param[in] csr_row_ptr - array of \p m+1 elements that point to the start
   !>               of every row of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_col_ind array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] csr_col_ind - array of \p nnz elements containing the column indices of the sparse
   !>               CSR matrix.
-  !>   @param[in]
-  !>   info information collected by \ref rocsparse_scsrmv_analysis "rocsparse_Xcsrmv_analysis()",
+  !>   @param[in] myInfo - information collected by \ref rocsparse_scsrmv_analysis
+  !>   "rocsparse_Xcsrmv_analysis()",
   !>               which can be \p NULL if no information is available.
-  !>   @param[in]
-  !>   x           array of \p n elements (\f$op(A) == A\f$) or \p m elements
+  !>   @param[in] x - array of \p n elements (\f$op(A) == A\f$) or \p m elements
   !>               (\f$op(A) == A^T\f$ or \f$op(A) == A^H\f$).
-  !>   @param[in]
-  !>   beta        scalar \f$\beta\f$.
-  !>   @param[inout]
-  !>   y           array of \p m elements (\f$op(A) == A\f$) or \p n elements
+  !>   @param[in] beta - scalar \f$\beta\f$.
+  !>   @param[inout] y - array of \p m elements (\f$op(A) == A\f$) or \p n elements
   !>               (\f$op(A) == A^T\f$ or \f$op(A) == A^H\f$).
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
@@ -22471,14 +20866,10 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   descr       descriptor of the sparse CSR matrix.
-  !>   @param[in]
-  !>   info        structure that holds the information collected during the analysis step.
-  !>   @param[inout]
-  !>   position    pointer to zero pivot \f$j\f$, can be in host or device memory.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] descr - descriptor of the sparse CSR matrix.
+  !>   @param[in] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[inout] position - pointer to zero pivot \f$j\f$, can be in host or device memory.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -22519,28 +20910,18 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   trans       matrix operation type.
-  !>   @param[in]
-  !>   m           number of rows of the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of the sparse CSR matrix.
-  !>   @param[in]
-  !>   descr       descriptor of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_val     array of \p nnz elements of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_row_ptr array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] trans - matrix operation type.
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix.
+  !>   @param[in] descr - descriptor of the sparse CSR matrix.
+  !>   @param[in] csr_val - array of \p nnz elements of the sparse CSR matrix.
+  !>   @param[in] csr_row_ptr - array of \p m+1 elements that point to the start of every row of the
   !>               sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_col_ind array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] csr_col_ind - array of \p nnz elements containing the column indices of the sparse
   !>               CSR matrix.
-  !>   @param[out]
-  !>   info        structure that holds the information collected during the analysis step.
-  !>   @param[out]
-  !>   buffer_size number of bytes of the temporary storage buffer required by
+  !>   @param[out] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[out] buffer_size - number of bytes of the temporary storage buffer required by
   !>               \ref rocsparse_scsrsv_analysis "rocsparse_Xcsrsv_analysis()" and
   !>               \ref rocsparse_scsrsv_solve "rocsparse_Xcsrsv_solve()".
   !>
@@ -22692,34 +21073,22 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   trans       matrix operation type.
-  !>   @param[in]
-  !>   m           number of rows of the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of the sparse CSR matrix.
-  !>   @param[in]
-  !>   descr       descriptor of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_val     array of \p nnz elements of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_row_ptr array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] trans - matrix operation type.
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix.
+  !>   @param[in] descr - descriptor of the sparse CSR matrix.
+  !>   @param[in] csr_val - array of \p nnz elements of the sparse CSR matrix.
+  !>   @param[in] csr_row_ptr - array of \p m+1 elements that point to the start of every row of the
   !>               sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_col_ind array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] csr_col_ind - array of \p nnz elements containing the column indices of the sparse
   !>               CSR matrix.
-  !>   @param[out]
-  !>   info        structure that holds the information collected during
+  !>   @param[out] myInfo - structure that holds the information collected during
   !>               the analysis step.
-  !>   @param[in]
-  !>   analysis    `rocsparse_analysis_policy_reuse` or
+  !>   @param[in] analysis - `rocsparse_analysis_policy_reuse` or
   !>               `rocsparse_analysis_policy_force`.
-  !>   @param[in]
-  !>   solve       `rocsparse_solve_policy_auto`.
-  !>   @param[in]
-  !>   temp_buffer temporary storage buffer allocated by the user.
+  !>   @param[in] solve - `rocsparse_solve_policy_auto`.
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -22861,12 +21230,10 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   descr       descriptor of the sparse CSR matrix.
-  !>   @param[inout]
-  !>   info        structure that holds the information collected during the analysis step.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] descr - descriptor of the sparse CSR matrix.
+  !>   @param[inout] myInfo - structure that holds the information collected during the analysis
+  !>   step.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -22964,36 +21331,22 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   trans       matrix operation type.
-  !>   @param[in]
-  !>   m           number of rows of the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of the sparse CSR matrix.
-  !>   @param[in]
-  !>   alpha       scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   descr       descriptor of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_val     array of \p nnz elements of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_row_ptr array of \p m+1 elements that point to the start
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] trans - matrix operation type.
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] descr - descriptor of the sparse CSR matrix.
+  !>   @param[in] csr_val - array of \p nnz elements of the sparse CSR matrix.
+  !>   @param[in] csr_row_ptr - array of \p m+1 elements that point to the start
   !>               of every row of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_col_ind array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] csr_col_ind - array of \p nnz elements containing the column indices of the sparse
   !>               CSR matrix.
-  !>   @param[in]
-  !>   info        structure that holds the information collected during the analysis step.
-  !>   @param[in]
-  !>   x           array of \p m elements, holding the right-hand side.
-  !>   @param[out]
-  !>   y           array of \p m elements, holding the solution.
-  !>   @param[in]
-  !>   policy      `rocsparse_solve_policy_auto`.
-  !>   @param[in]
-  !>   temp_buffer temporary storage buffer allocated by the user.
+  !>   @param[in] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[in] x - array of \p m elements, holding the right-hand side.
+  !>   @param[out] y - array of \p m elements, holding the solution.
+  !>   @param[in] policy - `rocsparse_solve_policy_auto`.
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -23182,34 +21535,22 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   trans       matrix operation type.
-  !>   @param[in]
-  !>   m           number of rows of the sparse ELL matrix.
-  !>   @param[in]
-  !>   n           number of columns of the sparse ELL matrix.
-  !>   @param[in]
-  !>   alpha       scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   descr       descriptor of the sparse ELL matrix. Currently, only
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] trans - matrix operation type.
+  !>   @param[in] m - number of rows of the sparse ELL matrix.
+  !>   @param[in] n - number of columns of the sparse ELL matrix.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] descr - descriptor of the sparse ELL matrix. Currently, only
   !>               `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   ell_val     array that contains the elements of the sparse ELL matrix. Padded
+  !>   @param[in] ell_val - array that contains the elements of the sparse ELL matrix. Padded
   !>               elements should be zero.
-  !>   @param[in]
-  !>   ell_col_ind array that contains the column indices of the sparse ELL matrix.
+  !>   @param[in] ell_col_ind - array that contains the column indices of the sparse ELL matrix.
   !>               Padded column indices should be -1.
-  !>   @param[in]
-  !>   ell_width   number of non-zero elements per row of the sparse ELL matrix.
-  !>   @param[in]
-  !>   x           array of \p n elements (\f$op(A) == A\f$) or \p m elements
+  !>   @param[in] ell_width - number of non-zero elements per row of the sparse ELL matrix.
+  !>   @param[in] x - array of \p n elements (\f$op(A) == A\f$) or \p m elements
   !>               (\f$op(A) == A^T\f$ or \f$op(A) == A^H\f$).
-  !>   @param[in]
-  !>   beta        scalar \f$\beta\f$.
-  !>   @param[inout]
-  !>   y           array of \p m elements (\f$op(A) == A\f$) or \p n elements
+  !>   @param[in] beta - scalar \f$\beta\f$.
+  !>   @param[inout] y - array of \p m elements (\f$op(A) == A\f$) or \p n elements
   !>               (\f$op(A) == A^T\f$ or \f$op(A) == A^H\f$).
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
@@ -23371,42 +21712,28 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   dir         matrix storage of GEBSR blocks.
-  !>   @param[in]
-  !>   trans       matrix operation type.
-  !>   @param[in]
-  !>   mb          number of block rows of the sparse GEBSR matrix.
-  !>   @param[in]
-  !>   nb          number of block columns of the sparse GEBSR matrix.
-  !>   @param[in]
-  !>   nnzb        number of non-zero blocks of the sparse GEBSR matrix.
-  !>   @param[in]
-  !>   alpha       scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   descr       descriptor of the sparse GEBSR matrix. Currently, only
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] dir - matrix storage of GEBSR blocks.
+  !>   @param[in] trans - matrix operation type.
+  !>   @param[in] mb - number of block rows of the sparse GEBSR matrix.
+  !>   @param[in] nb - number of block columns of the sparse GEBSR matrix.
+  !>   @param[in] nnzb - number of non-zero blocks of the sparse GEBSR matrix.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] descr - descriptor of the sparse GEBSR matrix. Currently, only
   !>               `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   bsr_val     array of \p nnzb blocks of the sparse GEBSR matrix.
-  !>   @param[in]
-  !>   bsr_row_ptr array of \p mb+1 elements that point to the start of every block row of
+  !>   @param[in] bsr_val - array of \p nnzb blocks of the sparse GEBSR matrix.
+  !>   @param[in] bsr_row_ptr - array of \p mb+1 elements that point to the start of every block row
+  !>   of
   !>               the sparse GEBSR matrix.
-  !>   @param[in]
-  !>   bsr_col_ind array of \p nnz containing the block column indices of the sparse
+  !>   @param[in] bsr_col_ind - array of \p nnz containing the block column indices of the sparse
   !>               GEBSR matrix.
-  !>   @param[in]
-  !>   row_block_dim row block dimension of the sparse GEBSR matrix.
-  !>   @param[in]
-  !>   col_block_dim column block dimension of the sparse GEBSR matrix.
-  !>   @param[in]
-  !>   x           array of \p nb*col_block_dim elements (\f$op(A) = A\f$) or \p mb*row_block_dim
+  !>   @param[in] row_block_dim - row block dimension of the sparse GEBSR matrix.
+  !>   @param[in] col_block_dim - column block dimension of the sparse GEBSR matrix.
+  !>   @param[in] x - array of \p nb*col_block_dim elements (\f$op(A) = A\f$) or \p mb*row_block_dim
   !>               elements (\f$op(A) = A^T\f$ or \f$op(A) = A^H\f$).
-  !>   @param[in]
-  !>   beta        scalar \f$\beta\f$.
-  !>   @param[inout]
-  !>   y           array of \p mb*row_block_dim elements (\f$op(A) = A\f$) or \p nb*col_block_dim
+  !>   @param[in] beta - scalar \f$\beta\f$.
+  !>   @param[inout] y - array of \p mb*row_block_dim elements (\f$op(A) = A\f$) or \p
+  !>   nb*col_block_dim
   !>               elements (\f$op(A) = A^T\f$ or \f$op(A) = A^H\f$).
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
@@ -23567,18 +21894,12 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   trans       matrix operation type.
-  !>   @param[in]
-  !>   m           number of rows of the dense matrix.
-  !>   @param[in]
-  !>   n           number of columns of the dense matrix.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries in the sparse vector.
-  !>   @param[out]
-  !>   buffer_size temporary storage buffer size.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] trans - matrix operation type.
+  !>   @param[in] m - number of rows of the dense matrix.
+  !>   @param[in] n - number of columns of the dense matrix.
+  !>   @param[in] nnz - number of non-zero entries in the sparse vector.
+  !>   @param[out] buffer_size - temporary storage buffer size.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -23687,35 +22008,21 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   trans       matrix operation type.
-  !>   @param[in]
-  !>   m           number of rows of the dense matrix.
-  !>   @param[in]
-  !>   n           number of columns of the dense matrix.
-  !>   @param[in]
-  !>   alpha       scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   A           pointer to the dense matrix.
-  !>   @param[in]
-  !>   lda         leading dimension of the dense matrix.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries in the sparse vector.
-  !>   @param[in]
-  !>   x_val       array of \p nnz elements containing the values of the sparse vector.
-  !>   @param[in]
-  !>   x_ind       array of \p nnz elements containing the indices of the sparse vector.
-  !>   @param[in]
-  !>   beta        scalar \f$\beta\f$.
-  !>   @param[inout]
-  !>   y           array of \p m elements (\f$op(A) == A\f$) or \p n elements
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] trans - matrix operation type.
+  !>   @param[in] m - number of rows of the dense matrix.
+  !>   @param[in] n - number of columns of the dense matrix.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] A - pointer to the dense matrix.
+  !>   @param[in] lda - leading dimension of the dense matrix.
+  !>   @param[in] nnz - number of non-zero entries in the sparse vector.
+  !>   @param[in] x_val - array of \p nnz elements containing the values of the sparse vector.
+  !>   @param[in] x_ind - array of \p nnz elements containing the indices of the sparse vector.
+  !>   @param[in] beta - scalar \f$\beta\f$.
+  !>   @param[inout] y - array of \p m elements (\f$op(A) == A\f$) or \p n elements
   !>               (\f$op(A) == A^T\f$ or \f$op(A) == A^H\f$).
-  !>   @param[in]
-  !>   idx_base    rocsparse_index_base_zero or rocsparse_index_base_one.
-  !>   @param[in]
-  !>   temp_buffer temporary storage buffer.
+  !>   @param[in] idx_base - rocsparse_index_base_zero or rocsparse_index_base_one.
+  !>   @param[in] temp_buffer - temporary storage buffer.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -23882,24 +22189,16 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   trans       matrix operation type.
-  !>   @param[in]
-  !>   alpha       scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   descr       descriptor of the sparse HYB matrix. Currently, only
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] trans - matrix operation type.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] descr - descriptor of the sparse HYB matrix. Currently, only
   !>               `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   hyb         matrix in HYB storage format.
-  !>   @param[in]
-  !>   x           array of \p n elements (\f$op(A) == A\f$) or \p m elements
+  !>   @param[in] hyb - matrix in HYB storage format.
+  !>   @param[in] x - array of \p n elements (\f$op(A) == A\f$) or \p m elements
   !>               (\f$op(A) == A^T\f$ or \f$op(A) == A^H\f$).
-  !>   @param[in]
-  !>   beta        scalar \f$\beta\f$.
-  !>   @param[inout]
-  !>   y           array of \p m elements (\f$op(A) == A\f$) or \p n elements
+  !>   @param[in] beta - scalar \f$\beta\f$.
+  !>   @param[inout] y - array of \p m elements (\f$op(A) == A\f$) or \p n elements
   !>               (\f$op(A) == A^T\f$ or \f$op(A) == A^H\f$).
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
@@ -24057,55 +22356,40 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   dir the storage format of the blocks. Can be `rocsparse_direction_row` or
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] dir - the storage format of the blocks. Can be `rocsparse_direction_row` or
   !>   `rocsparse_direction_column`.
-  !>   @param[in]
-  !>   trans_A matrix \f$A\f$ operation type. Currently, only `rocsparse_operation_none` is
-  !>   supported.
-  !>   @param[in]
-  !>   trans_B matrix \f$B\f$ operation type. Currently, only `rocsparse_operation_none` and
-  !>   rocsparse_operation_transpose
+  !>   @param[in] trans_A - matrix \f$A\f$ operation type. Currently, only
+  !>   `rocsparse_operation_none` is supported.
+  !>   @param[in] trans_B - matrix \f$B\f$ operation type. Currently, only
+  !>   `rocsparse_operation_none` and rocsparse_operation_transpose
   !>               are supported.
-  !>   @param[in]
-  !>   mb          number of block rows of the sparse BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   n           number of columns of the column-oriented dense matrix \f$op(B)\f$ and \f$C\f$.
-  !>   @param[in]
-  !>   kb          number of block columns of the sparse BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   nnzb        number of non-zero blocks of the sparse BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   alpha       scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   descr       descriptor of the sparse BSR matrix \f$A\f$. Currently, only
+  !>   @param[in] mb - number of block rows of the sparse BSR matrix \f$A\f$.
+  !>   @param[in] n - number of columns of the column-oriented dense matrix \f$op(B)\f$ and \f$C\f$.
+  !>   @param[in] kb - number of block columns of the sparse BSR matrix \f$A\f$.
+  !>   @param[in] nnzb - number of non-zero blocks of the sparse BSR matrix \f$A\f$.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] descr - descriptor of the sparse BSR matrix \f$A\f$. Currently, only
   !>               `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   bsr_val     array of \p nnzb*block_dim*block_dim elements of the sparse BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   bsr_row_ptr array of \p mb+1 elements that point to the start of every block row of the
+  !>   @param[in] bsr_val - array of \p nnzb*block_dim*block_dim elements of the sparse BSR matrix
+  !>   \f$A\f$.
+  !>   @param[in] bsr_row_ptr - array of \p mb+1 elements that point to the start of every block row
+  !>   of the
   !>               sparse BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   bsr_col_ind array of \p nnzb elements containing the block column indices of the sparse
+  !>   @param[in] bsr_col_ind - array of \p nnzb elements containing the block column indices of the
+  !>   sparse
   !>               BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   block_dim   size of the blocks in the sparse BSR matrix.
-  !>   @param[in]
-  !>   B           column-oriented dense matrix of dimension \f$ldb \times n\f$ (\f$op(B) == B\f$),
+  !>   @param[in] block_dim - size of the blocks in the sparse BSR matrix.
+  !>   @param[in] B - column-oriented dense matrix of dimension \f$ldb \times n\f$ (\f$op(B) ==
+  !>   B\f$),
   !>               \f$ldb \times k\f$ otherwise.
-  !>   @param[in]
-  !>   ldb leading dimension of \f$B\f$, must be at least \f$\max{(1, k)}\f$ (\f$ op(B) == B\f$)
-  !>   where \f$k = block\_dim \times kb\f$,
+  !>   @param[in] ldb - leading dimension of \f$B\f$, must be at least \f$\max{(1, k)}\f$ (\f$ op(B)
+  !>   == B\f$) where \f$k = block\_dim \times kb\f$,
   !>   \f$\max{(1, n)}\f$ otherwise.
-  !>   @param[in]
-  !>   beta        scalar \f$\beta\f$.
-  !>   @param[inout]
-  !>   C           column-oriented dense matrix of  dimension \f$ldc \times n\f$.
-  !>   @param[in]
-  !>   ldc leading dimension of \f$C\f$, must be at least \f$\max{(1, m)}\f$ (\f$ op(A) == A\f$)
-  !>   where \f$m = block\_dim \times mb\f$,
+  !>   @param[in] beta - scalar \f$\beta\f$.
+  !>   @param[inout] C - column-oriented dense matrix of  dimension \f$ldc \times n\f$.
+  !>   @param[in] ldc - leading dimension of \f$C\f$, must be at least \f$\max{(1, m)}\f$ (\f$ op(A)
+  !>   == A\f$) where \f$m = block\_dim \times mb\f$,
   !>   \f$\max{(1, k)}\f$ where \f$k = block\_dim \times kb\f$ otherwise.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
@@ -24287,12 +22571,10 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   info        structure that holds the information collected during the analysis step.
-  !>   @param[inout]
-  !>   position    pointer to zero pivot \f$j\f$, which can be in host or device memory.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[inout] position - pointer to zero pivot \f$j\f$, which can be in host or device
+  !>   memory.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -24327,36 +22609,23 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   dir         matrix storage of BSR blocks.
-  !>   @param[in]
-  !>   trans_A     matrix A operation type.
-  !>   @param[in]
-  !>   trans_X     matrix X operation type.
-  !>   @param[in]
-  !>   mb          number of block rows of the sparse BSR matrix A.
-  !>   @param[in]
-  !>   nrhs        number of columns of the column-oriented dense matrix op(X).
-  !>   @param[in]
-  !>   nnzb        number of non-zero blocks of the sparse BSR matrix A.
-  !>   @param[in]
-  !>   descr       descriptor of the sparse BSR matrix A.
-  !>   @param[in]
-  !>   bsr_val     array of \p nnzb blocks of the sparse BSR matrix.
-  !>   @param[in]
-  !>   bsr_row_ptr array of \p mb+1 elements that point to the start of every block row of
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] dir - matrix storage of BSR blocks.
+  !>   @param[in] trans_A - matrix A operation type.
+  !>   @param[in] trans_X - matrix X operation type.
+  !>   @param[in] mb - number of block rows of the sparse BSR matrix A.
+  !>   @param[in] nrhs - number of columns of the column-oriented dense matrix op(X).
+  !>   @param[in] nnzb - number of non-zero blocks of the sparse BSR matrix A.
+  !>   @param[in] descr - descriptor of the sparse BSR matrix A.
+  !>   @param[in] bsr_val - array of \p nnzb blocks of the sparse BSR matrix.
+  !>   @param[in] bsr_row_ptr - array of \p mb+1 elements that point to the start of every block row
+  !>   of
   !>               the sparse BSR matrix.
-  !>   @param[in]
-  !>   bsr_col_ind array of \p nnzb containing the block column indices of the sparse
+  !>   @param[in] bsr_col_ind - array of \p nnzb containing the block column indices of the sparse
   !>               BSR matrix.
-  !>   @param[in]
-  !>   block_dim   block dimension of the sparse BSR matrix.
-  !>   @param[in]
-  !>   info        structure that holds the information collected during the analysis step.
-  !>   @param[out]
-  !>   buffer_size number of bytes of the temporary storage buffer required by
+  !>   @param[in] block_dim - block dimension of the sparse BSR matrix.
+  !>   @param[in] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[out] buffer_size - number of bytes of the temporary storage buffer required by
   !>               \ref rocsparse_sbsrsm_analysis "rocsparse_Xbsrsm_analysis()" and
   !>               \ref rocsparse_sbsrsm_solve "rocsparse_Xbsrsm_solve()".
   !>
@@ -24520,41 +22789,26 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   dir         matrix storage of BSR blocks.
-  !>   @param[in]
-  !>   trans_A     matrix A operation type.
-  !>   @param[in]
-  !>   trans_X     matrix X operation type.
-  !>   @param[in]
-  !>   mb          number of block rows of the sparse BSR matrix A.
-  !>   @param[in]
-  !>   nrhs        number of columns of the column-oriented dense matrix op(X).
-  !>   @param[in]
-  !>   nnzb        number of non-zero blocks of the sparse BSR matrix A.
-  !>   @param[in]
-  !>   descr       descriptor of the sparse BSR matrix A.
-  !>   @param[in]
-  !>   bsr_val     array of \p nnzb blocks of the sparse BSR matrix A.
-  !>   @param[in]
-  !>   bsr_row_ptr array of \p mb+1 elements that point to the start of every block row of
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] dir - matrix storage of BSR blocks.
+  !>   @param[in] trans_A - matrix A operation type.
+  !>   @param[in] trans_X - matrix X operation type.
+  !>   @param[in] mb - number of block rows of the sparse BSR matrix A.
+  !>   @param[in] nrhs - number of columns of the column-oriented dense matrix op(X).
+  !>   @param[in] nnzb - number of non-zero blocks of the sparse BSR matrix A.
+  !>   @param[in] descr - descriptor of the sparse BSR matrix A.
+  !>   @param[in] bsr_val - array of \p nnzb blocks of the sparse BSR matrix A.
+  !>   @param[in] bsr_row_ptr - array of \p mb+1 elements that point to the start of every block row
+  !>   of
   !>               the sparse BSR matrix A.
-  !>   @param[in]
-  !>   bsr_col_ind array of \p nnzb containing the block column indices of the sparse
+  !>   @param[in] bsr_col_ind - array of \p nnzb containing the block column indices of the sparse
   !>               BSR matrix A.
-  !>   @param[in]
-  !>   block_dim   block dimension of the sparse BSR matrix A.
-  !>   @param[out]
-  !>   info        structure that holds the information collected during the analysis step.
-  !>   @param[in]
-  !>   analysis    `rocsparse_analysis_policy_reuse` or
+  !>   @param[in] block_dim - block dimension of the sparse BSR matrix A.
+  !>   @param[out] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[in] analysis - `rocsparse_analysis_policy_reuse` or
   !>               `rocsparse_analysis_policy_force`.
-  !>   @param[in]
-  !>   solve       `rocsparse_solve_policy_auto`.
-  !>   @param[in]
-  !>   temp_buffer temporary storage buffer allocated by the user.
+  !>   @param[in] solve - `rocsparse_solve_policy_auto`.
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -24711,10 +22965,9 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[inout]
-  !>   info        structure that holds the information collected during the analysis step.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[inout] myInfo - structure that holds the information collected during the analysis
+  !>   step.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -24947,48 +23200,29 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   dir         matrix storage of BSR blocks.
-  !>   @param[in]
-  !>   trans_A     matrix A operation type.
-  !>   @param[in]
-  !>   trans_X     matrix X operation type.
-  !>   @param[in]
-  !>   mb          number of block rows of the sparse BSR matrix A.
-  !>   @param[in]
-  !>   nrhs        number of columns of the column-oriented dense matrix op(X).
-  !>   @param[in]
-  !>   nnzb        number of non-zero blocks of the sparse BSR matrix A.
-  !>   @param[in]
-  !>   alpha       scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   descr       descriptor of the sparse BSR matrix A.
-  !>   @param[in]
-  !>   bsr_val     array of \p nnzb blocks of the sparse BSR matrix.
-  !>   @param[in]
-  !>   bsr_row_ptr array of \p mb+1 elements that point to the start of every block row of
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] dir - matrix storage of BSR blocks.
+  !>   @param[in] trans_A - matrix A operation type.
+  !>   @param[in] trans_X - matrix X operation type.
+  !>   @param[in] mb - number of block rows of the sparse BSR matrix A.
+  !>   @param[in] nrhs - number of columns of the column-oriented dense matrix op(X).
+  !>   @param[in] nnzb - number of non-zero blocks of the sparse BSR matrix A.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] descr - descriptor of the sparse BSR matrix A.
+  !>   @param[in] bsr_val - array of \p nnzb blocks of the sparse BSR matrix.
+  !>   @param[in] bsr_row_ptr - array of \p mb+1 elements that point to the start of every block row
+  !>   of
   !>               the sparse BSR matrix.
-  !>   @param[in]
-  !>   bsr_col_ind array of \p nnzb containing the block column indices of the sparse
+  !>   @param[in] bsr_col_ind - array of \p nnzb containing the block column indices of the sparse
   !>               BSR matrix.
-  !>   @param[in]
-  !>   block_dim   block dimension of the sparse BSR matrix.
-  !>   @param[in]
-  !>   info        structure that holds the information collected during the analysis step.
-  !>   @param[in]
-  !>   B           column-oriented dense matrix B with leading dimension \p ldb.
-  !>   @param[in]
-  !>   ldb         leading dimension of rhs matrix B.
-  !>   @param[out]
-  !>   X           column-oriented dense solution matrix X with leading dimension \p ldx.
-  !>   @param[in]
-  !>   ldx         leading dimension of solution matrix X.
-  !>   @param[in]
-  !>   policy      `rocsparse_solve_policy_auto`.
-  !>   @param[in]
-  !>   temp_buffer temporary storage buffer allocated by the user.
+  !>   @param[in] block_dim - block dimension of the sparse BSR matrix.
+  !>   @param[in] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[in] B - column-oriented dense matrix B with leading dimension \p ldb.
+  !>   @param[in] ldb - leading dimension of rhs matrix B.
+  !>   @param[out] X - column-oriented dense solution matrix X with leading dimension \p ldx.
+  !>   @param[in] ldx - leading dimension of solution matrix X.
+  !>   @param[in] policy - `rocsparse_solve_policy_auto`.
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -25215,45 +23449,29 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   trans_A     matrix \f$A\f$ operation type.
-  !>   @param[in]
-  !>   trans_B     matrix \f$B\f$ operation type.
-  !>   @param[in]
-  !>   m           number of rows of the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   n           number of columns of the column-oriented dense matrix \f$op(B)\f$ and \f$C\f$.
-  !>   @param[in]
-  !>   k           number of columns of the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   alpha       scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   descr       descriptor of the sparse CSR matrix \f$A\f$. Currently, only
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] trans_A - matrix \f$A\f$ operation type.
+  !>   @param[in] trans_B - matrix \f$B\f$ operation type.
+  !>   @param[in] m - number of rows of the sparse CSR matrix \f$A\f$.
+  !>   @param[in] n - number of columns of the column-oriented dense matrix \f$op(B)\f$ and \f$C\f$.
+  !>   @param[in] k - number of columns of the sparse CSR matrix \f$A\f$.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix \f$A\f$.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] descr - descriptor of the sparse CSR matrix \f$A\f$. Currently, only
   !>               `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   csr_val     array of \p nnz elements of the sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csr_row_ptr array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] csr_val - array of \p nnz elements of the sparse CSR matrix \f$A\f$.
+  !>   @param[in] csr_row_ptr - array of \p m+1 elements that point to the start of every row of the
   !>               sparse CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   csr_col_ind array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] csr_col_ind - array of \p nnz elements containing the column indices of the sparse
   !>               CSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   B           column-oriented dense matrix of dimension \f$ldb \times n\f$ (\f$op(B) == B\f$),
+  !>   @param[in] B - column-oriented dense matrix of dimension \f$ldb \times n\f$ (\f$op(B) ==
+  !>   B\f$),
   !>               \f$ldb \times k\f$ otherwise.
-  !>   @param[in]
-  !>   ldb         leading dimension of \f$B\f$, must be at least \f$\max{(1, k)}\f$
+  !>   @param[in] ldb - leading dimension of \f$B\f$, must be at least \f$\max{(1, k)}\f$
   !>               (\f$op(B) == B\f$), \f$\max{(1, n)}\f$ otherwise.
-  !>   @param[in]
-  !>   beta        scalar \f$\beta\f$.
-  !>   @param[inout]
-  !>   C           column-oriented dense matrix of dimension \f$ldc \times n\f$.
-  !>   @param[in]
-  !>   ldc         leading dimension of \f$C\f$, must be at least \f$\max{(1, m)}\f$
+  !>   @param[in] beta - scalar \f$\beta\f$.
+  !>   @param[inout] C - column-oriented dense matrix of dimension \f$ldc \times n\f$.
+  !>   @param[in] ldc - leading dimension of \f$C\f$, must be at least \f$\max{(1, m)}\f$
   !>               (\f$op(A) == A\f$), \f$\max{(1, k)}\f$ otherwise.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
@@ -25425,12 +23643,10 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   info        structure that holds the information collected during the analysis step.
-  !>   @param[inout]
-  !>   position    pointer to zero pivot \f$j\f$, which can be in host or device memory.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[inout] position - pointer to zero pivot \f$j\f$, which can be in host or device
+  !>   memory.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -25465,41 +23681,25 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   trans_A     matrix A operation type.
-  !>   @param[in]
-  !>   trans_B     matrix B operation type.
-  !>   @param[in]
-  !>   m           number of rows of the sparse CSR matrix A.
-  !>   @param[in]
-  !>   nrhs        number of columns of the column-oriented dense matrix op(B).
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of the sparse CSR matrix A.
-  !>   @param[in]
-  !>   alpha       scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   descr       descriptor of the sparse CSR matrix A.
-  !>   @param[in]
-  !>   csr_val     array of \p nnz elements of the sparse CSR matrix A.
-  !>   @param[in]
-  !>   csr_row_ptr array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] trans_A - matrix A operation type.
+  !>   @param[in] trans_B - matrix B operation type.
+  !>   @param[in] m - number of rows of the sparse CSR matrix A.
+  !>   @param[in] nrhs - number of columns of the column-oriented dense matrix op(B).
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix A.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] descr - descriptor of the sparse CSR matrix A.
+  !>   @param[in] csr_val - array of \p nnz elements of the sparse CSR matrix A.
+  !>   @param[in] csr_row_ptr - array of \p m+1 elements that point to the start of every row of the
   !>               sparse CSR matrix A.
-  !>   @param[in]
-  !>   csr_col_ind array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] csr_col_ind - array of \p nnz elements containing the column indices of the sparse
   !>               CSR matrix A.
-  !>   @param[in]
-  !>   B column-oriented dense matrix of dimension \p m \f$\times\f$ \p nrhs elements of the rhs
-  !>   matrix B.
-  !>   @param[in]
-  !>   ldb         leading dimension of rhs matrix B.
-  !>   @param[in]
-  !>   info        structure that holds the information collected during the analysis step.
-  !>   @param[in]
-  !>   policy      `rocsparse_solve_policy_auto`.
-  !>   @param[out]
-  !>   buffer_size number of bytes of the temporary storage buffer required by
+  !>   @param[in] B - column-oriented dense matrix of dimension \p m \f$\times\f$ \p nrhs elements
+  !>   of the rhs matrix B.
+  !>   @param[in] ldb - leading dimension of rhs matrix B.
+  !>   @param[in] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[in] policy - `rocsparse_solve_policy_auto`.
+  !>   @param[out] buffer_size - number of bytes of the temporary storage buffer required by
   !>               rocsparse_scsrsm_analysis(), rocsparse_dcsrsm_analysis(),
   !>               rocsparse_ccsrsm_analysis(), rocsparse_zcsrsm_analysis(),
   !>               rocsparse_scsrsm_solve(), rocsparse_dcsrsm_solve(),
@@ -25677,44 +23877,27 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   trans_A     matrix A operation type.
-  !>   @param[in]
-  !>   trans_B     matrix B operation type.
-  !>   @param[in]
-  !>   m           number of rows of the sparse CSR matrix A.
-  !>   @param[in]
-  !>   nrhs        number of columns of the column-oriented dense matrix op(B).
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of the sparse CSR matrix A.
-  !>   @param[in]
-  !>   alpha       scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   descr       descriptor of the sparse CSR matrix A.
-  !>   @param[in]
-  !>   csr_val     array of \p nnz elements of the sparse CSR matrix A.
-  !>   @param[in]
-  !>   csr_row_ptr array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] trans_A - matrix A operation type.
+  !>   @param[in] trans_B - matrix B operation type.
+  !>   @param[in] m - number of rows of the sparse CSR matrix A.
+  !>   @param[in] nrhs - number of columns of the column-oriented dense matrix op(B).
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix A.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] descr - descriptor of the sparse CSR matrix A.
+  !>   @param[in] csr_val - array of \p nnz elements of the sparse CSR matrix A.
+  !>   @param[in] csr_row_ptr - array of \p m+1 elements that point to the start of every row of the
   !>               sparse CSR matrix A.
-  !>   @param[in]
-  !>   csr_col_ind array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] csr_col_ind - array of \p nnz elements containing the column indices of the sparse
   !>               CSR matrix A.
-  !>   @param[in]
-  !>   B column-oriented dense matrix of dimension \p m \f$\times\f$ \p nrhs elements of the rhs
-  !>   matrix B.
-  !>   @param[in]
-  !>   ldb         leading dimension of rhs matrix B.
-  !>   @param[out]
-  !>   info        structure that holds the information collected during the analysis step.
-  !>   @param[in]
-  !>   analysis    `rocsparse_analysis_policy_reuse` or
+  !>   @param[in] B - column-oriented dense matrix of dimension \p m \f$\times\f$ \p nrhs elements
+  !>   of the rhs matrix B.
+  !>   @param[in] ldb - leading dimension of rhs matrix B.
+  !>   @param[out] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[in] analysis - `rocsparse_analysis_policy_reuse` or
   !>               `rocsparse_analysis_policy_force`.
-  !>   @param[in]
-  !>   solve       `rocsparse_solve_policy_auto`.
-  !>   @param[in]
-  !>   temp_buffer temporary storage buffer allocated by the user.
+  !>   @param[in] solve - `rocsparse_solve_policy_auto`.
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -25880,10 +24063,9 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[inout]
-  !>   info        structure that holds the information collected during the analysis step.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[inout] myInfo - structure that holds the information collected during the analysis
+  !>   step.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -26061,41 +24243,25 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   trans_A     matrix A operation type.
-  !>   @param[in]
-  !>   trans_B     matrix B operation type.
-  !>   @param[in]
-  !>   m           number of rows of the sparse CSR matrix A.
-  !>   @param[in]
-  !>   nrhs        number of columns of the column-oriented dense matrix op(B).
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of the sparse CSR matrix A.
-  !>   @param[in]
-  !>   alpha       scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   descr       descriptor of the sparse CSR matrix A.
-  !>   @param[in]
-  !>   csr_val     array of \p nnz elements of the sparse CSR matrix A.
-  !>   @param[in]
-  !>   csr_row_ptr array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] trans_A - matrix A operation type.
+  !>   @param[in] trans_B - matrix B operation type.
+  !>   @param[in] m - number of rows of the sparse CSR matrix A.
+  !>   @param[in] nrhs - number of columns of the column-oriented dense matrix op(B).
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix A.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] descr - descriptor of the sparse CSR matrix A.
+  !>   @param[in] csr_val - array of \p nnz elements of the sparse CSR matrix A.
+  !>   @param[in] csr_row_ptr - array of \p m+1 elements that point to the start of every row of the
   !>               sparse CSR matrix A.
-  !>   @param[in]
-  !>   csr_col_ind array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] csr_col_ind - array of \p nnz elements containing the column indices of the sparse
   !>               CSR matrix A.
-  !>   @param[inout]
-  !>   B column-oriented dense matrix of dimension \p m \f$\times\f$ \p nrhs elements of the rhs
-  !>   matrix B.
-  !>   @param[in]
-  !>   ldb         leading dimension of rhs matrix B.
-  !>   @param[in]
-  !>   info        structure that holds the information collected during the analysis step.
-  !>   @param[in]
-  !>   policy      `rocsparse_solve_policy_auto`.
-  !>   @param[in]
-  !>   temp_buffer temporary storage buffer allocated by the user.
+  !>   @param[inout] B - column-oriented dense matrix of dimension \p m \f$\times\f$ \p nrhs
+  !>   elements of the rhs matrix B.
+  !>   @param[in] ldb - leading dimension of rhs matrix B.
+  !>   @param[in] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[in] policy - `rocsparse_solve_policy_auto`.
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -26291,58 +24457,41 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   dir the storage format of the blocks. Can be `rocsparse_direction_row` or
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] dir - the storage format of the blocks. Can be `rocsparse_direction_row` or
   !>   `rocsparse_direction_column`.
-  !>   @param[in]
-  !>   trans_A matrix \f$A\f$ operation type. Currently, only `rocsparse_operation_none` is
-  !>   supported.
-  !>   @param[in]
-  !>   trans_B matrix \f$B\f$ operation type. Currently, only `rocsparse_operation_none` and
-  !>   rocsparse_operation_transpose
+  !>   @param[in] trans_A - matrix \f$A\f$ operation type. Currently, only
+  !>   `rocsparse_operation_none` is supported.
+  !>   @param[in] trans_B - matrix \f$B\f$ operation type. Currently, only
+  !>   `rocsparse_operation_none` and rocsparse_operation_transpose
   !>               are supported.
-  !>   @param[in]
-  !>   mb          number of block rows of the sparse general BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   n           number of columns of the column-oriented dense matrix \f$op(B)\f$ and \f$C\f$.
-  !>   @param[in]
-  !>   kb          number of block columns of the sparse general BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   nnzb        number of non-zero blocks of the sparse general BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   alpha       scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   descr       descriptor of the sparse general BSR matrix \f$A\f$. Currently, only
+  !>   @param[in] mb - number of block rows of the sparse general BSR matrix \f$A\f$.
+  !>   @param[in] n - number of columns of the column-oriented dense matrix \f$op(B)\f$ and \f$C\f$.
+  !>   @param[in] kb - number of block columns of the sparse general BSR matrix \f$A\f$.
+  !>   @param[in] nnzb - number of non-zero blocks of the sparse general BSR matrix \f$A\f$.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] descr - descriptor of the sparse general BSR matrix \f$A\f$. Currently, only
   !>               `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   bsr_val array of \p nnzb*row_block_dim*col_block_dim elements of the sparse general BSR
-  !>   matrix \f$A\f$.
-  !>   @param[in]
-  !>   bsr_row_ptr array of \p mb+1 elements that point to the start of every block row of the
+  !>   @param[in] bsr_val - array of \p nnzb*row_block_dim*col_block_dim elements of the sparse
+  !>   general BSR matrix \f$A\f$.
+  !>   @param[in] bsr_row_ptr - array of \p mb+1 elements that point to the start of every block row
+  !>   of the
   !>               sparse general BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   bsr_col_ind array of \p nnzb elements containing the block column indices of the sparse
+  !>   @param[in] bsr_col_ind - array of \p nnzb elements containing the block column indices of the
+  !>   sparse
   !>               general BSR matrix \f$A\f$.
-  !>   @param[in]
-  !>   row_block_dim   row size of the blocks in the sparse general BSR matrix.
-  !>   @param[in]
-  !>   col_block_dim   column size of the blocks in the sparse general BSR matrix.
-  !>   @param[in]
-  !>   B           column-oriented dense matrix of dimension \f$ldb \times n\f$ (\f$op(B) == B\f$),
+  !>   @param[in] row_block_dim - row size of the blocks in the sparse general BSR matrix.
+  !>   @param[in] col_block_dim - column size of the blocks in the sparse general BSR matrix.
+  !>   @param[in] B - column-oriented dense matrix of dimension \f$ldb \times n\f$ (\f$op(B) ==
+  !>   B\f$),
   !>               \f$ldb \times k\f$ otherwise.
-  !>   @param[in]
-  !>   ldb leading dimension of \f$B\f$, which must be at least \f$\max{(1, k)}\f$ (\f$ op(B) ==
-  !>   B\f$) where \f$k = col\_block\_dim \times kb\f$,
+  !>   @param[in] ldb - leading dimension of \f$B\f$, which must be at least \f$\max{(1, k)}\f$ (\f$
+  !>   op(B) == B\f$) where \f$k = col\_block\_dim \times kb\f$,
   !>   \f$\max{(1, n)}\f$ otherwise.
-  !>   @param[in]
-  !>   beta        scalar \f$\beta\f$.
-  !>   @param[inout]
-  !>   C           column-oriented dense matrix of dimension \f$ldc \times n\f$.
-  !>   @param[in]
-  !>   ldc leading dimension of \f$C\f$, which must be at least \f$\max{(1, m)}\f$ (\f$ op(A) ==
-  !>   A\f$) where \f$m = row\_block\_dim \times mb\f$,
+  !>   @param[in] beta - scalar \f$\beta\f$.
+  !>   @param[inout] C - column-oriented dense matrix of dimension \f$ldc \times n\f$.
+  !>   @param[in] ldc - leading dimension of \f$C\f$, which must be at least \f$\max{(1, m)}\f$ (\f$
+  !>   op(A) == A\f$) where \f$m = row\_block\_dim \times mb\f$,
   !>   \f$\max{(1, k)}\f$ where \f$k = col\_block\_dim \times kb\f$ otherwise.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
@@ -26559,47 +24708,31 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   trans_A     matrix \f$A\f$ operation type.
-  !>   @param[in]
-  !>   trans_B     matrix \f$B\f$ operation type.
-  !>   @param[in]
-  !>   m           number of rows of the column-oriented dense matrix \f$A\f$.
-  !>   @param[in]
-  !>   n           number of columns of the sparse CSR matrix \f$op(B)\f$ and \f$C\f$.
-  !>   @param[in]
-  !>   k           number of columns of the column-oriented dense matrix \f$A\f$.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of the sparse CSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   alpha       scalar \f$\alpha\f$.
-  !>   @param[in]
-  !>   A           array of dimension \f$lda \times k\f$ (\f$op(A) == A\f$) or
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] trans_A - matrix \f$A\f$ operation type.
+  !>   @param[in] trans_B - matrix \f$B\f$ operation type.
+  !>   @param[in] m - number of rows of the column-oriented dense matrix \f$A\f$.
+  !>   @param[in] n - number of columns of the sparse CSR matrix \f$op(B)\f$ and \f$C\f$.
+  !>   @param[in] k - number of columns of the column-oriented dense matrix \f$A\f$.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix \f$B\f$.
+  !>   @param[in] alpha - scalar \f$\alpha\f$.
+  !>   @param[in] A - array of dimension \f$lda \times k\f$ (\f$op(A) == A\f$) or
   !>               \f$lda \times m\f$ (\f$op(A) == A^T\f$ or \f$op(A) == A^H\f$).
-  !>   @param[in]
-  !>   lda         leading dimension of \f$A\f$, must be at least \f$m\f$
+  !>   @param[in] lda - leading dimension of \f$A\f$, must be at least \f$m\f$
   !>               (\f$op(A) == A\f$) or \f$k\f$ (\f$op(A) == A^T\f$ or
   !>               \f$op(A) == A^H\f$).
-  !>   @param[in]
-  !>   descr       descriptor of the sparse CSR matrix \f$B\f$. Currently, only
+  !>   @param[in] descr - descriptor of the sparse CSR matrix \f$B\f$. Currently, only
   !>               `rocsparse_matrix_type_general` is supported.
-  !>   @param[in]
-  !>   csr_val     array of \p nnz elements of the sparse CSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   csr_row_ptr array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] csr_val - array of \p nnz elements of the sparse CSR matrix \f$B\f$.
+  !>   @param[in] csr_row_ptr - array of \p m+1 elements that point to the start of every row of the
   !>               sparse CSR matrix \f$B\f$.
-  !>   @param[in]
-  !>   csr_col_ind array of \p nnz elements containing the column indices of the sparse CSR
+  !>   @param[in] csr_col_ind - array of \p nnz elements containing the column indices of the sparse
+  !>   CSR
   !>               matrix \f$B\f$.
-  !>   @param[in]
-  !>   beta        scalar \f$\beta\f$.
-  !>   @param[inout]
-  !>   C column-oriented dense matrix of dimension \f$ldc \times n\f$ that holds the values of
-  !>   \f$C\f$.
-  !>   @param[in]
-  !>   ldc         leading dimension of \f$C\f$, must be at least \f$m\f$.
+  !>   @param[in] beta - scalar \f$\beta\f$.
+  !>   @param[inout] C - column-oriented dense matrix of dimension \f$ldc \times n\f$ that holds the
+  !>   values of \f$C\f$.
+  !>   @param[in] ldc - leading dimension of \f$C\f$, must be at least \f$m\f$.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -26773,12 +24906,10 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   info        structure that holds the information collected during the analysis step.
-  !>   @param[inout]
-  !>   position    pointer to zero pivot \f$j\f$, which can be in host or device memory.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[inout] position - pointer to zero pivot \f$j\f$, which can be in host or device
+  !>   memory.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -26818,33 +24949,24 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   dir direction that specifies whether to count non-zero elements by `rocsparse_direction_row`
-  !>   or by
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] dir - direction that specifies whether to count non-zero elements by
+  !>   `rocsparse_direction_row` or by
   !>               `rocsparse_direction_column`.
-  !>   @param[in]
-  !>   mb          number of block rows in the sparse BSR matrix.
-  !>   @param[in]
-  !>   nnzb        number of non-zero block entries of the sparse BSR matrix.
-  !>   @param[in]
-  !>   descr       descriptor of the sparse BSR matrix.
-  !>   @param[in]
-  !>   bsr_val array of length \p nnzb*block_dim*block_dim containing the values of the sparse BSR
-  !>   matrix.
-  !>   @param[in]
-  !>   bsr_row_ptr array of \p mb+1 elements that point to the start of every block row of the
+  !>   @param[in] mb - number of block rows in the sparse BSR matrix.
+  !>   @param[in] nnzb - number of non-zero block entries of the sparse BSR matrix.
+  !>   @param[in] descr - descriptor of the sparse BSR matrix.
+  !>   @param[in] bsr_val - array of length \p nnzb*block_dim*block_dim containing the values of the
+  !>   sparse BSR matrix.
+  !>   @param[in] bsr_row_ptr - array of \p mb+1 elements that point to the start of every block row
+  !>   of the
   !>               sparse BSR matrix.
-  !>   @param[in]
-  !>   bsr_col_ind array of \p nnzb elements containing the block column indices of the sparse BSR
-  !>   matrix.
-  !>   @param[in]
-  !>   block_dim   the block dimension of the BSR matrix. Between 1 and m, where \p m=mb*block_dim.
-  !>   @param[out]
-  !>   info        structure that holds the information collected during the analysis step.
-  !>   @param[out]
-  !>   buffer_size number of bytes of the temporary storage buffer required by
+  !>   @param[in] bsr_col_ind - array of \p nnzb elements containing the block column indices of the
+  !>   sparse BSR matrix.
+  !>   @param[in] block_dim - the block dimension of the BSR matrix. Between 1 and m, where \p
+  !>   m=mb*block_dim.
+  !>   @param[out] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[out] buffer_size - number of bytes of the temporary storage buffer required by
   !>               \ref rocsparse_sbsric0_analysis "rocsparse_Xbsric0_analysis()" and
   !>               \ref rocsparse_sbsric0 "rocsparse_Xbsric0()".
   !>
@@ -26993,39 +25115,28 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   dir direction that specified whether to count non-zero elements by `rocsparse_direction_row`
-  !>   or by
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] dir - direction that specified whether to count non-zero elements by
+  !>   `rocsparse_direction_row` or by
   !>               `rocsparse_direction_column`.
-  !>   @param[in]
-  !>   mb          number of block rows in the sparse BSR matrix.
-  !>   @param[in]
-  !>   nnzb        number of non-zero block entries of the sparse BSR matrix.
-  !>   @param[in]
-  !>   descr       descriptor of the sparse BSR matrix.
-  !>   @param[in]
-  !>   bsr_val array of length \p nnzb*block_dim*block_dim containing the values of the sparse BSR
-  !>   matrix.
-  !>   @param[in]
-  !>   bsr_row_ptr array of \p mb+1 elements that point to the start of every block row of the
+  !>   @param[in] mb - number of block rows in the sparse BSR matrix.
+  !>   @param[in] nnzb - number of non-zero block entries of the sparse BSR matrix.
+  !>   @param[in] descr - descriptor of the sparse BSR matrix.
+  !>   @param[in] bsr_val - array of length \p nnzb*block_dim*block_dim containing the values of the
+  !>   sparse BSR matrix.
+  !>   @param[in] bsr_row_ptr - array of \p mb+1 elements that point to the start of every block row
+  !>   of the
   !>               sparse BSR matrix.
-  !>   @param[in]
-  !>   bsr_col_ind array of \p nnzb elements containing the block column indices of the sparse BSR
-  !>   matrix.
-  !>   @param[in]
-  !>   block_dim   the block dimension of the BSR matrix. Between 1 and m, where \p m=mb*block_dim.
-  !>   @param[out]
-  !>   info        structure that holds the information collected during
+  !>   @param[in] bsr_col_ind - array of \p nnzb elements containing the block column indices of the
+  !>   sparse BSR matrix.
+  !>   @param[in] block_dim - the block dimension of the BSR matrix. Between 1 and m, where \p
+  !>   m=mb*block_dim.
+  !>   @param[out] myInfo - structure that holds the information collected during
   !>               the analysis step.
-  !>   @param[in]
-  !>   analysis    `rocsparse_analysis_policy_reuse` or
+  !>   @param[in] analysis - `rocsparse_analysis_policy_reuse` or
   !>               `rocsparse_analysis_policy_force`.
-  !>   @param[in]
-  !>   solve       `rocsparse_solve_policy_auto`.
-  !>   @param[in]
-  !>   temp_buffer temporary storage buffer allocated by the user.
+  !>   @param[in] solve - `rocsparse_solve_policy_auto`.
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -27169,10 +25280,9 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[inout]
-  !>   info        structure that holds the information collected during the analysis step.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[inout] myInfo - structure that holds the information collected during the analysis
+  !>   step.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -27232,35 +25342,25 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   dir direction that specified whether to count non-zero elements by `rocsparse_direction_row`
-  !>   or by
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] dir - direction that specified whether to count non-zero elements by
+  !>   `rocsparse_direction_row` or by
   !>               `rocsparse_direction_column`.
-  !>   @param[in]
-  !>   mb          number of block rows in the sparse BSR matrix.
-  !>   @param[in]
-  !>   nnzb        number of non-zero block entries of the sparse BSR matrix.
-  !>   @param[in]
-  !>   descr       descriptor of the sparse BSR matrix.
-  !>   @param[inout]
-  !>   bsr_val array of length \p nnzb*block_dim*block_dim containing the values of the sparse BSR
-  !>   matrix.
-  !>   @param[in]
-  !>   bsr_row_ptr array of \p mb+1 elements that point to the start of every block row of the
+  !>   @param[in] mb - number of block rows in the sparse BSR matrix.
+  !>   @param[in] nnzb - number of non-zero block entries of the sparse BSR matrix.
+  !>   @param[in] descr - descriptor of the sparse BSR matrix.
+  !>   @param[inout] bsr_val - array of length \p nnzb*block_dim*block_dim containing the values of
+  !>   the sparse BSR matrix.
+  !>   @param[in] bsr_row_ptr - array of \p mb+1 elements that point to the start of every block row
+  !>   of the
   !>               sparse BSR matrix.
-  !>   @param[in]
-  !>   bsr_col_ind array of \p nnzb elements containing the block column indices of the sparse BSR
-  !>   matrix.
-  !>   @param[in]
-  !>   block_dim   the block dimension of the BSR matrix. Between 1 and m, where \p m=mb*block_dim.
-  !>   @param[in]
-  !>   info        structure that holds the information collected during the analysis step.
-  !>   @param[in]
-  !>   policy      `rocsparse_solve_policy_auto`.
-  !>   @param[in]
-  !>   temp_buffer temporary storage buffer allocated by the user.
+  !>   @param[in] bsr_col_ind - array of \p nnzb elements containing the block column indices of the
+  !>   sparse BSR matrix.
+  !>   @param[in] block_dim - the block dimension of the BSR matrix. Between 1 and m, where \p
+  !>   m=mb*block_dim.
+  !>   @param[in] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[in] policy - `rocsparse_solve_policy_auto`.
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -27415,12 +25515,10 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   info        structure that holds the information collected during the analysis step.
-  !>   @param[inout]
-  !>   position    pointer to zero pivot \f$j\f$, which can be in host or device memory.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[inout] position - pointer to zero pivot \f$j\f$, which can be in host or device
+  !>   memory.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -27460,16 +25558,11 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle          handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   info            structure that holds the information collected during the analysis step.
-  !>   @param[in]
-  !>   enable_boost    enable/disable numeric boost.
-  !>   @param[in]
-  !>   boost_tol       tolerance to determine whether a numerical value is replaced or not.
-  !>   @param[in]
-  !>   boost_val       boost value to replace a numerical value.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[in] enable_boost - enable/disable numeric boost.
+  !>   @param[in] boost_tol - tolerance to determine whether a numerical value is replaced or not.
+  !>   @param[in] boost_val - boost value to replace a numerical value.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -27586,33 +25679,24 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   dir direction that specifies whether to count non-zero elements by `rocsparse_direction_row`
-  !>   or by
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] dir - direction that specifies whether to count non-zero elements by
+  !>   `rocsparse_direction_row` or by
   !>               `rocsparse_direction_column`.
-  !>   @param[in]
-  !>   mb          number of block rows in the sparse BSR matrix.
-  !>   @param[in]
-  !>   nnzb        number of non-zero block entries of the sparse BSR matrix.
-  !>   @param[in]
-  !>   descr       descriptor of the sparse BSR matrix.
-  !>   @param[in]
-  !>   bsr_val array of length \p nnzb*block_dim*block_dim containing the values of the sparse BSR
-  !>   matrix.
-  !>   @param[in]
-  !>   bsr_row_ptr array of \p mb+1 elements that point to the start of every block row of the
+  !>   @param[in] mb - number of block rows in the sparse BSR matrix.
+  !>   @param[in] nnzb - number of non-zero block entries of the sparse BSR matrix.
+  !>   @param[in] descr - descriptor of the sparse BSR matrix.
+  !>   @param[in] bsr_val - array of length \p nnzb*block_dim*block_dim containing the values of the
+  !>   sparse BSR matrix.
+  !>   @param[in] bsr_row_ptr - array of \p mb+1 elements that point to the start of every block row
+  !>   of the
   !>               sparse BSR matrix.
-  !>   @param[in]
-  !>   bsr_col_ind array of \p nnzb elements containing the block column indices of the sparse BSR
-  !>   matrix.
-  !>   @param[in]
-  !>   block_dim   the block dimension of the BSR matrix. Between 1 and m, where \p m=mb*block_dim.
-  !>   @param[out]
-  !>   info        structure that holds the information collected during the analysis step.
-  !>   @param[out]
-  !>   buffer_size number of bytes of the temporary storage buffer required by
+  !>   @param[in] bsr_col_ind - array of \p nnzb elements containing the block column indices of the
+  !>   sparse BSR matrix.
+  !>   @param[in] block_dim - the block dimension of the BSR matrix. Between 1 and m, where \p
+  !>   m=mb*block_dim.
+  !>   @param[out] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[out] buffer_size - number of bytes of the temporary storage buffer required by
   !>               \ref rocsparse_sbsrilu0_analysis "rocsparse_Xbsrilu0_analysis()" and
   !>               \ref rocsparse_sbsrilu0 "rocsparse_Xbsrilu0()".
   !>
@@ -27761,38 +25845,27 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   dir         direction that specified whether to count non-zero elements by
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] dir - direction that specified whether to count non-zero elements by
   !>               `rocsparse_direction_row` or by `rocsparse_direction_column`.
-  !>   @param[in]
-  !>   mb          number of block rows in the sparse BSR matrix.
-  !>   @param[in]
-  !>   nnzb        number of non-zero block entries of the sparse BSR matrix.
-  !>   @param[in]
-  !>   descr       descriptor of the sparse BSR matrix.
-  !>   @param[in]
-  !>   bsr_val array of length \p nnzb*block_dim*block_dim containing the values of the sparse BSR
-  !>   matrix.
-  !>   @param[in]
-  !>   bsr_row_ptr array of \p mb+1 elements that point to the start of every block row of the
+  !>   @param[in] mb - number of block rows in the sparse BSR matrix.
+  !>   @param[in] nnzb - number of non-zero block entries of the sparse BSR matrix.
+  !>   @param[in] descr - descriptor of the sparse BSR matrix.
+  !>   @param[in] bsr_val - array of length \p nnzb*block_dim*block_dim containing the values of the
+  !>   sparse BSR matrix.
+  !>   @param[in] bsr_row_ptr - array of \p mb+1 elements that point to the start of every block row
+  !>   of the
   !>               sparse BSR matrix.
-  !>   @param[in]
-  !>   bsr_col_ind array of \p nnzb elements containing the block column indices of the sparse BSR
-  !>   matrix.
-  !>   @param[in]
-  !>   block_dim   the block dimension of the BSR matrix. Between 1 and m, where \p m=mb*block_dim.
-  !>   @param[out]
-  !>   info        structure that holds the information collected during
+  !>   @param[in] bsr_col_ind - array of \p nnzb elements containing the block column indices of the
+  !>   sparse BSR matrix.
+  !>   @param[in] block_dim - the block dimension of the BSR matrix. Between 1 and m, where \p
+  !>   m=mb*block_dim.
+  !>   @param[out] myInfo - structure that holds the information collected during
   !>               the analysis step.
-  !>   @param[in]
-  !>   analysis    `rocsparse_analysis_policy_reuse` or
+  !>   @param[in] analysis - `rocsparse_analysis_policy_reuse` or
   !>               `rocsparse_analysis_policy_force`.
-  !>   @param[in]
-  !>   solve       `rocsparse_solve_policy_auto`.
-  !>   @param[in]
-  !>   temp_buffer temporary storage buffer allocated by the user.
+  !>   @param[in] solve - `rocsparse_solve_policy_auto`.
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -27936,10 +26009,9 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[inout]
-  !>   info        structure that holds the information collected during the analysis step.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[inout] myInfo - structure that holds the information collected during the analysis
+  !>   step.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -27998,34 +26070,24 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   dir         direction that specified whether to count non-zero elements by
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] dir - direction that specified whether to count non-zero elements by
   !>               `rocsparse_direction_row` or by `rocsparse_direction_column`.
-  !>   @param[in]
-  !>   mb          number of block rows in the sparse BSR matrix.
-  !>   @param[in]
-  !>   nnzb        number of non-zero block entries of the sparse BSR matrix.
-  !>   @param[in]
-  !>   descr       descriptor of the sparse BSR matrix.
-  !>   @param[inout]
-  !>   bsr_val array of length \p nnzb*block_dim*block_dim containing the values of the sparse BSR
-  !>   matrix.
-  !>   @param[in]
-  !>   bsr_row_ptr array of \p mb+1 elements that point to the start of every block row of the
+  !>   @param[in] mb - number of block rows in the sparse BSR matrix.
+  !>   @param[in] nnzb - number of non-zero block entries of the sparse BSR matrix.
+  !>   @param[in] descr - descriptor of the sparse BSR matrix.
+  !>   @param[inout] bsr_val - array of length \p nnzb*block_dim*block_dim containing the values of
+  !>   the sparse BSR matrix.
+  !>   @param[in] bsr_row_ptr - array of \p mb+1 elements that point to the start of every block row
+  !>   of the
   !>               sparse BSR matrix.
-  !>   @param[in]
-  !>   bsr_col_ind array of \p nnzb elements containing the block column indices of the sparse BSR
-  !>   matrix.
-  !>   @param[in]
-  !>   block_dim   the block dimension of the BSR matrix. Between 1 and m, where \p m=mb*block_dim.
-  !>   @param[in]
-  !>   info        structure that holds the information collected during the analysis step.
-  !>   @param[in]
-  !>   policy      `rocsparse_solve_policy_auto`.
-  !>   @param[in]
-  !>   temp_buffer temporary storage buffer allocated by the user.
+  !>   @param[in] bsr_col_ind - array of \p nnzb elements containing the block column indices of the
+  !>   sparse BSR matrix.
+  !>   @param[in] block_dim - the block dimension of the BSR matrix. Between 1 and m, where \p
+  !>   m=mb*block_dim.
+  !>   @param[in] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[in] policy - `rocsparse_solve_policy_auto`.
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -28174,12 +26236,10 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   info        structure that holds the information collected during the analysis step.
-  !>   @param[inout]
-  !>   position    pointer to zero pivot \f$j\f$, which can be in host or device memory.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[inout] position - pointer to zero pivot \f$j\f$, which can be in host or device
+  !>   memory.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -28217,12 +26277,10 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   info        structure that holds the information collected during the analysis step.
-  !>   @param[inout]
-  !>   position    pointer to singular pivot \f$k\f$, which can be in host or device memory.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[inout] position - pointer to singular pivot \f$k\f$, which can be in host or device
+  !>   memory.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -28255,12 +26313,10 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   info        structure that holds the information collected during the analysis step.
-  !>   @param[in]
-  !>   tolerance    tolerance for detecting singular pivot (\f$|L_{j,j}|  &le; \text{tolerance}\f$).
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[in] tolerance - tolerance for detecting singular pivot (\f$|L_{j,j}| &le;
+  !>   \text{tolerance}\f$).
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -28292,12 +26348,9 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   info        structure that holds the information collected during the analysis step.
-  !>   @param[out]
-  !>   tolerance obtain tolerance for detecting singular pivot (\f$|L_{j,j}| &le;
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[out] tolerance - obtain tolerance for detecting singular pivot (\f$|L_{j,j}| &le;
   !>   \text{tolerance}\f$).
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
@@ -28335,26 +26388,17 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m           number of rows of the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of the sparse CSR matrix.
-  !>   @param[in]
-  !>   descr       descriptor of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_val     array of \p nnz elements of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_row_ptr array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix.
+  !>   @param[in] descr - descriptor of the sparse CSR matrix.
+  !>   @param[in] csr_val - array of \p nnz elements of the sparse CSR matrix.
+  !>   @param[in] csr_row_ptr - array of \p m+1 elements that point to the start of every row of the
   !>               sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_col_ind array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] csr_col_ind - array of \p nnz elements containing the column indices of the sparse
   !>               CSR matrix.
-  !>   @param[out]
-  !>   info        structure that holds the information collected during the analysis step.
-  !>   @param[out]
-  !>   buffer_size number of bytes of the temporary storage buffer required by
+  !>   @param[out] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[out] buffer_size - number of bytes of the temporary storage buffer required by
   !>               \ref rocsparse_scsric0_analysis "rocsparse_Xcsric0_analysis()" and
   !>               \ref rocsparse_scsric0 "rocsparse_Xcsric0()".
   !>
@@ -28495,32 +26539,21 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m           number of rows of the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of the sparse CSR matrix.
-  !>   @param[in]
-  !>   descr       descriptor of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_val     array of \p nnz elements of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_row_ptr array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix.
+  !>   @param[in] descr - descriptor of the sparse CSR matrix.
+  !>   @param[in] csr_val - array of \p nnz elements of the sparse CSR matrix.
+  !>   @param[in] csr_row_ptr - array of \p m+1 elements that point to the start of every row of the
   !>               sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_col_ind array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] csr_col_ind - array of \p nnz elements containing the column indices of the sparse
   !>               CSR matrix.
-  !>   @param[out]
-  !>   info        structure that holds the information collected during
+  !>   @param[out] myInfo - structure that holds the information collected during
   !>               the analysis step.
-  !>   @param[in]
-  !>   analysis    `rocsparse_analysis_policy_reuse` or
+  !>   @param[in] analysis - `rocsparse_analysis_policy_reuse` or
   !>               `rocsparse_analysis_policy_force`.
-  !>   @param[in]
-  !>   solve       `rocsparse_solve_policy_auto`.
-  !>   @param[in]
-  !>   temp_buffer temporary storage buffer allocated by the user.
+  !>   @param[in] solve - `rocsparse_solve_policy_auto`.
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -28657,10 +26690,9 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[inout]
-  !>   info        structure that holds the information collected during the analysis step.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[inout] myInfo - structure that holds the information collected during the analysis
+  !>   step.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -28821,28 +26853,18 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m           number of rows of the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of the sparse CSR matrix.
-  !>   @param[in]
-  !>   descr       descriptor of the sparse CSR matrix.
-  !>   @param[inout]
-  !>   csr_val     array of \p nnz elements of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_row_ptr array of \p m+1 elements that point to the start
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix.
+  !>   @param[in] descr - descriptor of the sparse CSR matrix.
+  !>   @param[inout] csr_val - array of \p nnz elements of the sparse CSR matrix.
+  !>   @param[in] csr_row_ptr - array of \p m+1 elements that point to the start
   !>               of every row of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_col_ind array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] csr_col_ind - array of \p nnz elements containing the column indices of the sparse
   !>               CSR matrix.
-  !>   @param[in]
-  !>   info        structure that holds the information collected during the analysis step.
-  !>   @param[in]
-  !>   policy      `rocsparse_solve_policy_auto`.
-  !>   @param[in]
-  !>   temp_buffer temporary storage buffer allocated by the user.
+  !>   @param[in] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[in] policy - `rocsparse_solve_policy_auto`.
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -28984,12 +27006,10 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   info        structure that holds the information collected during the analysis step.
-  !>   @param[inout]
-  !>   position    pointer to zero pivot \f$j\f$, which can be in host or device memory.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[inout] position - pointer to zero pivot \f$j\f$, which can be in host or device
+  !>   memory.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -29023,12 +27043,10 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   info        structure that holds the information collected during the analysis step.
-  !>   @param[in]
-  !>   tolerance tolerance value to determine singular pivot \f$|A_{j,j}| &le; \text{tolerance}\f$,
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[in] tolerance - tolerance value to determine singular pivot \f$|A_{j,j}| &le;
+  !>   \text{tolerance}\f$,
   !>                where variable tolerance is in host memory.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
@@ -29060,13 +27078,10 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   info        structure that holds the information collected during the analysis step.
-  !>   @param[out]
-  !>   tolerance obtain tolerance value to determine the singular pivot \f$|A_{j,j}| &le;
-  !>   \text{tolerance}\f$,
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[out] tolerance - obtain tolerance value to determine the singular pivot \f$|A_{j,j}|
+  !>   &le; \text{tolerance}\f$,
   !>               where variable tolerance is in host memory.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
@@ -29104,12 +27119,10 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   info        structure that holds the information collected during the analysis step.
-  !>   @param[inout]
-  !>   position    pointer to singular pivot \f$j\f$, which can be in host or device memory.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[inout] position - pointer to singular pivot \f$j\f$, which can be in host or device
+  !>   memory.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -29148,16 +27161,11 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle          handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   info            structure that holds the information collected during the analysis step.
-  !>   @param[in]
-  !>   enable_boost    enable/disable numeric boost.
-  !>   @param[in]
-  !>   boost_tol       tolerance to determine whether a numerical value is replaced or not.
-  !>   @param[in]
-  !>   boost_val       boost value to replace a numerical value.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[in] enable_boost - enable/disable numeric boost.
+  !>   @param[in] boost_tol - tolerance to determine whether a numerical value is replaced or not.
+  !>   @param[in] boost_val - boost value to replace a numerical value.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -29273,26 +27281,17 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m           number of rows of the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of the sparse CSR matrix.
-  !>   @param[in]
-  !>   descr       descriptor of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_val     array of \p nnz elements of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_row_ptr array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix.
+  !>   @param[in] descr - descriptor of the sparse CSR matrix.
+  !>   @param[in] csr_val - array of \p nnz elements of the sparse CSR matrix.
+  !>   @param[in] csr_row_ptr - array of \p m+1 elements that point to the start of every row of the
   !>               sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_col_ind array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] csr_col_ind - array of \p nnz elements containing the column indices of the sparse
   !>               CSR matrix.
-  !>   @param[out]
-  !>   info        structure that holds the information collected during the analysis step.
-  !>   @param[out]
-  !>   buffer_size number of bytes of the temporary storage buffer required by
+  !>   @param[out] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[out] buffer_size - number of bytes of the temporary storage buffer required by
   !>               \ref rocsparse_scsrilu0_analysis "rocsparse_Xcsrilu0_analysis()" and
   !>               \ref rocsparse_scsrilu0 "rocsparse_Xcsrilu0()".
   !>
@@ -29434,32 +27433,21 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m           number of rows of the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of the sparse CSR matrix.
-  !>   @param[in]
-  !>   descr       descriptor of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_val     array of \p nnz elements of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_row_ptr array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix.
+  !>   @param[in] descr - descriptor of the sparse CSR matrix.
+  !>   @param[in] csr_val - array of \p nnz elements of the sparse CSR matrix.
+  !>   @param[in] csr_row_ptr - array of \p m+1 elements that point to the start of every row of the
   !>               sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_col_ind array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] csr_col_ind - array of \p nnz elements containing the column indices of the sparse
   !>               CSR matrix.
-  !>   @param[out]
-  !>   info        structure that holds the information collected during
+  !>   @param[out] myInfo - structure that holds the information collected during
   !>               the analysis step.
-  !>   @param[in]
-  !>   analysis    `rocsparse_analysis_policy_reuse` or
+  !>   @param[in] analysis - `rocsparse_analysis_policy_reuse` or
   !>               `rocsparse_analysis_policy_force`.
-  !>   @param[in]
-  !>   solve       `rocsparse_solve_policy_auto`.
-  !>   @param[in]
-  !>   temp_buffer temporary storage buffer allocated by the user.
+  !>   @param[in] solve - `rocsparse_solve_policy_auto`.
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -29596,10 +27584,9 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[inout]
-  !>   info        structure that holds the information collected during the analysis step.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[inout] myInfo - structure that holds the information collected during the analysis
+  !>   step.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -29743,28 +27730,18 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m           number of rows of the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of the sparse CSR matrix.
-  !>   @param[in]
-  !>   descr       descriptor of the sparse CSR matrix.
-  !>   @param[inout]
-  !>   csr_val     array of \p nnz elements of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_row_ptr array of \p m+1 elements that point to the start
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix.
+  !>   @param[in] descr - descriptor of the sparse CSR matrix.
+  !>   @param[inout] csr_val - array of \p nnz elements of the sparse CSR matrix.
+  !>   @param[in] csr_row_ptr - array of \p m+1 elements that point to the start
   !>               of every row of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_col_ind array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] csr_col_ind - array of \p nnz elements containing the column indices of the sparse
   !>               CSR matrix.
-  !>   @param[in]
-  !>   info        structure that holds the information collected during the analysis step.
-  !>   @param[in]
-  !>   policy      `rocsparse_solve_policy_auto`.
-  !>   @param[in]
-  !>   temp_buffer temporary storage buffer allocated by the user.
+  !>   @param[in] myInfo - structure that holds the information collected during the analysis step.
+  !>   @param[in] policy - `rocsparse_solve_policy_auto`.
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -29907,30 +27884,19 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   alg         algorithm to use, `rocsparse_itilu0_alg`.
-  !>   @param[in]
-  !>   option      combination of enumeration values from `rocsparse_itilu0_option`.
-  !>   @param[in]
-  !>   nmaxiter     maximum number of iterations.
-  !>   @param[in]
-  !>   m           number of rows of the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_row_ptr array of \p m+1 elements that point to the start
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] alg - algorithm to use, `rocsparse_itilu0_alg`.
+  !>   @param[in] option - combination of enumeration values from `rocsparse_itilu0_option`.
+  !>   @param[in] nmaxiter - maximum number of iterations.
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix.
+  !>   @param[in] csr_row_ptr - array of \p m+1 elements that point to the start
   !>               of every row of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_col_ind array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] csr_col_ind - array of \p nnz elements containing the column indices of the sparse
   !>               CSR matrix.
-  !>   @param[in]
-  !>   idx_base    `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
-  !>   @param[in]
-  !>   datatype    Type of numerical values, `rocsparse_datatype`.
-  !>   @param[out]
-  !>   buffer_size size of the temporary storage buffer allocated by the user.
+  !>   @param[in] idx_base - `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
+  !>   @param[in] datatype - Type of numerical values, `rocsparse_datatype`.
+  !>   @param[out] buffer_size - size of the temporary storage buffer allocated by the user.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -29979,32 +27945,20 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   alg         algorithm to use, `rocsparse_itilu0_alg`.
-  !>   @param[in]
-  !>   option      combination of enumeration values from `rocsparse_itilu0_option`.
-  !>   @param[in]
-  !>   nmaxiter    maximum number of iterations.
-  !>   @param[in]
-  !>   m           number of rows of the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_row_ptr array of \p m+1 elements that point to the start
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] alg - algorithm to use, `rocsparse_itilu0_alg`.
+  !>   @param[in] option - combination of enumeration values from `rocsparse_itilu0_option`.
+  !>   @param[in] nmaxiter - maximum number of iterations.
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix.
+  !>   @param[in] csr_row_ptr - array of \p m+1 elements that point to the start
   !>               of every row of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_col_ind array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] csr_col_ind - array of \p nnz elements containing the column indices of the sparse
   !>               CSR matrix.
-  !>   @param[in]
-  !>   idx_base    `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
-  !>   @param[in]
-  !>   datatype    type of numerical values, `rocsparse_datatype`.
-  !>   @param[in]
-  !>   buffer_size size of the storage buffer allocated by the user.
-  !>   @param[in]
-  !>   buffer      storage buffer allocated by the user.
+  !>   @param[in] idx_base - `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
+  !>   @param[in] datatype - type of numerical values, `rocsparse_datatype`.
+  !>   @param[in] buffer_size - size of the storage buffer allocated by the user.
+  !>   @param[in] buffer - storage buffer allocated by the user.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -30117,38 +28071,24 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   alg         algorithm to use, `rocsparse_itilu0_alg`
-  !>   @param[in]
-  !>   option      combination of enumeration values from `rocsparse_itilu0_option`.
-  !>   @param[inout]
-  !>   nmaxiter maximum number of iterations on input and number of iterations on output. If the
-  !>   output number of iterations is strictly less than the input maximum number of iterations,
-  !>   then the algorithm converged.
-  !>   @param[in]
-  !>   tol tolerance to use for stopping criteria.
-  !>   @param[in]
-  !>   m           number of rows of the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_row_ptr array of \p m+1 elements that point to the start
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] alg - algorithm to use, `rocsparse_itilu0_alg`
+  !>   @param[in] option - combination of enumeration values from `rocsparse_itilu0_option`.
+  !>   @param[inout] nmaxiter - maximum number of iterations on input and number of iterations on
+  !>   output. If the output number of iterations is strictly less than the input maximum number of
+  !>   iterations, then the algorithm converged.
+  !>   @param[in] tol - tolerance to use for stopping criteria.
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix.
+  !>   @param[in] csr_row_ptr - array of \p m+1 elements that point to the start
   !>               of every row of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_col_ind array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] csr_col_ind - array of \p nnz elements containing the column indices of the sparse
   !>               CSR matrix.
-  !>   @param[inout]
-  !>   csr_val     array of \p nnz elements of the sparse CSR matrix.
-  !>   @param[out]
-  !>   ilu0        incomplete factorization.
-  !>   @param[in]
-  !>   idx_base    `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
-  !>   @param[in]
-  !>   buffer_size size of the storage buffer allocated by the user.
-  !>   @param[in]
-  !>   buffer      storage buffer allocated by the user.
+  !>   @param[inout] csr_val - array of \p nnz elements of the sparse CSR matrix.
+  !>   @param[out] ilu0 - incomplete factorization.
+  !>   @param[in] idx_base - `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
+  !>   @param[in] buffer_size - size of the storage buffer allocated by the user.
+  !>   @param[in] buffer - storage buffer allocated by the user.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_value \p alg or \p base is invalid.
@@ -30312,41 +28252,26 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   alg         algorithm to use, `rocsparse_itilu0_alg`.
-  !>   @param[in]
-  !>   option      combination of enumeration values from `rocsparse_itilu0_option`.
-  !>   @param[inout]
-  !>   nmaxiter maximum number of iterations on input and number of iterations on output. If the
-  !>   output number of iterations is strictly less than the input maximum number of iterations,
-  !>   then the algorithm converged.
-  !>   @param[inout]
-  !>   nfreeiter number of free iterations, that is, the number of iterations the algorithm will
-  !>   perform without stopping criteria evaluations.
-  !>   @param[in]
-  !>   tol tolerance to use for stopping criteria.
-  !>   @param[in]
-  !>   m           number of rows of the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_row_ptr array of \p m+1 elements that point to the start
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] alg - algorithm to use, `rocsparse_itilu0_alg`.
+  !>   @param[in] option - combination of enumeration values from `rocsparse_itilu0_option`.
+  !>   @param[inout] nmaxiter - maximum number of iterations on input and number of iterations on
+  !>   output. If the output number of iterations is strictly less than the input maximum number of
+  !>   iterations, then the algorithm converged.
+  !>   @param[inout] nfreeiter - number of free iterations, that is, the number of iterations the
+  !>   algorithm will perform without stopping criteria evaluations.
+  !>   @param[in] tol - tolerance to use for stopping criteria.
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix.
+  !>   @param[in] csr_row_ptr - array of \p m+1 elements that point to the start
   !>               of every row of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_col_ind array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] csr_col_ind - array of \p nnz elements containing the column indices of the sparse
   !>               CSR matrix.
-  !>   @param[inout]
-  !>   csr_val     array of \p nnz elements of the sparse CSR matrix.
-  !>   @param[out]
-  !>   ilu0        incomplete factorization.
-  !>   @param[in]
-  !>   idx_base    `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
-  !>   @param[in]
-  !>   buffer_size size of the storage buffer allocated by the user.
-  !>   @param[in]
-  !>   buffer      storage buffer allocated by the user.
+  !>   @param[inout] csr_val - array of \p nnz elements of the sparse CSR matrix.
+  !>   @param[out] ilu0 - incomplete factorization.
+  !>   @param[in] idx_base - `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
+  !>   @param[in] buffer_size - size of the storage buffer allocated by the user.
+  !>   @param[in] buffer - storage buffer allocated by the user.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_value \p alg or \p base is invalid.
@@ -30516,18 +28441,12 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   alg         algorithm to use, `rocsparse_itilu0_alg`.
-  !>   @param[out]
-  !>   niter       number of performed iterations.
-  !>   @param[out]
-  !>   data        norms.
-  !>   @param[in]
-  !>   buffer_size size of the buffer allocated by the user.
-  !>   @param[in]
-  !>   buffer buffer allocated by the user.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] alg - algorithm to use, `rocsparse_itilu0_alg`.
+  !>   @param[out] niter - number of performed iterations.
+  !>   @param[out] myData - norms.
+  !>   @param[in] buffer_size - size of the buffer allocated by the user.
+  !>   @param[in] buffer - buffer allocated by the user.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -30611,33 +28530,22 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle       handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   alg          algorithm to solve the linear system.
-  !>   @param[in]
-  !>   m            size of the pentadiagonal linear system.
-  !>   @param[in]
-  !>   ds           lower diagonal (distance 2) of pentadiagonal system. The first two entries
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] alg - algorithm to solve the linear system.
+  !>   @param[in] m - size of the pentadiagonal linear system.
+  !>   @param[in] ds - lower diagonal (distance 2) of pentadiagonal system. The first two entries
   !>                must be zero.
-  !>   @param[in]
-  !>   dl           lower diagonal of pentadiagonal system. The first entry must be zero.
-  !>   @param[in]
-  !>   d            main diagonal of pentadiagonal system.
-  !>   @param[in]
-  !>   du           upper diagonal of pentadiagonal system. The last entry must be zero.
-  !>   @param[in]
-  !>   dw           upper diagonal (distance 2) of pentadiagonal system. The last two entries
+  !>   @param[in] dl - lower diagonal of pentadiagonal system. The first entry must be zero.
+  !>   @param[in] d - main diagonal of pentadiagonal system.
+  !>   @param[in] du - upper diagonal of pentadiagonal system. The last entry must be zero.
+  !>   @param[in] dw - upper diagonal (distance 2) of pentadiagonal system. The last two entries
   !>                must be zero.
-  !>   @param[in]
-  !>   x            Dense array of right-hand-sides, with dimension \p batch_stride by \p m.
-  !>   @param[in]
-  !>   batch_count  The number of systems to solve.
-  !>   @param[in]
-  !>   batch_stride The number of elements that separate consecutive elements in a system.
+  !>   @param[in] x - Dense array of right-hand-sides, with dimension \p batch_stride by \p m.
+  !>   @param[in] batch_count - The number of systems to solve.
+  !>   @param[in] batch_stride - The number of elements that separate consecutive elements in a
+  !>   system.
   !>                Must satisfy \p batch_stride >= \p batch_count.
-  !>   @param[out]
-  !>   buffer_size  Number of bytes of the temporary storage buffer required.
+  !>   @param[out] buffer_size - Number of bytes of the temporary storage buffer required.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -30850,33 +28758,22 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle       handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   alg          algorithm to solve the linear system.
-  !>   @param[in]
-  !>   m            size of the pentadiagonal linear system.
-  !>   @param[inout]
-  !>   ds           lower diagonal (distance 2) of pentadiagonal system. The first two entries
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] alg - algorithm to solve the linear system.
+  !>   @param[in] m - size of the pentadiagonal linear system.
+  !>   @param[inout] ds - lower diagonal (distance 2) of pentadiagonal system. The first two entries
   !>                must be zero.
-  !>   @param[inout]
-  !>   dl           lower diagonal of pentadiagonal system. The first entry must be zero.
-  !>   @param[inout]
-  !>   d            main diagonal of pentadiagonal system.
-  !>   @param[inout]
-  !>   du           upper diagonal of pentadiagonal system. The last entry must be zero.
-  !>   @param[inout]
-  !>   dw           upper diagonal (distance 2) of pentadiagonal system. The last two entries
+  !>   @param[inout] dl - lower diagonal of pentadiagonal system. The first entry must be zero.
+  !>   @param[inout] d - main diagonal of pentadiagonal system.
+  !>   @param[inout] du - upper diagonal of pentadiagonal system. The last entry must be zero.
+  !>   @param[inout] dw - upper diagonal (distance 2) of pentadiagonal system. The last two entries
   !>                must be zero.
-  !>   @param[inout]
-  !>   x            Dense array of right-hand-sides, with dimension \p batch_stride by \p m.
-  !>   @param[in]
-  !>   batch_count  The number of systems to solve.
-  !>   @param[in]
-  !>   batch_stride The number of elements that separate consecutive elements in a system.
+  !>   @param[inout] x - Dense array of right-hand-sides, with dimension \p batch_stride by \p m.
+  !>   @param[in] batch_count - The number of systems to solve.
+  !>   @param[in] batch_stride - The number of elements that separate consecutive elements in a
+  !>   system.
   !>                Must satisfy \p batch_stride >= \p batch_count.
-  !>   @param[in]
-  !>   temp_buffer  Temporary storage buffer allocated by the user.
+  !>   @param[in] temp_buffer - Temporary storage buffer allocated by the user.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -31016,24 +28913,15 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m           size of the tri-diagonal linear system (must be >= 2).
-  !>   @param[in]
-  !>   n           number of columns in the dense matrix B.
-  !>   @param[in]
-  !>   dl          lower diagonal of tri-diagonal system. The first entry must be zero.
-  !>   @param[in]
-  !>   d           main diagonal of tri-diagonal system.
-  !>   @param[in]
-  !>   du          upper diagonal of tri-diagonal system. The last entry must be zero.
-  !>   @param[in]
-  !>   B           dense matrix of size ( \p ldb, \p n ).
-  !>   @param[in]
-  !>   ldb         leading dimension of B. Must satisfy \p ldb >= max(1, m).
-  !>   @param[out]
-  !>   buffer_size number of bytes of the temporary storage buffer required by
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - size of the tri-diagonal linear system (must be >= 2).
+  !>   @param[in] n - number of columns in the dense matrix B.
+  !>   @param[in] dl - lower diagonal of tri-diagonal system. The first entry must be zero.
+  !>   @param[in] d - main diagonal of tri-diagonal system.
+  !>   @param[in] du - upper diagonal of tri-diagonal system. The last entry must be zero.
+  !>   @param[in] B - dense matrix of size ( \p ldb, \p n ).
+  !>   @param[in] ldb - leading dimension of B. Must satisfy \p ldb >= max(1, m).
+  !>   @param[out] buffer_size - number of bytes of the temporary storage buffer required by
   !>               rocsparse_sgtsv(), rocsparse_dgtsv(), rocsparse_cgtsv(),
   !>               and rocsparse_zgtsv().
   !>
@@ -31178,24 +29066,15 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m           size of the tri-diagonal linear system (must be >= 2).
-  !>   @param[in]
-  !>   n           number of columns in the dense matrix B.
-  !>   @param[in]
-  !>   dl          lower diagonal of tri-diagonal system. The first entry must be zero.
-  !>   @param[in]
-  !>   d           main diagonal of tri-diagonal system.
-  !>   @param[in]
-  !>   du          upper diagonal of tri-diagonal system. The last entry must be zero.
-  !>   @param[inout]
-  !>   B           dense matrix of size ( \p ldb, \p n ).
-  !>   @param[in]
-  !>   ldb         leading dimension of B. Must satisfy \p ldb >= max(1, m).
-  !>   @param[in]
-  !>   temp_buffer temporary storage buffer allocated by the user.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - size of the tri-diagonal linear system (must be >= 2).
+  !>   @param[in] n - number of columns in the dense matrix B.
+  !>   @param[in] dl - lower diagonal of tri-diagonal system. The first entry must be zero.
+  !>   @param[in] d - main diagonal of tri-diagonal system.
+  !>   @param[in] du - upper diagonal of tri-diagonal system. The last entry must be zero.
+  !>   @param[inout] B - dense matrix of size ( \p ldb, \p n ).
+  !>   @param[in] ldb - leading dimension of B. Must satisfy \p ldb >= max(1, m).
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -31318,24 +29197,15 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m           size of the tri-diagonal linear system (must be >= 2).
-  !>   @param[in]
-  !>   n           number of columns in the dense matrix B.
-  !>   @param[in]
-  !>   dl          lower diagonal of tri-diagonal system. The first entry must be zero.
-  !>   @param[in]
-  !>   d           main diagonal of tri-diagonal system.
-  !>   @param[in]
-  !>   du          upper diagonal of tri-diagonal system. The last entry must be zero.
-  !>   @param[in]
-  !>   B           dense matrix of size ( \p ldb, \p n ).
-  !>   @param[in]
-  !>   ldb         leading dimension of B. Must satisfy \p ldb >= max(1, m).
-  !>   @param[out]
-  !>   buffer_size number of bytes of the temporary storage buffer required by
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - size of the tri-diagonal linear system (must be >= 2).
+  !>   @param[in] n - number of columns in the dense matrix B.
+  !>   @param[in] dl - lower diagonal of tri-diagonal system. The first entry must be zero.
+  !>   @param[in] d - main diagonal of tri-diagonal system.
+  !>   @param[in] du - upper diagonal of tri-diagonal system. The last entry must be zero.
+  !>   @param[in] B - dense matrix of size ( \p ldb, \p n ).
+  !>   @param[in] ldb - leading dimension of B. Must satisfy \p ldb >= max(1, m).
+  !>   @param[out] buffer_size - number of bytes of the temporary storage buffer required by
   !>               rocsparse_sgtsv_no_pivot(), rocsparse_dgtsv_no_pivot(),
   !>               rocsparse_cgtsv_no_pivot(),
   !>               and rocsparse_zgtsv_no_pivot().
@@ -31484,24 +29354,15 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m           size of the tri-diagonal linear system (must be >= 2).
-  !>   @param[in]
-  !>   n           number of columns in the dense matrix B.
-  !>   @param[in]
-  !>   dl          lower diagonal of tri-diagonal system. The first entry must be zero.
-  !>   @param[in]
-  !>   d           main diagonal of tri-diagonal system.
-  !>   @param[in]
-  !>   du          upper diagonal of tri-diagonal system. The last entry must be zero.
-  !>   @param[inout]
-  !>   B           dense matrix of size ( \p ldb, \p n ).
-  !>   @param[in]
-  !>   ldb         leading dimension of B. Must satisfy \p ldb >= max(1, m).
-  !>   @param[in]
-  !>   temp_buffer temporary storage buffer allocated by the user.
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - size of the tri-diagonal linear system (must be >= 2).
+  !>   @param[in] n - number of columns in the dense matrix B.
+  !>   @param[in] dl - lower diagonal of tri-diagonal system. The first entry must be zero.
+  !>   @param[in] d - main diagonal of tri-diagonal system.
+  !>   @param[in] du - upper diagonal of tri-diagonal system. The last entry must be zero.
+  !>   @param[inout] B - dense matrix of size ( \p ldb, \p n ).
+  !>   @param[in] ldb - leading dimension of B. Must satisfy \p ldb >= max(1, m).
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -31630,28 +29491,20 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m           size of the tri-diagonal linear system.
-  !>   @param[in]
-  !>   dl lower diagonal of tri-diagonal system, where the ith system lower diagonal starts at \p
-  !>   dl+batch_stride*i.
-  !>   @param[in]
-  !>   d main diagonal of tri-diagonal system, where the ith system diagonal starts at \p
-  !>   d+batch_stride*i.
-  !>   @param[in]
-  !>   du upper diagonal of tri-diagonal system, where the ith system upper diagonal starts at \p
-  !>   du+batch_stride*i.
-  !>   @param[inout]
-  !>   x dense array of righthand-sides where the ith righthand-side starts at \p x+batch_stride*i.
-  !>   @param[in]
-  !>   batch_count the number of systems to solve.
-  !>   @param[in]
-  !>   batch_stride the number of elements that separate each system. Must satisfy \p batch_stride
-  !>   >= \p m.
-  !>   @param[out]
-  !>   buffer_size number of bytes of the temporary storage buffer required by
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - size of the tri-diagonal linear system.
+  !>   @param[in] dl - lower diagonal of tri-diagonal system, where the ith system lower diagonal
+  !>   starts at \p dl+batch_stride*i.
+  !>   @param[in] d - main diagonal of tri-diagonal system, where the ith system diagonal starts at
+  !>   \p d+batch_stride*i.
+  !>   @param[in] du - upper diagonal of tri-diagonal system, where the ith system upper diagonal
+  !>   starts at \p du+batch_stride*i.
+  !>   @param[inout] x - dense array of righthand-sides where the ith righthand-side starts at \p
+  !>   x+batch_stride*i.
+  !>   @param[in] batch_count - the number of systems to solve.
+  !>   @param[in] batch_stride - the number of elements that separate each system. Must satisfy \p
+  !>   batch_stride >= \p m.
+  !>   @param[out] buffer_size - number of bytes of the temporary storage buffer required by
   !>               \ref rocsparse_sgtsv_no_pivot_strided_batch
   !>               "rocsparse_Xgtsv_no_pivot_strided_batch()".
   !>
@@ -31839,26 +29692,17 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m           size of the tri-diagonal linear system (must be >= 2).
-  !>   @param[in]
-  !>   dl          lower diagonal of tri-diagonal system. The first entry must be zero.
-  !>   @param[in]
-  !>   d           main diagonal of tri-diagonal system.
-  !>   @param[in]
-  !>   du          upper diagonal of tri-diagonal system. The last entry must be zero.
-  !>   @param[inout]
-  !>   x dense array of righthand-sides, where the ith right-hand side starts at \p
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - size of the tri-diagonal linear system (must be >= 2).
+  !>   @param[in] dl - lower diagonal of tri-diagonal system. The first entry must be zero.
+  !>   @param[in] d - main diagonal of tri-diagonal system.
+  !>   @param[in] du - upper diagonal of tri-diagonal system. The last entry must be zero.
+  !>   @param[inout] x - dense array of righthand-sides, where the ith right-hand side starts at \p
   !>   x+batch_stride*i.
-  !>   @param[in]
-  !>   batch_count the number of systems to solve.
-  !>   @param[in]
-  !>   batch_stride the number of elements that separate each system. Must satisfy \p batch_stride
-  !>   >= \p m.
-  !>   @param[in]
-  !>   temp_buffer temporary storage buffer allocated by the user.
+  !>   @param[in] batch_count - the number of systems to solve.
+  !>   @param[in] batch_stride - the number of elements that separate each system. Must satisfy \p
+  !>   batch_stride >= \p m.
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -31987,35 +29831,25 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   alg algorithm to use when solving tridiagonal systems. Options are Thomas (
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] alg - algorithm to use when solving tridiagonal systems. Options are Thomas (
   !>   `rocsparse_gtsv_interleaved_alg_thomas` ),
   !>               LU ( `rocsparse_gtsv_interleaved_alg_lu` ), or QR (
   !>               `rocsparse_gtsv_interleaved_alg_qr` ). Passing
   !>               `rocsparse_gtsv_interleaved_alg_default` defaults to using the QR algorithm. The
   !>               Thomas algorithm is the fastest but is not
   !>               stable, while LU and QR are slower but are stable.
-  !>   @param[in]
-  !>   m           size of the tri-diagonal linear system.
-  !>   @param[in]
-  !>   dl lower diagonal of tri-diagonal system. The first element of the lower diagonal must be
-  !>   zero.
-  !>   @param[in]
-  !>   d           main diagonal of tri-diagonal system.
-  !>   @param[in]
-  !>   du upper diagonal of tri-diagonal system. The last element of the upper diagonal must be
-  !>   zero.
-  !>   @param[inout]
-  !>   x           dense array of right-hand sides with dimension \p batch_stride by \p m.
-  !>   @param[in]
-  !>   batch_count the number of systems to solve.
-  !>   @param[in]
-  !>   batch_stride the number of elements that separate consecutive elements in a system. Must
-  !>   satisfy \p batch_stride >= \p batch_count.
-  !>   @param[out]
-  !>   buffer_size number of bytes of the temporary storage buffer required by
+  !>   @param[in] m - size of the tri-diagonal linear system.
+  !>   @param[in] dl - lower diagonal of tri-diagonal system. The first element of the lower
+  !>   diagonal must be zero.
+  !>   @param[in] d - main diagonal of tri-diagonal system.
+  !>   @param[in] du - upper diagonal of tri-diagonal system. The last element of the upper diagonal
+  !>   must be zero.
+  !>   @param[inout] x - dense array of right-hand sides with dimension \p batch_stride by \p m.
+  !>   @param[in] batch_count - the number of systems to solve.
+  !>   @param[in] batch_stride - the number of elements that separate consecutive elements in a
+  !>   system. Must satisfy \p batch_stride >= \p batch_count.
+  !>   @param[out] buffer_size - number of bytes of the temporary storage buffer required by
   !>               \ref rocsparse_sgtsv_interleaved_batch "rocsparse_Xgtsv_interleaved_batch()".
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
@@ -32189,35 +30023,25 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine supports execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   alg algorithm to use when solving tridiagonal systems. Options are Thomas (
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] alg - algorithm to use when solving tridiagonal systems. Options are Thomas (
   !>   `rocsparse_gtsv_interleaved_alg_thomas` ),
   !>               LU ( `rocsparse_gtsv_interleaved_alg_lu` ), or QR (
   !>               `rocsparse_gtsv_interleaved_alg_qr` ). Passing
   !>               `rocsparse_gtsv_interleaved_alg_default` defaults to using the QR algorithm. The
   !>               Thomas algorithm is the fastest but is not
   !>               stable, while LU and QR are slower but are stable.
-  !>   @param[in]
-  !>   m           size of the tri-diagonal linear system.
-  !>   @param[inout]
-  !>   dl lower diagonal of tri-diagonal system. The first element of the lower diagonal must be
-  !>   zero.
-  !>   @param[inout]
-  !>   d           main diagonal of tri-diagonal system.
-  !>   @param[inout]
-  !>   du upper diagonal of tri-diagonal system. The last element of the upper diagonal must be
-  !>   zero.
-  !>   @param[inout]
-  !>   x           dense array of right-hand sides, with dimension \p batch_stride by \p m.
-  !>   @param[in]
-  !>   batch_count the number of systems to solve.
-  !>   @param[in]
-  !>   batch_stride the number of elements that separate consecutive elements in a system. Must
-  !>   satisfy \p batch_stride >= \p batch_count.
-  !>   @param[in]
-  !>   temp_buffer temporary storage buffer allocated by the user.
+  !>   @param[in] m - size of the tri-diagonal linear system.
+  !>   @param[inout] dl - lower diagonal of tri-diagonal system. The first element of the lower
+  !>   diagonal must be zero.
+  !>   @param[inout] d - main diagonal of tri-diagonal system.
+  !>   @param[inout] du - upper diagonal of tri-diagonal system. The last element of the upper
+  !>   diagonal must be zero.
+  !>   @param[inout] x - dense array of right-hand sides, with dimension \p batch_stride by \p m.
+  !>   @param[in] batch_count - the number of systems to solve.
+  !>   @param[in] batch_stride - the number of elements that separate consecutive elements in a
+  !>   system. Must satisfy \p batch_stride >= \p batch_count.
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user.
   !>
   !>   \retval     rocsparse_status_success the operation completed successfully.
   !>   \retval     rocsparse_status_invalid_handle the library context was not initialized.
@@ -32334,33 +30158,23 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m           number of rows of sparse matrix \f$A\f$.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of sparse matrix \f$A\f$.
-  !>   @param[in]
-  !>   descr      sparse matrix descriptor.
-  !>   @param[in]
-  !>   csr_val     array of \p nnz elements of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_row_ptr array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - number of rows of sparse matrix \f$A\f$.
+  !>   @param[in] nnz - number of non-zero entries of sparse matrix \f$A\f$.
+  !>   @param[in] descr - sparse matrix descriptor.
+  !>   @param[in] csr_val - array of \p nnz elements of the sparse CSR matrix.
+  !>   @param[in] csr_row_ptr - array of \p m+1 elements that point to the start of every row of the
   !>               sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_col_ind array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] csr_col_ind - array of \p nnz elements containing the column indices of the sparse
   !>               CSR matrix.
-  !>   @param[in]
-  !>   fraction_to_color fraction of nodes to be colored, which should be in the interval [0.0,1.0],
-  !>   for example, 0.8 implies that 80 percent of nodes will be colored.
-  !>   @param[out]
-  !>   ncolors      resulting number of distinct colors.
-  !>   @param[out]
-  !>   coloring     resulting mapping of colors.
-  !>   @param[out]
-  !>   reordering optional resulting reordering permutation if \p reordering is a non-null pointer.
-  !>   @param[inout]
-  !>   info    structure that holds the information collected during the coloring algorithm.
+  !>   @param[in] fraction_to_color - fraction of nodes to be colored, which should be in the
+  !>   interval [0.0,1.0], for example, 0.8 implies that 80 percent of nodes will be colored.
+  !>   @param[out] ncolors - resulting number of distinct colors.
+  !>   @param[out] coloring - resulting mapping of colors.
+  !>   @param[out] reordering - optional resulting reordering permutation if \p reordering is a
+  !>   non-null pointer.
+  !>   @param[inout] myInfo - structure that holds the information collected during the coloring
+  !>   algorithm.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_handle the library context was not initialized.
@@ -32491,33 +30305,21 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m           number of rows of the sparse CSR matrix.
-  !>   @param[in]
-  !>   n           number of columns of the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of the sparse CSR matrix.
-  !>   @param[in]
-  !>   coo_val     array of \p nnz elements of the sparse COO matrix.
-  !>   @param[in]
-  !>   coo_row_ind array of \p nnz elements containing the row indices of the sparse
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
+  !>   @param[in] n - number of columns of the sparse CSR matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix.
+  !>   @param[in] coo_val - array of \p nnz elements of the sparse COO matrix.
+  !>   @param[in] coo_row_ind - array of \p nnz elements containing the row indices of the sparse
   !>               COO matrix.
-  !>   @param[in]
-  !>   coo_col_ind array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] coo_col_ind - array of \p nnz elements containing the column indices of the sparse
   !>               COO matrix.
-  !>   @param[in]
-  !>   idx_base    `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
-  !>   @param[in]
-  !>   matrix_type `rocsparse_matrix_type_general`, `rocsparse_matrix_type_symmetric`,
+  !>   @param[in] idx_base - `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
+  !>   @param[in] matrix_type - `rocsparse_matrix_type_general`, `rocsparse_matrix_type_symmetric`,
   !>               `rocsparse_matrix_type_hermitian`, or `rocsparse_matrix_type_triangular`.
-  !>   @param[in]
-  !>   uplo        `rocsparse_fill_mode_lower` or `rocsparse_fill_mode_upper`.
-  !>   @param[in]
-  !>   storage     `rocsparse_storage_mode_sorted` or `rocsparse_storage_mode_sorted`.
-  !>   @param[out]
-  !>   buffer_size number of bytes of the temporary storage buffer required by
+  !>   @param[in] uplo - `rocsparse_fill_mode_lower` or `rocsparse_fill_mode_upper`.
+  !>   @param[in] storage - `rocsparse_storage_mode_sorted` or `rocsparse_storage_mode_sorted`.
+  !>   @param[out] buffer_size - number of bytes of the temporary storage buffer required by
   !>               \ref rocsparse_scheck_matrix_coo "rocsparse_Xcheck_matrix_coo()".
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
@@ -32649,35 +30451,22 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m           number of rows of the sparse COO matrix.
-  !>   @param[in]
-  !>   n           number of columns of the sparse COO matrix.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of the sparse COO matrix.
-  !>   @param[in]
-  !>   coo_val     array of \p nnz elements of the sparse COO matrix.
-  !>   @param[in]
-  !>   coo_row_ind array of \p nnz elements containing the row indices of the sparse
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse COO matrix.
+  !>   @param[in] n - number of columns of the sparse COO matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse COO matrix.
+  !>   @param[in] coo_val - array of \p nnz elements of the sparse COO matrix.
+  !>   @param[in] coo_row_ind - array of \p nnz elements containing the row indices of the sparse
   !>               COO matrix.
-  !>   @param[in]
-  !>   coo_col_ind array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] coo_col_ind - array of \p nnz elements containing the column indices of the sparse
   !>               COO matrix.
-  !>   @param[in]
-  !>   idx_base    `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
-  !>   @param[in]
-  !>   matrix_type `rocsparse_matrix_type_general`, `rocsparse_matrix_type_symmetric`,
+  !>   @param[in] idx_base - `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
+  !>   @param[in] matrix_type - `rocsparse_matrix_type_general`, `rocsparse_matrix_type_symmetric`,
   !>               `rocsparse_matrix_type_hermitian`, or `rocsparse_matrix_type_triangular`.
-  !>   @param[in]
-  !>   uplo        `rocsparse_fill_mode_lower` or `rocsparse_fill_mode_upper`.
-  !>   @param[in]
-  !>   storage     `rocsparse_storage_mode_sorted` or `rocsparse_storage_mode_sorted`.
-  !>   @param[out]
-  !>   data_status modified to indicate the status of the data.
-  !>   @param[in]
-  !>   temp_buffer temporary storage buffer allocated by the user.
+  !>   @param[in] uplo - `rocsparse_fill_mode_lower` or `rocsparse_fill_mode_upper`.
+  !>   @param[in] storage - `rocsparse_storage_mode_sorted` or `rocsparse_storage_mode_sorted`.
+  !>   @param[out] data_status - modified to indicate the status of the data.
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_handle the library context was not initialized.
@@ -32848,33 +30637,22 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m           number of rows of the sparse CSC matrix.
-  !>   @param[in]
-  !>   n           number of columns of the sparse CSC matrix.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of the sparse CSC matrix.
-  !>   @param[in]
-  !>   csc_val     array of \p nnz elements of the sparse CSC matrix.
-  !>   @param[in]
-  !>   csc_col_ptr array of \p m+1 elements that point to the start of every column of the
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse CSC matrix.
+  !>   @param[in] n - number of columns of the sparse CSC matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSC matrix.
+  !>   @param[in] csc_val - array of \p nnz elements of the sparse CSC matrix.
+  !>   @param[in] csc_col_ptr - array of \p m+1 elements that point to the start of every column of
+  !>   the
   !>               sparse CSC matrix.
-  !>   @param[in]
-  !>   csc_row_ind array of \p nnz elements containing the row indices of the sparse
+  !>   @param[in] csc_row_ind - array of \p nnz elements containing the row indices of the sparse
   !>               CSC matrix.
-  !>   @param[in]
-  !>   idx_base    `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
-  !>   @param[in]
-  !>   matrix_type `rocsparse_matrix_type_general`, `rocsparse_matrix_type_symmetric`,
+  !>   @param[in] idx_base - `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
+  !>   @param[in] matrix_type - `rocsparse_matrix_type_general`, `rocsparse_matrix_type_symmetric`,
   !>               `rocsparse_matrix_type_hermitian`, or `rocsparse_matrix_type_triangular`.
-  !>   @param[in]
-  !>   uplo        `rocsparse_fill_mode_lower` or `rocsparse_fill_mode_upper`.
-  !>   @param[in]
-  !>   storage     `rocsparse_storage_mode_sorted` or `rocsparse_storage_mode_sorted`.
-  !>   @param[out]
-  !>   buffer_size number of bytes of the temporary storage buffer required by
+  !>   @param[in] uplo - `rocsparse_fill_mode_lower` or `rocsparse_fill_mode_upper`.
+  !>   @param[in] storage - `rocsparse_storage_mode_sorted` or `rocsparse_storage_mode_sorted`.
+  !>   @param[out] buffer_size - number of bytes of the temporary storage buffer required by
   !>               \ref rocsparse_scheck_matrix_csc "rocsparse_Xcheck_matrix_csc()".
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
@@ -33006,35 +30784,23 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m           number of rows of the sparse CSC matrix.
-  !>   @param[in]
-  !>   n           number of columns of the sparse CSC matrix.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of the sparse CSC matrix.
-  !>   @param[in]
-  !>   csc_val     array of \p nnz elements of the sparse CSC matrix.
-  !>   @param[in]
-  !>   csc_col_ptr array of \p m+1 elements that point to the start of every column of the
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse CSC matrix.
+  !>   @param[in] n - number of columns of the sparse CSC matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSC matrix.
+  !>   @param[in] csc_val - array of \p nnz elements of the sparse CSC matrix.
+  !>   @param[in] csc_col_ptr - array of \p m+1 elements that point to the start of every column of
+  !>   the
   !>               sparse CSC matrix.
-  !>   @param[in]
-  !>   csc_row_ind array of \p nnz elements containing the row indices of the sparse
+  !>   @param[in] csc_row_ind - array of \p nnz elements containing the row indices of the sparse
   !>               CSC matrix.
-  !>   @param[in]
-  !>   idx_base    `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
-  !>   @param[in]
-  !>   matrix_type `rocsparse_matrix_type_general`, `rocsparse_matrix_type_symmetric`,
+  !>   @param[in] idx_base - `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
+  !>   @param[in] matrix_type - `rocsparse_matrix_type_general`, `rocsparse_matrix_type_symmetric`,
   !>               `rocsparse_matrix_type_hermitian`, or `rocsparse_matrix_type_triangular`.
-  !>   @param[in]
-  !>   uplo        `rocsparse_fill_mode_lower` or `rocsparse_fill_mode_upper`.
-  !>   @param[in]
-  !>   storage     `rocsparse_storage_mode_sorted` or `rocsparse_storage_mode_sorted`.
-  !>   @param[out]
-  !>   data_status modified to indicate the status of the data.
-  !>   @param[in]
-  !>   temp_buffer temporary storage buffer allocated by the user.
+  !>   @param[in] uplo - `rocsparse_fill_mode_lower` or `rocsparse_fill_mode_upper`.
+  !>   @param[in] storage - `rocsparse_storage_mode_sorted` or `rocsparse_storage_mode_sorted`.
+  !>   @param[out] data_status - modified to indicate the status of the data.
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_handle the library context was not initialized.
@@ -33207,33 +30973,21 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m           number of rows of the sparse CSR matrix.
-  !>   @param[in]
-  !>   n           number of columns of the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_val     array of \p nnz elements of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_row_ptr array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
+  !>   @param[in] n - number of columns of the sparse CSR matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix.
+  !>   @param[in] csr_val - array of \p nnz elements of the sparse CSR matrix.
+  !>   @param[in] csr_row_ptr - array of \p m+1 elements that point to the start of every row of the
   !>               sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_col_ind array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] csr_col_ind - array of \p nnz elements containing the column indices of the sparse
   !>               CSR matrix.
-  !>   @param[in]
-  !>   idx_base    `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
-  !>   @param[in]
-  !>   matrix_type `rocsparse_matrix_type_general`, `rocsparse_matrix_type_symmetric`,
+  !>   @param[in] idx_base - `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
+  !>   @param[in] matrix_type - `rocsparse_matrix_type_general`, `rocsparse_matrix_type_symmetric`,
   !>               `rocsparse_matrix_type_hermitian`, or `rocsparse_matrix_type_triangular`.
-  !>   @param[in]
-  !>   uplo        `rocsparse_fill_mode_lower` or `rocsparse_fill_mode_upper`.
-  !>   @param[in]
-  !>   storage     `rocsparse_storage_mode_sorted` or `rocsparse_storage_mode_sorted`.
-  !>   @param[out]
-  !>   buffer_size number of bytes of the temporary storage buffer required by
+  !>   @param[in] uplo - `rocsparse_fill_mode_lower` or `rocsparse_fill_mode_upper`.
+  !>   @param[in] storage - `rocsparse_storage_mode_sorted` or `rocsparse_storage_mode_sorted`.
+  !>   @param[out] buffer_size - number of bytes of the temporary storage buffer required by
   !>               rocsparse_scheck_matrix_csr(), rocsparse_dcheck_matrix_csr(),
   !>               rocsparse_ccheck_matrix_csr(), and rocsparse_zcheck_matrix_csr().
   !>
@@ -33366,35 +31120,22 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m           number of rows of the sparse CSR matrix.
-  !>   @param[in]
-  !>   n           number of columns of the sparse CSR matrix.
-  !>   @param[in]
-  !>   nnz         number of non-zero entries of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_val     array of \p nnz elements of the sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_row_ptr array of \p m+1 elements that point to the start of every row of the
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse CSR matrix.
+  !>   @param[in] n - number of columns of the sparse CSR matrix.
+  !>   @param[in] nnz - number of non-zero entries of the sparse CSR matrix.
+  !>   @param[in] csr_val - array of \p nnz elements of the sparse CSR matrix.
+  !>   @param[in] csr_row_ptr - array of \p m+1 elements that point to the start of every row of the
   !>               sparse CSR matrix.
-  !>   @param[in]
-  !>   csr_col_ind array of \p nnz elements containing the column indices of the sparse
+  !>   @param[in] csr_col_ind - array of \p nnz elements containing the column indices of the sparse
   !>               CSR matrix.
-  !>   @param[in]
-  !>   idx_base    `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
-  !>   @param[in]
-  !>   matrix_type `rocsparse_matrix_type_general`, `rocsparse_matrix_type_symmetric`,
+  !>   @param[in] idx_base - `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
+  !>   @param[in] matrix_type - `rocsparse_matrix_type_general`, `rocsparse_matrix_type_symmetric`,
   !>               `rocsparse_matrix_type_hermitian`, or `rocsparse_matrix_type_triangular`.
-  !>   @param[in]
-  !>   uplo        `rocsparse_fill_mode_lower` or `rocsparse_fill_mode_upper`.
-  !>   @param[in]
-  !>   storage     `rocsparse_storage_mode_sorted` or `rocsparse_storage_mode_sorted`.
-  !>   @param[out]
-  !>   data_status modified to indicate the status of the data.
-  !>   @param[in]
-  !>   temp_buffer temporary storage buffer allocated by the user.
+  !>   @param[in] uplo - `rocsparse_fill_mode_lower` or `rocsparse_fill_mode_upper`.
+  !>   @param[in] storage - `rocsparse_storage_mode_sorted` or `rocsparse_storage_mode_sorted`.
+  !>   @param[out] data_status - modified to indicate the status of the data.
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_handle the library context was not initialized.
@@ -33565,31 +31306,20 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m           number of rows of the sparse ELL matrix.
-  !>   @param[in]
-  !>   n           number of columns of the sparse ELL matrix.
-  !>   @param[in]
-  !>   ell_width   number of non-zero elements per row of the sparse ELL matrix.
-  !>   @param[in]
-  !>   ell_val     array that contains the elements of the sparse ELL matrix. Padded
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse ELL matrix.
+  !>   @param[in] n - number of columns of the sparse ELL matrix.
+  !>   @param[in] ell_width - number of non-zero elements per row of the sparse ELL matrix.
+  !>   @param[in] ell_val - array that contains the elements of the sparse ELL matrix. Padded
   !>               elements should be zero.
-  !>   @param[in]
-  !>   ell_col_ind array that contains the column indices of the sparse ELL matrix.
+  !>   @param[in] ell_col_ind - array that contains the column indices of the sparse ELL matrix.
   !>               Padded column indices should be -1.
-  !>   @param[in]
-  !>   idx_base    `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
-  !>   @param[in]
-  !>   matrix_type `rocsparse_matrix_type_general`, `rocsparse_matrix_type_symmetric`,
+  !>   @param[in] idx_base - `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
+  !>   @param[in] matrix_type - `rocsparse_matrix_type_general`, `rocsparse_matrix_type_symmetric`,
   !>               `rocsparse_matrix_type_hermitian`, or `rocsparse_matrix_type_triangular`.
-  !>   @param[in]
-  !>   uplo        `rocsparse_fill_mode_lower` or `rocsparse_fill_mode_upper`.
-  !>   @param[in]
-  !>   storage     `rocsparse_storage_mode_sorted` or `rocsparse_storage_mode_sorted`.
-  !>   @param[out]
-  !>   buffer_size number of bytes of the temporary storage buffer required by
+  !>   @param[in] uplo - `rocsparse_fill_mode_lower` or `rocsparse_fill_mode_upper`.
+  !>   @param[in] storage - `rocsparse_storage_mode_sorted` or `rocsparse_storage_mode_sorted`.
+  !>   @param[out] buffer_size - number of bytes of the temporary storage buffer required by
   !>               rocsparse_scheck_matrix_ell(), rocsparse_dcheck_matrix_ell(),
   !>               rocsparse_ccheck_matrix_ell(), and rocsparse_zcheck_matrix_ell().
   !>
@@ -33711,33 +31441,21 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   m           number of rows of the sparse ELL matrix.
-  !>   @param[in]
-  !>   n           number of columns of the sparse ELL matrix.
-  !>   @param[in]
-  !>   ell_width   number of non-zero elements per row of the sparse ELL matrix.
-  !>   @param[in]
-  !>   ell_val     array that contains the elements of the sparse ELL matrix. Padded
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] m - number of rows of the sparse ELL matrix.
+  !>   @param[in] n - number of columns of the sparse ELL matrix.
+  !>   @param[in] ell_width - number of non-zero elements per row of the sparse ELL matrix.
+  !>   @param[in] ell_val - array that contains the elements of the sparse ELL matrix. Padded
   !>               elements should be zero.
-  !>   @param[in]
-  !>   ell_col_ind array that contains the column indices of the sparse ELL matrix.
+  !>   @param[in] ell_col_ind - array that contains the column indices of the sparse ELL matrix.
   !>               Padded column indices should be -1.
-  !>   @param[in]
-  !>   idx_base    `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
-  !>   @param[in]
-  !>   matrix_type `rocsparse_matrix_type_general`, `rocsparse_matrix_type_symmetric`,
+  !>   @param[in] idx_base - `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
+  !>   @param[in] matrix_type - `rocsparse_matrix_type_general`, `rocsparse_matrix_type_symmetric`,
   !>               `rocsparse_matrix_type_hermitian`, or `rocsparse_matrix_type_triangular`.
-  !>   @param[in]
-  !>   uplo        `rocsparse_fill_mode_lower` or `rocsparse_fill_mode_upper`.
-  !>   @param[in]
-  !>   storage     `rocsparse_storage_mode_sorted` or `rocsparse_storage_mode_sorted`.
-  !>   @param[out]
-  !>   data_status modified to indicate the status of the data.
-  !>   @param[in]
-  !>   temp_buffer temporary storage buffer allocated by the user.
+  !>   @param[in] uplo - `rocsparse_fill_mode_lower` or `rocsparse_fill_mode_upper`.
+  !>   @param[in] storage - `rocsparse_storage_mode_sorted` or `rocsparse_storage_mode_sorted`.
+  !>   @param[out] data_status - modified to indicate the status of the data.
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_handle the library context was not initialized.
@@ -33847,39 +31565,25 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   dir          matrix storage of GEBSC blocks.
-  !>   @param[in]
-  !>   mb           number of block rows of the sparse GEBSC matrix.
-  !>   @param[in]
-  !>   nb           number of block columns of the sparse GEBSC matrix.
-  !>   @param[in]
-  !>   nnzb         number of non-zero blocks of the sparse GEBSC matrix.
-  !>   @param[in]
-  !>   row_block_dim row block dimension of the sparse GEBSC matrix.
-  !>   @param[in]
-  !>   col_block_dim column block dimension of the sparse GEBSC matrix.
-  !>   @param[in]
-  !>   bsc_val     array of \p nnzb elements of the sparse GEBSC matrix.
-  !>   @param[in]
-  !>   bsc_col_ptr array of \p nb+1 elements that point to the start of every column of the
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] dir - matrix storage of GEBSC blocks.
+  !>   @param[in] mb - number of block rows of the sparse GEBSC matrix.
+  !>   @param[in] nb - number of block columns of the sparse GEBSC matrix.
+  !>   @param[in] nnzb - number of non-zero blocks of the sparse GEBSC matrix.
+  !>   @param[in] row_block_dim - row block dimension of the sparse GEBSC matrix.
+  !>   @param[in] col_block_dim - column block dimension of the sparse GEBSC matrix.
+  !>   @param[in] bsc_val - array of \p nnzb elements of the sparse GEBSC matrix.
+  !>   @param[in] bsc_col_ptr - array of \p nb+1 elements that point to the start of every column of
+  !>   the
   !>               sparse GEBSC matrix.
-  !>   @param[in]
-  !>   bsc_row_ind array of \p nnzb elements containing the row indices of the sparse
+  !>   @param[in] bsc_row_ind - array of \p nnzb elements containing the row indices of the sparse
   !>               GEBSC matrix.
-  !>   @param[in]
-  !>   idx_base    `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
-  !>   @param[in]
-  !>   matrix_type `rocsparse_matrix_type_general`, `rocsparse_matrix_type_symmetric`,
+  !>   @param[in] idx_base - `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
+  !>   @param[in] matrix_type - `rocsparse_matrix_type_general`, `rocsparse_matrix_type_symmetric`,
   !>               `rocsparse_matrix_type_hermitian`, or `rocsparse_matrix_type_triangular`.
-  !>   @param[in]
-  !>   uplo        `rocsparse_fill_mode_lower` or `rocsparse_fill_mode_upper`.
-  !>   @param[in]
-  !>   storage     `rocsparse_storage_mode_sorted` or `rocsparse_storage_mode_sorted`.
-  !>   @param[out]
-  !>   buffer_size number of bytes of the temporary storage buffer required by
+  !>   @param[in] uplo - `rocsparse_fill_mode_lower` or `rocsparse_fill_mode_upper`.
+  !>   @param[in] storage - `rocsparse_storage_mode_sorted` or `rocsparse_storage_mode_sorted`.
+  !>   @param[out] buffer_size - number of bytes of the temporary storage buffer required by
   !>               rocsparse_scheck_matrix_gebsc(), rocsparse_dcheck_matrix_gebsc(),
   !>               rocsparse_ccheck_matrix_gebsc(), and rocsparse_zcheck_matrix_gebsc().
   !>
@@ -34024,41 +31728,26 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   dir          matrix storage of GEBSC blocks.
-  !>   @param[in]
-  !>   mb           number of block rows of the sparse GEBSC matrix.
-  !>   @param[in]
-  !>   nb           number of block columns of the sparse GEBSC matrix.
-  !>   @param[in]
-  !>   nnzb         number of non-zero blocks of the sparse GEBSC matrix.
-  !>   @param[in]
-  !>   row_block_dim row block dimension of the sparse GEBSC matrix.
-  !>   @param[in]
-  !>   col_block_dim column block dimension of the sparse GEBSC matrix.
-  !>   @param[in]
-  !>   bsc_val     array of \p nnzb elements of the sparse GEBSC matrix.
-  !>   @param[in]
-  !>   bsc_col_ptr array of \p nb+1 elements that point to the start of every column of the
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] dir - matrix storage of GEBSC blocks.
+  !>   @param[in] mb - number of block rows of the sparse GEBSC matrix.
+  !>   @param[in] nb - number of block columns of the sparse GEBSC matrix.
+  !>   @param[in] nnzb - number of non-zero blocks of the sparse GEBSC matrix.
+  !>   @param[in] row_block_dim - row block dimension of the sparse GEBSC matrix.
+  !>   @param[in] col_block_dim - column block dimension of the sparse GEBSC matrix.
+  !>   @param[in] bsc_val - array of \p nnzb elements of the sparse GEBSC matrix.
+  !>   @param[in] bsc_col_ptr - array of \p nb+1 elements that point to the start of every column of
+  !>   the
   !>               sparse GEBSC matrix.
-  !>   @param[in]
-  !>   bsc_row_ind array of \p nnzb elements containing the row indices of the sparse
+  !>   @param[in] bsc_row_ind - array of \p nnzb elements containing the row indices of the sparse
   !>               GEBSC matrix.
-  !>   @param[in]
-  !>   idx_base    `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
-  !>   @param[in]
-  !>   matrix_type `rocsparse_matrix_type_general`, `rocsparse_matrix_type_symmetric`,
+  !>   @param[in] idx_base - `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
+  !>   @param[in] matrix_type - `rocsparse_matrix_type_general`, `rocsparse_matrix_type_symmetric`,
   !>               `rocsparse_matrix_type_hermitian`, or `rocsparse_matrix_type_triangular`.
-  !>   @param[in]
-  !>   uplo        `rocsparse_fill_mode_lower` or `rocsparse_fill_mode_upper`.
-  !>   @param[in]
-  !>   storage     `rocsparse_storage_mode_sorted` or `rocsparse_storage_mode_sorted`.
-  !>   @param[out]
-  !>   data_status modified to indicate the status of the data.
-  !>   @param[in]
-  !>   temp_buffer temporary storage buffer allocated by the user.
+  !>   @param[in] uplo - `rocsparse_fill_mode_lower` or `rocsparse_fill_mode_upper`.
+  !>   @param[in] storage - `rocsparse_storage_mode_sorted` or `rocsparse_storage_mode_sorted`.
+  !>   @param[out] data_status - modified to indicate the status of the data.
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_handle the library context was not initialized.
@@ -34187,39 +31876,26 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   dir          matrix storage of GEBSR blocks.
-  !>   @param[in]
-  !>   mb           number of block rows of the sparse GEBSR matrix.
-  !>   @param[in]
-  !>   nb           number of block columns of the sparse GEBSR matrix.
-  !>   @param[in]
-  !>   nnzb         number of non-zero blocks of the sparse GEBSR matrix.
-  !>   @param[in]
-  !>   row_block_dim row block dimension of the sparse GEBSR matrix.
-  !>   @param[in]
-  !>   col_block_dim column block dimension of the sparse GEBSR matrix.
-  !>   @param[in]
-  !>   bsr_val     array of \p nnzb elements of the sparse GEBSR matrix.
-  !>   @param[in]
-  !>   bsr_row_ptr array of \p mb+1 elements that point to the start of every row of the
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] dir - matrix storage of GEBSR blocks.
+  !>   @param[in] mb - number of block rows of the sparse GEBSR matrix.
+  !>   @param[in] nb - number of block columns of the sparse GEBSR matrix.
+  !>   @param[in] nnzb - number of non-zero blocks of the sparse GEBSR matrix.
+  !>   @param[in] row_block_dim - row block dimension of the sparse GEBSR matrix.
+  !>   @param[in] col_block_dim - column block dimension of the sparse GEBSR matrix.
+  !>   @param[in] bsr_val - array of \p nnzb elements of the sparse GEBSR matrix.
+  !>   @param[in] bsr_row_ptr - array of \p mb+1 elements that point to the start of every row of
+  !>   the
   !>               sparse GEBSR matrix.
-  !>   @param[in]
-  !>   bsr_col_ind array of \p nnzb elements containing the column indices of the sparse
+  !>   @param[in] bsr_col_ind - array of \p nnzb elements containing the column indices of the
+  !>   sparse
   !>               GEBSR matrix.
-  !>   @param[in]
-  !>   idx_base    `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
-  !>   @param[in]
-  !>   matrix_type `rocsparse_matrix_type_general`, `rocsparse_matrix_type_symmetric`,
+  !>   @param[in] idx_base - `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
+  !>   @param[in] matrix_type - `rocsparse_matrix_type_general`, `rocsparse_matrix_type_symmetric`,
   !>               `rocsparse_matrix_type_hermitian`, or `rocsparse_matrix_type_triangular`.
-  !>   @param[in]
-  !>   uplo        `rocsparse_fill_mode_lower` or `rocsparse_fill_mode_upper`.
-  !>   @param[in]
-  !>   storage     `rocsparse_storage_mode_sorted` or `rocsparse_storage_mode_sorted`.
-  !>   @param[out]
-  !>   buffer_size number of bytes of the temporary storage buffer required by
+  !>   @param[in] uplo - `rocsparse_fill_mode_lower` or `rocsparse_fill_mode_upper`.
+  !>   @param[in] storage - `rocsparse_storage_mode_sorted` or `rocsparse_storage_mode_sorted`.
+  !>   @param[out] buffer_size - number of bytes of the temporary storage buffer required by
   !>               rocsparse_scheck_matrix_gebsr(), rocsparse_dcheck_matrix_gebsr(),
   !>               rocsparse_ccheck_matrix_gebsr(), and rocsparse_zcheck_matrix_gebsr().
   !>
@@ -34369,41 +32045,27 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   dir          matrix storage of GEBSR blocks.
-  !>   @param[in]
-  !>   mb           number of block rows of the sparse GEBSR matrix.
-  !>   @param[in]
-  !>   nb           number of block columns of the sparse GEBSR matrix.
-  !>   @param[in]
-  !>   nnzb         number of non-zero blocks of the sparse GEBSR matrix.
-  !>   @param[in]
-  !>   row_block_dim row block dimension of the sparse GEBSR matrix.
-  !>   @param[in]
-  !>   col_block_dim column block dimension of the sparse GEBSR matrix.
-  !>   @param[in]
-  !>   bsr_val     array of \p nnzb elements of the sparse GEBSR matrix.
-  !>   @param[in]
-  !>   bsr_row_ptr array of \p mb+1 elements that point to the start of every row of the
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] dir - matrix storage of GEBSR blocks.
+  !>   @param[in] mb - number of block rows of the sparse GEBSR matrix.
+  !>   @param[in] nb - number of block columns of the sparse GEBSR matrix.
+  !>   @param[in] nnzb - number of non-zero blocks of the sparse GEBSR matrix.
+  !>   @param[in] row_block_dim - row block dimension of the sparse GEBSR matrix.
+  !>   @param[in] col_block_dim - column block dimension of the sparse GEBSR matrix.
+  !>   @param[in] bsr_val - array of \p nnzb elements of the sparse GEBSR matrix.
+  !>   @param[in] bsr_row_ptr - array of \p mb+1 elements that point to the start of every row of
+  !>   the
   !>               sparse GEBSR matrix.
-  !>   @param[in]
-  !>   bsr_col_ind array of \p nnzb elements containing the column indices of the sparse
+  !>   @param[in] bsr_col_ind - array of \p nnzb elements containing the column indices of the
+  !>   sparse
   !>               GEBSR matrix.
-  !>   @param[in]
-  !>   idx_base    `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
-  !>   @param[in]
-  !>   matrix_type `rocsparse_matrix_type_general`, `rocsparse_matrix_type_symmetric`,
+  !>   @param[in] idx_base - `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
+  !>   @param[in] matrix_type - `rocsparse_matrix_type_general`, `rocsparse_matrix_type_symmetric`,
   !>               `rocsparse_matrix_type_hermitian`, or `rocsparse_matrix_type_triangular`.
-  !>   @param[in]
-  !>   uplo        `rocsparse_fill_mode_lower` or `rocsparse_fill_mode_upper`.
-  !>   @param[in]
-  !>   storage     `rocsparse_storage_mode_sorted` or `rocsparse_storage_mode_sorted`.
-  !>   @param[out]
-  !>   data_status modified to indicate the status of the data.
-  !>   @param[in]
-  !>   temp_buffer temporary storage buffer allocated by the user.
+  !>   @param[in] uplo - `rocsparse_fill_mode_lower` or `rocsparse_fill_mode_upper`.
+  !>   @param[in] storage - `rocsparse_storage_mode_sorted` or `rocsparse_storage_mode_sorted`.
+  !>   @param[out] data_status - modified to indicate the status of the data.
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_handle the library context was not initialized.
@@ -34595,21 +32257,14 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   hyb         matrix in HYB storage format.
-  !>   @param[in]
-  !>   idx_base    `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
-  !>   @param[in]
-  !>   matrix_type `rocsparse_matrix_type_general`, `rocsparse_matrix_type_symmetric`,
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] hyb - matrix in HYB storage format.
+  !>   @param[in] idx_base - `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
+  !>   @param[in] matrix_type - `rocsparse_matrix_type_general`, `rocsparse_matrix_type_symmetric`,
   !>               `rocsparse_matrix_type_hermitian`, or `rocsparse_matrix_type_triangular`.
-  !>   @param[in]
-  !>   uplo        `rocsparse_fill_mode_lower` or `rocsparse_fill_mode_upper`.
-  !>   @param[in]
-  !>   storage     `rocsparse_storage_mode_sorted` or `rocsparse_storage_mode_sorted`.
-  !>   @param[out]
-  !>   buffer_size number of bytes of the temporary storage buffer required by
+  !>   @param[in] uplo - `rocsparse_fill_mode_lower` or `rocsparse_fill_mode_upper`.
+  !>   @param[in] storage - `rocsparse_storage_mode_sorted` or `rocsparse_storage_mode_sorted`.
+  !>   @param[out] buffer_size - number of bytes of the temporary storage buffer required by
   !>               rocsparse_check_matrix_hyb().
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
@@ -34659,23 +32314,15 @@ module hipfort_rocsparse
   !>   \note
   !>   This routine does not support execution in a hipGraph context.
   !>
-  !>   @param[in]
-  !>   handle      handle to the rocSPARSE library context queue.
-  !>   @param[in]
-  !>   hyb         matrix in HYB storage format.
-  !>   @param[in]
-  !>   idx_base    `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
-  !>   @param[in]
-  !>   matrix_type `rocsparse_matrix_type_general`, `rocsparse_matrix_type_symmetric`,
+  !>   @param[in] handle - handle to the rocSPARSE library context queue.
+  !>   @param[in] hyb - matrix in HYB storage format.
+  !>   @param[in] idx_base - `rocsparse_index_base_zero` or `rocsparse_index_base_one`.
+  !>   @param[in] matrix_type - `rocsparse_matrix_type_general`, `rocsparse_matrix_type_symmetric`,
   !>               `rocsparse_matrix_type_hermitian`, or `rocsparse_matrix_type_triangular`.
-  !>   @param[in]
-  !>   uplo        `rocsparse_fill_mode_lower` or `rocsparse_fill_mode_upper`.
-  !>   @param[in]
-  !>   storage     `rocsparse_storage_mode_sorted` or `rocsparse_storage_mode_sorted`.
-  !>   @param[out]
-  !>   data_status modified to indicate the status of the data.
-  !>   @param[in]
-  !>   temp_buffer temporary storage buffer allocated by the user.
+  !>   @param[in] uplo - `rocsparse_fill_mode_lower` or `rocsparse_fill_mode_upper`.
+  !>   @param[in] storage - `rocsparse_storage_mode_sorted` or `rocsparse_storage_mode_sorted`.
+  !>   @param[out] data_status - modified to indicate the status of the data.
+  !>   @param[in] temp_buffer - temporary storage buffer allocated by the user.
   !>
   !>   \retval rocsparse_status_success the operation completed successfully.
   !>   \retval rocsparse_status_invalid_handle the library context was not initialized.


### PR DESCRIPTION
rocBLAS, hipBLAS, rocSPARSE, hipSPARSE and rocSOLVER headers write `@param[dir]` on its own line, with the parameter name on the next line. The generator's ` - ` separator (between the name and its description) only applied when both were on one line, so these libraries had no separator, unlike the HIP runtime and FFT bindings.

The generator now merges the bare `@param[dir]` line with the following name line, so `fix_param_line` attaches the separator. For example:

```
!>     @param[in]                  ->   !>     @param[in] n - [rocblas_int]
!>     n           [rocblas_int]        !>                 number of elements in the vector
!>                 number of elements
```

Docstring-only change (verified: 0 non-`!>` lines changed across the 5 modules). Doxygen-clean under `WARN_AS_ERROR=YES`, builds clean. The net line drop is the merged pairs.