### PR TITLE
[rocSOLVER] type latrd W (matrix) and tau (vector) instead of c_ptr/scalar

### DIFF
--- a/lib/hipfort/hipfort_rocsolver.F90
+++ b/lib/hipfort/hipfort_rocsolver.F90
@@ -2042,7 +2042,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: E
-      real(c_float) :: tau
+      type(c_ptr),value :: tau
       type(c_ptr),value :: W
       integer(c_int),value :: ldw
     end function
@@ -2069,7 +2069,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: E
-      real(c_double) :: tau
+      type(c_ptr),value :: tau
       type(c_ptr),value :: W
       integer(c_int),value :: ldw
     end function
@@ -2096,7 +2096,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: E
-      complex(c_float_complex) :: tau
+      type(c_ptr),value :: tau
       type(c_ptr),value :: W
       integer(c_int),value :: ldw
     end function
@@ -2123,7 +2123,7 @@ module hipfort_rocsolver
       type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: E
-      complex(c_double_complex) :: tau
+      type(c_ptr),value :: tau
       type(c_ptr),value :: W
       integer(c_int),value :: ldw
     end function
@@ -44040,11 +44040,12 @@ module hipfort_rocsolver
       real(c_float),target :: A
       integer(c_int) :: lda
       real(c_float),target :: E
-      real(c_float) :: tau
-      type(c_ptr) :: W
+      real(c_float),target :: tau
+      real(c_float),target :: W
       integer(c_int) :: ldw
       !
-      rocsolver_slatrd_rank_0 = rocsolver_slatrd_(handle,uplo,n,k,c_loc(A),lda,c_loc(E),tau,W,ldw)
+      rocsolver_slatrd_rank_0 = rocsolver_slatrd_(handle,uplo,n,k,c_loc(A),lda,c_loc(E), &
+        c_loc(tau),c_loc(W),ldw)
     end function
 
     function rocsolver_slatrd_rank_1(handle,uplo,n,k,A,lda,E,tau,W,ldw)
@@ -44060,11 +44061,12 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:) :: A
       integer(c_int) :: lda
       real(c_float),target,dimension(:) :: E
-      real(c_float) :: tau
-      type(c_ptr) :: W
+      real(c_float),target,dimension(:) :: tau
+      real(c_float),target,dimension(:) :: W
       integer(c_int) :: ldw
       !
-      rocsolver_slatrd_rank_1 = rocsolver_slatrd_(handle,uplo,n,k,c_loc(A),lda,c_loc(E),tau,W,ldw)
+      rocsolver_slatrd_rank_1 = rocsolver_slatrd_(handle,uplo,n,k,c_loc(A),lda,c_loc(E), &
+        c_loc(tau),c_loc(W),ldw)
     end function
 
     function rocsolver_slatrd_full_rank(handle,uplo,n,k,A,lda,E,tau,W,ldw)
@@ -44080,12 +44082,12 @@ module hipfort_rocsolver
       real(c_float),target,dimension(:,:) :: A
       integer(c_int) :: lda
       real(c_float),target,dimension(:) :: E
-      real(c_float) :: tau
-      type(c_ptr) :: W
+      real(c_float),target,dimension(:) :: tau
+      real(c_float),target,dimension(:,:) :: W
       integer(c_int) :: ldw
       !
-      rocsolver_slatrd_full_rank = rocsolver_slatrd_(handle,uplo,n,k,c_loc(A),lda,c_loc(E),tau,W, &
-        ldw)
+      rocsolver_slatrd_full_rank = rocsolver_slatrd_(handle,uplo,n,k,c_loc(A),lda,c_loc(E), &
+        c_loc(tau),c_loc(W),ldw)
     end function
 
     function rocsolver_dlatrd_rank_0(handle,uplo,n,k,A,lda,E,tau,W,ldw)
@@ -44101,11 +44103,12 @@ module hipfort_rocsolver
       real(c_double),target :: A
       integer(c_int) :: lda
       real(c_double),target :: E
-      real(c_double) :: tau
-      type(c_ptr) :: W
+      real(c_double),target :: tau
+      real(c_double),target :: W
       integer(c_int) :: ldw
       !
-      rocsolver_dlatrd_rank_0 = rocsolver_dlatrd_(handle,uplo,n,k,c_loc(A),lda,c_loc(E),tau,W,ldw)
+      rocsolver_dlatrd_rank_0 = rocsolver_dlatrd_(handle,uplo,n,k,c_loc(A),lda,c_loc(E), &
+        c_loc(tau),c_loc(W),ldw)
     end function
 
     function rocsolver_dlatrd_rank_1(handle,uplo,n,k,A,lda,E,tau,W,ldw)
@@ -44121,11 +44124,12 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:) :: A
       integer(c_int) :: lda
       real(c_double),target,dimension(:) :: E
-      real(c_double) :: tau
-      type(c_ptr) :: W
+      real(c_double),target,dimension(:) :: tau
+      real(c_double),target,dimension(:) :: W
       integer(c_int) :: ldw
       !
-      rocsolver_dlatrd_rank_1 = rocsolver_dlatrd_(handle,uplo,n,k,c_loc(A),lda,c_loc(E),tau,W,ldw)
+      rocsolver_dlatrd_rank_1 = rocsolver_dlatrd_(handle,uplo,n,k,c_loc(A),lda,c_loc(E), &
+        c_loc(tau),c_loc(W),ldw)
     end function
 
     function rocsolver_dlatrd_full_rank(handle,uplo,n,k,A,lda,E,tau,W,ldw)
@@ -44141,12 +44145,12 @@ module hipfort_rocsolver
       real(c_double),target,dimension(:,:) :: A
       integer(c_int) :: lda
       real(c_double),target,dimension(:) :: E
-      real(c_double) :: tau
-      type(c_ptr) :: W
+      real(c_double),target,dimension(:) :: tau
+      real(c_double),target,dimension(:,:) :: W
       integer(c_int) :: ldw
       !
-      rocsolver_dlatrd_full_rank = rocsolver_dlatrd_(handle,uplo,n,k,c_loc(A),lda,c_loc(E),tau,W, &
-        ldw)
+      rocsolver_dlatrd_full_rank = rocsolver_dlatrd_(handle,uplo,n,k,c_loc(A),lda,c_loc(E), &
+        c_loc(tau),c_loc(W),ldw)
     end function
 
     function rocsolver_clatrd_rank_0(handle,uplo,n,k,A,lda,E,tau,W,ldw)
@@ -44162,11 +44166,12 @@ module hipfort_rocsolver
       complex(c_float_complex),target :: A
       integer(c_int) :: lda
       real(c_float),target :: E
-      complex(c_float_complex) :: tau
-      type(c_ptr) :: W
+      complex(c_float_complex),target :: tau
+      complex(c_float_complex),target :: W
       integer(c_int) :: ldw
       !
-      rocsolver_clatrd_rank_0 = rocsolver_clatrd_(handle,uplo,n,k,c_loc(A),lda,c_loc(E),tau,W,ldw)
+      rocsolver_clatrd_rank_0 = rocsolver_clatrd_(handle,uplo,n,k,c_loc(A),lda,c_loc(E), &
+        c_loc(tau),c_loc(W),ldw)
     end function
 
     function rocsolver_clatrd_rank_1(handle,uplo,n,k,A,lda,E,tau,W,ldw)
@@ -44182,11 +44187,12 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:) :: A
       integer(c_int) :: lda
       real(c_float),target,dimension(:) :: E
-      complex(c_float_complex) :: tau
-      type(c_ptr) :: W
+      complex(c_float_complex),target,dimension(:) :: tau
+      complex(c_float_complex),target,dimension(:) :: W
       integer(c_int) :: ldw
       !
-      rocsolver_clatrd_rank_1 = rocsolver_clatrd_(handle,uplo,n,k,c_loc(A),lda,c_loc(E),tau,W,ldw)
+      rocsolver_clatrd_rank_1 = rocsolver_clatrd_(handle,uplo,n,k,c_loc(A),lda,c_loc(E), &
+        c_loc(tau),c_loc(W),ldw)
     end function
 
     function rocsolver_clatrd_full_rank(handle,uplo,n,k,A,lda,E,tau,W,ldw)
@@ -44202,12 +44208,12 @@ module hipfort_rocsolver
       complex(c_float_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       real(c_float),target,dimension(:) :: E
-      complex(c_float_complex) :: tau
-      type(c_ptr) :: W
+      complex(c_float_complex),target,dimension(:) :: tau
+      complex(c_float_complex),target,dimension(:,:) :: W
       integer(c_int) :: ldw
       !
-      rocsolver_clatrd_full_rank = rocsolver_clatrd_(handle,uplo,n,k,c_loc(A),lda,c_loc(E),tau,W, &
-        ldw)
+      rocsolver_clatrd_full_rank = rocsolver_clatrd_(handle,uplo,n,k,c_loc(A),lda,c_loc(E), &
+        c_loc(tau),c_loc(W),ldw)
     end function
 
     function rocsolver_zlatrd_rank_0(handle,uplo,n,k,A,lda,E,tau,W,ldw)
@@ -44223,11 +44229,12 @@ module hipfort_rocsolver
       complex(c_double_complex),target :: A
       integer(c_int) :: lda
       real(c_double),target :: E
-      complex(c_double_complex) :: tau
-      type(c_ptr) :: W
+      complex(c_double_complex),target :: tau
+      complex(c_double_complex),target :: W
       integer(c_int) :: ldw
       !
-      rocsolver_zlatrd_rank_0 = rocsolver_zlatrd_(handle,uplo,n,k,c_loc(A),lda,c_loc(E),tau,W,ldw)
+      rocsolver_zlatrd_rank_0 = rocsolver_zlatrd_(handle,uplo,n,k,c_loc(A),lda,c_loc(E), &
+        c_loc(tau),c_loc(W),ldw)
     end function
 
     function rocsolver_zlatrd_rank_1(handle,uplo,n,k,A,lda,E,tau,W,ldw)
@@ -44243,11 +44250,12 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:) :: A
       integer(c_int) :: lda
       real(c_double),target,dimension(:) :: E
-      complex(c_double_complex) :: tau
-      type(c_ptr) :: W
+      complex(c_double_complex),target,dimension(:) :: tau
+      complex(c_double_complex),target,dimension(:) :: W
       integer(c_int) :: ldw
       !
-      rocsolver_zlatrd_rank_1 = rocsolver_zlatrd_(handle,uplo,n,k,c_loc(A),lda,c_loc(E),tau,W,ldw)
+      rocsolver_zlatrd_rank_1 = rocsolver_zlatrd_(handle,uplo,n,k,c_loc(A),lda,c_loc(E), &
+        c_loc(tau),c_loc(W),ldw)
     end function
 
     function rocsolver_zlatrd_full_rank(handle,uplo,n,k,A,lda,E,tau,W,ldw)
@@ -44263,12 +44271,12 @@ module hipfort_rocsolver
       complex(c_double_complex),target,dimension(:,:) :: A
       integer(c_int) :: lda
       real(c_double),target,dimension(:) :: E
-      complex(c_double_complex) :: tau
-      type(c_ptr) :: W
+      complex(c_double_complex),target,dimension(:) :: tau
+      complex(c_double_complex),target,dimension(:,:) :: W
       integer(c_int) :: ldw
       !
-      rocsolver_zlatrd_full_rank = rocsolver_zlatrd_(handle,uplo,n,k,c_loc(A),lda,c_loc(E),tau,W, &
-        ldw)
+      rocsolver_zlatrd_full_rank = rocsolver_zlatrd_(handle,uplo,n,k,c_loc(A),lda,c_loc(E), &
+        c_loc(tau),c_loc(W),ldw)
     end function
 
     function rocsolver_slasyf_rank_0(handle,uplo,n,nb,kb,A,lda,ipiv,myInfo)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -423,6 +423,8 @@ if(BUILD_TESTING)
     hipfort_add_test(rocsolver rocsolver_dgesv f2008)
     hipfort_add_test(rocsolver rocsolver_dgetri f2003)
     hipfort_add_test(rocsolver rocsolver_dgetri f2008)
+    hipfort_add_test(rocsolver rocsolver_dlatrd f2003)
+    hipfort_add_test(rocsolver rocsolver_dlatrd f2008)
   endif()
 
   if(TARGET hipfort::rocsparse)

--- a/test/f2003/rocsolver/rocsolver_dlatrd.f03
+++ b/test/f2003/rocsolver/rocsolver_dlatrd.f03
@@ -1,0 +1,83 @@
+!!!!!!!!!!!!!!
+! dlatrd example (rocSOLVER)
+! see: https:!rocm.docs.amd.com/projects/rocSOLVER/en/latest/reference/auxiliary.html
+!
+! Reduces the first k columns of a symmetric matrix A to symmetric tridiagonal
+! form (uplo = lower). The device buffers are passed as type(c_ptr), which
+! resolves to the raw bind(c) interface. tau is now a type(c_ptr) there (it used
+! to be a scalar by reference), so a device tau pointer can be supplied at all.
+!!!!!!!!!!!!!!
+!
+program dlatrd
+  use iso_c_binding
+  use hipfort
+  use hipfort_check
+  use hipfort_rocblas
+  use hipfort_rocblas_enums
+  use hipfort_rocsolver
+
+  implicit none
+
+  integer(c_int), parameter :: n = 4, k = 2, lda = 4, ldw = 4
+
+  ! Symmetric 4x4 matrix (column-major). Its first sub-column A(2:n,1) = [2,3,6]
+  ! has 2-norm 7, which is the quantity we check below.
+  real(c_double), target :: hA(n,n) = reshape([ &
+      10.0d0,  2.0d0,  3.0d0,  6.0d0, &
+       2.0d0, 11.0d0,  1.0d0,  0.0d0, &
+       3.0d0,  1.0d0, 12.0d0,  2.0d0, &
+       6.0d0,  0.0d0,  2.0d0, 13.0d0], [n,n])
+  real(c_double), target :: hE(n-1) = 0.0d0
+
+  integer(c_size_t) :: size_A   = n*n
+  integer(c_size_t) :: size_E   = n-1
+  integer(c_size_t) :: size_tau = n-1
+  integer(c_size_t) :: size_W   = n*k
+
+  type(c_ptr) :: dA, dE, dtau, dW
+  type(c_ptr) :: handle ! rocblas_handle
+
+  real(c_double) :: expected, error
+  real(c_double), parameter :: rtol = 1.0d-10
+
+  write(*,"(a)",advance="no") "-- Running test 'rocsolver_dlatrd' (Fortran 2003 interfaces) - "
+
+  ! Allocate device-side memory
+  call hipCheck(hipMalloc(dA,   size_A   * 8))
+  call hipCheck(hipMalloc(dE,   size_E   * 8))
+  call hipCheck(hipMalloc(dtau, size_tau * 8))
+  call hipCheck(hipMalloc(dW,   size_W   * 8))
+
+  call rocblasCheck(rocblas_create_handle(handle))
+
+  ! Copy the input matrix from host to device
+  call hipCheck(hipMemcpy(dA, c_loc(hA(1,1)), size_A * 8, hipMemcpyHostToDevice))
+
+  ! Reduce the first k columns to tridiagonal form. Device buffers are passed as
+  ! type(c_ptr) (resolves to the raw bind(c) interface).
+  call rocsolverCheck(rocsolver_dlatrd(handle, rocblas_fill_lower, n, k, dA, lda, dE, dtau, dW, ldw))
+
+  call hipCheck(hipDeviceSynchronize())
+  call hipCheck(hipMemcpy(c_loc(hE(1)), dE, size_E * 8, hipMemcpyDeviceToHost))
+
+  ! The first Householder reflector maps the original sub-column A(2:n,1) onto
+  ! [E(1), 0, ..., 0], so |E(1)| == ||A(2:n,1)||_2, independent of the sign
+  ! convention rocSOLVER uses for the reflector.
+  expected = sqrt(2.0d0**2 + 3.0d0**2 + 6.0d0**2)   ! = 7
+  error = abs(abs(hE(1)) - expected) / expected
+  if (error > rtol) then
+     write(*,*) "FAILED! |E(1)| = ", abs(hE(1)), " expected ", expected
+     call exit(1)
+  end if
+
+  ! Clean up
+  call hipCheck(hipFree(dA))
+  call hipCheck(hipFree(dE))
+  call hipCheck(hipFree(dtau))
+  call hipCheck(hipFree(dW))
+  call rocblasCheck(rocblas_destroy_handle(handle))
+  call hipCheck(hipDeviceReset())
+
+  write(*,*) "PASSED!"
+
+end program dlatrd

--- a/test/f2008/rocsolver/rocsolver_dlatrd.f08
+++ b/test/f2008/rocsolver/rocsolver_dlatrd.f08
@@ -1,0 +1,82 @@
+!!!!!!!!!!!!!!
+! dlatrd example (rocSOLVER)
+! see: https:!rocm.docs.amd.com/projects/rocSOLVER/en/latest/reference/auxiliary.html
+!
+! Reduces the first k columns of a symmetric matrix A to symmetric tridiagonal
+! form (uplo = lower). This test passes A, E, tau and W as native Fortran device
+! arrays: W is a 2-D matrix (dimension(:,:)) and tau a 1-D vector (dimension(:)).
+! Before the binding fix, W was a bare type(c_ptr) and tau a scalar, so this
+! call could not be expressed with typed arrays at all.
+!!!!!!!!!!!!!!
+!
+program dlatrd
+  use iso_c_binding
+  use hipfort
+  use hipfort_check
+  use hipfort_rocblas
+  use hipfort_rocblas_enums
+  use hipfort_rocsolver
+
+  implicit none
+
+  integer(c_int), parameter :: n = 4, k = 2, lda = 4, ldw = 4
+
+  ! Symmetric 4x4 matrix (column-major). Its first sub-column A(2:n,1) = [2,3,6]
+  ! has 2-norm 7, which is the quantity we check below.
+  real(c_double) :: hA(n,n) = reshape([ &
+      10.0d0,  2.0d0,  3.0d0,  6.0d0, &
+       2.0d0, 11.0d0,  1.0d0,  0.0d0, &
+       3.0d0,  1.0d0, 12.0d0,  2.0d0, &
+       6.0d0,  0.0d0,  2.0d0, 13.0d0], [n,n])
+  real(c_double) :: hE(n-1)   = 0.0d0
+  real(c_double) :: htau(n-1) = 0.0d0
+  real(c_double) :: hW(n,k)   = 0.0d0
+
+  real(c_double), pointer :: dA(:,:)   ! GPU buffer for A
+  real(c_double), pointer :: dE(:)     ! GPU buffer for the off-diagonal E
+  real(c_double), pointer :: dtau(:)   ! GPU buffer for the Householder scalars
+  real(c_double), pointer :: dW(:,:)   ! GPU buffer for the update matrix W
+
+  type(c_ptr) :: handle ! rocblas_handle
+
+  real(c_double) :: expected, error
+  real(c_double), parameter :: rtol = 1.0d-10
+
+  write(*,"(a)",advance="no") "-- Running test 'rocsolver_dlatrd' (Fortran 2008 interfaces) - "
+
+  ! Allocate device-side memory & copy the inputs from host to device
+  call hipCheck(hipMalloc(dA,   source=hA))
+  call hipCheck(hipMalloc(dE,   source=hE))
+  call hipCheck(hipMalloc(dtau, source=htau))
+  call hipCheck(hipMalloc(dW,   source=hW))
+
+  call rocblasCheck(rocblas_create_handle(handle))
+
+  ! Reduce the first k columns to tridiagonal form. A/E/tau/W are all passed as
+  ! native Fortran device arrays (resolves to the _full_rank generic wrapper).
+  call rocsolverCheck(rocsolver_dlatrd(handle, rocblas_fill_lower, n, k, dA, lda, dE, dtau, dW, ldw))
+
+  call hipCheck(hipDeviceSynchronize())
+  call hipCheck(hipMemcpy(hE, dE, hipMemcpyDeviceToHost))
+
+  ! The first Householder reflector maps the original sub-column A(2:n,1) onto
+  ! [E(1), 0, ..., 0], so |E(1)| == ||A(2:n,1)||_2, independent of the sign
+  ! convention rocSOLVER uses for the reflector.
+  expected = sqrt(2.0d0**2 + 3.0d0**2 + 6.0d0**2)   ! = 7
+  error = abs(abs(hE(1)) - expected) / expected
+  if (error > rtol) then
+     write(*,*) "FAILED! |E(1)| = ", abs(hE(1)), " expected ", expected
+     call exit(1)
+  end if
+
+  ! Clean up
+  call hipCheck(hipFree(dA))
+  call hipCheck(hipFree(dE))
+  call hipCheck(hipFree(dtau))
+  call hipCheck(hipFree(dW))
+  call rocblasCheck(rocblas_destroy_handle(handle))
+  call hipCheck(hipDeviceReset())
+
+  write(*,*) "PASSED!"
+
+end program dlatrd


### PR DESCRIPTION
## Motivation

In the `rocsolver_?latrd` bindings, `W` was emitted as a bare `type(c_ptr)` and `tau` as a scalar by reference. The native-array (`_rank_*` / `_full_rank`) wrappers therefore could not accept them, and `latrd` was effectively uncallable with typed device arrays. Per the rocSOLVER docs both are ordinary device data buffers:

- `W`   — array of dimension `ldw*k`, the *n*-by-*k* update matrix
- `tau` — array of dimension `n-1`, the Householder scalar factors

Both were inherited verbatim from the old hand-written hipfort wrappers, not from the actual API shape.

## Technical details

Regenerated `hipfort_rocsolver.F90` from the generator (`ROCm/rocm-fortran`, companion PR removing `W`/`tau` from `rocsolver.cptrargs`/`rocsolver.argkinds`). In the native wrappers `W` is now `dimension(:,:)` and `tau` is `dimension(:)`, both forwarded via `c_loc`; in the raw `bind(c)` interface `tau` becomes `type(c_ptr),value` like every other buffer. **Only the `?latrd` interfaces change** (verified: the diff is confined to the four `?latrd` raw interfaces and their `rank_0`/`rank_1`/`full_rank` wrappers — 96 lines, no other symbol touched).

`W` follows `ldw` so its natural rank is 2; `tau` (a vector) is rank 1. The three native overloads stay unambiguous (rank signatures `(0,0,0,0)`, `(1,1,1,1)`, `(2,1,1,2)` for A,E,tau,W).

## Tests

Add `rocsolver_dlatrd` tests in both dialects:

- **f2008** — passes `A(:,:)`, `E(:)`, `tau(:)`, `W(:,:)` as native device arrays (resolves to `_full_rank`), exercising the new typed `W`/`tau`.
- **f2003** — passes all buffers as `type(c_ptr)` (resolves to the raw interface), exercising `tau` now being `type(c_ptr)` (a device `tau` pointer previously would not compile).

Both reduce the first columns of a symmetric matrix and check the sign-convention-independent invariant `|E(1)| == ||A(2:n,1)||_2` (chosen so `||A(2:n,1)|| = 7` exactly).

## Test plan

Configure with `-DBUILD_TESTING=ON`, build, and run `ctest -R dlatrd`.

Locally (WSL2, no GPU): both test executables **compile and link** cleanly with `amdflang` against the regenerated binding; they cannot execute here (HIP error 100 = no device). The numerical check runs in CI.