### PR TITLE
[hipSOLVER] type gesvd jobu/jobv as character(c_char); add gesvd test

### DIFF
--- a/lib/hipfort/hipfort_hipsolver.F90
+++ b/lib/hipfort/hipfort_hipsolver.F90
@@ -2402,8 +2402,8 @@ module hipfort_hipsolver
       implicit none
       integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSgesvd_bufferSize_
       type(c_ptr),value :: handle
-      type(c_ptr),value :: jobu
-      type(c_ptr),value :: jobv
+      character(c_char),value :: jobu
+      character(c_char),value :: jobv
       integer(c_int),value :: m
       integer(c_int),value :: n
       integer(c_int) :: lwork
@@ -2423,8 +2423,8 @@ module hipfort_hipsolver
       implicit none
       integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDgesvd_bufferSize_
       type(c_ptr),value :: handle
-      type(c_ptr),value :: jobu
-      type(c_ptr),value :: jobv
+      character(c_char),value :: jobu
+      character(c_char),value :: jobv
       integer(c_int),value :: m
       integer(c_int),value :: n
       integer(c_int) :: lwork
@@ -2444,8 +2444,8 @@ module hipfort_hipsolver
       implicit none
       integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCgesvd_bufferSize_
       type(c_ptr),value :: handle
-      type(c_ptr),value :: jobu
-      type(c_ptr),value :: jobv
+      character(c_char),value :: jobu
+      character(c_char),value :: jobv
       integer(c_int),value :: m
       integer(c_int),value :: n
       integer(c_int) :: lwork
@@ -2465,8 +2465,8 @@ module hipfort_hipsolver
       implicit none
       integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZgesvd_bufferSize_
       type(c_ptr),value :: handle
-      type(c_ptr),value :: jobu
-      type(c_ptr),value :: jobv
+      character(c_char),value :: jobu
+      character(c_char),value :: jobv
       integer(c_int),value :: m
       integer(c_int),value :: n
       integer(c_int) :: lwork
@@ -2486,8 +2486,8 @@ module hipfort_hipsolver
       implicit none
       integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSgesvd_
       type(c_ptr),value :: handle
-      type(c_ptr),value :: jobu
-      type(c_ptr),value :: jobv
+      character(c_char),value :: jobu
+      character(c_char),value :: jobv
       integer(c_int),value :: m
       integer(c_int),value :: n
       type(c_ptr),value :: A
@@ -2517,8 +2517,8 @@ module hipfort_hipsolver
       implicit none
       integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDgesvd_
       type(c_ptr),value :: handle
-      type(c_ptr),value :: jobu
-      type(c_ptr),value :: jobv
+      character(c_char),value :: jobu
+      character(c_char),value :: jobv
       integer(c_int),value :: m
       integer(c_int),value :: n
       type(c_ptr),value :: A
@@ -2548,8 +2548,8 @@ module hipfort_hipsolver
       implicit none
       integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCgesvd_
       type(c_ptr),value :: handle
-      type(c_ptr),value :: jobu
-      type(c_ptr),value :: jobv
+      character(c_char),value :: jobu
+      character(c_char),value :: jobv
       integer(c_int),value :: m
       integer(c_int),value :: n
       type(c_ptr),value :: A
@@ -2579,8 +2579,8 @@ module hipfort_hipsolver
       implicit none
       integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZgesvd_
       type(c_ptr),value :: handle
-      type(c_ptr),value :: jobu
-      type(c_ptr),value :: jobv
+      character(c_char),value :: jobu
+      character(c_char),value :: jobv
       integer(c_int),value :: m
       integer(c_int),value :: n
       type(c_ptr),value :: A
@@ -8697,8 +8697,8 @@ module hipfort_hipsolver
       implicit none
       integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDnSgesvd_
       type(c_ptr),value :: handle
-      type(c_ptr),value :: jobu
-      type(c_ptr),value :: jobv
+      character(c_char),value :: jobu
+      character(c_char),value :: jobv
       integer(c_int),value :: m
       integer(c_int),value :: n
       type(c_ptr),value :: A
@@ -8728,8 +8728,8 @@ module hipfort_hipsolver
       implicit none
       integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDnDgesvd_
       type(c_ptr),value :: handle
-      type(c_ptr),value :: jobu
-      type(c_ptr),value :: jobv
+      character(c_char),value :: jobu
+      character(c_char),value :: jobv
       integer(c_int),value :: m
       integer(c_int),value :: n
       type(c_ptr),value :: A
@@ -8759,8 +8759,8 @@ module hipfort_hipsolver
       implicit none
       integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDnCgesvd_
       type(c_ptr),value :: handle
-      type(c_ptr),value :: jobu
-      type(c_ptr),value :: jobv
+      character(c_char),value :: jobu
+      character(c_char),value :: jobv
       integer(c_int),value :: m
       integer(c_int),value :: n
       type(c_ptr),value :: A
@@ -8790,8 +8790,8 @@ module hipfort_hipsolver
       implicit none
       integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDnZgesvd_
       type(c_ptr),value :: handle
-      type(c_ptr),value :: jobu
-      type(c_ptr),value :: jobv
+      character(c_char),value :: jobu
+      character(c_char),value :: jobv
       integer(c_int),value :: m
       integer(c_int),value :: n
       type(c_ptr),value :: A

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -215,6 +215,7 @@ if(BUILD_TESTING)
     hipfort_add_test(hipsolver hipsolver_dpotrf f2008)
     hipfort_add_test(hipsolver hipsolver_dsyevd f2008)
     hipfort_add_test(hipsolver hipsolver_dgetrs f2008)
+    hipfort_add_test(hipsolver hipsolver_dgesvd f2008)
   endif()
 
   if(TARGET hipfort::hipsparse)

--- a/test/f2008/hipsolver/hipsolver_dgesvd.f08
+++ b/test/f2008/hipsolver/hipsolver_dgesvd.f08
@@ -1,0 +1,73 @@
+!!!!!!!!!!!!!!
+! hipsolver dgesvd example (singular value decomposition)
+! see: https:!rocm.docs.amd.com/projects/hipSOLVER/en/latest/
+!
+! Computes the singular values of A (jobu = jobv = 'N', values only) and checks
+! the convention-independent invariant sum(sigma_i^2) == ||A||_F^2.
+!
+! Note: jobu/jobv are `signed char` job codes passed by value; the hipfort
+! binding now types them as character(c_char) (they were previously type(c_ptr),
+! which made this routine uncallable). devInfo lives on the DEVICE.
+!!!!!!!!!!!!!!
+!
+program hipsolver_dgesvd
+  use iso_c_binding
+  use hipfort
+  use hipfort_check
+  use hipfort_hipsolver
+
+  implicit none
+
+  integer(c_int), parameter :: M = 2, N = 2, lda = 2, ldu = 2, ldv = 2
+  integer(c_int), parameter :: mn = 2   ! min(M,N)
+
+  ! A = [[1,2],[3,4]] (column-major); ||A||_F^2 = 1+9+4+16 = 30.
+  real(c_double), target :: hA(M,N) = reshape((/1.0d0, 3.0d0, 2.0d0, 4.0d0/), (/M,N/))
+  real(c_double), target :: hS(mn)
+
+  type(c_ptr) :: dA, dS, dU, dV, dWork, dRwork, dInfo, handle = c_null_ptr
+  integer(c_int) :: lwork
+  integer(c_size_t) :: szA = M*N, szS = mn, szU = M*M, szV = N*N, szR = mn
+  real(c_double) :: frob, ssum, error
+  real(c_double), parameter :: rtol = 1.0d-9
+  integer :: i
+
+  write(*,"(a)",advance="no") "-- Running test 'hipsolver_dgesvd' (Fortran 2008 interfaces) - "
+
+  call hipsolverCheck(hipsolverCreate(handle))
+  call hipCheck(hipMalloc(dA,    szA * 8))
+  call hipCheck(hipMalloc(dS,    szS * 8))
+  call hipCheck(hipMalloc(dU,    szU * 8))
+  call hipCheck(hipMalloc(dV,    szV * 8))
+  call hipCheck(hipMalloc(dRwork, szR * 8))
+  call hipCheck(hipMalloc(dInfo, 4_c_size_t))
+  call hipCheck(hipMemcpy(dA, c_loc(hA(1,1)), szA * 8, hipMemcpyHostToDevice))
+
+  call hipsolverCheck(hipsolverDgesvd_bufferSize(handle, 'N', 'N', M, N, lwork))
+  call hipCheck(hipMalloc(dWork, max(int(lwork,c_size_t) * 8, 1_c_size_t)))
+
+  ! Singular values only (jobu = jobv = 'N').
+  call hipsolverCheck(hipsolverDgesvd(handle, 'N', 'N', M, N, dA, lda, dS, &
+                                      dU, ldu, dV, ldv, dWork, lwork, dRwork, dInfo))
+
+  call hipCheck(hipMemcpy(c_loc(hS(1)), dS, szS * 8, hipMemcpyDeviceToHost))
+
+  frob = 1.0d0 + 9.0d0 + 4.0d0 + 16.0d0   ! ||A||_F^2
+  ssum = 0.0d0
+  do i = 1, mn
+     ssum = ssum + hS(i)**2
+  end do
+  error = abs(ssum - frob) / frob
+  if (error > rtol) then
+     write(*,*) "FAILED! sum(sigma^2) = ", ssum, " expected ||A||_F^2 = ", frob
+     call exit(1)
+  end if
+
+  call hipCheck(hipFree(dA)); call hipCheck(hipFree(dS)); call hipCheck(hipFree(dU))
+  call hipCheck(hipFree(dV)); call hipCheck(hipFree(dRwork)); call hipCheck(hipFree(dWork))
+  call hipCheck(hipFree(dInfo))
+  call hipsolverCheck(hipsolverDestroy(handle))
+
+  write(*,*) "PASSED!"
+
+end program hipsolver_dgesvd


### PR DESCRIPTION
## Problem

`hipsolver?gesvd` take the SVD job codes `jobu`/`jobv` as `signed char` **by value**, but the binding typed them as `type(c_ptr),value`:

```fortran
type(c_ptr),value :: jobu   ! should be character(c_char),value
type(c_ptr),value :: jobv
```

so `?gesvd` could not be called at all (no way to pass a `'N'`/`'A'`/`'S'` job code). Root cause: the generator handled plain `char` (`CXType_Char_S`/`Char_U`) but not the explicit `signed char` kind (`CXType_SChar`), so a by-value `signed char` fell through to the default `type(c_ptr),value`.

## Fix

- Generator (companion change on the `rocm-fortran` side): map `signed`/`unsigned char` to `character(c_char)` by value (scalar) and `type(c_ptr)` as a pointer element, matching the plain-char handling.
- Here: retype `jobu`/`jobv` as `character(c_char),value` in the four `?gesvd` interfaces (the only by-value char args in hipSOLVER — a surgical change to avoid unrelated regeneration churn).

## Test

Adds `hipsolver_dgesvd` (jobu = jobv = `'N'`, singular values only) checking the convention-independent invariant `sum(sigma_i^2) == ||A||_F^2`.

## Test plan
`-DBUILD_TESTING=ON`, then `ctest -R hipsolver_dgesvd`. Locally (no GPU) it compiles+links with amdflang against the retyped binding; execution in CI.

## Related finding (not in this PR)
The same `signed char` mishandling also inflated some `reserved` struct fields in `hipfort_types.F90` (e.g. `type(c_ptr) :: reserved(56)` instead of `character(c_char) :: reserved(56)` — 8× the intended size). The generator fix corrects those on a full regen; worth a follow-up sync.