### PR TITLE
cmake: don't build the Fortran 2008 interfaces for the nvptx backend

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -74,9 +74,12 @@ set(HIPFORT_ARCH "nvptx")
     ADD_LIBRARY(${HIPFORT_LIB} STATIC 
          ${HIPFORT_SRC_HIP} 
          )
-    IF(HIPFORT_USE_FPOINTER_INTERFACES)
-    	target_compile_definitions(${HIPFORT_LIB} PRIVATE USE_FPOINTER_INTERFACES)
-    ENDIF(HIPFORT_USE_FPOINTER_INTERFACES)
+    # The CUDA/NVIDIA backend only exposes the interfaces that have a cu*
+    # equivalent (the bogus cu* name mappings were dropped in #394), so the
+    # Fortran 2008 array wrappers -- which call the raw hip* bindings that are
+    # not declared under USE_CUDA_NAMES -- cannot be built here. Build only the
+    # Fortran 2003 (type(c_ptr)) interfaces on nvptx, so do NOT define
+    # USE_FPOINTER_INTERFACES for this target.
     target_compile_definitions(${HIPFORT_LIB} PRIVATE USE_CUDA_NAMES)
     target_compile_definitions(${HIPFORT_LIB} PRIVATE _HIPFORT_ARCH='${HIPFORT_ARCH}')
     # Install Target hipfort-nvptx


### PR DESCRIPTION
## Problem (build broken on develop)

Building `hipfort-nvptx` fails with hundreds of:

```
error: No explicit type declared for 'hipblas...strided...batched_'
      hipblasIsamaxStridedBatched_rank_0 = hipblasIsamaxStridedBatched_(handle,n,c_loc(x),incx, &
```

across `hipfort_hipblas.F90`, `hipfort_hipsolver.F90`, and `hipfort_hipsparse.F90`.

## Cause

#394 ("drop bogus cu* name mappings") correctly guarded the raw `hip*` interface bodies and their `module procedure` lists under `#ifndef USE_CUDA_NAMES` (there is no `cu*` equivalent for these). But the Fortran 2008 wrapper **definitions** (`*_rank_0`, ...) in the `contains` section are still guarded by `#ifdef USE_FPOINTER_INTERFACES` only. On the nvptx build (`USE_CUDA_NAMES` **and** `USE_FPOINTER_INTERFACES`), those wrappers are compiled but call raw bindings that are no longer declared → the error above.

## Fix

The CUDA backend cannot provide these array wrappers, so stop defining `USE_FPOINTER_INTERFACES` for the `hipfort-nvptx` target. It now builds the Fortran 2003 (`type(c_ptr)`) interfaces only. The `hipfort-amdgcn` backend is unchanged and keeps the full Fortran 2008 interfaces.

## Verified

Clean `amdflang` (roc-7.2.3, flang-22) RELEASE build of **both** `hipfort-amdgcn` and `hipfort-nvptx` now succeeds (0 errors, both static libs produced).

> Follow-up (not urgent): to offer the f2008 array interfaces on CUDA where a `cu*` equivalent exists, the generator would need to guard the wrapper definitions with `#ifndef USE_CUDA_NAMES` the same way #394 guarded the interfaces.