### PR TITLE
test: fix misleading rocSOLVER info comment in the f2008 getrf/potrf tests

### DIFF
--- a/test/f2008/rocsolver/rocsolver_cgetrf.f08
+++ b/test/f2008/rocsolver/rocsolver_cgetrf.f08
@@ -3,7 +3,7 @@
 ! see: https:!www.netlib.org/lapack/explore-html/dd/d9a/group__double_g_ecomputational_ga0019443faea08275ca60a734d0593e60.html
 !
 ! NOTE: rocSOLVER writes the `info` output to DEVICE memory. The hipfort
-! binding types the info argument as a plain integer, so it must be backed
+! binding types the info argument as a device pointer (type(c_ptr)), so it must be backed
 ! by a device allocation (dInfo below) and passed as c_loc(dInfo); passing a
 ! host scalar faults on the GPU.
 !!!!!!!!!!!!!!/

--- a/test/f2008/rocsolver/rocsolver_cpotrf.f08
+++ b/test/f2008/rocsolver/rocsolver_cpotrf.f08
@@ -3,7 +3,7 @@
 ! see: https:!www.netlib.org/lapack/explore-html/d1/d7a/group__double_p_ocomputational_ga2f55f604a6003d03b5cd4a0adcfb9e07.html
 !
 ! NOTE: rocSOLVER writes the `info` output to DEVICE memory. The hipfort
-! binding types the info argument as a plain integer, so it must be backed
+! binding types the info argument as a device pointer (type(c_ptr)), so it must be backed
 ! by a device allocation (dInfo below) and passed as c_loc(dInfo); passing a
 ! host scalar faults on the GPU.
 !

--- a/test/f2008/rocsolver/rocsolver_dgetrf.f08
+++ b/test/f2008/rocsolver/rocsolver_dgetrf.f08
@@ -3,7 +3,7 @@
 ! see: https:!www.netlib.org/lapack/explore-html/dd/d9a/group__double_g_ecomputational_ga0019443faea08275ca60a734d0593e60.html
 !
 ! NOTE: rocSOLVER writes the `info` output to DEVICE memory. The hipfort
-! binding types the info argument as a plain integer, so it must be backed
+! binding types the info argument as a device pointer (type(c_ptr)), so it must be backed
 ! by a device allocation (dInfo below) and passed as c_loc(dInfo); passing a
 ! host scalar faults on the GPU.
 !!!!!!!!!!!!!!/

--- a/test/f2008/rocsolver/rocsolver_dpotrf.f08
+++ b/test/f2008/rocsolver/rocsolver_dpotrf.f08
@@ -3,7 +3,7 @@
 ! see: https:!www.netlib.org/lapack/explore-html/d1/d7a/group__double_p_ocomputational_ga2f55f604a6003d03b5cd4a0adcfb9e07.html
 !
 ! NOTE: rocSOLVER writes the `info` output to DEVICE memory. The hipfort
-! binding types the info argument as a plain integer, so it must be backed
+! binding types the info argument as a device pointer (type(c_ptr)), so it must be backed
 ! by a device allocation (dInfo below) and passed as c_loc(dInfo); passing a
 ! host scalar faults on the GPU.
 !

--- a/test/f2008/rocsolver/rocsolver_sgetrf.f08
+++ b/test/f2008/rocsolver/rocsolver_sgetrf.f08
@@ -3,7 +3,7 @@
 ! see: https:!www.netlib.org/lapack/explore-html/dd/d9a/group__double_g_ecomputational_ga0019443faea08275ca60a734d0593e60.html
 !
 ! NOTE: rocSOLVER writes the `info` output to DEVICE memory. The hipfort
-! binding types the info argument as a plain integer, so it must be backed
+! binding types the info argument as a device pointer (type(c_ptr)), so it must be backed
 ! by a device allocation (dInfo below) and passed as c_loc(dInfo); passing a
 ! host scalar faults on the GPU.
 !!!!!!!!!!!!!!/

--- a/test/f2008/rocsolver/rocsolver_spotrf.f08
+++ b/test/f2008/rocsolver/rocsolver_spotrf.f08
@@ -3,7 +3,7 @@
 ! see: https:!www.netlib.org/lapack/explore-html/d1/d7a/group__double_p_ocomputational_ga2f55f604a6003d03b5cd4a0adcfb9e07.html
 !
 ! NOTE: rocSOLVER writes the `info` output to DEVICE memory. The hipfort
-! binding types the info argument as a plain integer, so it must be backed
+! binding types the info argument as a device pointer (type(c_ptr)), so it must be backed
 ! by a device allocation (dInfo below) and passed as c_loc(dInfo); passing a
 ! host scalar faults on the GPU.
 !

--- a/test/f2008/rocsolver/rocsolver_zgetrf.f08
+++ b/test/f2008/rocsolver/rocsolver_zgetrf.f08
@@ -3,7 +3,7 @@
 ! see: https:!www.netlib.org/lapack/explore-html/dd/d9a/group__double_g_ecomputational_ga0019443faea08275ca60a734d0593e60.html
 !
 ! NOTE: rocSOLVER writes the `info` output to DEVICE memory. The hipfort
-! binding types the info argument as a plain integer, so it must be backed
+! binding types the info argument as a device pointer (type(c_ptr)), so it must be backed
 ! by a device allocation (dInfo below) and passed as c_loc(dInfo); passing a
 ! host scalar faults on the GPU.
 !!!!!!!!!!!!!!/

--- a/test/f2008/rocsolver/rocsolver_zpotrf.f08
+++ b/test/f2008/rocsolver/rocsolver_zpotrf.f08
@@ -3,7 +3,7 @@
 ! see: https:!www.netlib.org/lapack/explore-html/d1/d7a/group__double_p_ocomputational_ga2f55f604a6003d03b5cd4a0adcfb9e07.html
 !
 ! NOTE: rocSOLVER writes the `info` output to DEVICE memory. The hipfort
-! binding types the info argument as a plain integer, so it must be backed
+! binding types the info argument as a device pointer (type(c_ptr)), so it must be backed
 ! by a device allocation (dInfo below) and passed as c_loc(dInfo); passing a
 ! host scalar faults on the GPU.
 !


### PR DESCRIPTION
The NOTE in the f2008 `getrf`/`potrf` tests said the hipfort binding types the `info` argument "as a plain integer". That is inaccurate: the binding types it as a device pointer (`type(c_ptr)`), which is exactly why the test allocates `dInfo` on the device and passes `c_loc(dInfo)`. Corrected the wording. No code change. The f2003 tests already describe it correctly.