### PR TITLE
docs: fix stale variant column in supported_api_hipfft.md

### DIFF
--- a/docs/doxygen/input/supported_api_hipfft.md
+++ b/docs/doxygen/input/supported_api_hipfft.md
@@ -8,21 +8,21 @@
 4 | [hipfftPlanMany](https://rocm.docs.amd.com/projects/hipfort/en/latest/doxygen/html/interfacehipfort__hipfft_1_1hipfft_plan_many.html "Interface documentation") | C binding, rank_0, rank_1
 5 | [hipfftCreate](https://rocm.docs.amd.com/projects/hipfort/en/latest/doxygen/html/interfacehipfort__hipfft_1_1hipfft_create.html "Interface documentation") | C binding
 6 | [hipfftExtPlanScaleFactor](https://rocm.docs.amd.com/projects/hipfort/en/latest/doxygen/html/interfacehipfort__hipfft_1_1hipfft_ext_plan_scale_factor.html "Interface documentation") | C binding
-7 | [hipfftMakePlan1d](https://rocm.docs.amd.com/projects/hipfort/en/latest/doxygen/html/interfacehipfort__hipfft_1_1hipfft_make_plan1d.html "Interface documentation") | C binding, rank_0, rank_1
-8 | [hipfftMakePlan2d](https://rocm.docs.amd.com/projects/hipfort/en/latest/doxygen/html/interfacehipfort__hipfft_1_1hipfft_make_plan2d.html "Interface documentation") | C binding, rank_0, rank_1
-9 | [hipfftMakePlan3d](https://rocm.docs.amd.com/projects/hipfort/en/latest/doxygen/html/interfacehipfort__hipfft_1_1hipfft_make_plan3d.html "Interface documentation") | C binding, rank_0, rank_1
+7 | [hipfftMakePlan1d](https://rocm.docs.amd.com/projects/hipfort/en/latest/doxygen/html/interfacehipfort__hipfft_1_1hipfft_make_plan1d.html "Interface documentation") | C binding
+8 | [hipfftMakePlan2d](https://rocm.docs.amd.com/projects/hipfort/en/latest/doxygen/html/interfacehipfort__hipfft_1_1hipfft_make_plan2d.html "Interface documentation") | C binding
+9 | [hipfftMakePlan3d](https://rocm.docs.amd.com/projects/hipfort/en/latest/doxygen/html/interfacehipfort__hipfft_1_1hipfft_make_plan3d.html "Interface documentation") | C binding
 10 | [hipfftMakePlanMany](https://rocm.docs.amd.com/projects/hipfort/en/latest/doxygen/html/interfacehipfort__hipfft_1_1hipfft_make_plan_many.html "Interface documentation") | C binding, rank_0, rank_1
 11 | [hipfftMakePlanMany64](https://rocm.docs.amd.com/projects/hipfort/en/latest/doxygen/html/interfacehipfort__hipfft_1_1hipfft_make_plan_many64.html "Interface documentation") | C binding, rank_0, rank_1
-12 | [hipfftEstimate1d](https://rocm.docs.amd.com/projects/hipfort/en/latest/doxygen/html/interfacehipfort__hipfft_1_1hipfft_estimate1d.html "Interface documentation") | C binding, rank_0, rank_1
-13 | [hipfftEstimate2d](https://rocm.docs.amd.com/projects/hipfort/en/latest/doxygen/html/interfacehipfort__hipfft_1_1hipfft_estimate2d.html "Interface documentation") | C binding, rank_0, rank_1
-14 | [hipfftEstimate3d](https://rocm.docs.amd.com/projects/hipfort/en/latest/doxygen/html/interfacehipfort__hipfft_1_1hipfft_estimate3d.html "Interface documentation") | C binding, rank_0, rank_1
+12 | [hipfftEstimate1d](https://rocm.docs.amd.com/projects/hipfort/en/latest/doxygen/html/interfacehipfort__hipfft_1_1hipfft_estimate1d.html "Interface documentation") | C binding
+13 | [hipfftEstimate2d](https://rocm.docs.amd.com/projects/hipfort/en/latest/doxygen/html/interfacehipfort__hipfft_1_1hipfft_estimate2d.html "Interface documentation") | C binding
+14 | [hipfftEstimate3d](https://rocm.docs.amd.com/projects/hipfort/en/latest/doxygen/html/interfacehipfort__hipfft_1_1hipfft_estimate3d.html "Interface documentation") | C binding
 15 | [hipfftEstimateMany](https://rocm.docs.amd.com/projects/hipfort/en/latest/doxygen/html/interfacehipfort__hipfft_1_1hipfft_estimate_many.html "Interface documentation") | C binding, rank_0, rank_1
-16 | [hipfftGetSize1d](https://rocm.docs.amd.com/projects/hipfort/en/latest/doxygen/html/interfacehipfort__hipfft_1_1hipfft_get_size1d.html "Interface documentation") | C binding, rank_0, rank_1
-17 | [hipfftGetSize2d](https://rocm.docs.amd.com/projects/hipfort/en/latest/doxygen/html/interfacehipfort__hipfft_1_1hipfft_get_size2d.html "Interface documentation") | C binding, rank_0, rank_1
-18 | [hipfftGetSize3d](https://rocm.docs.amd.com/projects/hipfort/en/latest/doxygen/html/interfacehipfort__hipfft_1_1hipfft_get_size3d.html "Interface documentation") | C binding, rank_0, rank_1
+16 | [hipfftGetSize1d](https://rocm.docs.amd.com/projects/hipfort/en/latest/doxygen/html/interfacehipfort__hipfft_1_1hipfft_get_size1d.html "Interface documentation") | C binding
+17 | [hipfftGetSize2d](https://rocm.docs.amd.com/projects/hipfort/en/latest/doxygen/html/interfacehipfort__hipfft_1_1hipfft_get_size2d.html "Interface documentation") | C binding
+18 | [hipfftGetSize3d](https://rocm.docs.amd.com/projects/hipfort/en/latest/doxygen/html/interfacehipfort__hipfft_1_1hipfft_get_size3d.html "Interface documentation") | C binding
 19 | [hipfftGetSizeMany](https://rocm.docs.amd.com/projects/hipfort/en/latest/doxygen/html/interfacehipfort__hipfft_1_1hipfft_get_size_many.html "Interface documentation") | C binding, rank_0, rank_1
 20 | [hipfftGetSizeMany64](https://rocm.docs.amd.com/projects/hipfort/en/latest/doxygen/html/interfacehipfort__hipfft_1_1hipfft_get_size_many64.html "Interface documentation") | C binding, rank_0, rank_1
-21 | [hipfftGetSize](https://rocm.docs.amd.com/projects/hipfort/en/latest/doxygen/html/interfacehipfort__hipfft_1_1hipfft_get_size.html "Interface documentation") | C binding, rank_0, rank_1
+21 | [hipfftGetSize](https://rocm.docs.amd.com/projects/hipfort/en/latest/doxygen/html/interfacehipfort__hipfft_1_1hipfft_get_size.html "Interface documentation") | C binding
 22 | [hipfftSetAutoAllocation](https://rocm.docs.amd.com/projects/hipfort/en/latest/doxygen/html/interfacehipfort__hipfft_1_1hipfft_set_auto_allocation.html "Interface documentation") | C binding
 23 | [hipfftSetWorkArea](https://rocm.docs.amd.com/projects/hipfort/en/latest/doxygen/html/interfacehipfort__hipfft_1_1hipfft_set_work_area.html "Interface documentation") | C binding
 24 | [hipfftExecC2C](https://rocm.docs.amd.com/projects/hipfort/en/latest/doxygen/html/interfacehipfort__hipfft_1_1hipfft_exec_c2_c.html "Interface documentation") | C binding, rank_0, rank_1, rank_2, rank_3


### PR DESCRIPTION
`supported_api_hipfft.md` listed `C binding, rank_0, rank_1` for ten interfaces (`hipfftMakePlan1d/2d/3d`, `hipfftEstimate1d/2d/3d`, `hipfftGetSize1d/2d/3d`, and one more), but those interfaces take scalar arguments and have no rank overloads in the bindings, so the actual variant is `C binding` only. This was pre-existing drift, unrelated to any binding change.

Regenerated the table with `gen_supported_api.py`; only these ten variant cells change. No binding change.