### PR TITLE
Fix hipfort-nvptx build broken by #394 (guard F2008 wrappers of hip-only functions)

### DIFF
--- a/lib/hipfort/hipfort_hipblas.F90
+++ b/lib/hipfort/hipfort_hipblas.F90
@@ -40518,6 +40518,7 @@ module hipfort_hipblas
       hipblasIzamax_rank_1 = hipblasIzamax_(handle,n,c_loc(x),incx,myResult)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasIsamaxStridedBatched_rank_0(handle,n,x,incx,stridex,batchCount,myResult)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -40552,6 +40553,8 @@ module hipfort_hipblas
         stridex,batchCount,myResult)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasIdamaxStridedBatched_rank_0(handle,n,x,incx,stridex,batchCount,myResult)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -40586,6 +40589,8 @@ module hipfort_hipblas
         stridex,batchCount,myResult)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasIcamaxStridedBatched_rank_0(handle,n,x,incx,stridex,batchCount,myResult)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -40620,6 +40625,8 @@ module hipfort_hipblas
         stridex,batchCount,myResult)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasIzamaxStridedBatched_rank_0(handle,n,x,incx,stridex,batchCount,myResult)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -40654,6 +40661,7 @@ module hipfort_hipblas
         stridex,batchCount,myResult)
     end function
 
+#endif
     function hipblasIsamin_rank_0(handle,n,x,incx,myResult)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -40766,6 +40774,7 @@ module hipfort_hipblas
       hipblasIzamin_rank_1 = hipblasIzamin_(handle,n,c_loc(x),incx,myResult)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasIsaminStridedBatched_rank_0(handle,n,x,incx,stridex,batchCount,myResult)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -40800,6 +40809,8 @@ module hipfort_hipblas
         stridex,batchCount,myResult)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasIdaminStridedBatched_rank_0(handle,n,x,incx,stridex,batchCount,myResult)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -40834,6 +40845,8 @@ module hipfort_hipblas
         stridex,batchCount,myResult)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasIcaminStridedBatched_rank_0(handle,n,x,incx,stridex,batchCount,myResult)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -40868,6 +40881,8 @@ module hipfort_hipblas
         stridex,batchCount,myResult)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasIzaminStridedBatched_rank_0(handle,n,x,incx,stridex,batchCount,myResult)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -40902,6 +40917,7 @@ module hipfort_hipblas
         stridex,batchCount,myResult)
     end function
 
+#endif
     function hipblasSasum_rank_0(handle,n,x,incx,myResult)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -41014,6 +41030,7 @@ module hipfort_hipblas
       hipblasDzasum_rank_1 = hipblasDzasum_(handle,n,c_loc(x),incx,myResult)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasSasumStridedBatched_rank_0(handle,n,x,incx,stridex,batchCount,myResult)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -41048,6 +41065,8 @@ module hipfort_hipblas
         stridex,batchCount,myResult)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasDasumStridedBatched_rank_0(handle,n,x,incx,stridex,batchCount,myResult)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -41082,6 +41101,8 @@ module hipfort_hipblas
         stridex,batchCount,myResult)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasScasumStridedBatched_rank_0(handle,n,x,incx,stridex,batchCount,myResult)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -41116,6 +41137,8 @@ module hipfort_hipblas
         stridex,batchCount,myResult)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasDzasumStridedBatched_rank_0(handle,n,x,incx,stridex,batchCount,myResult)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -41150,6 +41173,7 @@ module hipfort_hipblas
         stridex,batchCount,myResult)
     end function
 
+#endif
     function hipblasSaxpy_rank_0(handle,n,alpha,x,incx,y,incy)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -41278,6 +41302,7 @@ module hipfort_hipblas
       hipblasZaxpy_rank_1 = hipblasZaxpy_(handle,n,alpha,c_loc(x),incx,c_loc(y),incy)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasSaxpyStridedBatched_rank_0(handle,n,alpha,x,incx,stridex,y,incy,stridey, &
         batchCount)
       use iso_c_binding
@@ -41320,6 +41345,8 @@ module hipfort_hipblas
         incx,stridex,c_loc(y),incy,stridey,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasDaxpyStridedBatched_rank_0(handle,n,alpha,x,incx,stridex,y,incy,stridey, &
         batchCount)
       use iso_c_binding
@@ -41362,6 +41389,8 @@ module hipfort_hipblas
         incx,stridex,c_loc(y),incy,stridey,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasCaxpyStridedBatched_rank_0(handle,n,alpha,x,incx,stridex,y,incy,stridey, &
         batchCount)
       use iso_c_binding
@@ -41404,6 +41433,8 @@ module hipfort_hipblas
         incx,stridex,c_loc(y),incy,stridey,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasZaxpyStridedBatched_rank_0(handle,n,alpha,x,incx,stridex,y,incy,stridey, &
         batchCount)
       use iso_c_binding
@@ -41446,6 +41477,7 @@ module hipfort_hipblas
         incx,stridex,c_loc(y),incy,stridey,batchCount)
     end function
 
+#endif
     function hipblasScopy_rank_0(handle,n,x,incx,y,incy)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -41566,6 +41598,7 @@ module hipfort_hipblas
       hipblasZcopy_rank_1 = hipblasZcopy_(handle,n,c_loc(x),incx,c_loc(y),incy)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasScopyStridedBatched_rank_0(handle,n,x,incx,stridex,y,incy,stridey,batchCount)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -41604,6 +41637,8 @@ module hipfort_hipblas
         stridex,c_loc(y),incy,stridey,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasDcopyStridedBatched_rank_0(handle,n,x,incx,stridex,y,incy,stridey,batchCount)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -41642,6 +41677,8 @@ module hipfort_hipblas
         stridex,c_loc(y),incy,stridey,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasCcopyStridedBatched_rank_0(handle,n,x,incx,stridex,y,incy,stridey,batchCount)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -41680,6 +41717,8 @@ module hipfort_hipblas
         stridex,c_loc(y),incy,stridey,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasZcopyStridedBatched_rank_0(handle,n,x,incx,stridex,y,incy,stridey,batchCount)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -41718,6 +41757,7 @@ module hipfort_hipblas
         stridex,c_loc(y),incy,stridey,batchCount)
     end function
 
+#endif
     function hipblasSdot_rank_0(handle,n,x,incx,y,incy,myResult)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -41910,6 +41950,7 @@ module hipfort_hipblas
       hipblasZdotu_rank_1 = hipblasZdotu_(handle,n,c_loc(x),incx,c_loc(y),incy,myResult)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasSdotStridedBatched_rank_0(handle,n,x,incx,stridex,y,incy,stridey,batchCount, &
         myResult)
       use iso_c_binding
@@ -41952,6 +41993,8 @@ module hipfort_hipblas
         stridex,c_loc(y),incy,stridey,batchCount,myResult)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasDdotStridedBatched_rank_0(handle,n,x,incx,stridex,y,incy,stridey,batchCount, &
         myResult)
       use iso_c_binding
@@ -41994,6 +42037,8 @@ module hipfort_hipblas
         stridex,c_loc(y),incy,stridey,batchCount,myResult)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasCdotcStridedBatched_rank_0(handle,n,x,incx,stridex,y,incy,stridey,batchCount, &
         myResult)
       use iso_c_binding
@@ -42036,6 +42081,8 @@ module hipfort_hipblas
         stridex,c_loc(y),incy,stridey,batchCount,myResult)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasCdotuStridedBatched_rank_0(handle,n,x,incx,stridex,y,incy,stridey,batchCount, &
         myResult)
       use iso_c_binding
@@ -42078,6 +42125,8 @@ module hipfort_hipblas
         stridex,c_loc(y),incy,stridey,batchCount,myResult)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasZdotcStridedBatched_rank_0(handle,n,x,incx,stridex,y,incy,stridey,batchCount, &
         myResult)
       use iso_c_binding
@@ -42120,6 +42169,8 @@ module hipfort_hipblas
         stridex,c_loc(y),incy,stridey,batchCount,myResult)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasZdotuStridedBatched_rank_0(handle,n,x,incx,stridex,y,incy,stridey,batchCount, &
         myResult)
       use iso_c_binding
@@ -42162,6 +42213,7 @@ module hipfort_hipblas
         stridex,c_loc(y),incy,stridey,batchCount,myResult)
     end function
 
+#endif
     function hipblasSnrm2_rank_0(handle,n,x,incx,myResult)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -42274,6 +42326,7 @@ module hipfort_hipblas
       hipblasDznrm2_rank_1 = hipblasDznrm2_(handle,n,c_loc(x),incx,myResult)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasSnrm2StridedBatched_rank_0(handle,n,x,incx,stridex,batchCount,myResult)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -42308,6 +42361,8 @@ module hipfort_hipblas
         stridex,batchCount,myResult)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasDnrm2StridedBatched_rank_0(handle,n,x,incx,stridex,batchCount,myResult)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -42342,6 +42397,8 @@ module hipfort_hipblas
         stridex,batchCount,myResult)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasScnrm2StridedBatched_rank_0(handle,n,x,incx,stridex,batchCount,myResult)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -42376,6 +42433,8 @@ module hipfort_hipblas
         stridex,batchCount,myResult)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasDznrm2StridedBatched_rank_0(handle,n,x,incx,stridex,batchCount,myResult)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -42410,6 +42469,7 @@ module hipfort_hipblas
         stridex,batchCount,myResult)
     end function
 
+#endif
     function hipblasSrot_rank_0(handle,n,x,incx,y,incy,c,s)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -42614,6 +42674,7 @@ module hipfort_hipblas
       hipblasZdrot_rank_1 = hipblasZdrot_(handle,n,c_loc(x),incx,c_loc(y),incy,c,s)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasSrotStridedBatched_rank_0(handle,n,x,incx,stridex,y,incy,stridey,c,s,batchCount)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -42656,6 +42717,8 @@ module hipfort_hipblas
         stridex,c_loc(y),incy,stridey,c,s,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasDrotStridedBatched_rank_0(handle,n,x,incx,stridex,y,incy,stridey,c,s,batchCount)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -42698,6 +42761,8 @@ module hipfort_hipblas
         stridex,c_loc(y),incy,stridey,c,s,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasCrotStridedBatched_rank_0(handle,n,x,incx,stridex,y,incy,stridey,c,s,batchCount)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -42740,6 +42805,8 @@ module hipfort_hipblas
         stridex,c_loc(y),incy,stridey,c,s,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasCsrotStridedBatched_rank_0(handle,n,x,incx,stridex,y,incy,stridey,c,s, &
         batchCount)
       use iso_c_binding
@@ -42784,6 +42851,8 @@ module hipfort_hipblas
         stridex,c_loc(y),incy,stridey,c,s,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasZrotStridedBatched_rank_0(handle,n,x,incx,stridex,y,incy,stridey,c,s,batchCount)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -42826,6 +42895,8 @@ module hipfort_hipblas
         stridex,c_loc(y),incy,stridey,c,s,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasZdrotStridedBatched_rank_0(handle,n,x,incx,stridex,y,incy,stridey,c,s, &
         batchCount)
       use iso_c_binding
@@ -42870,6 +42941,7 @@ module hipfort_hipblas
         stridex,c_loc(y),incy,stridey,c,s,batchCount)
     end function
 
+#endif
     function hipblasSrotm_rank_0(handle,n,x,incx,y,incy,param)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -42934,6 +43006,7 @@ module hipfort_hipblas
       hipblasDrotm_rank_1 = hipblasDrotm_(handle,n,c_loc(x),incx,c_loc(y),incy,param)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasSrotmStridedBatched_rank_0(handle,n,x,incx,stridex,y,incy,stridey,param, &
         strideParam,batchCount)
       use iso_c_binding
@@ -42978,6 +43051,8 @@ module hipfort_hipblas
         stridex,c_loc(y),incy,stridey,param,strideParam,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasDrotmStridedBatched_rank_0(handle,n,x,incx,stridex,y,incy,stridey,param, &
         strideParam,batchCount)
       use iso_c_binding
@@ -43022,6 +43097,7 @@ module hipfort_hipblas
         stridex,c_loc(y),incy,stridey,param,strideParam,batchCount)
     end function
 
+#endif
     function hipblasSscal_rank_0(handle,n,alpha,x,incx)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -43190,6 +43266,7 @@ module hipfort_hipblas
       hipblasZdscal_rank_1 = hipblasZdscal_(handle,n,alpha,c_loc(x),incx)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasSscalStridedBatched_rank_0(handle,n,alpha,x,incx,stridex,batchCount)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -43224,6 +43301,8 @@ module hipfort_hipblas
         incx,stridex,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasDscalStridedBatched_rank_0(handle,n,alpha,x,incx,stridex,batchCount)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -43258,6 +43337,8 @@ module hipfort_hipblas
         incx,stridex,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasCscalStridedBatched_rank_0(handle,n,alpha,x,incx,stridex,batchCount)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -43292,6 +43373,8 @@ module hipfort_hipblas
         incx,stridex,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasZscalStridedBatched_rank_0(handle,n,alpha,x,incx,stridex,batchCount)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -43326,6 +43409,8 @@ module hipfort_hipblas
         incx,stridex,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasCsscalStridedBatched_rank_0(handle,n,alpha,x,incx,stridex,batchCount)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -43360,6 +43445,8 @@ module hipfort_hipblas
         incx,stridex,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasZdscalStridedBatched_rank_0(handle,n,alpha,x,incx,stridex,batchCount)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -43394,6 +43481,7 @@ module hipfort_hipblas
         incx,stridex,batchCount)
     end function
 
+#endif
     function hipblasSswap_rank_0(handle,n,x,incx,y,incy)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -43514,6 +43602,7 @@ module hipfort_hipblas
       hipblasZswap_rank_1 = hipblasZswap_(handle,n,c_loc(x),incx,c_loc(y),incy)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasSswapStridedBatched_rank_0(handle,n,x,incx,stridex,y,incy,stridey,batchCount)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -43552,6 +43641,8 @@ module hipfort_hipblas
         stridex,c_loc(y),incy,stridey,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasDswapStridedBatched_rank_0(handle,n,x,incx,stridex,y,incy,stridey,batchCount)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -43590,6 +43681,8 @@ module hipfort_hipblas
         stridex,c_loc(y),incy,stridey,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasCswapStridedBatched_rank_0(handle,n,x,incx,stridex,y,incy,stridey,batchCount)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -43628,6 +43721,8 @@ module hipfort_hipblas
         stridex,c_loc(y),incy,stridey,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasZswapStridedBatched_rank_0(handle,n,x,incx,stridex,y,incy,stridey,batchCount)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -43666,6 +43761,7 @@ module hipfort_hipblas
         stridex,c_loc(y),incy,stridey,batchCount)
     end function
 
+#endif
     function hipblasSgbmv_rank_0(handle,trans,m,n,kl,ku,alpha,AP,lda,x,incx,beta,y,incy)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -43954,6 +44050,7 @@ module hipfort_hipblas
         incx,beta,c_loc(y),incy)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasSgbmvStridedBatched_rank_0(handle,trans,m,n,kl,ku,alpha,AP,lda,strideA,x,incx, &
         stridex,beta,y,incy,stridey,batchCount)
       use iso_c_binding
@@ -44041,6 +44138,8 @@ module hipfort_hipblas
         alpha,c_loc(AP),lda,strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasDgbmvStridedBatched_rank_0(handle,trans,m,n,kl,ku,alpha,AP,lda,strideA,x,incx, &
         stridex,beta,y,incy,stridey,batchCount)
       use iso_c_binding
@@ -44128,6 +44227,8 @@ module hipfort_hipblas
         alpha,c_loc(AP),lda,strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasCgbmvStridedBatched_rank_0(handle,trans,m,n,kl,ku,alpha,AP,lda,strideA,x,incx, &
         stridex,beta,y,incy,stridey,batchCount)
       use iso_c_binding
@@ -44215,6 +44316,8 @@ module hipfort_hipblas
         alpha,c_loc(AP),lda,strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasZgbmvStridedBatched_rank_0(handle,trans,m,n,kl,ku,alpha,AP,lda,strideA,x,incx, &
         stridex,beta,y,incy,stridey,batchCount)
       use iso_c_binding
@@ -44302,6 +44405,7 @@ module hipfort_hipblas
         alpha,c_loc(AP),lda,strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
     end function
 
+#endif
     function hipblasSgemv_rank_0(handle,trans,m,n,alpha,AP,lda,x,incx,beta,y,incy)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -45246,6 +45350,7 @@ module hipfort_hipblas
         c_loc(AP),lda)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasSgerStridedBatched_rank_0(handle,m,n,alpha,x,incx,stridex,y,incy,stridey,AP, &
         lda,strideA,batchCount)
       use iso_c_binding
@@ -45321,6 +45426,8 @@ module hipfort_hipblas
         incx,stridex,c_loc(y),incy,stridey,c_loc(AP),lda,strideA,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasDgerStridedBatched_rank_0(handle,m,n,alpha,x,incx,stridex,y,incy,stridey,AP, &
         lda,strideA,batchCount)
       use iso_c_binding
@@ -45396,6 +45503,8 @@ module hipfort_hipblas
         incx,stridex,c_loc(y),incy,stridey,c_loc(AP),lda,strideA,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasCgeruStridedBatched_rank_0(handle,m,n,alpha,x,incx,stridex,y,incy,stridey,AP, &
         lda,strideA,batchCount)
       use iso_c_binding
@@ -45471,6 +45580,8 @@ module hipfort_hipblas
         c_loc(x),incx,stridex,c_loc(y),incy,stridey,c_loc(AP),lda,strideA,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasCgercStridedBatched_rank_0(handle,m,n,alpha,x,incx,stridex,y,incy,stridey,AP, &
         lda,strideA,batchCount)
       use iso_c_binding
@@ -45546,6 +45657,8 @@ module hipfort_hipblas
         c_loc(x),incx,stridex,c_loc(y),incy,stridey,c_loc(AP),lda,strideA,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasZgeruStridedBatched_rank_0(handle,m,n,alpha,x,incx,stridex,y,incy,stridey,AP, &
         lda,strideA,batchCount)
       use iso_c_binding
@@ -45621,6 +45734,8 @@ module hipfort_hipblas
         c_loc(x),incx,stridex,c_loc(y),incy,stridey,c_loc(AP),lda,strideA,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasZgercStridedBatched_rank_0(handle,m,n,alpha,x,incx,stridex,y,incy,stridey,AP, &
         lda,strideA,batchCount)
       use iso_c_binding
@@ -45696,6 +45811,7 @@ module hipfort_hipblas
         c_loc(x),incx,stridex,c_loc(y),incy,stridey,c_loc(AP),lda,strideA,batchCount)
     end function
 
+#endif
     function hipblasChbmv_rank_0(handle,uplo,n,k,alpha,AP,lda,x,incx,beta,y,incy)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -45828,6 +45944,7 @@ module hipfort_hipblas
         beta,c_loc(y),incy)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasChbmvStridedBatched_rank_0(handle,uplo,n,k,alpha,AP,lda,strideA,x,incx, &
         stridex,beta,y,incy,stridey,batchCount)
       use iso_c_binding
@@ -45909,6 +46026,8 @@ module hipfort_hipblas
         c_loc(AP),lda,strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasZhbmvStridedBatched_rank_0(handle,uplo,n,k,alpha,AP,lda,strideA,x,incx, &
         stridex,beta,y,incy,stridey,batchCount)
       use iso_c_binding
@@ -45990,6 +46109,7 @@ module hipfort_hipblas
         c_loc(AP),lda,strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
     end function
 
+#endif
     function hipblasChemv_rank_0(handle,uplo,n,alpha,AP,lda,x,incx,beta,y,incy)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -46116,6 +46236,7 @@ module hipfort_hipblas
         c_loc(y),incy)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasChemvStridedBatched_rank_0(handle,uplo,n,alpha,AP,lda,strideA,x,incx,stridex, &
         beta,y,incy,stridey,batchCount)
       use iso_c_binding
@@ -46194,6 +46315,8 @@ module hipfort_hipblas
         c_loc(AP),lda,strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasZhemvStridedBatched_rank_0(handle,uplo,n,alpha,AP,lda,strideA,x,incx,stridex, &
         beta,y,incy,stridey,batchCount)
       use iso_c_binding
@@ -46272,6 +46395,7 @@ module hipfort_hipblas
         c_loc(AP),lda,strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
     end function
 
+#endif
     function hipblasCher_rank_0(handle,uplo,n,alpha,x,incx,AP,lda)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -46374,6 +46498,7 @@ module hipfort_hipblas
       hipblasZher_full_rank = hipblasZher_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(AP),lda)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasCherStridedBatched_rank_0(handle,uplo,n,alpha,x,incx,stridex,AP,lda,strideA, &
         batchCount)
       use iso_c_binding
@@ -46440,6 +46565,8 @@ module hipfort_hipblas
         c_loc(x),incx,stridex,c_loc(AP),lda,strideA,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasZherStridedBatched_rank_0(handle,uplo,n,alpha,x,incx,stridex,AP,lda,strideA, &
         batchCount)
       use iso_c_binding
@@ -46506,6 +46633,7 @@ module hipfort_hipblas
         c_loc(x),incx,stridex,c_loc(AP),lda,strideA,batchCount)
     end function
 
+#endif
     function hipblasCher2_rank_0(handle,uplo,n,alpha,x,incx,y,incy,AP,lda)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -46626,6 +46754,7 @@ module hipfort_hipblas
         c_loc(AP),lda)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasCher2StridedBatched_rank_0(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey, &
         AP,lda,strideA,batchCount)
       use iso_c_binding
@@ -46701,6 +46830,8 @@ module hipfort_hipblas
         c_loc(x),incx,stridex,c_loc(y),incy,stridey,c_loc(AP),lda,strideA,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasZher2StridedBatched_rank_0(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey, &
         AP,lda,strideA,batchCount)
       use iso_c_binding
@@ -46776,6 +46907,7 @@ module hipfort_hipblas
         c_loc(x),incx,stridex,c_loc(y),incy,stridey,c_loc(AP),lda,strideA,batchCount)
     end function
 
+#endif
     function hipblasChpmv_rank_0(handle,uplo,n,alpha,AP,x,incx,beta,y,incy)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -46852,6 +46984,7 @@ module hipfort_hipblas
       hipblasZhpmv_rank_1 = hipblasZhpmv_(handle,uplo,n,alpha,AP,c_loc(x),incx,beta,c_loc(y),incy)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasChpmvStridedBatched_rank_0(handle,uplo,n,alpha,AP,strideA,x,incx,stridex,beta, &
         y,incy,stridey,batchCount)
       use iso_c_binding
@@ -46902,6 +47035,8 @@ module hipfort_hipblas
         strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasZhpmvStridedBatched_rank_0(handle,uplo,n,alpha,AP,strideA,x,incx,stridex,beta, &
         y,incy,stridey,batchCount)
       use iso_c_binding
@@ -46952,6 +47087,7 @@ module hipfort_hipblas
         strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
     end function
 
+#endif
     function hipblasChpr_rank_0(handle,uplo,n,alpha,x,incx,AP)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -47016,6 +47152,7 @@ module hipfort_hipblas
       hipblasZhpr_rank_1 = hipblasZhpr_(handle,uplo,n,alpha,c_loc(x),incx,AP)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasChprStridedBatched_rank_0(handle,uplo,n,alpha,x,incx,stridex,AP,strideA, &
         batchCount)
       use iso_c_binding
@@ -47058,6 +47195,8 @@ module hipfort_hipblas
         incx,stridex,AP,strideA,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasZhprStridedBatched_rank_0(handle,uplo,n,alpha,x,incx,stridex,AP,strideA, &
         batchCount)
       use iso_c_binding
@@ -47100,6 +47239,7 @@ module hipfort_hipblas
         incx,stridex,AP,strideA,batchCount)
     end function
 
+#endif
     function hipblasChpr2_rank_0(handle,uplo,n,alpha,x,incx,y,incy,AP)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -47172,6 +47312,7 @@ module hipfort_hipblas
       hipblasZhpr2_rank_1 = hipblasZhpr2_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(y),incy,AP)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasChpr2StridedBatched_rank_0(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey, &
         AP,strideA,batchCount)
       use iso_c_binding
@@ -47220,6 +47361,8 @@ module hipfort_hipblas
         c_loc(x),incx,stridex,c_loc(y),incy,stridey,AP,strideA,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasZhpr2StridedBatched_rank_0(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey, &
         AP,strideA,batchCount)
       use iso_c_binding
@@ -47268,6 +47411,7 @@ module hipfort_hipblas
         c_loc(x),incx,stridex,c_loc(y),incy,stridey,AP,strideA,batchCount)
     end function
 
+#endif
     function hipblasSsbmv_rank_0(handle,uplo,n,k,alpha,AP,lda,x,incx,beta,y,incy)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -47400,6 +47544,7 @@ module hipfort_hipblas
         beta,c_loc(y),incy)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasSsbmvStridedBatched_rank_0(handle,uplo,n,k,alpha,AP,lda,strideA,x,incx, &
         stridex,beta,y,incy,stridey,batchCount)
       use iso_c_binding
@@ -47481,6 +47626,8 @@ module hipfort_hipblas
         c_loc(AP),lda,strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasDsbmvStridedBatched_rank_0(handle,uplo,n,k,alpha,AP,lda,strideA,x,incx, &
         stridex,beta,y,incy,stridey,batchCount)
       use iso_c_binding
@@ -47562,6 +47709,7 @@ module hipfort_hipblas
         c_loc(AP),lda,strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
     end function
 
+#endif
     function hipblasSspmv_rank_0(handle,uplo,n,alpha,AP,x,incx,beta,y,incy)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -47638,6 +47786,7 @@ module hipfort_hipblas
       hipblasDspmv_rank_1 = hipblasDspmv_(handle,uplo,n,alpha,AP,c_loc(x),incx,beta,c_loc(y),incy)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasSspmvStridedBatched_rank_0(handle,uplo,n,alpha,AP,strideA,x,incx,stridex,beta, &
         y,incy,stridey,batchCount)
       use iso_c_binding
@@ -47688,6 +47837,8 @@ module hipfort_hipblas
         strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasDspmvStridedBatched_rank_0(handle,uplo,n,alpha,AP,strideA,x,incx,stridex,beta, &
         y,incy,stridey,batchCount)
       use iso_c_binding
@@ -47738,6 +47889,7 @@ module hipfort_hipblas
         strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
     end function
 
+#endif
     function hipblasSspr_rank_0(handle,uplo,n,alpha,x,incx,AP)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -47802,6 +47954,7 @@ module hipfort_hipblas
       hipblasDspr_rank_1 = hipblasDspr_(handle,uplo,n,alpha,c_loc(x),incx,AP)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasCspr_rank_0(handle,uplo,n,alpha,x,incx,AP)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -47834,6 +47987,8 @@ module hipfort_hipblas
       hipblasCspr_rank_1 = hipblasCspr_(handle,uplo,n,alpha,c_loc(x),incx,AP)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasZspr_rank_0(handle,uplo,n,alpha,x,incx,AP)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -47866,6 +48021,8 @@ module hipfort_hipblas
       hipblasZspr_rank_1 = hipblasZspr_(handle,uplo,n,alpha,c_loc(x),incx,AP)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasSsprStridedBatched_rank_0(handle,uplo,n,alpha,x,incx,stridex,AP,strideA, &
         batchCount)
       use iso_c_binding
@@ -47908,6 +48065,8 @@ module hipfort_hipblas
         incx,stridex,AP,strideA,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasDsprStridedBatched_rank_0(handle,uplo,n,alpha,x,incx,stridex,AP,strideA, &
         batchCount)
       use iso_c_binding
@@ -47950,6 +48109,8 @@ module hipfort_hipblas
         incx,stridex,AP,strideA,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasCsprStridedBatched_rank_0(handle,uplo,n,alpha,x,incx,stridex,AP,strideA, &
         batchCount)
       use iso_c_binding
@@ -47992,6 +48153,8 @@ module hipfort_hipblas
         incx,stridex,AP,strideA,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasZsprStridedBatched_rank_0(handle,uplo,n,alpha,x,incx,stridex,AP,strideA, &
         batchCount)
       use iso_c_binding
@@ -48034,6 +48197,7 @@ module hipfort_hipblas
         incx,stridex,AP,strideA,batchCount)
     end function
 
+#endif
     function hipblasSspr2_rank_0(handle,uplo,n,alpha,x,incx,y,incy,AP)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -48106,6 +48270,7 @@ module hipfort_hipblas
       hipblasDspr2_rank_1 = hipblasDspr2_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(y),incy,AP)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasSspr2StridedBatched_rank_0(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey, &
         AP,strideA,batchCount)
       use iso_c_binding
@@ -48154,6 +48319,8 @@ module hipfort_hipblas
         c_loc(x),incx,stridex,c_loc(y),incy,stridey,AP,strideA,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasDspr2StridedBatched_rank_0(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey, &
         AP,strideA,batchCount)
       use iso_c_binding
@@ -48202,6 +48369,7 @@ module hipfort_hipblas
         c_loc(x),incx,stridex,c_loc(y),incy,stridey,AP,strideA,batchCount)
     end function
 
+#endif
     function hipblasSsymv_rank_0(handle,uplo,n,alpha,AP,lda,x,incx,beta,y,incy)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -48454,6 +48622,7 @@ module hipfort_hipblas
         c_loc(y),incy)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasSsymvStridedBatched_rank_0(handle,uplo,n,alpha,AP,lda,strideA,x,incx,stridex, &
         beta,y,incy,stridey,batchCount)
       use iso_c_binding
@@ -48532,6 +48701,8 @@ module hipfort_hipblas
         c_loc(AP),lda,strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasDsymvStridedBatched_rank_0(handle,uplo,n,alpha,AP,lda,strideA,x,incx,stridex, &
         beta,y,incy,stridey,batchCount)
       use iso_c_binding
@@ -48610,6 +48781,8 @@ module hipfort_hipblas
         c_loc(AP),lda,strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasCsymvStridedBatched_rank_0(handle,uplo,n,alpha,AP,lda,strideA,x,incx,stridex, &
         beta,y,incy,stridey,batchCount)
       use iso_c_binding
@@ -48688,6 +48861,8 @@ module hipfort_hipblas
         c_loc(AP),lda,strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasZsymvStridedBatched_rank_0(handle,uplo,n,alpha,AP,lda,strideA,x,incx,stridex, &
         beta,y,incy,stridey,batchCount)
       use iso_c_binding
@@ -48766,6 +48941,7 @@ module hipfort_hipblas
         c_loc(AP),lda,strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
     end function
 
+#endif
     function hipblasSsyr_rank_0(handle,uplo,n,alpha,x,incx,AP,lda)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -48970,6 +49146,7 @@ module hipfort_hipblas
       hipblasZsyr_full_rank = hipblasZsyr_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(AP),lda)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasSsyrStridedBatched_rank_0(handle,uplo,n,alpha,x,incx,stridex,AP,lda,strideA, &
         batchCount)
       use iso_c_binding
@@ -49036,6 +49213,8 @@ module hipfort_hipblas
         c_loc(x),incx,stridex,c_loc(AP),lda,strideA,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasDsyrStridedBatched_rank_0(handle,uplo,n,alpha,x,incx,stridex,AP,lda,strideA, &
         batchCount)
       use iso_c_binding
@@ -49102,6 +49281,8 @@ module hipfort_hipblas
         c_loc(x),incx,stridex,c_loc(AP),lda,strideA,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasCsyrStridedBatched_rank_0(handle,uplo,n,alpha,x,incx,stridex,AP,lda,strideA, &
         batchCount)
       use iso_c_binding
@@ -49168,6 +49349,8 @@ module hipfort_hipblas
         c_loc(x),incx,stridex,c_loc(AP),lda,strideA,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasZsyrStridedBatched_rank_0(handle,uplo,n,alpha,x,incx,stridex,AP,lda,strideA, &
         batchCount)
       use iso_c_binding
@@ -49234,6 +49417,7 @@ module hipfort_hipblas
         c_loc(x),incx,stridex,c_loc(AP),lda,strideA,batchCount)
     end function
 
+#endif
     function hipblasSsyr2_rank_0(handle,uplo,n,alpha,x,incx,y,incy,AP,lda)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -49474,6 +49658,7 @@ module hipfort_hipblas
         c_loc(AP),lda)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasSsyr2StridedBatched_rank_0(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey, &
         AP,lda,strideA,batchCount)
       use iso_c_binding
@@ -49549,6 +49734,8 @@ module hipfort_hipblas
         c_loc(x),incx,stridex,c_loc(y),incy,stridey,c_loc(AP),lda,strideA,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasDsyr2StridedBatched_rank_0(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey, &
         AP,lda,strideA,batchCount)
       use iso_c_binding
@@ -49624,6 +49811,8 @@ module hipfort_hipblas
         c_loc(x),incx,stridex,c_loc(y),incy,stridey,c_loc(AP),lda,strideA,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasCsyr2StridedBatched_rank_0(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey, &
         AP,lda,strideA,batchCount)
       use iso_c_binding
@@ -49699,6 +49888,8 @@ module hipfort_hipblas
         c_loc(x),incx,stridex,c_loc(y),incy,stridey,c_loc(AP),lda,strideA,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasZsyr2StridedBatched_rank_0(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey, &
         AP,lda,strideA,batchCount)
       use iso_c_binding
@@ -49774,6 +49965,7 @@ module hipfort_hipblas
         c_loc(x),incx,stridex,c_loc(y),incy,stridey,c_loc(AP),lda,strideA,batchCount)
     end function
 
+#endif
     function hipblasStbmv_rank_0(handle,uplo,transA,diag,n,k,AP,lda,x,incx)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -50006,6 +50198,7 @@ module hipfort_hipblas
         incx)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasStbmvStridedBatched_rank_0(handle,uplo,transA,diag,n,k,AP,lda,strideA,x,incx, &
         stridex,batchCount)
       use iso_c_binding
@@ -50078,6 +50271,8 @@ module hipfort_hipblas
         n,k,c_loc(AP),lda,strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasDtbmvStridedBatched_rank_0(handle,uplo,transA,diag,n,k,AP,lda,strideA,x,incx, &
         stridex,batchCount)
       use iso_c_binding
@@ -50150,6 +50345,8 @@ module hipfort_hipblas
         n,k,c_loc(AP),lda,strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasCtbmvStridedBatched_rank_0(handle,uplo,transA,diag,n,k,AP,lda,strideA,x,incx, &
         stridex,batchCount)
       use iso_c_binding
@@ -50222,6 +50419,8 @@ module hipfort_hipblas
         n,k,c_loc(AP),lda,strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasZtbmvStridedBatched_rank_0(handle,uplo,transA,diag,n,k,AP,lda,strideA,x,incx, &
         stridex,batchCount)
       use iso_c_binding
@@ -50294,6 +50493,7 @@ module hipfort_hipblas
         n,k,c_loc(AP),lda,strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
+#endif
     function hipblasStbsv_rank_0(handle,uplo,transA,diag,n,k,AP,lda,x,incx)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -50526,6 +50726,7 @@ module hipfort_hipblas
         incx)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasStbsvStridedBatched_rank_0(handle,uplo,transA,diag,n,k,AP,lda,strideA,x,incx, &
         stridex,batchCount)
       use iso_c_binding
@@ -50598,6 +50799,8 @@ module hipfort_hipblas
         n,k,c_loc(AP),lda,strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasDtbsvStridedBatched_rank_0(handle,uplo,transA,diag,n,k,AP,lda,strideA,x,incx, &
         stridex,batchCount)
       use iso_c_binding
@@ -50670,6 +50873,8 @@ module hipfort_hipblas
         n,k,c_loc(AP),lda,strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasCtbsvStridedBatched_rank_0(handle,uplo,transA,diag,n,k,AP,lda,strideA,x,incx, &
         stridex,batchCount)
       use iso_c_binding
@@ -50742,6 +50947,8 @@ module hipfort_hipblas
         n,k,c_loc(AP),lda,strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasZtbsvStridedBatched_rank_0(handle,uplo,transA,diag,n,k,AP,lda,strideA,x,incx, &
         stridex,batchCount)
       use iso_c_binding
@@ -50814,6 +51021,7 @@ module hipfort_hipblas
         n,k,c_loc(AP),lda,strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
+#endif
     function hipblasStpmv_rank_0(handle,uplo,transA,diag,n,AP,x,incx)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -50950,6 +51158,7 @@ module hipfort_hipblas
       hipblasZtpmv_rank_1 = hipblasZtpmv_(handle,uplo,transA,diag,n,AP,c_loc(x),incx)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasStpmvStridedBatched_rank_0(handle,uplo,transA,diag,n,AP,strideA,x,incx, &
         stridex,batchCount)
       use iso_c_binding
@@ -50994,6 +51203,8 @@ module hipfort_hipblas
         AP,strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasDtpmvStridedBatched_rank_0(handle,uplo,transA,diag,n,AP,strideA,x,incx, &
         stridex,batchCount)
       use iso_c_binding
@@ -51038,6 +51249,8 @@ module hipfort_hipblas
         AP,strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasCtpmvStridedBatched_rank_0(handle,uplo,transA,diag,n,AP,strideA,x,incx, &
         stridex,batchCount)
       use iso_c_binding
@@ -51082,6 +51295,8 @@ module hipfort_hipblas
         AP,strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasZtpmvStridedBatched_rank_0(handle,uplo,transA,diag,n,AP,strideA,x,incx, &
         stridex,batchCount)
       use iso_c_binding
@@ -51126,6 +51341,7 @@ module hipfort_hipblas
         AP,strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
+#endif
     function hipblasStpsv_rank_0(handle,uplo,transA,diag,n,AP,x,incx)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -51262,6 +51478,7 @@ module hipfort_hipblas
       hipblasZtpsv_rank_1 = hipblasZtpsv_(handle,uplo,transA,diag,n,AP,c_loc(x),incx)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasStpsvStridedBatched_rank_0(handle,uplo,transA,diag,n,AP,strideA,x,incx, &
         stridex,batchCount)
       use iso_c_binding
@@ -51306,6 +51523,8 @@ module hipfort_hipblas
         AP,strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasDtpsvStridedBatched_rank_0(handle,uplo,transA,diag,n,AP,strideA,x,incx, &
         stridex,batchCount)
       use iso_c_binding
@@ -51350,6 +51569,8 @@ module hipfort_hipblas
         AP,strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasCtpsvStridedBatched_rank_0(handle,uplo,transA,diag,n,AP,strideA,x,incx, &
         stridex,batchCount)
       use iso_c_binding
@@ -51394,6 +51615,8 @@ module hipfort_hipblas
         AP,strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasZtpsvStridedBatched_rank_0(handle,uplo,transA,diag,n,AP,strideA,x,incx, &
         stridex,batchCount)
       use iso_c_binding
@@ -51438,6 +51661,7 @@ module hipfort_hipblas
         AP,strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
+#endif
     function hipblasStrmv_rank_0(handle,uplo,transA,diag,n,AP,lda,x,incx)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -51654,6 +51878,7 @@ module hipfort_hipblas
       hipblasZtrmv_full_rank = hipblasZtrmv_(handle,uplo,transA,diag,n,c_loc(AP),lda,c_loc(x),incx)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasStrmvStridedBatched_rank_0(handle,uplo,transA,diag,n,AP,lda,strideA,x,incx, &
         stridex,batchCount)
       use iso_c_binding
@@ -51723,6 +51948,8 @@ module hipfort_hipblas
         n,c_loc(AP),lda,strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasDtrmvStridedBatched_rank_0(handle,uplo,transA,diag,n,AP,lda,strideA,x,incx, &
         stridex,batchCount)
       use iso_c_binding
@@ -51792,6 +52019,8 @@ module hipfort_hipblas
         n,c_loc(AP),lda,strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasCtrmvStridedBatched_rank_0(handle,uplo,transA,diag,n,AP,lda,strideA,x,incx, &
         stridex,batchCount)
       use iso_c_binding
@@ -51861,6 +52090,8 @@ module hipfort_hipblas
         n,c_loc(AP),lda,strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasZtrmvStridedBatched_rank_0(handle,uplo,transA,diag,n,AP,lda,strideA,x,incx, &
         stridex,batchCount)
       use iso_c_binding
@@ -51930,6 +52161,7 @@ module hipfort_hipblas
         n,c_loc(AP),lda,strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
+#endif
     function hipblasStrsv_rank_0(handle,uplo,transA,diag,n,AP,lda,x,incx)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -52146,6 +52378,7 @@ module hipfort_hipblas
       hipblasZtrsv_full_rank = hipblasZtrsv_(handle,uplo,transA,diag,n,c_loc(AP),lda,c_loc(x),incx)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasStrsvStridedBatched_rank_0(handle,uplo,transA,diag,n,AP,lda,strideA,x,incx, &
         stridex,batchCount)
       use iso_c_binding
@@ -52215,6 +52448,8 @@ module hipfort_hipblas
         n,c_loc(AP),lda,strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasDtrsvStridedBatched_rank_0(handle,uplo,transA,diag,n,AP,lda,strideA,x,incx, &
         stridex,batchCount)
       use iso_c_binding
@@ -52284,6 +52519,8 @@ module hipfort_hipblas
         n,c_loc(AP),lda,strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasCtrsvStridedBatched_rank_0(handle,uplo,transA,diag,n,AP,lda,strideA,x,incx, &
         stridex,batchCount)
       use iso_c_binding
@@ -52353,6 +52590,8 @@ module hipfort_hipblas
         n,c_loc(AP),lda,strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasZtrsvStridedBatched_rank_0(handle,uplo,transA,diag,n,AP,lda,strideA,x,incx, &
         stridex,batchCount)
       use iso_c_binding
@@ -52422,6 +52661,7 @@ module hipfort_hipblas
         n,c_loc(AP),lda,strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
+#endif
     function hipblasSgemm_rank_0(handle,transA,transB,m,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -53184,6 +53424,7 @@ module hipfort_hipblas
         c_loc(CP),ldc)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasCherkStridedBatched_rank_0(handle,uplo,transA,n,k,alpha,AP,lda,strideA,beta, &
         CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -53259,6 +53500,8 @@ module hipfort_hipblas
         alpha,c_loc(AP),lda,strideA,beta,c_loc(CP),ldc,strideC,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasZherkStridedBatched_rank_0(handle,uplo,transA,n,k,alpha,AP,lda,strideA,beta, &
         CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -53334,6 +53577,7 @@ module hipfort_hipblas
         alpha,c_loc(AP),lda,strideA,beta,c_loc(CP),ldc,strideC,batchCount)
     end function
 
+#endif
     function hipblasCherkx_rank_0(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -53472,6 +53716,7 @@ module hipfort_hipblas
         c_loc(BP),ldb,beta,c_loc(CP),ldc)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasCherkxStridedBatched_rank_0(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP, &
         ldb,strideB,beta,CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -53556,6 +53801,8 @@ module hipfort_hipblas
         alpha,c_loc(AP),lda,strideA,c_loc(BP),ldb,strideB,beta,c_loc(CP),ldc,strideC,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasZherkxStridedBatched_rank_0(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP, &
         ldb,strideB,beta,CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -53640,6 +53887,7 @@ module hipfort_hipblas
         alpha,c_loc(AP),lda,strideA,c_loc(BP),ldb,strideB,beta,c_loc(CP),ldc,strideC,batchCount)
     end function
 
+#endif
     function hipblasCher2k_rank_0(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -53778,6 +54026,7 @@ module hipfort_hipblas
         c_loc(BP),ldb,beta,c_loc(CP),ldc)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasCher2kStridedBatched_rank_0(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP, &
         ldb,strideB,beta,CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -53862,6 +54111,8 @@ module hipfort_hipblas
         alpha,c_loc(AP),lda,strideA,c_loc(BP),ldb,strideB,beta,c_loc(CP),ldc,strideC,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasZher2kStridedBatched_rank_0(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP, &
         ldb,strideB,beta,CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -53946,6 +54197,7 @@ module hipfort_hipblas
         alpha,c_loc(AP),lda,strideA,c_loc(BP),ldb,strideB,beta,c_loc(CP),ldc,strideC,batchCount)
     end function
 
+#endif
     function hipblasSsymm_rank_0(handle,side,uplo,m,n,alpha,AP,lda,BP,ldb,beta,CP,ldc)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -54222,6 +54474,7 @@ module hipfort_hipblas
         ldb,beta,c_loc(CP),ldc)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasSsymmStridedBatched_rank_0(handle,side,uplo,m,n,alpha,AP,lda,strideA,BP,ldb, &
         strideB,beta,CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -54306,6 +54559,8 @@ module hipfort_hipblas
         alpha,c_loc(AP),lda,strideA,c_loc(BP),ldb,strideB,beta,c_loc(CP),ldc,strideC,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasDsymmStridedBatched_rank_0(handle,side,uplo,m,n,alpha,AP,lda,strideA,BP,ldb, &
         strideB,beta,CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -54390,6 +54645,8 @@ module hipfort_hipblas
         alpha,c_loc(AP),lda,strideA,c_loc(BP),ldb,strideB,beta,c_loc(CP),ldc,strideC,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasCsymmStridedBatched_rank_0(handle,side,uplo,m,n,alpha,AP,lda,strideA,BP,ldb, &
         strideB,beta,CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -54474,6 +54731,8 @@ module hipfort_hipblas
         alpha,c_loc(AP),lda,strideA,c_loc(BP),ldb,strideB,beta,c_loc(CP),ldc,strideC,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasZsymmStridedBatched_rank_0(handle,side,uplo,m,n,alpha,AP,lda,strideA,BP,ldb, &
         strideB,beta,CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -54558,6 +54817,7 @@ module hipfort_hipblas
         alpha,c_loc(AP),lda,strideA,c_loc(BP),ldb,strideB,beta,c_loc(CP),ldc,strideC,batchCount)
     end function
 
+#endif
     function hipblasSsyrk_rank_0(handle,uplo,transA,n,k,alpha,AP,lda,beta,CP,ldc)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -54810,6 +55070,7 @@ module hipfort_hipblas
         c_loc(CP),ldc)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasSsyrkStridedBatched_rank_0(handle,uplo,transA,n,k,alpha,AP,lda,strideA,beta, &
         CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -54885,6 +55146,8 @@ module hipfort_hipblas
         alpha,c_loc(AP),lda,strideA,beta,c_loc(CP),ldc,strideC,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasDsyrkStridedBatched_rank_0(handle,uplo,transA,n,k,alpha,AP,lda,strideA,beta, &
         CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -54960,6 +55223,8 @@ module hipfort_hipblas
         alpha,c_loc(AP),lda,strideA,beta,c_loc(CP),ldc,strideC,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasCsyrkStridedBatched_rank_0(handle,uplo,transA,n,k,alpha,AP,lda,strideA,beta, &
         CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -55035,6 +55300,8 @@ module hipfort_hipblas
         alpha,c_loc(AP),lda,strideA,beta,c_loc(CP),ldc,strideC,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasZsyrkStridedBatched_rank_0(handle,uplo,transA,n,k,alpha,AP,lda,strideA,beta, &
         CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -55110,6 +55377,7 @@ module hipfort_hipblas
         alpha,c_loc(AP),lda,strideA,beta,c_loc(CP),ldc,strideC,batchCount)
     end function
 
+#endif
     function hipblasSsyr2k_rank_0(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -55386,6 +55654,7 @@ module hipfort_hipblas
         c_loc(BP),ldb,beta,c_loc(CP),ldc)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasSsyr2kStridedBatched_rank_0(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP, &
         ldb,strideB,beta,CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -55470,6 +55739,8 @@ module hipfort_hipblas
         alpha,c_loc(AP),lda,strideA,c_loc(BP),ldb,strideB,beta,c_loc(CP),ldc,strideC,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasDsyr2kStridedBatched_rank_0(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP, &
         ldb,strideB,beta,CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -55554,6 +55825,8 @@ module hipfort_hipblas
         alpha,c_loc(AP),lda,strideA,c_loc(BP),ldb,strideB,beta,c_loc(CP),ldc,strideC,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasCsyr2kStridedBatched_rank_0(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP, &
         ldb,strideB,beta,CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -55638,6 +55911,8 @@ module hipfort_hipblas
         alpha,c_loc(AP),lda,strideA,c_loc(BP),ldb,strideB,beta,c_loc(CP),ldc,strideC,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasZsyr2kStridedBatched_rank_0(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP, &
         ldb,strideB,beta,CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -55722,6 +55997,7 @@ module hipfort_hipblas
         alpha,c_loc(AP),lda,strideA,c_loc(BP),ldb,strideB,beta,c_loc(CP),ldc,strideC,batchCount)
     end function
 
+#endif
     function hipblasSsyrkx_rank_0(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -55998,6 +56274,7 @@ module hipfort_hipblas
         c_loc(BP),ldb,beta,c_loc(CP),ldc)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasSsyrkxStridedBatched_rank_0(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP, &
         ldb,strideB,beta,CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -56082,6 +56359,8 @@ module hipfort_hipblas
         alpha,c_loc(AP),lda,strideA,c_loc(BP),ldb,strideB,beta,c_loc(CP),ldc,strideC,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasDsyrkxStridedBatched_rank_0(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP, &
         ldb,strideB,beta,CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -56166,6 +56445,8 @@ module hipfort_hipblas
         alpha,c_loc(AP),lda,strideA,c_loc(BP),ldb,strideB,beta,c_loc(CP),ldc,strideC,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasCsyrkxStridedBatched_rank_0(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP, &
         ldb,strideB,beta,CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -56250,6 +56531,8 @@ module hipfort_hipblas
         alpha,c_loc(AP),lda,strideA,c_loc(BP),ldb,strideB,beta,c_loc(CP),ldc,strideC,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasZsyrkxStridedBatched_rank_0(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP, &
         ldb,strideB,beta,CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -56334,6 +56617,7 @@ module hipfort_hipblas
         alpha,c_loc(AP),lda,strideA,c_loc(BP),ldb,strideB,beta,c_loc(CP),ldc,strideC,batchCount)
     end function
 
+#endif
     function hipblasSgeam_rank_0(handle,transA,transB,m,n,alpha,AP,lda,beta,BP,ldb,CP,ldc)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -56610,6 +56894,7 @@ module hipfort_hipblas
         c_loc(BP),ldb,c_loc(CP),ldc)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasSgeamStridedBatched_rank_0(handle,transA,transB,m,n,alpha,AP,lda,strideA,beta, &
         BP,ldb,strideB,CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -56694,6 +56979,8 @@ module hipfort_hipblas
         alpha,c_loc(AP),lda,strideA,beta,c_loc(BP),ldb,strideB,c_loc(CP),ldc,strideC,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasDgeamStridedBatched_rank_0(handle,transA,transB,m,n,alpha,AP,lda,strideA,beta, &
         BP,ldb,strideB,CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -56778,6 +57065,8 @@ module hipfort_hipblas
         alpha,c_loc(AP),lda,strideA,beta,c_loc(BP),ldb,strideB,c_loc(CP),ldc,strideC,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasCgeamStridedBatched_rank_0(handle,transA,transB,m,n,alpha,AP,lda,strideA,beta, &
         BP,ldb,strideB,CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -56862,6 +57151,8 @@ module hipfort_hipblas
         alpha,c_loc(AP),lda,strideA,beta,c_loc(BP),ldb,strideB,c_loc(CP),ldc,strideC,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasZgeamStridedBatched_rank_0(handle,transA,transB,m,n,alpha,AP,lda,strideA,beta, &
         BP,ldb,strideB,CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -56946,6 +57237,7 @@ module hipfort_hipblas
         alpha,c_loc(AP),lda,strideA,beta,c_loc(BP),ldb,strideB,c_loc(CP),ldc,strideC,batchCount)
     end function
 
+#endif
     function hipblasChemm_rank_0(handle,side,uplo,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -57084,6 +57376,7 @@ module hipfort_hipblas
         ldb,beta,c_loc(CP),ldc)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasChemmStridedBatched_rank_0(handle,side,uplo,n,k,alpha,AP,lda,strideA,BP,ldb, &
         strideB,beta,CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -57168,6 +57461,8 @@ module hipfort_hipblas
         alpha,c_loc(AP),lda,strideA,c_loc(BP),ldb,strideB,beta,c_loc(CP),ldc,strideC,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasZhemmStridedBatched_rank_0(handle,side,uplo,n,k,alpha,AP,lda,strideA,BP,ldb, &
         strideB,beta,CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -57252,6 +57547,7 @@ module hipfort_hipblas
         alpha,c_loc(AP),lda,strideA,c_loc(BP),ldb,strideB,beta,c_loc(CP),ldc,strideC,batchCount)
     end function
 
+#endif
     function hipblasStrmm_rank_0(handle,side,uplo,transA,diag,m,n,alpha,A,lda,B,ldb,C,ldc)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -57540,6 +57836,7 @@ module hipfort_hipblas
         c_loc(B),ldb,c_loc(C),ldc)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasStrmmStridedBatched_rank_0(handle,side,uplo,transA,diag,m,n,alpha,A,lda, &
         strideA,B,ldb,strideB,C,ldc,strideC,batchCount)
       use iso_c_binding
@@ -57627,6 +57924,8 @@ module hipfort_hipblas
         diag,m,n,alpha,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(C),ldc,strideC,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasDtrmmStridedBatched_rank_0(handle,side,uplo,transA,diag,m,n,alpha,A,lda, &
         strideA,B,ldb,strideB,C,ldc,strideC,batchCount)
       use iso_c_binding
@@ -57714,6 +58013,8 @@ module hipfort_hipblas
         diag,m,n,alpha,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(C),ldc,strideC,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasCtrmmStridedBatched_rank_0(handle,side,uplo,transA,diag,m,n,alpha,A,lda, &
         strideA,B,ldb,strideB,C,ldc,strideC,batchCount)
       use iso_c_binding
@@ -57801,6 +58102,8 @@ module hipfort_hipblas
         diag,m,n,alpha,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(C),ldc,strideC,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasZtrmmStridedBatched_rank_0(handle,side,uplo,transA,diag,m,n,alpha,A,lda, &
         strideA,B,ldb,strideB,C,ldc,strideC,batchCount)
       use iso_c_binding
@@ -57888,6 +58191,7 @@ module hipfort_hipblas
         diag,m,n,alpha,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(C),ldc,strideC,batchCount)
     end function
 
+#endif
     function hipblasStrsm_rank_0(handle,side,uplo,transA,diag,m,n,alpha,AP,lda,BP,ldb)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -58152,6 +58456,7 @@ module hipfort_hipblas
         c_loc(BP),ldb)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasStrsmStridedBatched_rank_0(handle,side,uplo,transA,diag,m,n,alpha,AP,lda, &
         strideA,BP,ldb,strideB,batchCount)
       use iso_c_binding
@@ -58230,6 +58535,8 @@ module hipfort_hipblas
         diag,m,n,alpha,c_loc(AP),lda,strideA,c_loc(BP),ldb,strideB,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasDtrsmStridedBatched_rank_0(handle,side,uplo,transA,diag,m,n,alpha,AP,lda, &
         strideA,BP,ldb,strideB,batchCount)
       use iso_c_binding
@@ -58308,6 +58615,8 @@ module hipfort_hipblas
         diag,m,n,alpha,c_loc(AP),lda,strideA,c_loc(BP),ldb,strideB,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasCtrsmStridedBatched_rank_0(handle,side,uplo,transA,diag,m,n,alpha,AP,lda, &
         strideA,BP,ldb,strideB,batchCount)
       use iso_c_binding
@@ -58386,6 +58695,8 @@ module hipfort_hipblas
         diag,m,n,alpha,c_loc(AP),lda,strideA,c_loc(BP),ldb,strideB,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasZtrsmStridedBatched_rank_0(handle,side,uplo,transA,diag,m,n,alpha,AP,lda, &
         strideA,BP,ldb,strideB,batchCount)
       use iso_c_binding
@@ -58464,6 +58775,8 @@ module hipfort_hipblas
         diag,m,n,alpha,c_loc(AP),lda,strideA,c_loc(BP),ldb,strideB,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasStrtri_rank_0(handle,uplo,diag,n,AP,lda,invA,ldinvA)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -58515,6 +58828,8 @@ module hipfort_hipblas
       hipblasStrtri_full_rank = hipblasStrtri_(handle,uplo,diag,n,c_loc(AP),lda,c_loc(invA),ldinvA)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasDtrtri_rank_0(handle,uplo,diag,n,AP,lda,invA,ldinvA)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -58566,6 +58881,8 @@ module hipfort_hipblas
       hipblasDtrtri_full_rank = hipblasDtrtri_(handle,uplo,diag,n,c_loc(AP),lda,c_loc(invA),ldinvA)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasCtrtri_rank_0(handle,uplo,diag,n,AP,lda,invA,ldinvA)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -58617,6 +58934,8 @@ module hipfort_hipblas
       hipblasCtrtri_full_rank = hipblasCtrtri_(handle,uplo,diag,n,c_loc(AP),lda,c_loc(invA),ldinvA)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasZtrtri_rank_0(handle,uplo,diag,n,AP,lda,invA,ldinvA)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -58668,6 +58987,8 @@ module hipfort_hipblas
       hipblasZtrtri_full_rank = hipblasZtrtri_(handle,uplo,diag,n,c_loc(AP),lda,c_loc(invA),ldinvA)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasStrtriStridedBatched_rank_0(handle,uplo,diag,n,AP,lda,strideA,invA,ldinvA, &
         stride_invA,batchCount)
       use iso_c_binding
@@ -58734,6 +59055,8 @@ module hipfort_hipblas
         c_loc(AP),lda,strideA,c_loc(invA),ldinvA,stride_invA,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasDtrtriStridedBatched_rank_0(handle,uplo,diag,n,AP,lda,strideA,invA,ldinvA, &
         stride_invA,batchCount)
       use iso_c_binding
@@ -58800,6 +59123,8 @@ module hipfort_hipblas
         c_loc(AP),lda,strideA,c_loc(invA),ldinvA,stride_invA,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasCtrtriStridedBatched_rank_0(handle,uplo,diag,n,AP,lda,strideA,invA,ldinvA, &
         stride_invA,batchCount)
       use iso_c_binding
@@ -58866,6 +59191,8 @@ module hipfort_hipblas
         c_loc(AP),lda,strideA,c_loc(invA),ldinvA,stride_invA,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasZtrtriStridedBatched_rank_0(handle,uplo,diag,n,AP,lda,strideA,invA,ldinvA, &
         stride_invA,batchCount)
       use iso_c_binding
@@ -58932,6 +59259,7 @@ module hipfort_hipblas
         c_loc(AP),lda,strideA,c_loc(invA),ldinvA,stride_invA,batchCount)
     end function
 
+#endif
     function hipblasSdgmm_rank_0(handle,side,m,n,AP,lda,x,incx,CP,ldc)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -59164,6 +59492,7 @@ module hipfort_hipblas
         c_loc(CP),ldc)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasSdgmmStridedBatched_rank_0(handle,side,m,n,AP,lda,strideA,x,incx,stridex,CP, &
         ldc,strideC,batchCount)
       use iso_c_binding
@@ -59239,6 +59568,8 @@ module hipfort_hipblas
         c_loc(AP),lda,strideA,c_loc(x),incx,stridex,c_loc(CP),ldc,strideC,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasDdgmmStridedBatched_rank_0(handle,side,m,n,AP,lda,strideA,x,incx,stridex,CP, &
         ldc,strideC,batchCount)
       use iso_c_binding
@@ -59314,6 +59645,8 @@ module hipfort_hipblas
         c_loc(AP),lda,strideA,c_loc(x),incx,stridex,c_loc(CP),ldc,strideC,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasCdgmmStridedBatched_rank_0(handle,side,m,n,AP,lda,strideA,x,incx,stridex,CP, &
         ldc,strideC,batchCount)
       use iso_c_binding
@@ -59389,6 +59722,8 @@ module hipfort_hipblas
         c_loc(AP),lda,strideA,c_loc(x),incx,stridex,c_loc(CP),ldc,strideC,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasZdgmmStridedBatched_rank_0(handle,side,m,n,AP,lda,strideA,x,incx,stridex,CP, &
         ldc,strideC,batchCount)
       use iso_c_binding
@@ -59464,6 +59799,8 @@ module hipfort_hipblas
         c_loc(AP),lda,strideA,c_loc(x),incx,stridex,c_loc(CP),ldc,strideC,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasSgetrf_rank_0(handle,n,A,lda,ipiv,myInfo)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -59509,6 +59846,8 @@ module hipfort_hipblas
       hipblasSgetrf_full_rank = hipblasSgetrf_(handle,n,c_loc(A),lda,ipiv,myInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasDgetrf_rank_0(handle,n,A,lda,ipiv,myInfo)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -59554,6 +59893,8 @@ module hipfort_hipblas
       hipblasDgetrf_full_rank = hipblasDgetrf_(handle,n,c_loc(A),lda,ipiv,myInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasCgetrf_rank_0(handle,n,A,lda,ipiv,myInfo)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -59599,6 +59940,8 @@ module hipfort_hipblas
       hipblasCgetrf_full_rank = hipblasCgetrf_(handle,n,c_loc(A),lda,ipiv,myInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasZgetrf_rank_0(handle,n,A,lda,ipiv,myInfo)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -59644,6 +59987,8 @@ module hipfort_hipblas
       hipblasZgetrf_full_rank = hipblasZgetrf_(handle,n,c_loc(A),lda,ipiv,myInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasSgetrfStridedBatched_rank_0(handle,n,A,lda,strideA,ipiv,strideP,myInfo, &
         batchCount)
       use iso_c_binding
@@ -59704,6 +60049,8 @@ module hipfort_hipblas
         strideA,ipiv,strideP,myInfo,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasDgetrfStridedBatched_rank_0(handle,n,A,lda,strideA,ipiv,strideP,myInfo, &
         batchCount)
       use iso_c_binding
@@ -59764,6 +60111,8 @@ module hipfort_hipblas
         strideA,ipiv,strideP,myInfo,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasCgetrfStridedBatched_rank_0(handle,n,A,lda,strideA,ipiv,strideP,myInfo, &
         batchCount)
       use iso_c_binding
@@ -59824,6 +60173,8 @@ module hipfort_hipblas
         strideA,ipiv,strideP,myInfo,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasZgetrfStridedBatched_rank_0(handle,n,A,lda,strideA,ipiv,strideP,myInfo, &
         batchCount)
       use iso_c_binding
@@ -59884,6 +60235,8 @@ module hipfort_hipblas
         strideA,ipiv,strideP,myInfo,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasSgetrs_rank_0(handle,trans,n,nrhs,A,lda,ipiv,B,ldb,myInfo)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -59944,6 +60297,8 @@ module hipfort_hipblas
         myInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasDgetrs_rank_0(handle,trans,n,nrhs,A,lda,ipiv,B,ldb,myInfo)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -60004,6 +60359,8 @@ module hipfort_hipblas
         myInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasCgetrs_rank_0(handle,trans,n,nrhs,A,lda,ipiv,B,ldb,myInfo)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -60064,6 +60421,8 @@ module hipfort_hipblas
         myInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasZgetrs_rank_0(handle,trans,n,nrhs,A,lda,ipiv,B,ldb,myInfo)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -60124,6 +60483,8 @@ module hipfort_hipblas
         myInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasSgetrsStridedBatched_rank_0(handle,trans,n,nrhs,A,lda,strideA,ipiv,strideP,B, &
         ldb,strideB,myInfo,batchCount)
       use iso_c_binding
@@ -60199,6 +60560,8 @@ module hipfort_hipblas
         c_loc(A),lda,strideA,ipiv,strideP,c_loc(B),ldb,strideB,myInfo,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasDgetrsStridedBatched_rank_0(handle,trans,n,nrhs,A,lda,strideA,ipiv,strideP,B, &
         ldb,strideB,myInfo,batchCount)
       use iso_c_binding
@@ -60274,6 +60637,8 @@ module hipfort_hipblas
         c_loc(A),lda,strideA,ipiv,strideP,c_loc(B),ldb,strideB,myInfo,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasCgetrsStridedBatched_rank_0(handle,trans,n,nrhs,A,lda,strideA,ipiv,strideP,B, &
         ldb,strideB,myInfo,batchCount)
       use iso_c_binding
@@ -60349,6 +60714,8 @@ module hipfort_hipblas
         c_loc(A),lda,strideA,ipiv,strideP,c_loc(B),ldb,strideB,myInfo,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasZgetrsStridedBatched_rank_0(handle,trans,n,nrhs,A,lda,strideA,ipiv,strideP,B, &
         ldb,strideB,myInfo,batchCount)
       use iso_c_binding
@@ -60424,6 +60791,8 @@ module hipfort_hipblas
         c_loc(A),lda,strideA,ipiv,strideP,c_loc(B),ldb,strideB,myInfo,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasSgeqrf_rank_0(handle,m,n,A,lda,ipiv,myInfo)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -60472,6 +60841,8 @@ module hipfort_hipblas
       hipblasSgeqrf_full_rank = hipblasSgeqrf_(handle,m,n,c_loc(A),lda,ipiv,myInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasDgeqrf_rank_0(handle,m,n,A,lda,ipiv,myInfo)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -60520,6 +60891,8 @@ module hipfort_hipblas
       hipblasDgeqrf_full_rank = hipblasDgeqrf_(handle,m,n,c_loc(A),lda,ipiv,myInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasCgeqrf_rank_0(handle,m,n,A,lda,ipiv,myInfo)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -60568,6 +60941,8 @@ module hipfort_hipblas
       hipblasCgeqrf_full_rank = hipblasCgeqrf_(handle,m,n,c_loc(A),lda,ipiv,myInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasZgeqrf_rank_0(handle,m,n,A,lda,ipiv,myInfo)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -60616,6 +60991,8 @@ module hipfort_hipblas
       hipblasZgeqrf_full_rank = hipblasZgeqrf_(handle,m,n,c_loc(A),lda,ipiv,myInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasSgeqrfStridedBatched_rank_0(handle,m,n,A,lda,strideA,ipiv,strideP,myInfo, &
         batchCount)
       use iso_c_binding
@@ -60679,6 +61056,8 @@ module hipfort_hipblas
         lda,strideA,ipiv,strideP,myInfo,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasDgeqrfStridedBatched_rank_0(handle,m,n,A,lda,strideA,ipiv,strideP,myInfo, &
         batchCount)
       use iso_c_binding
@@ -60742,6 +61121,8 @@ module hipfort_hipblas
         lda,strideA,ipiv,strideP,myInfo,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasCgeqrfStridedBatched_rank_0(handle,m,n,A,lda,strideA,ipiv,strideP,myInfo, &
         batchCount)
       use iso_c_binding
@@ -60805,6 +61186,8 @@ module hipfort_hipblas
         lda,strideA,ipiv,strideP,myInfo,batchCount)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipblasZgeqrfStridedBatched_rank_0(handle,m,n,A,lda,strideA,ipiv,strideP,myInfo, &
         batchCount)
       use iso_c_binding
@@ -60868,5 +61251,6 @@ module hipfort_hipblas
         lda,strideA,ipiv,strideP,myInfo,batchCount)
     end function
 
+#endif
 #endif
 end module hipfort_hipblas

--- a/lib/hipfort/hipfort_hipsolver.F90
+++ b/lib/hipfort/hipfort_hipsolver.F90
@@ -13790,6 +13790,7 @@ module hipfort_hipsolver
 #ifdef USE_FPOINTER_INTERFACES
   contains
 
+#ifndef USE_CUDA_NAMES
     function hipsolverSorgbr_bufferSize_rank_0(handle,side,m,n,k,A,lda,tau,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -13847,6 +13848,8 @@ module hipfort_hipsolver
         c_loc(A),lda,tau,lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverDorgbr_bufferSize_rank_0(handle,side,m,n,k,A,lda,tau,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -13904,6 +13907,8 @@ module hipfort_hipsolver
         c_loc(A),lda,tau,lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverCungbr_bufferSize_rank_0(handle,side,m,n,k,A,lda,tau,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -13961,6 +13966,8 @@ module hipfort_hipsolver
         c_loc(A),lda,tau,lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverZungbr_bufferSize_rank_0(handle,side,m,n,k,A,lda,tau,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -14018,6 +14025,8 @@ module hipfort_hipsolver
         c_loc(A),lda,tau,lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverSorgbr_rank_0(handle,side,m,n,k,A,lda,tau,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -14081,6 +14090,8 @@ module hipfort_hipsolver
         devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverDorgbr_rank_0(handle,side,m,n,k,A,lda,tau,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -14144,6 +14155,8 @@ module hipfort_hipsolver
         devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverCungbr_rank_0(handle,side,m,n,k,A,lda,tau,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -14207,6 +14220,8 @@ module hipfort_hipsolver
         devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverZungbr_rank_0(handle,side,m,n,k,A,lda,tau,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -14270,6 +14285,8 @@ module hipfort_hipsolver
         devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverSorgqr_bufferSize_rank_0(handle,m,n,k,A,lda,tau,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -14324,6 +14341,8 @@ module hipfort_hipsolver
         lda,tau,lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverDorgqr_bufferSize_rank_0(handle,m,n,k,A,lda,tau,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -14378,6 +14397,8 @@ module hipfort_hipsolver
         lda,tau,lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverCungqr_bufferSize_rank_0(handle,m,n,k,A,lda,tau,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -14432,6 +14453,8 @@ module hipfort_hipsolver
         lda,tau,lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverZungqr_bufferSize_rank_0(handle,m,n,k,A,lda,tau,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -14486,6 +14509,8 @@ module hipfort_hipsolver
         lda,tau,lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverSorgqr_rank_0(handle,m,n,k,A,lda,tau,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -14543,6 +14568,8 @@ module hipfort_hipsolver
       hipsolverSorgqr_full_rank = hipsolverSorgqr_(handle,m,n,k,c_loc(A),lda,tau,work,lwork,devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverDorgqr_rank_0(handle,m,n,k,A,lda,tau,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -14600,6 +14627,8 @@ module hipfort_hipsolver
       hipsolverDorgqr_full_rank = hipsolverDorgqr_(handle,m,n,k,c_loc(A),lda,tau,work,lwork,devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverCungqr_rank_0(handle,m,n,k,A,lda,tau,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -14657,6 +14686,8 @@ module hipfort_hipsolver
       hipsolverCungqr_full_rank = hipsolverCungqr_(handle,m,n,k,c_loc(A),lda,tau,work,lwork,devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverZungqr_rank_0(handle,m,n,k,A,lda,tau,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -14714,6 +14745,8 @@ module hipfort_hipsolver
       hipsolverZungqr_full_rank = hipsolverZungqr_(handle,m,n,k,c_loc(A),lda,tau,work,lwork,devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverSorgtr_bufferSize_rank_0(handle,uplo,n,A,lda,tau,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -14765,6 +14798,8 @@ module hipfort_hipsolver
         lda,tau,lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverDorgtr_bufferSize_rank_0(handle,uplo,n,A,lda,tau,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -14816,6 +14851,8 @@ module hipfort_hipsolver
         lda,tau,lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverCungtr_bufferSize_rank_0(handle,uplo,n,A,lda,tau,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -14867,6 +14904,8 @@ module hipfort_hipsolver
         lda,tau,lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverZungtr_bufferSize_rank_0(handle,uplo,n,A,lda,tau,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -14918,6 +14957,8 @@ module hipfort_hipsolver
         lda,tau,lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverSorgtr_rank_0(handle,uplo,n,A,lda,tau,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -14973,6 +15014,8 @@ module hipfort_hipsolver
         devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverDorgtr_rank_0(handle,uplo,n,A,lda,tau,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15028,6 +15071,8 @@ module hipfort_hipsolver
         devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverCungtr_rank_0(handle,uplo,n,A,lda,tau,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15083,6 +15128,8 @@ module hipfort_hipsolver
         devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverZungtr_rank_0(handle,uplo,n,A,lda,tau,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15138,6 +15185,8 @@ module hipfort_hipsolver
         devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverSormqr_bufferSize_rank_0(handle,side,trans,m,n,k,A,lda,tau,C,ldc,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15204,6 +15253,8 @@ module hipfort_hipsolver
         c_loc(A),lda,tau,c_loc(C),ldc,lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverDormqr_bufferSize_rank_0(handle,side,trans,m,n,k,A,lda,tau,C,ldc,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15270,6 +15321,8 @@ module hipfort_hipsolver
         c_loc(A),lda,tau,c_loc(C),ldc,lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverCunmqr_bufferSize_rank_0(handle,side,trans,m,n,k,A,lda,tau,C,ldc,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15336,6 +15389,8 @@ module hipfort_hipsolver
         c_loc(A),lda,tau,c_loc(C),ldc,lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverZunmqr_bufferSize_rank_0(handle,side,trans,m,n,k,A,lda,tau,C,ldc,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15402,6 +15457,8 @@ module hipfort_hipsolver
         c_loc(A),lda,tau,c_loc(C),ldc,lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverSormqr_rank_0(handle,side,trans,m,n,k,A,lda,tau,C,ldc,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15474,6 +15531,8 @@ module hipfort_hipsolver
         c_loc(C),ldc,work,lwork,devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverDormqr_rank_0(handle,side,trans,m,n,k,A,lda,tau,C,ldc,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15546,6 +15605,8 @@ module hipfort_hipsolver
         c_loc(C),ldc,work,lwork,devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverCunmqr_rank_0(handle,side,trans,m,n,k,A,lda,tau,C,ldc,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15618,6 +15679,8 @@ module hipfort_hipsolver
         c_loc(C),ldc,work,lwork,devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverZunmqr_rank_0(handle,side,trans,m,n,k,A,lda,tau,C,ldc,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15690,6 +15753,8 @@ module hipfort_hipsolver
         c_loc(C),ldc,work,lwork,devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverSormtr_bufferSize_rank_0(handle,side,uplo,trans,m,n,A,lda,tau,C,ldc,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15756,6 +15821,8 @@ module hipfort_hipsolver
         n,c_loc(A),lda,tau,c_loc(C),ldc,lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverDormtr_bufferSize_rank_0(handle,side,uplo,trans,m,n,A,lda,tau,C,ldc,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15822,6 +15889,8 @@ module hipfort_hipsolver
         n,c_loc(A),lda,tau,c_loc(C),ldc,lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverCunmtr_bufferSize_rank_0(handle,side,uplo,trans,m,n,A,lda,tau,C,ldc,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15888,6 +15957,8 @@ module hipfort_hipsolver
         n,c_loc(A),lda,tau,c_loc(C),ldc,lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverZunmtr_bufferSize_rank_0(handle,side,uplo,trans,m,n,A,lda,tau,C,ldc,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15954,6 +16025,8 @@ module hipfort_hipsolver
         n,c_loc(A),lda,tau,c_loc(C),ldc,lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverSormtr_rank_0(handle,side,uplo,trans,m,n,A,lda,tau,C,ldc,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16027,6 +16100,8 @@ module hipfort_hipsolver
         c_loc(C),ldc,work,lwork,devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverDormtr_rank_0(handle,side,uplo,trans,m,n,A,lda,tau,C,ldc,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16100,6 +16175,8 @@ module hipfort_hipsolver
         c_loc(C),ldc,work,lwork,devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverCunmtr_rank_0(handle,side,uplo,trans,m,n,A,lda,tau,C,ldc,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16173,6 +16250,8 @@ module hipfort_hipsolver
         c_loc(C),ldc,work,lwork,devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverZunmtr_rank_0(handle,side,uplo,trans,m,n,A,lda,tau,C,ldc,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16246,6 +16325,8 @@ module hipfort_hipsolver
         c_loc(C),ldc,work,lwork,devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverSgebrd_rank_0(handle,m,n,A,lda,D,E,tauq,taup,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16312,6 +16393,8 @@ module hipfort_hipsolver
         c_loc(tauq),c_loc(taup),work,lwork,devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverDgebrd_rank_0(handle,m,n,A,lda,D,E,tauq,taup,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16378,6 +16461,8 @@ module hipfort_hipsolver
         c_loc(tauq),c_loc(taup),work,lwork,devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverCgebrd_rank_0(handle,m,n,A,lda,D,E,tauq,taup,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16444,6 +16529,8 @@ module hipfort_hipsolver
         c_loc(tauq),c_loc(taup),work,lwork,devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverZgebrd_rank_0(handle,m,n,A,lda,D,E,tauq,taup,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16510,6 +16597,8 @@ module hipfort_hipsolver
         c_loc(tauq),c_loc(taup),work,lwork,devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverSgeqrf_bufferSize_rank_0(handle,m,n,A,lda,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16556,6 +16645,8 @@ module hipfort_hipsolver
         lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverDgeqrf_bufferSize_rank_0(handle,m,n,A,lda,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16602,6 +16693,8 @@ module hipfort_hipsolver
         lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverCgeqrf_bufferSize_rank_0(handle,m,n,A,lda,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16648,6 +16741,8 @@ module hipfort_hipsolver
         lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverZgeqrf_bufferSize_rank_0(handle,m,n,A,lda,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16694,6 +16789,8 @@ module hipfort_hipsolver
         lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverSgeqrf_rank_0(handle,m,n,A,lda,tau,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16748,6 +16845,8 @@ module hipfort_hipsolver
       hipsolverSgeqrf_full_rank = hipsolverSgeqrf_(handle,m,n,c_loc(A),lda,tau,work,lwork,devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverDgeqrf_rank_0(handle,m,n,A,lda,tau,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16802,6 +16901,8 @@ module hipfort_hipsolver
       hipsolverDgeqrf_full_rank = hipsolverDgeqrf_(handle,m,n,c_loc(A),lda,tau,work,lwork,devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverCgeqrf_rank_0(handle,m,n,A,lda,tau,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16856,6 +16957,8 @@ module hipfort_hipsolver
       hipsolverCgeqrf_full_rank = hipsolverCgeqrf_(handle,m,n,c_loc(A),lda,tau,work,lwork,devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverZgeqrf_rank_0(handle,m,n,A,lda,tau,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16910,6 +17013,8 @@ module hipfort_hipsolver
       hipsolverZgeqrf_full_rank = hipsolverZgeqrf_(handle,m,n,c_loc(A),lda,tau,work,lwork,devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverSSgesv_bufferSize_rank_0(handle,n,nrhs,A,lda,devIpiv,B,ldb,X,ldx,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16973,6 +17078,8 @@ module hipfort_hipsolver
         lda,c_loc(devIpiv),c_loc(B),ldb,c_loc(X),ldx,lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverDDgesv_bufferSize_rank_0(handle,n,nrhs,A,lda,devIpiv,B,ldb,X,ldx,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -17036,6 +17143,8 @@ module hipfort_hipsolver
         lda,c_loc(devIpiv),c_loc(B),ldb,c_loc(X),ldx,lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverCCgesv_bufferSize_rank_0(handle,n,nrhs,A,lda,devIpiv,B,ldb,X,ldx,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -17099,6 +17208,8 @@ module hipfort_hipsolver
         lda,c_loc(devIpiv),c_loc(B),ldb,c_loc(X),ldx,lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverZZgesv_bufferSize_rank_0(handle,n,nrhs,A,lda,devIpiv,B,ldb,X,ldx,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -17162,6 +17273,8 @@ module hipfort_hipsolver
         lda,c_loc(devIpiv),c_loc(B),ldb,c_loc(X),ldx,lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverSSgesv_rank_0(handle,n,nrhs,A,lda,devIpiv,B,ldb,X,ldx,work,lwork,niters, &
         devInfo)
       use iso_c_binding
@@ -17237,6 +17350,8 @@ module hipfort_hipsolver
         c_loc(B),ldb,c_loc(X),ldx,work,lwork,niters,devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverDDgesv_rank_0(handle,n,nrhs,A,lda,devIpiv,B,ldb,X,ldx,work,lwork,niters, &
         devInfo)
       use iso_c_binding
@@ -17312,6 +17427,8 @@ module hipfort_hipsolver
         c_loc(B),ldb,c_loc(X),ldx,work,lwork,niters,devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverCCgesv_rank_0(handle,n,nrhs,A,lda,devIpiv,B,ldb,X,ldx,work,lwork,niters, &
         devInfo)
       use iso_c_binding
@@ -17387,6 +17504,8 @@ module hipfort_hipsolver
         c_loc(B),ldb,c_loc(X),ldx,work,lwork,niters,devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverZZgesv_rank_0(handle,n,nrhs,A,lda,devIpiv,B,ldb,X,ldx,work,lwork,niters, &
         devInfo)
       use iso_c_binding
@@ -17462,6 +17581,8 @@ module hipfort_hipsolver
         c_loc(B),ldb,c_loc(X),ldx,work,lwork,niters,devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverSgetrf_bufferSize_rank_0(handle,m,n,A,lda,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -17508,6 +17629,8 @@ module hipfort_hipsolver
         lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverDgetrf_bufferSize_rank_0(handle,m,n,A,lda,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -17554,6 +17677,8 @@ module hipfort_hipsolver
         lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverCgetrf_bufferSize_rank_0(handle,m,n,A,lda,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -17600,6 +17725,8 @@ module hipfort_hipsolver
         lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverZgetrf_bufferSize_rank_0(handle,m,n,A,lda,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -17646,6 +17773,8 @@ module hipfort_hipsolver
         lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverSgetrf_rank_0(handle,m,n,A,lda,work,lwork,devIpiv,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -17703,6 +17832,8 @@ module hipfort_hipsolver
         c_loc(devIpiv),devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverDgetrf_rank_0(handle,m,n,A,lda,work,lwork,devIpiv,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -17760,6 +17891,8 @@ module hipfort_hipsolver
         c_loc(devIpiv),devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverCgetrf_rank_0(handle,m,n,A,lda,work,lwork,devIpiv,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -17817,6 +17950,8 @@ module hipfort_hipsolver
         c_loc(devIpiv),devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverZgetrf_rank_0(handle,m,n,A,lda,work,lwork,devIpiv,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -17874,6 +18009,8 @@ module hipfort_hipsolver
         c_loc(devIpiv),devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverSgetrs_bufferSize_rank_0(handle,trans,n,nrhs,A,lda,devIpiv,B,ldb,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -17934,6 +18071,8 @@ module hipfort_hipsolver
         c_loc(A),lda,c_loc(devIpiv),c_loc(B),ldb,lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverDgetrs_bufferSize_rank_0(handle,trans,n,nrhs,A,lda,devIpiv,B,ldb,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -17994,6 +18133,8 @@ module hipfort_hipsolver
         c_loc(A),lda,c_loc(devIpiv),c_loc(B),ldb,lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverCgetrs_bufferSize_rank_0(handle,trans,n,nrhs,A,lda,devIpiv,B,ldb,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -18054,6 +18195,8 @@ module hipfort_hipsolver
         c_loc(A),lda,c_loc(devIpiv),c_loc(B),ldb,lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverZgetrs_bufferSize_rank_0(handle,trans,n,nrhs,A,lda,devIpiv,B,ldb,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -18114,6 +18257,8 @@ module hipfort_hipsolver
         c_loc(A),lda,c_loc(devIpiv),c_loc(B),ldb,lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverSgetrs_rank_0(handle,trans,n,nrhs,A,lda,devIpiv,B,ldb,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -18180,6 +18325,8 @@ module hipfort_hipsolver
         c_loc(devIpiv),c_loc(B),ldb,work,lwork,devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverDgetrs_rank_0(handle,trans,n,nrhs,A,lda,devIpiv,B,ldb,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -18246,6 +18393,8 @@ module hipfort_hipsolver
         c_loc(devIpiv),c_loc(B),ldb,work,lwork,devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverCgetrs_rank_0(handle,trans,n,nrhs,A,lda,devIpiv,B,ldb,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -18312,6 +18461,8 @@ module hipfort_hipsolver
         c_loc(devIpiv),c_loc(B),ldb,work,lwork,devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverZgetrs_rank_0(handle,trans,n,nrhs,A,lda,devIpiv,B,ldb,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -18378,6 +18529,8 @@ module hipfort_hipsolver
         c_loc(devIpiv),c_loc(B),ldb,work,lwork,devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverSpotrf_bufferSize_rank_0(handle,uplo,n,A,lda,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -18426,6 +18579,8 @@ module hipfort_hipsolver
         lda,lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverDpotrf_bufferSize_rank_0(handle,uplo,n,A,lda,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -18474,6 +18629,8 @@ module hipfort_hipsolver
         lda,lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverCpotrf_bufferSize_rank_0(handle,uplo,n,A,lda,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -18522,6 +18679,8 @@ module hipfort_hipsolver
         lda,lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverZpotrf_bufferSize_rank_0(handle,uplo,n,A,lda,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -18570,6 +18729,8 @@ module hipfort_hipsolver
         lda,lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverSpotrf_rank_0(handle,uplo,n,A,lda,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -18621,6 +18782,8 @@ module hipfort_hipsolver
       hipsolverSpotrf_full_rank = hipsolverSpotrf_(handle,uplo,n,c_loc(A),lda,work,lwork,devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverDpotrf_rank_0(handle,uplo,n,A,lda,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -18672,6 +18835,8 @@ module hipfort_hipsolver
       hipsolverDpotrf_full_rank = hipsolverDpotrf_(handle,uplo,n,c_loc(A),lda,work,lwork,devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverCpotrf_rank_0(handle,uplo,n,A,lda,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -18723,6 +18888,8 @@ module hipfort_hipsolver
       hipsolverCpotrf_full_rank = hipsolverCpotrf_(handle,uplo,n,c_loc(A),lda,work,lwork,devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverZpotrf_rank_0(handle,uplo,n,A,lda,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -18774,6 +18941,8 @@ module hipfort_hipsolver
       hipsolverZpotrf_full_rank = hipsolverZpotrf_(handle,uplo,n,c_loc(A),lda,work,lwork,devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverSpotri_bufferSize_rank_0(handle,uplo,n,A,lda,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -18822,6 +18991,8 @@ module hipfort_hipsolver
         lda,lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverDpotri_bufferSize_rank_0(handle,uplo,n,A,lda,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -18870,6 +19041,8 @@ module hipfort_hipsolver
         lda,lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverCpotri_bufferSize_rank_0(handle,uplo,n,A,lda,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -18918,6 +19091,8 @@ module hipfort_hipsolver
         lda,lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverZpotri_bufferSize_rank_0(handle,uplo,n,A,lda,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -18966,6 +19141,8 @@ module hipfort_hipsolver
         lda,lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverSpotri_rank_0(handle,uplo,n,A,lda,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -19017,6 +19194,8 @@ module hipfort_hipsolver
       hipsolverSpotri_full_rank = hipsolverSpotri_(handle,uplo,n,c_loc(A),lda,work,lwork,devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverDpotri_rank_0(handle,uplo,n,A,lda,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -19068,6 +19247,8 @@ module hipfort_hipsolver
       hipsolverDpotri_full_rank = hipsolverDpotri_(handle,uplo,n,c_loc(A),lda,work,lwork,devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverCpotri_rank_0(handle,uplo,n,A,lda,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -19119,6 +19300,8 @@ module hipfort_hipsolver
       hipsolverCpotri_full_rank = hipsolverCpotri_(handle,uplo,n,c_loc(A),lda,work,lwork,devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverZpotri_rank_0(handle,uplo,n,A,lda,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -19170,6 +19353,8 @@ module hipfort_hipsolver
       hipsolverZpotri_full_rank = hipsolverZpotri_(handle,uplo,n,c_loc(A),lda,work,lwork,devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverSpotrs_bufferSize_rank_0(handle,uplo,n,nrhs,A,lda,B,ldb,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -19227,6 +19412,8 @@ module hipfort_hipsolver
         c_loc(A),lda,c_loc(B),ldb,lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverDpotrs_bufferSize_rank_0(handle,uplo,n,nrhs,A,lda,B,ldb,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -19284,6 +19471,8 @@ module hipfort_hipsolver
         c_loc(A),lda,c_loc(B),ldb,lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverCpotrs_bufferSize_rank_0(handle,uplo,n,nrhs,A,lda,B,ldb,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -19341,6 +19530,8 @@ module hipfort_hipsolver
         c_loc(A),lda,c_loc(B),ldb,lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverZpotrs_bufferSize_rank_0(handle,uplo,n,nrhs,A,lda,B,ldb,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -19398,6 +19589,8 @@ module hipfort_hipsolver
         c_loc(A),lda,c_loc(B),ldb,lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverSpotrs_rank_0(handle,uplo,n,nrhs,A,lda,B,ldb,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -19461,6 +19654,8 @@ module hipfort_hipsolver
         work,lwork,devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverDpotrs_rank_0(handle,uplo,n,nrhs,A,lda,B,ldb,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -19524,6 +19719,8 @@ module hipfort_hipsolver
         work,lwork,devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverCpotrs_rank_0(handle,uplo,n,nrhs,A,lda,B,ldb,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -19587,6 +19784,8 @@ module hipfort_hipsolver
         work,lwork,devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverZpotrs_rank_0(handle,uplo,n,nrhs,A,lda,B,ldb,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -19650,6 +19849,8 @@ module hipfort_hipsolver
         work,lwork,devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverSsyevd_bufferSize_rank_0(handle,jobz,uplo,n,A,lda,D,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -19704,6 +19905,8 @@ module hipfort_hipsolver
         c_loc(A),lda,c_loc(D),lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverDsyevd_bufferSize_rank_0(handle,jobz,uplo,n,A,lda,D,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -19758,6 +19961,8 @@ module hipfort_hipsolver
         c_loc(A),lda,c_loc(D),lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverCheevd_bufferSize_rank_0(handle,jobz,uplo,n,A,lda,D,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -19812,6 +20017,8 @@ module hipfort_hipsolver
         c_loc(A),lda,c_loc(D),lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverZheevd_bufferSize_rank_0(handle,jobz,uplo,n,A,lda,D,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -19866,6 +20073,8 @@ module hipfort_hipsolver
         c_loc(A),lda,c_loc(D),lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverSsyevd_rank_0(handle,jobz,uplo,n,A,lda,D,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -19926,6 +20135,8 @@ module hipfort_hipsolver
         lwork,devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverDsyevd_rank_0(handle,jobz,uplo,n,A,lda,D,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -19986,6 +20197,8 @@ module hipfort_hipsolver
         lwork,devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverCheevd_rank_0(handle,jobz,uplo,n,A,lda,D,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -20046,6 +20259,8 @@ module hipfort_hipsolver
         lwork,devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverZheevd_rank_0(handle,jobz,uplo,n,A,lda,D,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -20106,6 +20321,8 @@ module hipfort_hipsolver
         lwork,devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverSsygvd_bufferSize_rank_0(handle,itype,jobz,uplo,n,A,lda,B,ldb,W,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -20169,6 +20386,8 @@ module hipfort_hipsolver
         c_loc(A),lda,c_loc(B),ldb,c_loc(W),lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverDsygvd_bufferSize_rank_0(handle,itype,jobz,uplo,n,A,lda,B,ldb,W,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -20232,6 +20451,8 @@ module hipfort_hipsolver
         c_loc(A),lda,c_loc(B),ldb,c_loc(W),lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverChegvd_bufferSize_rank_0(handle,itype,jobz,uplo,n,A,lda,B,ldb,W,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -20295,6 +20516,8 @@ module hipfort_hipsolver
         c_loc(A),lda,c_loc(B),ldb,c_loc(W),lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverZhegvd_bufferSize_rank_0(handle,itype,jobz,uplo,n,A,lda,B,ldb,W,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -20358,6 +20581,8 @@ module hipfort_hipsolver
         c_loc(A),lda,c_loc(B),ldb,c_loc(W),lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverSsygvd_rank_0(handle,itype,jobz,uplo,n,A,lda,B,ldb,W,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -20427,6 +20652,8 @@ module hipfort_hipsolver
         ldb,c_loc(W),work,lwork,devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverDsygvd_rank_0(handle,itype,jobz,uplo,n,A,lda,B,ldb,W,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -20496,6 +20723,8 @@ module hipfort_hipsolver
         ldb,c_loc(W),work,lwork,devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverChegvd_rank_0(handle,itype,jobz,uplo,n,A,lda,B,ldb,W,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -20565,6 +20794,8 @@ module hipfort_hipsolver
         ldb,c_loc(W),work,lwork,devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverZhegvd_rank_0(handle,itype,jobz,uplo,n,A,lda,B,ldb,W,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -20634,6 +20865,8 @@ module hipfort_hipsolver
         ldb,c_loc(W),work,lwork,devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverSsytrd_bufferSize_rank_0(handle,uplo,n,A,lda,D,E,tau,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -20691,6 +20924,8 @@ module hipfort_hipsolver
         lda,c_loc(D),c_loc(E),tau,lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverDsytrd_bufferSize_rank_0(handle,uplo,n,A,lda,D,E,tau,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -20748,6 +20983,8 @@ module hipfort_hipsolver
         lda,c_loc(D),c_loc(E),tau,lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverChetrd_bufferSize_rank_0(handle,uplo,n,A,lda,D,E,tau,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -20805,6 +21042,8 @@ module hipfort_hipsolver
         lda,c_loc(D),c_loc(E),tau,lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverZhetrd_bufferSize_rank_0(handle,uplo,n,A,lda,D,E,tau,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -20862,6 +21101,8 @@ module hipfort_hipsolver
         lda,c_loc(D),c_loc(E),tau,lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverSsytrd_rank_0(handle,uplo,n,A,lda,D,E,tau,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -20925,6 +21166,8 @@ module hipfort_hipsolver
         tau,work,lwork,devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverDsytrd_rank_0(handle,uplo,n,A,lda,D,E,tau,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -20988,6 +21231,8 @@ module hipfort_hipsolver
         tau,work,lwork,devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverChetrd_rank_0(handle,uplo,n,A,lda,D,E,tau,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -21051,6 +21296,8 @@ module hipfort_hipsolver
         tau,work,lwork,devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverZhetrd_rank_0(handle,uplo,n,A,lda,D,E,tau,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -21114,6 +21361,8 @@ module hipfort_hipsolver
         tau,work,lwork,devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverSsytrf_bufferSize_rank_0(handle,n,A,lda,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -21157,6 +21406,8 @@ module hipfort_hipsolver
         lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverDsytrf_bufferSize_rank_0(handle,n,A,lda,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -21200,6 +21451,8 @@ module hipfort_hipsolver
         lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverCsytrf_bufferSize_rank_0(handle,n,A,lda,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -21243,6 +21496,8 @@ module hipfort_hipsolver
         lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverZsytrf_bufferSize_rank_0(handle,n,A,lda,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -21286,6 +21541,8 @@ module hipfort_hipsolver
         lwork)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverSsytrf_rank_0(handle,uplo,n,A,lda,ipiv,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -21341,6 +21598,8 @@ module hipfort_hipsolver
         devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverDsytrf_rank_0(handle,uplo,n,A,lda,ipiv,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -21396,6 +21655,8 @@ module hipfort_hipsolver
         devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverCsytrf_rank_0(handle,uplo,n,A,lda,ipiv,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -21451,6 +21712,8 @@ module hipfort_hipsolver
         devInfo)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsolverZsytrf_rank_0(handle,uplo,n,A,lda,ipiv,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -21506,5 +21769,6 @@ module hipfort_hipsolver
         devInfo)
     end function
 
+#endif
 #endif
 end module hipfort_hipsolver

--- a/lib/hipfort/hipfort_hipsparse.F90
+++ b/lib/hipfort/hipfort_hipsparse.F90
@@ -23610,6 +23610,7 @@ module hipfort_hipsparse
 #ifdef USE_FPOINTER_INTERFACES
   contains
 
+#ifndef USE_CUDA_NAMES
     function hipsparseSaxpyi_rank_0(handle,nnz,alpha,xVal,xInd,y,idxBase)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -23644,6 +23645,8 @@ module hipfort_hipsparse
         idxBase)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseDaxpyi_rank_0(handle,nnz,alpha,xVal,xInd,y,idxBase)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -23678,6 +23681,8 @@ module hipfort_hipsparse
         idxBase)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseCaxpyi_rank_0(handle,nnz,alpha,xVal,xInd,y,idxBase)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -23712,6 +23717,8 @@ module hipfort_hipsparse
         idxBase)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseZaxpyi_rank_0(handle,nnz,alpha,xVal,xInd,y,idxBase)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -23746,6 +23753,8 @@ module hipfort_hipsparse
         idxBase)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseCdotci_rank_0(handle,nnz,xVal,xInd,y,myResult,idxBase)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -23780,6 +23789,8 @@ module hipfort_hipsparse
         c_loc(myResult),idxBase)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseZdotci_rank_0(handle,nnz,xVal,xInd,y,myResult,idxBase)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -23814,6 +23825,8 @@ module hipfort_hipsparse
         c_loc(myResult),idxBase)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseSdoti_rank_0(handle,nnz,xVal,xInd,y,myResult,idxBase)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -23848,6 +23861,8 @@ module hipfort_hipsparse
         c_loc(myResult),idxBase)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseDdoti_rank_0(handle,nnz,xVal,xInd,y,myResult,idxBase)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -23882,6 +23897,8 @@ module hipfort_hipsparse
         c_loc(myResult),idxBase)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseCdoti_rank_0(handle,nnz,xVal,xInd,y,myResult,idxBase)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -23916,6 +23933,8 @@ module hipfort_hipsparse
         c_loc(myResult),idxBase)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseZdoti_rank_0(handle,nnz,xVal,xInd,y,myResult,idxBase)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -23950,6 +23969,8 @@ module hipfort_hipsparse
         c_loc(myResult),idxBase)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseSgthr_rank_0(handle,nnz,y,xVal,xInd,idxBase)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -23980,6 +24001,8 @@ module hipfort_hipsparse
       hipsparseSgthr_rank_1 = hipsparseSgthr_(handle,nnz,c_loc(y),c_loc(xVal),c_loc(xInd),idxBase)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseDgthr_rank_0(handle,nnz,y,xVal,xInd,idxBase)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -24010,6 +24033,8 @@ module hipfort_hipsparse
       hipsparseDgthr_rank_1 = hipsparseDgthr_(handle,nnz,c_loc(y),c_loc(xVal),c_loc(xInd),idxBase)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseCgthr_rank_0(handle,nnz,y,xVal,xInd,idxBase)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -24040,6 +24065,8 @@ module hipfort_hipsparse
       hipsparseCgthr_rank_1 = hipsparseCgthr_(handle,nnz,c_loc(y),c_loc(xVal),c_loc(xInd),idxBase)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseZgthr_rank_0(handle,nnz,y,xVal,xInd,idxBase)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -24070,6 +24097,8 @@ module hipfort_hipsparse
       hipsparseZgthr_rank_1 = hipsparseZgthr_(handle,nnz,c_loc(y),c_loc(xVal),c_loc(xInd),idxBase)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseSgthrz_rank_0(handle,nnz,y,xVal,xInd,idxBase)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -24100,6 +24129,8 @@ module hipfort_hipsparse
       hipsparseSgthrz_rank_1 = hipsparseSgthrz_(handle,nnz,c_loc(y),c_loc(xVal),c_loc(xInd),idxBase)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseDgthrz_rank_0(handle,nnz,y,xVal,xInd,idxBase)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -24130,6 +24161,8 @@ module hipfort_hipsparse
       hipsparseDgthrz_rank_1 = hipsparseDgthrz_(handle,nnz,c_loc(y),c_loc(xVal),c_loc(xInd),idxBase)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseCgthrz_rank_0(handle,nnz,y,xVal,xInd,idxBase)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -24160,6 +24193,8 @@ module hipfort_hipsparse
       hipsparseCgthrz_rank_1 = hipsparseCgthrz_(handle,nnz,c_loc(y),c_loc(xVal),c_loc(xInd),idxBase)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseZgthrz_rank_0(handle,nnz,y,xVal,xInd,idxBase)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -24190,6 +24225,8 @@ module hipfort_hipsparse
       hipsparseZgthrz_rank_1 = hipsparseZgthrz_(handle,nnz,c_loc(y),c_loc(xVal),c_loc(xInd),idxBase)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseSroti_rank_0(handle,nnz,xVal,xInd,y,c,s,idxBase)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -24226,6 +24263,8 @@ module hipfort_hipsparse
         idxBase)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseDroti_rank_0(handle,nnz,xVal,xInd,y,c,s,idxBase)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -24262,6 +24301,8 @@ module hipfort_hipsparse
         idxBase)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseSsctr_rank_0(handle,nnz,xVal,xInd,y,idxBase)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -24292,6 +24333,8 @@ module hipfort_hipsparse
       hipsparseSsctr_rank_1 = hipsparseSsctr_(handle,nnz,c_loc(xVal),c_loc(xInd),c_loc(y),idxBase)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseDsctr_rank_0(handle,nnz,xVal,xInd,y,idxBase)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -24322,6 +24365,8 @@ module hipfort_hipsparse
       hipsparseDsctr_rank_1 = hipsparseDsctr_(handle,nnz,c_loc(xVal),c_loc(xInd),c_loc(y),idxBase)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseCsctr_rank_0(handle,nnz,xVal,xInd,y,idxBase)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -24352,6 +24397,8 @@ module hipfort_hipsparse
       hipsparseCsctr_rank_1 = hipsparseCsctr_(handle,nnz,c_loc(xVal),c_loc(xInd),c_loc(y),idxBase)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseZsctr_rank_0(handle,nnz,xVal,xInd,y,idxBase)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -24382,6 +24429,7 @@ module hipfort_hipsparse
       hipsparseZsctr_rank_1 = hipsparseZsctr_(handle,nnz,c_loc(xVal),c_loc(xInd),c_loc(y),idxBase)
     end function
 
+#endif
     function hipsparseSbsrmv_rank_0(handle,dirA,transA,mb,nb,nnzb,alpha,descrA,bsrSortedValA, &
         bsrSortedRowPtrA,bsrSortedColIndA,blockDim,x,beta,y)
       use iso_c_binding
@@ -24790,6 +24838,7 @@ module hipfort_hipsparse
         myInfo,pBufferSizeInBytes)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipsparseSbsrsv2_bufferSizeExt_rank_0(handle,dirA,transA,mb,nnzb,descrA, &
         bsrSortedValA,bsrSortedRowPtrA,bsrSortedColIndA,blockDim,myInfo,pBufferSizeInBytes)
       use iso_c_binding
@@ -24838,6 +24887,8 @@ module hipfort_hipsparse
         blockDim,myInfo,pBufferSizeInBytes)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseDbsrsv2_bufferSizeExt_rank_0(handle,dirA,transA,mb,nnzb,descrA, &
         bsrSortedValA,bsrSortedRowPtrA,bsrSortedColIndA,blockDim,myInfo,pBufferSizeInBytes)
       use iso_c_binding
@@ -24886,6 +24937,8 @@ module hipfort_hipsparse
         blockDim,myInfo,pBufferSizeInBytes)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseCbsrsv2_bufferSizeExt_rank_0(handle,dirA,transA,mb,nnzb,descrA, &
         bsrSortedValA,bsrSortedRowPtrA,bsrSortedColIndA,blockDim,myInfo,pBufferSizeInBytes)
       use iso_c_binding
@@ -24934,6 +24987,8 @@ module hipfort_hipsparse
         blockDim,myInfo,pBufferSizeInBytes)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseZbsrsv2_bufferSizeExt_rank_0(handle,dirA,transA,mb,nnzb,descrA, &
         bsrSortedValA,bsrSortedRowPtrA,bsrSortedColIndA,blockDim,myInfo,pBufferSizeInBytes)
       use iso_c_binding
@@ -24982,6 +25037,7 @@ module hipfort_hipsparse
         blockDim,myInfo,pBufferSizeInBytes)
     end function
 
+#endif
     function hipsparseSbsrsv2_analysis_rank_0(handle,dirA,transA,mb,nnzb,descrA,bsrSortedValA, &
         bsrSortedRowPtrA,bsrSortedColIndA,blockDim,myInfo,policy,pBuffer)
       use iso_c_binding
@@ -25638,6 +25694,7 @@ module hipfort_hipsparse
         descr,bsrVal,bsrMaskPtr,bsrRowPtr,bsrEndPtr,bsrColInd,blockDim,c_loc(x),beta,c_loc(y))
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipsparseScsrmv_rank_0(handle,transA,m,n,nnz,alpha,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,x,beta,y)
       use iso_c_binding
@@ -25686,6 +25743,8 @@ module hipfort_hipsparse
         c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),c_loc(x),beta,c_loc(y))
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseDcsrmv_rank_0(handle,transA,m,n,nnz,alpha,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,x,beta,y)
       use iso_c_binding
@@ -25734,6 +25793,8 @@ module hipfort_hipsparse
         c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),c_loc(x),beta,c_loc(y))
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseCcsrmv_rank_0(handle,transA,m,n,nnz,alpha,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,x,beta,y)
       use iso_c_binding
@@ -25782,6 +25843,8 @@ module hipfort_hipsparse
         c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),c_loc(x),beta,c_loc(y))
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseZcsrmv_rank_0(handle,transA,m,n,nnz,alpha,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,x,beta,y)
       use iso_c_binding
@@ -25830,6 +25893,8 @@ module hipfort_hipsparse
         c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),c_loc(x),beta,c_loc(y))
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseScsrsv2_bufferSize_rank_0(handle,transA,m,nnz,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,pBufferSizeInBytes)
       use iso_c_binding
@@ -25874,6 +25939,8 @@ module hipfort_hipsparse
         pBufferSizeInBytes)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseDcsrsv2_bufferSize_rank_0(handle,transA,m,nnz,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,pBufferSizeInBytes)
       use iso_c_binding
@@ -25918,6 +25985,8 @@ module hipfort_hipsparse
         pBufferSizeInBytes)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseCcsrsv2_bufferSize_rank_0(handle,transA,m,nnz,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,pBufferSizeInBytes)
       use iso_c_binding
@@ -25962,6 +26031,8 @@ module hipfort_hipsparse
         pBufferSizeInBytes)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseZcsrsv2_bufferSize_rank_0(handle,transA,m,nnz,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,pBufferSizeInBytes)
       use iso_c_binding
@@ -26006,6 +26077,8 @@ module hipfort_hipsparse
         pBufferSizeInBytes)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseScsrsv2_bufferSizeExt_rank_0(handle,transA,m,nnz,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,pBufferSizeInBytes)
       use iso_c_binding
@@ -26050,6 +26123,8 @@ module hipfort_hipsparse
         pBufferSizeInBytes)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseDcsrsv2_bufferSizeExt_rank_0(handle,transA,m,nnz,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,pBufferSizeInBytes)
       use iso_c_binding
@@ -26094,6 +26169,8 @@ module hipfort_hipsparse
         pBufferSizeInBytes)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseCcsrsv2_bufferSizeExt_rank_0(handle,transA,m,nnz,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,pBufferSizeInBytes)
       use iso_c_binding
@@ -26138,6 +26215,8 @@ module hipfort_hipsparse
         pBufferSizeInBytes)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseZcsrsv2_bufferSizeExt_rank_0(handle,transA,m,nnz,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,pBufferSizeInBytes)
       use iso_c_binding
@@ -26182,6 +26261,8 @@ module hipfort_hipsparse
         pBufferSizeInBytes)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseScsrsv2_analysis_rank_0(handle,transA,m,nnz,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,policy,pBuffer)
       use iso_c_binding
@@ -26226,6 +26307,8 @@ module hipfort_hipsparse
         c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),myInfo,policy,pBuffer)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseDcsrsv2_analysis_rank_0(handle,transA,m,nnz,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,policy,pBuffer)
       use iso_c_binding
@@ -26270,6 +26353,8 @@ module hipfort_hipsparse
         c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),myInfo,policy,pBuffer)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseCcsrsv2_analysis_rank_0(handle,transA,m,nnz,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,policy,pBuffer)
       use iso_c_binding
@@ -26314,6 +26399,8 @@ module hipfort_hipsparse
         c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),myInfo,policy,pBuffer)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseZcsrsv2_analysis_rank_0(handle,transA,m,nnz,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,policy,pBuffer)
       use iso_c_binding
@@ -26358,6 +26445,8 @@ module hipfort_hipsparse
         c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),myInfo,policy,pBuffer)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseScsrsv2_solve_rank_0(handle,transA,m,nnz,alpha,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,f,x,policy,pBuffer)
       use iso_c_binding
@@ -26410,6 +26499,8 @@ module hipfort_hipsparse
         c_loc(x),policy,pBuffer)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseDcsrsv2_solve_rank_0(handle,transA,m,nnz,alpha,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,f,x,policy,pBuffer)
       use iso_c_binding
@@ -26462,6 +26553,8 @@ module hipfort_hipsparse
         c_loc(x),policy,pBuffer)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseCcsrsv2_solve_rank_0(handle,transA,m,nnz,alpha,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,f,x,policy,pBuffer)
       use iso_c_binding
@@ -26514,6 +26607,8 @@ module hipfort_hipsparse
         c_loc(x),policy,pBuffer)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseZcsrsv2_solve_rank_0(handle,transA,m,nnz,alpha,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,f,x,policy,pBuffer)
       use iso_c_binding
@@ -26566,6 +26661,7 @@ module hipfort_hipsparse
         c_loc(x),policy,pBuffer)
     end function
 
+#endif
     function hipsparseSgemvi_rank_0(handle,transA,m,n,alpha,A,lda,nnz,x,xInd,beta,y,idxBase,pBuffer)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -26858,6 +26954,7 @@ module hipfort_hipsparse
         c_loc(x),c_loc(xInd),beta,c_loc(y),idxBase,pBuffer)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipsparseShybmv_rank_0(handle,transA,alpha,descrA,hybA,x,beta,y)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -26894,6 +26991,8 @@ module hipfort_hipsparse
         c_loc(y))
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseDhybmv_rank_0(handle,transA,alpha,descrA,hybA,x,beta,y)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -26930,6 +27029,8 @@ module hipfort_hipsparse
         c_loc(y))
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseChybmv_rank_0(handle,transA,alpha,descrA,hybA,x,beta,y)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -26966,6 +27067,8 @@ module hipfort_hipsparse
         c_loc(y))
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseZhybmv_rank_0(handle,transA,alpha,descrA,hybA,x,beta,y)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -27002,6 +27105,7 @@ module hipfort_hipsparse
         c_loc(y))
     end function
 
+#endif
     function hipsparseSbsrmm_rank_0(handle,dirA,transA,transB,mb,n,kb,nnzb,alpha,descrA,bsrValA, &
         bsrRowPtrA,bsrColIndA,blockDim,B,ldb,beta,C,ldc)
       use iso_c_binding
@@ -28182,6 +28286,7 @@ module hipfort_hipsparse
         c_loc(bsrSortedColIndA),blockDim,myInfo,c_loc(B),ldb,X,ldx,policy,pBuffer)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipsparseScsrmm_rank_0(handle,transA,m,n,k,nnz,alpha,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,B,ldb,beta,C,ldc)
       use iso_c_binding
@@ -28266,6 +28371,8 @@ module hipfort_hipsparse
         c_loc(C),ldc)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseDcsrmm_rank_0(handle,transA,m,n,k,nnz,alpha,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,B,ldb,beta,C,ldc)
       use iso_c_binding
@@ -28350,6 +28457,8 @@ module hipfort_hipsparse
         c_loc(C),ldc)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseCcsrmm_rank_0(handle,transA,m,n,k,nnz,alpha,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,B,ldb,beta,C,ldc)
       use iso_c_binding
@@ -28434,6 +28543,8 @@ module hipfort_hipsparse
         c_loc(C),ldc)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseZcsrmm_rank_0(handle,transA,m,n,k,nnz,alpha,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,B,ldb,beta,C,ldc)
       use iso_c_binding
@@ -28518,6 +28629,8 @@ module hipfort_hipsparse
         c_loc(C),ldc)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseScsrmm2_rank_0(handle,transA,transB,m,n,k,nnz,alpha,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,B,ldb,beta,C,ldc)
       use iso_c_binding
@@ -28605,6 +28718,8 @@ module hipfort_hipsparse
         c_loc(C),ldc)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseDcsrmm2_rank_0(handle,transA,transB,m,n,k,nnz,alpha,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,B,ldb,beta,C,ldc)
       use iso_c_binding
@@ -28692,6 +28807,8 @@ module hipfort_hipsparse
         c_loc(C),ldc)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseCcsrmm2_rank_0(handle,transA,transB,m,n,k,nnz,alpha,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,B,ldb,beta,C,ldc)
       use iso_c_binding
@@ -28779,6 +28896,8 @@ module hipfort_hipsparse
         c_loc(C),ldc)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseZcsrmm2_rank_0(handle,transA,transB,m,n,k,nnz,alpha,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,B,ldb,beta,C,ldc)
       use iso_c_binding
@@ -28866,6 +28985,8 @@ module hipfort_hipsparse
         c_loc(C),ldc)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseScsrsm2_bufferSizeExt_rank_0(handle,algo,transA,transB,m,nrhs,nnz,alpha, &
         descrA,csrSortedValA,csrSortedRowPtrA,csrSortedColIndA,B,ldb,myInfo,policy, &
         pBufferSizeInBytes)
@@ -28956,6 +29077,8 @@ module hipfort_hipsparse
         c_loc(csrSortedColIndA),c_loc(B),ldb,myInfo,policy,pBufferSizeInBytes)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseDcsrsm2_bufferSizeExt_rank_0(handle,algo,transA,transB,m,nrhs,nnz,alpha, &
         descrA,csrSortedValA,csrSortedRowPtrA,csrSortedColIndA,B,ldb,myInfo,policy, &
         pBufferSizeInBytes)
@@ -29046,6 +29169,8 @@ module hipfort_hipsparse
         c_loc(csrSortedColIndA),c_loc(B),ldb,myInfo,policy,pBufferSizeInBytes)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseCcsrsm2_bufferSizeExt_rank_0(handle,algo,transA,transB,m,nrhs,nnz,alpha, &
         descrA,csrSortedValA,csrSortedRowPtrA,csrSortedColIndA,B,ldb,myInfo,policy, &
         pBufferSizeInBytes)
@@ -29136,6 +29261,8 @@ module hipfort_hipsparse
         c_loc(csrSortedColIndA),c_loc(B),ldb,myInfo,policy,pBufferSizeInBytes)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseZcsrsm2_bufferSizeExt_rank_0(handle,algo,transA,transB,m,nrhs,nnz,alpha, &
         descrA,csrSortedValA,csrSortedRowPtrA,csrSortedColIndA,B,ldb,myInfo,policy, &
         pBufferSizeInBytes)
@@ -29226,6 +29353,8 @@ module hipfort_hipsparse
         c_loc(csrSortedColIndA),c_loc(B),ldb,myInfo,policy,pBufferSizeInBytes)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseScsrsm2_analysis_rank_0(handle,algo,transA,transB,m,nrhs,nnz,alpha,descrA, &
         csrSortedValA,csrSortedRowPtrA,csrSortedColIndA,B,ldb,myInfo,policy,pBuffer)
       use iso_c_binding
@@ -29313,6 +29442,8 @@ module hipfort_hipsparse
         c_loc(csrSortedColIndA),c_loc(B),ldb,myInfo,policy,pBuffer)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseDcsrsm2_analysis_rank_0(handle,algo,transA,transB,m,nrhs,nnz,alpha,descrA, &
         csrSortedValA,csrSortedRowPtrA,csrSortedColIndA,B,ldb,myInfo,policy,pBuffer)
       use iso_c_binding
@@ -29400,6 +29531,8 @@ module hipfort_hipsparse
         c_loc(csrSortedColIndA),c_loc(B),ldb,myInfo,policy,pBuffer)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseCcsrsm2_analysis_rank_0(handle,algo,transA,transB,m,nrhs,nnz,alpha,descrA, &
         csrSortedValA,csrSortedRowPtrA,csrSortedColIndA,B,ldb,myInfo,policy,pBuffer)
       use iso_c_binding
@@ -29487,6 +29620,8 @@ module hipfort_hipsparse
         c_loc(csrSortedColIndA),c_loc(B),ldb,myInfo,policy,pBuffer)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseZcsrsm2_analysis_rank_0(handle,algo,transA,transB,m,nrhs,nnz,alpha,descrA, &
         csrSortedValA,csrSortedRowPtrA,csrSortedColIndA,B,ldb,myInfo,policy,pBuffer)
       use iso_c_binding
@@ -29574,6 +29709,8 @@ module hipfort_hipsparse
         c_loc(csrSortedColIndA),c_loc(B),ldb,myInfo,policy,pBuffer)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseScsrsm2_solve_rank_0(handle,algo,transA,transB,m,nrhs,nnz,alpha,descrA, &
         csrSortedValA,csrSortedRowPtrA,csrSortedColIndA,B,ldb,myInfo,policy,pBuffer)
       use iso_c_binding
@@ -29661,6 +29798,8 @@ module hipfort_hipsparse
         c_loc(B),ldb,myInfo,policy,pBuffer)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseDcsrsm2_solve_rank_0(handle,algo,transA,transB,m,nrhs,nnz,alpha,descrA, &
         csrSortedValA,csrSortedRowPtrA,csrSortedColIndA,B,ldb,myInfo,policy,pBuffer)
       use iso_c_binding
@@ -29748,6 +29887,8 @@ module hipfort_hipsparse
         c_loc(B),ldb,myInfo,policy,pBuffer)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseCcsrsm2_solve_rank_0(handle,algo,transA,transB,m,nrhs,nnz,alpha,descrA, &
         csrSortedValA,csrSortedRowPtrA,csrSortedColIndA,B,ldb,myInfo,policy,pBuffer)
       use iso_c_binding
@@ -29835,6 +29976,8 @@ module hipfort_hipsparse
         c_loc(B),ldb,myInfo,policy,pBuffer)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseZcsrsm2_solve_rank_0(handle,algo,transA,transB,m,nrhs,nnz,alpha,descrA, &
         csrSortedValA,csrSortedRowPtrA,csrSortedColIndA,B,ldb,myInfo,policy,pBuffer)
       use iso_c_binding
@@ -29922,6 +30065,8 @@ module hipfort_hipsparse
         c_loc(B),ldb,myInfo,policy,pBuffer)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseSgemmi_rank_0(handle,m,n,k,nnz,alpha,A,lda,cscValB,cscColPtrB,cscRowIndB, &
         beta,C,ldc)
       use iso_c_binding
@@ -29997,6 +30142,8 @@ module hipfort_hipsparse
         c_loc(cscValB),c_loc(cscColPtrB),c_loc(cscRowIndB),beta,c_loc(C),ldc)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseDgemmi_rank_0(handle,m,n,k,nnz,alpha,A,lda,cscValB,cscColPtrB,cscRowIndB, &
         beta,C,ldc)
       use iso_c_binding
@@ -30072,6 +30219,8 @@ module hipfort_hipsparse
         c_loc(cscValB),c_loc(cscColPtrB),c_loc(cscRowIndB),beta,c_loc(C),ldc)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseCgemmi_rank_0(handle,m,n,k,nnz,alpha,A,lda,cscValB,cscColPtrB,cscRowIndB, &
         beta,C,ldc)
       use iso_c_binding
@@ -30147,6 +30296,8 @@ module hipfort_hipsparse
         c_loc(cscValB),c_loc(cscColPtrB),c_loc(cscRowIndB),beta,c_loc(C),ldc)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseZgemmi_rank_0(handle,m,n,k,nnz,alpha,A,lda,cscValB,cscColPtrB,cscRowIndB, &
         beta,C,ldc)
       use iso_c_binding
@@ -30222,6 +30373,8 @@ module hipfort_hipsparse
         c_loc(cscValB),c_loc(cscColPtrB),c_loc(cscRowIndB),beta,c_loc(C),ldc)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseXcsrgeamNnz_rank_0(handle,m,n,descrA,nnzA,csrRowPtrA,csrColIndA,descrB,nnzB, &
         csrRowPtrB,csrColIndB,descrC,csrRowPtrC,nnzTotalDevHostPtr)
       use iso_c_binding
@@ -30274,6 +30427,8 @@ module hipfort_hipsparse
         descrC,c_loc(csrRowPtrC),nnzTotalDevHostPtr)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseScsrgeam_rank_0(handle,m,n,alpha,descrA,nnzA,csrValA,csrRowPtrA,csrColIndA, &
         beta,descrB,nnzB,csrValB,csrRowPtrB,csrColIndB,descrC,csrValC,csrRowPtrC,csrColIndC)
       use iso_c_binding
@@ -30336,6 +30491,8 @@ module hipfort_hipsparse
         c_loc(csrColIndB),descrC,c_loc(csrValC),c_loc(csrRowPtrC),c_loc(csrColIndC))
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseDcsrgeam_rank_0(handle,m,n,alpha,descrA,nnzA,csrValA,csrRowPtrA,csrColIndA, &
         beta,descrB,nnzB,csrValB,csrRowPtrB,csrColIndB,descrC,csrValC,csrRowPtrC,csrColIndC)
       use iso_c_binding
@@ -30398,6 +30555,8 @@ module hipfort_hipsparse
         c_loc(csrColIndB),descrC,c_loc(csrValC),c_loc(csrRowPtrC),c_loc(csrColIndC))
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseCcsrgeam_rank_0(handle,m,n,alpha,descrA,nnzA,csrValA,csrRowPtrA,csrColIndA, &
         beta,descrB,nnzB,csrValB,csrRowPtrB,csrColIndB,descrC,csrValC,csrRowPtrC,csrColIndC)
       use iso_c_binding
@@ -30460,6 +30619,8 @@ module hipfort_hipsparse
         c_loc(csrColIndB),descrC,c_loc(csrValC),c_loc(csrRowPtrC),c_loc(csrColIndC))
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseZcsrgeam_rank_0(handle,m,n,alpha,descrA,nnzA,csrValA,csrRowPtrA,csrColIndA, &
         beta,descrB,nnzB,csrValB,csrRowPtrB,csrColIndB,descrC,csrValC,csrRowPtrC,csrColIndC)
       use iso_c_binding
@@ -30522,6 +30683,7 @@ module hipfort_hipsparse
         c_loc(csrColIndB),descrC,c_loc(csrValC),c_loc(csrRowPtrC),c_loc(csrColIndC))
     end function
 
+#endif
     function hipsparseScsrgeam2_bufferSizeExt_rank_0(handle,m,n,alpha,descrA,nnzA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,beta,descrB,nnzB,csrSortedValB,csrSortedRowPtrB, &
         csrSortedColIndB,descrC,csrSortedValC,csrSortedRowPtrC,csrSortedColIndC,pBufferSizeInBytes)
@@ -31130,6 +31292,7 @@ module hipfort_hipsparse
         c_loc(csrSortedValC),c_loc(csrSortedRowPtrC),c_loc(csrSortedColIndC),pBuffer)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipsparseXcsrgemmNnz_rank_0(handle,transA,transB,m,n,k,descrA,nnzA,csrRowPtrA, &
         csrColIndA,descrB,nnzB,csrRowPtrB,csrColIndB,descrC,csrRowPtrC,nnzTotalDevHostPtr)
       use iso_c_binding
@@ -31188,6 +31351,8 @@ module hipfort_hipsparse
         descrC,c_loc(csrRowPtrC),nnzTotalDevHostPtr)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseScsrgemm_rank_0(handle,transA,transB,m,n,k,descrA,nnzA,csrValA,csrRowPtrA, &
         csrColIndA,descrB,nnzB,csrValB,csrRowPtrB,csrColIndB,descrC,csrValC,csrRowPtrC,csrColIndC)
       use iso_c_binding
@@ -31254,6 +31419,8 @@ module hipfort_hipsparse
         c_loc(csrColIndC))
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseDcsrgemm_rank_0(handle,transA,transB,m,n,k,descrA,nnzA,csrValA,csrRowPtrA, &
         csrColIndA,descrB,nnzB,csrValB,csrRowPtrB,csrColIndB,descrC,csrValC,csrRowPtrC,csrColIndC)
       use iso_c_binding
@@ -31320,6 +31487,8 @@ module hipfort_hipsparse
         c_loc(csrColIndC))
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseCcsrgemm_rank_0(handle,transA,transB,m,n,k,descrA,nnzA,csrValA,csrRowPtrA, &
         csrColIndA,descrB,nnzB,csrValB,csrRowPtrB,csrColIndB,descrC,csrValC,csrRowPtrC,csrColIndC)
       use iso_c_binding
@@ -31386,6 +31555,8 @@ module hipfort_hipsparse
         c_loc(csrColIndC))
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseZcsrgemm_rank_0(handle,transA,transB,m,n,k,descrA,nnzA,csrValA,csrRowPtrA, &
         csrColIndA,descrB,nnzB,csrValB,csrRowPtrB,csrColIndB,descrC,csrValC,csrRowPtrC,csrColIndC)
       use iso_c_binding
@@ -31452,6 +31623,8 @@ module hipfort_hipsparse
         c_loc(csrColIndC))
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseScsrgemm2_bufferSizeExt_rank_0(handle,m,n,k,alpha,descrA,nnzA,csrRowPtrA, &
         csrColIndA,descrB,nnzB,csrRowPtrB,csrColIndB,beta,descrD,nnzD,csrRowPtrD,csrColIndD, &
         myInfo,pBufferSizeInBytes)
@@ -31520,6 +31693,8 @@ module hipfort_hipsparse
         pBufferSizeInBytes)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseDcsrgemm2_bufferSizeExt_rank_0(handle,m,n,k,alpha,descrA,nnzA,csrRowPtrA, &
         csrColIndA,descrB,nnzB,csrRowPtrB,csrColIndB,beta,descrD,nnzD,csrRowPtrD,csrColIndD, &
         myInfo,pBufferSizeInBytes)
@@ -31588,6 +31763,8 @@ module hipfort_hipsparse
         pBufferSizeInBytes)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseCcsrgemm2_bufferSizeExt_rank_0(handle,m,n,k,alpha,descrA,nnzA,csrRowPtrA, &
         csrColIndA,descrB,nnzB,csrRowPtrB,csrColIndB,beta,descrD,nnzD,csrRowPtrD,csrColIndD, &
         myInfo,pBufferSizeInBytes)
@@ -31656,6 +31833,8 @@ module hipfort_hipsparse
         pBufferSizeInBytes)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseZcsrgemm2_bufferSizeExt_rank_0(handle,m,n,k,alpha,descrA,nnzA,csrRowPtrA, &
         csrColIndA,descrB,nnzB,csrRowPtrB,csrColIndB,beta,descrD,nnzD,csrRowPtrD,csrColIndD, &
         myInfo,pBufferSizeInBytes)
@@ -31724,6 +31903,8 @@ module hipfort_hipsparse
         pBufferSizeInBytes)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseXcsrgemm2Nnz_rank_0(handle,m,n,k,descrA,nnzA,csrRowPtrA,csrColIndA,descrB, &
         nnzB,csrRowPtrB,csrColIndB,descrD,nnzD,csrRowPtrD,csrColIndD,descrC,csrRowPtrC, &
         nnzTotalDevHostPtr,myInfo,pBuffer)
@@ -31794,6 +31975,8 @@ module hipfort_hipsparse
         nnzTotalDevHostPtr,myInfo,pBuffer)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseScsrgemm2_rank_0(handle,m,n,k,alpha,descrA,nnzA,csrValA,csrRowPtrA, &
         csrColIndA,descrB,nnzB,csrValB,csrRowPtrB,csrColIndB,beta,descrD,nnzD,csrValD,csrRowPtrD, &
         csrColIndD,descrC,csrValC,csrRowPtrC,csrColIndC,myInfo,pBuffer)
@@ -31876,6 +32059,8 @@ module hipfort_hipsparse
         c_loc(csrColIndD),descrC,c_loc(csrValC),c_loc(csrRowPtrC),c_loc(csrColIndC),myInfo,pBuffer)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseDcsrgemm2_rank_0(handle,m,n,k,alpha,descrA,nnzA,csrValA,csrRowPtrA, &
         csrColIndA,descrB,nnzB,csrValB,csrRowPtrB,csrColIndB,beta,descrD,nnzD,csrValD,csrRowPtrD, &
         csrColIndD,descrC,csrValC,csrRowPtrC,csrColIndC,myInfo,pBuffer)
@@ -31958,6 +32143,8 @@ module hipfort_hipsparse
         c_loc(csrColIndD),descrC,c_loc(csrValC),c_loc(csrRowPtrC),c_loc(csrColIndC),myInfo,pBuffer)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseCcsrgemm2_rank_0(handle,m,n,k,alpha,descrA,nnzA,csrValA,csrRowPtrA, &
         csrColIndA,descrB,nnzB,csrValB,csrRowPtrB,csrColIndB,beta,descrD,nnzD,csrValD,csrRowPtrD, &
         csrColIndD,descrC,csrValC,csrRowPtrC,csrColIndC,myInfo,pBuffer)
@@ -32040,6 +32227,8 @@ module hipfort_hipsparse
         c_loc(csrColIndD),descrC,c_loc(csrValC),c_loc(csrRowPtrC),c_loc(csrColIndC),myInfo,pBuffer)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseZcsrgemm2_rank_0(handle,m,n,k,alpha,descrA,nnzA,csrValA,csrRowPtrA, &
         csrColIndA,descrB,nnzB,csrValB,csrRowPtrB,csrColIndB,beta,descrD,nnzD,csrValD,csrRowPtrD, &
         csrColIndD,descrC,csrValC,csrRowPtrC,csrColIndC,myInfo,pBuffer)
@@ -32122,6 +32311,7 @@ module hipfort_hipsparse
         c_loc(csrColIndD),descrC,c_loc(csrValC),c_loc(csrRowPtrC),c_loc(csrColIndC),myInfo,pBuffer)
     end function
 
+#endif
     function hipsparseSbsric02_bufferSize_rank_0(handle,dirA,mb,nnzb,descrA,bsrValA,bsrRowPtrA, &
         bsrColIndA,blockDim,myInfo,pBufferSizeInBytes)
       use iso_c_binding
@@ -33410,6 +33600,7 @@ module hipfort_hipsparse
         pBufferSizeInBytes)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipsparseScsric02_bufferSizeExt_rank_0(handle,m,nnz,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,pBufferSizeInBytes)
       use iso_c_binding
@@ -33452,6 +33643,8 @@ module hipfort_hipsparse
         pBufferSizeInBytes)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseDcsric02_bufferSizeExt_rank_0(handle,m,nnz,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,pBufferSizeInBytes)
       use iso_c_binding
@@ -33494,6 +33687,8 @@ module hipfort_hipsparse
         pBufferSizeInBytes)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseCcsric02_bufferSizeExt_rank_0(handle,m,nnz,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,pBufferSizeInBytes)
       use iso_c_binding
@@ -33536,6 +33731,8 @@ module hipfort_hipsparse
         pBufferSizeInBytes)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseZcsric02_bufferSizeExt_rank_0(handle,m,nnz,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,pBufferSizeInBytes)
       use iso_c_binding
@@ -33578,6 +33775,7 @@ module hipfort_hipsparse
         pBufferSizeInBytes)
     end function
 
+#endif
     function hipsparseScsric02_analysis_rank_0(handle,m,nnz,descrA,csrSortedValA,csrSortedRowPtrA, &
         csrSortedColIndA,myInfo,policy,pBuffer)
       use iso_c_binding
@@ -34082,6 +34280,7 @@ module hipfort_hipsparse
         pBufferSizeInBytes)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipsparseScsrilu02_bufferSizeExt_rank_0(handle,m,nnz,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,pBufferSizeInBytes)
       use iso_c_binding
@@ -34124,6 +34323,8 @@ module hipfort_hipsparse
         pBufferSizeInBytes)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseDcsrilu02_bufferSizeExt_rank_0(handle,m,nnz,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,pBufferSizeInBytes)
       use iso_c_binding
@@ -34166,6 +34367,8 @@ module hipfort_hipsparse
         pBufferSizeInBytes)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseCcsrilu02_bufferSizeExt_rank_0(handle,m,nnz,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,pBufferSizeInBytes)
       use iso_c_binding
@@ -34208,6 +34411,8 @@ module hipfort_hipsparse
         pBufferSizeInBytes)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseZcsrilu02_bufferSizeExt_rank_0(handle,m,nnz,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,pBufferSizeInBytes)
       use iso_c_binding
@@ -34250,6 +34455,7 @@ module hipfort_hipsparse
         pBufferSizeInBytes)
     end function
 
+#endif
     function hipsparseScsrilu02_analysis_rank_0(handle,m,nnz,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,policy,pBuffer)
       use iso_c_binding
@@ -36544,6 +36750,7 @@ module hipfort_hipsparse
         c_loc(p))
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipsparseScsc2dense_rank_0(handle,m,n,descr,cscVal,cscRowInd,cscColPtr,A,ld)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -36601,6 +36808,8 @@ module hipfort_hipsparse
         c_loc(cscRowInd),c_loc(cscColPtr),c_loc(A),ld)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseDcsc2dense_rank_0(handle,m,n,descr,cscVal,cscRowInd,cscColPtr,A,ld)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -36658,6 +36867,8 @@ module hipfort_hipsparse
         c_loc(cscRowInd),c_loc(cscColPtr),c_loc(A),ld)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseCcsc2dense_rank_0(handle,m,n,descr,cscVal,cscRowInd,cscColPtr,A,ld)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -36715,6 +36926,8 @@ module hipfort_hipsparse
         c_loc(cscRowInd),c_loc(cscColPtr),c_loc(A),ld)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseZcsc2dense_rank_0(handle,m,n,descr,cscVal,cscRowInd,cscColPtr,A,ld)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -36772,6 +36985,7 @@ module hipfort_hipsparse
         c_loc(cscRowInd),c_loc(cscColPtr),c_loc(A),ld)
     end function
 
+#endif
     function hipsparseXcscsort_bufferSizeExt_rank_0(handle,m,n,nnz,cscColPtr,cscRowInd, &
         pBufferSizeInBytes)
       use iso_c_binding
@@ -37122,6 +37336,7 @@ module hipfort_hipsparse
         c_loc(cooRowInd),idxBase)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipsparseScsr2csc_rank_0(handle,m,n,nnz,csrSortedVal,csrSortedRowPtr,csrSortedColInd, &
         cscSortedVal,cscSortedRowInd,cscSortedColPtr,copyValues,idxBase)
       use iso_c_binding
@@ -37170,6 +37385,8 @@ module hipfort_hipsparse
         c_loc(cscSortedColPtr),copyValues,idxBase)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseDcsr2csc_rank_0(handle,m,n,nnz,csrSortedVal,csrSortedRowPtr,csrSortedColInd, &
         cscSortedVal,cscSortedRowInd,cscSortedColPtr,copyValues,idxBase)
       use iso_c_binding
@@ -37218,6 +37435,8 @@ module hipfort_hipsparse
         c_loc(cscSortedColPtr),copyValues,idxBase)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseCcsr2csc_rank_0(handle,m,n,nnz,csrSortedVal,csrSortedRowPtr,csrSortedColInd, &
         cscSortedVal,cscSortedRowInd,cscSortedColPtr,copyValues,idxBase)
       use iso_c_binding
@@ -37266,6 +37485,8 @@ module hipfort_hipsparse
         c_loc(cscSortedColPtr),copyValues,idxBase)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseZcsr2csc_rank_0(handle,m,n,nnz,csrSortedVal,csrSortedRowPtr,csrSortedColInd, &
         cscSortedVal,cscSortedRowInd,cscSortedColPtr,copyValues,idxBase)
       use iso_c_binding
@@ -37314,6 +37535,7 @@ module hipfort_hipsparse
         c_loc(cscSortedColPtr),copyValues,idxBase)
     end function
 
+#endif
     function hipsparseScsr2csr_compress_rank_0(handle,m,n,descrA,csrValA,csrColIndA,csrRowPtrA, &
         nnzA,nnzPerRow,csrValC,csrColIndC,csrRowPtrC,tol)
       use iso_c_binding
@@ -37682,6 +37904,7 @@ module hipfort_hipsparse
         c_loc(csrRowPtr),c_loc(csrColInd),myInfo,pBuffer)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipsparseScsr2dense_rank_0(handle,m,n,descr,csrVal,csrRowPtr,csrColInd,A,ld)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -37739,6 +37962,8 @@ module hipfort_hipsparse
         c_loc(csrRowPtr),c_loc(csrColInd),c_loc(A),ld)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseDcsr2dense_rank_0(handle,m,n,descr,csrVal,csrRowPtr,csrColInd,A,ld)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -37796,6 +38021,8 @@ module hipfort_hipsparse
         c_loc(csrRowPtr),c_loc(csrColInd),c_loc(A),ld)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseCcsr2dense_rank_0(handle,m,n,descr,csrVal,csrRowPtr,csrColInd,A,ld)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -37853,6 +38080,8 @@ module hipfort_hipsparse
         c_loc(csrRowPtr),c_loc(csrColInd),c_loc(A),ld)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseZcsr2dense_rank_0(handle,m,n,descr,csrVal,csrRowPtr,csrColInd,A,ld)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -37910,6 +38139,7 @@ module hipfort_hipsparse
         c_loc(csrRowPtr),c_loc(csrColInd),c_loc(A),ld)
     end function
 
+#endif
     function hipsparseScsr2gebsr_bufferSize_rank_0(handle,dir,m,n,csr_descr,csrVal,csrRowPtr, &
         csrColInd,rowBlockDim,colBlockDim,pBufferSizeInBytes)
       use iso_c_binding
@@ -38360,6 +38590,7 @@ module hipfort_hipsparse
         c_loc(bsrColInd),rowBlockDim,colBlockDim,pbuffer)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipsparseScsr2hyb_rank_0(handle,m,n,descrA,csrSortedValA,csrSortedRowPtrA, &
         csrSortedColIndA,hybA,userEllWidth,partitionType)
       use iso_c_binding
@@ -38402,6 +38633,8 @@ module hipfort_hipsparse
         c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),hybA,userEllWidth,partitionType)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseDcsr2hyb_rank_0(handle,m,n,descrA,csrSortedValA,csrSortedRowPtrA, &
         csrSortedColIndA,hybA,userEllWidth,partitionType)
       use iso_c_binding
@@ -38444,6 +38677,8 @@ module hipfort_hipsparse
         c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),hybA,userEllWidth,partitionType)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseCcsr2hyb_rank_0(handle,m,n,descrA,csrSortedValA,csrSortedRowPtrA, &
         csrSortedColIndA,hybA,userEllWidth,partitionType)
       use iso_c_binding
@@ -38486,6 +38721,8 @@ module hipfort_hipsparse
         c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),hybA,userEllWidth,partitionType)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseZcsr2hyb_rank_0(handle,m,n,descrA,csrSortedValA,csrSortedRowPtrA, &
         csrSortedColIndA,hybA,userEllWidth,partitionType)
       use iso_c_binding
@@ -38528,6 +38765,7 @@ module hipfort_hipsparse
         c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),hybA,userEllWidth,partitionType)
     end function
 
+#endif
     function hipsparseXcsrsort_bufferSizeExt_rank_0(handle,m,n,nnz,csrRowPtr,csrColInd, &
         pBufferSizeInBytes)
       use iso_c_binding
@@ -38930,6 +39168,7 @@ module hipfort_hipsparse
         c_loc(csrRowPtr),c_loc(csrColInd),myInfo,pBuffer)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipsparseSdense2csc_rank_0(handle,m,n,descr,A,ld,nnzPerColumn,cscVal,cscRowInd, &
         cscColPtr)
       use iso_c_binding
@@ -38993,6 +39232,8 @@ module hipfort_hipsparse
         c_loc(nnzPerColumn),c_loc(cscVal),c_loc(cscRowInd),c_loc(cscColPtr))
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseDdense2csc_rank_0(handle,m,n,descr,A,ld,nnzPerColumn,cscVal,cscRowInd, &
         cscColPtr)
       use iso_c_binding
@@ -39056,6 +39297,8 @@ module hipfort_hipsparse
         c_loc(nnzPerColumn),c_loc(cscVal),c_loc(cscRowInd),c_loc(cscColPtr))
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseCdense2csc_rank_0(handle,m,n,descr,A,ld,nnzPerColumn,cscVal,cscRowInd, &
         cscColPtr)
       use iso_c_binding
@@ -39119,6 +39362,8 @@ module hipfort_hipsparse
         c_loc(nnzPerColumn),c_loc(cscVal),c_loc(cscRowInd),c_loc(cscColPtr))
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseZdense2csc_rank_0(handle,m,n,descr,A,ld,nnzPerColumn,cscVal,cscRowInd, &
         cscColPtr)
       use iso_c_binding
@@ -39182,6 +39427,8 @@ module hipfort_hipsparse
         c_loc(nnzPerColumn),c_loc(cscVal),c_loc(cscRowInd),c_loc(cscColPtr))
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseSdense2csr_rank_0(handle,m,n,descr,A,ld,nnzPerRow,csrVal,csrRowPtr,csrColInd)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -39243,6 +39490,8 @@ module hipfort_hipsparse
         c_loc(nnzPerRow),c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd))
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseDdense2csr_rank_0(handle,m,n,descr,A,ld,nnzPerRow,csrVal,csrRowPtr,csrColInd)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -39304,6 +39553,8 @@ module hipfort_hipsparse
         c_loc(nnzPerRow),c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd))
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseCdense2csr_rank_0(handle,m,n,descr,A,ld,nnzPerRow,csrVal,csrRowPtr,csrColInd)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -39365,6 +39616,8 @@ module hipfort_hipsparse
         c_loc(nnzPerRow),c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd))
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseZdense2csr_rank_0(handle,m,n,descr,A,ld,nnzPerRow,csrVal,csrRowPtr,csrColInd)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -39426,6 +39679,7 @@ module hipfort_hipsparse
         c_loc(nnzPerRow),c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd))
     end function
 
+#endif
     function hipsparseSgebsr2csr_rank_0(handle,dirA,mb,nb,descrA,bsrValA,bsrRowPtrA,bsrColIndA, &
         rowBlockDim,colBlockDim,descrC,csrValC,csrRowPtrC,csrColIndC)
       use iso_c_binding
@@ -40156,6 +40410,7 @@ module hipfort_hipsparse
         c_loc(bsrValC),c_loc(bsrRowPtrC),c_loc(bsrColIndC),rowBlockDimC,colBlockDimC,buffer)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipsparseShyb2csr_rank_0(handle,descrA,hybA,csrSortedValA,csrSortedRowPtrA, &
         csrSortedColIndA)
       use iso_c_binding
@@ -40190,6 +40445,8 @@ module hipfort_hipsparse
         c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA))
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseDhyb2csr_rank_0(handle,descrA,hybA,csrSortedValA,csrSortedRowPtrA, &
         csrSortedColIndA)
       use iso_c_binding
@@ -40224,6 +40481,8 @@ module hipfort_hipsparse
         c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA))
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseChyb2csr_rank_0(handle,descrA,hybA,csrSortedValA,csrSortedRowPtrA, &
         csrSortedColIndA)
       use iso_c_binding
@@ -40258,6 +40517,8 @@ module hipfort_hipsparse
         c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA))
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseZhyb2csr_rank_0(handle,descrA,hybA,csrSortedValA,csrSortedRowPtrA, &
         csrSortedColIndA)
       use iso_c_binding
@@ -40292,6 +40553,7 @@ module hipfort_hipsparse
         c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA))
     end function
 
+#endif
     function hipsparseSnnz_rank_0(handle,dirA,m,n,descrA,A,lda,nnzPerRowColumn,nnzTotalDevHostPtr)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -40668,6 +40930,7 @@ module hipfort_hipsparse
         c_loc(csrRowPtrA),c_loc(nnzPerRow),c_loc(nnzC),tol)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipsparseSpruneCsr2csr_bufferSize_rank_0(handle,m,n,nnzA,descrA,csrValA,csrRowPtrA, &
         csrColIndA,threshold,descrC,csrValC,csrRowPtrC,csrColIndC,pBufferSizeInBytes)
       use iso_c_binding
@@ -40720,6 +40983,8 @@ module hipfort_hipsparse
         c_loc(csrValC),c_loc(csrRowPtrC),c_loc(csrColIndC),pBufferSizeInBytes)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseDpruneCsr2csr_bufferSize_rank_0(handle,m,n,nnzA,descrA,csrValA,csrRowPtrA, &
         csrColIndA,threshold,descrC,csrValC,csrRowPtrC,csrColIndC,pBufferSizeInBytes)
       use iso_c_binding
@@ -40772,6 +41037,7 @@ module hipfort_hipsparse
         c_loc(csrValC),c_loc(csrRowPtrC),c_loc(csrColIndC),pBufferSizeInBytes)
     end function
 
+#endif
     function hipsparseSpruneCsr2csr_bufferSizeExt_rank_0(handle,m,n,nnzA,descrA,csrValA, &
         csrRowPtrA,csrColIndA,threshold,descrC,csrValC,csrRowPtrC,csrColIndC,pBufferSizeInBytes)
       use iso_c_binding
@@ -41080,6 +41346,7 @@ module hipfort_hipsparse
         c_loc(csrRowPtrC),c_loc(csrColIndC),buffer)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipsparseSpruneCsr2csrByPercentage_bufferSize_rank_0(handle,m,n,nnzA,descrA,csrValA, &
         csrRowPtrA,csrColIndA,percentage,descrC,csrValC,csrRowPtrC,csrColIndC,myInfo, &
         pBufferSizeInBytes)
@@ -41138,6 +41405,8 @@ module hipfort_hipsparse
         c_loc(csrColIndC),myInfo,pBufferSizeInBytes)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseDpruneCsr2csrByPercentage_bufferSize_rank_0(handle,m,n,nnzA,descrA,csrValA, &
         csrRowPtrA,csrColIndA,percentage,descrC,csrValC,csrRowPtrC,csrColIndC,myInfo, &
         pBufferSizeInBytes)
@@ -41196,6 +41465,7 @@ module hipfort_hipsparse
         c_loc(csrColIndC),myInfo,pBufferSizeInBytes)
     end function
 
+#endif
     function hipsparseSpruneCsr2csrByPercentage_bufferSizeExt_rank_0(handle,m,n,nnzA,descrA, &
         csrValA,csrRowPtrA,csrColIndA,percentage,descrC,csrValC,csrRowPtrC,csrColIndC,myInfo, &
         pBufferSizeInBytes)
@@ -41524,6 +41794,7 @@ module hipfort_hipsparse
         c_loc(csrValC),c_loc(csrRowPtrC),c_loc(csrColIndC),myInfo,buffer)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipsparseSpruneDense2csr_bufferSize_rank_0(handle,m,n,A,lda,threshold,descr,csrVal, &
         csrRowPtr,csrColInd,pBufferSizeInBytes)
       use iso_c_binding
@@ -41593,6 +41864,8 @@ module hipfort_hipsparse
         pBufferSizeInBytes)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseDpruneDense2csr_bufferSize_rank_0(handle,m,n,A,lda,threshold,descr,csrVal, &
         csrRowPtr,csrColInd,pBufferSizeInBytes)
       use iso_c_binding
@@ -41662,6 +41935,7 @@ module hipfort_hipsparse
         pBufferSizeInBytes)
     end function
 
+#endif
     function hipsparseSpruneDense2csr_bufferSizeExt_rank_0(handle,m,n,A,lda,threshold,descr, &
         csrVal,csrRowPtr,csrColInd,pBufferSizeInBytes)
       use iso_c_binding
@@ -42058,6 +42332,7 @@ module hipfort_hipsparse
         threshold,descr,c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd),buffer)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipsparseSpruneDense2csrByPercentage_bufferSize_rank_0(handle,m,n,A,lda,percentage, &
         descr,csrVal,csrRowPtr,csrColInd,myInfo,pBufferSizeInBytes)
       use iso_c_binding
@@ -42130,6 +42405,8 @@ module hipfort_hipsparse
         c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd),myInfo,pBufferSizeInBytes)
     end function
 
+#endif
+#ifndef USE_CUDA_NAMES
     function hipsparseDpruneDense2csrByPercentage_bufferSize_rank_0(handle,m,n,A,lda,percentage, &
         descr,csrVal,csrRowPtr,csrColInd,myInfo,pBufferSizeInBytes)
       use iso_c_binding
@@ -42202,6 +42479,7 @@ module hipfort_hipsparse
         c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd),myInfo,pBufferSizeInBytes)
     end function
 
+#endif
     function hipsparseSpruneDense2csrByPercentage_bufferSizeExt_rank_0(handle,m,n,A,lda, &
         percentage,descr,csrVal,csrRowPtr,csrColInd,myInfo,pBufferSizeInBytes)
       use iso_c_binding


### PR DESCRIPTION
Fixes the `hipfort-nvptx` build breakage introduced by #394.

**Cause.** #394 correctly guarded the raw `hip*` interface bodies (and their `module procedure` lists) of functions with no cu* equivalent under `#ifndef USE_CUDA_NAMES`. But their Fortran 2008 wrapper **definitions** (`*_rank_0`, ...) in the `contains` section were still guarded by `#ifdef USE_FPOINTER_INTERFACES` only. On the nvptx build (`USE_CUDA_NAMES` **and** `USE_FPOINTER_INTERFACES`) those wrappers were compiled but called raw bindings that are no longer declared, giving hundreds of `No explicit type declared for 'hipblas...StridedBatched_'`.

**Fix (generator).** `emit_wrappers_body` now wraps a hip-only function's wrapper definitions in `#ifndef USE_CUDA_NAMES` too, matching the guard on its raw specific. Functions that *do* have a cu* equivalent keep their wrappers under `USE_FPOINTER_INTERFACES` only, so the nvptx build still gets the F2008 array interfaces where cuBLAS/cuSPARSE/cuSOLVER provide them.

**Verified.** RELEASE build of **both** `hipfort-amdgcn` and `hipfort-nvptx` succeeds (0 errors). Diff is purely added `#ifndef USE_CUDA_NAMES`/`#endif` guards (3 modules: hipBLAS, hipSOLVER, hipSPARSE).

This makes the CMake workaround (dropping `USE_FPOINTER_INTERFACES` from the nvptx target) unnecessary: nvptx keeps the F2008 interfaces for functions with a CUDA equivalent.