### PR TITLE
[HIP] re-export hipfort_hiphostregister from the hipfort module

### DIFF
--- a/lib/hipfort/hipfort.F90
+++ b/lib/hipfort/hipfort.F90
@@ -32,6 +32,7 @@ module hipfort
   use hipfort_types
   use hipfort_hipmalloc
   use hipfort_hipmemcpy
+  use hipfort_hiphostregister
   use hipfort_auxiliary
   implicit none
 


### PR DESCRIPTION
## Problem

`use hipfort` re-exports `hipfort_hipmalloc`, `hipfort_hipmemcpy` and `hipfort_auxiliary`, but **not** `hipfort_hiphostregister`. As a result `hipHostRegister`, `hipHostGetDevicePointer` and `hipHostUnregister` are the only runtime memory helpers not reachable through `use hipfort` — callers need an extra explicit `use hipfort_hiphostregister`, even though `hipHostMalloc`/`hipHostFree` (in `hipfort_hipmalloc`) work fine through `use hipfort`.

Found while adding HIP runtime tests (the `host_register` test needed the extra `use`).

## Fix

Add `use hipfort_hiphostregister` to the `hipfort` module (regenerated; the companion generator change adds it to the hip `extra_modules` list). The diff to `hipfort.F90` is the single new `use` line.

## Verification

Built the library with `amdflang` and compiled a program that does **only** `use hipfort` and references `hipHostRegister` / `hipHostGetDevicePointer` / `hipHostUnregister` — it now resolves them (previously a "No explicit type declared" error).

No behavior change for existing code; this only widens what `use hipfort` exposes.