### PR TITLE
docs: recommend amdflang as the default Fortran compiler

### DIFF
--- a/docs/how-to/using-hipfort.rst
+++ b/docs/how-to/using-hipfort.rst
@@ -54,7 +54,8 @@ which hipFORT enables automatically once it detects Fortran 2008 support in your
 application and test sources that rely on them use the ``.f08`` file extension (see the ``test/f2008``
 examples), while Fortran 2003 sources use ``.f03``.
 
-GFortran is the primary tested compiler, and AMD's ``amdflang`` (LLVM Flang) is also supported.
+AMD's ``amdflang`` (ROCm's LLVM Flang, bundled with ROCm) is the recommended default, and
+``gfortran`` (version 7.5.0 or newer) is also supported.
 Other standard-conforming Fortran compilers such as NVIDIA ``nvfortran``, Intel ``ifx``/``ifort``,
 and the Cray Fortran compiler (for example on LUMI) are not officially supported, but hipFORT
 should build with them too. Please open an issue at https://github.com/ROCm/hipfort/issues if you run into problems.

--- a/docs/install/install.rst
+++ b/docs/install/install.rst
@@ -13,9 +13,10 @@ Prerequisites
 ===============
 
 hipFORT requires a Fortran compiler that supports at least the Fortran 2003 standard.
-GFortran version 7.5.0 or newer is the primary tested compiler (see the `GFortran website
-<https://fortran-lang.org/learn/os_setup/install_gfortran/>`_), and AMD ``amdflang`` (LLVM Flang) is
-also supported. Other standard-conforming compilers such as NVIDIA ``nvfortran``, Intel ``ifx``/``ifort``,
+AMD ``amdflang`` (ROCm's LLVM Flang, bundled with ROCm) is the recommended default;
+``gfortran`` version 7.5.0 or newer (see the `GFortran website
+<https://fortran-lang.org/learn/os_setup/install_gfortran/>`_) is also supported. Other
+standard-conforming compilers such as NVIDIA ``nvfortran``, Intel ``ifx``/``ifort``,
 and the Cray Fortran compiler (for example on LUMI) are not officially supported, but hipFORT should
 build with them too. Please open an issue at https://github.com/ROCm/hipfort/issues if you run into problems.
 Ready-made CMake toolchain files for each of these compilers are provided; see :ref:`hipfort-toolchain-files`.
@@ -25,7 +26,7 @@ Ready-made CMake toolchain files for each of these compilers are provided; see :
 Building and testing hipFORT from source
 ==========================================
 
-#. Ensure you have installed ``gfortran``, ``git``, ``cmake``, and :doc:`HIP <hip:index>`.
+#. Ensure you have installed a Fortran compiler (``amdflang`` or ``gfortran``), ``git``, ``cmake``, and :doc:`HIP <hip:index>`.
 #. Build, install, and test hipFORT from source using the following commands:
 
    .. code-block:: shell

--- a/docs/install/quick-start.rst
+++ b/docs/install/quick-start.rst
@@ -12,16 +12,17 @@ Prerequisites
 ===============
 
 hipFORT requires a Fortran compiler that supports at least the Fortran 2003 standard.
-GFortran version 7.5.0 or newer is the primary tested compiler (see the `GFortran website
-<https://fortran-lang.org/learn/os_setup/install_gfortran/>`_), and AMD ``amdflang`` (LLVM Flang) is
-also supported. Other standard-conforming compilers such as NVIDIA ``nvfortran``, Intel ``ifx``/``ifort``,
+AMD ``amdflang`` (ROCm's LLVM Flang, bundled with ROCm) is the recommended default;
+``gfortran`` version 7.5.0 or newer (see the `GFortran website
+<https://fortran-lang.org/learn/os_setup/install_gfortran/>`_) is also supported. Other
+standard-conforming compilers such as NVIDIA ``nvfortran``, Intel ``ifx``/``ifort``,
 and the Cray Fortran compiler (for example on LUMI) are not officially supported, but hipFORT should
 build with them too. Please open an issue at https://github.com/ROCm/hipfort/issues if you run into problems.
 
 Building and testing hipFORT from source
 ==========================================
 
-1. Ensure you have installed ``gfortran``, ``git``, ``cmake``, and :doc:`HIP <hip:index>`.
+1. Ensure you have installed a Fortran compiler (``amdflang`` or ``gfortran``), ``git``, ``cmake``, and :doc:`HIP <hip:index>`.
 2. Build, install, and test hipFORT from source using the following commands:
 
    .. code-block:: shell


### PR DESCRIPTION
The install and how-to pages described `gfortran` as "the primary tested compiler" and told readers to install `gfortran`, while the toolchain table lists `amdflang` (ROCm's LLVM Flang) as the recommended default. This aligns the prose with the toolchain table and with the README.

Changes (three pages):
- `docs/install/quick-start.rst`, `docs/install/install.rst`: prerequisites now lead with `amdflang` (bundled with ROCm) as the recommended default, `gfortran` 7.5.0+ as also supported; step 1 says "a Fortran compiler (`amdflang` or `gfortran`)".
- `docs/how-to/using-hipfort.rst`: same reframing of the compiler note.

No other stale references were found (the removed `hipfc`/`mygpu` utilities are not mentioned anywhere in the docs). Text-only.