### PR TITLE
CHANGELOG: document the rocSOLVER info and batched device-pointer changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,11 @@
   and descriptor getters. Call them directly, for example
   `istat = hipDeviceGetAttribute(value, attr, dev)`, with no `C_LOC(value)`. Existing
   code that passes `C_LOC(x)` to these routines must now pass `x`.
+* **rocSOLVER `info` is now a device pointer.** The `info` output is written on the
+  GPU, so these routines now take a `type(c_ptr)` that points to device memory,
+  instead of a host `integer`. Allocate it with `hipMalloc` and pass the device
+  pointer. This affects `getrf`, `getri`, `potrf`, `sytrf`, `gesv`, `posv`, `syev`,
+  `heev`, `trtri`, and the related factorization and eigenvalue routines.
 * Derived types are emitted in per-library `hipfort_<lib>_types` modules. A module is
   generated only when a binding references one of its types. Unreferenced complex,
   half, and bfloat16 struct mirrors are no longer emitted.
@@ -87,6 +92,10 @@
 * `fftw_iodim64` members now use `c_ptrdiff_t` instead of `c_long`, matching FFTW's
   `ptrdiff_t` fields. This gives the correct struct layout on LLP64 platforms such
   as Windows.
+* Batched rocBLAS, hipBLAS, and rocSOLVER routines now pass their array of device
+  pointers by value. The array holds device pointers and lives on the device, so it
+  is passed directly, not by reference. This fixes an illegal-address failure (HIP
+  error `700`) in `*_gemm_batched` and the other `*_batched` routines.
 
 ## hipfort 0.7.1 for ROCm 7.1.0
 


### PR DESCRIPTION
While cross-checking the regenerated bindings against the last release of `hipfort`, I found two breaking changes in how device pointers are passed that were not yet in the changelog.

### rocSOLVER `info`

In `rocm-7.2.4` the `info` argument of the rocSOLVER factorization and eigenvalue routines was typed as a host `integer(c_int)` passed by reference. The C API documents `info` as a `rocblas_int` **on the GPU** ("pointer to a rocblas_int on the GPU"), so the old binding wrote to a host address interpreted as device memory. The regenerated bindings now pass it as a `type(c_ptr)` device pointer. This is a correctness fix, but it is breaking for callers migrating from 7.2.4: they must allocate `info` with `hipMalloc` and pass the device pointer.

This affects 71 interfaces (`getf2`/`getrf`/`getri` and `_npvt` variants, `potf2`/`potrf`/`potri`, `sytf2`/`sytrf`, `gesv`, `posv`, `syev`/`heev`, `stedc`/`steqr`/`sterf`, `trtri`, all precisions).

### Batched routines

The `*_batched` routines take an array of device pointers. That array lives on the device, so it must be passed by value, not by reference. This was already merged (illegal-address / HIP error `700` in `*_gemm_batched`) but had no changelog entry.

### How this was found

A type-level diff of every C symbol bound in both the last release and `develop` (743 common symbols). All 131 type changes are fixes, more precise typing, or cosmetic (equivalent kinds). No regressions. These two are the ones with user-visible migration impact that were undocumented.