### PR TITLE
test: fix hip graph_nodes node-count query (CI failure)

### DIFF
--- a/test/f2003/hip/graph_nodes.f03
+++ b/test/f2003/hip/graph_nodes.f03
@@ -23,6 +23,7 @@ program graph_nodes
   type(c_ptr) :: stream = c_null_ptr, dptr = c_null_ptr
   type(c_ptr) :: nodeH2D = c_null_ptr, nodeD2H = c_null_ptr
   integer(c_size_t), target :: numnodes
+  type(c_ptr) :: nodes_out(8)   ! capacity buffer for hipGraphGetNodes
   integer(c_size_t) :: nbytes
   integer :: i
 
@@ -48,9 +49,11 @@ program graph_nodes
   ! Make the device->host copy depend on the host->device copy.
   call hipCheck(hipGraphAddDependencies(graph, nodeH2D, nodeD2H, 1_c_size_t))
 
-  ! Query the node count (nodes = NULL -> numNodes returns the count).
-  numnodes = 0
-  call hipCheck(hipGraphGetNodes(graph, c_null_ptr, c_loc(numnodes)))
+  ! Query the node count: pass an array and its capacity in numnodes; on return
+  ! numnodes holds the actual count. (nodes is a by-reference c_ptr in the
+  ! binding, so a real capacity buffer is used rather than a null query.)
+  numnodes = size(nodes_out, kind=c_size_t)
+  call hipCheck(hipGraphGetNodes(graph, nodes_out(1), c_loc(numnodes)))
   if (numnodes /= 2) then
      write(*,*) "FAILED! graph node count = ", numnodes, " (expected 2)"
      call exit(1)


### PR DESCRIPTION
## Problem

CI:
```
Test #368: hipfort_test_f2003_hip_graph_nodes ...***Failed
-- Running test 'hip graph_nodes' ... FAILED! graph node count = 0 (expected 2)
```

`hipGraphGetNodes` was called with `nodes = c_null_ptr` and `numNodes = 0`. In the binding `nodes` is a **by-reference** `type(c_ptr)`, so passing `c_null_ptr` does not hand C a real `NULL` — it passes the address of a null `c_ptr` (non-NULL). With `numNodes = 0` (capacity), the call returns 0 nodes.

## Fix

Query with a real capacity buffer: pass an 8-entry `nodes` array and set `numNodes` to its size. Per the documented semantics ("if numNodes is higher than the actual number of nodes, the remaining entries are set to NULL and the number actually obtained is returned in numNodes"), the call fills the real nodes and returns the true count (2).

Introduced in #442. Build-checked with amdflang; the count assertion now matches the documented behavior.