### PR TITLE
Fix rocblas/hipblas/rocsolver *_batched

### DIFF
--- a/lib/hipfort/hipfort_hipblas.F90
+++ b/lib/hipfort/hipfort_hipblas.F90
@@ -839,7 +839,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasIsamaxBatched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batchCount
       type(c_ptr),value :: myResult
@@ -857,7 +857,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasIdamaxBatched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batchCount
       type(c_ptr),value :: myResult
@@ -875,7 +875,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasIcamaxBatched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batchCount
       type(c_ptr),value :: myResult
@@ -893,7 +893,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasIzamaxBatched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batchCount
       type(c_ptr),value :: myResult
@@ -911,7 +911,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasIsamaxBatched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batchCount
       type(c_ptr),value :: myResult
@@ -929,7 +929,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasIdamaxBatched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batchCount
       type(c_ptr),value :: myResult
@@ -947,7 +947,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasIcamaxBatched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batchCount
       type(c_ptr),value :: myResult
@@ -965,7 +965,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasIzamaxBatched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batchCount
       type(c_ptr),value :: myResult
@@ -1390,7 +1390,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasIsaminBatched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batchCount
       type(c_ptr),value :: myResult
@@ -1408,7 +1408,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasIdaminBatched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batchCount
       type(c_ptr),value :: myResult
@@ -1426,7 +1426,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasIcaminBatched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batchCount
       type(c_ptr),value :: myResult
@@ -1444,7 +1444,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasIzaminBatched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batchCount
       type(c_ptr),value :: myResult
@@ -1462,7 +1462,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasIsaminBatched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batchCount
       type(c_ptr),value :: myResult
@@ -1480,7 +1480,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasIdaminBatched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batchCount
       type(c_ptr),value :: myResult
@@ -1498,7 +1498,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasIcaminBatched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batchCount
       type(c_ptr),value :: myResult
@@ -1516,7 +1516,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasIzaminBatched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batchCount
       type(c_ptr),value :: myResult
@@ -1945,7 +1945,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasSasumBatched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batchCount
       type(c_ptr),value :: myResult
@@ -1963,7 +1963,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasDasumBatched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batchCount
       type(c_ptr),value :: myResult
@@ -1981,7 +1981,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasScasumBatched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batchCount
       type(c_ptr),value :: myResult
@@ -1999,7 +1999,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasDzasumBatched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batchCount
       type(c_ptr),value :: myResult
@@ -2017,7 +2017,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasSasumBatched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batchCount
       type(c_ptr),value :: myResult
@@ -2035,7 +2035,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasDasumBatched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batchCount
       type(c_ptr),value :: myResult
@@ -2053,7 +2053,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasScasumBatched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batchCount
       type(c_ptr),value :: myResult
@@ -2071,7 +2071,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasDzasumBatched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batchCount
       type(c_ptr),value :: myResult
@@ -2560,9 +2560,9 @@ module hipfort_hipblas
       type(c_ptr),value :: handle
       integer(c_int),value :: n
       type(c_ptr),value :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batchCount
     end function
@@ -2580,9 +2580,9 @@ module hipfort_hipblas
       type(c_ptr),value :: handle
       integer(c_int),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batchCount
     end function
@@ -2600,9 +2600,9 @@ module hipfort_hipblas
       type(c_ptr),value :: handle
       integer(c_int),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batchCount
     end function
@@ -2620,9 +2620,9 @@ module hipfort_hipblas
       type(c_ptr),value :: handle
       integer(c_int),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batchCount
     end function
@@ -2640,9 +2640,9 @@ module hipfort_hipblas
       type(c_ptr),value :: handle
       integer(c_int),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batchCount
     end function
@@ -2660,9 +2660,9 @@ module hipfort_hipblas
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
       type(c_ptr),value :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batchCount
     end function
@@ -2680,9 +2680,9 @@ module hipfort_hipblas
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batchCount
     end function
@@ -2700,9 +2700,9 @@ module hipfort_hipblas
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batchCount
     end function
@@ -2720,9 +2720,9 @@ module hipfort_hipblas
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batchCount
     end function
@@ -2740,9 +2740,9 @@ module hipfort_hipblas
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batchCount
     end function
@@ -3256,9 +3256,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasScopyBatched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batchCount
     end function
@@ -3275,9 +3275,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasDcopyBatched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batchCount
     end function
@@ -3294,9 +3294,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasCcopyBatched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batchCount
     end function
@@ -3313,9 +3313,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasZcopyBatched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batchCount
     end function
@@ -3332,9 +3332,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasScopyBatched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batchCount
     end function
@@ -3351,9 +3351,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasDcopyBatched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batchCount
     end function
@@ -3370,9 +3370,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasCcopyBatched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batchCount
     end function
@@ -3389,9 +3389,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasZcopyBatched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batchCount
     end function
@@ -4046,9 +4046,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasHdotBatched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batchCount
       type(c_ptr),value :: myResult
@@ -4066,9 +4066,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasBfdotBatched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batchCount
       type(c_ptr),value :: myResult
@@ -4086,9 +4086,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasSdotBatched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batchCount
       type(c_ptr),value :: myResult
@@ -4106,9 +4106,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasDdotBatched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batchCount
       type(c_ptr),value :: myResult
@@ -4126,9 +4126,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasCdotcBatched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batchCount
       type(c_ptr),value :: myResult
@@ -4146,9 +4146,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasCdotuBatched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batchCount
       type(c_ptr),value :: myResult
@@ -4166,9 +4166,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasZdotcBatched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batchCount
       type(c_ptr),value :: myResult
@@ -4186,9 +4186,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasZdotuBatched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batchCount
       type(c_ptr),value :: myResult
@@ -4206,9 +4206,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasHdotBatched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batchCount
       type(c_ptr),value :: myResult
@@ -4226,9 +4226,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasBfdotBatched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batchCount
       type(c_ptr),value :: myResult
@@ -4246,9 +4246,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasSdotBatched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batchCount
       type(c_ptr),value :: myResult
@@ -4266,9 +4266,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasDdotBatched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batchCount
       type(c_ptr),value :: myResult
@@ -4286,9 +4286,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasCdotcBatched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batchCount
       type(c_ptr),value :: myResult
@@ -4306,9 +4306,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasCdotuBatched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batchCount
       type(c_ptr),value :: myResult
@@ -4326,9 +4326,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasZdotcBatched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batchCount
       type(c_ptr),value :: myResult
@@ -4346,9 +4346,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasZdotuBatched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batchCount
       type(c_ptr),value :: myResult
@@ -5022,7 +5022,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasSnrm2Batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batchCount
       type(c_ptr),value :: myResult
@@ -5040,7 +5040,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasDnrm2Batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batchCount
       type(c_ptr),value :: myResult
@@ -5058,7 +5058,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasScnrm2Batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batchCount
       type(c_ptr),value :: myResult
@@ -5076,7 +5076,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasDznrm2Batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batchCount
       type(c_ptr),value :: myResult
@@ -5094,7 +5094,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasSnrm2Batched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batchCount
       type(c_ptr),value :: myResult
@@ -5112,7 +5112,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasDnrm2Batched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batchCount
       type(c_ptr),value :: myResult
@@ -5130,7 +5130,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasScnrm2Batched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batchCount
       type(c_ptr),value :: myResult
@@ -5148,7 +5148,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasDznrm2Batched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batchCount
       type(c_ptr),value :: myResult
@@ -5713,9 +5713,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasSrotBatched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       type(c_ptr),value :: c
       type(c_ptr),value :: s
@@ -5734,9 +5734,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasDrotBatched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       type(c_ptr),value :: c
       type(c_ptr),value :: s
@@ -5755,9 +5755,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasCrotBatched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       type(c_ptr),value :: c
       type(c_ptr),value :: s
@@ -5776,9 +5776,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasCsrotBatched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       type(c_ptr),value :: c
       type(c_ptr),value :: s
@@ -5797,9 +5797,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasZrotBatched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       type(c_ptr),value :: c
       type(c_ptr),value :: s
@@ -5818,9 +5818,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasZdrotBatched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       type(c_ptr),value :: c
       type(c_ptr),value :: s
@@ -5839,9 +5839,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasSrotBatched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       type(c_ptr),value :: c
       type(c_ptr),value :: s
@@ -5860,9 +5860,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasDrotBatched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       type(c_ptr),value :: c
       type(c_ptr),value :: s
@@ -5881,9 +5881,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasCrotBatched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       type(c_ptr),value :: c
       type(c_ptr),value :: s
@@ -5902,9 +5902,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasCsrotBatched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       type(c_ptr),value :: c
       type(c_ptr),value :: s
@@ -5923,9 +5923,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasZrotBatched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       type(c_ptr),value :: c
       type(c_ptr),value :: s
@@ -5944,9 +5944,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasZdrotBatched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       type(c_ptr),value :: c
       type(c_ptr),value :: s
@@ -6494,10 +6494,10 @@ module hipfort_hipblas
       implicit none
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasSrotgBatched_
       type(c_ptr),value :: handle
-      type(c_ptr) :: a
-      type(c_ptr) :: b
-      type(c_ptr) :: c
-      type(c_ptr) :: s
+      type(c_ptr),value :: a
+      type(c_ptr),value :: b
+      type(c_ptr),value :: c
+      type(c_ptr),value :: s
       integer(c_int),value :: batchCount
     end function
   end interface
@@ -6511,10 +6511,10 @@ module hipfort_hipblas
       implicit none
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasDrotgBatched_
       type(c_ptr),value :: handle
-      type(c_ptr) :: a
-      type(c_ptr) :: b
-      type(c_ptr) :: c
-      type(c_ptr) :: s
+      type(c_ptr),value :: a
+      type(c_ptr),value :: b
+      type(c_ptr),value :: c
+      type(c_ptr),value :: s
       integer(c_int),value :: batchCount
     end function
   end interface
@@ -6528,10 +6528,10 @@ module hipfort_hipblas
       implicit none
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasCrotgBatched_
       type(c_ptr),value :: handle
-      type(c_ptr) :: a
-      type(c_ptr) :: b
-      type(c_ptr) :: c
-      type(c_ptr) :: s
+      type(c_ptr),value :: a
+      type(c_ptr),value :: b
+      type(c_ptr),value :: c
+      type(c_ptr),value :: s
       integer(c_int),value :: batchCount
     end function
   end interface
@@ -6545,10 +6545,10 @@ module hipfort_hipblas
       implicit none
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasZrotgBatched_
       type(c_ptr),value :: handle
-      type(c_ptr) :: a
-      type(c_ptr) :: b
-      type(c_ptr) :: c
-      type(c_ptr) :: s
+      type(c_ptr),value :: a
+      type(c_ptr),value :: b
+      type(c_ptr),value :: c
+      type(c_ptr),value :: s
       integer(c_int),value :: batchCount
     end function
   end interface
@@ -6563,10 +6563,10 @@ module hipfort_hipblas
       implicit none
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasSrotgBatched_64_
       type(c_ptr),value :: handle
-      type(c_ptr) :: a
-      type(c_ptr) :: b
-      type(c_ptr) :: c
-      type(c_ptr) :: s
+      type(c_ptr),value :: a
+      type(c_ptr),value :: b
+      type(c_ptr),value :: c
+      type(c_ptr),value :: s
       integer(c_int64_t),value :: batchCount
     end function
   end interface
@@ -6581,10 +6581,10 @@ module hipfort_hipblas
       implicit none
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasDrotgBatched_64_
       type(c_ptr),value :: handle
-      type(c_ptr) :: a
-      type(c_ptr) :: b
-      type(c_ptr) :: c
-      type(c_ptr) :: s
+      type(c_ptr),value :: a
+      type(c_ptr),value :: b
+      type(c_ptr),value :: c
+      type(c_ptr),value :: s
       integer(c_int64_t),value :: batchCount
     end function
   end interface
@@ -6599,10 +6599,10 @@ module hipfort_hipblas
       implicit none
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasCrotgBatched_64_
       type(c_ptr),value :: handle
-      type(c_ptr) :: a
-      type(c_ptr) :: b
-      type(c_ptr) :: c
-      type(c_ptr) :: s
+      type(c_ptr),value :: a
+      type(c_ptr),value :: b
+      type(c_ptr),value :: c
+      type(c_ptr),value :: s
       integer(c_int64_t),value :: batchCount
     end function
   end interface
@@ -6617,10 +6617,10 @@ module hipfort_hipblas
       implicit none
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasZrotgBatched_64_
       type(c_ptr),value :: handle
-      type(c_ptr) :: a
-      type(c_ptr) :: b
-      type(c_ptr) :: c
-      type(c_ptr) :: s
+      type(c_ptr),value :: a
+      type(c_ptr),value :: b
+      type(c_ptr),value :: c
+      type(c_ptr),value :: s
       integer(c_int64_t),value :: batchCount
     end function
   end interface
@@ -7012,11 +7012,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasSrotmBatched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
-      type(c_ptr) :: param
+      type(c_ptr),value :: param
       integer(c_int),value :: batchCount
     end function
   end interface
@@ -7032,11 +7032,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasDrotmBatched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
-      type(c_ptr) :: param
+      type(c_ptr),value :: param
       integer(c_int),value :: batchCount
     end function
   end interface
@@ -7052,11 +7052,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasSrotmBatched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
-      type(c_ptr) :: param
+      type(c_ptr),value :: param
       integer(c_int64_t),value :: batchCount
     end function
   end interface
@@ -7072,11 +7072,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasDrotmBatched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
-      type(c_ptr) :: param
+      type(c_ptr),value :: param
       integer(c_int64_t),value :: batchCount
     end function
   end interface
@@ -7387,11 +7387,11 @@ module hipfort_hipblas
       implicit none
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasSrotmgBatched_
       type(c_ptr),value :: handle
-      type(c_ptr) :: d1
-      type(c_ptr) :: d2
-      type(c_ptr) :: x1
-      type(c_ptr) :: y1
-      type(c_ptr) :: param
+      type(c_ptr),value :: d1
+      type(c_ptr),value :: d2
+      type(c_ptr),value :: x1
+      type(c_ptr),value :: y1
+      type(c_ptr),value :: param
       integer(c_int),value :: batchCount
     end function
   end interface
@@ -7406,11 +7406,11 @@ module hipfort_hipblas
       implicit none
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasDrotmgBatched_
       type(c_ptr),value :: handle
-      type(c_ptr) :: d1
-      type(c_ptr) :: d2
-      type(c_ptr) :: x1
-      type(c_ptr) :: y1
-      type(c_ptr) :: param
+      type(c_ptr),value :: d1
+      type(c_ptr),value :: d2
+      type(c_ptr),value :: x1
+      type(c_ptr),value :: y1
+      type(c_ptr),value :: param
       integer(c_int),value :: batchCount
     end function
   end interface
@@ -7425,11 +7425,11 @@ module hipfort_hipblas
       implicit none
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasSrotmgBatched_64_
       type(c_ptr),value :: handle
-      type(c_ptr) :: d1
-      type(c_ptr) :: d2
-      type(c_ptr) :: x1
-      type(c_ptr) :: y1
-      type(c_ptr) :: param
+      type(c_ptr),value :: d1
+      type(c_ptr),value :: d2
+      type(c_ptr),value :: x1
+      type(c_ptr),value :: y1
+      type(c_ptr),value :: param
       integer(c_int64_t),value :: batchCount
     end function
   end interface
@@ -7444,11 +7444,11 @@ module hipfort_hipblas
       implicit none
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasDrotmgBatched_64_
       type(c_ptr),value :: handle
-      type(c_ptr) :: d1
-      type(c_ptr) :: d2
-      type(c_ptr) :: x1
-      type(c_ptr) :: y1
-      type(c_ptr) :: param
+      type(c_ptr),value :: d1
+      type(c_ptr),value :: d2
+      type(c_ptr),value :: x1
+      type(c_ptr),value :: y1
+      type(c_ptr),value :: param
       integer(c_int64_t),value :: batchCount
     end function
   end interface
@@ -7908,7 +7908,7 @@ module hipfort_hipblas
       type(c_ptr),value :: handle
       integer(c_int),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batchCount
     end function
@@ -7926,7 +7926,7 @@ module hipfort_hipblas
       type(c_ptr),value :: handle
       integer(c_int),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batchCount
     end function
@@ -7944,7 +7944,7 @@ module hipfort_hipblas
       type(c_ptr),value :: handle
       integer(c_int),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batchCount
     end function
@@ -7962,7 +7962,7 @@ module hipfort_hipblas
       type(c_ptr),value :: handle
       integer(c_int),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batchCount
     end function
@@ -7980,7 +7980,7 @@ module hipfort_hipblas
       type(c_ptr),value :: handle
       integer(c_int),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batchCount
     end function
@@ -7998,7 +7998,7 @@ module hipfort_hipblas
       type(c_ptr),value :: handle
       integer(c_int),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batchCount
     end function
@@ -8016,7 +8016,7 @@ module hipfort_hipblas
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batchCount
     end function
@@ -8034,7 +8034,7 @@ module hipfort_hipblas
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batchCount
     end function
@@ -8052,7 +8052,7 @@ module hipfort_hipblas
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batchCount
     end function
@@ -8070,7 +8070,7 @@ module hipfort_hipblas
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batchCount
     end function
@@ -8088,7 +8088,7 @@ module hipfort_hipblas
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batchCount
     end function
@@ -8106,7 +8106,7 @@ module hipfort_hipblas
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batchCount
     end function
@@ -8633,9 +8633,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasSswapBatched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batchCount
     end function
@@ -8652,9 +8652,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasDswapBatched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batchCount
     end function
@@ -8671,9 +8671,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasCswapBatched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batchCount
     end function
@@ -8690,9 +8690,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasZswapBatched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batchCount
     end function
@@ -8709,9 +8709,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasSswapBatched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batchCount
     end function
@@ -8728,9 +8728,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasDswapBatched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batchCount
     end function
@@ -8747,9 +8747,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasCswapBatched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batchCount
     end function
@@ -8766,9 +8766,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasZswapBatched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batchCount
     end function
@@ -9386,12 +9386,12 @@ module hipfort_hipblas
       integer(c_int),value :: kl
       integer(c_int),value :: ku
       real(c_float) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       real(c_float) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batchCount
     end function
@@ -9414,12 +9414,12 @@ module hipfort_hipblas
       integer(c_int),value :: kl
       integer(c_int),value :: ku
       real(c_double) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       real(c_double) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batchCount
     end function
@@ -9442,12 +9442,12 @@ module hipfort_hipblas
       integer(c_int),value :: kl
       integer(c_int),value :: ku
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       complex(c_float_complex) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batchCount
     end function
@@ -9470,12 +9470,12 @@ module hipfort_hipblas
       integer(c_int),value :: kl
       integer(c_int),value :: ku
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       complex(c_double_complex) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batchCount
     end function
@@ -9498,12 +9498,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: kl
       integer(c_int64_t),value :: ku
       real(c_float) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       real(c_float) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batchCount
     end function
@@ -9526,12 +9526,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: kl
       integer(c_int64_t),value :: ku
       real(c_double) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       real(c_double) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batchCount
     end function
@@ -9554,12 +9554,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: kl
       integer(c_int64_t),value :: ku
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       complex(c_float_complex) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batchCount
     end function
@@ -9582,12 +9582,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: kl
       integer(c_int64_t),value :: ku
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       complex(c_double_complex) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batchCount
     end function
@@ -10265,12 +10265,12 @@ module hipfort_hipblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       real(c_float) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batchCount
     end function
@@ -10293,12 +10293,12 @@ module hipfort_hipblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       real(c_double) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batchCount
     end function
@@ -10321,12 +10321,12 @@ module hipfort_hipblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       complex(c_float_complex) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batchCount
     end function
@@ -10349,12 +10349,12 @@ module hipfort_hipblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       complex(c_double_complex) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batchCount
     end function
@@ -10377,12 +10377,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       real(c_float) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batchCount
     end function
@@ -10405,12 +10405,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       real(c_double) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batchCount
     end function
@@ -10433,12 +10433,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       complex(c_float_complex) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batchCount
     end function
@@ -10461,12 +10461,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       complex(c_double_complex) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batchCount
     end function
@@ -11214,11 +11214,11 @@ module hipfort_hipblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
       integer(c_int),value :: batchCount
     end function
@@ -11237,11 +11237,11 @@ module hipfort_hipblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
       integer(c_int),value :: batchCount
     end function
@@ -11260,11 +11260,11 @@ module hipfort_hipblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
       integer(c_int),value :: batchCount
     end function
@@ -11283,11 +11283,11 @@ module hipfort_hipblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
       integer(c_int),value :: batchCount
     end function
@@ -11306,11 +11306,11 @@ module hipfort_hipblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
       integer(c_int),value :: batchCount
     end function
@@ -11329,11 +11329,11 @@ module hipfort_hipblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
       integer(c_int),value :: batchCount
     end function
@@ -11352,11 +11352,11 @@ module hipfort_hipblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
       integer(c_int64_t),value :: batchCount
     end function
@@ -11375,11 +11375,11 @@ module hipfort_hipblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
       integer(c_int64_t),value :: batchCount
     end function
@@ -11398,11 +11398,11 @@ module hipfort_hipblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
       integer(c_int64_t),value :: batchCount
     end function
@@ -11421,11 +11421,11 @@ module hipfort_hipblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
       integer(c_int64_t),value :: batchCount
     end function
@@ -11444,11 +11444,11 @@ module hipfort_hipblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
       integer(c_int64_t),value :: batchCount
     end function
@@ -11467,11 +11467,11 @@ module hipfort_hipblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
       integer(c_int64_t),value :: batchCount
     end function
@@ -12152,12 +12152,12 @@ module hipfort_hipblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       complex(c_float_complex) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batchCount
     end function
@@ -12177,12 +12177,12 @@ module hipfort_hipblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       complex(c_double_complex) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batchCount
     end function
@@ -12202,12 +12202,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       complex(c_float_complex) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batchCount
     end function
@@ -12227,12 +12227,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       complex(c_double_complex) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batchCount
     end function
@@ -12662,12 +12662,12 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       complex(c_float_complex) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batchCount
     end function
@@ -12686,12 +12686,12 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       complex(c_double_complex) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batchCount
     end function
@@ -12710,12 +12710,12 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int64_t),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       complex(c_float_complex) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batchCount
     end function
@@ -12734,12 +12734,12 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int64_t),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       complex(c_double_complex) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batchCount
     end function
@@ -13124,9 +13124,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
       integer(c_int),value :: batchCount
     end function
@@ -13145,9 +13145,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
       integer(c_int),value :: batchCount
     end function
@@ -13166,9 +13166,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int64_t),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
       integer(c_int64_t),value :: batchCount
     end function
@@ -13187,9 +13187,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int64_t),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
       integer(c_int64_t),value :: batchCount
     end function
@@ -13572,11 +13572,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
       integer(c_int),value :: batchCount
     end function
@@ -13595,11 +13595,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
       integer(c_int),value :: batchCount
     end function
@@ -13618,11 +13618,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int64_t),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
       integer(c_int64_t),value :: batchCount
     end function
@@ -13641,11 +13641,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int64_t),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
       integer(c_int64_t),value :: batchCount
     end function
@@ -14077,11 +14077,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: AP
-      type(c_ptr) :: x
+      type(c_ptr),value :: AP
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       complex(c_float_complex) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batchCount
     end function
@@ -14100,11 +14100,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: AP
-      type(c_ptr) :: x
+      type(c_ptr),value :: AP
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       complex(c_double_complex) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batchCount
     end function
@@ -14123,11 +14123,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int64_t),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: AP
-      type(c_ptr) :: x
+      type(c_ptr),value :: AP
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       complex(c_float_complex) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batchCount
     end function
@@ -14146,11 +14146,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int64_t),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: AP
-      type(c_ptr) :: x
+      type(c_ptr),value :: AP
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       complex(c_double_complex) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batchCount
     end function
@@ -14572,9 +14572,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: batchCount
     end function
   end interface
@@ -14592,9 +14592,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: batchCount
     end function
   end interface
@@ -14612,9 +14612,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int64_t),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: batchCount
     end function
   end interface
@@ -14632,9 +14632,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int64_t),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: batchCount
     end function
   end interface
@@ -15048,11 +15048,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: batchCount
     end function
   end interface
@@ -15070,11 +15070,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: batchCount
     end function
   end interface
@@ -15092,11 +15092,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int64_t),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: batchCount
     end function
   end interface
@@ -15114,11 +15114,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int64_t),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: batchCount
     end function
   end interface
@@ -15521,12 +15521,12 @@ module hipfort_hipblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       real(c_float) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       real(c_float) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batchCount
     end function
@@ -15546,12 +15546,12 @@ module hipfort_hipblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       real(c_double) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       real(c_double) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batchCount
     end function
@@ -15571,12 +15571,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       real(c_float) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       real(c_float) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batchCount
     end function
@@ -15596,12 +15596,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       real(c_double) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       real(c_double) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batchCount
     end function
@@ -15977,11 +15977,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: AP
-      type(c_ptr) :: x
+      type(c_ptr),value :: AP
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       real(c_float) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batchCount
     end function
@@ -16000,11 +16000,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: AP
-      type(c_ptr) :: x
+      type(c_ptr),value :: AP
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       real(c_double) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batchCount
     end function
@@ -16023,11 +16023,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int64_t),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: AP
-      type(c_ptr) :: x
+      type(c_ptr),value :: AP
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       real(c_float) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batchCount
     end function
@@ -16046,11 +16046,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int64_t),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: AP
-      type(c_ptr) :: x
+      type(c_ptr),value :: AP
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       real(c_double) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batchCount
     end function
@@ -16531,9 +16531,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: batchCount
     end function
   end interface
@@ -16551,9 +16551,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: batchCount
     end function
   end interface
@@ -16571,9 +16571,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: batchCount
     end function
   end interface
@@ -16591,9 +16591,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: batchCount
     end function
   end interface
@@ -16611,9 +16611,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int64_t),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: batchCount
     end function
   end interface
@@ -16631,9 +16631,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int64_t),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: batchCount
     end function
   end interface
@@ -16651,9 +16651,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int64_t),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: batchCount
     end function
   end interface
@@ -16671,9 +16671,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int64_t),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: batchCount
     end function
   end interface
@@ -17186,11 +17186,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: batchCount
     end function
   end interface
@@ -17208,11 +17208,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: batchCount
     end function
   end interface
@@ -17230,11 +17230,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int64_t),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: batchCount
     end function
   end interface
@@ -17252,11 +17252,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int64_t),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: batchCount
     end function
   end interface
@@ -17768,12 +17768,12 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       real(c_float) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batchCount
     end function
@@ -17792,12 +17792,12 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       real(c_double) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batchCount
     end function
@@ -17816,12 +17816,12 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       complex(c_float_complex) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batchCount
     end function
@@ -17840,12 +17840,12 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       complex(c_double_complex) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batchCount
     end function
@@ -17864,12 +17864,12 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int64_t),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       real(c_float) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batchCount
     end function
@@ -17888,12 +17888,12 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int64_t),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       real(c_double) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batchCount
     end function
@@ -17912,12 +17912,12 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int64_t),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       complex(c_float_complex) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batchCount
     end function
@@ -17936,12 +17936,12 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int64_t),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       complex(c_double_complex) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batchCount
     end function
@@ -18522,9 +18522,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
       integer(c_int),value :: batchCount
     end function
@@ -18543,9 +18543,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
       integer(c_int),value :: batchCount
     end function
@@ -18564,9 +18564,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
       integer(c_int),value :: batchCount
     end function
@@ -18585,9 +18585,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
       integer(c_int),value :: batchCount
     end function
@@ -18606,9 +18606,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int64_t),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
       integer(c_int64_t),value :: batchCount
     end function
@@ -18627,9 +18627,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int64_t),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
       integer(c_int64_t),value :: batchCount
     end function
@@ -18648,9 +18648,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int64_t),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
       integer(c_int64_t),value :: batchCount
     end function
@@ -18669,9 +18669,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int64_t),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
       integer(c_int64_t),value :: batchCount
     end function
@@ -19236,11 +19236,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
       integer(c_int),value :: batchCount
     end function
@@ -19259,11 +19259,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
       integer(c_int),value :: batchCount
     end function
@@ -19282,11 +19282,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
       integer(c_int),value :: batchCount
     end function
@@ -19305,11 +19305,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
       integer(c_int),value :: batchCount
     end function
@@ -19328,11 +19328,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int64_t),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
       integer(c_int64_t),value :: batchCount
     end function
@@ -19351,11 +19351,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int64_t),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
       integer(c_int64_t),value :: batchCount
     end function
@@ -19374,11 +19374,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int64_t),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
       integer(c_int64_t),value :: batchCount
     end function
@@ -19397,11 +19397,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(c_int64_t),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
       integer(c_int64_t),value :: batchCount
     end function
@@ -20062,9 +20062,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_DIAG_NON_UNIT)),value :: diag
       integer(c_int),value :: n
       integer(c_int),value :: k
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batchCount
     end function
@@ -20085,9 +20085,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_DIAG_NON_UNIT)),value :: diag
       integer(c_int),value :: n
       integer(c_int),value :: k
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batchCount
     end function
@@ -20108,9 +20108,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_DIAG_NON_UNIT)),value :: diag
       integer(c_int),value :: n
       integer(c_int),value :: k
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batchCount
     end function
@@ -20131,9 +20131,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_DIAG_NON_UNIT)),value :: diag
       integer(c_int),value :: n
       integer(c_int),value :: k
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batchCount
     end function
@@ -20154,9 +20154,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_DIAG_NON_UNIT)),value :: diag
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batchCount
     end function
@@ -20177,9 +20177,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_DIAG_NON_UNIT)),value :: diag
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batchCount
     end function
@@ -20200,9 +20200,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_DIAG_NON_UNIT)),value :: diag
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batchCount
     end function
@@ -20223,9 +20223,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_DIAG_NON_UNIT)),value :: diag
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batchCount
     end function
@@ -20881,9 +20881,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_DIAG_NON_UNIT)),value :: diag
       integer(c_int),value :: n
       integer(c_int),value :: k
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batchCount
     end function
@@ -20904,9 +20904,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_DIAG_NON_UNIT)),value :: diag
       integer(c_int),value :: n
       integer(c_int),value :: k
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batchCount
     end function
@@ -20927,9 +20927,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_DIAG_NON_UNIT)),value :: diag
       integer(c_int),value :: n
       integer(c_int),value :: k
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batchCount
     end function
@@ -20950,9 +20950,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_DIAG_NON_UNIT)),value :: diag
       integer(c_int),value :: n
       integer(c_int),value :: k
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batchCount
     end function
@@ -20973,9 +20973,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_DIAG_NON_UNIT)),value :: diag
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batchCount
     end function
@@ -20996,9 +20996,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_DIAG_NON_UNIT)),value :: diag
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batchCount
     end function
@@ -21019,9 +21019,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_DIAG_NON_UNIT)),value :: diag
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batchCount
     end function
@@ -21042,9 +21042,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_DIAG_NON_UNIT)),value :: diag
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batchCount
     end function
@@ -21641,8 +21641,8 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)),value :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)),value :: diag
       integer(c_int),value :: n
-      type(c_ptr) :: AP
-      type(c_ptr) :: x
+      type(c_ptr),value :: AP
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batchCount
     end function
@@ -21662,8 +21662,8 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)),value :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)),value :: diag
       integer(c_int),value :: n
-      type(c_ptr) :: AP
-      type(c_ptr) :: x
+      type(c_ptr),value :: AP
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batchCount
     end function
@@ -21683,8 +21683,8 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)),value :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)),value :: diag
       integer(c_int),value :: n
-      type(c_ptr) :: AP
-      type(c_ptr) :: x
+      type(c_ptr),value :: AP
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batchCount
     end function
@@ -21704,8 +21704,8 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)),value :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)),value :: diag
       integer(c_int),value :: n
-      type(c_ptr) :: AP
-      type(c_ptr) :: x
+      type(c_ptr),value :: AP
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batchCount
     end function
@@ -21725,8 +21725,8 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)),value :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)),value :: diag
       integer(c_int64_t),value :: n
-      type(c_ptr) :: AP
-      type(c_ptr) :: x
+      type(c_ptr),value :: AP
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batchCount
     end function
@@ -21746,8 +21746,8 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)),value :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)),value :: diag
       integer(c_int64_t),value :: n
-      type(c_ptr) :: AP
-      type(c_ptr) :: x
+      type(c_ptr),value :: AP
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batchCount
     end function
@@ -21767,8 +21767,8 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)),value :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)),value :: diag
       integer(c_int64_t),value :: n
-      type(c_ptr) :: AP
-      type(c_ptr) :: x
+      type(c_ptr),value :: AP
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batchCount
     end function
@@ -21788,8 +21788,8 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)),value :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)),value :: diag
       integer(c_int64_t),value :: n
-      type(c_ptr) :: AP
-      type(c_ptr) :: x
+      type(c_ptr),value :: AP
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batchCount
     end function
@@ -22357,8 +22357,8 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)),value :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)),value :: diag
       integer(c_int),value :: n
-      type(c_ptr) :: AP
-      type(c_ptr) :: x
+      type(c_ptr),value :: AP
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batchCount
     end function
@@ -22378,8 +22378,8 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)),value :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)),value :: diag
       integer(c_int),value :: n
-      type(c_ptr) :: AP
-      type(c_ptr) :: x
+      type(c_ptr),value :: AP
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batchCount
     end function
@@ -22399,8 +22399,8 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)),value :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)),value :: diag
       integer(c_int),value :: n
-      type(c_ptr) :: AP
-      type(c_ptr) :: x
+      type(c_ptr),value :: AP
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batchCount
     end function
@@ -22420,8 +22420,8 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)),value :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)),value :: diag
       integer(c_int),value :: n
-      type(c_ptr) :: AP
-      type(c_ptr) :: x
+      type(c_ptr),value :: AP
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batchCount
     end function
@@ -22441,8 +22441,8 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)),value :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)),value :: diag
       integer(c_int64_t),value :: n
-      type(c_ptr) :: AP
-      type(c_ptr) :: x
+      type(c_ptr),value :: AP
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batchCount
     end function
@@ -22462,8 +22462,8 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)),value :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)),value :: diag
       integer(c_int64_t),value :: n
-      type(c_ptr) :: AP
-      type(c_ptr) :: x
+      type(c_ptr),value :: AP
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batchCount
     end function
@@ -22483,8 +22483,8 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)),value :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)),value :: diag
       integer(c_int64_t),value :: n
-      type(c_ptr) :: AP
-      type(c_ptr) :: x
+      type(c_ptr),value :: AP
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batchCount
     end function
@@ -22504,8 +22504,8 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)),value :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)),value :: diag
       integer(c_int64_t),value :: n
-      type(c_ptr) :: AP
-      type(c_ptr) :: x
+      type(c_ptr),value :: AP
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batchCount
     end function
@@ -23092,9 +23092,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)),value :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)),value :: diag
       integer(c_int),value :: n
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batchCount
     end function
@@ -23114,9 +23114,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)),value :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)),value :: diag
       integer(c_int),value :: n
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batchCount
     end function
@@ -23136,9 +23136,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)),value :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)),value :: diag
       integer(c_int),value :: n
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batchCount
     end function
@@ -23158,9 +23158,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)),value :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)),value :: diag
       integer(c_int),value :: n
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batchCount
     end function
@@ -23180,9 +23180,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)),value :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)),value :: diag
       integer(c_int64_t),value :: n
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batchCount
     end function
@@ -23202,9 +23202,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)),value :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)),value :: diag
       integer(c_int64_t),value :: n
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batchCount
     end function
@@ -23224,9 +23224,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)),value :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)),value :: diag
       integer(c_int64_t),value :: n
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batchCount
     end function
@@ -23246,9 +23246,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)),value :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)),value :: diag
       integer(c_int64_t),value :: n
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batchCount
     end function
@@ -23847,9 +23847,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)),value :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)),value :: diag
       integer(c_int),value :: n
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batchCount
     end function
@@ -23869,9 +23869,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)),value :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)),value :: diag
       integer(c_int),value :: n
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batchCount
     end function
@@ -23891,9 +23891,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)),value :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)),value :: diag
       integer(c_int),value :: n
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batchCount
     end function
@@ -23913,9 +23913,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)),value :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)),value :: diag
       integer(c_int),value :: n
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batchCount
     end function
@@ -23935,9 +23935,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)),value :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)),value :: diag
       integer(c_int64_t),value :: n
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batchCount
     end function
@@ -23957,9 +23957,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)),value :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)),value :: diag
       integer(c_int64_t),value :: n
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batchCount
     end function
@@ -23979,9 +23979,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)),value :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)),value :: diag
       integer(c_int64_t),value :: n
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batchCount
     end function
@@ -24001,9 +24001,9 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)),value :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)),value :: diag
       integer(c_int64_t),value :: n
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batchCount
     end function
@@ -24720,12 +24720,12 @@ module hipfort_hipblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       type(c_ptr),value :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int),value :: ldb
       type(c_ptr),value :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int),value :: ldc
       integer(c_int),value :: batchCount
     end function
@@ -24752,12 +24752,12 @@ module hipfort_hipblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       real(c_float) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int),value :: ldb
       real(c_float) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int),value :: ldc
       integer(c_int),value :: batchCount
     end function
@@ -24784,12 +24784,12 @@ module hipfort_hipblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       real(c_double) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int),value :: ldb
       real(c_double) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int),value :: ldc
       integer(c_int),value :: batchCount
     end function
@@ -24816,12 +24816,12 @@ module hipfort_hipblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int),value :: ldb
       complex(c_float_complex) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int),value :: ldc
       integer(c_int),value :: batchCount
     end function
@@ -24848,12 +24848,12 @@ module hipfort_hipblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int),value :: ldb
       complex(c_double_complex) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int),value :: ldc
       integer(c_int),value :: batchCount
     end function
@@ -24880,12 +24880,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       type(c_ptr),value :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int64_t),value :: ldb
       type(c_ptr),value :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batchCount
     end function
@@ -24912,12 +24912,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       real(c_float) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int64_t),value :: ldb
       real(c_float) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batchCount
     end function
@@ -24944,12 +24944,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       real(c_double) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int64_t),value :: ldb
       real(c_double) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batchCount
     end function
@@ -24976,12 +24976,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int64_t),value :: ldb
       complex(c_float_complex) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batchCount
     end function
@@ -25008,12 +25008,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int64_t),value :: ldb
       complex(c_double_complex) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batchCount
     end function
@@ -25704,10 +25704,10 @@ module hipfort_hipblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       real(c_float) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
       real(c_float) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int),value :: ldc
       integer(c_int),value :: batchCount
     end function
@@ -25728,10 +25728,10 @@ module hipfort_hipblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       real(c_double) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
       real(c_double) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int),value :: ldc
       integer(c_int),value :: batchCount
     end function
@@ -25752,10 +25752,10 @@ module hipfort_hipblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       real(c_float) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
       real(c_float) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batchCount
     end function
@@ -25776,10 +25776,10 @@ module hipfort_hipblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       real(c_double) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
       real(c_double) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batchCount
     end function
@@ -26260,12 +26260,12 @@ module hipfort_hipblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int),value :: ldb
       real(c_float) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int),value :: ldc
       integer(c_int),value :: batchCount
     end function
@@ -26287,12 +26287,12 @@ module hipfort_hipblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int),value :: ldb
       real(c_double) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int),value :: ldc
       integer(c_int),value :: batchCount
     end function
@@ -26314,12 +26314,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int64_t),value :: ldb
       real(c_float) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batchCount
     end function
@@ -26341,12 +26341,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int64_t),value :: ldb
       real(c_double) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batchCount
     end function
@@ -26847,12 +26847,12 @@ module hipfort_hipblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int),value :: ldb
       real(c_float) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int),value :: ldc
       integer(c_int),value :: batchCount
     end function
@@ -26874,12 +26874,12 @@ module hipfort_hipblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int),value :: ldb
       real(c_double) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int),value :: ldc
       integer(c_int),value :: batchCount
     end function
@@ -26901,12 +26901,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int64_t),value :: ldb
       real(c_float) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batchCount
     end function
@@ -26928,12 +26928,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int64_t),value :: ldb
       real(c_double) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batchCount
     end function
@@ -27546,12 +27546,12 @@ module hipfort_hipblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int),value :: ldb
       real(c_float) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int),value :: ldc
       integer(c_int),value :: batchCount
     end function
@@ -27572,12 +27572,12 @@ module hipfort_hipblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int),value :: ldb
       real(c_double) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int),value :: ldc
       integer(c_int),value :: batchCount
     end function
@@ -27598,12 +27598,12 @@ module hipfort_hipblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int),value :: ldb
       complex(c_float_complex) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int),value :: ldc
       integer(c_int),value :: batchCount
     end function
@@ -27624,12 +27624,12 @@ module hipfort_hipblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int),value :: ldb
       complex(c_double_complex) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int),value :: ldc
       integer(c_int),value :: batchCount
     end function
@@ -27651,12 +27651,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int64_t),value :: ldb
       real(c_float) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batchCount
     end function
@@ -27678,12 +27678,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int64_t),value :: ldb
       real(c_double) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batchCount
     end function
@@ -27705,12 +27705,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int64_t),value :: ldb
       complex(c_float_complex) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batchCount
     end function
@@ -27732,12 +27732,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int64_t),value :: ldb
       complex(c_double_complex) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batchCount
     end function
@@ -28455,10 +28455,10 @@ module hipfort_hipblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       real(c_float) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
       real(c_float) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int),value :: ldc
       integer(c_int),value :: batchCount
     end function
@@ -28479,10 +28479,10 @@ module hipfort_hipblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       real(c_double) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
       real(c_double) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int),value :: ldc
       integer(c_int),value :: batchCount
     end function
@@ -28503,10 +28503,10 @@ module hipfort_hipblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
       complex(c_float_complex) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int),value :: ldc
       integer(c_int),value :: batchCount
     end function
@@ -28527,10 +28527,10 @@ module hipfort_hipblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
       complex(c_double_complex) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int),value :: ldc
       integer(c_int),value :: batchCount
     end function
@@ -28551,10 +28551,10 @@ module hipfort_hipblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       real(c_float) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
       real(c_float) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batchCount
     end function
@@ -28575,10 +28575,10 @@ module hipfort_hipblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       real(c_double) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
       real(c_double) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batchCount
     end function
@@ -28599,10 +28599,10 @@ module hipfort_hipblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
       complex(c_float_complex) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batchCount
     end function
@@ -28623,10 +28623,10 @@ module hipfort_hipblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
       complex(c_double_complex) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batchCount
     end function
@@ -29344,12 +29344,12 @@ module hipfort_hipblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       real(c_float) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int),value :: ldb
       real(c_float) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int),value :: ldc
       integer(c_int),value :: batchCount
     end function
@@ -29371,12 +29371,12 @@ module hipfort_hipblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       real(c_double) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int),value :: ldb
       real(c_double) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int),value :: ldc
       integer(c_int),value :: batchCount
     end function
@@ -29398,12 +29398,12 @@ module hipfort_hipblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int),value :: ldb
       complex(c_float_complex) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int),value :: ldc
       integer(c_int),value :: batchCount
     end function
@@ -29425,12 +29425,12 @@ module hipfort_hipblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int),value :: ldb
       complex(c_double_complex) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int),value :: ldc
       integer(c_int),value :: batchCount
     end function
@@ -29452,12 +29452,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       real(c_float) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int64_t),value :: ldb
       real(c_float) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batchCount
     end function
@@ -29479,12 +29479,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       real(c_double) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int64_t),value :: ldb
       real(c_double) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batchCount
     end function
@@ -29506,12 +29506,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int64_t),value :: ldb
       complex(c_float_complex) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batchCount
     end function
@@ -29533,12 +29533,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int64_t),value :: ldb
       complex(c_double_complex) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batchCount
     end function
@@ -30300,12 +30300,12 @@ module hipfort_hipblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       real(c_float) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int),value :: ldb
       real(c_float) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int),value :: ldc
       integer(c_int),value :: batchCount
     end function
@@ -30327,12 +30327,12 @@ module hipfort_hipblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       real(c_double) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int),value :: ldb
       real(c_double) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int),value :: ldc
       integer(c_int),value :: batchCount
     end function
@@ -30354,12 +30354,12 @@ module hipfort_hipblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int),value :: ldb
       complex(c_float_complex) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int),value :: ldc
       integer(c_int),value :: batchCount
     end function
@@ -30381,12 +30381,12 @@ module hipfort_hipblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int),value :: ldb
       complex(c_double_complex) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int),value :: ldc
       integer(c_int),value :: batchCount
     end function
@@ -30408,12 +30408,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       real(c_float) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int64_t),value :: ldb
       real(c_float) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batchCount
     end function
@@ -30435,12 +30435,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       real(c_double) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int64_t),value :: ldb
       real(c_double) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batchCount
     end function
@@ -30462,12 +30462,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int64_t),value :: ldb
       complex(c_float_complex) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batchCount
     end function
@@ -30489,12 +30489,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int64_t),value :: ldb
       complex(c_double_complex) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batchCount
     end function
@@ -31205,12 +31205,12 @@ module hipfort_hipblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
       real(c_float) :: beta
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int),value :: ldb
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int),value :: ldc
       integer(c_int),value :: batchCount
     end function
@@ -31232,12 +31232,12 @@ module hipfort_hipblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
       real(c_double) :: beta
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int),value :: ldb
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int),value :: ldc
       integer(c_int),value :: batchCount
     end function
@@ -31259,12 +31259,12 @@ module hipfort_hipblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
       complex(c_float_complex) :: beta
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int),value :: ldb
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int),value :: ldc
       integer(c_int),value :: batchCount
     end function
@@ -31286,12 +31286,12 @@ module hipfort_hipblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
       complex(c_double_complex) :: beta
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int),value :: ldb
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int),value :: ldc
       integer(c_int),value :: batchCount
     end function
@@ -31313,12 +31313,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
       real(c_float) :: beta
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int64_t),value :: ldb
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batchCount
     end function
@@ -31340,12 +31340,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
       real(c_double) :: beta
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int64_t),value :: ldb
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batchCount
     end function
@@ -31367,12 +31367,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
       complex(c_float_complex) :: beta
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int64_t),value :: ldb
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batchCount
     end function
@@ -31394,12 +31394,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
       complex(c_double_complex) :: beta
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int64_t),value :: ldb
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batchCount
     end function
@@ -32012,12 +32012,12 @@ module hipfort_hipblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int),value :: ldb
       complex(c_float_complex) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int),value :: ldc
       integer(c_int),value :: batchCount
     end function
@@ -32038,12 +32038,12 @@ module hipfort_hipblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int),value :: ldb
       complex(c_double_complex) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int),value :: ldc
       integer(c_int),value :: batchCount
     end function
@@ -32065,12 +32065,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int64_t),value :: ldb
       complex(c_float_complex) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batchCount
     end function
@@ -32092,12 +32092,12 @@ module hipfort_hipblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int64_t),value :: ldb
       complex(c_double_complex) :: beta
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batchCount
     end function
@@ -32766,11 +32766,11 @@ module hipfort_hipblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       integer(c_int),value :: batchCount
     end function
@@ -32794,11 +32794,11 @@ module hipfort_hipblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       integer(c_int),value :: batchCount
     end function
@@ -32822,11 +32822,11 @@ module hipfort_hipblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       integer(c_int),value :: batchCount
     end function
@@ -32850,11 +32850,11 @@ module hipfort_hipblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       integer(c_int),value :: batchCount
     end function
@@ -32878,11 +32878,11 @@ module hipfort_hipblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batchCount
     end function
@@ -32906,11 +32906,11 @@ module hipfort_hipblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batchCount
     end function
@@ -32934,11 +32934,11 @@ module hipfort_hipblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batchCount
     end function
@@ -32962,11 +32962,11 @@ module hipfort_hipblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batchCount
     end function
@@ -33747,9 +33747,9 @@ module hipfort_hipblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int),value :: ldb
       integer(c_int),value :: batchCount
     end function
@@ -33775,9 +33775,9 @@ module hipfort_hipblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int),value :: ldb
       integer(c_int),value :: batchCount
     end function
@@ -33803,9 +33803,9 @@ module hipfort_hipblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int),value :: ldb
       integer(c_int),value :: batchCount
     end function
@@ -33831,9 +33831,9 @@ module hipfort_hipblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int),value :: ldb
       integer(c_int),value :: batchCount
     end function
@@ -33861,9 +33861,9 @@ module hipfort_hipblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int64_t),value :: ldb
       integer(c_int64_t),value :: batchCount
     end function
@@ -33891,9 +33891,9 @@ module hipfort_hipblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int64_t),value :: ldb
       integer(c_int64_t),value :: batchCount
     end function
@@ -33921,9 +33921,9 @@ module hipfort_hipblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int64_t),value :: ldb
       integer(c_int64_t),value :: batchCount
     end function
@@ -33951,9 +33951,9 @@ module hipfort_hipblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: BP
+      type(c_ptr),value :: BP
       integer(c_int64_t),value :: ldb
       integer(c_int64_t),value :: batchCount
     end function
@@ -34457,7 +34457,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(kind(HIPBLAS_DIAG_NON_UNIT)),value :: diag
       integer(c_int),value :: n
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
       type(c_ptr) :: invA
       integer(c_int),value :: ldinvA
@@ -34478,7 +34478,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(kind(HIPBLAS_DIAG_NON_UNIT)),value :: diag
       integer(c_int),value :: n
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
       type(c_ptr) :: invA
       integer(c_int),value :: ldinvA
@@ -34499,7 +34499,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(kind(HIPBLAS_DIAG_NON_UNIT)),value :: diag
       integer(c_int),value :: n
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
       type(c_ptr) :: invA
       integer(c_int),value :: ldinvA
@@ -34520,7 +34520,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)),value :: uplo
       integer(kind(HIPBLAS_DIAG_NON_UNIT)),value :: diag
       integer(c_int),value :: n
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
       type(c_ptr) :: invA
       integer(c_int),value :: ldinvA
@@ -34991,11 +34991,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_SIDE_LEFT)),value :: side
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int),value :: ldc
       integer(c_int),value :: batchCount
     end function
@@ -35014,11 +35014,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_SIDE_LEFT)),value :: side
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int),value :: ldc
       integer(c_int),value :: batchCount
     end function
@@ -35037,11 +35037,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_SIDE_LEFT)),value :: side
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int),value :: ldc
       integer(c_int),value :: batchCount
     end function
@@ -35060,11 +35060,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_SIDE_LEFT)),value :: side
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int),value :: ldc
       integer(c_int),value :: batchCount
     end function
@@ -35083,11 +35083,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_SIDE_LEFT)),value :: side
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batchCount
     end function
@@ -35106,11 +35106,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_SIDE_LEFT)),value :: side
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batchCount
     end function
@@ -35129,11 +35129,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_SIDE_LEFT)),value :: side
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batchCount
     end function
@@ -35152,11 +35152,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_SIDE_LEFT)),value :: side
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: CP
+      type(c_ptr),value :: CP
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batchCount
     end function
@@ -35657,7 +35657,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasSgetrfBatched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       type(c_ptr),value :: myInfo
@@ -35679,7 +35679,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasDgetrfBatched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       type(c_ptr),value :: myInfo
@@ -35701,7 +35701,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasCgetrfBatched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       type(c_ptr),value :: myInfo
@@ -35723,7 +35723,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasZgetrfBatched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       type(c_ptr),value :: myInfo
@@ -36131,10 +36131,10 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)),value :: trans
       integer(c_int),value :: n
       integer(c_int),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batchCount
@@ -36157,10 +36157,10 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)),value :: trans
       integer(c_int),value :: n
       integer(c_int),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batchCount
@@ -36183,10 +36183,10 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)),value :: trans
       integer(c_int),value :: n
       integer(c_int),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batchCount
@@ -36209,10 +36209,10 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)),value :: trans
       integer(c_int),value :: n
       integer(c_int),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batchCount
@@ -36476,10 +36476,10 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasSgetriBatched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batchCount
@@ -36500,10 +36500,10 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasDgetriBatched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batchCount
@@ -36524,10 +36524,10 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasCgetriBatched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batchCount
@@ -36548,10 +36548,10 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_STATUS_SUCCESS)) :: hipblasZgetriBatched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batchCount
@@ -36805,9 +36805,9 @@ module hipfort_hipblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       integer(c_int),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       type(c_ptr),value :: myInfo
       type(c_ptr),value :: deviceInfo
@@ -36832,9 +36832,9 @@ module hipfort_hipblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       integer(c_int),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       type(c_ptr),value :: myInfo
       type(c_ptr),value :: deviceInfo
@@ -36859,9 +36859,9 @@ module hipfort_hipblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       integer(c_int),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       type(c_ptr),value :: myInfo
       type(c_ptr),value :: deviceInfo
@@ -36886,9 +36886,9 @@ module hipfort_hipblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       integer(c_int),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       type(c_ptr),value :: myInfo
       type(c_ptr),value :: deviceInfo
@@ -37305,9 +37305,9 @@ module hipfort_hipblas
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: ipiv
+      type(c_ptr),value :: ipiv
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batchCount
     end function
@@ -37328,9 +37328,9 @@ module hipfort_hipblas
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: ipiv
+      type(c_ptr),value :: ipiv
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batchCount
     end function
@@ -37351,9 +37351,9 @@ module hipfort_hipblas
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: ipiv
+      type(c_ptr),value :: ipiv
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batchCount
     end function
@@ -37374,9 +37374,9 @@ module hipfort_hipblas
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: ipiv
+      type(c_ptr),value :: ipiv
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batchCount
     end function

--- a/lib/hipfort/hipfort_rocblas.F90
+++ b/lib/hipfort/hipfort_rocblas.F90
@@ -926,7 +926,7 @@ module hipfort_rocblas
       type(c_ptr),value :: handle
       integer(c_int),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batch_count
     end function
@@ -942,7 +942,7 @@ module hipfort_rocblas
       type(c_ptr),value :: handle
       integer(c_int),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batch_count
     end function
@@ -958,7 +958,7 @@ module hipfort_rocblas
       type(c_ptr),value :: handle
       integer(c_int),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batch_count
     end function
@@ -974,7 +974,7 @@ module hipfort_rocblas
       type(c_ptr),value :: handle
       integer(c_int),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batch_count
     end function
@@ -990,7 +990,7 @@ module hipfort_rocblas
       type(c_ptr),value :: handle
       integer(c_int),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batch_count
     end function
@@ -1006,7 +1006,7 @@ module hipfort_rocblas
       type(c_ptr),value :: handle
       integer(c_int),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batch_count
     end function
@@ -1022,7 +1022,7 @@ module hipfort_rocblas
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batch_count
     end function
@@ -1038,7 +1038,7 @@ module hipfort_rocblas
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batch_count
     end function
@@ -1054,7 +1054,7 @@ module hipfort_rocblas
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batch_count
     end function
@@ -1070,7 +1070,7 @@ module hipfort_rocblas
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batch_count
     end function
@@ -1086,7 +1086,7 @@ module hipfort_rocblas
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batch_count
     end function
@@ -1102,7 +1102,7 @@ module hipfort_rocblas
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batch_count
     end function
@@ -1566,9 +1566,9 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_scopy_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batch_count
     end function
@@ -1583,9 +1583,9 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_dcopy_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batch_count
     end function
@@ -1600,9 +1600,9 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_ccopy_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batch_count
     end function
@@ -1617,9 +1617,9 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_zcopy_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batch_count
     end function
@@ -1634,9 +1634,9 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_scopy_batched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batch_count
     end function
@@ -1651,9 +1651,9 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_dcopy_batched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batch_count
     end function
@@ -1668,9 +1668,9 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_ccopy_batched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batch_count
     end function
@@ -1685,9 +1685,9 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_zcopy_batched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batch_count
     end function
@@ -2259,9 +2259,9 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_sdot_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batch_count
       type(c_ptr),value :: myResult
@@ -2277,9 +2277,9 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_ddot_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batch_count
       type(c_ptr),value :: myResult
@@ -2295,9 +2295,9 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_hdot_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batch_count
       type(c_ptr),value :: myResult
@@ -2313,9 +2313,9 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_bfdot_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batch_count
       type(c_ptr),value :: myResult
@@ -2331,9 +2331,9 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_cdotu_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batch_count
       type(c_ptr),value :: myResult
@@ -2349,9 +2349,9 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_zdotu_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batch_count
       type(c_ptr),value :: myResult
@@ -2367,9 +2367,9 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_cdotc_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batch_count
       type(c_ptr),value :: myResult
@@ -2385,9 +2385,9 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_zdotc_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batch_count
       type(c_ptr),value :: myResult
@@ -2403,9 +2403,9 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_sdot_batched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batch_count
       type(c_ptr),value :: myResult
@@ -2421,9 +2421,9 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_ddot_batched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batch_count
       type(c_ptr),value :: myResult
@@ -2439,9 +2439,9 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_hdot_batched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batch_count
       type(c_ptr),value :: myResult
@@ -2457,9 +2457,9 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_bfdot_batched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batch_count
       type(c_ptr),value :: myResult
@@ -2475,9 +2475,9 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_cdotu_batched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batch_count
       type(c_ptr),value :: myResult
@@ -2493,9 +2493,9 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_zdotu_batched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batch_count
       type(c_ptr),value :: myResult
@@ -2511,9 +2511,9 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_cdotc_batched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batch_count
       type(c_ptr),value :: myResult
@@ -2529,9 +2529,9 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_zdotc_batched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batch_count
       type(c_ptr),value :: myResult
@@ -3126,9 +3126,9 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_sswap_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batch_count
     end function
@@ -3143,9 +3143,9 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_dswap_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batch_count
     end function
@@ -3160,9 +3160,9 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_cswap_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batch_count
     end function
@@ -3177,9 +3177,9 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_zswap_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batch_count
     end function
@@ -3194,9 +3194,9 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_sswap_batched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batch_count
     end function
@@ -3211,9 +3211,9 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_dswap_batched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batch_count
     end function
@@ -3228,9 +3228,9 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_cswap_batched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batch_count
     end function
@@ -3245,9 +3245,9 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_zswap_batched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batch_count
     end function
@@ -3691,9 +3691,9 @@ module hipfort_rocblas
       type(c_ptr),value :: handle
       integer(c_int),value :: n
       integer(c_short) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batch_count
     end function
@@ -3709,9 +3709,9 @@ module hipfort_rocblas
       type(c_ptr),value :: handle
       integer(c_int),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batch_count
     end function
@@ -3727,9 +3727,9 @@ module hipfort_rocblas
       type(c_ptr),value :: handle
       integer(c_int),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batch_count
     end function
@@ -3745,9 +3745,9 @@ module hipfort_rocblas
       type(c_ptr),value :: handle
       integer(c_int),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batch_count
     end function
@@ -3763,9 +3763,9 @@ module hipfort_rocblas
       type(c_ptr),value :: handle
       integer(c_int),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batch_count
     end function
@@ -3781,9 +3781,9 @@ module hipfort_rocblas
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
       integer(c_short) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batch_count
     end function
@@ -3799,9 +3799,9 @@ module hipfort_rocblas
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batch_count
     end function
@@ -3817,9 +3817,9 @@ module hipfort_rocblas
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batch_count
     end function
@@ -3835,9 +3835,9 @@ module hipfort_rocblas
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batch_count
     end function
@@ -3853,9 +3853,9 @@ module hipfort_rocblas
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batch_count
     end function
@@ -4289,7 +4289,7 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_sasum_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batch_count
       type(c_ptr),value :: results
@@ -4305,7 +4305,7 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_dasum_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batch_count
       type(c_ptr),value :: results
@@ -4321,7 +4321,7 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_scasum_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batch_count
       type(c_ptr),value :: results
@@ -4337,7 +4337,7 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_dzasum_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batch_count
       type(c_ptr),value :: results
@@ -4353,7 +4353,7 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_sasum_batched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batch_count
       type(c_ptr),value :: results
@@ -4369,7 +4369,7 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_dasum_batched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batch_count
       type(c_ptr),value :: results
@@ -4385,7 +4385,7 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_scasum_batched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batch_count
       type(c_ptr),value :: results
@@ -4401,7 +4401,7 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_dzasum_batched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batch_count
       type(c_ptr),value :: results
@@ -4767,7 +4767,7 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_snrm2_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batch_count
       type(c_ptr),value :: results
@@ -4783,7 +4783,7 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_dnrm2_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batch_count
       type(c_ptr),value :: results
@@ -4799,7 +4799,7 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_scnrm2_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batch_count
       type(c_ptr),value :: results
@@ -4815,7 +4815,7 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_dznrm2_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batch_count
       type(c_ptr),value :: results
@@ -4831,7 +4831,7 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_snrm2_batched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batch_count
       type(c_ptr),value :: results
@@ -4847,7 +4847,7 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_dnrm2_batched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batch_count
       type(c_ptr),value :: results
@@ -4863,7 +4863,7 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_scnrm2_batched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batch_count
       type(c_ptr),value :: results
@@ -4879,7 +4879,7 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_dznrm2_batched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batch_count
       type(c_ptr),value :: results
@@ -5240,7 +5240,7 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_isamax_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batch_count
       type(c_ptr),value :: myResult
@@ -5256,7 +5256,7 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_idamax_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batch_count
       type(c_ptr),value :: myResult
@@ -5272,7 +5272,7 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_icamax_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batch_count
       type(c_ptr),value :: myResult
@@ -5288,7 +5288,7 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_izamax_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batch_count
       type(c_ptr),value :: myResult
@@ -5304,7 +5304,7 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_isamax_batched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batch_count
       type(c_ptr),value :: myResult
@@ -5320,7 +5320,7 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_idamax_batched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batch_count
       type(c_ptr),value :: myResult
@@ -5336,7 +5336,7 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_icamax_batched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batch_count
       type(c_ptr),value :: myResult
@@ -5352,7 +5352,7 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_izamax_batched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batch_count
       type(c_ptr),value :: myResult
@@ -5706,7 +5706,7 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_isamin_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batch_count
       type(c_ptr),value :: myResult
@@ -5722,7 +5722,7 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_idamin_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batch_count
       type(c_ptr),value :: myResult
@@ -5738,7 +5738,7 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_icamin_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batch_count
       type(c_ptr),value :: myResult
@@ -5754,7 +5754,7 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_izamin_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batch_count
       type(c_ptr),value :: myResult
@@ -5770,7 +5770,7 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_isamin_batched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batch_count
       type(c_ptr),value :: myResult
@@ -5786,7 +5786,7 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_idamin_batched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batch_count
       type(c_ptr),value :: myResult
@@ -5802,7 +5802,7 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_icamin_batched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batch_count
       type(c_ptr),value :: myResult
@@ -5818,7 +5818,7 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_izamin_batched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batch_count
       type(c_ptr),value :: myResult
@@ -6301,9 +6301,9 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_srot_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       real(c_float) :: c
       real(c_float) :: s
@@ -6320,9 +6320,9 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_drot_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       real(c_double) :: c
       real(c_double) :: s
@@ -6339,9 +6339,9 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_crot_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       real(c_float) :: c
       complex(c_float_complex) :: s
@@ -6358,9 +6358,9 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_csrot_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       real(c_float) :: c
       real(c_float) :: s
@@ -6377,9 +6377,9 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_zrot_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       real(c_double) :: c
       complex(c_double_complex) :: s
@@ -6396,9 +6396,9 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_zdrot_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       real(c_double) :: c
       real(c_double) :: s
@@ -6415,9 +6415,9 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_srot_batched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       real(c_float) :: c
       real(c_float) :: s
@@ -6434,9 +6434,9 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_drot_batched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       real(c_double) :: c
       real(c_double) :: s
@@ -6453,9 +6453,9 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_crot_batched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       real(c_float) :: c
       complex(c_float_complex) :: s
@@ -6472,9 +6472,9 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_csrot_batched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       real(c_float) :: c
       real(c_float) :: s
@@ -6491,9 +6491,9 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_zrot_batched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       real(c_double) :: c
       complex(c_double_complex) :: s
@@ -6510,9 +6510,9 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_zdrot_batched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       real(c_double) :: c
       real(c_double) :: s
@@ -7018,10 +7018,10 @@ module hipfort_rocblas
       implicit none
       integer(kind(rocblas_status_success)) :: rocblas_srotg_batched_
       type(c_ptr),value :: handle
-      type(c_ptr) :: a
-      type(c_ptr) :: b
-      type(c_ptr) :: c
-      type(c_ptr) :: s
+      type(c_ptr),value :: a
+      type(c_ptr),value :: b
+      type(c_ptr),value :: c
+      type(c_ptr),value :: s
       integer(c_int),value :: batch_count
     end function
   end interface
@@ -7034,10 +7034,10 @@ module hipfort_rocblas
       implicit none
       integer(kind(rocblas_status_success)) :: rocblas_drotg_batched_
       type(c_ptr),value :: handle
-      type(c_ptr) :: a
-      type(c_ptr) :: b
-      type(c_ptr) :: c
-      type(c_ptr) :: s
+      type(c_ptr),value :: a
+      type(c_ptr),value :: b
+      type(c_ptr),value :: c
+      type(c_ptr),value :: s
       integer(c_int),value :: batch_count
     end function
   end interface
@@ -7050,10 +7050,10 @@ module hipfort_rocblas
       implicit none
       integer(kind(rocblas_status_success)) :: rocblas_crotg_batched_
       type(c_ptr),value :: handle
-      type(c_ptr) :: a
-      type(c_ptr) :: b
-      type(c_ptr) :: c
-      type(c_ptr) :: s
+      type(c_ptr),value :: a
+      type(c_ptr),value :: b
+      type(c_ptr),value :: c
+      type(c_ptr),value :: s
       integer(c_int),value :: batch_count
     end function
   end interface
@@ -7066,10 +7066,10 @@ module hipfort_rocblas
       implicit none
       integer(kind(rocblas_status_success)) :: rocblas_zrotg_batched_
       type(c_ptr),value :: handle
-      type(c_ptr) :: a
-      type(c_ptr) :: b
-      type(c_ptr) :: c
-      type(c_ptr) :: s
+      type(c_ptr),value :: a
+      type(c_ptr),value :: b
+      type(c_ptr),value :: c
+      type(c_ptr),value :: s
       integer(c_int),value :: batch_count
     end function
   end interface
@@ -7082,10 +7082,10 @@ module hipfort_rocblas
       implicit none
       integer(kind(rocblas_status_success)) :: rocblas_srotg_batched_64_
       type(c_ptr),value :: handle
-      type(c_ptr) :: a
-      type(c_ptr) :: b
-      type(c_ptr) :: c
-      type(c_ptr) :: s
+      type(c_ptr),value :: a
+      type(c_ptr),value :: b
+      type(c_ptr),value :: c
+      type(c_ptr),value :: s
       integer(c_int64_t),value :: batch_count
     end function
   end interface
@@ -7098,10 +7098,10 @@ module hipfort_rocblas
       implicit none
       integer(kind(rocblas_status_success)) :: rocblas_drotg_batched_64_
       type(c_ptr),value :: handle
-      type(c_ptr) :: a
-      type(c_ptr) :: b
-      type(c_ptr) :: c
-      type(c_ptr) :: s
+      type(c_ptr),value :: a
+      type(c_ptr),value :: b
+      type(c_ptr),value :: c
+      type(c_ptr),value :: s
       integer(c_int64_t),value :: batch_count
     end function
   end interface
@@ -7114,10 +7114,10 @@ module hipfort_rocblas
       implicit none
       integer(kind(rocblas_status_success)) :: rocblas_crotg_batched_64_
       type(c_ptr),value :: handle
-      type(c_ptr) :: a
-      type(c_ptr) :: b
-      type(c_ptr) :: c
-      type(c_ptr) :: s
+      type(c_ptr),value :: a
+      type(c_ptr),value :: b
+      type(c_ptr),value :: c
+      type(c_ptr),value :: s
       integer(c_int64_t),value :: batch_count
     end function
   end interface
@@ -7130,10 +7130,10 @@ module hipfort_rocblas
       implicit none
       integer(kind(rocblas_status_success)) :: rocblas_zrotg_batched_64_
       type(c_ptr),value :: handle
-      type(c_ptr) :: a
-      type(c_ptr) :: b
-      type(c_ptr) :: c
-      type(c_ptr) :: s
+      type(c_ptr),value :: a
+      type(c_ptr),value :: b
+      type(c_ptr),value :: c
+      type(c_ptr),value :: s
       integer(c_int64_t),value :: batch_count
     end function
   end interface
@@ -7487,11 +7487,11 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_srotm_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
-      type(c_ptr) :: param
+      type(c_ptr),value :: param
       integer(c_int),value :: batch_count
     end function
   end interface
@@ -7505,11 +7505,11 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_drotm_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
-      type(c_ptr) :: param
+      type(c_ptr),value :: param
       integer(c_int),value :: batch_count
     end function
   end interface
@@ -7523,11 +7523,11 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_srotm_batched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
-      type(c_ptr) :: param
+      type(c_ptr),value :: param
       integer(c_int64_t),value :: batch_count
     end function
   end interface
@@ -7541,11 +7541,11 @@ module hipfort_rocblas
       integer(kind(rocblas_status_success)) :: rocblas_drotm_batched_64_
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: n
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
-      type(c_ptr) :: param
+      type(c_ptr),value :: param
       integer(c_int64_t),value :: batch_count
     end function
   end interface
@@ -7836,11 +7836,11 @@ module hipfort_rocblas
       implicit none
       integer(kind(rocblas_status_success)) :: rocblas_srotmg_batched_
       type(c_ptr),value :: handle
-      type(c_ptr) :: d1
-      type(c_ptr) :: d2
-      type(c_ptr) :: x1
-      type(c_ptr) :: y1
-      type(c_ptr) :: param
+      type(c_ptr),value :: d1
+      type(c_ptr),value :: d2
+      type(c_ptr),value :: x1
+      type(c_ptr),value :: y1
+      type(c_ptr),value :: param
       integer(c_int),value :: batch_count
     end function
   end interface
@@ -7853,11 +7853,11 @@ module hipfort_rocblas
       implicit none
       integer(kind(rocblas_status_success)) :: rocblas_drotmg_batched_
       type(c_ptr),value :: handle
-      type(c_ptr) :: d1
-      type(c_ptr) :: d2
-      type(c_ptr) :: x1
-      type(c_ptr) :: y1
-      type(c_ptr) :: param
+      type(c_ptr),value :: d1
+      type(c_ptr),value :: d2
+      type(c_ptr),value :: x1
+      type(c_ptr),value :: y1
+      type(c_ptr),value :: param
       integer(c_int),value :: batch_count
     end function
   end interface
@@ -7870,11 +7870,11 @@ module hipfort_rocblas
       implicit none
       integer(kind(rocblas_status_success)) :: rocblas_srotmg_batched_64_
       type(c_ptr),value :: handle
-      type(c_ptr) :: d1
-      type(c_ptr) :: d2
-      type(c_ptr) :: x1
-      type(c_ptr) :: y1
-      type(c_ptr) :: param
+      type(c_ptr),value :: d1
+      type(c_ptr),value :: d2
+      type(c_ptr),value :: x1
+      type(c_ptr),value :: y1
+      type(c_ptr),value :: param
       integer(c_int64_t),value :: batch_count
     end function
   end interface
@@ -7887,11 +7887,11 @@ module hipfort_rocblas
       implicit none
       integer(kind(rocblas_status_success)) :: rocblas_drotmg_batched_64_
       type(c_ptr),value :: handle
-      type(c_ptr) :: d1
-      type(c_ptr) :: d2
-      type(c_ptr) :: x1
-      type(c_ptr) :: y1
-      type(c_ptr) :: param
+      type(c_ptr),value :: d1
+      type(c_ptr),value :: d2
+      type(c_ptr),value :: x1
+      type(c_ptr),value :: y1
+      type(c_ptr),value :: param
       integer(c_int64_t),value :: batch_count
     end function
   end interface
@@ -8386,12 +8386,12 @@ module hipfort_rocblas
       integer(c_int),value :: kl
       integer(c_int),value :: ku
       real(c_float) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       real(c_float) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batch_count
     end function
@@ -8412,12 +8412,12 @@ module hipfort_rocblas
       integer(c_int),value :: kl
       integer(c_int),value :: ku
       real(c_double) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       real(c_double) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batch_count
     end function
@@ -8438,12 +8438,12 @@ module hipfort_rocblas
       integer(c_int),value :: kl
       integer(c_int),value :: ku
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       complex(c_float_complex) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batch_count
     end function
@@ -8464,12 +8464,12 @@ module hipfort_rocblas
       integer(c_int),value :: kl
       integer(c_int),value :: ku
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       complex(c_double_complex) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batch_count
     end function
@@ -8490,12 +8490,12 @@ module hipfort_rocblas
       integer(c_int64_t),value :: kl
       integer(c_int64_t),value :: ku
       real(c_float) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       real(c_float) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batch_count
     end function
@@ -8516,12 +8516,12 @@ module hipfort_rocblas
       integer(c_int64_t),value :: kl
       integer(c_int64_t),value :: ku
       real(c_double) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       real(c_double) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batch_count
     end function
@@ -8542,12 +8542,12 @@ module hipfort_rocblas
       integer(c_int64_t),value :: kl
       integer(c_int64_t),value :: ku
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       complex(c_float_complex) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batch_count
     end function
@@ -8568,12 +8568,12 @@ module hipfort_rocblas
       integer(c_int64_t),value :: kl
       integer(c_int64_t),value :: ku
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       complex(c_double_complex) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batch_count
     end function
@@ -9182,12 +9182,12 @@ module hipfort_rocblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       real(c_float) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batch_count
     end function
@@ -9205,12 +9205,12 @@ module hipfort_rocblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       real(c_double) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batch_count
     end function
@@ -9228,12 +9228,12 @@ module hipfort_rocblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       complex(c_float_complex) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batch_count
     end function
@@ -9251,12 +9251,12 @@ module hipfort_rocblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       complex(c_double_complex) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batch_count
     end function
@@ -9274,12 +9274,12 @@ module hipfort_rocblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       real(c_float) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batch_count
     end function
@@ -9297,12 +9297,12 @@ module hipfort_rocblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       real(c_float) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batch_count
     end function
@@ -9320,12 +9320,12 @@ module hipfort_rocblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       real(c_float) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batch_count
     end function
@@ -9343,12 +9343,12 @@ module hipfort_rocblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       real(c_float) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batch_count
     end function
@@ -9367,12 +9367,12 @@ module hipfort_rocblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       real(c_float) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batch_count
     end function
@@ -9391,12 +9391,12 @@ module hipfort_rocblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       real(c_double) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batch_count
     end function
@@ -9415,12 +9415,12 @@ module hipfort_rocblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       complex(c_float_complex) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batch_count
     end function
@@ -9439,12 +9439,12 @@ module hipfort_rocblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       complex(c_double_complex) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batch_count
     end function
@@ -9463,12 +9463,12 @@ module hipfort_rocblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       real(c_float) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batch_count
     end function
@@ -9487,12 +9487,12 @@ module hipfort_rocblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       real(c_float) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batch_count
     end function
@@ -9511,12 +9511,12 @@ module hipfort_rocblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       real(c_float) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batch_count
     end function
@@ -9535,12 +9535,12 @@ module hipfort_rocblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       real(c_float) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batch_count
     end function
@@ -10291,12 +10291,12 @@ module hipfort_rocblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       complex(c_float_complex) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batch_count
     end function
@@ -10314,12 +10314,12 @@ module hipfort_rocblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       complex(c_double_complex) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batch_count
     end function
@@ -10337,12 +10337,12 @@ module hipfort_rocblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       complex(c_float_complex) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batch_count
     end function
@@ -10360,12 +10360,12 @@ module hipfort_rocblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       complex(c_double_complex) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batch_count
     end function
@@ -10761,12 +10761,12 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       complex(c_float_complex) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batch_count
     end function
@@ -10783,12 +10783,12 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       complex(c_double_complex) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batch_count
     end function
@@ -10805,12 +10805,12 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       complex(c_float_complex) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batch_count
     end function
@@ -10827,12 +10827,12 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       complex(c_double_complex) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batch_count
     end function
@@ -11182,9 +11182,9 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       integer(c_int),value :: batch_count
     end function
@@ -11201,9 +11201,9 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       integer(c_int),value :: batch_count
     end function
@@ -11220,9 +11220,9 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       integer(c_int64_t),value :: batch_count
     end function
@@ -11239,9 +11239,9 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       integer(c_int64_t),value :: batch_count
     end function
@@ -11579,11 +11579,11 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       integer(c_int),value :: batch_count
     end function
@@ -11600,11 +11600,11 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       integer(c_int),value :: batch_count
     end function
@@ -11621,11 +11621,11 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       integer(c_int64_t),value :: batch_count
     end function
@@ -11642,11 +11642,11 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       integer(c_int64_t),value :: batch_count
     end function
@@ -12043,11 +12043,11 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: AP
-      type(c_ptr) :: x
+      type(c_ptr),value :: AP
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       complex(c_float_complex) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batch_count
     end function
@@ -12064,11 +12064,11 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: AP
-      type(c_ptr) :: x
+      type(c_ptr),value :: AP
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       complex(c_double_complex) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batch_count
     end function
@@ -12085,11 +12085,11 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: AP
-      type(c_ptr) :: x
+      type(c_ptr),value :: AP
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       complex(c_float_complex) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batch_count
     end function
@@ -12106,11 +12106,11 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: AP
-      type(c_ptr) :: x
+      type(c_ptr),value :: AP
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       complex(c_double_complex) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batch_count
     end function
@@ -12498,9 +12498,9 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: batch_count
     end function
   end interface
@@ -12516,9 +12516,9 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: batch_count
     end function
   end interface
@@ -12534,9 +12534,9 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: batch_count
     end function
   end interface
@@ -12552,9 +12552,9 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: batch_count
     end function
   end interface
@@ -12931,11 +12931,11 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: batch_count
     end function
   end interface
@@ -12951,11 +12951,11 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: batch_count
     end function
   end interface
@@ -12971,11 +12971,11 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: batch_count
     end function
   end interface
@@ -12991,11 +12991,11 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: batch_count
     end function
   end interface
@@ -14872,9 +14872,9 @@ module hipfort_rocblas
       integer(kind(rocblas_diagonal_non_unit)),value :: diag
       integer(c_int),value :: n
       integer(c_int),value :: k
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batch_count
     end function
@@ -14893,9 +14893,9 @@ module hipfort_rocblas
       integer(kind(rocblas_diagonal_non_unit)),value :: diag
       integer(c_int),value :: n
       integer(c_int),value :: k
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batch_count
     end function
@@ -14914,9 +14914,9 @@ module hipfort_rocblas
       integer(kind(rocblas_diagonal_non_unit)),value :: diag
       integer(c_int),value :: n
       integer(c_int),value :: k
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batch_count
     end function
@@ -14935,9 +14935,9 @@ module hipfort_rocblas
       integer(kind(rocblas_diagonal_non_unit)),value :: diag
       integer(c_int),value :: n
       integer(c_int),value :: k
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batch_count
     end function
@@ -14956,9 +14956,9 @@ module hipfort_rocblas
       integer(kind(rocblas_diagonal_non_unit)),value :: diag
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batch_count
     end function
@@ -14977,9 +14977,9 @@ module hipfort_rocblas
       integer(kind(rocblas_diagonal_non_unit)),value :: diag
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batch_count
     end function
@@ -14998,9 +14998,9 @@ module hipfort_rocblas
       integer(kind(rocblas_diagonal_non_unit)),value :: diag
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batch_count
     end function
@@ -15019,9 +15019,9 @@ module hipfort_rocblas
       integer(kind(rocblas_diagonal_non_unit)),value :: diag
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batch_count
     end function
@@ -15625,9 +15625,9 @@ module hipfort_rocblas
       integer(kind(rocblas_diagonal_non_unit)),value :: diag
       integer(c_int),value :: n
       integer(c_int),value :: k
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batch_count
     end function
@@ -15646,9 +15646,9 @@ module hipfort_rocblas
       integer(kind(rocblas_diagonal_non_unit)),value :: diag
       integer(c_int),value :: n
       integer(c_int),value :: k
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batch_count
     end function
@@ -15667,9 +15667,9 @@ module hipfort_rocblas
       integer(kind(rocblas_diagonal_non_unit)),value :: diag
       integer(c_int),value :: n
       integer(c_int),value :: k
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batch_count
     end function
@@ -15688,9 +15688,9 @@ module hipfort_rocblas
       integer(kind(rocblas_diagonal_non_unit)),value :: diag
       integer(c_int),value :: n
       integer(c_int),value :: k
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batch_count
     end function
@@ -15709,9 +15709,9 @@ module hipfort_rocblas
       integer(kind(rocblas_diagonal_non_unit)),value :: diag
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batch_count
     end function
@@ -15730,9 +15730,9 @@ module hipfort_rocblas
       integer(kind(rocblas_diagonal_non_unit)),value :: diag
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batch_count
     end function
@@ -15751,9 +15751,9 @@ module hipfort_rocblas
       integer(kind(rocblas_diagonal_non_unit)),value :: diag
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batch_count
     end function
@@ -15772,9 +15772,9 @@ module hipfort_rocblas
       integer(kind(rocblas_diagonal_non_unit)),value :: diag
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batch_count
     end function
@@ -16345,9 +16345,9 @@ module hipfort_rocblas
       integer(kind(rocblas_operation_none)),value :: transA
       integer(kind(rocblas_diagonal_non_unit)),value :: diag
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batch_count
     end function
@@ -16365,9 +16365,9 @@ module hipfort_rocblas
       integer(kind(rocblas_operation_none)),value :: transA
       integer(kind(rocblas_diagonal_non_unit)),value :: diag
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batch_count
     end function
@@ -16385,9 +16385,9 @@ module hipfort_rocblas
       integer(kind(rocblas_operation_none)),value :: transA
       integer(kind(rocblas_diagonal_non_unit)),value :: diag
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batch_count
     end function
@@ -16405,9 +16405,9 @@ module hipfort_rocblas
       integer(kind(rocblas_operation_none)),value :: transA
       integer(kind(rocblas_diagonal_non_unit)),value :: diag
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batch_count
     end function
@@ -16425,9 +16425,9 @@ module hipfort_rocblas
       integer(kind(rocblas_operation_none)),value :: transA
       integer(kind(rocblas_diagonal_non_unit)),value :: diag
       integer(c_int64_t),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batch_count
     end function
@@ -16445,9 +16445,9 @@ module hipfort_rocblas
       integer(kind(rocblas_operation_none)),value :: transA
       integer(kind(rocblas_diagonal_non_unit)),value :: diag
       integer(c_int64_t),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batch_count
     end function
@@ -16465,9 +16465,9 @@ module hipfort_rocblas
       integer(kind(rocblas_operation_none)),value :: transA
       integer(kind(rocblas_diagonal_non_unit)),value :: diag
       integer(c_int64_t),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batch_count
     end function
@@ -16485,9 +16485,9 @@ module hipfort_rocblas
       integer(kind(rocblas_operation_none)),value :: transA
       integer(kind(rocblas_diagonal_non_unit)),value :: diag
       integer(c_int64_t),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batch_count
     end function
@@ -17021,8 +17021,8 @@ module hipfort_rocblas
       integer(kind(rocblas_operation_none)),value :: transA
       integer(kind(rocblas_diagonal_non_unit)),value :: diag
       integer(c_int),value :: n
-      type(c_ptr) :: AP
-      type(c_ptr) :: x
+      type(c_ptr),value :: AP
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batch_count
     end function
@@ -17040,8 +17040,8 @@ module hipfort_rocblas
       integer(kind(rocblas_operation_none)),value :: transA
       integer(kind(rocblas_diagonal_non_unit)),value :: diag
       integer(c_int),value :: n
-      type(c_ptr) :: AP
-      type(c_ptr) :: x
+      type(c_ptr),value :: AP
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batch_count
     end function
@@ -17059,8 +17059,8 @@ module hipfort_rocblas
       integer(kind(rocblas_operation_none)),value :: transA
       integer(kind(rocblas_diagonal_non_unit)),value :: diag
       integer(c_int),value :: n
-      type(c_ptr) :: AP
-      type(c_ptr) :: x
+      type(c_ptr),value :: AP
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batch_count
     end function
@@ -17078,8 +17078,8 @@ module hipfort_rocblas
       integer(kind(rocblas_operation_none)),value :: transA
       integer(kind(rocblas_diagonal_non_unit)),value :: diag
       integer(c_int),value :: n
-      type(c_ptr) :: AP
-      type(c_ptr) :: x
+      type(c_ptr),value :: AP
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       integer(c_int),value :: batch_count
     end function
@@ -17097,8 +17097,8 @@ module hipfort_rocblas
       integer(kind(rocblas_operation_none)),value :: transA
       integer(kind(rocblas_diagonal_non_unit)),value :: diag
       integer(c_int64_t),value :: n
-      type(c_ptr) :: AP
-      type(c_ptr) :: x
+      type(c_ptr),value :: AP
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batch_count
     end function
@@ -17116,8 +17116,8 @@ module hipfort_rocblas
       integer(kind(rocblas_operation_none)),value :: transA
       integer(kind(rocblas_diagonal_non_unit)),value :: diag
       integer(c_int64_t),value :: n
-      type(c_ptr) :: AP
-      type(c_ptr) :: x
+      type(c_ptr),value :: AP
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batch_count
     end function
@@ -17135,8 +17135,8 @@ module hipfort_rocblas
       integer(kind(rocblas_operation_none)),value :: transA
       integer(kind(rocblas_diagonal_non_unit)),value :: diag
       integer(c_int64_t),value :: n
-      type(c_ptr) :: AP
-      type(c_ptr) :: x
+      type(c_ptr),value :: AP
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batch_count
     end function
@@ -17154,8 +17154,8 @@ module hipfort_rocblas
       integer(kind(rocblas_operation_none)),value :: transA
       integer(kind(rocblas_diagonal_non_unit)),value :: diag
       integer(c_int64_t),value :: n
-      type(c_ptr) :: AP
-      type(c_ptr) :: x
+      type(c_ptr),value :: AP
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       integer(c_int64_t),value :: batch_count
     end function
@@ -17686,12 +17686,12 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       real(c_float) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batch_count
     end function
@@ -17708,12 +17708,12 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       real(c_double) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batch_count
     end function
@@ -17730,12 +17730,12 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       complex(c_float_complex) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batch_count
     end function
@@ -17752,12 +17752,12 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       complex(c_double_complex) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batch_count
     end function
@@ -17774,12 +17774,12 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       real(c_float) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batch_count
     end function
@@ -17796,12 +17796,12 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       real(c_double) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batch_count
     end function
@@ -17818,12 +17818,12 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       complex(c_float_complex) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batch_count
     end function
@@ -17840,12 +17840,12 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       complex(c_double_complex) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batch_count
     end function
@@ -18294,11 +18294,11 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: A
-      type(c_ptr) :: x
+      type(c_ptr),value :: A
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       real(c_float) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batch_count
     end function
@@ -18315,11 +18315,11 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: A
-      type(c_ptr) :: x
+      type(c_ptr),value :: A
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       real(c_double) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batch_count
     end function
@@ -18336,11 +18336,11 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: A
-      type(c_ptr) :: x
+      type(c_ptr),value :: A
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       real(c_float) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batch_count
     end function
@@ -18357,11 +18357,11 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: A
-      type(c_ptr) :: x
+      type(c_ptr),value :: A
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       real(c_double) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batch_count
     end function
@@ -18704,12 +18704,12 @@ module hipfort_rocblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       real(c_float) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       real(c_float) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batch_count
     end function
@@ -18727,12 +18727,12 @@ module hipfort_rocblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       real(c_double) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
       real(c_double) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
       integer(c_int),value :: batch_count
     end function
@@ -18750,12 +18750,12 @@ module hipfort_rocblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       real(c_float) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       real(c_float) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batch_count
     end function
@@ -18773,12 +18773,12 @@ module hipfort_rocblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       real(c_double) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
       real(c_double) :: beta
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
       integer(c_int64_t),value :: batch_count
     end function
@@ -19299,11 +19299,11 @@ module hipfort_rocblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       integer(c_int),value :: batch_count
     end function
@@ -19320,11 +19320,11 @@ module hipfort_rocblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       integer(c_int),value :: batch_count
     end function
@@ -19341,11 +19341,11 @@ module hipfort_rocblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       integer(c_int),value :: batch_count
     end function
@@ -19362,11 +19362,11 @@ module hipfort_rocblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       integer(c_int),value :: batch_count
     end function
@@ -19383,11 +19383,11 @@ module hipfort_rocblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       integer(c_int),value :: batch_count
     end function
@@ -19404,11 +19404,11 @@ module hipfort_rocblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       integer(c_int),value :: batch_count
     end function
@@ -19425,11 +19425,11 @@ module hipfort_rocblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       integer(c_int64_t),value :: batch_count
     end function
@@ -19446,11 +19446,11 @@ module hipfort_rocblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       integer(c_int64_t),value :: batch_count
     end function
@@ -19467,11 +19467,11 @@ module hipfort_rocblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       integer(c_int64_t),value :: batch_count
     end function
@@ -19488,11 +19488,11 @@ module hipfort_rocblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       integer(c_int64_t),value :: batch_count
     end function
@@ -19509,11 +19509,11 @@ module hipfort_rocblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       integer(c_int64_t),value :: batch_count
     end function
@@ -19530,11 +19530,11 @@ module hipfort_rocblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       integer(c_int64_t),value :: batch_count
     end function
@@ -20201,9 +20201,9 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: batch_count
     end function
   end interface
@@ -20219,9 +20219,9 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: batch_count
     end function
   end interface
@@ -20237,9 +20237,9 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: batch_count
     end function
   end interface
@@ -20255,9 +20255,9 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: batch_count
     end function
   end interface
@@ -20273,9 +20273,9 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: batch_count
     end function
   end interface
@@ -20291,9 +20291,9 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: batch_count
     end function
   end interface
@@ -20309,9 +20309,9 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: batch_count
     end function
   end interface
@@ -20327,9 +20327,9 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: batch_count
     end function
   end interface
@@ -20802,11 +20802,11 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: batch_count
     end function
   end interface
@@ -20822,11 +20822,11 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int),value :: batch_count
     end function
   end interface
@@ -20842,11 +20842,11 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: batch_count
     end function
   end interface
@@ -20862,11 +20862,11 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
-      type(c_ptr) :: AP
+      type(c_ptr),value :: AP
       integer(c_int64_t),value :: batch_count
     end function
   end interface
@@ -21275,9 +21275,9 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       integer(c_int),value :: batch_count
     end function
@@ -21294,9 +21294,9 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       integer(c_int),value :: batch_count
     end function
@@ -21313,9 +21313,9 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       integer(c_int),value :: batch_count
     end function
@@ -21332,9 +21332,9 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       integer(c_int),value :: batch_count
     end function
@@ -21351,9 +21351,9 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       integer(c_int64_t),value :: batch_count
     end function
@@ -21370,9 +21370,9 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       integer(c_int64_t),value :: batch_count
     end function
@@ -21389,9 +21389,9 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       integer(c_int64_t),value :: batch_count
     end function
@@ -21408,9 +21408,9 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       integer(c_int64_t),value :: batch_count
     end function
@@ -21908,11 +21908,11 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       integer(c_int),value :: batch_count
     end function
@@ -21929,11 +21929,11 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       integer(c_int),value :: batch_count
     end function
@@ -21950,11 +21950,11 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       integer(c_int),value :: batch_count
     end function
@@ -21971,11 +21971,11 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int),value :: incy
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       integer(c_int),value :: batch_count
     end function
@@ -21992,11 +21992,11 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       integer(c_int64_t),value :: batch_count
     end function
@@ -22013,11 +22013,11 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       integer(c_int64_t),value :: batch_count
     end function
@@ -22034,11 +22034,11 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       integer(c_int64_t),value :: batch_count
     end function
@@ -22055,11 +22055,11 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: y
+      type(c_ptr),value :: y
       integer(c_int64_t),value :: incy
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       integer(c_int64_t),value :: batch_count
     end function
@@ -22569,12 +22569,12 @@ module hipfort_rocblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       complex(c_float_complex) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       integer(c_int),value :: batch_count
     end function
@@ -22593,12 +22593,12 @@ module hipfort_rocblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       complex(c_double_complex) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       integer(c_int),value :: batch_count
     end function
@@ -22618,12 +22618,12 @@ module hipfort_rocblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
       complex(c_float_complex) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batch_count
     end function
@@ -22643,12 +22643,12 @@ module hipfort_rocblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
       complex(c_double_complex) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batch_count
     end function
@@ -23076,10 +23076,10 @@ module hipfort_rocblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       real(c_float) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       real(c_float) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       integer(c_int),value :: batch_count
     end function
@@ -23098,10 +23098,10 @@ module hipfort_rocblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       real(c_double) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       real(c_double) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       integer(c_int),value :: batch_count
     end function
@@ -23120,10 +23120,10 @@ module hipfort_rocblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       real(c_float) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       real(c_float) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batch_count
     end function
@@ -23142,10 +23142,10 @@ module hipfort_rocblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       real(c_double) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       real(c_double) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batch_count
     end function
@@ -23585,12 +23585,12 @@ module hipfort_rocblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       real(c_float) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       integer(c_int),value :: batch_count
     end function
@@ -23610,12 +23610,12 @@ module hipfort_rocblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       real(c_double) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       integer(c_int),value :: batch_count
     end function
@@ -23635,12 +23635,12 @@ module hipfort_rocblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
       real(c_float) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batch_count
     end function
@@ -23660,12 +23660,12 @@ module hipfort_rocblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
       real(c_double) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batch_count
     end function
@@ -24138,12 +24138,12 @@ module hipfort_rocblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       real(c_float) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       integer(c_int),value :: batch_count
     end function
@@ -24163,12 +24163,12 @@ module hipfort_rocblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       real(c_double) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       integer(c_int),value :: batch_count
     end function
@@ -24188,12 +24188,12 @@ module hipfort_rocblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
       real(c_float) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batch_count
     end function
@@ -24213,12 +24213,12 @@ module hipfort_rocblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
       real(c_double) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batch_count
     end function
@@ -24774,12 +24774,12 @@ module hipfort_rocblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       real(c_float) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       integer(c_int),value :: batch_count
     end function
@@ -24798,12 +24798,12 @@ module hipfort_rocblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       real(c_double) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       integer(c_int),value :: batch_count
     end function
@@ -24822,12 +24822,12 @@ module hipfort_rocblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       complex(c_float_complex) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       integer(c_int),value :: batch_count
     end function
@@ -24846,12 +24846,12 @@ module hipfort_rocblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       complex(c_double_complex) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       integer(c_int),value :: batch_count
     end function
@@ -24871,12 +24871,12 @@ module hipfort_rocblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
       real(c_float) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batch_count
     end function
@@ -24896,12 +24896,12 @@ module hipfort_rocblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
       real(c_double) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batch_count
     end function
@@ -24921,12 +24921,12 @@ module hipfort_rocblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
       complex(c_float_complex) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batch_count
     end function
@@ -24946,12 +24946,12 @@ module hipfort_rocblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
       complex(c_double_complex) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batch_count
     end function
@@ -25603,10 +25603,10 @@ module hipfort_rocblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       real(c_float) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       real(c_float) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       integer(c_int),value :: batch_count
     end function
@@ -25625,10 +25625,10 @@ module hipfort_rocblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       real(c_double) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       real(c_double) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       integer(c_int),value :: batch_count
     end function
@@ -25647,10 +25647,10 @@ module hipfort_rocblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       complex(c_float_complex) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       integer(c_int),value :: batch_count
     end function
@@ -25669,10 +25669,10 @@ module hipfort_rocblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       complex(c_double_complex) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       integer(c_int),value :: batch_count
     end function
@@ -25691,10 +25691,10 @@ module hipfort_rocblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       real(c_float) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       real(c_float) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batch_count
     end function
@@ -25713,10 +25713,10 @@ module hipfort_rocblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       real(c_double) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       real(c_double) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batch_count
     end function
@@ -25735,10 +25735,10 @@ module hipfort_rocblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       complex(c_float_complex) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batch_count
     end function
@@ -25757,10 +25757,10 @@ module hipfort_rocblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       complex(c_double_complex) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batch_count
     end function
@@ -26424,12 +26424,12 @@ module hipfort_rocblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       real(c_float) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       real(c_float) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       integer(c_int),value :: batch_count
     end function
@@ -26449,12 +26449,12 @@ module hipfort_rocblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       real(c_double) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       real(c_double) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       integer(c_int),value :: batch_count
     end function
@@ -26474,12 +26474,12 @@ module hipfort_rocblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       complex(c_float_complex) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       integer(c_int),value :: batch_count
     end function
@@ -26499,12 +26499,12 @@ module hipfort_rocblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       complex(c_double_complex) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       integer(c_int),value :: batch_count
     end function
@@ -26524,12 +26524,12 @@ module hipfort_rocblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       real(c_float) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
       real(c_float) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batch_count
     end function
@@ -26549,12 +26549,12 @@ module hipfort_rocblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       real(c_double) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
       real(c_double) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batch_count
     end function
@@ -26574,12 +26574,12 @@ module hipfort_rocblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
       complex(c_float_complex) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batch_count
     end function
@@ -26599,12 +26599,12 @@ module hipfort_rocblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
       complex(c_double_complex) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batch_count
     end function
@@ -27317,12 +27317,12 @@ module hipfort_rocblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       real(c_float) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       real(c_float) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       integer(c_int),value :: batch_count
     end function
@@ -27342,12 +27342,12 @@ module hipfort_rocblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       real(c_double) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       real(c_double) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       integer(c_int),value :: batch_count
     end function
@@ -27367,12 +27367,12 @@ module hipfort_rocblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       complex(c_float_complex) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       integer(c_int),value :: batch_count
     end function
@@ -27392,12 +27392,12 @@ module hipfort_rocblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       complex(c_double_complex) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       integer(c_int),value :: batch_count
     end function
@@ -27417,12 +27417,12 @@ module hipfort_rocblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       real(c_float) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
       real(c_float) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batch_count
     end function
@@ -27442,12 +27442,12 @@ module hipfort_rocblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       real(c_double) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
       real(c_double) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batch_count
     end function
@@ -27467,12 +27467,12 @@ module hipfort_rocblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
       complex(c_float_complex) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batch_count
     end function
@@ -27492,12 +27492,12 @@ module hipfort_rocblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
       complex(c_double_complex) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batch_count
     end function
@@ -28286,11 +28286,11 @@ module hipfort_rocblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       integer(c_int),value :: batch_count
     end function
@@ -28312,11 +28312,11 @@ module hipfort_rocblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       integer(c_int),value :: batch_count
     end function
@@ -28338,11 +28338,11 @@ module hipfort_rocblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       integer(c_int),value :: batch_count
     end function
@@ -28364,11 +28364,11 @@ module hipfort_rocblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       integer(c_int),value :: batch_count
     end function
@@ -28390,11 +28390,11 @@ module hipfort_rocblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batch_count
     end function
@@ -28416,11 +28416,11 @@ module hipfort_rocblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batch_count
     end function
@@ -28442,11 +28442,11 @@ module hipfort_rocblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batch_count
     end function
@@ -28468,11 +28468,11 @@ module hipfort_rocblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batch_count
     end function
@@ -28996,9 +28996,9 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(kind(rocblas_diagonal_non_unit)),value :: diag
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: invA
+      type(c_ptr),value :: invA
       integer(c_int),value :: ldinvA
       integer(c_int),value :: batch_count
     end function
@@ -29015,9 +29015,9 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(kind(rocblas_diagonal_non_unit)),value :: diag
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: invA
+      type(c_ptr),value :: invA
       integer(c_int),value :: ldinvA
       integer(c_int),value :: batch_count
     end function
@@ -29034,9 +29034,9 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(kind(rocblas_diagonal_non_unit)),value :: diag
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: invA
+      type(c_ptr),value :: invA
       integer(c_int),value :: ldinvA
       integer(c_int),value :: batch_count
     end function
@@ -29053,9 +29053,9 @@ module hipfort_rocblas
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(kind(rocblas_diagonal_non_unit)),value :: diag
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: invA
+      type(c_ptr),value :: invA
       integer(c_int),value :: ldinvA
       integer(c_int),value :: batch_count
     end function
@@ -29561,9 +29561,9 @@ module hipfort_rocblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       integer(c_int),value :: batch_count
     end function
@@ -29585,9 +29585,9 @@ module hipfort_rocblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       integer(c_int),value :: batch_count
     end function
@@ -29609,9 +29609,9 @@ module hipfort_rocblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       integer(c_int),value :: batch_count
     end function
@@ -29633,9 +29633,9 @@ module hipfort_rocblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       integer(c_int),value :: batch_count
     end function
@@ -29657,9 +29657,9 @@ module hipfort_rocblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
       integer(c_int64_t),value :: batch_count
     end function
@@ -29681,9 +29681,9 @@ module hipfort_rocblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
       integer(c_int64_t),value :: batch_count
     end function
@@ -29705,9 +29705,9 @@ module hipfort_rocblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
       integer(c_int64_t),value :: batch_count
     end function
@@ -29729,9 +29729,9 @@ module hipfort_rocblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
       integer(c_int64_t),value :: batch_count
     end function
@@ -30409,12 +30409,12 @@ module hipfort_rocblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       real(c_float) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       real(c_float) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       integer(c_int),value :: batch_count
     end function
@@ -30435,12 +30435,12 @@ module hipfort_rocblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       real(c_double) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       real(c_double) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       integer(c_int),value :: batch_count
     end function
@@ -30461,12 +30461,12 @@ module hipfort_rocblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       integer(c_short) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       integer(c_short) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       integer(c_int),value :: batch_count
     end function
@@ -30487,12 +30487,12 @@ module hipfort_rocblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       complex(c_float_complex) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       integer(c_int),value :: batch_count
     end function
@@ -30513,12 +30513,12 @@ module hipfort_rocblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       complex(c_double_complex) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       integer(c_int),value :: batch_count
     end function
@@ -30539,12 +30539,12 @@ module hipfort_rocblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       real(c_float) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
       real(c_float) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batch_count
     end function
@@ -30565,12 +30565,12 @@ module hipfort_rocblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       real(c_double) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
       real(c_double) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batch_count
     end function
@@ -30591,12 +30591,12 @@ module hipfort_rocblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       integer(c_short) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
       integer(c_short) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batch_count
     end function
@@ -30617,12 +30617,12 @@ module hipfort_rocblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
       complex(c_float_complex) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batch_count
     end function
@@ -30643,12 +30643,12 @@ module hipfort_rocblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
       complex(c_double_complex) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batch_count
     end function
@@ -31284,11 +31284,11 @@ module hipfort_rocblas
       integer(kind(rocblas_side_left)),value :: side
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       integer(c_int),value :: batch_count
     end function
@@ -31305,11 +31305,11 @@ module hipfort_rocblas
       integer(kind(rocblas_side_left)),value :: side
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       integer(c_int),value :: batch_count
     end function
@@ -31326,11 +31326,11 @@ module hipfort_rocblas
       integer(kind(rocblas_side_left)),value :: side
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       integer(c_int),value :: batch_count
     end function
@@ -31347,11 +31347,11 @@ module hipfort_rocblas
       integer(kind(rocblas_side_left)),value :: side
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int),value :: incx
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       integer(c_int),value :: batch_count
     end function
@@ -31368,11 +31368,11 @@ module hipfort_rocblas
       integer(kind(rocblas_side_left)),value :: side
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batch_count
     end function
@@ -31389,11 +31389,11 @@ module hipfort_rocblas
       integer(kind(rocblas_side_left)),value :: side
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batch_count
     end function
@@ -31410,11 +31410,11 @@ module hipfort_rocblas
       integer(kind(rocblas_side_left)),value :: side
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batch_count
     end function
@@ -31431,11 +31431,11 @@ module hipfort_rocblas
       integer(kind(rocblas_side_left)),value :: side
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: x
+      type(c_ptr),value :: x
       integer(c_int64_t),value :: incx
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batch_count
     end function
@@ -32021,12 +32021,12 @@ module hipfort_rocblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       real(c_float) :: beta
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       integer(c_int),value :: batch_count
     end function
@@ -32046,12 +32046,12 @@ module hipfort_rocblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       real(c_double) :: beta
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       integer(c_int),value :: batch_count
     end function
@@ -32071,12 +32071,12 @@ module hipfort_rocblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       complex(c_float_complex) :: beta
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       integer(c_int),value :: batch_count
     end function
@@ -32096,12 +32096,12 @@ module hipfort_rocblas
       integer(c_int),value :: m
       integer(c_int),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       complex(c_double_complex) :: beta
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       integer(c_int),value :: batch_count
     end function
@@ -32121,12 +32121,12 @@ module hipfort_rocblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       real(c_float) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       real(c_float) :: beta
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batch_count
     end function
@@ -32146,12 +32146,12 @@ module hipfort_rocblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       real(c_double) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       real(c_double) :: beta
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batch_count
     end function
@@ -32171,12 +32171,12 @@ module hipfort_rocblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       complex(c_float_complex) :: beta
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batch_count
     end function
@@ -32196,12 +32196,12 @@ module hipfort_rocblas
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       complex(c_double_complex) :: beta
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batch_count
     end function
@@ -33378,12 +33378,12 @@ module hipfort_rocblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       real(c_float) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       real(c_float) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       integer(c_int),value :: batch_count
     end function
@@ -33404,12 +33404,12 @@ module hipfort_rocblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       real(c_double) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       real(c_double) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       integer(c_int),value :: batch_count
     end function
@@ -33430,12 +33430,12 @@ module hipfort_rocblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       complex(c_float_complex) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       integer(c_int),value :: batch_count
     end function
@@ -33456,12 +33456,12 @@ module hipfort_rocblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       complex(c_double_complex) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       integer(c_int),value :: batch_count
     end function
@@ -33482,12 +33482,12 @@ module hipfort_rocblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       real(c_float) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
       real(c_float) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batch_count
     end function
@@ -33508,12 +33508,12 @@ module hipfort_rocblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       real(c_double) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
       real(c_double) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batch_count
     end function
@@ -33534,12 +33534,12 @@ module hipfort_rocblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
       complex(c_float_complex) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batch_count
     end function
@@ -33560,12 +33560,12 @@ module hipfort_rocblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
       complex(c_double_complex) :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batch_count
     end function

--- a/lib/hipfort/hipfort_rocsolver.F90
+++ b/lib/hipfort/hipfort_rocsolver.F90
@@ -6835,7 +6835,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -6853,7 +6853,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -6871,7 +6871,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -6889,7 +6889,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -6907,7 +6907,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       type(c_ptr),value :: myInfo
       integer(c_int64_t),value :: batch_count
@@ -6925,7 +6925,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       type(c_ptr),value :: myInfo
       integer(c_int64_t),value :: batch_count
@@ -6943,7 +6943,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       type(c_ptr),value :: myInfo
       integer(c_int64_t),value :: batch_count
@@ -6961,7 +6961,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       type(c_ptr),value :: myInfo
       integer(c_int64_t),value :: batch_count
@@ -7459,7 +7459,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -7477,7 +7477,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -7495,7 +7495,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -7513,7 +7513,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -7531,7 +7531,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       type(c_ptr),value :: myInfo
       integer(c_int64_t),value :: batch_count
@@ -7549,7 +7549,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       type(c_ptr),value :: myInfo
       integer(c_int64_t),value :: batch_count
@@ -7567,7 +7567,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       type(c_ptr),value :: myInfo
       integer(c_int64_t),value :: batch_count
@@ -7585,7 +7585,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       type(c_ptr),value :: myInfo
       integer(c_int64_t),value :: batch_count
@@ -8089,7 +8089,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -8115,7 +8115,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -8141,7 +8141,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -8167,7 +8167,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -8193,7 +8193,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -8213,7 +8213,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -8233,7 +8233,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -8253,7 +8253,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -8783,7 +8783,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -8809,7 +8809,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -8835,7 +8835,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -8861,7 +8861,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -8887,7 +8887,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -8907,7 +8907,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -8927,7 +8927,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -8947,7 +8947,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -9480,7 +9480,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -9505,7 +9505,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -9530,7 +9530,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -9555,7 +9555,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -9580,7 +9580,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -9599,7 +9599,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -9618,7 +9618,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -9637,7 +9637,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -10098,7 +10098,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -10123,7 +10123,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -10148,7 +10148,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -10173,7 +10173,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -10558,7 +10558,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -10583,7 +10583,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -10608,7 +10608,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -10633,7 +10633,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -11015,7 +11015,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -11040,7 +11040,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -11065,7 +11065,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -11090,7 +11090,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -11536,7 +11536,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -11561,7 +11561,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -11586,7 +11586,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -11611,7 +11611,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -11636,7 +11636,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -11655,7 +11655,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -11674,7 +11674,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -11693,7 +11693,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int64_t),value :: m
       integer(c_int64_t),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -12154,7 +12154,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -12179,7 +12179,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -12204,7 +12204,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -12229,7 +12229,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -12614,7 +12614,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -12639,7 +12639,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -12664,7 +12664,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -12689,7 +12689,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -13071,7 +13071,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -13096,7 +13096,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -13121,7 +13121,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -13146,7 +13146,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -13603,7 +13603,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: D
       integer(c_int64_t),value :: strideD
@@ -13635,7 +13635,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: D
       integer(c_int64_t),value :: strideD
@@ -13667,7 +13667,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: D
       integer(c_int64_t),value :: strideD
@@ -13699,7 +13699,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: D
       integer(c_int64_t),value :: strideD
@@ -14231,7 +14231,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: D
       integer(c_int64_t),value :: strideD
@@ -14263,7 +14263,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: D
       integer(c_int64_t),value :: strideD
@@ -14295,7 +14295,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: D
       integer(c_int64_t),value :: strideD
@@ -14327,7 +14327,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: D
       integer(c_int64_t),value :: strideD
@@ -14868,11 +14868,11 @@ module hipfort_rocsolver
       integer(kind(rocblas_operation_none)),value :: trans
       integer(c_int),value :: n
       integer(c_int),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       integer(c_int),value :: batch_count
     end function
@@ -14896,11 +14896,11 @@ module hipfort_rocsolver
       integer(kind(rocblas_operation_none)),value :: trans
       integer(c_int),value :: n
       integer(c_int),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       integer(c_int),value :: batch_count
     end function
@@ -14924,11 +14924,11 @@ module hipfort_rocsolver
       integer(kind(rocblas_operation_none)),value :: trans
       integer(c_int),value :: n
       integer(c_int),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       integer(c_int),value :: batch_count
     end function
@@ -14952,11 +14952,11 @@ module hipfort_rocsolver
       integer(kind(rocblas_operation_none)),value :: trans
       integer(c_int),value :: n
       integer(c_int),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       integer(c_int),value :: batch_count
     end function
@@ -14981,11 +14981,11 @@ module hipfort_rocsolver
       integer(kind(rocblas_operation_none)),value :: trans
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
       integer(c_int64_t),value :: batch_count
     end function
@@ -15004,11 +15004,11 @@ module hipfort_rocsolver
       integer(kind(rocblas_operation_none)),value :: trans
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
       integer(c_int64_t),value :: batch_count
     end function
@@ -15027,11 +15027,11 @@ module hipfort_rocsolver
       integer(kind(rocblas_operation_none)),value :: trans
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
       integer(c_int64_t),value :: batch_count
     end function
@@ -15050,11 +15050,11 @@ module hipfort_rocsolver
       integer(kind(rocblas_operation_none)),value :: trans
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
       integer(c_int64_t),value :: batch_count
     end function
@@ -15608,11 +15608,11 @@ module hipfort_rocsolver
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
       integer(c_int),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       integer(c_int),value :: batch_count
     end function
@@ -15630,11 +15630,11 @@ module hipfort_rocsolver
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
       integer(c_int),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       integer(c_int),value :: batch_count
     end function
@@ -15652,11 +15652,11 @@ module hipfort_rocsolver
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
       integer(c_int),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       integer(c_int),value :: batch_count
     end function
@@ -15674,11 +15674,11 @@ module hipfort_rocsolver
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
       integer(c_int),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       integer(c_int),value :: batch_count
     end function
@@ -15696,11 +15696,11 @@ module hipfort_rocsolver
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
       integer(c_int64_t),value :: batch_count
     end function
@@ -15718,11 +15718,11 @@ module hipfort_rocsolver
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
       integer(c_int64_t),value :: batch_count
     end function
@@ -15740,11 +15740,11 @@ module hipfort_rocsolver
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
       integer(c_int64_t),value :: batch_count
     end function
@@ -15762,11 +15762,11 @@ module hipfort_rocsolver
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
       integer(c_int64_t),value :: batch_count
     end function
@@ -16239,11 +16239,11 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: n
       integer(c_int),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -16267,11 +16267,11 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: n
       integer(c_int),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -16295,11 +16295,11 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: n
       integer(c_int),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -16323,11 +16323,11 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: n
       integer(c_int),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -16770,9 +16770,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_operation_none)),value :: trans
       integer(c_int),value :: n
       integer(c_int),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       integer(c_int),value :: batch_count
     end function
@@ -16790,9 +16790,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_operation_none)),value :: trans
       integer(c_int),value :: n
       integer(c_int),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       integer(c_int),value :: batch_count
     end function
@@ -16810,9 +16810,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_operation_none)),value :: trans
       integer(c_int),value :: n
       integer(c_int),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       integer(c_int),value :: batch_count
     end function
@@ -16830,9 +16830,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_operation_none)),value :: trans
       integer(c_int),value :: n
       integer(c_int),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       integer(c_int),value :: batch_count
     end function
@@ -16850,9 +16850,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_operation_none)),value :: trans
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
       integer(c_int64_t),value :: batch_count
     end function
@@ -16870,9 +16870,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_operation_none)),value :: trans
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
       integer(c_int64_t),value :: batch_count
     end function
@@ -16890,9 +16890,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_operation_none)),value :: trans
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
       integer(c_int64_t),value :: batch_count
     end function
@@ -16910,9 +16910,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_operation_none)),value :: trans
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
       integer(c_int64_t),value :: batch_count
     end function
@@ -17319,7 +17319,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_status_success)) :: rocsolver_sgetri_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -17344,7 +17344,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_status_success)) :: rocsolver_dgetri_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -17369,7 +17369,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_status_success)) :: rocsolver_cgetri_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -17394,7 +17394,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_status_success)) :: rocsolver_zgetri_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -17720,7 +17720,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_status_success)) :: rocsolver_sgetri_npvt_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -17737,7 +17737,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_status_success)) :: rocsolver_dgetri_npvt_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -17754,7 +17754,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_status_success)) :: rocsolver_cgetri_npvt_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -17771,7 +17771,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_status_success)) :: rocsolver_zgetri_npvt_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -18159,9 +18159,9 @@ module hipfort_rocsolver
       integer(c_int),value :: m
       integer(c_int),value :: n
       integer(c_int),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -18181,9 +18181,9 @@ module hipfort_rocsolver
       integer(c_int),value :: m
       integer(c_int),value :: n
       integer(c_int),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -18203,9 +18203,9 @@ module hipfort_rocsolver
       integer(c_int),value :: m
       integer(c_int),value :: n
       integer(c_int),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -18225,9 +18225,9 @@ module hipfort_rocsolver
       integer(c_int),value :: m
       integer(c_int),value :: n
       integer(c_int),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -18673,7 +18673,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -18691,7 +18691,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -18709,7 +18709,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -18727,7 +18727,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -18745,7 +18745,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       type(c_ptr),value :: myInfo
       integer(c_int64_t),value :: batch_count
@@ -18763,7 +18763,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       type(c_ptr),value :: myInfo
       integer(c_int64_t),value :: batch_count
@@ -18781,7 +18781,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       type(c_ptr),value :: myInfo
       integer(c_int64_t),value :: batch_count
@@ -18799,7 +18799,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       type(c_ptr),value :: myInfo
       integer(c_int64_t),value :: batch_count
@@ -19264,7 +19264,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -19282,7 +19282,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -19300,7 +19300,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -19318,7 +19318,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -19336,7 +19336,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       type(c_ptr),value :: myInfo
       integer(c_int64_t),value :: batch_count
@@ -19354,7 +19354,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       type(c_ptr),value :: myInfo
       integer(c_int64_t),value :: batch_count
@@ -19372,7 +19372,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       type(c_ptr),value :: myInfo
       integer(c_int64_t),value :: batch_count
@@ -19390,7 +19390,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       type(c_ptr),value :: myInfo
       integer(c_int64_t),value :: batch_count
@@ -19897,9 +19897,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
       integer(c_int),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       integer(c_int),value :: batch_count
     end function
@@ -19917,9 +19917,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
       integer(c_int),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       integer(c_int),value :: batch_count
     end function
@@ -19937,9 +19937,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
       integer(c_int),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       integer(c_int),value :: batch_count
     end function
@@ -19957,9 +19957,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
       integer(c_int),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       integer(c_int),value :: batch_count
     end function
@@ -19977,9 +19977,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
       integer(c_int64_t),value :: batch_count
     end function
@@ -19997,9 +19997,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
       integer(c_int64_t),value :: batch_count
     end function
@@ -20017,9 +20017,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
       integer(c_int64_t),value :: batch_count
     end function
@@ -20037,9 +20037,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int64_t),value :: ldb
       integer(c_int64_t),value :: batch_count
     end function
@@ -20520,9 +20520,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
       integer(c_int),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -20541,9 +20541,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
       integer(c_int),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -20562,9 +20562,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
       integer(c_int),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -20583,9 +20583,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
       integer(c_int),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -20945,7 +20945,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -20963,7 +20963,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -20981,7 +20981,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -20999,7 +20999,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -21533,7 +21533,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_svect_all)),value :: right_svect
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: S
       integer(c_int64_t),value :: strideS
@@ -21572,7 +21572,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_svect_all)),value :: right_svect
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: S
       integer(c_int64_t),value :: strideS
@@ -21611,7 +21611,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_svect_all)),value :: right_svect
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: S
       integer(c_int64_t),value :: strideS
@@ -21650,7 +21650,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_svect_all)),value :: right_svect
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: S
       integer(c_int64_t),value :: strideS
@@ -22237,7 +22237,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_svect_all)),value :: right_svect
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: S
       integer(c_int64_t),value :: strideS
@@ -22266,7 +22266,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_svect_all)),value :: right_svect
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: S
       integer(c_int64_t),value :: strideS
@@ -22295,7 +22295,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_svect_all)),value :: right_svect
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: S
       integer(c_int64_t),value :: strideS
@@ -22324,7 +22324,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_svect_all)),value :: right_svect
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: S
       integer(c_int64_t),value :: strideS
@@ -22885,7 +22885,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_svect_all)),value :: right_svect
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       real(c_float),value :: abstol
       type(c_ptr),value :: residual
@@ -22918,7 +22918,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_svect_all)),value :: right_svect
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       real(c_double),value :: abstol
       type(c_ptr),value :: residual
@@ -22951,7 +22951,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_svect_all)),value :: right_svect
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       real(c_float),value :: abstol
       type(c_ptr),value :: residual
@@ -22984,7 +22984,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_svect_all)),value :: right_svect
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       real(c_double),value :: abstol
       type(c_ptr),value :: residual
@@ -23657,7 +23657,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_srange_all)),value :: srange
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       real(c_float),value :: vl
       real(c_float),value :: vu
@@ -23694,7 +23694,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_srange_all)),value :: srange
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       real(c_double),value :: vl
       real(c_double),value :: vu
@@ -23731,7 +23731,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_srange_all)),value :: srange
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       real(c_float),value :: vl
       real(c_float),value :: vu
@@ -23768,7 +23768,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_srange_all)),value :: srange
       integer(c_int),value :: m
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       real(c_double),value :: vl
       real(c_double),value :: vu
@@ -24397,7 +24397,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: D
       integer(c_int64_t),value :: strideD
@@ -24427,7 +24427,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: D
       integer(c_int64_t),value :: strideD
@@ -24537,7 +24537,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: D
       integer(c_int64_t),value :: strideD
@@ -24567,7 +24567,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: D
       integer(c_int64_t),value :: strideD
@@ -25188,7 +25188,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: D
       integer(c_int64_t),value :: strideD
@@ -25218,7 +25218,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: D
       integer(c_int64_t),value :: strideD
@@ -25328,7 +25328,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: D
       integer(c_int64_t),value :: strideD
@@ -25358,7 +25358,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: D
       integer(c_int64_t),value :: strideD
@@ -25977,9 +25977,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_eform_ax)),value :: itype
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       integer(c_int),value :: batch_count
     end function
@@ -25997,9 +25997,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_eform_ax)),value :: itype
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       integer(c_int),value :: batch_count
     end function
@@ -26085,9 +26085,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_eform_ax)),value :: itype
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       integer(c_int),value :: batch_count
     end function
@@ -26105,9 +26105,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_eform_ax)),value :: itype
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       integer(c_int),value :: batch_count
     end function
@@ -26689,9 +26689,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_eform_ax)),value :: itype
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       integer(c_int),value :: batch_count
     end function
@@ -26709,9 +26709,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_eform_ax)),value :: itype
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       integer(c_int),value :: batch_count
     end function
@@ -26797,9 +26797,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_eform_ax)),value :: itype
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       integer(c_int),value :: batch_count
     end function
@@ -26817,9 +26817,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_eform_ax)),value :: itype
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       integer(c_int),value :: batch_count
     end function
@@ -27437,7 +27437,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_evect_original)),value :: evect
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: D
       integer(c_int64_t),value :: strideD
@@ -27467,7 +27467,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_evect_original)),value :: evect
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: D
       integer(c_int64_t),value :: strideD
@@ -27497,7 +27497,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_evect_original)),value :: evect
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       type(c_ptr),value :: D
       integer(c_int64_t),value :: strideD
@@ -27521,7 +27521,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_evect_original)),value :: evect
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       type(c_ptr),value :: D
       integer(c_int64_t),value :: strideD
@@ -27604,7 +27604,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_evect_original)),value :: evect
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: D
       integer(c_int64_t),value :: strideD
@@ -27634,7 +27634,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_evect_original)),value :: evect
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: D
       integer(c_int64_t),value :: strideD
@@ -27664,7 +27664,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_evect_original)),value :: evect
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       type(c_ptr),value :: D
       integer(c_int64_t),value :: strideD
@@ -27688,7 +27688,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_evect_original)),value :: evect
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       type(c_ptr),value :: D
       integer(c_int64_t),value :: strideD
@@ -28418,7 +28418,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_evect_original)),value :: evect
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: D
       integer(c_int64_t),value :: strideD
@@ -28448,7 +28448,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_evect_original)),value :: evect
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: D
       integer(c_int64_t),value :: strideD
@@ -28478,7 +28478,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_evect_original)),value :: evect
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       type(c_ptr),value :: D
       integer(c_int64_t),value :: strideD
@@ -28502,7 +28502,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_evect_original)),value :: evect
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       type(c_ptr),value :: D
       integer(c_int64_t),value :: strideD
@@ -28591,7 +28591,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_evect_original)),value :: evect
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: D
       integer(c_int64_t),value :: strideD
@@ -28621,7 +28621,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_evect_original)),value :: evect
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: D
       integer(c_int64_t),value :: strideD
@@ -28651,7 +28651,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_evect_original)),value :: evect
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       type(c_ptr),value :: D
       integer(c_int64_t),value :: strideD
@@ -28675,7 +28675,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_evect_original)),value :: evect
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int64_t),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int64_t),value :: lda
       type(c_ptr),value :: D
       integer(c_int64_t),value :: strideD
@@ -29246,7 +29246,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_evect_original)),value :: evect
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: D
       integer(c_int64_t),value :: strideD
@@ -29267,7 +29267,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_evect_original)),value :: evect
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: D
       integer(c_int64_t),value :: strideD
@@ -29330,7 +29330,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_evect_original)),value :: evect
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: D
       integer(c_int64_t),value :: strideD
@@ -29351,7 +29351,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_evect_original)),value :: evect
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: D
       integer(c_int64_t),value :: strideD
@@ -29834,9 +29834,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_evect_original)),value :: evect
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       type(c_ptr),value :: D
       integer(c_int64_t),value :: strideD
@@ -29859,9 +29859,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_evect_original)),value :: evect
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       type(c_ptr),value :: D
       integer(c_int64_t),value :: strideD
@@ -29956,9 +29956,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_evect_original)),value :: evect
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       type(c_ptr),value :: D
       integer(c_int64_t),value :: strideD
@@ -29981,9 +29981,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_evect_original)),value :: evect
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       type(c_ptr),value :: D
       integer(c_int64_t),value :: strideD
@@ -30589,7 +30589,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_evect_original)),value :: evect
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       real(c_float),value :: abstol
       type(c_ptr),value :: residual
@@ -30616,7 +30616,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_evect_original)),value :: evect
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       real(c_double),value :: abstol
       type(c_ptr),value :: residual
@@ -30722,7 +30722,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_evect_original)),value :: evect
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       real(c_float),value :: abstol
       type(c_ptr),value :: residual
@@ -30749,7 +30749,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_evect_original)),value :: evect
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       real(c_double),value :: abstol
       type(c_ptr),value :: residual
@@ -31433,7 +31433,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_erange_all)),value :: erange
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       real(c_float),value :: vl
       real(c_float),value :: vu
@@ -31443,7 +31443,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: nev
       type(c_ptr),value :: W
       integer(c_int64_t),value :: strideW
-      type(c_ptr) :: Z
+      type(c_ptr),value :: Z
       integer(c_int),value :: ldz
       type(c_ptr),value :: ifail
       integer(c_int64_t),value :: strideF
@@ -31466,7 +31466,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_erange_all)),value :: erange
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       real(c_double),value :: vl
       real(c_double),value :: vu
@@ -31476,7 +31476,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: nev
       type(c_ptr),value :: W
       integer(c_int64_t),value :: strideW
-      type(c_ptr) :: Z
+      type(c_ptr),value :: Z
       integer(c_int),value :: ldz
       type(c_ptr),value :: ifail
       integer(c_int64_t),value :: strideF
@@ -31596,7 +31596,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_erange_all)),value :: erange
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       real(c_float),value :: vl
       real(c_float),value :: vu
@@ -31606,7 +31606,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: nev
       type(c_ptr),value :: W
       integer(c_int64_t),value :: strideW
-      type(c_ptr) :: Z
+      type(c_ptr),value :: Z
       integer(c_int),value :: ldz
       type(c_ptr),value :: ifail
       integer(c_int64_t),value :: strideF
@@ -31629,7 +31629,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_erange_all)),value :: erange
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       real(c_double),value :: vl
       real(c_double),value :: vu
@@ -31639,7 +31639,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: nev
       type(c_ptr),value :: W
       integer(c_int64_t),value :: strideW
-      type(c_ptr) :: Z
+      type(c_ptr),value :: Z
       integer(c_int),value :: ldz
       type(c_ptr),value :: ifail
       integer(c_int64_t),value :: strideF
@@ -32355,9 +32355,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_evect_original)),value :: evect
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       type(c_ptr),value :: D
       integer(c_int64_t),value :: strideD
@@ -32388,9 +32388,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_evect_original)),value :: evect
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       type(c_ptr),value :: D
       integer(c_int64_t),value :: strideD
@@ -32504,9 +32504,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_evect_original)),value :: evect
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       type(c_ptr),value :: D
       integer(c_int64_t),value :: strideD
@@ -32537,9 +32537,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_evect_original)),value :: evect
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       type(c_ptr),value :: D
       integer(c_int64_t),value :: strideD
@@ -33260,9 +33260,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_evect_original)),value :: evect
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       type(c_ptr),value :: D
       integer(c_int64_t),value :: strideD
@@ -33293,9 +33293,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_evect_original)),value :: evect
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       type(c_ptr),value :: D
       integer(c_int64_t),value :: strideD
@@ -33420,9 +33420,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_evect_original)),value :: evect
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       type(c_ptr),value :: D
       integer(c_int64_t),value :: strideD
@@ -33453,9 +33453,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_evect_original)),value :: evect
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       type(c_ptr),value :: D
       integer(c_int64_t),value :: strideD
@@ -34176,9 +34176,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_evect_original)),value :: evect
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       real(c_float),value :: abstol
       type(c_ptr),value :: residual
@@ -34205,9 +34205,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_evect_original)),value :: evect
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       real(c_double),value :: abstol
       type(c_ptr),value :: residual
@@ -34316,9 +34316,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_evect_original)),value :: evect
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       real(c_float),value :: abstol
       type(c_ptr),value :: residual
@@ -34345,9 +34345,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_evect_original)),value :: evect
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       real(c_double),value :: abstol
       type(c_ptr),value :: residual
@@ -35165,9 +35165,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_erange_all)),value :: erange
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       real(c_float),value :: vl
       real(c_float),value :: vu
@@ -35177,7 +35177,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: nev
       type(c_ptr),value :: W
       integer(c_int64_t),value :: strideW
-      type(c_ptr) :: Z
+      type(c_ptr),value :: Z
       integer(c_int),value :: ldz
       type(c_ptr),value :: ifail
       integer(c_int64_t),value :: strideF
@@ -35201,9 +35201,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_erange_all)),value :: erange
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       real(c_double),value :: vl
       real(c_double),value :: vu
@@ -35213,7 +35213,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: nev
       type(c_ptr),value :: W
       integer(c_int64_t),value :: strideW
-      type(c_ptr) :: Z
+      type(c_ptr),value :: Z
       integer(c_int),value :: ldz
       type(c_ptr),value :: ifail
       integer(c_int64_t),value :: strideF
@@ -35367,9 +35367,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_erange_all)),value :: erange
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       real(c_float),value :: vl
       real(c_float),value :: vu
@@ -35379,7 +35379,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: nev
       type(c_ptr),value :: W
       integer(c_int64_t),value :: strideW
-      type(c_ptr) :: Z
+      type(c_ptr),value :: Z
       integer(c_int),value :: ldz
       type(c_ptr),value :: ifail
       integer(c_int64_t),value :: strideF
@@ -35403,9 +35403,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_erange_all)),value :: erange
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       real(c_double),value :: vl
       real(c_double),value :: vu
@@ -35415,7 +35415,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: nev
       type(c_ptr),value :: W
       integer(c_int64_t),value :: strideW
-      type(c_ptr) :: Z
+      type(c_ptr),value :: Z
       integer(c_int),value :: ldz
       type(c_ptr),value :: ifail
       integer(c_int64_t),value :: strideF
@@ -36052,11 +36052,11 @@ module hipfort_rocsolver
       integer(kind(rocblas_status_success)) :: rocsolver_sgetri_outofplace_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -36080,11 +36080,11 @@ module hipfort_rocsolver
       integer(kind(rocblas_status_success)) :: rocsolver_dgetri_outofplace_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -36108,11 +36108,11 @@ module hipfort_rocsolver
       integer(kind(rocblas_status_success)) :: rocsolver_cgetri_outofplace_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -36136,11 +36136,11 @@ module hipfort_rocsolver
       integer(kind(rocblas_status_success)) :: rocsolver_zgetri_outofplace_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -36496,9 +36496,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_status_success)) :: rocsolver_sgetri_npvt_outofplace_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -36515,9 +36515,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_status_success)) :: rocsolver_dgetri_npvt_outofplace_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -36534,9 +36534,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_status_success)) :: rocsolver_cgetri_npvt_outofplace_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -36553,9 +36553,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_status_success)) :: rocsolver_zgetri_npvt_outofplace_batched_
       type(c_ptr),value :: handle
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -36884,7 +36884,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(kind(rocblas_diagonal_non_unit)),value :: diag
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -36903,7 +36903,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(kind(rocblas_diagonal_non_unit)),value :: diag
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -36922,7 +36922,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(kind(rocblas_diagonal_non_unit)),value :: diag
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -36941,7 +36941,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(kind(rocblas_diagonal_non_unit)),value :: diag
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -37389,7 +37389,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -37415,7 +37415,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -37441,7 +37441,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -37467,7 +37467,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -37993,7 +37993,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -38019,7 +38019,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -38045,7 +38045,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -38071,7 +38071,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: ipiv
       integer(c_int64_t),value :: strideP
@@ -38532,11 +38532,11 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: nb
       integer(c_int),value :: nblocks
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -38555,11 +38555,11 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: nb
       integer(c_int),value :: nblocks
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -38578,11 +38578,11 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: nb
       integer(c_int),value :: nblocks
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -38601,11 +38601,11 @@ module hipfort_rocsolver
       type(c_ptr),value :: handle
       integer(c_int),value :: nb
       integer(c_int),value :: nblocks
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -39267,13 +39267,13 @@ module hipfort_rocsolver
       integer(c_int),value :: nb
       integer(c_int),value :: nblocks
       integer(c_int),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
-      type(c_ptr) :: X
+      type(c_ptr),value :: X
       integer(c_int),value :: ldx
       integer(c_int),value :: batch_count
     end function
@@ -39292,13 +39292,13 @@ module hipfort_rocsolver
       integer(c_int),value :: nb
       integer(c_int),value :: nblocks
       integer(c_int),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
-      type(c_ptr) :: X
+      type(c_ptr),value :: X
       integer(c_int),value :: ldx
       integer(c_int),value :: batch_count
     end function
@@ -39317,13 +39317,13 @@ module hipfort_rocsolver
       integer(c_int),value :: nb
       integer(c_int),value :: nblocks
       integer(c_int),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
-      type(c_ptr) :: X
+      type(c_ptr),value :: X
       integer(c_int),value :: ldx
       integer(c_int),value :: batch_count
     end function
@@ -39342,13 +39342,13 @@ module hipfort_rocsolver
       integer(c_int),value :: nb
       integer(c_int),value :: nblocks
       integer(c_int),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(c_int),value :: ldc
-      type(c_ptr) :: X
+      type(c_ptr),value :: X
       integer(c_int),value :: ldx
       integer(c_int),value :: batch_count
     end function
@@ -40955,7 +40955,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_erange_all)),value :: erange
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       real(c_float),value :: vl
       real(c_float),value :: vu
@@ -40964,7 +40964,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: nev
       type(c_ptr),value :: W
       integer(c_int64_t),value :: strideW
-      type(c_ptr) :: Z
+      type(c_ptr),value :: Z
       integer(c_int),value :: ldz
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -40985,7 +40985,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_erange_all)),value :: erange
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       real(c_double),value :: vl
       real(c_double),value :: vu
@@ -40994,7 +40994,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: nev
       type(c_ptr),value :: W
       integer(c_int64_t),value :: strideW
-      type(c_ptr) :: Z
+      type(c_ptr),value :: Z
       integer(c_int),value :: ldz
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -41097,7 +41097,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_erange_all)),value :: erange
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       real(c_float),value :: vl
       real(c_float),value :: vu
@@ -41106,7 +41106,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: nev
       type(c_ptr),value :: W
       integer(c_int64_t),value :: strideW
-      type(c_ptr) :: Z
+      type(c_ptr),value :: Z
       integer(c_int),value :: ldz
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -41127,7 +41127,7 @@ module hipfort_rocsolver
       integer(kind(rocblas_erange_all)),value :: erange
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       real(c_double),value :: vl
       real(c_double),value :: vu
@@ -41136,7 +41136,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: nev
       type(c_ptr),value :: W
       integer(c_int64_t),value :: strideW
-      type(c_ptr) :: Z
+      type(c_ptr),value :: Z
       integer(c_int),value :: ldz
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -41919,9 +41919,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_erange_all)),value :: erange
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       real(c_float),value :: vl
       real(c_float),value :: vu
@@ -41930,7 +41930,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: nev
       type(c_ptr),value :: W
       integer(c_int64_t),value :: strideW
-      type(c_ptr) :: Z
+      type(c_ptr),value :: Z
       integer(c_int),value :: ldz
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -41952,9 +41952,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_erange_all)),value :: erange
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       real(c_double),value :: vl
       real(c_double),value :: vu
@@ -41963,7 +41963,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: nev
       type(c_ptr),value :: W
       integer(c_int64_t),value :: strideW
-      type(c_ptr) :: Z
+      type(c_ptr),value :: Z
       integer(c_int),value :: ldz
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -42098,9 +42098,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_erange_all)),value :: erange
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       real(c_float),value :: vl
       real(c_float),value :: vu
@@ -42109,7 +42109,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: nev
       type(c_ptr),value :: W
       integer(c_int64_t),value :: strideW
-      type(c_ptr) :: Z
+      type(c_ptr),value :: Z
       integer(c_int),value :: ldz
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count
@@ -42131,9 +42131,9 @@ module hipfort_rocsolver
       integer(kind(rocblas_erange_all)),value :: erange
       integer(kind(rocblas_fill_upper)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       real(c_double),value :: vl
       real(c_double),value :: vu
@@ -42142,7 +42142,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: nev
       type(c_ptr),value :: W
       integer(c_int64_t),value :: strideW
-      type(c_ptr) :: Z
+      type(c_ptr),value :: Z
       integer(c_int),value :: ldz
       type(c_ptr),value :: myInfo
       integer(c_int),value :: batch_count


### PR DESCRIPTION
Fixes the `*gemm_batched` (and other `*_batched`) tests failing at runtime with HIP error 700 (`hipErrorIllegalAddress`).

**Cause.** A batched argument is `const T* const A[]` (an array of device pointers). The C parameter is a single pointer value: the base address of that array, which lives in **device** memory. The binding declared it as `type(c_ptr) :: A` (by reference), so Fortran passed `&A` (the address of a host `c_ptr` variable) instead of the device array address. rocBLAS then dereferenced host memory on the device, giving error 700. The tests pass a device pointer array (`hipMalloc` + `hipMemcpy` of the host pointer array into `da_p`, then `rocblas_?gemm_batched(..., da_p, ...)`), which only works with a by-value argument. (Pre-existing: the same by-reference binding shipped in rocm-7.2.4.)

**Fix (generator).** `cltype_to_fortran` now maps an array whose element is a **const-qualified pointer** (`const T* const A[]`, `T* const C[]`, i.e. rocBLAS/rocSOLVER `*_batched`) to `type(c_ptr), value`. A non-const pointer array (`void* buffer[]`, e.g. `rocfft_execute`, a host-side array read by the callee) stays `type(c_ptr)` by reference. Output double-pointers (`void** ptr`, pointer syntax not array syntax) are unaffected.

**Verified.** Diff is purely `type(c_ptr)` -> `type(c_ptr), value` on the batched array arguments (rocBLAS, hipBLAS, rocSOLVER). `rocfft_execute` stays by reference. Both `hipfort-amdgcn` and `hipfort-nvptx` build cleanly.