### PR TITLE
README: replace the top 'Known issues' section with a Limitations section

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,18 +8,9 @@ This is a FORTRAN interface library for accessing GPU Kernels.
 > [!NOTE]
 > The published hipfort documentation is available at [hipfort](https://rocm.docs.amd.com/projects/hipfort/en/latest/index.html) in an organized, easy-to-read format, with search and a table of contents. The documentation source files reside in the hipfort/docs folder of this repository. As with all ROCm projects, the documentation is open source. For more information, see [Contribute to ROCm documentation](https://rocm.docs.amd.com/en/latest/contribute/contributing.html).
 
-## Known issues
-
-* The `-DUSE_CUDA_NAMES` build targets NVIDIA machines with the CUDA toolkit but no
-  HIP/ROCm libraries: interfaces bind directly to the CUDA libraries (cuBLAS,
-  cuSOLVER, …) instead of HIP. Coverage is not complete, interfaces with no CUDA
-  equivalent (e.g. the regular `hipSOLVER` API, legacy `hipSPARSE`, some `hipBLAS`
-  extensions) are compiled for AMD only.
-* We recommend `gfortran` version 7.5.0 or newer as we have observed problems with older versions.
-
 ## Build and test hipfort from source
 
-Install `gfortran`, `git`, `cmake`, and HIP, if not yet installed.
+Install `gfortran` (version 7.5.0 or newer), `git`, `cmake`, and HIP, if not yet installed.
 Then build, install, and test hipfort from source with the commands below:
 
 ```shell
@@ -148,6 +139,15 @@ The following tables list the supported API:
 
 You may further find it convenient to directly use the search function on
 [HIPFORT's documentation page](https://rocm.docs.amd.com/projects/hipfort/en/latest/) to get information on the arguments of an interface
+
+## Limitations
+
+* **NVIDIA/CUDA backend (`-DUSE_CUDA_NAMES`).** This build targets NVIDIA machines that
+  have the CUDA toolkit but no HIP/ROCm libraries, so the interfaces bind directly to the
+  CUDA libraries (cuBLAS, cuSOLVER, ...) instead of HIP. Coverage is not complete:
+  interfaces with no CUDA equivalent (the regular hipSOLVER API, the legacy hipSPARSE API,
+  some hipBLAS extensions, and a few HIP runtime and hipRAND calls) are compiled for AMD
+  only.
 
 ## Linking against hipfort
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ This is a FORTRAN interface library for accessing GPU Kernels.
 
 ## Build and test hipfort from source
 
-Install `gfortran` (version 7.5.0 or newer), `git`, `cmake`, and HIP, if not yet installed.
+Install `git`, `cmake`, HIP, and a Fortran compiler, if not yet installed. `amdflang`
+(ROCm's LLVM Flang, bundled with ROCm) is the recommended default; `gfortran` (version
+7.5.0 or newer) is also supported.
 Then build, install, and test hipfort from source with the commands below:
 
 ```shell


### PR DESCRIPTION
The `## Known issues` section sat right after the title, so it was one of the first things a reader saw, before learning what hipfort is or how to build it. Its two bullets were not bugs either:
- The `-DUSE_CUDA_NAMES` coverage note is a scope limitation.
- The `gfortran` version note is a build prerequisite.

Changes:
- Removed the top `## Known issues` section.
- Folded the `gfortran` version recommendation into the build prerequisites line (it was also duplicated by the existing note in the *Fortran interfaces* section).
- Added a `## Limitations` section lower down (after the supported-API tables), with the CUDA-backend coverage note reworded as a limitation rather than a bug.

No content was lost; it is reworded and repositioned. Net diff is small.