### PR TITLE
test: fix corrupted sgtsv f2008 tests (stray scsr2csc fragment)

### DIFF
--- a/test/f2008/hipsparse/hipsparse_sgtsv.f08
+++ b/test/f2008/hipsparse/hipsparse_sgtsv.f08
@@ -1,27 +1,13 @@
-!!!!!!!!!!!!!/
-! scsr2csc example (single-precision CSR -> CSC conversion / sparse transpose)
-! see: https:!rocm.docs.amd.com/projects/rocSPARSE/en/latest/reference/conversion.html
+!!!!!!!!!!!!!!
+! sgtsv example (single-precision tridiagonal solve, hipSPARSE)
+! see: https:!rocm.docs.amd.com/projects/hipSPARSE/en/latest/
 !
-! Converting A from CSR to CSC is equivalent to producing the CSR of A**T.
-! We check the resulting csc_col_ptr / csc_row_ind / csc_val against the known
-! transpose. csr2csc needs a workspace buffer sized by csr2csc_buffer_size.
-!!!!!!!!!!!!!!/
+! Solves A x = b for a tridiagonal system. Here A is the identity tridiagonal
+! (dl = du = 0, d = 1), so the exact solution of A x = b is x = b. dl/d/du/B are
+! passed as Fortran arrays, exercising the generic array form of the diagonal
+! arguments (they used to be declared type(c_ptr), SWDEV-485451).
+!!!!!!!!!!!!!!
 !
-program scsr2csc
-  use iso_c_binding
-  use hipfort
-  use hipfort_check
-  use hipfort_rocsparse
-
-  implicit none
-  integer :: i
-
-  ! 3x3 sparse matrix in CSR (0-based):
-  !   row 0: (0,0)=1, (0,2)=2
-  !   row 1: (1,1)=3
-  !   row 2: (2,0)=4, (2,2)=5
-  integer(c_int), parameter :: M = 3, N = 3, nnz = 5
-
 program hipsparse_sgtsv_test
 
   use iso_c_binding

--- a/test/f2008/rocsparse/rocsparse_sgtsv.f08
+++ b/test/f2008/rocsparse/rocsparse_sgtsv.f08
@@ -1,27 +1,13 @@
-!!!!!!!!!!!!!/
-! scsr2csc example (single-precision CSR -> CSC conversion / sparse transpose)
-! see: https:!rocm.docs.amd.com/projects/rocSPARSE/en/latest/reference/conversion.html
+!!!!!!!!!!!!!!
+! sgtsv example (single-precision tridiagonal solve, rocSPARSE)
+! see: https:!rocm.docs.amd.com/projects/rocSPARSE/en/latest/reference/precond.html
 !
-! Converting A from CSR to CSC is equivalent to producing the CSR of A**T.
-! We check the resulting csc_col_ptr / csc_row_ind / csc_val against the known
-! transpose. csr2csc needs a workspace buffer sized by csr2csc_buffer_size.
-!!!!!!!!!!!!!!/
+! Solves A x = b for a tridiagonal system. Here A is the identity tridiagonal
+! (dl = du = 0, d = 1), so the exact solution of A x = b is x = b. dl/d/du/B are
+! passed as Fortran arrays, exercising the generic array form of the diagonal
+! arguments (they used to be declared type(c_ptr), SWDEV-485451).
+!!!!!!!!!!!!!!
 !
-program scsr2csc
-  use iso_c_binding
-  use hipfort
-  use hipfort_check
-  use hipfort_rocsparse
-
-  implicit none
-  integer :: i
-
-  ! 3x3 sparse matrix in CSR (0-based):
-  !   row 0: (0,0)=1, (0,2)=2
-  !   row 1: (1,1)=3
-  !   row 2: (2,0)=4, (2,2)=5
-  integer(c_int), parameter :: M = 3, N = 3, nnz = 5
-
 program rocsparse_sgtsv_test
 
   use iso_c_binding


### PR DESCRIPTION
## Problem

`test/f2008/rocsparse/rocsparse_sgtsv.f08` and `test/f2008/hipsparse/hipsparse_sgtsv.f08` fail to compile with flang:

```
error: Could not parse .../rocsparse_sgtsv.f08
rocsparse_sgtsv.f08:25:9: error: expected '('
  program rocsparse_sgtsv_test
rocsparse_sgtsv.f08:27:20: error: misplaced USE statement
    use iso_c_binding
```

## Cause

Both tests were created from the `scsr2csc.f08` template and accidentally kept a leftover `scsr2csc` program header (comment block + `program scsr2csc ... implicit none ... integer(c_int), parameter :: M = 3, N = 3, nnz = 5`) at the top of the file, **before** the actual SGTSV program. Each file therefore contained two `program` units, which flang refuses to parse.

## Fix

- Remove the stray `scsr2csc` fragment from both files.
- Replace the misleading comment header with a proper SGTSV description.

The imported module and the API calls in the bodies were already correct (`hipfort_rocsparse` / `rocsparse_sgtsv*` and `hipfort_hipsparse` / `hipsparseSgtsv2*`); only the duplicated header was dropped.