### PR TITLE
test: add hipSPARSE csr2csc and csr2coo tests (P3)

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -216,6 +216,8 @@ if(BUILD_TESTING)
 
   if(TARGET hipfort::hipsparse)
     hipfort_add_test(hipsparse hipsparse_sgtsv f2008)
+    hipfort_add_test(hipsparse hipsparse_scsr2csc f2008)
+    hipfort_add_test(hipsparse hipsparse_xcsr2coo f2008)
   endif()
 
   if(TARGET hipfort::rocblas)

--- a/test/f2008/hipsparse/hipsparse_scsr2csc.f08
+++ b/test/f2008/hipsparse/hipsparse_scsr2csc.f08
@@ -1,0 +1,66 @@
+!!!!!!!!!!!!!!
+! hipsparse scsr2csc example (single-precision CSR -> CSC / sparse transpose)
+! see: https:!rocm.docs.amd.com/projects/hipSPARSE/en/latest/
+!
+! Converting A from CSR to CSC is the CSR of A**T. We check the resulting
+! csc_col_ptr / csc_row_ind / csc_val against the known transpose. The hipSPARSE
+! legacy csr2csc needs no external workspace.
+!!!!!!!!!!!!!!
+!
+program hipsparse_scsr2csc
+  use iso_c_binding
+  use hipfort
+  use hipfort_check
+  use hipfort_hipsparse
+  implicit none
+  integer :: i
+  ! 3x3 CSR (0-based): row0:(0,0)=1,(0,2)=2  row1:(1,1)=3  row2:(2,0)=4,(2,2)=5
+  integer(c_int), parameter :: M = 3, N = 3, nnz = 5
+  integer(c_int) :: h_csr_row_ptr(4) = (/0, 2, 3, 5/)
+  integer(c_int) :: h_csr_col_ind(5) = (/0, 2, 1, 0, 2/)
+  real(c_float)  :: h_csr_val(5)     = (/1, 2, 3, 4, 5/)
+  integer(c_int) :: h_exp_col_ptr(4) = (/0, 2, 3, 5/)
+  integer(c_int) :: h_exp_row_ind(5) = (/0, 2, 1, 0, 2/)
+  real(c_float)  :: h_exp_val(5)     = (/1, 4, 3, 2, 5/)
+  integer(c_int) :: h_csc_col_ptr(4), h_csc_row_ind(5)
+  real(c_float)  :: h_csc_val(5)
+  integer(c_int), pointer :: d_csr_row_ptr(:), d_csr_col_ind(:), d_csc_col_ptr(:), d_csc_row_ind(:)
+  real(c_float),  pointer :: d_csr_val(:), d_csc_val(:)
+  type(c_ptr) :: handle = c_null_ptr
+  real(c_float) :: error
+  real(c_float), parameter :: error_max = 10 * epsilon(error_max)
+  write(*,"(a)",advance="no") "-- Running test 'hipsparse_scsr2csc' (Fortran 2008 interfaces) - "
+  call hipCheck(hipMalloc(d_csr_row_ptr, source=h_csr_row_ptr))
+  call hipCheck(hipMalloc(d_csr_col_ind, source=h_csr_col_ind))
+  call hipCheck(hipMalloc(d_csr_val,     source=h_csr_val))
+  call hipCheck(hipMalloc(d_csc_col_ptr, mold=h_csc_col_ptr))
+  call hipCheck(hipMalloc(d_csc_row_ind, mold=h_csc_row_ind))
+  call hipCheck(hipMalloc(d_csc_val,     mold=h_csc_val))
+  call hipsparseCheck(hipsparseCreate(handle))
+  call hipsparseCheck(hipsparseScsr2csc(handle, M, N, nnz, &
+                         d_csr_val, d_csr_row_ptr, d_csr_col_ind, &
+                         d_csc_val, d_csc_row_ind, d_csc_col_ptr, &
+                         HIPSPARSE_ACTION_NUMERIC, HIPSPARSE_INDEX_BASE_ZERO))
+  call hipCheck(hipDeviceSynchronize())
+  call hipCheck(hipMemcpy(h_csc_col_ptr, d_csc_col_ptr, hipMemcpyDeviceToHost))
+  call hipCheck(hipMemcpy(h_csc_row_ind, d_csc_row_ind, hipMemcpyDeviceToHost))
+  call hipCheck(hipMemcpy(h_csc_val,     d_csc_val,     hipMemcpyDeviceToHost))
+  do i = 1,N+1
+    if(h_csc_col_ptr(i) /= h_exp_col_ptr(i)) then
+        write(*,*) "FAILED! csc_col_ptr(", i, ") = ", h_csc_col_ptr(i), " expected ", h_exp_col_ptr(i); call exit(1)
+    end if
+  end do
+  do i = 1,nnz
+    if(h_csc_row_ind(i) /= h_exp_row_ind(i)) then
+        write(*,*) "FAILED! csc_row_ind(", i, ") = ", h_csc_row_ind(i); call exit(1)
+    end if
+    error = abs(h_csc_val(i) - h_exp_val(i))
+    if(error .gt. error_max) then
+        write(*,*) "FAILED! csc_val(", i, ") = ", h_csc_val(i); call exit(1)
+    end if
+  end do
+  call hipsparseCheck(hipsparseDestroy(handle))
+  call hipCheck(hipFree(d_csr_row_ptr)); call hipCheck(hipFree(d_csr_col_ind)); call hipCheck(hipFree(d_csr_val))
+  call hipCheck(hipFree(d_csc_col_ptr)); call hipCheck(hipFree(d_csc_row_ind)); call hipCheck(hipFree(d_csc_val))
+  write(*,*) "PASSED!"
+end program hipsparse_scsr2csc

--- a/test/f2008/hipsparse/hipsparse_xcsr2coo.f08
+++ b/test/f2008/hipsparse/hipsparse_xcsr2coo.f08
@@ -1,0 +1,37 @@
+!!!!!!!!!!!!!!
+! hipsparse Xcsr2coo example (CSR row pointers -> COO row indices)
+! see: https:!rocm.docs.amd.com/projects/hipSPARSE/en/latest/
+!
+! Expands the CSR row-pointer array into one row index per nonzero and checks
+! it against the expected COO row indices.
+!!!!!!!!!!!!!!
+!
+program hipsparse_xcsr2coo
+  use iso_c_binding
+  use hipfort
+  use hipfort_check
+  use hipfort_hipsparse
+  implicit none
+  integer :: i
+  integer(c_int), parameter :: M = 3, nnz = 5
+  integer(c_int) :: h_csr_row_ptr(4) = (/0, 2, 3, 5/)
+  integer(c_int) :: h_exp_coo_row(5) = (/0, 0, 1, 2, 2/)
+  integer(c_int) :: h_coo_row(5)
+  integer(c_int), pointer :: d_csr_row_ptr(:), d_coo_row(:)
+  type(c_ptr) :: handle = c_null_ptr
+  write(*,"(a)",advance="no") "-- Running test 'hipsparse_xcsr2coo' (Fortran 2008 interfaces) - "
+  call hipCheck(hipMalloc(d_csr_row_ptr, source=h_csr_row_ptr))
+  call hipCheck(hipMalloc(d_coo_row,     mold=h_coo_row))
+  call hipsparseCheck(hipsparseCreate(handle))
+  call hipsparseCheck(hipsparseXcsr2coo(handle, d_csr_row_ptr, nnz, M, d_coo_row, HIPSPARSE_INDEX_BASE_ZERO))
+  call hipCheck(hipDeviceSynchronize())
+  call hipCheck(hipMemcpy(h_coo_row, d_coo_row, hipMemcpyDeviceToHost))
+  do i = 1, nnz
+     if (h_coo_row(i) /= h_exp_coo_row(i)) then
+        write(*,*) "FAILED! coo_row(", i, ") = ", h_coo_row(i), " expected ", h_exp_coo_row(i); call exit(1)
+     end if
+  end do
+  call hipsparseCheck(hipsparseDestroy(handle))
+  call hipCheck(hipFree(d_csr_row_ptr)); call hipCheck(hipFree(d_coo_row))
+  write(*,*) "PASSED!"
+end program hipsparse_xcsr2coo


### PR DESCRIPTION
Starts filling the **empty hipSPARSE** coverage (issue #411).

| Test | Routine | Check |
|---|---|---|
| `hipsparse_scsr2csc` | CSR → CSC (sparse transpose) | `col_ptr` / `row_ind` / `val` match the known transpose |
| `hipsparse_xcsr2coo` | CSR row pointers → COO row indices | expanded row indices match |

Both use native-array f2008 interfaces on a small known 3×3 matrix and need no external workspace.

## Test plan
`-DBUILD_TESTING=ON`, then `ctest -R 'hipsparse_scsr2csc|hipsparse_xcsr2coo'`.