### PR TITLE
Regenerate hipBLAS/hipSOLVER/HIP bindings to match the generator (resolve drift)

### DIFF
--- a/lib/hipfort/hipfort.F90
+++ b/lib/hipfort/hipfort.F90
@@ -4482,7 +4482,7 @@ module hipfort
       implicit none
       integer(kind(hipSuccess)) :: hipMemsetD8_
       type(c_ptr),value :: dest
-      type(c_ptr),value :: myValue
+      character(c_char),value :: myValue
       integer(c_size_t),value :: count
     end function
   end interface
@@ -4511,7 +4511,7 @@ module hipfort
       implicit none
       integer(kind(hipSuccess)) :: hipMemsetD8Async_
       type(c_ptr),value :: dest
-      type(c_ptr),value :: myValue
+      character(c_char),value :: myValue
       integer(c_size_t),value :: count
       type(c_ptr),value :: stream
     end function
@@ -4781,7 +4781,7 @@ module hipfort
       integer(kind(hipSuccess)) :: hipMemsetD2D8_
       type(c_ptr),value :: dst
       integer(c_size_t),value :: dstPitch
-      type(c_ptr),value :: myValue
+      character(c_char),value :: myValue
       integer(c_size_t),value :: width
       integer(c_size_t),value :: height
     end function
@@ -4813,7 +4813,7 @@ module hipfort
       integer(kind(hipSuccess)) :: hipMemsetD2D8Async_
       type(c_ptr),value :: dst
       integer(c_size_t),value :: dstPitch
-      type(c_ptr),value :: myValue
+      character(c_char),value :: myValue
       integer(c_size_t),value :: width
       integer(c_size_t),value :: height
       type(c_ptr),value :: stream

--- a/lib/hipfort/hipfort_hipblas.F90
+++ b/lib/hipfort/hipfort_hipblas.F90
@@ -34459,7 +34459,7 @@ module hipfort_hipblas
       integer(c_int),value :: n
       type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: invA
+      type(c_ptr),value :: invA
       integer(c_int),value :: ldinvA
       integer(c_int),value :: batchCount
     end function
@@ -34480,7 +34480,7 @@ module hipfort_hipblas
       integer(c_int),value :: n
       type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: invA
+      type(c_ptr),value :: invA
       integer(c_int),value :: ldinvA
       integer(c_int),value :: batchCount
     end function
@@ -34501,7 +34501,7 @@ module hipfort_hipblas
       integer(c_int),value :: n
       type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: invA
+      type(c_ptr),value :: invA
       integer(c_int),value :: ldinvA
       integer(c_int),value :: batchCount
     end function
@@ -34522,7 +34522,7 @@ module hipfort_hipblas
       integer(c_int),value :: n
       type(c_ptr),value :: AP
       integer(c_int),value :: lda
-      type(c_ptr) :: invA
+      type(c_ptr),value :: invA
       integer(c_int),value :: ldinvA
       integer(c_int),value :: batchCount
     end function
@@ -37887,14 +37887,14 @@ module hipfort_hipblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       type(c_ptr),value :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(kind(HIP_R_32F)),value :: aType
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(kind(HIP_R_32F)),value :: bType
       integer(c_int),value :: ldb
       type(c_ptr),value :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(kind(HIP_R_32F)),value :: cType
       integer(c_int),value :: ldc
       integer(c_int),value :: batchCount
@@ -37920,14 +37920,14 @@ module hipfort_hipblas
       integer(c_int),value :: n
       integer(c_int),value :: k
       type(c_ptr),value :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(kind(HIP_R_32F)),value :: aType
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(kind(HIP_R_32F)),value :: bType
       integer(c_int),value :: ldb
       type(c_ptr),value :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(kind(HIP_R_32F)),value :: cType
       integer(c_int),value :: ldc
       integer(c_int),value :: batchCount
@@ -37960,14 +37960,14 @@ module hipfort_hipblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       type(c_ptr),value :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(kind(HIP_R_32F)),value :: aType
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(kind(HIP_R_32F)),value :: bType
       integer(c_int64_t),value :: ldb
       type(c_ptr),value :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(kind(HIP_R_32F)),value :: cType
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batchCount
@@ -37993,14 +37993,14 @@ module hipfort_hipblas
       integer(c_int64_t),value :: n
       integer(c_int64_t),value :: k
       type(c_ptr),value :: alpha
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(kind(HIP_R_32F)),value :: aType
       integer(c_int64_t),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(kind(HIP_R_32F)),value :: bType
       integer(c_int64_t),value :: ldb
       type(c_ptr),value :: beta
-      type(c_ptr) :: C
+      type(c_ptr),value :: C
       integer(kind(HIP_R_32F)),value :: cType
       integer(c_int64_t),value :: ldc
       integer(c_int64_t),value :: batchCount

--- a/lib/hipfort/hipfort_hipsolver.F90
+++ b/lib/hipfort/hipfort_hipsolver.F90
@@ -3708,7 +3708,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: handle
       integer(kind(HIPSOLVER_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       integer(c_int) :: lwork
       integer(c_int),value :: batch_count
@@ -3727,7 +3727,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: handle
       integer(kind(HIPSOLVER_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       integer(c_int) :: lwork
       integer(c_int),value :: batch_count
@@ -3746,7 +3746,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: handle
       integer(kind(HIPSOLVER_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       integer(c_int) :: lwork
       integer(c_int),value :: batch_count
@@ -3765,7 +3765,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: handle
       integer(kind(HIPSOLVER_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       integer(c_int) :: lwork
       integer(c_int),value :: batch_count
@@ -3784,7 +3784,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: handle
       integer(kind(HIPSOLVER_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: work
       integer(c_int),value :: lwork
@@ -3805,7 +3805,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: handle
       integer(kind(HIPSOLVER_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: work
       integer(c_int),value :: lwork
@@ -3826,7 +3826,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: handle
       integer(kind(HIPSOLVER_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: work
       integer(c_int),value :: lwork
@@ -3847,7 +3847,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: handle
       integer(kind(HIPSOLVER_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: work
       integer(c_int),value :: lwork
@@ -4309,9 +4309,9 @@ module hipfort_hipsolver
       integer(kind(HIPSOLVER_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
       integer(c_int),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       integer(c_int) :: lwork
       integer(c_int),value :: batch_count
@@ -4331,9 +4331,9 @@ module hipfort_hipsolver
       integer(kind(HIPSOLVER_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
       integer(c_int),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       integer(c_int) :: lwork
       integer(c_int),value :: batch_count
@@ -4353,9 +4353,9 @@ module hipfort_hipsolver
       integer(kind(HIPSOLVER_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
       integer(c_int),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       integer(c_int) :: lwork
       integer(c_int),value :: batch_count
@@ -4375,9 +4375,9 @@ module hipfort_hipsolver
       integer(kind(HIPSOLVER_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
       integer(c_int),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       integer(c_int) :: lwork
       integer(c_int),value :: batch_count
@@ -4398,9 +4398,9 @@ module hipfort_hipsolver
       integer(kind(HIPSOLVER_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
       integer(c_int),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       type(c_ptr),value :: work
       integer(c_int),value :: lwork
@@ -4423,9 +4423,9 @@ module hipfort_hipsolver
       integer(kind(HIPSOLVER_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
       integer(c_int),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       type(c_ptr),value :: work
       integer(c_int),value :: lwork
@@ -4448,9 +4448,9 @@ module hipfort_hipsolver
       integer(kind(HIPSOLVER_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
       integer(c_int),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       type(c_ptr),value :: work
       integer(c_int),value :: lwork
@@ -4473,9 +4473,9 @@ module hipfort_hipsolver
       integer(kind(HIPSOLVER_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
       integer(c_int),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       type(c_ptr),value :: work
       integer(c_int),value :: lwork
@@ -10071,7 +10071,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: handle
       integer(kind(HIPSOLVER_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: devInfo
       integer(c_int),value :: batch_count
@@ -10093,7 +10093,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: handle
       integer(kind(HIPSOLVER_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: devInfo
       integer(c_int),value :: batch_count
@@ -10115,7 +10115,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: handle
       integer(kind(HIPSOLVER_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: devInfo
       integer(c_int),value :: batch_count
@@ -10137,7 +10137,7 @@ module hipfort_hipsolver
       type(c_ptr),value :: handle
       integer(kind(HIPSOLVER_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
       type(c_ptr),value :: devInfo
       integer(c_int),value :: batch_count
@@ -10432,9 +10432,9 @@ module hipfort_hipsolver
       integer(kind(HIPSOLVER_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
       integer(c_int),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       type(c_ptr),value :: devInfo
       integer(c_int),value :: batch_count
@@ -10457,9 +10457,9 @@ module hipfort_hipsolver
       integer(kind(HIPSOLVER_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
       integer(c_int),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       type(c_ptr),value :: devInfo
       integer(c_int),value :: batch_count
@@ -10482,9 +10482,9 @@ module hipfort_hipsolver
       integer(kind(HIPSOLVER_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
       integer(c_int),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       type(c_ptr),value :: devInfo
       integer(c_int),value :: batch_count
@@ -10507,9 +10507,9 @@ module hipfort_hipsolver
       integer(kind(HIPSOLVER_FILL_MODE_UPPER)),value :: uplo
       integer(c_int),value :: n
       integer(c_int),value :: nrhs
-      type(c_ptr) :: A
+      type(c_ptr),value :: A
       integer(c_int),value :: lda
-      type(c_ptr) :: B
+      type(c_ptr),value :: B
       integer(c_int),value :: ldb
       type(c_ptr),value :: devInfo
       integer(c_int),value :: batch_count

--- a/lib/hipfort/hipfort_types.F90
+++ b/lib/hipfort/hipfort_types.F90
@@ -526,11 +526,11 @@ module hipfort_types
     type(hipMemLocation) :: location !< Location where allocations should reside
     type(c_ptr) :: win32SecurityAttributes !< Windows-specific LPSECURITYATTRIBUTES required when @p hipMemHandleTypeWin32 is...
     integer(c_size_t) :: maxSize !< Maximum pool size. When set to 0, defaults to a system dependent value
-    type(c_ptr) :: reserved(56) !< Reserved for future use, must be 0
+    character(c_char) :: reserved(56) !< Reserved for future use, must be 0
   end type hipMemPoolProps
 
   type, bind(c) :: hipMemPoolPtrExportData
-    type(c_ptr) :: reserved(64)
+    character(c_char) :: reserved(64)
   end type hipMemPoolPtrExportData
 
   type, bind(c) :: dim3
@@ -632,8 +632,8 @@ module hipfort_types
   end type hipAccessPolicyWindow
 
   type, bind(c) :: hipLaunchMemSyncDomainMap
-    type(c_ptr) :: default_ !< The default domain ID to use for designated kernels
-    type(c_ptr) :: remote !< The remote domain ID to use for designated kernels
+    character(c_char) :: default_ !< The default domain ID to use for designated kernels
+    character(c_char) :: remote !< The remote domain ID to use for designated kernels
   end type hipLaunchMemSyncDomainMap
 
   type, bind(c) :: hipGraphInstantiateParams
@@ -692,10 +692,10 @@ module hipfort_types
   end type hipGraphNodeParams
 
   type, bind(c) :: hipGraphEdgeData
-    type(c_ptr) :: from_port !< This indicates when the dependency is triggered from the upstream node on the edge. The meani...
-    type(c_ptr) :: reserved(5) !< These bytes are unused and must be zeroed
-    type(c_ptr) :: to_port !< Currently no node types define non-zero ports. This field must be set to zero.
-    type(c_ptr) :: type !< This should be populated with a value from hipGraphDependencyType
+    character(c_char) :: from_port !< This indicates when the dependency is triggered from the upstream node on the edge. The...
+    character(c_char) :: reserved(5) !< These bytes are unused and must be zeroed
+    character(c_char) :: to_port !< Currently no node types define non-zero ports. This field must be set to zero.
+    character(c_char) :: type !< This should be populated with a value from hipGraphDependencyType
   end type hipGraphEdgeData
 
   type, bind(c) :: hipLaunchAttribute


### PR DESCRIPTION
## Why

The committed `hipfort_hipblas.F90` / `hipfort_hipsolver.F90` / `hipfort.F90` / `hipfort_types.F90` had drifted from the generator, so anyone regenerating had to re-apply hand edits. **This is not lost hand-patches** — the generator already reproduces the ipiv/AP array patches. The drift is committed bugs the generator fixes. Regenerating brings the tree back in sync so future regenerations are a no-op.

## What changed (all generator output)

- **Batched array-of-pointer args typed by value.** `hipblasGemmBatchedEx`(`_64`, `WithFlags`) `A`/`B`/`C`, `hipblas?trtriBatched` `invA`, and `hipsolver?*Batched*_bufferSize` `A`/`B` are `T* const*` passed by value, so they must be `type(c_ptr),value` — they were `type(c_ptr)` (by reference), which passed one level of indirection too many.
- **`char` job codes/values → `character(c_char)`.** `hipsolver?gesvd` `jobu`/`jobv` (`signed char`) and a few HIP `char` value args were mistyped as `type(c_ptr)`. Root cause (fixed in the generator): the explicit `signed char`/`unsigned char` Clang kinds (`CXType_SChar`/`UChar`) weren't handled and fell back to `c_ptr`.
- **Struct fields.** `signed char` fields in `hipfort_types` (e.g. `reserved(56)`) are now `character(c_char)` arrays instead of `type(c_ptr)` arrays (which made those structs ~8× too large).

Verified: no `ipiv`/`AP`/typed-array argument is reverted; the full library builds (amdgcn + nvptx) with amdflang.

## Relationship to other PRs
- Subsumes the surgical `gesvd` char fix in #450 (that PR can drop its binding change and keep just the test).
- Independent of #443 (`hipfort_hiphostregister` re-export), already reflected here.

The generator-side fix (map `signed`/`unsigned char` to `character(c_char)`) is committed on the `rocm-fortran` generator `main`.