### PR TITLE
[hipBLAS] declare packed-matrix AP args as arrays

### DIFF
--- a/lib/hipfort/hipfort_hipblas.F90
+++ b/lib/hipfort/hipfort_hipblas.F90
@@ -46917,14 +46917,15 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: AP
+      complex(c_float_complex),target :: AP
       complex(c_float_complex),target :: x
       integer(c_int) :: incx
       complex(c_float_complex) :: beta
       complex(c_float_complex),target :: y
       integer(c_int) :: incy
       !
-      hipblasChpmv_rank_0 = hipblasChpmv_(handle,uplo,n,alpha,AP,c_loc(x),incx,beta,c_loc(y),incy)
+      hipblasChpmv_rank_0 = hipblasChpmv_(handle,uplo,n,alpha,c_loc(AP),c_loc(x),incx,beta, &
+        c_loc(y),incy)
     end function
 
     function hipblasChpmv_rank_1(handle,uplo,n,alpha,AP,x,incx,beta,y,incy)
@@ -46936,14 +46937,15 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: AP
+      complex(c_float_complex),target,dimension(:) :: AP
       complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       complex(c_float_complex) :: beta
       complex(c_float_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       !
-      hipblasChpmv_rank_1 = hipblasChpmv_(handle,uplo,n,alpha,AP,c_loc(x),incx,beta,c_loc(y),incy)
+      hipblasChpmv_rank_1 = hipblasChpmv_(handle,uplo,n,alpha,c_loc(AP),c_loc(x),incx,beta, &
+        c_loc(y),incy)
     end function
 
     function hipblasZhpmv_rank_0(handle,uplo,n,alpha,AP,x,incx,beta,y,incy)
@@ -46955,14 +46957,15 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: AP
+      complex(c_double_complex),target :: AP
       complex(c_double_complex),target :: x
       integer(c_int) :: incx
       complex(c_double_complex) :: beta
       complex(c_double_complex),target :: y
       integer(c_int) :: incy
       !
-      hipblasZhpmv_rank_0 = hipblasZhpmv_(handle,uplo,n,alpha,AP,c_loc(x),incx,beta,c_loc(y),incy)
+      hipblasZhpmv_rank_0 = hipblasZhpmv_(handle,uplo,n,alpha,c_loc(AP),c_loc(x),incx,beta, &
+        c_loc(y),incy)
     end function
 
     function hipblasZhpmv_rank_1(handle,uplo,n,alpha,AP,x,incx,beta,y,incy)
@@ -46974,14 +46977,15 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: AP
+      complex(c_double_complex),target,dimension(:) :: AP
       complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       complex(c_double_complex) :: beta
       complex(c_double_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       !
-      hipblasZhpmv_rank_1 = hipblasZhpmv_(handle,uplo,n,alpha,AP,c_loc(x),incx,beta,c_loc(y),incy)
+      hipblasZhpmv_rank_1 = hipblasZhpmv_(handle,uplo,n,alpha,c_loc(AP),c_loc(x),incx,beta, &
+        c_loc(y),incy)
     end function
 
 #ifndef USE_CUDA_NAMES
@@ -46995,7 +46999,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: AP
+      complex(c_float_complex),target :: AP
       integer(c_int64_t) :: strideA
       complex(c_float_complex),target :: x
       integer(c_int) :: incx
@@ -47006,8 +47010,8 @@ module hipfort_hipblas
       integer(c_int64_t) :: stridey
       integer(c_int) :: batchCount
       !
-      hipblasChpmvStridedBatched_rank_0 = hipblasChpmvStridedBatched_(handle,uplo,n,alpha,AP, &
-        strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
+      hipblasChpmvStridedBatched_rank_0 = hipblasChpmvStridedBatched_(handle,uplo,n,alpha, &
+        c_loc(AP),strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
     end function
 
     function hipblasChpmvStridedBatched_rank_1(handle,uplo,n,alpha,AP,strideA,x,incx,stridex,beta, &
@@ -47020,7 +47024,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       complex(c_float_complex) :: alpha
-      type(c_ptr) :: AP
+      complex(c_float_complex),target,dimension(:) :: AP
       integer(c_int64_t) :: strideA
       complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
@@ -47031,8 +47035,8 @@ module hipfort_hipblas
       integer(c_int64_t) :: stridey
       integer(c_int) :: batchCount
       !
-      hipblasChpmvStridedBatched_rank_1 = hipblasChpmvStridedBatched_(handle,uplo,n,alpha,AP, &
-        strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
+      hipblasChpmvStridedBatched_rank_1 = hipblasChpmvStridedBatched_(handle,uplo,n,alpha, &
+        c_loc(AP),strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
     end function
 
 #endif
@@ -47047,7 +47051,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: AP
+      complex(c_double_complex),target :: AP
       integer(c_int64_t) :: strideA
       complex(c_double_complex),target :: x
       integer(c_int) :: incx
@@ -47058,8 +47062,8 @@ module hipfort_hipblas
       integer(c_int64_t) :: stridey
       integer(c_int) :: batchCount
       !
-      hipblasZhpmvStridedBatched_rank_0 = hipblasZhpmvStridedBatched_(handle,uplo,n,alpha,AP, &
-        strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
+      hipblasZhpmvStridedBatched_rank_0 = hipblasZhpmvStridedBatched_(handle,uplo,n,alpha, &
+        c_loc(AP),strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
     end function
 
     function hipblasZhpmvStridedBatched_rank_1(handle,uplo,n,alpha,AP,strideA,x,incx,stridex,beta, &
@@ -47072,7 +47076,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       complex(c_double_complex) :: alpha
-      type(c_ptr) :: AP
+      complex(c_double_complex),target,dimension(:) :: AP
       integer(c_int64_t) :: strideA
       complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
@@ -47083,8 +47087,8 @@ module hipfort_hipblas
       integer(c_int64_t) :: stridey
       integer(c_int) :: batchCount
       !
-      hipblasZhpmvStridedBatched_rank_1 = hipblasZhpmvStridedBatched_(handle,uplo,n,alpha,AP, &
-        strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
+      hipblasZhpmvStridedBatched_rank_1 = hipblasZhpmvStridedBatched_(handle,uplo,n,alpha, &
+        c_loc(AP),strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
     end function
 
 #endif
@@ -47099,9 +47103,9 @@ module hipfort_hipblas
       real(c_float) :: alpha
       complex(c_float_complex),target :: x
       integer(c_int) :: incx
-      type(c_ptr) :: AP
+      complex(c_float_complex),target :: AP
       !
-      hipblasChpr_rank_0 = hipblasChpr_(handle,uplo,n,alpha,c_loc(x),incx,AP)
+      hipblasChpr_rank_0 = hipblasChpr_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(AP))
     end function
 
     function hipblasChpr_rank_1(handle,uplo,n,alpha,x,incx,AP)
@@ -47115,9 +47119,9 @@ module hipfort_hipblas
       real(c_float) :: alpha
       complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
-      type(c_ptr) :: AP
+      complex(c_float_complex),target,dimension(:) :: AP
       !
-      hipblasChpr_rank_1 = hipblasChpr_(handle,uplo,n,alpha,c_loc(x),incx,AP)
+      hipblasChpr_rank_1 = hipblasChpr_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(AP))
     end function
 
     function hipblasZhpr_rank_0(handle,uplo,n,alpha,x,incx,AP)
@@ -47131,9 +47135,9 @@ module hipfort_hipblas
       real(c_double) :: alpha
       complex(c_double_complex),target :: x
       integer(c_int) :: incx
-      type(c_ptr) :: AP
+      complex(c_double_complex),target :: AP
       !
-      hipblasZhpr_rank_0 = hipblasZhpr_(handle,uplo,n,alpha,c_loc(x),incx,AP)
+      hipblasZhpr_rank_0 = hipblasZhpr_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(AP))
     end function
 
     function hipblasZhpr_rank_1(handle,uplo,n,alpha,x,incx,AP)
@@ -47147,9 +47151,9 @@ module hipfort_hipblas
       real(c_double) :: alpha
       complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
-      type(c_ptr) :: AP
+      complex(c_double_complex),target,dimension(:) :: AP
       !
-      hipblasZhpr_rank_1 = hipblasZhpr_(handle,uplo,n,alpha,c_loc(x),incx,AP)
+      hipblasZhpr_rank_1 = hipblasZhpr_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(AP))
     end function
 
 #ifndef USE_CUDA_NAMES
@@ -47166,12 +47170,12 @@ module hipfort_hipblas
       complex(c_float_complex),target :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
-      type(c_ptr) :: AP
+      complex(c_float_complex),target :: AP
       integer(c_int64_t) :: strideA
       integer(c_int) :: batchCount
       !
       hipblasChprStridedBatched_rank_0 = hipblasChprStridedBatched_(handle,uplo,n,alpha,c_loc(x), &
-        incx,stridex,AP,strideA,batchCount)
+        incx,stridex,c_loc(AP),strideA,batchCount)
     end function
 
     function hipblasChprStridedBatched_rank_1(handle,uplo,n,alpha,x,incx,stridex,AP,strideA, &
@@ -47187,12 +47191,12 @@ module hipfort_hipblas
       complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
-      type(c_ptr) :: AP
+      complex(c_float_complex),target,dimension(:) :: AP
       integer(c_int64_t) :: strideA
       integer(c_int) :: batchCount
       !
       hipblasChprStridedBatched_rank_1 = hipblasChprStridedBatched_(handle,uplo,n,alpha,c_loc(x), &
-        incx,stridex,AP,strideA,batchCount)
+        incx,stridex,c_loc(AP),strideA,batchCount)
     end function
 
 #endif
@@ -47210,12 +47214,12 @@ module hipfort_hipblas
       complex(c_double_complex),target :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
-      type(c_ptr) :: AP
+      complex(c_double_complex),target :: AP
       integer(c_int64_t) :: strideA
       integer(c_int) :: batchCount
       !
       hipblasZhprStridedBatched_rank_0 = hipblasZhprStridedBatched_(handle,uplo,n,alpha,c_loc(x), &
-        incx,stridex,AP,strideA,batchCount)
+        incx,stridex,c_loc(AP),strideA,batchCount)
     end function
 
     function hipblasZhprStridedBatched_rank_1(handle,uplo,n,alpha,x,incx,stridex,AP,strideA, &
@@ -47231,12 +47235,12 @@ module hipfort_hipblas
       complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
-      type(c_ptr) :: AP
+      complex(c_double_complex),target,dimension(:) :: AP
       integer(c_int64_t) :: strideA
       integer(c_int) :: batchCount
       !
       hipblasZhprStridedBatched_rank_1 = hipblasZhprStridedBatched_(handle,uplo,n,alpha,c_loc(x), &
-        incx,stridex,AP,strideA,batchCount)
+        incx,stridex,c_loc(AP),strideA,batchCount)
     end function
 
 #endif
@@ -47253,9 +47257,9 @@ module hipfort_hipblas
       integer(c_int) :: incx
       complex(c_float_complex),target :: y
       integer(c_int) :: incy
-      type(c_ptr) :: AP
+      complex(c_float_complex),target :: AP
       !
-      hipblasChpr2_rank_0 = hipblasChpr2_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(y),incy,AP)
+      hipblasChpr2_rank_0 = hipblasChpr2_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(y),incy,c_loc(AP))
     end function
 
     function hipblasChpr2_rank_1(handle,uplo,n,alpha,x,incx,y,incy,AP)
@@ -47271,9 +47275,9 @@ module hipfort_hipblas
       integer(c_int) :: incx
       complex(c_float_complex),target,dimension(:) :: y
       integer(c_int) :: incy
-      type(c_ptr) :: AP
+      complex(c_float_complex),target,dimension(:) :: AP
       !
-      hipblasChpr2_rank_1 = hipblasChpr2_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(y),incy,AP)
+      hipblasChpr2_rank_1 = hipblasChpr2_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(y),incy,c_loc(AP))
     end function
 
     function hipblasZhpr2_rank_0(handle,uplo,n,alpha,x,incx,y,incy,AP)
@@ -47289,9 +47293,9 @@ module hipfort_hipblas
       integer(c_int) :: incx
       complex(c_double_complex),target :: y
       integer(c_int) :: incy
-      type(c_ptr) :: AP
+      complex(c_double_complex),target :: AP
       !
-      hipblasZhpr2_rank_0 = hipblasZhpr2_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(y),incy,AP)
+      hipblasZhpr2_rank_0 = hipblasZhpr2_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(y),incy,c_loc(AP))
     end function
 
     function hipblasZhpr2_rank_1(handle,uplo,n,alpha,x,incx,y,incy,AP)
@@ -47307,9 +47311,9 @@ module hipfort_hipblas
       integer(c_int) :: incx
       complex(c_double_complex),target,dimension(:) :: y
       integer(c_int) :: incy
-      type(c_ptr) :: AP
+      complex(c_double_complex),target,dimension(:) :: AP
       !
-      hipblasZhpr2_rank_1 = hipblasZhpr2_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(y),incy,AP)
+      hipblasZhpr2_rank_1 = hipblasZhpr2_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(y),incy,c_loc(AP))
     end function
 
 #ifndef USE_CUDA_NAMES
@@ -47329,12 +47333,12 @@ module hipfort_hipblas
       complex(c_float_complex),target :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
-      type(c_ptr) :: AP
+      complex(c_float_complex),target :: AP
       integer(c_int64_t) :: strideA
       integer(c_int) :: batchCount
       !
       hipblasChpr2StridedBatched_rank_0 = hipblasChpr2StridedBatched_(handle,uplo,n,alpha, &
-        c_loc(x),incx,stridex,c_loc(y),incy,stridey,AP,strideA,batchCount)
+        c_loc(x),incx,stridex,c_loc(y),incy,stridey,c_loc(AP),strideA,batchCount)
     end function
 
     function hipblasChpr2StridedBatched_rank_1(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey, &
@@ -47353,12 +47357,12 @@ module hipfort_hipblas
       complex(c_float_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
-      type(c_ptr) :: AP
+      complex(c_float_complex),target,dimension(:) :: AP
       integer(c_int64_t) :: strideA
       integer(c_int) :: batchCount
       !
       hipblasChpr2StridedBatched_rank_1 = hipblasChpr2StridedBatched_(handle,uplo,n,alpha, &
-        c_loc(x),incx,stridex,c_loc(y),incy,stridey,AP,strideA,batchCount)
+        c_loc(x),incx,stridex,c_loc(y),incy,stridey,c_loc(AP),strideA,batchCount)
     end function
 
 #endif
@@ -47379,12 +47383,12 @@ module hipfort_hipblas
       complex(c_double_complex),target :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
-      type(c_ptr) :: AP
+      complex(c_double_complex),target :: AP
       integer(c_int64_t) :: strideA
       integer(c_int) :: batchCount
       !
       hipblasZhpr2StridedBatched_rank_0 = hipblasZhpr2StridedBatched_(handle,uplo,n,alpha, &
-        c_loc(x),incx,stridex,c_loc(y),incy,stridey,AP,strideA,batchCount)
+        c_loc(x),incx,stridex,c_loc(y),incy,stridey,c_loc(AP),strideA,batchCount)
     end function
 
     function hipblasZhpr2StridedBatched_rank_1(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey, &
@@ -47403,12 +47407,12 @@ module hipfort_hipblas
       complex(c_double_complex),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
-      type(c_ptr) :: AP
+      complex(c_double_complex),target,dimension(:) :: AP
       integer(c_int64_t) :: strideA
       integer(c_int) :: batchCount
       !
       hipblasZhpr2StridedBatched_rank_1 = hipblasZhpr2StridedBatched_(handle,uplo,n,alpha, &
-        c_loc(x),incx,stridex,c_loc(y),incy,stridey,AP,strideA,batchCount)
+        c_loc(x),incx,stridex,c_loc(y),incy,stridey,c_loc(AP),strideA,batchCount)
     end function
 
 #endif
@@ -47719,14 +47723,15 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       real(c_float) :: alpha
-      type(c_ptr) :: AP
+      real(c_float),target :: AP
       real(c_float),target :: x
       integer(c_int) :: incx
       real(c_float) :: beta
       real(c_float),target :: y
       integer(c_int) :: incy
       !
-      hipblasSspmv_rank_0 = hipblasSspmv_(handle,uplo,n,alpha,AP,c_loc(x),incx,beta,c_loc(y),incy)
+      hipblasSspmv_rank_0 = hipblasSspmv_(handle,uplo,n,alpha,c_loc(AP),c_loc(x),incx,beta, &
+        c_loc(y),incy)
     end function
 
     function hipblasSspmv_rank_1(handle,uplo,n,alpha,AP,x,incx,beta,y,incy)
@@ -47738,14 +47743,15 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       real(c_float) :: alpha
-      type(c_ptr) :: AP
+      real(c_float),target,dimension(:) :: AP
       real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       real(c_float) :: beta
       real(c_float),target,dimension(:) :: y
       integer(c_int) :: incy
       !
-      hipblasSspmv_rank_1 = hipblasSspmv_(handle,uplo,n,alpha,AP,c_loc(x),incx,beta,c_loc(y),incy)
+      hipblasSspmv_rank_1 = hipblasSspmv_(handle,uplo,n,alpha,c_loc(AP),c_loc(x),incx,beta, &
+        c_loc(y),incy)
     end function
 
     function hipblasDspmv_rank_0(handle,uplo,n,alpha,AP,x,incx,beta,y,incy)
@@ -47757,14 +47763,15 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       real(c_double) :: alpha
-      type(c_ptr) :: AP
+      real(c_double),target :: AP
       real(c_double),target :: x
       integer(c_int) :: incx
       real(c_double) :: beta
       real(c_double),target :: y
       integer(c_int) :: incy
       !
-      hipblasDspmv_rank_0 = hipblasDspmv_(handle,uplo,n,alpha,AP,c_loc(x),incx,beta,c_loc(y),incy)
+      hipblasDspmv_rank_0 = hipblasDspmv_(handle,uplo,n,alpha,c_loc(AP),c_loc(x),incx,beta, &
+        c_loc(y),incy)
     end function
 
     function hipblasDspmv_rank_1(handle,uplo,n,alpha,AP,x,incx,beta,y,incy)
@@ -47776,14 +47783,15 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       real(c_double) :: alpha
-      type(c_ptr) :: AP
+      real(c_double),target,dimension(:) :: AP
       real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       real(c_double) :: beta
       real(c_double),target,dimension(:) :: y
       integer(c_int) :: incy
       !
-      hipblasDspmv_rank_1 = hipblasDspmv_(handle,uplo,n,alpha,AP,c_loc(x),incx,beta,c_loc(y),incy)
+      hipblasDspmv_rank_1 = hipblasDspmv_(handle,uplo,n,alpha,c_loc(AP),c_loc(x),incx,beta, &
+        c_loc(y),incy)
     end function
 
 #ifndef USE_CUDA_NAMES
@@ -47797,7 +47805,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       real(c_float) :: alpha
-      type(c_ptr) :: AP
+      real(c_float),target :: AP
       integer(c_int64_t) :: strideA
       real(c_float),target :: x
       integer(c_int) :: incx
@@ -47808,8 +47816,8 @@ module hipfort_hipblas
       integer(c_int64_t) :: stridey
       integer(c_int) :: batchCount
       !
-      hipblasSspmvStridedBatched_rank_0 = hipblasSspmvStridedBatched_(handle,uplo,n,alpha,AP, &
-        strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
+      hipblasSspmvStridedBatched_rank_0 = hipblasSspmvStridedBatched_(handle,uplo,n,alpha, &
+        c_loc(AP),strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
     end function
 
     function hipblasSspmvStridedBatched_rank_1(handle,uplo,n,alpha,AP,strideA,x,incx,stridex,beta, &
@@ -47822,7 +47830,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       real(c_float) :: alpha
-      type(c_ptr) :: AP
+      real(c_float),target,dimension(:) :: AP
       integer(c_int64_t) :: strideA
       real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
@@ -47833,8 +47841,8 @@ module hipfort_hipblas
       integer(c_int64_t) :: stridey
       integer(c_int) :: batchCount
       !
-      hipblasSspmvStridedBatched_rank_1 = hipblasSspmvStridedBatched_(handle,uplo,n,alpha,AP, &
-        strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
+      hipblasSspmvStridedBatched_rank_1 = hipblasSspmvStridedBatched_(handle,uplo,n,alpha, &
+        c_loc(AP),strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
     end function
 
 #endif
@@ -47849,7 +47857,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       real(c_double) :: alpha
-      type(c_ptr) :: AP
+      real(c_double),target :: AP
       integer(c_int64_t) :: strideA
       real(c_double),target :: x
       integer(c_int) :: incx
@@ -47860,8 +47868,8 @@ module hipfort_hipblas
       integer(c_int64_t) :: stridey
       integer(c_int) :: batchCount
       !
-      hipblasDspmvStridedBatched_rank_0 = hipblasDspmvStridedBatched_(handle,uplo,n,alpha,AP, &
-        strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
+      hipblasDspmvStridedBatched_rank_0 = hipblasDspmvStridedBatched_(handle,uplo,n,alpha, &
+        c_loc(AP),strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
     end function
 
     function hipblasDspmvStridedBatched_rank_1(handle,uplo,n,alpha,AP,strideA,x,incx,stridex,beta, &
@@ -47874,7 +47882,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_FILL_MODE_UPPER)) :: uplo
       integer(c_int) :: n
       real(c_double) :: alpha
-      type(c_ptr) :: AP
+      real(c_double),target,dimension(:) :: AP
       integer(c_int64_t) :: strideA
       real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
@@ -47885,8 +47893,8 @@ module hipfort_hipblas
       integer(c_int64_t) :: stridey
       integer(c_int) :: batchCount
       !
-      hipblasDspmvStridedBatched_rank_1 = hipblasDspmvStridedBatched_(handle,uplo,n,alpha,AP, &
-        strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
+      hipblasDspmvStridedBatched_rank_1 = hipblasDspmvStridedBatched_(handle,uplo,n,alpha, &
+        c_loc(AP),strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
     end function
 
 #endif
@@ -47901,9 +47909,9 @@ module hipfort_hipblas
       real(c_float) :: alpha
       real(c_float),target :: x
       integer(c_int) :: incx
-      type(c_ptr) :: AP
+      real(c_float),target :: AP
       !
-      hipblasSspr_rank_0 = hipblasSspr_(handle,uplo,n,alpha,c_loc(x),incx,AP)
+      hipblasSspr_rank_0 = hipblasSspr_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(AP))
     end function
 
     function hipblasSspr_rank_1(handle,uplo,n,alpha,x,incx,AP)
@@ -47917,9 +47925,9 @@ module hipfort_hipblas
       real(c_float) :: alpha
       real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
-      type(c_ptr) :: AP
+      real(c_float),target,dimension(:) :: AP
       !
-      hipblasSspr_rank_1 = hipblasSspr_(handle,uplo,n,alpha,c_loc(x),incx,AP)
+      hipblasSspr_rank_1 = hipblasSspr_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(AP))
     end function
 
     function hipblasDspr_rank_0(handle,uplo,n,alpha,x,incx,AP)
@@ -47933,9 +47941,9 @@ module hipfort_hipblas
       real(c_double) :: alpha
       real(c_double),target :: x
       integer(c_int) :: incx
-      type(c_ptr) :: AP
+      real(c_double),target :: AP
       !
-      hipblasDspr_rank_0 = hipblasDspr_(handle,uplo,n,alpha,c_loc(x),incx,AP)
+      hipblasDspr_rank_0 = hipblasDspr_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(AP))
     end function
 
     function hipblasDspr_rank_1(handle,uplo,n,alpha,x,incx,AP)
@@ -47949,9 +47957,9 @@ module hipfort_hipblas
       real(c_double) :: alpha
       real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
-      type(c_ptr) :: AP
+      real(c_double),target,dimension(:) :: AP
       !
-      hipblasDspr_rank_1 = hipblasDspr_(handle,uplo,n,alpha,c_loc(x),incx,AP)
+      hipblasDspr_rank_1 = hipblasDspr_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(AP))
     end function
 
 #ifndef USE_CUDA_NAMES
@@ -47966,9 +47974,9 @@ module hipfort_hipblas
       complex(c_float_complex) :: alpha
       complex(c_float_complex),target :: x
       integer(c_int) :: incx
-      type(c_ptr) :: AP
+      complex(c_float_complex),target :: AP
       !
-      hipblasCspr_rank_0 = hipblasCspr_(handle,uplo,n,alpha,c_loc(x),incx,AP)
+      hipblasCspr_rank_0 = hipblasCspr_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(AP))
     end function
 
     function hipblasCspr_rank_1(handle,uplo,n,alpha,x,incx,AP)
@@ -47982,9 +47990,9 @@ module hipfort_hipblas
       complex(c_float_complex) :: alpha
       complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
-      type(c_ptr) :: AP
+      complex(c_float_complex),target,dimension(:) :: AP
       !
-      hipblasCspr_rank_1 = hipblasCspr_(handle,uplo,n,alpha,c_loc(x),incx,AP)
+      hipblasCspr_rank_1 = hipblasCspr_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(AP))
     end function
 
 #endif
@@ -48000,9 +48008,9 @@ module hipfort_hipblas
       complex(c_double_complex) :: alpha
       complex(c_double_complex),target :: x
       integer(c_int) :: incx
-      type(c_ptr) :: AP
+      complex(c_double_complex),target :: AP
       !
-      hipblasZspr_rank_0 = hipblasZspr_(handle,uplo,n,alpha,c_loc(x),incx,AP)
+      hipblasZspr_rank_0 = hipblasZspr_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(AP))
     end function
 
     function hipblasZspr_rank_1(handle,uplo,n,alpha,x,incx,AP)
@@ -48016,9 +48024,9 @@ module hipfort_hipblas
       complex(c_double_complex) :: alpha
       complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
-      type(c_ptr) :: AP
+      complex(c_double_complex),target,dimension(:) :: AP
       !
-      hipblasZspr_rank_1 = hipblasZspr_(handle,uplo,n,alpha,c_loc(x),incx,AP)
+      hipblasZspr_rank_1 = hipblasZspr_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(AP))
     end function
 
 #endif
@@ -48036,12 +48044,12 @@ module hipfort_hipblas
       real(c_float),target :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
-      type(c_ptr) :: AP
+      real(c_float),target :: AP
       integer(c_int64_t) :: strideA
       integer(c_int) :: batchCount
       !
       hipblasSsprStridedBatched_rank_0 = hipblasSsprStridedBatched_(handle,uplo,n,alpha,c_loc(x), &
-        incx,stridex,AP,strideA,batchCount)
+        incx,stridex,c_loc(AP),strideA,batchCount)
     end function
 
     function hipblasSsprStridedBatched_rank_1(handle,uplo,n,alpha,x,incx,stridex,AP,strideA, &
@@ -48057,12 +48065,12 @@ module hipfort_hipblas
       real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
-      type(c_ptr) :: AP
+      real(c_float),target,dimension(:) :: AP
       integer(c_int64_t) :: strideA
       integer(c_int) :: batchCount
       !
       hipblasSsprStridedBatched_rank_1 = hipblasSsprStridedBatched_(handle,uplo,n,alpha,c_loc(x), &
-        incx,stridex,AP,strideA,batchCount)
+        incx,stridex,c_loc(AP),strideA,batchCount)
     end function
 
 #endif
@@ -48080,12 +48088,12 @@ module hipfort_hipblas
       real(c_double),target :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
-      type(c_ptr) :: AP
+      real(c_double),target :: AP
       integer(c_int64_t) :: strideA
       integer(c_int) :: batchCount
       !
       hipblasDsprStridedBatched_rank_0 = hipblasDsprStridedBatched_(handle,uplo,n,alpha,c_loc(x), &
-        incx,stridex,AP,strideA,batchCount)
+        incx,stridex,c_loc(AP),strideA,batchCount)
     end function
 
     function hipblasDsprStridedBatched_rank_1(handle,uplo,n,alpha,x,incx,stridex,AP,strideA, &
@@ -48101,12 +48109,12 @@ module hipfort_hipblas
       real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
-      type(c_ptr) :: AP
+      real(c_double),target,dimension(:) :: AP
       integer(c_int64_t) :: strideA
       integer(c_int) :: batchCount
       !
       hipblasDsprStridedBatched_rank_1 = hipblasDsprStridedBatched_(handle,uplo,n,alpha,c_loc(x), &
-        incx,stridex,AP,strideA,batchCount)
+        incx,stridex,c_loc(AP),strideA,batchCount)
     end function
 
 #endif
@@ -48124,12 +48132,12 @@ module hipfort_hipblas
       complex(c_float_complex),target :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
-      type(c_ptr) :: AP
+      complex(c_float_complex),target :: AP
       integer(c_int64_t) :: strideA
       integer(c_int) :: batchCount
       !
       hipblasCsprStridedBatched_rank_0 = hipblasCsprStridedBatched_(handle,uplo,n,alpha,c_loc(x), &
-        incx,stridex,AP,strideA,batchCount)
+        incx,stridex,c_loc(AP),strideA,batchCount)
     end function
 
     function hipblasCsprStridedBatched_rank_1(handle,uplo,n,alpha,x,incx,stridex,AP,strideA, &
@@ -48145,12 +48153,12 @@ module hipfort_hipblas
       complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
-      type(c_ptr) :: AP
+      complex(c_float_complex),target,dimension(:) :: AP
       integer(c_int64_t) :: strideA
       integer(c_int) :: batchCount
       !
       hipblasCsprStridedBatched_rank_1 = hipblasCsprStridedBatched_(handle,uplo,n,alpha,c_loc(x), &
-        incx,stridex,AP,strideA,batchCount)
+        incx,stridex,c_loc(AP),strideA,batchCount)
     end function
 
 #endif
@@ -48168,12 +48176,12 @@ module hipfort_hipblas
       complex(c_double_complex),target :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
-      type(c_ptr) :: AP
+      complex(c_double_complex),target :: AP
       integer(c_int64_t) :: strideA
       integer(c_int) :: batchCount
       !
       hipblasZsprStridedBatched_rank_0 = hipblasZsprStridedBatched_(handle,uplo,n,alpha,c_loc(x), &
-        incx,stridex,AP,strideA,batchCount)
+        incx,stridex,c_loc(AP),strideA,batchCount)
     end function
 
     function hipblasZsprStridedBatched_rank_1(handle,uplo,n,alpha,x,incx,stridex,AP,strideA, &
@@ -48189,12 +48197,12 @@ module hipfort_hipblas
       complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       integer(c_int64_t) :: stridex
-      type(c_ptr) :: AP
+      complex(c_double_complex),target,dimension(:) :: AP
       integer(c_int64_t) :: strideA
       integer(c_int) :: batchCount
       !
       hipblasZsprStridedBatched_rank_1 = hipblasZsprStridedBatched_(handle,uplo,n,alpha,c_loc(x), &
-        incx,stridex,AP,strideA,batchCount)
+        incx,stridex,c_loc(AP),strideA,batchCount)
     end function
 
 #endif
@@ -48211,9 +48219,9 @@ module hipfort_hipblas
       integer(c_int) :: incx
       real(c_float),target :: y
       integer(c_int) :: incy
-      type(c_ptr) :: AP
+      real(c_float),target :: AP
       !
-      hipblasSspr2_rank_0 = hipblasSspr2_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(y),incy,AP)
+      hipblasSspr2_rank_0 = hipblasSspr2_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(y),incy,c_loc(AP))
     end function
 
     function hipblasSspr2_rank_1(handle,uplo,n,alpha,x,incx,y,incy,AP)
@@ -48229,9 +48237,9 @@ module hipfort_hipblas
       integer(c_int) :: incx
       real(c_float),target,dimension(:) :: y
       integer(c_int) :: incy
-      type(c_ptr) :: AP
+      real(c_float),target,dimension(:) :: AP
       !
-      hipblasSspr2_rank_1 = hipblasSspr2_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(y),incy,AP)
+      hipblasSspr2_rank_1 = hipblasSspr2_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(y),incy,c_loc(AP))
     end function
 
     function hipblasDspr2_rank_0(handle,uplo,n,alpha,x,incx,y,incy,AP)
@@ -48247,9 +48255,9 @@ module hipfort_hipblas
       integer(c_int) :: incx
       real(c_double),target :: y
       integer(c_int) :: incy
-      type(c_ptr) :: AP
+      real(c_double),target :: AP
       !
-      hipblasDspr2_rank_0 = hipblasDspr2_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(y),incy,AP)
+      hipblasDspr2_rank_0 = hipblasDspr2_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(y),incy,c_loc(AP))
     end function
 
     function hipblasDspr2_rank_1(handle,uplo,n,alpha,x,incx,y,incy,AP)
@@ -48265,9 +48273,9 @@ module hipfort_hipblas
       integer(c_int) :: incx
       real(c_double),target,dimension(:) :: y
       integer(c_int) :: incy
-      type(c_ptr) :: AP
+      real(c_double),target,dimension(:) :: AP
       !
-      hipblasDspr2_rank_1 = hipblasDspr2_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(y),incy,AP)
+      hipblasDspr2_rank_1 = hipblasDspr2_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(y),incy,c_loc(AP))
     end function
 
 #ifndef USE_CUDA_NAMES
@@ -48287,12 +48295,12 @@ module hipfort_hipblas
       real(c_float),target :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
-      type(c_ptr) :: AP
+      real(c_float),target :: AP
       integer(c_int64_t) :: strideA
       integer(c_int) :: batchCount
       !
       hipblasSspr2StridedBatched_rank_0 = hipblasSspr2StridedBatched_(handle,uplo,n,alpha, &
-        c_loc(x),incx,stridex,c_loc(y),incy,stridey,AP,strideA,batchCount)
+        c_loc(x),incx,stridex,c_loc(y),incy,stridey,c_loc(AP),strideA,batchCount)
     end function
 
     function hipblasSspr2StridedBatched_rank_1(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey, &
@@ -48311,12 +48319,12 @@ module hipfort_hipblas
       real(c_float),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
-      type(c_ptr) :: AP
+      real(c_float),target,dimension(:) :: AP
       integer(c_int64_t) :: strideA
       integer(c_int) :: batchCount
       !
       hipblasSspr2StridedBatched_rank_1 = hipblasSspr2StridedBatched_(handle,uplo,n,alpha, &
-        c_loc(x),incx,stridex,c_loc(y),incy,stridey,AP,strideA,batchCount)
+        c_loc(x),incx,stridex,c_loc(y),incy,stridey,c_loc(AP),strideA,batchCount)
     end function
 
 #endif
@@ -48337,12 +48345,12 @@ module hipfort_hipblas
       real(c_double),target :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
-      type(c_ptr) :: AP
+      real(c_double),target :: AP
       integer(c_int64_t) :: strideA
       integer(c_int) :: batchCount
       !
       hipblasDspr2StridedBatched_rank_0 = hipblasDspr2StridedBatched_(handle,uplo,n,alpha, &
-        c_loc(x),incx,stridex,c_loc(y),incy,stridey,AP,strideA,batchCount)
+        c_loc(x),incx,stridex,c_loc(y),incy,stridey,c_loc(AP),strideA,batchCount)
     end function
 
     function hipblasDspr2StridedBatched_rank_1(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey, &
@@ -48361,12 +48369,12 @@ module hipfort_hipblas
       real(c_double),target,dimension(:) :: y
       integer(c_int) :: incy
       integer(c_int64_t) :: stridey
-      type(c_ptr) :: AP
+      real(c_double),target,dimension(:) :: AP
       integer(c_int64_t) :: strideA
       integer(c_int) :: batchCount
       !
       hipblasDspr2StridedBatched_rank_1 = hipblasDspr2StridedBatched_(handle,uplo,n,alpha, &
-        c_loc(x),incx,stridex,c_loc(y),incy,stridey,AP,strideA,batchCount)
+        c_loc(x),incx,stridex,c_loc(y),incy,stridey,c_loc(AP),strideA,batchCount)
     end function
 
 #endif
@@ -51032,11 +51040,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      type(c_ptr) :: AP
+      real(c_float),target :: AP
       real(c_float),target :: x
       integer(c_int) :: incx
       !
-      hipblasStpmv_rank_0 = hipblasStpmv_(handle,uplo,transA,diag,n,AP,c_loc(x),incx)
+      hipblasStpmv_rank_0 = hipblasStpmv_(handle,uplo,transA,diag,n,c_loc(AP),c_loc(x),incx)
     end function
 
     function hipblasStpmv_rank_1(handle,uplo,transA,diag,n,AP,x,incx)
@@ -51049,11 +51057,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      type(c_ptr) :: AP
+      real(c_float),target,dimension(:) :: AP
       real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       !
-      hipblasStpmv_rank_1 = hipblasStpmv_(handle,uplo,transA,diag,n,AP,c_loc(x),incx)
+      hipblasStpmv_rank_1 = hipblasStpmv_(handle,uplo,transA,diag,n,c_loc(AP),c_loc(x),incx)
     end function
 
     function hipblasDtpmv_rank_0(handle,uplo,transA,diag,n,AP,x,incx)
@@ -51066,11 +51074,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      type(c_ptr) :: AP
+      real(c_double),target :: AP
       real(c_double),target :: x
       integer(c_int) :: incx
       !
-      hipblasDtpmv_rank_0 = hipblasDtpmv_(handle,uplo,transA,diag,n,AP,c_loc(x),incx)
+      hipblasDtpmv_rank_0 = hipblasDtpmv_(handle,uplo,transA,diag,n,c_loc(AP),c_loc(x),incx)
     end function
 
     function hipblasDtpmv_rank_1(handle,uplo,transA,diag,n,AP,x,incx)
@@ -51083,11 +51091,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      type(c_ptr) :: AP
+      real(c_double),target,dimension(:) :: AP
       real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       !
-      hipblasDtpmv_rank_1 = hipblasDtpmv_(handle,uplo,transA,diag,n,AP,c_loc(x),incx)
+      hipblasDtpmv_rank_1 = hipblasDtpmv_(handle,uplo,transA,diag,n,c_loc(AP),c_loc(x),incx)
     end function
 
     function hipblasCtpmv_rank_0(handle,uplo,transA,diag,n,AP,x,incx)
@@ -51100,11 +51108,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      type(c_ptr) :: AP
+      complex(c_float_complex),target :: AP
       complex(c_float_complex),target :: x
       integer(c_int) :: incx
       !
-      hipblasCtpmv_rank_0 = hipblasCtpmv_(handle,uplo,transA,diag,n,AP,c_loc(x),incx)
+      hipblasCtpmv_rank_0 = hipblasCtpmv_(handle,uplo,transA,diag,n,c_loc(AP),c_loc(x),incx)
     end function
 
     function hipblasCtpmv_rank_1(handle,uplo,transA,diag,n,AP,x,incx)
@@ -51117,11 +51125,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      type(c_ptr) :: AP
+      complex(c_float_complex),target,dimension(:) :: AP
       complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       !
-      hipblasCtpmv_rank_1 = hipblasCtpmv_(handle,uplo,transA,diag,n,AP,c_loc(x),incx)
+      hipblasCtpmv_rank_1 = hipblasCtpmv_(handle,uplo,transA,diag,n,c_loc(AP),c_loc(x),incx)
     end function
 
     function hipblasZtpmv_rank_0(handle,uplo,transA,diag,n,AP,x,incx)
@@ -51134,11 +51142,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      type(c_ptr) :: AP
+      complex(c_double_complex),target :: AP
       complex(c_double_complex),target :: x
       integer(c_int) :: incx
       !
-      hipblasZtpmv_rank_0 = hipblasZtpmv_(handle,uplo,transA,diag,n,AP,c_loc(x),incx)
+      hipblasZtpmv_rank_0 = hipblasZtpmv_(handle,uplo,transA,diag,n,c_loc(AP),c_loc(x),incx)
     end function
 
     function hipblasZtpmv_rank_1(handle,uplo,transA,diag,n,AP,x,incx)
@@ -51151,11 +51159,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      type(c_ptr) :: AP
+      complex(c_double_complex),target,dimension(:) :: AP
       complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       !
-      hipblasZtpmv_rank_1 = hipblasZtpmv_(handle,uplo,transA,diag,n,AP,c_loc(x),incx)
+      hipblasZtpmv_rank_1 = hipblasZtpmv_(handle,uplo,transA,diag,n,c_loc(AP),c_loc(x),incx)
     end function
 
 #ifndef USE_CUDA_NAMES
@@ -51170,7 +51178,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      type(c_ptr) :: AP
+      real(c_float),target :: AP
       integer(c_int64_t) :: strideA
       real(c_float),target :: x
       integer(c_int) :: incx
@@ -51178,7 +51186,7 @@ module hipfort_hipblas
       integer(c_int) :: batchCount
       !
       hipblasStpmvStridedBatched_rank_0 = hipblasStpmvStridedBatched_(handle,uplo,transA,diag,n, &
-        AP,strideA,c_loc(x),incx,stridex,batchCount)
+        c_loc(AP),strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
     function hipblasStpmvStridedBatched_rank_1(handle,uplo,transA,diag,n,AP,strideA,x,incx, &
@@ -51192,7 +51200,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      type(c_ptr) :: AP
+      real(c_float),target,dimension(:) :: AP
       integer(c_int64_t) :: strideA
       real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
@@ -51200,7 +51208,7 @@ module hipfort_hipblas
       integer(c_int) :: batchCount
       !
       hipblasStpmvStridedBatched_rank_1 = hipblasStpmvStridedBatched_(handle,uplo,transA,diag,n, &
-        AP,strideA,c_loc(x),incx,stridex,batchCount)
+        c_loc(AP),strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
 #endif
@@ -51216,7 +51224,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      type(c_ptr) :: AP
+      real(c_double),target :: AP
       integer(c_int64_t) :: strideA
       real(c_double),target :: x
       integer(c_int) :: incx
@@ -51224,7 +51232,7 @@ module hipfort_hipblas
       integer(c_int) :: batchCount
       !
       hipblasDtpmvStridedBatched_rank_0 = hipblasDtpmvStridedBatched_(handle,uplo,transA,diag,n, &
-        AP,strideA,c_loc(x),incx,stridex,batchCount)
+        c_loc(AP),strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
     function hipblasDtpmvStridedBatched_rank_1(handle,uplo,transA,diag,n,AP,strideA,x,incx, &
@@ -51238,7 +51246,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      type(c_ptr) :: AP
+      real(c_double),target,dimension(:) :: AP
       integer(c_int64_t) :: strideA
       real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
@@ -51246,7 +51254,7 @@ module hipfort_hipblas
       integer(c_int) :: batchCount
       !
       hipblasDtpmvStridedBatched_rank_1 = hipblasDtpmvStridedBatched_(handle,uplo,transA,diag,n, &
-        AP,strideA,c_loc(x),incx,stridex,batchCount)
+        c_loc(AP),strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
 #endif
@@ -51262,7 +51270,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      type(c_ptr) :: AP
+      complex(c_float_complex),target :: AP
       integer(c_int64_t) :: strideA
       complex(c_float_complex),target :: x
       integer(c_int) :: incx
@@ -51270,7 +51278,7 @@ module hipfort_hipblas
       integer(c_int) :: batchCount
       !
       hipblasCtpmvStridedBatched_rank_0 = hipblasCtpmvStridedBatched_(handle,uplo,transA,diag,n, &
-        AP,strideA,c_loc(x),incx,stridex,batchCount)
+        c_loc(AP),strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
     function hipblasCtpmvStridedBatched_rank_1(handle,uplo,transA,diag,n,AP,strideA,x,incx, &
@@ -51284,7 +51292,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      type(c_ptr) :: AP
+      complex(c_float_complex),target,dimension(:) :: AP
       integer(c_int64_t) :: strideA
       complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
@@ -51292,7 +51300,7 @@ module hipfort_hipblas
       integer(c_int) :: batchCount
       !
       hipblasCtpmvStridedBatched_rank_1 = hipblasCtpmvStridedBatched_(handle,uplo,transA,diag,n, &
-        AP,strideA,c_loc(x),incx,stridex,batchCount)
+        c_loc(AP),strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
 #endif
@@ -51308,7 +51316,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      type(c_ptr) :: AP
+      complex(c_double_complex),target :: AP
       integer(c_int64_t) :: strideA
       complex(c_double_complex),target :: x
       integer(c_int) :: incx
@@ -51316,7 +51324,7 @@ module hipfort_hipblas
       integer(c_int) :: batchCount
       !
       hipblasZtpmvStridedBatched_rank_0 = hipblasZtpmvStridedBatched_(handle,uplo,transA,diag,n, &
-        AP,strideA,c_loc(x),incx,stridex,batchCount)
+        c_loc(AP),strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
     function hipblasZtpmvStridedBatched_rank_1(handle,uplo,transA,diag,n,AP,strideA,x,incx, &
@@ -51330,7 +51338,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      type(c_ptr) :: AP
+      complex(c_double_complex),target,dimension(:) :: AP
       integer(c_int64_t) :: strideA
       complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
@@ -51338,7 +51346,7 @@ module hipfort_hipblas
       integer(c_int) :: batchCount
       !
       hipblasZtpmvStridedBatched_rank_1 = hipblasZtpmvStridedBatched_(handle,uplo,transA,diag,n, &
-        AP,strideA,c_loc(x),incx,stridex,batchCount)
+        c_loc(AP),strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
 #endif
@@ -51352,11 +51360,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      type(c_ptr) :: AP
+      real(c_float),target :: AP
       real(c_float),target :: x
       integer(c_int) :: incx
       !
-      hipblasStpsv_rank_0 = hipblasStpsv_(handle,uplo,transA,diag,n,AP,c_loc(x),incx)
+      hipblasStpsv_rank_0 = hipblasStpsv_(handle,uplo,transA,diag,n,c_loc(AP),c_loc(x),incx)
     end function
 
     function hipblasStpsv_rank_1(handle,uplo,transA,diag,n,AP,x,incx)
@@ -51369,11 +51377,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      type(c_ptr) :: AP
+      real(c_float),target,dimension(:) :: AP
       real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
       !
-      hipblasStpsv_rank_1 = hipblasStpsv_(handle,uplo,transA,diag,n,AP,c_loc(x),incx)
+      hipblasStpsv_rank_1 = hipblasStpsv_(handle,uplo,transA,diag,n,c_loc(AP),c_loc(x),incx)
     end function
 
     function hipblasDtpsv_rank_0(handle,uplo,transA,diag,n,AP,x,incx)
@@ -51386,11 +51394,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      type(c_ptr) :: AP
+      real(c_double),target :: AP
       real(c_double),target :: x
       integer(c_int) :: incx
       !
-      hipblasDtpsv_rank_0 = hipblasDtpsv_(handle,uplo,transA,diag,n,AP,c_loc(x),incx)
+      hipblasDtpsv_rank_0 = hipblasDtpsv_(handle,uplo,transA,diag,n,c_loc(AP),c_loc(x),incx)
     end function
 
     function hipblasDtpsv_rank_1(handle,uplo,transA,diag,n,AP,x,incx)
@@ -51403,11 +51411,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      type(c_ptr) :: AP
+      real(c_double),target,dimension(:) :: AP
       real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
       !
-      hipblasDtpsv_rank_1 = hipblasDtpsv_(handle,uplo,transA,diag,n,AP,c_loc(x),incx)
+      hipblasDtpsv_rank_1 = hipblasDtpsv_(handle,uplo,transA,diag,n,c_loc(AP),c_loc(x),incx)
     end function
 
     function hipblasCtpsv_rank_0(handle,uplo,transA,diag,n,AP,x,incx)
@@ -51420,11 +51428,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      type(c_ptr) :: AP
+      complex(c_float_complex),target :: AP
       complex(c_float_complex),target :: x
       integer(c_int) :: incx
       !
-      hipblasCtpsv_rank_0 = hipblasCtpsv_(handle,uplo,transA,diag,n,AP,c_loc(x),incx)
+      hipblasCtpsv_rank_0 = hipblasCtpsv_(handle,uplo,transA,diag,n,c_loc(AP),c_loc(x),incx)
     end function
 
     function hipblasCtpsv_rank_1(handle,uplo,transA,diag,n,AP,x,incx)
@@ -51437,11 +51445,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      type(c_ptr) :: AP
+      complex(c_float_complex),target,dimension(:) :: AP
       complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       !
-      hipblasCtpsv_rank_1 = hipblasCtpsv_(handle,uplo,transA,diag,n,AP,c_loc(x),incx)
+      hipblasCtpsv_rank_1 = hipblasCtpsv_(handle,uplo,transA,diag,n,c_loc(AP),c_loc(x),incx)
     end function
 
     function hipblasZtpsv_rank_0(handle,uplo,transA,diag,n,AP,x,incx)
@@ -51454,11 +51462,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      type(c_ptr) :: AP
+      complex(c_double_complex),target :: AP
       complex(c_double_complex),target :: x
       integer(c_int) :: incx
       !
-      hipblasZtpsv_rank_0 = hipblasZtpsv_(handle,uplo,transA,diag,n,AP,c_loc(x),incx)
+      hipblasZtpsv_rank_0 = hipblasZtpsv_(handle,uplo,transA,diag,n,c_loc(AP),c_loc(x),incx)
     end function
 
     function hipblasZtpsv_rank_1(handle,uplo,transA,diag,n,AP,x,incx)
@@ -51471,11 +51479,11 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      type(c_ptr) :: AP
+      complex(c_double_complex),target,dimension(:) :: AP
       complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
       !
-      hipblasZtpsv_rank_1 = hipblasZtpsv_(handle,uplo,transA,diag,n,AP,c_loc(x),incx)
+      hipblasZtpsv_rank_1 = hipblasZtpsv_(handle,uplo,transA,diag,n,c_loc(AP),c_loc(x),incx)
     end function
 
 #ifndef USE_CUDA_NAMES
@@ -51490,7 +51498,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      type(c_ptr) :: AP
+      real(c_float),target :: AP
       integer(c_int64_t) :: strideA
       real(c_float),target :: x
       integer(c_int) :: incx
@@ -51498,7 +51506,7 @@ module hipfort_hipblas
       integer(c_int) :: batchCount
       !
       hipblasStpsvStridedBatched_rank_0 = hipblasStpsvStridedBatched_(handle,uplo,transA,diag,n, &
-        AP,strideA,c_loc(x),incx,stridex,batchCount)
+        c_loc(AP),strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
     function hipblasStpsvStridedBatched_rank_1(handle,uplo,transA,diag,n,AP,strideA,x,incx, &
@@ -51512,7 +51520,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      type(c_ptr) :: AP
+      real(c_float),target,dimension(:) :: AP
       integer(c_int64_t) :: strideA
       real(c_float),target,dimension(:) :: x
       integer(c_int) :: incx
@@ -51520,7 +51528,7 @@ module hipfort_hipblas
       integer(c_int) :: batchCount
       !
       hipblasStpsvStridedBatched_rank_1 = hipblasStpsvStridedBatched_(handle,uplo,transA,diag,n, &
-        AP,strideA,c_loc(x),incx,stridex,batchCount)
+        c_loc(AP),strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
 #endif
@@ -51536,7 +51544,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      type(c_ptr) :: AP
+      real(c_double),target :: AP
       integer(c_int64_t) :: strideA
       real(c_double),target :: x
       integer(c_int) :: incx
@@ -51544,7 +51552,7 @@ module hipfort_hipblas
       integer(c_int) :: batchCount
       !
       hipblasDtpsvStridedBatched_rank_0 = hipblasDtpsvStridedBatched_(handle,uplo,transA,diag,n, &
-        AP,strideA,c_loc(x),incx,stridex,batchCount)
+        c_loc(AP),strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
     function hipblasDtpsvStridedBatched_rank_1(handle,uplo,transA,diag,n,AP,strideA,x,incx, &
@@ -51558,7 +51566,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      type(c_ptr) :: AP
+      real(c_double),target,dimension(:) :: AP
       integer(c_int64_t) :: strideA
       real(c_double),target,dimension(:) :: x
       integer(c_int) :: incx
@@ -51566,7 +51574,7 @@ module hipfort_hipblas
       integer(c_int) :: batchCount
       !
       hipblasDtpsvStridedBatched_rank_1 = hipblasDtpsvStridedBatched_(handle,uplo,transA,diag,n, &
-        AP,strideA,c_loc(x),incx,stridex,batchCount)
+        c_loc(AP),strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
 #endif
@@ -51582,7 +51590,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      type(c_ptr) :: AP
+      complex(c_float_complex),target :: AP
       integer(c_int64_t) :: strideA
       complex(c_float_complex),target :: x
       integer(c_int) :: incx
@@ -51590,7 +51598,7 @@ module hipfort_hipblas
       integer(c_int) :: batchCount
       !
       hipblasCtpsvStridedBatched_rank_0 = hipblasCtpsvStridedBatched_(handle,uplo,transA,diag,n, &
-        AP,strideA,c_loc(x),incx,stridex,batchCount)
+        c_loc(AP),strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
     function hipblasCtpsvStridedBatched_rank_1(handle,uplo,transA,diag,n,AP,strideA,x,incx, &
@@ -51604,7 +51612,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      type(c_ptr) :: AP
+      complex(c_float_complex),target,dimension(:) :: AP
       integer(c_int64_t) :: strideA
       complex(c_float_complex),target,dimension(:) :: x
       integer(c_int) :: incx
@@ -51612,7 +51620,7 @@ module hipfort_hipblas
       integer(c_int) :: batchCount
       !
       hipblasCtpsvStridedBatched_rank_1 = hipblasCtpsvStridedBatched_(handle,uplo,transA,diag,n, &
-        AP,strideA,c_loc(x),incx,stridex,batchCount)
+        c_loc(AP),strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
 #endif
@@ -51628,7 +51636,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      type(c_ptr) :: AP
+      complex(c_double_complex),target :: AP
       integer(c_int64_t) :: strideA
       complex(c_double_complex),target :: x
       integer(c_int) :: incx
@@ -51636,7 +51644,7 @@ module hipfort_hipblas
       integer(c_int) :: batchCount
       !
       hipblasZtpsvStridedBatched_rank_0 = hipblasZtpsvStridedBatched_(handle,uplo,transA,diag,n, &
-        AP,strideA,c_loc(x),incx,stridex,batchCount)
+        c_loc(AP),strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
     function hipblasZtpsvStridedBatched_rank_1(handle,uplo,transA,diag,n,AP,strideA,x,incx, &
@@ -51650,7 +51658,7 @@ module hipfort_hipblas
       integer(kind(HIPBLAS_OP_N)) :: transA
       integer(kind(HIPBLAS_DIAG_NON_UNIT)) :: diag
       integer(c_int) :: n
-      type(c_ptr) :: AP
+      complex(c_double_complex),target,dimension(:) :: AP
       integer(c_int64_t) :: strideA
       complex(c_double_complex),target,dimension(:) :: x
       integer(c_int) :: incx
@@ -51658,7 +51666,7 @@ module hipfort_hipblas
       integer(c_int) :: batchCount
       !
       hipblasZtpsvStridedBatched_rank_1 = hipblasZtpsvStridedBatched_(handle,uplo,transA,diag,n, &
-        AP,strideA,c_loc(x),incx,stridex,batchCount)
+        c_loc(AP),strideA,c_loc(x),incx,stridex,batchCount)
     end function
 
 #endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -137,6 +137,7 @@ if(BUILD_TESTING)
     hipfort_add_test(hipblas zdotc f2008)
     hipfort_add_test(hipblas sger f2008)
     hipfort_add_test(hipblas sswap f2008)
+    hipfort_add_test(hipblas stpsv f2008)
   endif()
 
   if(TARGET hipfort::hipfft)

--- a/test/f2008/hipblas/stpsv.f08
+++ b/test/f2008/hipblas/stpsv.f08
@@ -1,0 +1,93 @@
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Copyright (c) 2020-2026 Advanced Micro Devices, Inc.
+!
+! Permission is hereby granted, free of charge, to any person obtaining a copy
+! of this software and associated documentation files (the "Software"), to deal
+! in the Software without restriction, including without limitation the rights
+! to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+! copies of the Software, and to permit persons to whom the Software is
+! furnished to do so, subject to the following conditions:
+!
+! The above copyright notice and this permission notice shall be included in
+! all copies or substantial portions of the Software.
+!
+! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+! IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+! AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+! OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+! THE SOFTWARE.
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+
+program hipblas_stpsv_test
+
+  use iso_c_binding
+  use hipfort
+  use hipfort_check
+  use hipfort_hipblas
+
+  implicit none
+
+  integer(kind(HIPBLAS_FILL_MODE_LOWER)), parameter :: uplo   = HIPBLAS_FILL_MODE_LOWER
+  integer(kind(HIPBLAS_OP_N)),            parameter :: transA = HIPBLAS_OP_N
+  integer(kind(HIPBLAS_DIAG_NON_UNIT)),   parameter :: diag   = HIPBLAS_DIAG_NON_UNIT
+
+  integer, parameter :: n = 64
+
+  ! Packed lower-triangular matrix (column-by-column). Every stored element of an
+  ! all-ones lower-triangular matrix is 1, so the packing order is irrelevant here.
+  real(c_float), allocatable, dimension(:) :: hAP, hx
+  real(c_float), parameter :: x_exact = 1.0
+
+  real(c_float), pointer, dimension(:) :: dAP => null(), dx => null()
+  type(c_ptr) :: handle = c_null_ptr
+
+  integer :: i
+  real(c_float) :: error
+  real(c_float), parameter :: error_max = 10*epsilon(error)
+
+  write(*,"(a)",advance="no") "-- Running test 'STPSV' (Fortran 2008 interfaces) - "
+
+  call hipblasCheck(hipblasCreate(handle))
+
+  allocate(hAP(n*(n+1)/2), hx(n))
+
+  hAP(:) = 1.0            ! all-ones lower-triangular L, packed
+  do i = 1, n
+    hx(i) = real(i)       ! b(i) = i  ->  exact solution of L x = b is x(i) = 1
+  end do
+
+  ! Allocate device memory (source= implies a blocking memcpy)
+  call hipCheck(hipMalloc(dAP, source=hAP))
+  call hipCheck(hipMalloc(dx,  source=hx))
+
+  ! Packed triangular solve L x = b, in place. dAP is passed as a Fortran array
+  ! (the generic array form) — this is the case that used to fail to compile
+  ! because the packed matrix dummy was declared type(c_ptr) (SWDEV-485451).
+  call hipblasCheck(hipblasStpsv(handle, uplo, transA, diag, n, dAP, dx, 1))
+
+  call hipCheck(hipDeviceSynchronize())
+
+  call hipCheck(hipMemcpy(hx, dx, hipMemcpyDeviceToHost))
+
+  do i = 1, n
+    error = abs((x_exact - hx(i))/x_exact)
+    if( error > error_max )then
+      write(*,*) "FAILED! Error bigger than max! Error = ", error, " hx(", i, ") = ", hx(i)
+      call exit(1)
+    end if
+  end do
+
+  call hipCheck(hipFree(dAP))
+  call hipCheck(hipFree(dx))
+
+  call hipblasCheck(hipblasDestroy(handle))
+
+  deallocate(hAP, hx)
+
+  write(*,*) "PASSED!"
+
+end program hipblas_stpsv_test


### PR DESCRIPTION
## Problem

Same issue as the rocBLAS fix (#426), for hipBLAS: passing a Fortran array to the packed Level-2 routines fails to compile because the packed matrix argument `AP` is declared as `type(c_ptr)` in the generic's specifics.

```fortran
real(c_float), pointer :: dAP(:), dx(:)
rc = hipblasStpsv(handle, HIPBLAS_FILL_MODE_LOWER, HIPBLAS_OP_N, &
                  HIPBLAS_DIAG_NON_UNIT, n, dAP, dx, 1)
!   error: No specific function of generic 'hipblasStpsv' matches the actual arguments
```

## Root cause

`hipblas.cptrargs` listed `AP` for the packed/triangular Level-2 families (`hpmv, hpr, hpr2, spmv, spr, spr2, tpmv, tpsv`), which keeps it as `type(c_ptr)` instead of arrayifying it like the dense Level-2 matrices. `AP` is a data buffer, not a scalar output pointer (the intended use of `cptrargs`).

## Fix

Removed the 66 `AP` entries from `hipblas.cptrargs` and regenerated. The packed matrix dummy is now a `target` array for every packed Level-2 routine and precision, matching the dense generics. The raw `bind(c)` specific (all-`c_ptr`) stays in each generic, so existing `c_ptr` callers are unaffected — this only **adds** array support. The diff is entirely the `AP` argument (`type(c_ptr)` → `target[,dimension(:)]` and `AP` → `c_loc(AP)` at call sites).

## Verification (amdflang)

- The patched module compiles with **no new generic ambiguity**.
- Both `hipblasStpmv` and `hipblasStpsv` now resolve when passed a Fortran array.

## Notes

- Companion to #426 (rocBLAS). Generator change lives in the `rocm-fortran` repo.

JIRA ID: ROCM-26106