### PR TITLE
test: add HIP runtime API tests (device mgmt, streams, events, memset, async copy)

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -508,6 +508,16 @@ if(BUILD_TESTING)
     hipfort_add_test(rocsparse rocsparse_zsptrsm f2003)
   endif()
 
+  # HIP runtime API tests (pure Fortran, no custom kernel): device management,
+  # streams, events, memset and asynchronous copies.
+  if(TARGET hipfort::hip)
+    hipfort_add_test(hip device_management f2003)
+    hipfort_add_test(hip stream f2003)
+    hipfort_add_test(hip event f2003)
+    hipfort_add_test(hip memset f2003)
+    hipfort_add_test(hip memcpy_async f2003)
+  endif()
+
   # vecadd mixes a Fortran driver with a HIP C++ kernel, so it needs the HIP
   # language enabled rather than the plain hipfort_add_test() helper.
   include(CheckLanguage)

--- a/test/f2003/hip/device_management.f03
+++ b/test/f2003/hip/device_management.f03
@@ -1,0 +1,68 @@
+!!!!!!!!!!!!!!
+! HIP runtime device-management queries
+! see: https:!rocm.docs.amd.com/projects/HIP/en/latest/
+!
+! Exercises hipGetDeviceCount, hipSetDevice/hipGetDevice, hipDeviceGetAttribute,
+! hipDeviceGetLimit, hipDeviceTotalMem and hipMemGetInfo, checking basic
+! invariants that hold on any working device.
+!!!!!!!!!!!!!!
+!
+program device_management
+  use iso_c_binding
+  use hipfort
+  use hipfort_check
+  use hipfort_enums
+
+  implicit none
+
+  integer(c_int)    :: ndev, dev, warp, nmp
+  integer(c_size_t) :: totmem, freemem, total2, stacklimit
+
+  write(*,"(a)",advance="no") "-- Running test 'hip device_management' (Fortran 2003 interfaces) - "
+
+  call hipCheck(hipGetDeviceCount(ndev))
+  if (ndev < 1) then
+     write(*,*) "FAILED! device count = ", ndev
+     call exit(1)
+  end if
+
+  call hipCheck(hipSetDevice(0))
+  call hipCheck(hipGetDevice(dev))
+  if (dev /= 0) then
+     write(*,*) "FAILED! current device = ", dev, " (expected 0)"
+     call exit(1)
+  end if
+
+  call hipCheck(hipDeviceGetAttribute(warp, hipDeviceAttributeWarpSize, 0))
+  if (warp <= 0) then
+     write(*,*) "FAILED! warp size = ", warp
+     call exit(1)
+  end if
+
+  call hipCheck(hipDeviceGetAttribute(nmp, hipDeviceAttributeMultiprocessorCount, 0))
+  if (nmp <= 0) then
+     write(*,*) "FAILED! multiprocessor count = ", nmp
+     call exit(1)
+  end if
+
+  call hipCheck(hipDeviceGetLimit(stacklimit, hipLimitStackSize))
+  if (stacklimit <= 0) then
+     write(*,*) "FAILED! stack size limit = ", stacklimit
+     call exit(1)
+  end if
+
+  call hipCheck(hipDeviceTotalMem(totmem, 0))
+  if (totmem <= 0) then
+     write(*,*) "FAILED! total device memory = ", totmem
+     call exit(1)
+  end if
+
+  call hipCheck(hipMemGetInfo(freemem, total2))
+  if (total2 <= 0 .or. freemem > total2) then
+     write(*,*) "FAILED! memGetInfo free = ", freemem, " total = ", total2
+     call exit(1)
+  end if
+
+  write(*,*) "PASSED!"
+
+end program device_management

--- a/test/f2003/hip/event.f03
+++ b/test/f2003/hip/event.f03
@@ -1,0 +1,48 @@
+!!!!!!!!!!!!!!
+! HIP runtime event timing
+! see: https:!rocm.docs.amd.com/projects/HIP/en/latest/
+!
+! Exercises hipEventCreate, hipEventRecord, hipEventSynchronize,
+! hipEventElapsedTime and hipEventDestroy by timing a device memset on the
+! default stream.
+!!!!!!!!!!!!!!
+!
+program event
+  use iso_c_binding
+  use hipfort
+  use hipfort_check
+
+  implicit none
+
+  type(c_ptr) :: estart = c_null_ptr, estop = c_null_ptr, dptr = c_null_ptr
+  real(c_float) :: ms
+  integer(c_size_t), parameter :: nbytes = 4 * 1024 * 1024
+
+  write(*,"(a)",advance="no") "-- Running test 'hip event' (Fortran 2003 interfaces) - "
+
+  call hipCheck(hipSetDevice(0))
+  call hipCheck(hipMalloc(dptr, nbytes))
+
+  call hipCheck(hipEventCreate(estart))
+  call hipCheck(hipEventCreate(estop))
+
+  ! Record around some device work on the default stream (stream = c_null_ptr).
+  call hipCheck(hipEventRecord(estart, c_null_ptr))
+  call hipCheck(hipMemset(dptr, 0, nbytes))
+  call hipCheck(hipEventRecord(estop, c_null_ptr))
+
+  call hipCheck(hipEventSynchronize(estop))
+  call hipCheck(hipEventElapsedTime(ms, estart, estop))
+
+  if (ms < 0.0) then
+     write(*,*) "FAILED! elapsed time = ", ms, " ms (expected >= 0)"
+     call exit(1)
+  end if
+
+  call hipCheck(hipEventDestroy(estart))
+  call hipCheck(hipEventDestroy(estop))
+  call hipCheck(hipFree(dptr))
+
+  write(*,*) "PASSED!"
+
+end program event

--- a/test/f2003/hip/memcpy_async.f03
+++ b/test/f2003/hip/memcpy_async.f03
@@ -1,0 +1,55 @@
+!!!!!!!!!!!!!!
+! HIP runtime asynchronous copies
+! see: https:!rocm.docs.amd.com/projects/HIP/en/latest/
+!
+! Copies host -> device with hipMemcpyAsync and device -> host with
+! hipMemcpyWithStream on a user stream, then verifies the round trip.
+!!!!!!!!!!!!!!
+!
+program memcpy_async
+  use iso_c_binding
+  use hipfort
+  use hipfort_check
+  use hipfort_enums
+
+  implicit none
+
+  integer(c_int), parameter :: n = 1024
+  real(c_double), target :: hsrc(n), hdst(n)
+  type(c_ptr) :: dptr = c_null_ptr, stream = c_null_ptr
+  integer(c_size_t) :: nbytes
+  integer :: i
+
+  write(*,"(a)",advance="no") "-- Running test 'hip memcpy_async' (Fortran 2003 interfaces) - "
+
+  nbytes = int(n, c_size_t) * 8
+
+  do i = 1, n
+     hsrc(i) = real(i, c_double)
+  end do
+  hdst = 0.0d0
+
+  call hipCheck(hipSetDevice(0))
+  call hipCheck(hipStreamCreate(stream))
+  call hipCheck(hipMalloc(dptr, nbytes))
+
+  ! Host -> device (async on the stream)
+  call hipCheck(hipMemcpyAsync(dptr, c_loc(hsrc(1)), nbytes, hipMemcpyHostToDevice, stream))
+  ! Device -> host (with the same stream)
+  call hipCheck(hipMemcpyWithStream(c_loc(hdst(1)), dptr, nbytes, hipMemcpyDeviceToHost, stream))
+
+  call hipCheck(hipStreamSynchronize(stream))
+
+  do i = 1, n
+     if (hdst(i) /= hsrc(i)) then
+        write(*,*) "FAILED! hdst(", i, ") = ", hdst(i), " (expected ", hsrc(i), ")"
+        call exit(1)
+     end if
+  end do
+
+  call hipCheck(hipFree(dptr))
+  call hipCheck(hipStreamDestroy(stream))
+
+  write(*,*) "PASSED!"
+
+end program memcpy_async

--- a/test/f2003/hip/memset.f03
+++ b/test/f2003/hip/memset.f03
@@ -1,0 +1,47 @@
+!!!!!!!!!!!!!!
+! HIP runtime hipMemset
+! see: https:!rocm.docs.amd.com/projects/HIP/en/latest/
+!
+! Sets every byte of a device buffer to a known value and copies it back to
+! verify.
+!!!!!!!!!!!!!!
+!
+program memset
+  use iso_c_binding
+  use hipfort
+  use hipfort_check
+  use hipfort_enums
+
+  implicit none
+
+  integer(c_int), parameter :: n = 256
+  integer(c_int8_t), target :: hbuf(n)
+  type(c_ptr) :: dptr = c_null_ptr
+  integer(c_size_t) :: nbytes
+  integer :: i
+
+  write(*,"(a)",advance="no") "-- Running test 'hip memset' (Fortran 2003 interfaces) - "
+
+  nbytes = int(n, c_size_t)   ! one byte per element
+
+  call hipCheck(hipSetDevice(0))
+  call hipCheck(hipMalloc(dptr, nbytes))
+
+  ! Set every byte to 7.
+  call hipCheck(hipMemset(dptr, 7, nbytes))
+
+  hbuf = 0
+  call hipCheck(hipMemcpy(c_loc(hbuf(1)), dptr, nbytes, hipMemcpyDeviceToHost))
+
+  do i = 1, n
+     if (hbuf(i) /= 7_c_int8_t) then
+        write(*,*) "FAILED! hbuf(", i, ") = ", hbuf(i), " (expected 7)"
+        call exit(1)
+     end if
+  end do
+
+  call hipCheck(hipFree(dptr))
+
+  write(*,*) "PASSED!"
+
+end program memset

--- a/test/f2003/hip/stream.f03
+++ b/test/f2003/hip/stream.f03
@@ -1,0 +1,41 @@
+!!!!!!!!!!!!!!
+! HIP runtime stream management
+! see: https:!rocm.docs.amd.com/projects/HIP/en/latest/
+!
+! Exercises hipStreamCreate, hipStreamGetDevice, hipStreamSynchronize and
+! hipStreamDestroy.
+!!!!!!!!!!!!!!
+!
+program stream
+  use iso_c_binding
+  use hipfort
+  use hipfort_check
+
+  implicit none
+
+  type(c_ptr)    :: stream = c_null_ptr
+  integer(c_int) :: dev, sdev
+
+  write(*,"(a)",advance="no") "-- Running test 'hip stream' (Fortran 2003 interfaces) - "
+
+  call hipCheck(hipSetDevice(0))
+  call hipCheck(hipGetDevice(dev))
+
+  call hipCheck(hipStreamCreate(stream))
+  if (.not. c_associated(stream)) then
+     write(*,*) "FAILED! stream is null after hipStreamCreate"
+     call exit(1)
+  end if
+
+  call hipCheck(hipStreamGetDevice(stream, sdev))
+  if (sdev /= dev) then
+     write(*,*) "FAILED! stream device = ", sdev, " (expected ", dev, ")"
+     call exit(1)
+  end if
+
+  call hipCheck(hipStreamSynchronize(stream))
+  call hipCheck(hipStreamDestroy(stream))
+
+  write(*,*) "PASSED!"
+
+end program stream


### PR DESCRIPTION
## Motivation

P2 test-coverage push for 0.8.0: the core HIP runtime API had only the `vecadd`/`roctx` end-to-end tests and no focused coverage of device management, streams, events or the copy/set primitives.

## Tests

New `test/f2003/hip/` group (pure Fortran, linked against `hipfort::hip`), each checking invariants that hold on any working device:

| Test | Exercises | Check |
|---|---|---|
| `device_management` | `hipGetDeviceCount`, `hipSetDevice`/`hipGetDevice`, `hipDeviceGetAttribute`, `hipDeviceGetLimit`, `hipDeviceTotalMem`, `hipMemGetInfo` | count ≥ 1, current device = 0, warp size & MP count > 0, stack limit > 0, total mem > 0, free ≤ total |
| `stream` | `hipStreamCreate`, `hipStreamGetDevice`, `hipStreamSynchronize`, `hipStreamDestroy` | stream non-null, its device = current device |
| `event` | `hipEventCreate`/`Record`/`Synchronize`/`ElapsedTime`/`Destroy` | times a device memset, elapsed ≥ 0 |
| `memset` | `hipMemset` | every byte set to 7, verified after copyback |
| `memcpy_async` | `hipMemcpyAsync` (H2D) + `hipMemcpyWithStream` (D2H) on a user stream | round trip matches |

## Test plan

`-DBUILD_TESTING=ON`, then `ctest -R '^hipfort_test_f2003_hip_'`.