### PR TITLE
test: add HIP graph memset-node and peer-access tests (P2)

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -525,6 +525,8 @@ if(BUILD_TESTING)
     hipfort_add_test(hip host_register f2003)
     hipfort_add_test(hip graph f2003)
     hipfort_add_test(hip graph_nodes f2003)
+    hipfort_add_test(hip graph_memset_node f2003)
+    hipfort_add_test(hip peer_access f2003)
   endif()
 
   # vecadd mixes a Fortran driver with a HIP C++ kernel, so it needs the HIP

--- a/test/f2003/hip/graph_memset_node.f03
+++ b/test/f2003/hip/graph_memset_node.f03
@@ -1,0 +1,66 @@
+!!!!!!!!!!!!!!
+! HIP graph memset node built from a hipMemsetParams struct (Fortran 2003)
+! see: https:!rocm.docs.amd.com/projects/HIP/en/latest/
+!
+! Adds a memset node to a graph via hipGraphAddMemsetNode (which takes a
+! hipMemsetParams derived type), instantiates and launches it, and verifies the
+! device buffer was set. Complements the memcpy-node / stream-capture graph
+! tests with the struct-parameterised node API.
+!!!!!!!!!!!!!!
+!
+program graph_memset_node
+  use iso_c_binding
+  use hipfort
+  use hipfort_check
+  use hipfort_types
+
+  implicit none
+
+  integer(c_int), parameter :: n = 256
+  integer(c_int8_t), target :: hbuf(n)
+  type(c_ptr) :: graph = c_null_ptr, gexec = c_null_ptr, errnode = c_null_ptr
+  type(c_ptr) :: stream = c_null_ptr, dptr = c_null_ptr, node = c_null_ptr
+  type(hipMemsetParams) :: mp
+  integer(c_size_t) :: nbytes
+  integer :: i
+
+  write(*,"(a)",advance="no") "-- Running test 'hip graph_memset_node' (Fortran 2003 interfaces) - "
+
+  nbytes = int(n, c_size_t)
+
+  call hipCheck(hipSetDevice(0))
+  call hipCheck(hipStreamCreate(stream))
+  call hipCheck(hipMalloc(dptr, nbytes))
+  call hipCheck(hipGraphCreate(graph, 0))
+
+  ! Describe a 1-D byte memset (value 9) over the whole buffer.
+  mp%dst         = dptr
+  mp%elementSize = 1
+  mp%width       = nbytes   ! elements (bytes)
+  mp%height      = 1
+  mp%pitch       = nbytes
+  mp%value       = 9
+
+  call hipCheck(hipGraphAddMemsetNode(node, graph, c_null_ptr, 0_c_size_t, mp))
+
+  call hipCheck(hipGraphInstantiate(gexec, graph, errnode, c_null_ptr, 0_c_size_t))
+  call hipCheck(hipGraphLaunch(gexec, stream))
+  call hipCheck(hipStreamSynchronize(stream))
+
+  hbuf = 0
+  call hipCheck(hipMemcpy(c_loc(hbuf(1)), dptr, nbytes, hipMemcpyDeviceToHost))
+  do i = 1, n
+     if (hbuf(i) /= 9_c_int8_t) then
+        write(*,*) "FAILED! hbuf(", i, ") = ", hbuf(i), " (expected 9)"
+        call exit(1)
+     end if
+  end do
+
+  call hipCheck(hipGraphExecDestroy(gexec))
+  call hipCheck(hipGraphDestroy(graph))
+  call hipCheck(hipFree(dptr))
+  call hipCheck(hipStreamDestroy(stream))
+
+  write(*,*) "PASSED!"
+
+end program graph_memset_node

--- a/test/f2003/hip/peer_access.f03
+++ b/test/f2003/hip/peer_access.f03
@@ -1,0 +1,42 @@
+!!!!!!!!!!!!!!
+! HIP peer access query/enable (Fortran 2003 interfaces)
+! see: https:!rocm.docs.amd.com/projects/HIP/en/latest/
+!
+! Exercises hipDeviceCanAccessPeer (and enable/disable when a second device is
+! present). On a single-GPU host a device is not its own peer, so the query must
+! return 0 without error.
+!!!!!!!!!!!!!!
+!
+program peer_access
+  use iso_c_binding
+  use hipfort
+  use hipfort_check
+
+  implicit none
+
+  integer(c_int) :: ndev, canAccess
+
+  write(*,"(a)",advance="no") "-- Running test 'hip peer_access' (Fortran 2003 interfaces) - "
+
+  call hipCheck(hipGetDeviceCount(ndev))
+  call hipCheck(hipSetDevice(0))
+
+  if (ndev >= 2) then
+     call hipCheck(hipDeviceCanAccessPeer(canAccess, 0, 1))
+     if (canAccess == 1) then
+        ! Enable then disable peer access from device 0 to device 1.
+        call hipCheck(hipDeviceEnablePeerAccess(1, 0))
+        call hipCheck(hipDeviceDisablePeerAccess(1))
+     end if
+  else
+     ! Single device: a device is not its own peer.
+     call hipCheck(hipDeviceCanAccessPeer(canAccess, 0, 0))
+     if (canAccess /= 0) then
+        write(*,*) "FAILED! canAccessPeer(0,0) = ", canAccess, " (expected 0)"
+        call exit(1)
+     end if
+  end if
+
+  write(*,*) "PASSED!"
+
+end program peer_access


### PR DESCRIPTION
Fills two of the remaining **P2** HIP-runtime gaps (issue #411).

| Test | Exercises | Check |
|---|---|---|
| `graph_memset_node` | `hipGraphAddMemsetNode` (takes a `hipMemsetParams` derived type) + instantiate/launch | buffer set to the requested byte value |
| `peer_access` | `hipDeviceCanAccessPeer` (+ `hipDeviceEnablePeerAccess`/`Disable` when a 2nd device exists) | single-GPU: a device is not its own peer (query returns 0, no error) |

`graph_memset_node` extends the graph coverage to the **struct-parameterised** node API (the earlier graph tests used stream capture and the struct-free `hipGraphAddMemcpyNode1D`). `peer_access` runs on a single-GPU CI host via the self-query path and best-effort enable/disable when two devices are present.

## Test plan
`-DBUILD_TESTING=ON`, then `ctest -R 'graph_memset_node|peer_access'`. Locally (no GPU) both compile+link with amdflang; execution in CI.

Remaining P2: kernel graph nodes (`hipGraphAddKernelNode`, needs a HIP kernel) and occupancy (needs a kernel handle).