### PR TITLE
test: fix dgetrf_64 / dgetf2_64 / dgetrf_batched CI failures

### DIFF
--- a/test/f2008/rocsolver/rocsolver_dgetf2_64.f08
+++ b/test/f2008/rocsolver/rocsolver_dgetf2_64.f08
@@ -1,8 +1,10 @@
 !!!!!!!!!!!!!!
 ! dgetf2_64 example (unblocked LU with the 64-bit integer API)
-! Same result as dgetrf; dimensions, pivots and info are 64-bit. The device
-! buffers (including int64 ipiv/info) are passed as type(c_ptr) - the _64
-! routines have no native-array overloads. info lives on the DEVICE.
+! Same math as dgetrf; dimensions, pivots and info are 64-bit. Device buffers
+! (int64 ipiv/info included) are passed as type(c_ptr) - the _64 routines have
+! no native-array overloads. info lives on the DEVICE. The input is diagonally
+! dominant so no pivoting occurs and L*U == A is checked by reconstruction
+! (layout-agnostic).
 !!!!!!!!!!!!!!
 !
 program dgetf2_64
@@ -13,16 +15,13 @@ program dgetf2_64
   use hipfort_rocsolver
   implicit none
   integer(c_int64_t), parameter :: M = 3, N = 3, lda = 3
-  real(c_double), target :: hA(3,3) = reshape((/12, 6, -4, -51, 167, 24, 4, -68, -41/), (/3, 3/))
-  real(c_double), target :: hResult(3,3) = reshape((/&
-    12.0000000000000000d0,   0.500000000000000000d0,  -0.333333333333333315d0,&
-   -51.0000000000000000d0, 192.500000000000000d0,      0.363636363636363688d-01,&
-     4.00000000000000000d0, -70.0000000000000000d0,   -37.1212121212121176d0/), shape(hResult), order=(/2,1/))
+  real(c_double), target :: hA(3,3)  = reshape((/4, 1, 1,  1, 4, 1,  1, 1, 4/), (/3, 3/))
+  real(c_double), target :: hLU(3,3)
   integer(c_size_t) :: size_A = 9
   type(c_ptr) :: dA, dIpiv, dInfo, handle
-  integer :: i, j
-  real(c_double) :: error
-  real(c_double), parameter :: error_max = 10 * epsilon(error_max)
+  integer :: i, j, k
+  real(c_double) :: lij, recon, error
+  real(c_double), parameter :: error_max = 1.0d-10
   write(*,"(a)",advance="no") "-- Running test 'rocsolver_dgetf2_64' (Fortran 2008 interfaces) - "
   call hipCheck(hipMalloc(dA,    size_A * 8))
   call hipCheck(hipMalloc(dIpiv, 3_c_size_t * 8))   ! int64 pivots
@@ -30,12 +29,18 @@ program dgetf2_64
   call hipCheck(rocblas_create_handle(handle))
   call hipCheck(hipMemcpy(dA, c_loc(hA(1,1)), size_A * 8, hipMemcpyHostToDevice))
   call hipCheck(rocsolver_dgetf2_64(handle, M, N, dA, lda, dIpiv, dInfo))
-  call hipCheck(hipMemcpy(c_loc(hA(1,1)), dA, size_A * 8, hipMemcpyDeviceToHost))
+  call hipCheck(hipMemcpy(c_loc(hLU(1,1)), dA, size_A * 8, hipMemcpyDeviceToHost))
+  ! Reconstruct A = L*U (unit-lower L below the diagonal, U on/above).
   do j = 1, 3
      do i = 1, 3
-        error = abs(hA(i,j) - hResult(i,j)) / max(abs(hResult(i,j)), 1.0_c_double)
+        recon = 0.0d0
+        do k = 1, min(i,j)
+           if (k == i) then; lij = 1.0d0; else; lij = hLU(i,k); end if
+           recon = recon + lij * hLU(k,j)
+        end do
+        error = abs(recon - hA(i,j))
         if (error > error_max) then
-           write(*,*) "FAILED! hA(", i, ",", j, ") = ", hA(i,j)
+           write(*,*) "FAILED! (L*U)(", i, ",", j, ") = ", recon, " expected ", hA(i,j)
            call exit(1)
         end if
      end do

--- a/test/f2008/rocsolver/rocsolver_dgetrf_64.f08
+++ b/test/f2008/rocsolver/rocsolver_dgetrf_64.f08
@@ -1,8 +1,10 @@
 !!!!!!!!!!!!!!
 ! dgetrf_64 example (LU with the 64-bit integer API)
-! Same result as dgetrf; dimensions, pivots and info are 64-bit. The device
-! buffers (including int64 ipiv/info) are passed as type(c_ptr) - the _64
-! routines have no native-array overloads. info lives on the DEVICE.
+! Same math as dgetrf; dimensions, pivots and info are 64-bit. Device buffers
+! (int64 ipiv/info included) are passed as type(c_ptr) - the _64 routines have
+! no native-array overloads. info lives on the DEVICE. The input is diagonally
+! dominant so no pivoting occurs and L*U == A is checked by reconstruction
+! (layout-agnostic).
 !!!!!!!!!!!!!!
 !
 program dgetrf_64
@@ -13,16 +15,13 @@ program dgetrf_64
   use hipfort_rocsolver
   implicit none
   integer(c_int64_t), parameter :: M = 3, N = 3, lda = 3
-  real(c_double), target :: hA(3,3) = reshape((/12, 6, -4, -51, 167, 24, 4, -68, -41/), (/3, 3/))
-  real(c_double), target :: hResult(3,3) = reshape((/&
-    12.0000000000000000d0,   0.500000000000000000d0,  -0.333333333333333315d0,&
-   -51.0000000000000000d0, 192.500000000000000d0,      0.363636363636363688d-01,&
-     4.00000000000000000d0, -70.0000000000000000d0,   -37.1212121212121176d0/), shape(hResult), order=(/2,1/))
+  real(c_double), target :: hA(3,3)  = reshape((/4, 1, 1,  1, 4, 1,  1, 1, 4/), (/3, 3/))
+  real(c_double), target :: hLU(3,3)
   integer(c_size_t) :: size_A = 9
   type(c_ptr) :: dA, dIpiv, dInfo, handle
-  integer :: i, j
-  real(c_double) :: error
-  real(c_double), parameter :: error_max = 10 * epsilon(error_max)
+  integer :: i, j, k
+  real(c_double) :: lij, recon, error
+  real(c_double), parameter :: error_max = 1.0d-10
   write(*,"(a)",advance="no") "-- Running test 'rocsolver_dgetrf_64' (Fortran 2008 interfaces) - "
   call hipCheck(hipMalloc(dA,    size_A * 8))
   call hipCheck(hipMalloc(dIpiv, 3_c_size_t * 8))   ! int64 pivots
@@ -30,12 +29,18 @@ program dgetrf_64
   call hipCheck(rocblas_create_handle(handle))
   call hipCheck(hipMemcpy(dA, c_loc(hA(1,1)), size_A * 8, hipMemcpyHostToDevice))
   call hipCheck(rocsolver_dgetrf_64(handle, M, N, dA, lda, dIpiv, dInfo))
-  call hipCheck(hipMemcpy(c_loc(hA(1,1)), dA, size_A * 8, hipMemcpyDeviceToHost))
+  call hipCheck(hipMemcpy(c_loc(hLU(1,1)), dA, size_A * 8, hipMemcpyDeviceToHost))
+  ! Reconstruct A = L*U (unit-lower L below the diagonal, U on/above).
   do j = 1, 3
      do i = 1, 3
-        error = abs(hA(i,j) - hResult(i,j)) / max(abs(hResult(i,j)), 1.0_c_double)
+        recon = 0.0d0
+        do k = 1, min(i,j)
+           if (k == i) then; lij = 1.0d0; else; lij = hLU(i,k); end if
+           recon = recon + lij * hLU(k,j)
+        end do
+        error = abs(recon - hA(i,j))
         if (error > error_max) then
-           write(*,*) "FAILED! hA(", i, ",", j, ") = ", hA(i,j)
+           write(*,*) "FAILED! (L*U)(", i, ",", j, ") = ", recon, " expected ", hA(i,j)
            call exit(1)
         end if
      end do

--- a/test/f2008/rocsolver/rocsolver_dgetrf_batched.f08
+++ b/test/f2008/rocsolver/rocsolver_dgetrf_batched.f08
@@ -1,11 +1,9 @@
 !!!!!!!!!!!!!!
 ! dgetrf_batched example (batched LU, array-of-pointers form)
-! see: https:!rocm.docs.amd.com/projects/rocSOLVER/en/latest/
-!
 ! Exercises the "array of device pointers" argument class: A is a device array
-! of pointers, one per batch matrix (not the strided form). We factor two copies
-! of the same matrix and check each against the known packed LU, plus info == 0.
-! rocSOLVER writes info to DEVICE memory.
+! of per-batch matrix pointers (not the strided form). The input is diagonally
+! dominant (no pivoting), so each batch's L*U == A is checked by reconstruction,
+! plus info == 0 per batch. rocSOLVER writes info to DEVICE memory.
 !!!!!!!!!!!!!!
 !
 program dgetrf_batched
@@ -15,49 +13,42 @@ program dgetrf_batched
   use hipfort_rocblas
   use hipfort_rocsolver
   implicit none
-  integer :: i, j, b
+  integer :: i, j, k, b
   integer(c_int), parameter :: M = 3, N = 3, lda = 3, batch = 2
-  real(c_double), target :: hA1(3,3) = reshape((/12, 6, -4, -51, 167, 24, 4, -68, -41/), (/3,3/))
-  real(c_double), target :: hA2(3,3) = reshape((/12, 6, -4, -51, 167, 24, 4, -68, -41/), (/3,3/))
-  real(c_double) :: hResult(3,3) = reshape((/&
-    12.0000000000000000d0,   0.500000000000000000d0,  -0.333333333333333315d0,&
-   -51.0000000000000000d0, 192.500000000000000d0,      0.363636363636363688d-01,&
-     4.00000000000000000d0, -70.0000000000000000d0,   -37.1212121212121176d0/), shape(hResult), order=(/2,1/))
-  real(c_double), target :: hOut(3,3)
-  integer(c_int), target :: hInfo(batch)
+  real(c_double), target :: hA(3,3)  = reshape((/4, 1, 1,  1, 4, 1,  1, 1, 4/), (/3,3/))
+  real(c_double), target :: hLU(3,3)
+  integer(c_int) :: hInfo(batch)
+  integer(c_int), target :: hInfo_t(batch)
   type(c_ptr) :: d1 = c_null_ptr, d2 = c_null_ptr
   type(c_ptr), target :: hptrs(batch)
   type(c_ptr) :: dA_ptrs = c_null_ptr, dIpiv = c_null_ptr, dInfo = c_null_ptr, handle = c_null_ptr
   integer(c_size_t) :: matbytes, psize
-  real(c_double) :: error
-  real(c_double), parameter :: error_max = 10 * epsilon(error_max)
+  real(c_double) :: lij, recon, error
+  real(c_double), parameter :: error_max = 1.0d-10
 
   write(*,"(a)",advance="no") "-- Running test 'rocsolver_dgetrf_batched' (Fortran 2008 interfaces) - "
 
   matbytes = int(M,c_size_t) * int(N,c_size_t) * 8
-  psize    = c_sizeof(d1)   ! size of one device pointer
+  psize    = c_sizeof(d1)
 
-  ! Per-batch device matrices, copied from host.
   call hipCheck(hipMalloc(d1, matbytes))
   call hipCheck(hipMalloc(d2, matbytes))
-  call hipCheck(hipMemcpy(d1, c_loc(hA1(1,1)), matbytes, hipMemcpyHostToDevice))
-  call hipCheck(hipMemcpy(d2, c_loc(hA2(1,1)), matbytes, hipMemcpyHostToDevice))
+  call hipCheck(hipMemcpy(d1, c_loc(hA(1,1)), matbytes, hipMemcpyHostToDevice))
+  call hipCheck(hipMemcpy(d2, c_loc(hA(1,1)), matbytes, hipMemcpyHostToDevice))
 
-  ! Device array of the two matrix pointers.
   hptrs(1) = d1
   hptrs(2) = d2
   call hipCheck(hipMalloc(dA_ptrs, int(batch,c_size_t) * psize))
   call hipCheck(hipMemcpy(dA_ptrs, c_loc(hptrs(1)), int(batch,c_size_t) * psize, hipMemcpyHostToDevice))
 
-  ! Strided pivots (n per matrix) and one info per batch.
   call hipCheck(hipMalloc(dIpiv, int(N,c_size_t) * int(batch,c_size_t) * 4))
   call hipCheck(hipMalloc(dInfo, int(batch,c_size_t) * 4))
 
   call hipCheck(rocblas_create_handle(handle))
-
   call hipCheck(rocsolver_dgetrf_batched(handle, M, N, dA_ptrs, lda, dIpiv, int(N,c_int64_t), dInfo, batch))
 
-  call hipCheck(hipMemcpy(c_loc(hInfo(1)), dInfo, int(batch,c_size_t)*4, hipMemcpyDeviceToHost))
+  call hipCheck(hipMemcpy(c_loc(hInfo_t(1)), dInfo, int(batch,c_size_t)*4, hipMemcpyDeviceToHost))
+  hInfo = hInfo_t
   do b = 1, batch
      if (hInfo(b) /= 0) then
         write(*,*) "FAILED! info(", b, ") = ", hInfo(b)
@@ -65,18 +56,23 @@ program dgetrf_batched
      end if
   end do
 
-  ! Check both factored matrices against the reference packed LU.
+  ! Reconstruct L*U == A for each batch matrix.
   do b = 1, batch
      if (b == 1) then
-        call hipCheck(hipMemcpy(c_loc(hOut(1,1)), d1, matbytes, hipMemcpyDeviceToHost))
+        call hipCheck(hipMemcpy(c_loc(hLU(1,1)), d1, matbytes, hipMemcpyDeviceToHost))
      else
-        call hipCheck(hipMemcpy(c_loc(hOut(1,1)), d2, matbytes, hipMemcpyDeviceToHost))
+        call hipCheck(hipMemcpy(c_loc(hLU(1,1)), d2, matbytes, hipMemcpyDeviceToHost))
      end if
      do j = 1, N
         do i = 1, M
-           error = abs(hOut(i,j) - hResult(i,j)) / max(abs(hResult(i,j)), 1.0_c_double)
+           recon = 0.0d0
+           do k = 1, min(i,j)
+              if (k == i) then; lij = 1.0d0; else; lij = hLU(i,k); end if
+              recon = recon + lij * hLU(k,j)
+           end do
+           error = abs(recon - hA(i,j))
            if (error > error_max) then
-              write(*,*) "FAILED! batch ", b, " hOut(", i, ",", j, ") = ", hOut(i,j)
+              write(*,*) "FAILED! batch ", b, " (L*U)(", i, ",", j, ") = ", recon
               call exit(1)
            end if
         end do
@@ -88,5 +84,4 @@ program dgetrf_batched
   call hipCheck(rocblas_destroy_handle(handle)); call hipCheck(hipDeviceReset())
 
   write(*,*) "PASSED!"
-
 end program dgetrf_batched


### PR DESCRIPTION
## Problem

CI (3 failures):
```
#295 rocsolver_dgetrf_batched  FAILED! batch 1 hOut(2,1) = .5
#303 rocsolver_dgetrf_64       FAILED! hA(2,1) = .5
#304 rocsolver_dgetf2_64       FAILED! hA(2,1) = .5
```
`.5` is the correct `L(2,1)` — the routines are fine. These three compared the packed-LU byte-for-byte against a hardcoded reference built with `reshape(..., order=[2,1])`; on the `type(c_ptr)` round-trip path the reference orientation didn't line up, so `(2,1)` mismatched. (The native-array `dgetf2`/`dgetf2_npvt` tests were unaffected.)

## Fix

Verify by **reconstruction** `L*U == A` instead of comparing to a stored packed-LU, using a symmetric, diagonally dominant input `[[4,1,1],[1,4,1],[1,1,4]]` that needs no pivoting — the same layout-agnostic approach as the passing `rocsolver_dgetrf_npvt`. `dgetrf_batched` also checks `info == 0` per batch.

Introduced in #445/#448. Build-checked with amdflang.