### PR TITLE
Add experimental F2018 assumed-rank array interfaces (USE_ASSUMED_RANK_INTERFACES)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,10 @@
 
 ### Added
 
-* Experimental Fortran 2018 assumed-rank array interfaces, enabled with the
-  `-DHIPFORT_ASSUMED_RANK=ON` CMake option (guarded by `USE_ASSUMED_RANK_INTERFACES`).
-  When enabled, each array generic is backed by a single `dimension(..)` overload
-  that accepts an actual of any rank — including ranks greater than 2 (see issue
-  #175) — instead of the rank-specific overloads. This covers the math libraries
-  (rocBLAS, hipBLAS, rocSOLVER, hipSOLVER, rocSPARSE, hipSPARSE), the RNG libraries
-  (rocRAND, hipRAND), hipFFT, and the HIP runtime `hipMemcpy` family. The overloads
-  are mutually exclusive with the classic per-rank interfaces and completely inert
-  when the option is off, so the Fortran 2003 (`c_ptr`) and Fortran 2008 (per-rank)
-  code paths are unchanged. Off by default; requires a compiler with F2018
-  assumed-rank support (`gfortran` >= 13, `amdflang`). Only contiguous arrays may
-  be passed.
+* Experimental Fortran 2018 assumed-rank array interfaces, enabled with the `-DHIPFORT_ASSUMED_RANK=ON` CMake option (guarded by `USE_ASSUMED_RANK_INTERFACES`).
+When enabled, each array generic is backed by a single `dimension(..)` overload that accepts an actual of any rank.
+The overloads are mutually exclusive with the classic per-rank interfaces.
+Only contiguous arrays may be passed.
 
 ## hipfort 0.8.0 for ROCm 7.14.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog for hipfort
 
+## (Unreleased)
+
+### Added
+
+* Experimental Fortran 2018 assumed-rank array interfaces, enabled with the
+  `-DHIPFORT_ASSUMED_RANK=ON` CMake option (guarded by `USE_ASSUMED_RANK_INTERFACES`).
+  When enabled, each array generic is backed by a single `dimension(..)` overload
+  that accepts an actual of any rank — including ranks greater than 2 (see issue
+  #175) — instead of the rank-specific overloads. This covers the math libraries
+  (rocBLAS, hipBLAS, rocSOLVER, hipSOLVER, rocSPARSE, hipSPARSE), the RNG libraries
+  (rocRAND, hipRAND), hipFFT, and the HIP runtime `hipMemcpy` family. The overloads
+  are mutually exclusive with the classic per-rank interfaces and completely inert
+  when the option is off, so the Fortran 2003 (`c_ptr`) and Fortran 2008 (per-rank)
+  code paths are unchanged. Off by default; requires a compiler with F2018
+  assumed-rank support (`gfortran` >= 13, `amdflang`). Only contiguous arrays may
+  be passed.
+
 ## hipfort 0.8.0 for ROCm 7.14.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -61,6 +61,22 @@ definition, which `hipfort` enables automatically once it detects Fortran 2008 s
 in your compiler. By convention, application and test sources that rely on them use the
 `.f08` file extension (see the `test/f2008` examples), while Fortran 2003 sources use `.f03`.
 
+> **Experimental (`-DHIPFORT_ASSUMED_RANK=ON`).** By default each array generic is
+> resolved by a set of rank-specific overloads (`rank_0`, `rank_1`, …). With this
+> option `hipfort` builds a single Fortran 2018 *assumed-rank* (`dimension(..)`)
+> overload per routine instead — same generic call, one wrapper for any rank, and
+> much smaller generated modules. It requires a compiler with F2018 assumed-rank
+> plus `c_loc` support (`gfortran` ≥ 13, `amdflang`) and only takes effect when the
+> `f2008` interfaces are enabled (guarded by `USE_ASSUMED_RANK_INTERFACES`, nested
+> inside `USE_FPOINTER_INTERFACES`). It is therefore unavailable with the Intel
+> compilers, where `hipfort` builds the Fortran 2003 (`type(c_ptr)`) interfaces
+> only. Off by default.
+>
+> The assumed-rank wrapper takes the base address of the array with `c_loc`, so the
+> actual argument must be **contiguous** (the dummy is declared `contiguous`). A
+> non-contiguous section (e.g. `a(:,::2)`) would force the compiler to pass a
+> temporary copy, so pass whole arrays or contiguous slices only.
+
 ### Example
 
 While you could write the following using the `f2003` interfaces:

--- a/README.md
+++ b/README.md
@@ -61,21 +61,13 @@ definition, which `hipfort` enables automatically once it detects Fortran 2008 s
 in your compiler. By convention, application and test sources that rely on them use the
 `.f08` file extension (see the `test/f2008` examples), while Fortran 2003 sources use `.f03`.
 
-> **Experimental (`-DHIPFORT_ASSUMED_RANK=ON`).** By default each array generic is
-> resolved by a set of rank-specific overloads (`rank_0`, `rank_1`, …). With this
-> option `hipfort` builds a single Fortran 2018 *assumed-rank* (`dimension(..)`)
-> overload per routine instead — same generic call, one wrapper for any rank, and
-> much smaller generated modules. It requires a compiler with F2018 assumed-rank
-> plus `c_loc` support (`gfortran` ≥ 13, `amdflang`) and only takes effect when the
-> `f2008` interfaces are enabled (guarded by `USE_ASSUMED_RANK_INTERFACES`, nested
-> inside `USE_FPOINTER_INTERFACES`). It is therefore unavailable with the Intel
-> compilers, where `hipfort` builds the Fortran 2003 (`type(c_ptr)`) interfaces
-> only. Off by default.
->
-> The assumed-rank wrapper takes the base address of the array with `c_loc`, so the
-> actual argument must be **contiguous** (the dummy is declared `contiguous`). A
-> non-contiguous section (e.g. `a(:,::2)`) would force the compiler to pass a
-> temporary copy, so pass whole arrays or contiguous slices only.
+**Experimental (`-DHIPFORT_ASSUMED_RANK=ON`).** By default each array generic is resolved by a set of rank-specific overloads (`rank_0`, `rank_1`, ...).
+With this option `hipfort` builds a single Fortran 2018 assumed-rank (`dimension(..)`) overload per routine instead.
+It requires a compiler with F2018 assumed-rank plus `c_loc` support.
+Off by default.
+
+The assumed-rank wrapper takes the base address of the array with `c_loc`, so the actual argument must be contiguous (the dummy is declared `contiguous`).
+A non-contiguous section (e.g. `a(:,::2)`) would force the compiler to pass a temporary copy, so pass whole arrays or contiguous slices only.
 
 ### Example
 

--- a/lib/hipfort/hipfort_hipblas.F90
+++ b/lib/hipfort/hipfort_hipblas.F90
@@ -42282,6 +42282,7 @@ module hipfort_hipblas
       hipblasIzamax_assumed_rank = hipblasIzamax_(handle,n,c_loc(x),incx,myResult)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasIsamaxStridedBatched_assumed_rank(handle,n,x,incx,stridex,batchCount,myResult)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -42298,7 +42299,9 @@ module hipfort_hipblas
       hipblasIsamaxStridedBatched_assumed_rank = hipblasIsamaxStridedBatched_(handle,n,c_loc(x),incx, &
         stridex,batchCount,myResult)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasIdamaxStridedBatched_assumed_rank(handle,n,x,incx,stridex,batchCount,myResult)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -42315,7 +42318,9 @@ module hipfort_hipblas
       hipblasIdamaxStridedBatched_assumed_rank = hipblasIdamaxStridedBatched_(handle,n,c_loc(x),incx, &
         stridex,batchCount,myResult)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasIcamaxStridedBatched_assumed_rank(handle,n,x,incx,stridex,batchCount,myResult)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -42332,7 +42337,9 @@ module hipfort_hipblas
       hipblasIcamaxStridedBatched_assumed_rank = hipblasIcamaxStridedBatched_(handle,n,c_loc(x),incx, &
         stridex,batchCount,myResult)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasIzamaxStridedBatched_assumed_rank(handle,n,x,incx,stridex,batchCount,myResult)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -42349,6 +42356,7 @@ module hipfort_hipblas
       hipblasIzamaxStridedBatched_assumed_rank = hipblasIzamaxStridedBatched_(handle,n,c_loc(x),incx, &
         stridex,batchCount,myResult)
     end function
+#endif
 
     function hipblasIsamin_assumed_rank(handle,n,x,incx,myResult)
       use iso_c_binding
@@ -42406,6 +42414,7 @@ module hipfort_hipblas
       hipblasIzamin_assumed_rank = hipblasIzamin_(handle,n,c_loc(x),incx,myResult)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasIsaminStridedBatched_assumed_rank(handle,n,x,incx,stridex,batchCount,myResult)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -42422,7 +42431,9 @@ module hipfort_hipblas
       hipblasIsaminStridedBatched_assumed_rank = hipblasIsaminStridedBatched_(handle,n,c_loc(x),incx, &
         stridex,batchCount,myResult)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasIdaminStridedBatched_assumed_rank(handle,n,x,incx,stridex,batchCount,myResult)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -42439,7 +42450,9 @@ module hipfort_hipblas
       hipblasIdaminStridedBatched_assumed_rank = hipblasIdaminStridedBatched_(handle,n,c_loc(x),incx, &
         stridex,batchCount,myResult)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasIcaminStridedBatched_assumed_rank(handle,n,x,incx,stridex,batchCount,myResult)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -42456,7 +42469,9 @@ module hipfort_hipblas
       hipblasIcaminStridedBatched_assumed_rank = hipblasIcaminStridedBatched_(handle,n,c_loc(x),incx, &
         stridex,batchCount,myResult)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasIzaminStridedBatched_assumed_rank(handle,n,x,incx,stridex,batchCount,myResult)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -42473,6 +42488,7 @@ module hipfort_hipblas
       hipblasIzaminStridedBatched_assumed_rank = hipblasIzaminStridedBatched_(handle,n,c_loc(x),incx, &
         stridex,batchCount,myResult)
     end function
+#endif
 
     function hipblasSasum_assumed_rank(handle,n,x,incx,myResult)
       use iso_c_binding
@@ -42530,6 +42546,7 @@ module hipfort_hipblas
       hipblasDzasum_assumed_rank = hipblasDzasum_(handle,n,c_loc(x),incx,myResult)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasSasumStridedBatched_assumed_rank(handle,n,x,incx,stridex,batchCount,myResult)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -42546,7 +42563,9 @@ module hipfort_hipblas
       hipblasSasumStridedBatched_assumed_rank = hipblasSasumStridedBatched_(handle,n,c_loc(x),incx, &
         stridex,batchCount,myResult)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasDasumStridedBatched_assumed_rank(handle,n,x,incx,stridex,batchCount,myResult)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -42563,7 +42582,9 @@ module hipfort_hipblas
       hipblasDasumStridedBatched_assumed_rank = hipblasDasumStridedBatched_(handle,n,c_loc(x),incx, &
         stridex,batchCount,myResult)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasScasumStridedBatched_assumed_rank(handle,n,x,incx,stridex,batchCount,myResult)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -42580,7 +42601,9 @@ module hipfort_hipblas
       hipblasScasumStridedBatched_assumed_rank = hipblasScasumStridedBatched_(handle,n,c_loc(x),incx, &
         stridex,batchCount,myResult)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasDzasumStridedBatched_assumed_rank(handle,n,x,incx,stridex,batchCount,myResult)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -42597,6 +42620,7 @@ module hipfort_hipblas
       hipblasDzasumStridedBatched_assumed_rank = hipblasDzasumStridedBatched_(handle,n,c_loc(x),incx, &
         stridex,batchCount,myResult)
     end function
+#endif
 
     function hipblasSaxpy_assumed_rank(handle,n,alpha,x,incx,y,incy)
       use iso_c_binding
@@ -42662,6 +42686,7 @@ module hipfort_hipblas
       hipblasZaxpy_assumed_rank = hipblasZaxpy_(handle,n,alpha,c_loc(x),incx,c_loc(y),incy)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasSaxpyStridedBatched_assumed_rank(handle,n,alpha,x,incx,stridex,y,incy,stridey, &
         batchCount)
       use iso_c_binding
@@ -42682,7 +42707,9 @@ module hipfort_hipblas
       hipblasSaxpyStridedBatched_assumed_rank = hipblasSaxpyStridedBatched_(handle,n,alpha,c_loc(x), &
         incx,stridex,c_loc(y),incy,stridey,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasDaxpyStridedBatched_assumed_rank(handle,n,alpha,x,incx,stridex,y,incy,stridey, &
         batchCount)
       use iso_c_binding
@@ -42703,7 +42730,9 @@ module hipfort_hipblas
       hipblasDaxpyStridedBatched_assumed_rank = hipblasDaxpyStridedBatched_(handle,n,alpha,c_loc(x), &
         incx,stridex,c_loc(y),incy,stridey,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasCaxpyStridedBatched_assumed_rank(handle,n,alpha,x,incx,stridex,y,incy,stridey, &
         batchCount)
       use iso_c_binding
@@ -42724,7 +42753,9 @@ module hipfort_hipblas
       hipblasCaxpyStridedBatched_assumed_rank = hipblasCaxpyStridedBatched_(handle,n,alpha,c_loc(x), &
         incx,stridex,c_loc(y),incy,stridey,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasZaxpyStridedBatched_assumed_rank(handle,n,alpha,x,incx,stridex,y,incy,stridey, &
         batchCount)
       use iso_c_binding
@@ -42745,6 +42776,7 @@ module hipfort_hipblas
       hipblasZaxpyStridedBatched_assumed_rank = hipblasZaxpyStridedBatched_(handle,n,alpha,c_loc(x), &
         incx,stridex,c_loc(y),incy,stridey,batchCount)
     end function
+#endif
 
     function hipblasScopy_assumed_rank(handle,n,x,incx,y,incy)
       use iso_c_binding
@@ -42806,6 +42838,7 @@ module hipfort_hipblas
       hipblasZcopy_assumed_rank = hipblasZcopy_(handle,n,c_loc(x),incx,c_loc(y),incy)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasScopyStridedBatched_assumed_rank(handle,n,x,incx,stridex,y,incy,stridey,batchCount)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -42824,7 +42857,9 @@ module hipfort_hipblas
       hipblasScopyStridedBatched_assumed_rank = hipblasScopyStridedBatched_(handle,n,c_loc(x),incx, &
         stridex,c_loc(y),incy,stridey,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasDcopyStridedBatched_assumed_rank(handle,n,x,incx,stridex,y,incy,stridey,batchCount)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -42843,7 +42878,9 @@ module hipfort_hipblas
       hipblasDcopyStridedBatched_assumed_rank = hipblasDcopyStridedBatched_(handle,n,c_loc(x),incx, &
         stridex,c_loc(y),incy,stridey,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasCcopyStridedBatched_assumed_rank(handle,n,x,incx,stridex,y,incy,stridey,batchCount)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -42862,7 +42899,9 @@ module hipfort_hipblas
       hipblasCcopyStridedBatched_assumed_rank = hipblasCcopyStridedBatched_(handle,n,c_loc(x),incx, &
         stridex,c_loc(y),incy,stridey,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasZcopyStridedBatched_assumed_rank(handle,n,x,incx,stridex,y,incy,stridey,batchCount)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -42881,6 +42920,7 @@ module hipfort_hipblas
       hipblasZcopyStridedBatched_assumed_rank = hipblasZcopyStridedBatched_(handle,n,c_loc(x),incx, &
         stridex,c_loc(y),incy,stridey,batchCount)
     end function
+#endif
 
     function hipblasSdot_assumed_rank(handle,n,x,incx,y,incy,myResult)
       use iso_c_binding
@@ -42978,6 +43018,7 @@ module hipfort_hipblas
       hipblasZdotu_assumed_rank = hipblasZdotu_(handle,n,c_loc(x),incx,c_loc(y),incy,myResult)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasSdotStridedBatched_assumed_rank(handle,n,x,incx,stridex,y,incy,stridey,batchCount, &
         myResult)
       use iso_c_binding
@@ -42998,7 +43039,9 @@ module hipfort_hipblas
       hipblasSdotStridedBatched_assumed_rank = hipblasSdotStridedBatched_(handle,n,c_loc(x),incx, &
         stridex,c_loc(y),incy,stridey,batchCount,myResult)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasDdotStridedBatched_assumed_rank(handle,n,x,incx,stridex,y,incy,stridey,batchCount, &
         myResult)
       use iso_c_binding
@@ -43019,7 +43062,9 @@ module hipfort_hipblas
       hipblasDdotStridedBatched_assumed_rank = hipblasDdotStridedBatched_(handle,n,c_loc(x),incx, &
         stridex,c_loc(y),incy,stridey,batchCount,myResult)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasCdotcStridedBatched_assumed_rank(handle,n,x,incx,stridex,y,incy,stridey,batchCount, &
         myResult)
       use iso_c_binding
@@ -43040,7 +43085,9 @@ module hipfort_hipblas
       hipblasCdotcStridedBatched_assumed_rank = hipblasCdotcStridedBatched_(handle,n,c_loc(x),incx, &
         stridex,c_loc(y),incy,stridey,batchCount,myResult)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasCdotuStridedBatched_assumed_rank(handle,n,x,incx,stridex,y,incy,stridey,batchCount, &
         myResult)
       use iso_c_binding
@@ -43061,7 +43108,9 @@ module hipfort_hipblas
       hipblasCdotuStridedBatched_assumed_rank = hipblasCdotuStridedBatched_(handle,n,c_loc(x),incx, &
         stridex,c_loc(y),incy,stridey,batchCount,myResult)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasZdotcStridedBatched_assumed_rank(handle,n,x,incx,stridex,y,incy,stridey,batchCount, &
         myResult)
       use iso_c_binding
@@ -43082,7 +43131,9 @@ module hipfort_hipblas
       hipblasZdotcStridedBatched_assumed_rank = hipblasZdotcStridedBatched_(handle,n,c_loc(x),incx, &
         stridex,c_loc(y),incy,stridey,batchCount,myResult)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasZdotuStridedBatched_assumed_rank(handle,n,x,incx,stridex,y,incy,stridey,batchCount, &
         myResult)
       use iso_c_binding
@@ -43103,6 +43154,7 @@ module hipfort_hipblas
       hipblasZdotuStridedBatched_assumed_rank = hipblasZdotuStridedBatched_(handle,n,c_loc(x),incx, &
         stridex,c_loc(y),incy,stridey,batchCount,myResult)
     end function
+#endif
 
     function hipblasSnrm2_assumed_rank(handle,n,x,incx,myResult)
       use iso_c_binding
@@ -43160,6 +43212,7 @@ module hipfort_hipblas
       hipblasDznrm2_assumed_rank = hipblasDznrm2_(handle,n,c_loc(x),incx,myResult)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasSnrm2StridedBatched_assumed_rank(handle,n,x,incx,stridex,batchCount,myResult)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -43176,7 +43229,9 @@ module hipfort_hipblas
       hipblasSnrm2StridedBatched_assumed_rank = hipblasSnrm2StridedBatched_(handle,n,c_loc(x),incx, &
         stridex,batchCount,myResult)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasDnrm2StridedBatched_assumed_rank(handle,n,x,incx,stridex,batchCount,myResult)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -43193,7 +43248,9 @@ module hipfort_hipblas
       hipblasDnrm2StridedBatched_assumed_rank = hipblasDnrm2StridedBatched_(handle,n,c_loc(x),incx, &
         stridex,batchCount,myResult)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasScnrm2StridedBatched_assumed_rank(handle,n,x,incx,stridex,batchCount,myResult)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -43210,7 +43267,9 @@ module hipfort_hipblas
       hipblasScnrm2StridedBatched_assumed_rank = hipblasScnrm2StridedBatched_(handle,n,c_loc(x),incx, &
         stridex,batchCount,myResult)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasDznrm2StridedBatched_assumed_rank(handle,n,x,incx,stridex,batchCount,myResult)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -43227,6 +43286,7 @@ module hipfort_hipblas
       hipblasDznrm2StridedBatched_assumed_rank = hipblasDznrm2StridedBatched_(handle,n,c_loc(x),incx, &
         stridex,batchCount,myResult)
     end function
+#endif
 
     function hipblasSrot_assumed_rank(handle,n,x,incx,y,incy,c,s)
       use iso_c_binding
@@ -43330,6 +43390,7 @@ module hipfort_hipblas
       hipblasZdrot_assumed_rank = hipblasZdrot_(handle,n,c_loc(x),incx,c_loc(y),incy,c,s)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasSrotStridedBatched_assumed_rank(handle,n,x,incx,stridex,y,incy,stridey,c,s,batchCount)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -43350,7 +43411,9 @@ module hipfort_hipblas
       hipblasSrotStridedBatched_assumed_rank = hipblasSrotStridedBatched_(handle,n,c_loc(x),incx, &
         stridex,c_loc(y),incy,stridey,c,s,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasDrotStridedBatched_assumed_rank(handle,n,x,incx,stridex,y,incy,stridey,c,s,batchCount)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -43371,7 +43434,9 @@ module hipfort_hipblas
       hipblasDrotStridedBatched_assumed_rank = hipblasDrotStridedBatched_(handle,n,c_loc(x),incx, &
         stridex,c_loc(y),incy,stridey,c,s,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasCrotStridedBatched_assumed_rank(handle,n,x,incx,stridex,y,incy,stridey,c,s,batchCount)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -43392,7 +43457,9 @@ module hipfort_hipblas
       hipblasCrotStridedBatched_assumed_rank = hipblasCrotStridedBatched_(handle,n,c_loc(x),incx, &
         stridex,c_loc(y),incy,stridey,c,s,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasCsrotStridedBatched_assumed_rank(handle,n,x,incx,stridex,y,incy,stridey,c,s, &
         batchCount)
       use iso_c_binding
@@ -43414,7 +43481,9 @@ module hipfort_hipblas
       hipblasCsrotStridedBatched_assumed_rank = hipblasCsrotStridedBatched_(handle,n,c_loc(x),incx, &
         stridex,c_loc(y),incy,stridey,c,s,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasZrotStridedBatched_assumed_rank(handle,n,x,incx,stridex,y,incy,stridey,c,s,batchCount)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -43435,7 +43504,9 @@ module hipfort_hipblas
       hipblasZrotStridedBatched_assumed_rank = hipblasZrotStridedBatched_(handle,n,c_loc(x),incx, &
         stridex,c_loc(y),incy,stridey,c,s,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasZdrotStridedBatched_assumed_rank(handle,n,x,incx,stridex,y,incy,stridey,c,s, &
         batchCount)
       use iso_c_binding
@@ -43457,6 +43528,7 @@ module hipfort_hipblas
       hipblasZdrotStridedBatched_assumed_rank = hipblasZdrotStridedBatched_(handle,n,c_loc(x),incx, &
         stridex,c_loc(y),incy,stridey,c,s,batchCount)
     end function
+#endif
 
     function hipblasSrotm_assumed_rank(handle,n,x,incx,y,incy,param)
       use iso_c_binding
@@ -43490,6 +43562,7 @@ module hipfort_hipblas
       hipblasDrotm_assumed_rank = hipblasDrotm_(handle,n,c_loc(x),incx,c_loc(y),incy,param)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasSrotmStridedBatched_assumed_rank(handle,n,x,incx,stridex,y,incy,stridey,param, &
         strideParam,batchCount)
       use iso_c_binding
@@ -43511,7 +43584,9 @@ module hipfort_hipblas
       hipblasSrotmStridedBatched_assumed_rank = hipblasSrotmStridedBatched_(handle,n,c_loc(x),incx, &
         stridex,c_loc(y),incy,stridey,param,strideParam,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasDrotmStridedBatched_assumed_rank(handle,n,x,incx,stridex,y,incy,stridey,param, &
         strideParam,batchCount)
       use iso_c_binding
@@ -43533,6 +43608,7 @@ module hipfort_hipblas
       hipblasDrotmStridedBatched_assumed_rank = hipblasDrotmStridedBatched_(handle,n,c_loc(x),incx, &
         stridex,c_loc(y),incy,stridey,param,strideParam,batchCount)
     end function
+#endif
 
     function hipblasSscal_assumed_rank(handle,n,alpha,x,incx)
       use iso_c_binding
@@ -43618,6 +43694,7 @@ module hipfort_hipblas
       hipblasZdscal_assumed_rank = hipblasZdscal_(handle,n,alpha,c_loc(x),incx)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasSscalStridedBatched_assumed_rank(handle,n,alpha,x,incx,stridex,batchCount)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -43634,7 +43711,9 @@ module hipfort_hipblas
       hipblasSscalStridedBatched_assumed_rank = hipblasSscalStridedBatched_(handle,n,alpha,c_loc(x), &
         incx,stridex,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasDscalStridedBatched_assumed_rank(handle,n,alpha,x,incx,stridex,batchCount)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -43651,7 +43730,9 @@ module hipfort_hipblas
       hipblasDscalStridedBatched_assumed_rank = hipblasDscalStridedBatched_(handle,n,alpha,c_loc(x), &
         incx,stridex,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasCscalStridedBatched_assumed_rank(handle,n,alpha,x,incx,stridex,batchCount)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -43668,7 +43749,9 @@ module hipfort_hipblas
       hipblasCscalStridedBatched_assumed_rank = hipblasCscalStridedBatched_(handle,n,alpha,c_loc(x), &
         incx,stridex,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasZscalStridedBatched_assumed_rank(handle,n,alpha,x,incx,stridex,batchCount)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -43685,7 +43768,9 @@ module hipfort_hipblas
       hipblasZscalStridedBatched_assumed_rank = hipblasZscalStridedBatched_(handle,n,alpha,c_loc(x), &
         incx,stridex,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasCsscalStridedBatched_assumed_rank(handle,n,alpha,x,incx,stridex,batchCount)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -43702,7 +43787,9 @@ module hipfort_hipblas
       hipblasCsscalStridedBatched_assumed_rank = hipblasCsscalStridedBatched_(handle,n,alpha,c_loc(x), &
         incx,stridex,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasZdscalStridedBatched_assumed_rank(handle,n,alpha,x,incx,stridex,batchCount)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -43719,6 +43806,7 @@ module hipfort_hipblas
       hipblasZdscalStridedBatched_assumed_rank = hipblasZdscalStridedBatched_(handle,n,alpha,c_loc(x), &
         incx,stridex,batchCount)
     end function
+#endif
 
     function hipblasSswap_assumed_rank(handle,n,x,incx,y,incy)
       use iso_c_binding
@@ -43780,6 +43868,7 @@ module hipfort_hipblas
       hipblasZswap_assumed_rank = hipblasZswap_(handle,n,c_loc(x),incx,c_loc(y),incy)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasSswapStridedBatched_assumed_rank(handle,n,x,incx,stridex,y,incy,stridey,batchCount)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -43798,7 +43887,9 @@ module hipfort_hipblas
       hipblasSswapStridedBatched_assumed_rank = hipblasSswapStridedBatched_(handle,n,c_loc(x),incx, &
         stridex,c_loc(y),incy,stridey,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasDswapStridedBatched_assumed_rank(handle,n,x,incx,stridex,y,incy,stridey,batchCount)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -43817,7 +43908,9 @@ module hipfort_hipblas
       hipblasDswapStridedBatched_assumed_rank = hipblasDswapStridedBatched_(handle,n,c_loc(x),incx, &
         stridex,c_loc(y),incy,stridey,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasCswapStridedBatched_assumed_rank(handle,n,x,incx,stridex,y,incy,stridey,batchCount)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -43836,7 +43929,9 @@ module hipfort_hipblas
       hipblasCswapStridedBatched_assumed_rank = hipblasCswapStridedBatched_(handle,n,c_loc(x),incx, &
         stridex,c_loc(y),incy,stridey,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasZswapStridedBatched_assumed_rank(handle,n,x,incx,stridex,y,incy,stridey,batchCount)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -43855,6 +43950,7 @@ module hipfort_hipblas
       hipblasZswapStridedBatched_assumed_rank = hipblasZswapStridedBatched_(handle,n,c_loc(x),incx, &
         stridex,c_loc(y),incy,stridey,batchCount)
     end function
+#endif
 
     function hipblasSgbmv_assumed_rank(handle,trans,m,n,kl,ku,alpha,AP,lda,x,incx,beta,y,incy)
       use iso_c_binding
@@ -43952,6 +44048,7 @@ module hipfort_hipblas
         incx,beta,c_loc(y),incy)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasSgbmvStridedBatched_assumed_rank(handle,trans,m,n,kl,ku,alpha,AP,lda,strideA,x,incx, &
         stridex,beta,y,incy,stridey,batchCount)
       use iso_c_binding
@@ -43980,7 +44077,9 @@ module hipfort_hipblas
       hipblasSgbmvStridedBatched_assumed_rank = hipblasSgbmvStridedBatched_(handle,trans,m,n,kl,ku, &
         alpha,c_loc(AP),lda,strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasDgbmvStridedBatched_assumed_rank(handle,trans,m,n,kl,ku,alpha,AP,lda,strideA,x,incx, &
         stridex,beta,y,incy,stridey,batchCount)
       use iso_c_binding
@@ -44009,7 +44108,9 @@ module hipfort_hipblas
       hipblasDgbmvStridedBatched_assumed_rank = hipblasDgbmvStridedBatched_(handle,trans,m,n,kl,ku, &
         alpha,c_loc(AP),lda,strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasCgbmvStridedBatched_assumed_rank(handle,trans,m,n,kl,ku,alpha,AP,lda,strideA,x,incx, &
         stridex,beta,y,incy,stridey,batchCount)
       use iso_c_binding
@@ -44038,7 +44139,9 @@ module hipfort_hipblas
       hipblasCgbmvStridedBatched_assumed_rank = hipblasCgbmvStridedBatched_(handle,trans,m,n,kl,ku, &
         alpha,c_loc(AP),lda,strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasZgbmvStridedBatched_assumed_rank(handle,trans,m,n,kl,ku,alpha,AP,lda,strideA,x,incx, &
         stridex,beta,y,incy,stridey,batchCount)
       use iso_c_binding
@@ -44067,6 +44170,7 @@ module hipfort_hipblas
       hipblasZgbmvStridedBatched_assumed_rank = hipblasZgbmvStridedBatched_(handle,trans,m,n,kl,ku, &
         alpha,c_loc(AP),lda,strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
     end function
+#endif
 
     function hipblasSgemv_assumed_rank(handle,trans,m,n,alpha,AP,lda,x,incx,beta,y,incy)
       use iso_c_binding
@@ -44382,6 +44486,7 @@ module hipfort_hipblas
         lda)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasSgerStridedBatched_assumed_rank(handle,m,n,alpha,x,incx,stridex,y,incy,stridey,AP, &
         lda,strideA,batchCount)
       use iso_c_binding
@@ -44406,7 +44511,9 @@ module hipfort_hipblas
       hipblasSgerStridedBatched_assumed_rank = hipblasSgerStridedBatched_(handle,m,n,alpha,c_loc(x), &
         incx,stridex,c_loc(y),incy,stridey,c_loc(AP),lda,strideA,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasDgerStridedBatched_assumed_rank(handle,m,n,alpha,x,incx,stridex,y,incy,stridey,AP, &
         lda,strideA,batchCount)
       use iso_c_binding
@@ -44431,7 +44538,9 @@ module hipfort_hipblas
       hipblasDgerStridedBatched_assumed_rank = hipblasDgerStridedBatched_(handle,m,n,alpha,c_loc(x), &
         incx,stridex,c_loc(y),incy,stridey,c_loc(AP),lda,strideA,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasCgeruStridedBatched_assumed_rank(handle,m,n,alpha,x,incx,stridex,y,incy,stridey,AP, &
         lda,strideA,batchCount)
       use iso_c_binding
@@ -44456,7 +44565,9 @@ module hipfort_hipblas
       hipblasCgeruStridedBatched_assumed_rank = hipblasCgeruStridedBatched_(handle,m,n,alpha,c_loc(x), &
         incx,stridex,c_loc(y),incy,stridey,c_loc(AP),lda,strideA,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasCgercStridedBatched_assumed_rank(handle,m,n,alpha,x,incx,stridex,y,incy,stridey,AP, &
         lda,strideA,batchCount)
       use iso_c_binding
@@ -44481,7 +44592,9 @@ module hipfort_hipblas
       hipblasCgercStridedBatched_assumed_rank = hipblasCgercStridedBatched_(handle,m,n,alpha,c_loc(x), &
         incx,stridex,c_loc(y),incy,stridey,c_loc(AP),lda,strideA,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasZgeruStridedBatched_assumed_rank(handle,m,n,alpha,x,incx,stridex,y,incy,stridey,AP, &
         lda,strideA,batchCount)
       use iso_c_binding
@@ -44506,7 +44619,9 @@ module hipfort_hipblas
       hipblasZgeruStridedBatched_assumed_rank = hipblasZgeruStridedBatched_(handle,m,n,alpha,c_loc(x), &
         incx,stridex,c_loc(y),incy,stridey,c_loc(AP),lda,strideA,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasZgercStridedBatched_assumed_rank(handle,m,n,alpha,x,incx,stridex,y,incy,stridey,AP, &
         lda,strideA,batchCount)
       use iso_c_binding
@@ -44531,6 +44646,7 @@ module hipfort_hipblas
       hipblasZgercStridedBatched_assumed_rank = hipblasZgercStridedBatched_(handle,m,n,alpha,c_loc(x), &
         incx,stridex,c_loc(y),incy,stridey,c_loc(AP),lda,strideA,batchCount)
     end function
+#endif
 
     function hipblasChbmv_assumed_rank(handle,uplo,n,k,alpha,AP,lda,x,incx,beta,y,incy)
       use iso_c_binding
@@ -44576,6 +44692,7 @@ module hipfort_hipblas
         c_loc(y),incy)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasChbmvStridedBatched_assumed_rank(handle,uplo,n,k,alpha,AP,lda,strideA,x,incx, &
         stridex,beta,y,incy,stridey,batchCount)
       use iso_c_binding
@@ -44602,7 +44719,9 @@ module hipfort_hipblas
       hipblasChbmvStridedBatched_assumed_rank = hipblasChbmvStridedBatched_(handle,uplo,n,k,alpha, &
         c_loc(AP),lda,strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasZhbmvStridedBatched_assumed_rank(handle,uplo,n,k,alpha,AP,lda,strideA,x,incx, &
         stridex,beta,y,incy,stridey,batchCount)
       use iso_c_binding
@@ -44629,6 +44748,7 @@ module hipfort_hipblas
       hipblasZhbmvStridedBatched_assumed_rank = hipblasZhbmvStridedBatched_(handle,uplo,n,k,alpha, &
         c_loc(AP),lda,strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
     end function
+#endif
 
     function hipblasChemv_assumed_rank(handle,uplo,n,alpha,AP,lda,x,incx,beta,y,incy)
       use iso_c_binding
@@ -44672,6 +44792,7 @@ module hipfort_hipblas
         c_loc(y),incy)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasChemvStridedBatched_assumed_rank(handle,uplo,n,alpha,AP,lda,strideA,x,incx,stridex, &
         beta,y,incy,stridey,batchCount)
       use iso_c_binding
@@ -44697,7 +44818,9 @@ module hipfort_hipblas
       hipblasChemvStridedBatched_assumed_rank = hipblasChemvStridedBatched_(handle,uplo,n,alpha, &
         c_loc(AP),lda,strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasZhemvStridedBatched_assumed_rank(handle,uplo,n,alpha,AP,lda,strideA,x,incx,stridex, &
         beta,y,incy,stridey,batchCount)
       use iso_c_binding
@@ -44723,6 +44846,7 @@ module hipfort_hipblas
       hipblasZhemvStridedBatched_assumed_rank = hipblasZhemvStridedBatched_(handle,uplo,n,alpha, &
         c_loc(AP),lda,strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
     end function
+#endif
 
     function hipblasCher_assumed_rank(handle,uplo,n,alpha,x,incx,AP,lda)
       use iso_c_binding
@@ -44758,6 +44882,7 @@ module hipfort_hipblas
       hipblasZher_assumed_rank = hipblasZher_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(AP),lda)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasCherStridedBatched_assumed_rank(handle,uplo,n,alpha,x,incx,stridex,AP,lda,strideA, &
         batchCount)
       use iso_c_binding
@@ -44779,7 +44904,9 @@ module hipfort_hipblas
       hipblasCherStridedBatched_assumed_rank = hipblasCherStridedBatched_(handle,uplo,n,alpha,c_loc(x), &
         incx,stridex,c_loc(AP),lda,strideA,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasZherStridedBatched_assumed_rank(handle,uplo,n,alpha,x,incx,stridex,AP,lda,strideA, &
         batchCount)
       use iso_c_binding
@@ -44801,6 +44928,7 @@ module hipfort_hipblas
       hipblasZherStridedBatched_assumed_rank = hipblasZherStridedBatched_(handle,uplo,n,alpha,c_loc(x), &
         incx,stridex,c_loc(AP),lda,strideA,batchCount)
     end function
+#endif
 
     function hipblasCher2_assumed_rank(handle,uplo,n,alpha,x,incx,y,incy,AP,lda)
       use iso_c_binding
@@ -44842,6 +44970,7 @@ module hipfort_hipblas
         c_loc(AP),lda)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasCher2StridedBatched_assumed_rank(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey, &
         AP,lda,strideA,batchCount)
       use iso_c_binding
@@ -44866,7 +44995,9 @@ module hipfort_hipblas
       hipblasCher2StridedBatched_assumed_rank = hipblasCher2StridedBatched_(handle,uplo,n,alpha, &
         c_loc(x),incx,stridex,c_loc(y),incy,stridey,c_loc(AP),lda,strideA,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasZher2StridedBatched_assumed_rank(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey, &
         AP,lda,strideA,batchCount)
       use iso_c_binding
@@ -44891,6 +45022,7 @@ module hipfort_hipblas
       hipblasZher2StridedBatched_assumed_rank = hipblasZher2StridedBatched_(handle,uplo,n,alpha, &
         c_loc(x),incx,stridex,c_loc(y),incy,stridey,c_loc(AP),lda,strideA,batchCount)
     end function
+#endif
 
     function hipblasChpmv_assumed_rank(handle,uplo,n,alpha,AP,x,incx,beta,y,incy)
       use iso_c_binding
@@ -44932,6 +45064,7 @@ module hipfort_hipblas
         c_loc(y),incy)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasChpmvStridedBatched_assumed_rank(handle,uplo,n,alpha,AP,strideA,x,incx,stridex,beta, &
         y,incy,stridey,batchCount)
       use iso_c_binding
@@ -44956,7 +45089,9 @@ module hipfort_hipblas
       hipblasChpmvStridedBatched_assumed_rank = hipblasChpmvStridedBatched_(handle,uplo,n,alpha, &
         c_loc(AP),strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasZhpmvStridedBatched_assumed_rank(handle,uplo,n,alpha,AP,strideA,x,incx,stridex,beta, &
         y,incy,stridey,batchCount)
       use iso_c_binding
@@ -44981,6 +45116,7 @@ module hipfort_hipblas
       hipblasZhpmvStridedBatched_assumed_rank = hipblasZhpmvStridedBatched_(handle,uplo,n,alpha, &
         c_loc(AP),strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
     end function
+#endif
 
     function hipblasChpr_assumed_rank(handle,uplo,n,alpha,x,incx,AP)
       use iso_c_binding
@@ -45014,6 +45150,7 @@ module hipfort_hipblas
       hipblasZhpr_assumed_rank = hipblasZhpr_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(AP))
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasChprStridedBatched_assumed_rank(handle,uplo,n,alpha,x,incx,stridex,AP,strideA, &
         batchCount)
       use iso_c_binding
@@ -45034,7 +45171,9 @@ module hipfort_hipblas
       hipblasChprStridedBatched_assumed_rank = hipblasChprStridedBatched_(handle,uplo,n,alpha,c_loc(x), &
         incx,stridex,c_loc(AP),strideA,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasZhprStridedBatched_assumed_rank(handle,uplo,n,alpha,x,incx,stridex,AP,strideA, &
         batchCount)
       use iso_c_binding
@@ -45055,6 +45194,7 @@ module hipfort_hipblas
       hipblasZhprStridedBatched_assumed_rank = hipblasZhprStridedBatched_(handle,uplo,n,alpha,c_loc(x), &
         incx,stridex,c_loc(AP),strideA,batchCount)
     end function
+#endif
 
     function hipblasChpr2_assumed_rank(handle,uplo,n,alpha,x,incx,y,incy,AP)
       use iso_c_binding
@@ -45092,6 +45232,7 @@ module hipfort_hipblas
       hipblasZhpr2_assumed_rank = hipblasZhpr2_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(y),incy,c_loc(AP))
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasChpr2StridedBatched_assumed_rank(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey, &
         AP,strideA,batchCount)
       use iso_c_binding
@@ -45115,7 +45256,9 @@ module hipfort_hipblas
       hipblasChpr2StridedBatched_assumed_rank = hipblasChpr2StridedBatched_(handle,uplo,n,alpha, &
         c_loc(x),incx,stridex,c_loc(y),incy,stridey,c_loc(AP),strideA,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasZhpr2StridedBatched_assumed_rank(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey, &
         AP,strideA,batchCount)
       use iso_c_binding
@@ -45139,6 +45282,7 @@ module hipfort_hipblas
       hipblasZhpr2StridedBatched_assumed_rank = hipblasZhpr2StridedBatched_(handle,uplo,n,alpha, &
         c_loc(x),incx,stridex,c_loc(y),incy,stridey,c_loc(AP),strideA,batchCount)
     end function
+#endif
 
     function hipblasSsbmv_assumed_rank(handle,uplo,n,k,alpha,AP,lda,x,incx,beta,y,incy)
       use iso_c_binding
@@ -45184,6 +45328,7 @@ module hipfort_hipblas
         c_loc(y),incy)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasSsbmvStridedBatched_assumed_rank(handle,uplo,n,k,alpha,AP,lda,strideA,x,incx, &
         stridex,beta,y,incy,stridey,batchCount)
       use iso_c_binding
@@ -45210,7 +45355,9 @@ module hipfort_hipblas
       hipblasSsbmvStridedBatched_assumed_rank = hipblasSsbmvStridedBatched_(handle,uplo,n,k,alpha, &
         c_loc(AP),lda,strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasDsbmvStridedBatched_assumed_rank(handle,uplo,n,k,alpha,AP,lda,strideA,x,incx, &
         stridex,beta,y,incy,stridey,batchCount)
       use iso_c_binding
@@ -45237,6 +45384,7 @@ module hipfort_hipblas
       hipblasDsbmvStridedBatched_assumed_rank = hipblasDsbmvStridedBatched_(handle,uplo,n,k,alpha, &
         c_loc(AP),lda,strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
     end function
+#endif
 
     function hipblasSspmv_assumed_rank(handle,uplo,n,alpha,AP,x,incx,beta,y,incy)
       use iso_c_binding
@@ -45278,6 +45426,7 @@ module hipfort_hipblas
         c_loc(y),incy)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasSspmvStridedBatched_assumed_rank(handle,uplo,n,alpha,AP,strideA,x,incx,stridex,beta, &
         y,incy,stridey,batchCount)
       use iso_c_binding
@@ -45302,7 +45451,9 @@ module hipfort_hipblas
       hipblasSspmvStridedBatched_assumed_rank = hipblasSspmvStridedBatched_(handle,uplo,n,alpha, &
         c_loc(AP),strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasDspmvStridedBatched_assumed_rank(handle,uplo,n,alpha,AP,strideA,x,incx,stridex,beta, &
         y,incy,stridey,batchCount)
       use iso_c_binding
@@ -45327,6 +45478,7 @@ module hipfort_hipblas
       hipblasDspmvStridedBatched_assumed_rank = hipblasDspmvStridedBatched_(handle,uplo,n,alpha, &
         c_loc(AP),strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
     end function
+#endif
 
     function hipblasSspr_assumed_rank(handle,uplo,n,alpha,x,incx,AP)
       use iso_c_binding
@@ -45360,6 +45512,7 @@ module hipfort_hipblas
       hipblasDspr_assumed_rank = hipblasDspr_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(AP))
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasCspr_assumed_rank(handle,uplo,n,alpha,x,incx,AP)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -45375,7 +45528,9 @@ module hipfort_hipblas
       !
       hipblasCspr_assumed_rank = hipblasCspr_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(AP))
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasZspr_assumed_rank(handle,uplo,n,alpha,x,incx,AP)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -45391,7 +45546,9 @@ module hipfort_hipblas
       !
       hipblasZspr_assumed_rank = hipblasZspr_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(AP))
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasSsprStridedBatched_assumed_rank(handle,uplo,n,alpha,x,incx,stridex,AP,strideA, &
         batchCount)
       use iso_c_binding
@@ -45412,7 +45569,9 @@ module hipfort_hipblas
       hipblasSsprStridedBatched_assumed_rank = hipblasSsprStridedBatched_(handle,uplo,n,alpha,c_loc(x), &
         incx,stridex,c_loc(AP),strideA,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasDsprStridedBatched_assumed_rank(handle,uplo,n,alpha,x,incx,stridex,AP,strideA, &
         batchCount)
       use iso_c_binding
@@ -45433,7 +45592,9 @@ module hipfort_hipblas
       hipblasDsprStridedBatched_assumed_rank = hipblasDsprStridedBatched_(handle,uplo,n,alpha,c_loc(x), &
         incx,stridex,c_loc(AP),strideA,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasCsprStridedBatched_assumed_rank(handle,uplo,n,alpha,x,incx,stridex,AP,strideA, &
         batchCount)
       use iso_c_binding
@@ -45454,7 +45615,9 @@ module hipfort_hipblas
       hipblasCsprStridedBatched_assumed_rank = hipblasCsprStridedBatched_(handle,uplo,n,alpha,c_loc(x), &
         incx,stridex,c_loc(AP),strideA,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasZsprStridedBatched_assumed_rank(handle,uplo,n,alpha,x,incx,stridex,AP,strideA, &
         batchCount)
       use iso_c_binding
@@ -45475,6 +45638,7 @@ module hipfort_hipblas
       hipblasZsprStridedBatched_assumed_rank = hipblasZsprStridedBatched_(handle,uplo,n,alpha,c_loc(x), &
         incx,stridex,c_loc(AP),strideA,batchCount)
     end function
+#endif
 
     function hipblasSspr2_assumed_rank(handle,uplo,n,alpha,x,incx,y,incy,AP)
       use iso_c_binding
@@ -45512,6 +45676,7 @@ module hipfort_hipblas
       hipblasDspr2_assumed_rank = hipblasDspr2_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(y),incy,c_loc(AP))
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasSspr2StridedBatched_assumed_rank(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey, &
         AP,strideA,batchCount)
       use iso_c_binding
@@ -45535,7 +45700,9 @@ module hipfort_hipblas
       hipblasSspr2StridedBatched_assumed_rank = hipblasSspr2StridedBatched_(handle,uplo,n,alpha, &
         c_loc(x),incx,stridex,c_loc(y),incy,stridey,c_loc(AP),strideA,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasDspr2StridedBatched_assumed_rank(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey, &
         AP,strideA,batchCount)
       use iso_c_binding
@@ -45559,6 +45726,7 @@ module hipfort_hipblas
       hipblasDspr2StridedBatched_assumed_rank = hipblasDspr2StridedBatched_(handle,uplo,n,alpha, &
         c_loc(x),incx,stridex,c_loc(y),incy,stridey,c_loc(AP),strideA,batchCount)
     end function
+#endif
 
     function hipblasSsymv_assumed_rank(handle,uplo,n,alpha,AP,lda,x,incx,beta,y,incy)
       use iso_c_binding
@@ -45644,6 +45812,7 @@ module hipfort_hipblas
         c_loc(y),incy)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasSsymvStridedBatched_assumed_rank(handle,uplo,n,alpha,AP,lda,strideA,x,incx,stridex, &
         beta,y,incy,stridey,batchCount)
       use iso_c_binding
@@ -45669,7 +45838,9 @@ module hipfort_hipblas
       hipblasSsymvStridedBatched_assumed_rank = hipblasSsymvStridedBatched_(handle,uplo,n,alpha, &
         c_loc(AP),lda,strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasDsymvStridedBatched_assumed_rank(handle,uplo,n,alpha,AP,lda,strideA,x,incx,stridex, &
         beta,y,incy,stridey,batchCount)
       use iso_c_binding
@@ -45695,7 +45866,9 @@ module hipfort_hipblas
       hipblasDsymvStridedBatched_assumed_rank = hipblasDsymvStridedBatched_(handle,uplo,n,alpha, &
         c_loc(AP),lda,strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasCsymvStridedBatched_assumed_rank(handle,uplo,n,alpha,AP,lda,strideA,x,incx,stridex, &
         beta,y,incy,stridey,batchCount)
       use iso_c_binding
@@ -45721,7 +45894,9 @@ module hipfort_hipblas
       hipblasCsymvStridedBatched_assumed_rank = hipblasCsymvStridedBatched_(handle,uplo,n,alpha, &
         c_loc(AP),lda,strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasZsymvStridedBatched_assumed_rank(handle,uplo,n,alpha,AP,lda,strideA,x,incx,stridex, &
         beta,y,incy,stridey,batchCount)
       use iso_c_binding
@@ -45747,6 +45922,7 @@ module hipfort_hipblas
       hipblasZsymvStridedBatched_assumed_rank = hipblasZsymvStridedBatched_(handle,uplo,n,alpha, &
         c_loc(AP),lda,strideA,c_loc(x),incx,stridex,beta,c_loc(y),incy,stridey,batchCount)
     end function
+#endif
 
     function hipblasSsyr_assumed_rank(handle,uplo,n,alpha,x,incx,AP,lda)
       use iso_c_binding
@@ -45816,6 +45992,7 @@ module hipfort_hipblas
       hipblasZsyr_assumed_rank = hipblasZsyr_(handle,uplo,n,alpha,c_loc(x),incx,c_loc(AP),lda)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasSsyrStridedBatched_assumed_rank(handle,uplo,n,alpha,x,incx,stridex,AP,lda,strideA, &
         batchCount)
       use iso_c_binding
@@ -45837,7 +46014,9 @@ module hipfort_hipblas
       hipblasSsyrStridedBatched_assumed_rank = hipblasSsyrStridedBatched_(handle,uplo,n,alpha,c_loc(x), &
         incx,stridex,c_loc(AP),lda,strideA,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasDsyrStridedBatched_assumed_rank(handle,uplo,n,alpha,x,incx,stridex,AP,lda,strideA, &
         batchCount)
       use iso_c_binding
@@ -45859,7 +46038,9 @@ module hipfort_hipblas
       hipblasDsyrStridedBatched_assumed_rank = hipblasDsyrStridedBatched_(handle,uplo,n,alpha,c_loc(x), &
         incx,stridex,c_loc(AP),lda,strideA,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasCsyrStridedBatched_assumed_rank(handle,uplo,n,alpha,x,incx,stridex,AP,lda,strideA, &
         batchCount)
       use iso_c_binding
@@ -45881,7 +46062,9 @@ module hipfort_hipblas
       hipblasCsyrStridedBatched_assumed_rank = hipblasCsyrStridedBatched_(handle,uplo,n,alpha,c_loc(x), &
         incx,stridex,c_loc(AP),lda,strideA,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasZsyrStridedBatched_assumed_rank(handle,uplo,n,alpha,x,incx,stridex,AP,lda,strideA, &
         batchCount)
       use iso_c_binding
@@ -45903,6 +46086,7 @@ module hipfort_hipblas
       hipblasZsyrStridedBatched_assumed_rank = hipblasZsyrStridedBatched_(handle,uplo,n,alpha,c_loc(x), &
         incx,stridex,c_loc(AP),lda,strideA,batchCount)
     end function
+#endif
 
     function hipblasSsyr2_assumed_rank(handle,uplo,n,alpha,x,incx,y,incy,AP,lda)
       use iso_c_binding
@@ -45984,6 +46168,7 @@ module hipfort_hipblas
         c_loc(AP),lda)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasSsyr2StridedBatched_assumed_rank(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey, &
         AP,lda,strideA,batchCount)
       use iso_c_binding
@@ -46008,7 +46193,9 @@ module hipfort_hipblas
       hipblasSsyr2StridedBatched_assumed_rank = hipblasSsyr2StridedBatched_(handle,uplo,n,alpha, &
         c_loc(x),incx,stridex,c_loc(y),incy,stridey,c_loc(AP),lda,strideA,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasDsyr2StridedBatched_assumed_rank(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey, &
         AP,lda,strideA,batchCount)
       use iso_c_binding
@@ -46033,7 +46220,9 @@ module hipfort_hipblas
       hipblasDsyr2StridedBatched_assumed_rank = hipblasDsyr2StridedBatched_(handle,uplo,n,alpha, &
         c_loc(x),incx,stridex,c_loc(y),incy,stridey,c_loc(AP),lda,strideA,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasCsyr2StridedBatched_assumed_rank(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey, &
         AP,lda,strideA,batchCount)
       use iso_c_binding
@@ -46058,7 +46247,9 @@ module hipfort_hipblas
       hipblasCsyr2StridedBatched_assumed_rank = hipblasCsyr2StridedBatched_(handle,uplo,n,alpha, &
         c_loc(x),incx,stridex,c_loc(y),incy,stridey,c_loc(AP),lda,strideA,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasZsyr2StridedBatched_assumed_rank(handle,uplo,n,alpha,x,incx,stridex,y,incy,stridey, &
         AP,lda,strideA,batchCount)
       use iso_c_binding
@@ -46083,6 +46274,7 @@ module hipfort_hipblas
       hipblasZsyr2StridedBatched_assumed_rank = hipblasZsyr2StridedBatched_(handle,uplo,n,alpha, &
         c_loc(x),incx,stridex,c_loc(y),incy,stridey,c_loc(AP),lda,strideA,batchCount)
     end function
+#endif
 
     function hipblasStbmv_assumed_rank(handle,uplo,transA,diag,n,k,AP,lda,x,incx)
       use iso_c_binding
@@ -46160,6 +46352,7 @@ module hipfort_hipblas
       hipblasZtbmv_assumed_rank = hipblasZtbmv_(handle,uplo,transA,diag,n,k,c_loc(AP),lda,c_loc(x),incx)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasStbmvStridedBatched_assumed_rank(handle,uplo,transA,diag,n,k,AP,lda,strideA,x,incx, &
         stridex,batchCount)
       use iso_c_binding
@@ -46183,7 +46376,9 @@ module hipfort_hipblas
       hipblasStbmvStridedBatched_assumed_rank = hipblasStbmvStridedBatched_(handle,uplo,transA,diag,n,k, &
         c_loc(AP),lda,strideA,c_loc(x),incx,stridex,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasDtbmvStridedBatched_assumed_rank(handle,uplo,transA,diag,n,k,AP,lda,strideA,x,incx, &
         stridex,batchCount)
       use iso_c_binding
@@ -46207,7 +46402,9 @@ module hipfort_hipblas
       hipblasDtbmvStridedBatched_assumed_rank = hipblasDtbmvStridedBatched_(handle,uplo,transA,diag,n,k, &
         c_loc(AP),lda,strideA,c_loc(x),incx,stridex,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasCtbmvStridedBatched_assumed_rank(handle,uplo,transA,diag,n,k,AP,lda,strideA,x,incx, &
         stridex,batchCount)
       use iso_c_binding
@@ -46231,7 +46428,9 @@ module hipfort_hipblas
       hipblasCtbmvStridedBatched_assumed_rank = hipblasCtbmvStridedBatched_(handle,uplo,transA,diag,n,k, &
         c_loc(AP),lda,strideA,c_loc(x),incx,stridex,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasZtbmvStridedBatched_assumed_rank(handle,uplo,transA,diag,n,k,AP,lda,strideA,x,incx, &
         stridex,batchCount)
       use iso_c_binding
@@ -46255,6 +46454,7 @@ module hipfort_hipblas
       hipblasZtbmvStridedBatched_assumed_rank = hipblasZtbmvStridedBatched_(handle,uplo,transA,diag,n,k, &
         c_loc(AP),lda,strideA,c_loc(x),incx,stridex,batchCount)
     end function
+#endif
 
     function hipblasStbsv_assumed_rank(handle,uplo,transA,diag,n,k,AP,lda,x,incx)
       use iso_c_binding
@@ -46332,6 +46532,7 @@ module hipfort_hipblas
       hipblasZtbsv_assumed_rank = hipblasZtbsv_(handle,uplo,transA,diag,n,k,c_loc(AP),lda,c_loc(x),incx)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasStbsvStridedBatched_assumed_rank(handle,uplo,transA,diag,n,k,AP,lda,strideA,x,incx, &
         stridex,batchCount)
       use iso_c_binding
@@ -46355,7 +46556,9 @@ module hipfort_hipblas
       hipblasStbsvStridedBatched_assumed_rank = hipblasStbsvStridedBatched_(handle,uplo,transA,diag,n,k, &
         c_loc(AP),lda,strideA,c_loc(x),incx,stridex,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasDtbsvStridedBatched_assumed_rank(handle,uplo,transA,diag,n,k,AP,lda,strideA,x,incx, &
         stridex,batchCount)
       use iso_c_binding
@@ -46379,7 +46582,9 @@ module hipfort_hipblas
       hipblasDtbsvStridedBatched_assumed_rank = hipblasDtbsvStridedBatched_(handle,uplo,transA,diag,n,k, &
         c_loc(AP),lda,strideA,c_loc(x),incx,stridex,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasCtbsvStridedBatched_assumed_rank(handle,uplo,transA,diag,n,k,AP,lda,strideA,x,incx, &
         stridex,batchCount)
       use iso_c_binding
@@ -46403,7 +46608,9 @@ module hipfort_hipblas
       hipblasCtbsvStridedBatched_assumed_rank = hipblasCtbsvStridedBatched_(handle,uplo,transA,diag,n,k, &
         c_loc(AP),lda,strideA,c_loc(x),incx,stridex,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasZtbsvStridedBatched_assumed_rank(handle,uplo,transA,diag,n,k,AP,lda,strideA,x,incx, &
         stridex,batchCount)
       use iso_c_binding
@@ -46427,6 +46634,7 @@ module hipfort_hipblas
       hipblasZtbsvStridedBatched_assumed_rank = hipblasZtbsvStridedBatched_(handle,uplo,transA,diag,n,k, &
         c_loc(AP),lda,strideA,c_loc(x),incx,stridex,batchCount)
     end function
+#endif
 
     function hipblasStpmv_assumed_rank(handle,uplo,transA,diag,n,AP,x,incx)
       use iso_c_binding
@@ -46496,6 +46704,7 @@ module hipfort_hipblas
       hipblasZtpmv_assumed_rank = hipblasZtpmv_(handle,uplo,transA,diag,n,c_loc(AP),c_loc(x),incx)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasStpmvStridedBatched_assumed_rank(handle,uplo,transA,diag,n,AP,strideA,x,incx, &
         stridex,batchCount)
       use iso_c_binding
@@ -46517,7 +46726,9 @@ module hipfort_hipblas
       hipblasStpmvStridedBatched_assumed_rank = hipblasStpmvStridedBatched_(handle,uplo,transA,diag,n, &
         c_loc(AP),strideA,c_loc(x),incx,stridex,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasDtpmvStridedBatched_assumed_rank(handle,uplo,transA,diag,n,AP,strideA,x,incx, &
         stridex,batchCount)
       use iso_c_binding
@@ -46539,7 +46750,9 @@ module hipfort_hipblas
       hipblasDtpmvStridedBatched_assumed_rank = hipblasDtpmvStridedBatched_(handle,uplo,transA,diag,n, &
         c_loc(AP),strideA,c_loc(x),incx,stridex,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasCtpmvStridedBatched_assumed_rank(handle,uplo,transA,diag,n,AP,strideA,x,incx, &
         stridex,batchCount)
       use iso_c_binding
@@ -46561,7 +46774,9 @@ module hipfort_hipblas
       hipblasCtpmvStridedBatched_assumed_rank = hipblasCtpmvStridedBatched_(handle,uplo,transA,diag,n, &
         c_loc(AP),strideA,c_loc(x),incx,stridex,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasZtpmvStridedBatched_assumed_rank(handle,uplo,transA,diag,n,AP,strideA,x,incx, &
         stridex,batchCount)
       use iso_c_binding
@@ -46583,6 +46798,7 @@ module hipfort_hipblas
       hipblasZtpmvStridedBatched_assumed_rank = hipblasZtpmvStridedBatched_(handle,uplo,transA,diag,n, &
         c_loc(AP),strideA,c_loc(x),incx,stridex,batchCount)
     end function
+#endif
 
     function hipblasStpsv_assumed_rank(handle,uplo,transA,diag,n,AP,x,incx)
       use iso_c_binding
@@ -46652,6 +46868,7 @@ module hipfort_hipblas
       hipblasZtpsv_assumed_rank = hipblasZtpsv_(handle,uplo,transA,diag,n,c_loc(AP),c_loc(x),incx)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasStpsvStridedBatched_assumed_rank(handle,uplo,transA,diag,n,AP,strideA,x,incx, &
         stridex,batchCount)
       use iso_c_binding
@@ -46673,7 +46890,9 @@ module hipfort_hipblas
       hipblasStpsvStridedBatched_assumed_rank = hipblasStpsvStridedBatched_(handle,uplo,transA,diag,n, &
         c_loc(AP),strideA,c_loc(x),incx,stridex,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasDtpsvStridedBatched_assumed_rank(handle,uplo,transA,diag,n,AP,strideA,x,incx, &
         stridex,batchCount)
       use iso_c_binding
@@ -46695,7 +46914,9 @@ module hipfort_hipblas
       hipblasDtpsvStridedBatched_assumed_rank = hipblasDtpsvStridedBatched_(handle,uplo,transA,diag,n, &
         c_loc(AP),strideA,c_loc(x),incx,stridex,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasCtpsvStridedBatched_assumed_rank(handle,uplo,transA,diag,n,AP,strideA,x,incx, &
         stridex,batchCount)
       use iso_c_binding
@@ -46717,7 +46938,9 @@ module hipfort_hipblas
       hipblasCtpsvStridedBatched_assumed_rank = hipblasCtpsvStridedBatched_(handle,uplo,transA,diag,n, &
         c_loc(AP),strideA,c_loc(x),incx,stridex,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasZtpsvStridedBatched_assumed_rank(handle,uplo,transA,diag,n,AP,strideA,x,incx, &
         stridex,batchCount)
       use iso_c_binding
@@ -46739,6 +46962,7 @@ module hipfort_hipblas
       hipblasZtpsvStridedBatched_assumed_rank = hipblasZtpsvStridedBatched_(handle,uplo,transA,diag,n, &
         c_loc(AP),strideA,c_loc(x),incx,stridex,batchCount)
     end function
+#endif
 
     function hipblasStrmv_assumed_rank(handle,uplo,transA,diag,n,AP,lda,x,incx)
       use iso_c_binding
@@ -46812,6 +47036,7 @@ module hipfort_hipblas
       hipblasZtrmv_assumed_rank = hipblasZtrmv_(handle,uplo,transA,diag,n,c_loc(AP),lda,c_loc(x),incx)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasStrmvStridedBatched_assumed_rank(handle,uplo,transA,diag,n,AP,lda,strideA,x,incx, &
         stridex,batchCount)
       use iso_c_binding
@@ -46834,7 +47059,9 @@ module hipfort_hipblas
       hipblasStrmvStridedBatched_assumed_rank = hipblasStrmvStridedBatched_(handle,uplo,transA,diag,n, &
         c_loc(AP),lda,strideA,c_loc(x),incx,stridex,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasDtrmvStridedBatched_assumed_rank(handle,uplo,transA,diag,n,AP,lda,strideA,x,incx, &
         stridex,batchCount)
       use iso_c_binding
@@ -46857,7 +47084,9 @@ module hipfort_hipblas
       hipblasDtrmvStridedBatched_assumed_rank = hipblasDtrmvStridedBatched_(handle,uplo,transA,diag,n, &
         c_loc(AP),lda,strideA,c_loc(x),incx,stridex,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasCtrmvStridedBatched_assumed_rank(handle,uplo,transA,diag,n,AP,lda,strideA,x,incx, &
         stridex,batchCount)
       use iso_c_binding
@@ -46880,7 +47109,9 @@ module hipfort_hipblas
       hipblasCtrmvStridedBatched_assumed_rank = hipblasCtrmvStridedBatched_(handle,uplo,transA,diag,n, &
         c_loc(AP),lda,strideA,c_loc(x),incx,stridex,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasZtrmvStridedBatched_assumed_rank(handle,uplo,transA,diag,n,AP,lda,strideA,x,incx, &
         stridex,batchCount)
       use iso_c_binding
@@ -46903,6 +47134,7 @@ module hipfort_hipblas
       hipblasZtrmvStridedBatched_assumed_rank = hipblasZtrmvStridedBatched_(handle,uplo,transA,diag,n, &
         c_loc(AP),lda,strideA,c_loc(x),incx,stridex,batchCount)
     end function
+#endif
 
     function hipblasStrsv_assumed_rank(handle,uplo,transA,diag,n,AP,lda,x,incx)
       use iso_c_binding
@@ -46976,6 +47208,7 @@ module hipfort_hipblas
       hipblasZtrsv_assumed_rank = hipblasZtrsv_(handle,uplo,transA,diag,n,c_loc(AP),lda,c_loc(x),incx)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasStrsvStridedBatched_assumed_rank(handle,uplo,transA,diag,n,AP,lda,strideA,x,incx, &
         stridex,batchCount)
       use iso_c_binding
@@ -46998,7 +47231,9 @@ module hipfort_hipblas
       hipblasStrsvStridedBatched_assumed_rank = hipblasStrsvStridedBatched_(handle,uplo,transA,diag,n, &
         c_loc(AP),lda,strideA,c_loc(x),incx,stridex,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasDtrsvStridedBatched_assumed_rank(handle,uplo,transA,diag,n,AP,lda,strideA,x,incx, &
         stridex,batchCount)
       use iso_c_binding
@@ -47021,7 +47256,9 @@ module hipfort_hipblas
       hipblasDtrsvStridedBatched_assumed_rank = hipblasDtrsvStridedBatched_(handle,uplo,transA,diag,n, &
         c_loc(AP),lda,strideA,c_loc(x),incx,stridex,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasCtrsvStridedBatched_assumed_rank(handle,uplo,transA,diag,n,AP,lda,strideA,x,incx, &
         stridex,batchCount)
       use iso_c_binding
@@ -47044,7 +47281,9 @@ module hipfort_hipblas
       hipblasCtrsvStridedBatched_assumed_rank = hipblasCtrsvStridedBatched_(handle,uplo,transA,diag,n, &
         c_loc(AP),lda,strideA,c_loc(x),incx,stridex,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasZtrsvStridedBatched_assumed_rank(handle,uplo,transA,diag,n,AP,lda,strideA,x,incx, &
         stridex,batchCount)
       use iso_c_binding
@@ -47067,6 +47306,7 @@ module hipfort_hipblas
       hipblasZtrsvStridedBatched_assumed_rank = hipblasZtrsvStridedBatched_(handle,uplo,transA,diag,n, &
         c_loc(AP),lda,strideA,c_loc(x),incx,stridex,batchCount)
     end function
+#endif
 
     function hipblasSgemm_assumed_rank(handle,transA,transB,m,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc)
       use iso_c_binding
@@ -47322,6 +47562,7 @@ module hipfort_hipblas
         c_loc(CP),ldc)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasCherkStridedBatched_assumed_rank(handle,uplo,transA,n,k,alpha,AP,lda,strideA,beta, &
         CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -47346,7 +47587,9 @@ module hipfort_hipblas
       hipblasCherkStridedBatched_assumed_rank = hipblasCherkStridedBatched_(handle,uplo,transA,n,k, &
         alpha,c_loc(AP),lda,strideA,beta,c_loc(CP),ldc,strideC,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasZherkStridedBatched_assumed_rank(handle,uplo,transA,n,k,alpha,AP,lda,strideA,beta, &
         CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -47371,6 +47614,7 @@ module hipfort_hipblas
       hipblasZherkStridedBatched_assumed_rank = hipblasZherkStridedBatched_(handle,uplo,transA,n,k, &
         alpha,c_loc(AP),lda,strideA,beta,c_loc(CP),ldc,strideC,batchCount)
     end function
+#endif
 
     function hipblasCherkx_assumed_rank(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc)
       use iso_c_binding
@@ -47418,6 +47662,7 @@ module hipfort_hipblas
         ldb,beta,c_loc(CP),ldc)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasCherkxStridedBatched_assumed_rank(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP, &
         ldb,strideB,beta,CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -47445,7 +47690,9 @@ module hipfort_hipblas
       hipblasCherkxStridedBatched_assumed_rank = hipblasCherkxStridedBatched_(handle,uplo,transA,n,k, &
         alpha,c_loc(AP),lda,strideA,c_loc(BP),ldb,strideB,beta,c_loc(CP),ldc,strideC,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasZherkxStridedBatched_assumed_rank(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP, &
         ldb,strideB,beta,CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -47473,6 +47720,7 @@ module hipfort_hipblas
       hipblasZherkxStridedBatched_assumed_rank = hipblasZherkxStridedBatched_(handle,uplo,transA,n,k, &
         alpha,c_loc(AP),lda,strideA,c_loc(BP),ldb,strideB,beta,c_loc(CP),ldc,strideC,batchCount)
     end function
+#endif
 
     function hipblasCher2k_assumed_rank(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc)
       use iso_c_binding
@@ -47520,6 +47768,7 @@ module hipfort_hipblas
         ldb,beta,c_loc(CP),ldc)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasCher2kStridedBatched_assumed_rank(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP, &
         ldb,strideB,beta,CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -47547,7 +47796,9 @@ module hipfort_hipblas
       hipblasCher2kStridedBatched_assumed_rank = hipblasCher2kStridedBatched_(handle,uplo,transA,n,k, &
         alpha,c_loc(AP),lda,strideA,c_loc(BP),ldb,strideB,beta,c_loc(CP),ldc,strideC,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasZher2kStridedBatched_assumed_rank(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP, &
         ldb,strideB,beta,CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -47575,6 +47826,7 @@ module hipfort_hipblas
       hipblasZher2kStridedBatched_assumed_rank = hipblasZher2kStridedBatched_(handle,uplo,transA,n,k, &
         alpha,c_loc(AP),lda,strideA,c_loc(BP),ldb,strideB,beta,c_loc(CP),ldc,strideC,batchCount)
     end function
+#endif
 
     function hipblasSsymm_assumed_rank(handle,side,uplo,m,n,alpha,AP,lda,BP,ldb,beta,CP,ldc)
       use iso_c_binding
@@ -47668,6 +47920,7 @@ module hipfort_hipblas
         beta,c_loc(CP),ldc)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasSsymmStridedBatched_assumed_rank(handle,side,uplo,m,n,alpha,AP,lda,strideA,BP,ldb, &
         strideB,beta,CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -47695,7 +47948,9 @@ module hipfort_hipblas
       hipblasSsymmStridedBatched_assumed_rank = hipblasSsymmStridedBatched_(handle,side,uplo,m,n,alpha, &
         c_loc(AP),lda,strideA,c_loc(BP),ldb,strideB,beta,c_loc(CP),ldc,strideC,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasDsymmStridedBatched_assumed_rank(handle,side,uplo,m,n,alpha,AP,lda,strideA,BP,ldb, &
         strideB,beta,CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -47723,7 +47978,9 @@ module hipfort_hipblas
       hipblasDsymmStridedBatched_assumed_rank = hipblasDsymmStridedBatched_(handle,side,uplo,m,n,alpha, &
         c_loc(AP),lda,strideA,c_loc(BP),ldb,strideB,beta,c_loc(CP),ldc,strideC,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasCsymmStridedBatched_assumed_rank(handle,side,uplo,m,n,alpha,AP,lda,strideA,BP,ldb, &
         strideB,beta,CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -47751,7 +48008,9 @@ module hipfort_hipblas
       hipblasCsymmStridedBatched_assumed_rank = hipblasCsymmStridedBatched_(handle,side,uplo,m,n,alpha, &
         c_loc(AP),lda,strideA,c_loc(BP),ldb,strideB,beta,c_loc(CP),ldc,strideC,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasZsymmStridedBatched_assumed_rank(handle,side,uplo,m,n,alpha,AP,lda,strideA,BP,ldb, &
         strideB,beta,CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -47779,6 +48038,7 @@ module hipfort_hipblas
       hipblasZsymmStridedBatched_assumed_rank = hipblasZsymmStridedBatched_(handle,side,uplo,m,n,alpha, &
         c_loc(AP),lda,strideA,c_loc(BP),ldb,strideB,beta,c_loc(CP),ldc,strideC,batchCount)
     end function
+#endif
 
     function hipblasSsyrk_assumed_rank(handle,uplo,transA,n,k,alpha,AP,lda,beta,CP,ldc)
       use iso_c_binding
@@ -47864,6 +48124,7 @@ module hipfort_hipblas
         c_loc(CP),ldc)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasSsyrkStridedBatched_assumed_rank(handle,uplo,transA,n,k,alpha,AP,lda,strideA,beta, &
         CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -47888,7 +48149,9 @@ module hipfort_hipblas
       hipblasSsyrkStridedBatched_assumed_rank = hipblasSsyrkStridedBatched_(handle,uplo,transA,n,k, &
         alpha,c_loc(AP),lda,strideA,beta,c_loc(CP),ldc,strideC,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasDsyrkStridedBatched_assumed_rank(handle,uplo,transA,n,k,alpha,AP,lda,strideA,beta, &
         CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -47913,7 +48176,9 @@ module hipfort_hipblas
       hipblasDsyrkStridedBatched_assumed_rank = hipblasDsyrkStridedBatched_(handle,uplo,transA,n,k, &
         alpha,c_loc(AP),lda,strideA,beta,c_loc(CP),ldc,strideC,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasCsyrkStridedBatched_assumed_rank(handle,uplo,transA,n,k,alpha,AP,lda,strideA,beta, &
         CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -47938,7 +48203,9 @@ module hipfort_hipblas
       hipblasCsyrkStridedBatched_assumed_rank = hipblasCsyrkStridedBatched_(handle,uplo,transA,n,k, &
         alpha,c_loc(AP),lda,strideA,beta,c_loc(CP),ldc,strideC,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasZsyrkStridedBatched_assumed_rank(handle,uplo,transA,n,k,alpha,AP,lda,strideA,beta, &
         CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -47963,6 +48230,7 @@ module hipfort_hipblas
       hipblasZsyrkStridedBatched_assumed_rank = hipblasZsyrkStridedBatched_(handle,uplo,transA,n,k, &
         alpha,c_loc(AP),lda,strideA,beta,c_loc(CP),ldc,strideC,batchCount)
     end function
+#endif
 
     function hipblasSsyr2k_assumed_rank(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc)
       use iso_c_binding
@@ -48056,6 +48324,7 @@ module hipfort_hipblas
         ldb,beta,c_loc(CP),ldc)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasSsyr2kStridedBatched_assumed_rank(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP, &
         ldb,strideB,beta,CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -48083,7 +48352,9 @@ module hipfort_hipblas
       hipblasSsyr2kStridedBatched_assumed_rank = hipblasSsyr2kStridedBatched_(handle,uplo,transA,n,k, &
         alpha,c_loc(AP),lda,strideA,c_loc(BP),ldb,strideB,beta,c_loc(CP),ldc,strideC,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasDsyr2kStridedBatched_assumed_rank(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP, &
         ldb,strideB,beta,CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -48111,7 +48382,9 @@ module hipfort_hipblas
       hipblasDsyr2kStridedBatched_assumed_rank = hipblasDsyr2kStridedBatched_(handle,uplo,transA,n,k, &
         alpha,c_loc(AP),lda,strideA,c_loc(BP),ldb,strideB,beta,c_loc(CP),ldc,strideC,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasCsyr2kStridedBatched_assumed_rank(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP, &
         ldb,strideB,beta,CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -48139,7 +48412,9 @@ module hipfort_hipblas
       hipblasCsyr2kStridedBatched_assumed_rank = hipblasCsyr2kStridedBatched_(handle,uplo,transA,n,k, &
         alpha,c_loc(AP),lda,strideA,c_loc(BP),ldb,strideB,beta,c_loc(CP),ldc,strideC,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasZsyr2kStridedBatched_assumed_rank(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP, &
         ldb,strideB,beta,CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -48167,6 +48442,7 @@ module hipfort_hipblas
       hipblasZsyr2kStridedBatched_assumed_rank = hipblasZsyr2kStridedBatched_(handle,uplo,transA,n,k, &
         alpha,c_loc(AP),lda,strideA,c_loc(BP),ldb,strideB,beta,c_loc(CP),ldc,strideC,batchCount)
     end function
+#endif
 
     function hipblasSsyrkx_assumed_rank(handle,uplo,transA,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc)
       use iso_c_binding
@@ -48260,6 +48536,7 @@ module hipfort_hipblas
         ldb,beta,c_loc(CP),ldc)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasSsyrkxStridedBatched_assumed_rank(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP, &
         ldb,strideB,beta,CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -48287,7 +48564,9 @@ module hipfort_hipblas
       hipblasSsyrkxStridedBatched_assumed_rank = hipblasSsyrkxStridedBatched_(handle,uplo,transA,n,k, &
         alpha,c_loc(AP),lda,strideA,c_loc(BP),ldb,strideB,beta,c_loc(CP),ldc,strideC,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasDsyrkxStridedBatched_assumed_rank(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP, &
         ldb,strideB,beta,CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -48315,7 +48594,9 @@ module hipfort_hipblas
       hipblasDsyrkxStridedBatched_assumed_rank = hipblasDsyrkxStridedBatched_(handle,uplo,transA,n,k, &
         alpha,c_loc(AP),lda,strideA,c_loc(BP),ldb,strideB,beta,c_loc(CP),ldc,strideC,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasCsyrkxStridedBatched_assumed_rank(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP, &
         ldb,strideB,beta,CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -48343,7 +48624,9 @@ module hipfort_hipblas
       hipblasCsyrkxStridedBatched_assumed_rank = hipblasCsyrkxStridedBatched_(handle,uplo,transA,n,k, &
         alpha,c_loc(AP),lda,strideA,c_loc(BP),ldb,strideB,beta,c_loc(CP),ldc,strideC,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasZsyrkxStridedBatched_assumed_rank(handle,uplo,transA,n,k,alpha,AP,lda,strideA,BP, &
         ldb,strideB,beta,CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -48371,6 +48654,7 @@ module hipfort_hipblas
       hipblasZsyrkxStridedBatched_assumed_rank = hipblasZsyrkxStridedBatched_(handle,uplo,transA,n,k, &
         alpha,c_loc(AP),lda,strideA,c_loc(BP),ldb,strideB,beta,c_loc(CP),ldc,strideC,batchCount)
     end function
+#endif
 
     function hipblasSgeam_assumed_rank(handle,transA,transB,m,n,alpha,AP,lda,beta,BP,ldb,CP,ldc)
       use iso_c_binding
@@ -48464,6 +48748,7 @@ module hipfort_hipblas
         c_loc(BP),ldb,c_loc(CP),ldc)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasSgeamStridedBatched_assumed_rank(handle,transA,transB,m,n,alpha,AP,lda,strideA,beta, &
         BP,ldb,strideB,CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -48491,7 +48776,9 @@ module hipfort_hipblas
       hipblasSgeamStridedBatched_assumed_rank = hipblasSgeamStridedBatched_(handle,transA,transB,m,n, &
         alpha,c_loc(AP),lda,strideA,beta,c_loc(BP),ldb,strideB,c_loc(CP),ldc,strideC,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasDgeamStridedBatched_assumed_rank(handle,transA,transB,m,n,alpha,AP,lda,strideA,beta, &
         BP,ldb,strideB,CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -48519,7 +48806,9 @@ module hipfort_hipblas
       hipblasDgeamStridedBatched_assumed_rank = hipblasDgeamStridedBatched_(handle,transA,transB,m,n, &
         alpha,c_loc(AP),lda,strideA,beta,c_loc(BP),ldb,strideB,c_loc(CP),ldc,strideC,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasCgeamStridedBatched_assumed_rank(handle,transA,transB,m,n,alpha,AP,lda,strideA,beta, &
         BP,ldb,strideB,CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -48547,7 +48836,9 @@ module hipfort_hipblas
       hipblasCgeamStridedBatched_assumed_rank = hipblasCgeamStridedBatched_(handle,transA,transB,m,n, &
         alpha,c_loc(AP),lda,strideA,beta,c_loc(BP),ldb,strideB,c_loc(CP),ldc,strideC,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasZgeamStridedBatched_assumed_rank(handle,transA,transB,m,n,alpha,AP,lda,strideA,beta, &
         BP,ldb,strideB,CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -48575,6 +48866,7 @@ module hipfort_hipblas
       hipblasZgeamStridedBatched_assumed_rank = hipblasZgeamStridedBatched_(handle,transA,transB,m,n, &
         alpha,c_loc(AP),lda,strideA,beta,c_loc(BP),ldb,strideB,c_loc(CP),ldc,strideC,batchCount)
     end function
+#endif
 
     function hipblasChemm_assumed_rank(handle,side,uplo,n,k,alpha,AP,lda,BP,ldb,beta,CP,ldc)
       use iso_c_binding
@@ -48622,6 +48914,7 @@ module hipfort_hipblas
         beta,c_loc(CP),ldc)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasChemmStridedBatched_assumed_rank(handle,side,uplo,n,k,alpha,AP,lda,strideA,BP,ldb, &
         strideB,beta,CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -48649,7 +48942,9 @@ module hipfort_hipblas
       hipblasChemmStridedBatched_assumed_rank = hipblasChemmStridedBatched_(handle,side,uplo,n,k,alpha, &
         c_loc(AP),lda,strideA,c_loc(BP),ldb,strideB,beta,c_loc(CP),ldc,strideC,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasZhemmStridedBatched_assumed_rank(handle,side,uplo,n,k,alpha,AP,lda,strideA,BP,ldb, &
         strideB,beta,CP,ldc,strideC,batchCount)
       use iso_c_binding
@@ -48677,6 +48972,7 @@ module hipfort_hipblas
       hipblasZhemmStridedBatched_assumed_rank = hipblasZhemmStridedBatched_(handle,side,uplo,n,k,alpha, &
         c_loc(AP),lda,strideA,c_loc(BP),ldb,strideB,beta,c_loc(CP),ldc,strideC,batchCount)
     end function
+#endif
 
     function hipblasStrmm_assumed_rank(handle,side,uplo,transA,diag,m,n,alpha,A,lda,B,ldb,C,ldc)
       use iso_c_binding
@@ -48774,6 +49070,7 @@ module hipfort_hipblas
         c_loc(B),ldb,c_loc(C),ldc)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasStrmmStridedBatched_assumed_rank(handle,side,uplo,transA,diag,m,n,alpha,A,lda, &
         strideA,B,ldb,strideB,C,ldc,strideC,batchCount)
       use iso_c_binding
@@ -48802,7 +49099,9 @@ module hipfort_hipblas
       hipblasStrmmStridedBatched_assumed_rank = hipblasStrmmStridedBatched_(handle,side,uplo,transA, &
         diag,m,n,alpha,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(C),ldc,strideC,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasDtrmmStridedBatched_assumed_rank(handle,side,uplo,transA,diag,m,n,alpha,A,lda, &
         strideA,B,ldb,strideB,C,ldc,strideC,batchCount)
       use iso_c_binding
@@ -48831,7 +49130,9 @@ module hipfort_hipblas
       hipblasDtrmmStridedBatched_assumed_rank = hipblasDtrmmStridedBatched_(handle,side,uplo,transA, &
         diag,m,n,alpha,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(C),ldc,strideC,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasCtrmmStridedBatched_assumed_rank(handle,side,uplo,transA,diag,m,n,alpha,A,lda, &
         strideA,B,ldb,strideB,C,ldc,strideC,batchCount)
       use iso_c_binding
@@ -48860,7 +49161,9 @@ module hipfort_hipblas
       hipblasCtrmmStridedBatched_assumed_rank = hipblasCtrmmStridedBatched_(handle,side,uplo,transA, &
         diag,m,n,alpha,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(C),ldc,strideC,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasZtrmmStridedBatched_assumed_rank(handle,side,uplo,transA,diag,m,n,alpha,A,lda, &
         strideA,B,ldb,strideB,C,ldc,strideC,batchCount)
       use iso_c_binding
@@ -48889,6 +49192,7 @@ module hipfort_hipblas
       hipblasZtrmmStridedBatched_assumed_rank = hipblasZtrmmStridedBatched_(handle,side,uplo,transA, &
         diag,m,n,alpha,c_loc(A),lda,strideA,c_loc(B),ldb,strideB,c_loc(C),ldc,strideC,batchCount)
     end function
+#endif
 
     function hipblasStrsm_assumed_rank(handle,side,uplo,transA,diag,m,n,alpha,AP,lda,BP,ldb)
       use iso_c_binding
@@ -48978,6 +49282,7 @@ module hipfort_hipblas
         c_loc(BP),ldb)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasStrsmStridedBatched_assumed_rank(handle,side,uplo,transA,diag,m,n,alpha,AP,lda, &
         strideA,BP,ldb,strideB,batchCount)
       use iso_c_binding
@@ -49003,7 +49308,9 @@ module hipfort_hipblas
       hipblasStrsmStridedBatched_assumed_rank = hipblasStrsmStridedBatched_(handle,side,uplo,transA, &
         diag,m,n,alpha,c_loc(AP),lda,strideA,c_loc(BP),ldb,strideB,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasDtrsmStridedBatched_assumed_rank(handle,side,uplo,transA,diag,m,n,alpha,AP,lda, &
         strideA,BP,ldb,strideB,batchCount)
       use iso_c_binding
@@ -49029,7 +49336,9 @@ module hipfort_hipblas
       hipblasDtrsmStridedBatched_assumed_rank = hipblasDtrsmStridedBatched_(handle,side,uplo,transA, &
         diag,m,n,alpha,c_loc(AP),lda,strideA,c_loc(BP),ldb,strideB,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasCtrsmStridedBatched_assumed_rank(handle,side,uplo,transA,diag,m,n,alpha,AP,lda, &
         strideA,BP,ldb,strideB,batchCount)
       use iso_c_binding
@@ -49055,7 +49364,9 @@ module hipfort_hipblas
       hipblasCtrsmStridedBatched_assumed_rank = hipblasCtrsmStridedBatched_(handle,side,uplo,transA, &
         diag,m,n,alpha,c_loc(AP),lda,strideA,c_loc(BP),ldb,strideB,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasZtrsmStridedBatched_assumed_rank(handle,side,uplo,transA,diag,m,n,alpha,AP,lda, &
         strideA,BP,ldb,strideB,batchCount)
       use iso_c_binding
@@ -49081,7 +49392,9 @@ module hipfort_hipblas
       hipblasZtrsmStridedBatched_assumed_rank = hipblasZtrsmStridedBatched_(handle,side,uplo,transA, &
         diag,m,n,alpha,c_loc(AP),lda,strideA,c_loc(BP),ldb,strideB,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasStrtri_assumed_rank(handle,uplo,diag,n,AP,lda,invA,ldinvA)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -49098,7 +49411,9 @@ module hipfort_hipblas
       !
       hipblasStrtri_assumed_rank = hipblasStrtri_(handle,uplo,diag,n,c_loc(AP),lda,c_loc(invA),ldinvA)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasDtrtri_assumed_rank(handle,uplo,diag,n,AP,lda,invA,ldinvA)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -49115,7 +49430,9 @@ module hipfort_hipblas
       !
       hipblasDtrtri_assumed_rank = hipblasDtrtri_(handle,uplo,diag,n,c_loc(AP),lda,c_loc(invA),ldinvA)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasCtrtri_assumed_rank(handle,uplo,diag,n,AP,lda,invA,ldinvA)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -49132,7 +49449,9 @@ module hipfort_hipblas
       !
       hipblasCtrtri_assumed_rank = hipblasCtrtri_(handle,uplo,diag,n,c_loc(AP),lda,c_loc(invA),ldinvA)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasZtrtri_assumed_rank(handle,uplo,diag,n,AP,lda,invA,ldinvA)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -49149,7 +49468,9 @@ module hipfort_hipblas
       !
       hipblasZtrtri_assumed_rank = hipblasZtrtri_(handle,uplo,diag,n,c_loc(AP),lda,c_loc(invA),ldinvA)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasStrtriStridedBatched_assumed_rank(handle,uplo,diag,n,AP,lda,strideA,invA,ldinvA, &
         stride_invA,batchCount)
       use iso_c_binding
@@ -49171,7 +49492,9 @@ module hipfort_hipblas
       hipblasStrtriStridedBatched_assumed_rank = hipblasStrtriStridedBatched_(handle,uplo,diag,n, &
         c_loc(AP),lda,strideA,c_loc(invA),ldinvA,stride_invA,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasDtrtriStridedBatched_assumed_rank(handle,uplo,diag,n,AP,lda,strideA,invA,ldinvA, &
         stride_invA,batchCount)
       use iso_c_binding
@@ -49193,7 +49516,9 @@ module hipfort_hipblas
       hipblasDtrtriStridedBatched_assumed_rank = hipblasDtrtriStridedBatched_(handle,uplo,diag,n, &
         c_loc(AP),lda,strideA,c_loc(invA),ldinvA,stride_invA,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasCtrtriStridedBatched_assumed_rank(handle,uplo,diag,n,AP,lda,strideA,invA,ldinvA, &
         stride_invA,batchCount)
       use iso_c_binding
@@ -49215,7 +49540,9 @@ module hipfort_hipblas
       hipblasCtrtriStridedBatched_assumed_rank = hipblasCtrtriStridedBatched_(handle,uplo,diag,n, &
         c_loc(AP),lda,strideA,c_loc(invA),ldinvA,stride_invA,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasZtrtriStridedBatched_assumed_rank(handle,uplo,diag,n,AP,lda,strideA,invA,ldinvA, &
         stride_invA,batchCount)
       use iso_c_binding
@@ -49237,6 +49564,7 @@ module hipfort_hipblas
       hipblasZtrtriStridedBatched_assumed_rank = hipblasZtrtriStridedBatched_(handle,uplo,diag,n, &
         c_loc(AP),lda,strideA,c_loc(invA),ldinvA,stride_invA,batchCount)
     end function
+#endif
 
     function hipblasSdgmm_assumed_rank(handle,side,m,n,AP,lda,x,incx,CP,ldc)
       use iso_c_binding
@@ -49314,6 +49642,7 @@ module hipfort_hipblas
       hipblasZdgmm_assumed_rank = hipblasZdgmm_(handle,side,m,n,c_loc(AP),lda,c_loc(x),incx,c_loc(CP),ldc)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipblasSdgmmStridedBatched_assumed_rank(handle,side,m,n,AP,lda,strideA,x,incx,stridex,CP, &
         ldc,strideC,batchCount)
       use iso_c_binding
@@ -49338,7 +49667,9 @@ module hipfort_hipblas
       hipblasSdgmmStridedBatched_assumed_rank = hipblasSdgmmStridedBatched_(handle,side,m,n,c_loc(AP), &
         lda,strideA,c_loc(x),incx,stridex,c_loc(CP),ldc,strideC,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasDdgmmStridedBatched_assumed_rank(handle,side,m,n,AP,lda,strideA,x,incx,stridex,CP, &
         ldc,strideC,batchCount)
       use iso_c_binding
@@ -49363,7 +49694,9 @@ module hipfort_hipblas
       hipblasDdgmmStridedBatched_assumed_rank = hipblasDdgmmStridedBatched_(handle,side,m,n,c_loc(AP), &
         lda,strideA,c_loc(x),incx,stridex,c_loc(CP),ldc,strideC,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasCdgmmStridedBatched_assumed_rank(handle,side,m,n,AP,lda,strideA,x,incx,stridex,CP, &
         ldc,strideC,batchCount)
       use iso_c_binding
@@ -49388,7 +49721,9 @@ module hipfort_hipblas
       hipblasCdgmmStridedBatched_assumed_rank = hipblasCdgmmStridedBatched_(handle,side,m,n,c_loc(AP), &
         lda,strideA,c_loc(x),incx,stridex,c_loc(CP),ldc,strideC,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasZdgmmStridedBatched_assumed_rank(handle,side,m,n,AP,lda,strideA,x,incx,stridex,CP, &
         ldc,strideC,batchCount)
       use iso_c_binding
@@ -49413,7 +49748,9 @@ module hipfort_hipblas
       hipblasZdgmmStridedBatched_assumed_rank = hipblasZdgmmStridedBatched_(handle,side,m,n,c_loc(AP), &
         lda,strideA,c_loc(x),incx,stridex,c_loc(CP),ldc,strideC,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasSgetrf_assumed_rank(handle,n,A,lda,ipiv,myInfo)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -49428,7 +49765,9 @@ module hipfort_hipblas
       !
       hipblasSgetrf_assumed_rank = hipblasSgetrf_(handle,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasDgetrf_assumed_rank(handle,n,A,lda,ipiv,myInfo)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -49443,7 +49782,9 @@ module hipfort_hipblas
       !
       hipblasDgetrf_assumed_rank = hipblasDgetrf_(handle,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasCgetrf_assumed_rank(handle,n,A,lda,ipiv,myInfo)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -49458,7 +49799,9 @@ module hipfort_hipblas
       !
       hipblasCgetrf_assumed_rank = hipblasCgetrf_(handle,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasZgetrf_assumed_rank(handle,n,A,lda,ipiv,myInfo)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -49473,7 +49816,9 @@ module hipfort_hipblas
       !
       hipblasZgetrf_assumed_rank = hipblasZgetrf_(handle,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasSgetrfStridedBatched_assumed_rank(handle,n,A,lda,strideA,ipiv,strideP,myInfo, &
         batchCount)
       use iso_c_binding
@@ -49493,7 +49838,9 @@ module hipfort_hipblas
       hipblasSgetrfStridedBatched_assumed_rank = hipblasSgetrfStridedBatched_(handle,n,c_loc(A),lda, &
         strideA,c_loc(ipiv),strideP,myInfo,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasDgetrfStridedBatched_assumed_rank(handle,n,A,lda,strideA,ipiv,strideP,myInfo, &
         batchCount)
       use iso_c_binding
@@ -49513,7 +49860,9 @@ module hipfort_hipblas
       hipblasDgetrfStridedBatched_assumed_rank = hipblasDgetrfStridedBatched_(handle,n,c_loc(A),lda, &
         strideA,c_loc(ipiv),strideP,myInfo,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasCgetrfStridedBatched_assumed_rank(handle,n,A,lda,strideA,ipiv,strideP,myInfo, &
         batchCount)
       use iso_c_binding
@@ -49533,7 +49882,9 @@ module hipfort_hipblas
       hipblasCgetrfStridedBatched_assumed_rank = hipblasCgetrfStridedBatched_(handle,n,c_loc(A),lda, &
         strideA,c_loc(ipiv),strideP,myInfo,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasZgetrfStridedBatched_assumed_rank(handle,n,A,lda,strideA,ipiv,strideP,myInfo, &
         batchCount)
       use iso_c_binding
@@ -49553,7 +49904,9 @@ module hipfort_hipblas
       hipblasZgetrfStridedBatched_assumed_rank = hipblasZgetrfStridedBatched_(handle,n,c_loc(A),lda, &
         strideA,c_loc(ipiv),strideP,myInfo,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasSgetrs_assumed_rank(handle,trans,n,nrhs,A,lda,ipiv,B,ldb,myInfo)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -49573,7 +49926,9 @@ module hipfort_hipblas
       hipblasSgetrs_assumed_rank = hipblasSgetrs_(handle,trans,n,nrhs,c_loc(A),lda,c_loc(ipiv),c_loc(B), &
         ldb,myInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasDgetrs_assumed_rank(handle,trans,n,nrhs,A,lda,ipiv,B,ldb,myInfo)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -49593,7 +49948,9 @@ module hipfort_hipblas
       hipblasDgetrs_assumed_rank = hipblasDgetrs_(handle,trans,n,nrhs,c_loc(A),lda,c_loc(ipiv),c_loc(B), &
         ldb,myInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasCgetrs_assumed_rank(handle,trans,n,nrhs,A,lda,ipiv,B,ldb,myInfo)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -49613,7 +49970,9 @@ module hipfort_hipblas
       hipblasCgetrs_assumed_rank = hipblasCgetrs_(handle,trans,n,nrhs,c_loc(A),lda,c_loc(ipiv),c_loc(B), &
         ldb,myInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasZgetrs_assumed_rank(handle,trans,n,nrhs,A,lda,ipiv,B,ldb,myInfo)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -49633,7 +49992,9 @@ module hipfort_hipblas
       hipblasZgetrs_assumed_rank = hipblasZgetrs_(handle,trans,n,nrhs,c_loc(A),lda,c_loc(ipiv),c_loc(B), &
         ldb,myInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasSgetrsStridedBatched_assumed_rank(handle,trans,n,nrhs,A,lda,strideA,ipiv,strideP,B, &
         ldb,strideB,myInfo,batchCount)
       use iso_c_binding
@@ -49658,7 +50019,9 @@ module hipfort_hipblas
       hipblasSgetrsStridedBatched_assumed_rank = hipblasSgetrsStridedBatched_(handle,trans,n,nrhs, &
         c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(B),ldb,strideB,myInfo,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasDgetrsStridedBatched_assumed_rank(handle,trans,n,nrhs,A,lda,strideA,ipiv,strideP,B, &
         ldb,strideB,myInfo,batchCount)
       use iso_c_binding
@@ -49683,7 +50046,9 @@ module hipfort_hipblas
       hipblasDgetrsStridedBatched_assumed_rank = hipblasDgetrsStridedBatched_(handle,trans,n,nrhs, &
         c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(B),ldb,strideB,myInfo,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasCgetrsStridedBatched_assumed_rank(handle,trans,n,nrhs,A,lda,strideA,ipiv,strideP,B, &
         ldb,strideB,myInfo,batchCount)
       use iso_c_binding
@@ -49708,7 +50073,9 @@ module hipfort_hipblas
       hipblasCgetrsStridedBatched_assumed_rank = hipblasCgetrsStridedBatched_(handle,trans,n,nrhs, &
         c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(B),ldb,strideB,myInfo,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasZgetrsStridedBatched_assumed_rank(handle,trans,n,nrhs,A,lda,strideA,ipiv,strideP,B, &
         ldb,strideB,myInfo,batchCount)
       use iso_c_binding
@@ -49733,7 +50100,9 @@ module hipfort_hipblas
       hipblasZgetrsStridedBatched_assumed_rank = hipblasZgetrsStridedBatched_(handle,trans,n,nrhs, &
         c_loc(A),lda,strideA,c_loc(ipiv),strideP,c_loc(B),ldb,strideB,myInfo,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasSgeqrf_assumed_rank(handle,m,n,A,lda,ipiv,myInfo)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -49749,7 +50118,9 @@ module hipfort_hipblas
       !
       hipblasSgeqrf_assumed_rank = hipblasSgeqrf_(handle,m,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasDgeqrf_assumed_rank(handle,m,n,A,lda,ipiv,myInfo)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -49765,7 +50136,9 @@ module hipfort_hipblas
       !
       hipblasDgeqrf_assumed_rank = hipblasDgeqrf_(handle,m,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasCgeqrf_assumed_rank(handle,m,n,A,lda,ipiv,myInfo)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -49781,7 +50154,9 @@ module hipfort_hipblas
       !
       hipblasCgeqrf_assumed_rank = hipblasCgeqrf_(handle,m,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasZgeqrf_assumed_rank(handle,m,n,A,lda,ipiv,myInfo)
       use iso_c_binding
       use hipfort_hipblas_enums
@@ -49797,7 +50172,9 @@ module hipfort_hipblas
       !
       hipblasZgeqrf_assumed_rank = hipblasZgeqrf_(handle,m,n,c_loc(A),lda,c_loc(ipiv),myInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasSgeqrfStridedBatched_assumed_rank(handle,m,n,A,lda,strideA,ipiv,strideP,myInfo, &
         batchCount)
       use iso_c_binding
@@ -49818,7 +50195,9 @@ module hipfort_hipblas
       hipblasSgeqrfStridedBatched_assumed_rank = hipblasSgeqrfStridedBatched_(handle,m,n,c_loc(A),lda, &
         strideA,c_loc(ipiv),strideP,myInfo,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasDgeqrfStridedBatched_assumed_rank(handle,m,n,A,lda,strideA,ipiv,strideP,myInfo, &
         batchCount)
       use iso_c_binding
@@ -49839,7 +50218,9 @@ module hipfort_hipblas
       hipblasDgeqrfStridedBatched_assumed_rank = hipblasDgeqrfStridedBatched_(handle,m,n,c_loc(A),lda, &
         strideA,c_loc(ipiv),strideP,myInfo,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasCgeqrfStridedBatched_assumed_rank(handle,m,n,A,lda,strideA,ipiv,strideP,myInfo, &
         batchCount)
       use iso_c_binding
@@ -49860,7 +50241,9 @@ module hipfort_hipblas
       hipblasCgeqrfStridedBatched_assumed_rank = hipblasCgeqrfStridedBatched_(handle,m,n,c_loc(A),lda, &
         strideA,c_loc(ipiv),strideP,myInfo,batchCount)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipblasZgeqrfStridedBatched_assumed_rank(handle,m,n,A,lda,strideA,ipiv,strideP,myInfo, &
         batchCount)
       use iso_c_binding
@@ -49881,6 +50264,7 @@ module hipfort_hipblas
       hipblasZgeqrfStridedBatched_assumed_rank = hipblasZgeqrfStridedBatched_(handle,m,n,c_loc(A),lda, &
         strideA,c_loc(ipiv),strideP,myInfo,batchCount)
     end function
+#endif
 
 #else
 

--- a/lib/hipfort/hipfort_hipmemcpy.F90
+++ b/lib/hipfort/hipfort_hipmemcpy.F90
@@ -80,6 +80,30 @@ module hipfort_hipmemcpy
     end function
         
 #ifdef USE_FPOINTER_INTERFACES
+#ifdef USE_ASSUMED_RANK_INTERFACES
+    module procedure &
+      hipMemcpy_l_assumed_rank,&
+      hipMemcpy_l_assumed_rank_c_int,&
+      hipMemcpy_l_assumed_rank_c_size_t,&
+      hipMemcpy_i4_assumed_rank,&
+      hipMemcpy_i4_assumed_rank_c_int,&
+      hipMemcpy_i4_assumed_rank_c_size_t,&
+      hipMemcpy_i8_assumed_rank,&
+      hipMemcpy_i8_assumed_rank_c_int,&
+      hipMemcpy_i8_assumed_rank_c_size_t,&
+      hipMemcpy_r4_assumed_rank,&
+      hipMemcpy_r4_assumed_rank_c_int,&
+      hipMemcpy_r4_assumed_rank_c_size_t,&
+      hipMemcpy_r8_assumed_rank,&
+      hipMemcpy_r8_assumed_rank_c_int,&
+      hipMemcpy_r8_assumed_rank_c_size_t,&
+      hipMemcpy_c4_assumed_rank,&
+      hipMemcpy_c4_assumed_rank_c_int,&
+      hipMemcpy_c4_assumed_rank_c_size_t,&
+      hipMemcpy_c8_assumed_rank,&
+      hipMemcpy_c8_assumed_rank_c_int,&
+      hipMemcpy_c8_assumed_rank_c_size_t
+#else
     module procedure hipMemcpy_l_0,&
       hipMemcpy_l_0_c_int,&
       hipMemcpy_l_0_c_size_t,&
@@ -249,6 +273,7 @@ module hipfort_hipmemcpy
       hipMemcpy_c8_7_c_int,&
       hipMemcpy_c8_7_c_size_t 
 #endif
+#endif
   end interface
   
   interface hipMemcpyAsync
@@ -306,6 +331,30 @@ module hipfort_hipmemcpy
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
+#ifdef USE_ASSUMED_RANK_INTERFACES
+    module procedure &
+      hipMemcpyAsync_l_assumed_rank,&
+      hipMemcpyAsync_l_assumed_rank_c_int,&
+      hipMemcpyAsync_l_assumed_rank_c_size_t,&
+      hipMemcpyAsync_i4_assumed_rank,&
+      hipMemcpyAsync_i4_assumed_rank_c_int,&
+      hipMemcpyAsync_i4_assumed_rank_c_size_t,&
+      hipMemcpyAsync_i8_assumed_rank,&
+      hipMemcpyAsync_i8_assumed_rank_c_int,&
+      hipMemcpyAsync_i8_assumed_rank_c_size_t,&
+      hipMemcpyAsync_r4_assumed_rank,&
+      hipMemcpyAsync_r4_assumed_rank_c_int,&
+      hipMemcpyAsync_r4_assumed_rank_c_size_t,&
+      hipMemcpyAsync_r8_assumed_rank,&
+      hipMemcpyAsync_r8_assumed_rank_c_int,&
+      hipMemcpyAsync_r8_assumed_rank_c_size_t,&
+      hipMemcpyAsync_c4_assumed_rank,&
+      hipMemcpyAsync_c4_assumed_rank_c_int,&
+      hipMemcpyAsync_c4_assumed_rank_c_size_t,&
+      hipMemcpyAsync_c8_assumed_rank,&
+      hipMemcpyAsync_c8_assumed_rank_c_int,&
+      hipMemcpyAsync_c8_assumed_rank_c_size_t
+#else
     module procedure hipMemcpyAsync_l_0,&
       hipMemcpyAsync_l_0_c_int,&
       hipMemcpyAsync_l_0_c_size_t,&
@@ -475,6 +524,7 @@ module hipfort_hipmemcpy
       hipMemcpyAsync_c8_7_c_int,&
       hipMemcpyAsync_c8_7_c_size_t 
 #endif
+#endif
   end interface
   
   interface hipMemcpy2D
@@ -521,6 +571,23 @@ module hipfort_hipmemcpy
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
+#ifdef USE_ASSUMED_RANK_INTERFACES
+    module procedure &
+      hipMemcpy2D_l_assumed_rank_c_int,&
+      hipMemcpy2D_l_assumed_rank_c_size_t,&
+      hipMemcpy2D_i4_assumed_rank_c_int,&
+      hipMemcpy2D_i4_assumed_rank_c_size_t,&
+      hipMemcpy2D_i8_assumed_rank_c_int,&
+      hipMemcpy2D_i8_assumed_rank_c_size_t,&
+      hipMemcpy2D_r4_assumed_rank_c_int,&
+      hipMemcpy2D_r4_assumed_rank_c_size_t,&
+      hipMemcpy2D_r8_assumed_rank_c_int,&
+      hipMemcpy2D_r8_assumed_rank_c_size_t,&
+      hipMemcpy2D_c4_assumed_rank_c_int,&
+      hipMemcpy2D_c4_assumed_rank_c_size_t,&
+      hipMemcpy2D_c8_assumed_rank_c_int,&
+      hipMemcpy2D_c8_assumed_rank_c_size_t
+#else
     module procedure hipMemcpy2D_l_0_c_int,&
       hipMemcpy2D_l_0_c_size_t,&
       hipMemcpy2D_l_1_c_int,&
@@ -563,6 +630,7 @@ module hipfort_hipmemcpy
       hipMemcpy2D_c8_1_c_size_t,&
       hipMemcpy2D_c8_2_c_int,&
       hipMemcpy2D_c8_2_c_size_t 
+#endif
 #endif
   end interface
   
@@ -612,6 +680,23 @@ module hipfort_hipmemcpy
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
+#ifdef USE_ASSUMED_RANK_INTERFACES
+    module procedure &
+      hipMemcpy2DAsync_l_assumed_rank_c_int,&
+      hipMemcpy2DAsync_l_assumed_rank_c_size_t,&
+      hipMemcpy2DAsync_i4_assumed_rank_c_int,&
+      hipMemcpy2DAsync_i4_assumed_rank_c_size_t,&
+      hipMemcpy2DAsync_i8_assumed_rank_c_int,&
+      hipMemcpy2DAsync_i8_assumed_rank_c_size_t,&
+      hipMemcpy2DAsync_r4_assumed_rank_c_int,&
+      hipMemcpy2DAsync_r4_assumed_rank_c_size_t,&
+      hipMemcpy2DAsync_r8_assumed_rank_c_int,&
+      hipMemcpy2DAsync_r8_assumed_rank_c_size_t,&
+      hipMemcpy2DAsync_c4_assumed_rank_c_int,&
+      hipMemcpy2DAsync_c4_assumed_rank_c_size_t,&
+      hipMemcpy2DAsync_c8_assumed_rank_c_int,&
+      hipMemcpy2DAsync_c8_assumed_rank_c_size_t
+#else
     module procedure hipMemcpy2DAsync_l_0_c_int,&
       hipMemcpy2DAsync_l_0_c_size_t,&
       hipMemcpy2DAsync_l_1_c_int,&
@@ -655,10 +740,1620 @@ module hipfort_hipmemcpy
       hipMemcpy2DAsync_c8_2_c_int,&
       hipMemcpy2DAsync_c8_2_c_size_t 
 #endif
+#endif
   end interface
 
 #ifdef USE_FPOINTER_INTERFACES
   contains
+#ifdef USE_ASSUMED_RANK_INTERFACES
+    function hipMemcpy_l_assumed_rank_c_int(dest,src,length,myKind)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      logical(c_bool),target,contiguous,dimension(..),intent(inout) :: dest
+      logical(c_bool),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_int),intent(in) :: length
+      integer(kind(hipMemcpyHostToHost)) :: myKind
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpy_l_assumed_rank_c_int 
+#else
+      integer(kind(hipSuccess)) :: hipMemcpy_l_assumed_rank_c_int
+#endif
+      !
+      hipMemcpy_l_assumed_rank_c_int = hipMemcpy_(c_loc(dest),c_loc(src),length*1_8,myKind)
+    end function
+
+    function hipMemcpy_l_assumed_rank_c_size_t(dest,src,length,myKind)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      logical(c_bool),target,contiguous,dimension(..),intent(inout) :: dest
+      logical(c_bool),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_size_t),intent(in) :: length
+      integer(kind(hipMemcpyHostToHost)) :: myKind
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpy_l_assumed_rank_c_size_t 
+#else
+      integer(kind(hipSuccess)) :: hipMemcpy_l_assumed_rank_c_size_t
+#endif
+      !
+      hipMemcpy_l_assumed_rank_c_size_t = hipMemcpy_(c_loc(dest),c_loc(src),length*1_8,myKind)
+    end function
+
+function hipMemcpy_l_assumed_rank(dest,src,myKind)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      logical(c_bool),target,contiguous,dimension(..),intent(inout) :: dest
+      logical(c_bool),target,contiguous,dimension(..),intent(in)    :: src
+      integer(kind(hipMemcpyHostToHost)) :: myKind
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpy_l_assumed_rank 
+#else
+      integer(kind(hipSuccess)) :: hipMemcpy_l_assumed_rank
+#endif
+      !
+      hipMemcpy_l_assumed_rank = hipMemcpy_(c_loc(dest),c_loc(src),size(dest)*1_8,myKind)
+    end function
+
+    function hipMemcpy_i4_assumed_rank_c_int(dest,src,length,myKind)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      integer(c_int),target,contiguous,dimension(..),intent(inout) :: dest
+      integer(c_int),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_int),intent(in) :: length
+      integer(kind(hipMemcpyHostToHost)) :: myKind
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpy_i4_assumed_rank_c_int 
+#else
+      integer(kind(hipSuccess)) :: hipMemcpy_i4_assumed_rank_c_int
+#endif
+      !
+      hipMemcpy_i4_assumed_rank_c_int = hipMemcpy_(c_loc(dest),c_loc(src),length*4_8,myKind)
+    end function
+
+    function hipMemcpy_i4_assumed_rank_c_size_t(dest,src,length,myKind)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      integer(c_int),target,contiguous,dimension(..),intent(inout) :: dest
+      integer(c_int),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_size_t),intent(in) :: length
+      integer(kind(hipMemcpyHostToHost)) :: myKind
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpy_i4_assumed_rank_c_size_t 
+#else
+      integer(kind(hipSuccess)) :: hipMemcpy_i4_assumed_rank_c_size_t
+#endif
+      !
+      hipMemcpy_i4_assumed_rank_c_size_t = hipMemcpy_(c_loc(dest),c_loc(src),length*4_8,myKind)
+    end function
+
+function hipMemcpy_i4_assumed_rank(dest,src,myKind)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      integer(c_int),target,contiguous,dimension(..),intent(inout) :: dest
+      integer(c_int),target,contiguous,dimension(..),intent(in)    :: src
+      integer(kind(hipMemcpyHostToHost)) :: myKind
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpy_i4_assumed_rank 
+#else
+      integer(kind(hipSuccess)) :: hipMemcpy_i4_assumed_rank
+#endif
+      !
+      hipMemcpy_i4_assumed_rank = hipMemcpy_(c_loc(dest),c_loc(src),size(dest)*4_8,myKind)
+    end function
+
+    function hipMemcpy_i8_assumed_rank_c_int(dest,src,length,myKind)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      integer(c_long),target,contiguous,dimension(..),intent(inout) :: dest
+      integer(c_long),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_int),intent(in) :: length
+      integer(kind(hipMemcpyHostToHost)) :: myKind
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpy_i8_assumed_rank_c_int 
+#else
+      integer(kind(hipSuccess)) :: hipMemcpy_i8_assumed_rank_c_int
+#endif
+      !
+      hipMemcpy_i8_assumed_rank_c_int = hipMemcpy_(c_loc(dest),c_loc(src),length*8_8,myKind)
+    end function
+
+    function hipMemcpy_i8_assumed_rank_c_size_t(dest,src,length,myKind)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      integer(c_long),target,contiguous,dimension(..),intent(inout) :: dest
+      integer(c_long),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_size_t),intent(in) :: length
+      integer(kind(hipMemcpyHostToHost)) :: myKind
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpy_i8_assumed_rank_c_size_t 
+#else
+      integer(kind(hipSuccess)) :: hipMemcpy_i8_assumed_rank_c_size_t
+#endif
+      !
+      hipMemcpy_i8_assumed_rank_c_size_t = hipMemcpy_(c_loc(dest),c_loc(src),length*8_8,myKind)
+    end function
+
+function hipMemcpy_i8_assumed_rank(dest,src,myKind)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      integer(c_long),target,contiguous,dimension(..),intent(inout) :: dest
+      integer(c_long),target,contiguous,dimension(..),intent(in)    :: src
+      integer(kind(hipMemcpyHostToHost)) :: myKind
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpy_i8_assumed_rank 
+#else
+      integer(kind(hipSuccess)) :: hipMemcpy_i8_assumed_rank
+#endif
+      !
+      hipMemcpy_i8_assumed_rank = hipMemcpy_(c_loc(dest),c_loc(src),size(dest)*8_8,myKind)
+    end function
+
+    function hipMemcpy_r4_assumed_rank_c_int(dest,src,length,myKind)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      real(c_float),target,contiguous,dimension(..),intent(inout) :: dest
+      real(c_float),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_int),intent(in) :: length
+      integer(kind(hipMemcpyHostToHost)) :: myKind
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpy_r4_assumed_rank_c_int 
+#else
+      integer(kind(hipSuccess)) :: hipMemcpy_r4_assumed_rank_c_int
+#endif
+      !
+      hipMemcpy_r4_assumed_rank_c_int = hipMemcpy_(c_loc(dest),c_loc(src),length*4_8,myKind)
+    end function
+
+    function hipMemcpy_r4_assumed_rank_c_size_t(dest,src,length,myKind)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      real(c_float),target,contiguous,dimension(..),intent(inout) :: dest
+      real(c_float),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_size_t),intent(in) :: length
+      integer(kind(hipMemcpyHostToHost)) :: myKind
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpy_r4_assumed_rank_c_size_t 
+#else
+      integer(kind(hipSuccess)) :: hipMemcpy_r4_assumed_rank_c_size_t
+#endif
+      !
+      hipMemcpy_r4_assumed_rank_c_size_t = hipMemcpy_(c_loc(dest),c_loc(src),length*4_8,myKind)
+    end function
+
+function hipMemcpy_r4_assumed_rank(dest,src,myKind)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      real(c_float),target,contiguous,dimension(..),intent(inout) :: dest
+      real(c_float),target,contiguous,dimension(..),intent(in)    :: src
+      integer(kind(hipMemcpyHostToHost)) :: myKind
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpy_r4_assumed_rank 
+#else
+      integer(kind(hipSuccess)) :: hipMemcpy_r4_assumed_rank
+#endif
+      !
+      hipMemcpy_r4_assumed_rank = hipMemcpy_(c_loc(dest),c_loc(src),size(dest)*4_8,myKind)
+    end function
+
+    function hipMemcpy_r8_assumed_rank_c_int(dest,src,length,myKind)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      real(c_double),target,contiguous,dimension(..),intent(inout) :: dest
+      real(c_double),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_int),intent(in) :: length
+      integer(kind(hipMemcpyHostToHost)) :: myKind
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpy_r8_assumed_rank_c_int 
+#else
+      integer(kind(hipSuccess)) :: hipMemcpy_r8_assumed_rank_c_int
+#endif
+      !
+      hipMemcpy_r8_assumed_rank_c_int = hipMemcpy_(c_loc(dest),c_loc(src),length*8_8,myKind)
+    end function
+
+    function hipMemcpy_r8_assumed_rank_c_size_t(dest,src,length,myKind)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      real(c_double),target,contiguous,dimension(..),intent(inout) :: dest
+      real(c_double),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_size_t),intent(in) :: length
+      integer(kind(hipMemcpyHostToHost)) :: myKind
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpy_r8_assumed_rank_c_size_t 
+#else
+      integer(kind(hipSuccess)) :: hipMemcpy_r8_assumed_rank_c_size_t
+#endif
+      !
+      hipMemcpy_r8_assumed_rank_c_size_t = hipMemcpy_(c_loc(dest),c_loc(src),length*8_8,myKind)
+    end function
+
+function hipMemcpy_r8_assumed_rank(dest,src,myKind)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      real(c_double),target,contiguous,dimension(..),intent(inout) :: dest
+      real(c_double),target,contiguous,dimension(..),intent(in)    :: src
+      integer(kind(hipMemcpyHostToHost)) :: myKind
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpy_r8_assumed_rank 
+#else
+      integer(kind(hipSuccess)) :: hipMemcpy_r8_assumed_rank
+#endif
+      !
+      hipMemcpy_r8_assumed_rank = hipMemcpy_(c_loc(dest),c_loc(src),size(dest)*8_8,myKind)
+    end function
+
+    function hipMemcpy_c4_assumed_rank_c_int(dest,src,length,myKind)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      complex(c_float_complex),target,contiguous,dimension(..),intent(inout) :: dest
+      complex(c_float_complex),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_int),intent(in) :: length
+      integer(kind(hipMemcpyHostToHost)) :: myKind
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpy_c4_assumed_rank_c_int 
+#else
+      integer(kind(hipSuccess)) :: hipMemcpy_c4_assumed_rank_c_int
+#endif
+      !
+      hipMemcpy_c4_assumed_rank_c_int = hipMemcpy_(c_loc(dest),c_loc(src),length*2*4_8,myKind)
+    end function
+
+    function hipMemcpy_c4_assumed_rank_c_size_t(dest,src,length,myKind)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      complex(c_float_complex),target,contiguous,dimension(..),intent(inout) :: dest
+      complex(c_float_complex),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_size_t),intent(in) :: length
+      integer(kind(hipMemcpyHostToHost)) :: myKind
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpy_c4_assumed_rank_c_size_t 
+#else
+      integer(kind(hipSuccess)) :: hipMemcpy_c4_assumed_rank_c_size_t
+#endif
+      !
+      hipMemcpy_c4_assumed_rank_c_size_t = hipMemcpy_(c_loc(dest),c_loc(src),length*2*4_8,myKind)
+    end function
+
+function hipMemcpy_c4_assumed_rank(dest,src,myKind)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      complex(c_float_complex),target,contiguous,dimension(..),intent(inout) :: dest
+      complex(c_float_complex),target,contiguous,dimension(..),intent(in)    :: src
+      integer(kind(hipMemcpyHostToHost)) :: myKind
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpy_c4_assumed_rank 
+#else
+      integer(kind(hipSuccess)) :: hipMemcpy_c4_assumed_rank
+#endif
+      !
+      hipMemcpy_c4_assumed_rank = hipMemcpy_(c_loc(dest),c_loc(src),size(dest)*2*4_8,myKind)
+    end function
+
+    function hipMemcpy_c8_assumed_rank_c_int(dest,src,length,myKind)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      complex(c_double_complex),target,contiguous,dimension(..),intent(inout) :: dest
+      complex(c_double_complex),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_int),intent(in) :: length
+      integer(kind(hipMemcpyHostToHost)) :: myKind
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpy_c8_assumed_rank_c_int 
+#else
+      integer(kind(hipSuccess)) :: hipMemcpy_c8_assumed_rank_c_int
+#endif
+      !
+      hipMemcpy_c8_assumed_rank_c_int = hipMemcpy_(c_loc(dest),c_loc(src),length*2*8_8,myKind)
+    end function
+
+    function hipMemcpy_c8_assumed_rank_c_size_t(dest,src,length,myKind)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      complex(c_double_complex),target,contiguous,dimension(..),intent(inout) :: dest
+      complex(c_double_complex),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_size_t),intent(in) :: length
+      integer(kind(hipMemcpyHostToHost)) :: myKind
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpy_c8_assumed_rank_c_size_t 
+#else
+      integer(kind(hipSuccess)) :: hipMemcpy_c8_assumed_rank_c_size_t
+#endif
+      !
+      hipMemcpy_c8_assumed_rank_c_size_t = hipMemcpy_(c_loc(dest),c_loc(src),length*2*8_8,myKind)
+    end function
+
+function hipMemcpy_c8_assumed_rank(dest,src,myKind)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      complex(c_double_complex),target,contiguous,dimension(..),intent(inout) :: dest
+      complex(c_double_complex),target,contiguous,dimension(..),intent(in)    :: src
+      integer(kind(hipMemcpyHostToHost)) :: myKind
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpy_c8_assumed_rank 
+#else
+      integer(kind(hipSuccess)) :: hipMemcpy_c8_assumed_rank
+#endif
+      !
+      hipMemcpy_c8_assumed_rank = hipMemcpy_(c_loc(dest),c_loc(src),size(dest)*2*8_8,myKind)
+    end function
+
+function hipMemcpyAsync_l_assumed_rank_c_int(dest,src,length,myKind,stream)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      logical(c_bool),target,contiguous,dimension(..),intent(inout) :: dest
+      logical(c_bool),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_int),intent(in) :: length
+      integer(kind(hipMemcpyHostToHost)) :: myKind
+      type(c_ptr) :: stream
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpyAsync_l_assumed_rank_c_int
+#else
+      integer(kind(hipSuccess)) :: hipMemcpyAsync_l_assumed_rank_c_int
+#endif
+      !
+      hipMemcpyAsync_l_assumed_rank_c_int = hipMemcpyAsync_(c_loc(dest),c_loc(src),length*1_8,myKind,stream)
+    end function
+
+function hipMemcpyAsync_l_assumed_rank_c_size_t(dest,src,length,myKind,stream)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      logical(c_bool),target,contiguous,dimension(..),intent(inout) :: dest
+      logical(c_bool),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_size_t),intent(in) :: length
+      integer(kind(hipMemcpyHostToHost)) :: myKind
+      type(c_ptr) :: stream
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpyAsync_l_assumed_rank_c_size_t
+#else
+      integer(kind(hipSuccess)) :: hipMemcpyAsync_l_assumed_rank_c_size_t
+#endif
+      !
+      hipMemcpyAsync_l_assumed_rank_c_size_t = hipMemcpyAsync_(c_loc(dest),c_loc(src),length*1_8,myKind,stream)
+    end function
+
+function hipMemcpyAsync_l_assumed_rank(dest,src,myKind,stream)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      logical(c_bool),target,contiguous,dimension(..),intent(inout) :: dest
+      logical(c_bool),target,contiguous,dimension(..),intent(in)    :: src
+      integer(kind(hipMemcpyHostToHost)) :: myKind
+      type(c_ptr) :: stream
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpyAsync_l_assumed_rank
+#else
+      integer(kind(hipSuccess)) :: hipMemcpyAsync_l_assumed_rank
+#endif
+      !
+      hipMemcpyAsync_l_assumed_rank = hipMemcpyAsync_(c_loc(dest),c_loc(src),size(dest)*1_8,myKind,stream)
+    end function
+
+function hipMemcpyAsync_i4_assumed_rank_c_int(dest,src,length,myKind,stream)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      integer(c_int),target,contiguous,dimension(..),intent(inout) :: dest
+      integer(c_int),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_int),intent(in) :: length
+      integer(kind(hipMemcpyHostToHost)) :: myKind
+      type(c_ptr) :: stream
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpyAsync_i4_assumed_rank_c_int
+#else
+      integer(kind(hipSuccess)) :: hipMemcpyAsync_i4_assumed_rank_c_int
+#endif
+      !
+      hipMemcpyAsync_i4_assumed_rank_c_int = hipMemcpyAsync_(c_loc(dest),c_loc(src),length*4_8,myKind,stream)
+    end function
+
+function hipMemcpyAsync_i4_assumed_rank_c_size_t(dest,src,length,myKind,stream)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      integer(c_int),target,contiguous,dimension(..),intent(inout) :: dest
+      integer(c_int),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_size_t),intent(in) :: length
+      integer(kind(hipMemcpyHostToHost)) :: myKind
+      type(c_ptr) :: stream
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpyAsync_i4_assumed_rank_c_size_t
+#else
+      integer(kind(hipSuccess)) :: hipMemcpyAsync_i4_assumed_rank_c_size_t
+#endif
+      !
+      hipMemcpyAsync_i4_assumed_rank_c_size_t = hipMemcpyAsync_(c_loc(dest),c_loc(src),length*4_8,myKind,stream)
+    end function
+
+function hipMemcpyAsync_i4_assumed_rank(dest,src,myKind,stream)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      integer(c_int),target,contiguous,dimension(..),intent(inout) :: dest
+      integer(c_int),target,contiguous,dimension(..),intent(in)    :: src
+      integer(kind(hipMemcpyHostToHost)) :: myKind
+      type(c_ptr) :: stream
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpyAsync_i4_assumed_rank
+#else
+      integer(kind(hipSuccess)) :: hipMemcpyAsync_i4_assumed_rank
+#endif
+      !
+      hipMemcpyAsync_i4_assumed_rank = hipMemcpyAsync_(c_loc(dest),c_loc(src),size(dest)*4_8,myKind,stream)
+    end function
+
+function hipMemcpyAsync_i8_assumed_rank_c_int(dest,src,length,myKind,stream)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      integer(c_long),target,contiguous,dimension(..),intent(inout) :: dest
+      integer(c_long),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_int),intent(in) :: length
+      integer(kind(hipMemcpyHostToHost)) :: myKind
+      type(c_ptr) :: stream
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpyAsync_i8_assumed_rank_c_int
+#else
+      integer(kind(hipSuccess)) :: hipMemcpyAsync_i8_assumed_rank_c_int
+#endif
+      !
+      hipMemcpyAsync_i8_assumed_rank_c_int = hipMemcpyAsync_(c_loc(dest),c_loc(src),length*8_8,myKind,stream)
+    end function
+
+function hipMemcpyAsync_i8_assumed_rank_c_size_t(dest,src,length,myKind,stream)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      integer(c_long),target,contiguous,dimension(..),intent(inout) :: dest
+      integer(c_long),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_size_t),intent(in) :: length
+      integer(kind(hipMemcpyHostToHost)) :: myKind
+      type(c_ptr) :: stream
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpyAsync_i8_assumed_rank_c_size_t
+#else
+      integer(kind(hipSuccess)) :: hipMemcpyAsync_i8_assumed_rank_c_size_t
+#endif
+      !
+      hipMemcpyAsync_i8_assumed_rank_c_size_t = hipMemcpyAsync_(c_loc(dest),c_loc(src),length*8_8,myKind,stream)
+    end function
+
+function hipMemcpyAsync_i8_assumed_rank(dest,src,myKind,stream)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      integer(c_long),target,contiguous,dimension(..),intent(inout) :: dest
+      integer(c_long),target,contiguous,dimension(..),intent(in)    :: src
+      integer(kind(hipMemcpyHostToHost)) :: myKind
+      type(c_ptr) :: stream
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpyAsync_i8_assumed_rank
+#else
+      integer(kind(hipSuccess)) :: hipMemcpyAsync_i8_assumed_rank
+#endif
+      !
+      hipMemcpyAsync_i8_assumed_rank = hipMemcpyAsync_(c_loc(dest),c_loc(src),size(dest)*8_8,myKind,stream)
+    end function
+
+function hipMemcpyAsync_r4_assumed_rank_c_int(dest,src,length,myKind,stream)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      real(c_float),target,contiguous,dimension(..),intent(inout) :: dest
+      real(c_float),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_int),intent(in) :: length
+      integer(kind(hipMemcpyHostToHost)) :: myKind
+      type(c_ptr) :: stream
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpyAsync_r4_assumed_rank_c_int
+#else
+      integer(kind(hipSuccess)) :: hipMemcpyAsync_r4_assumed_rank_c_int
+#endif
+      !
+      hipMemcpyAsync_r4_assumed_rank_c_int = hipMemcpyAsync_(c_loc(dest),c_loc(src),length*4_8,myKind,stream)
+    end function
+
+function hipMemcpyAsync_r4_assumed_rank_c_size_t(dest,src,length,myKind,stream)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      real(c_float),target,contiguous,dimension(..),intent(inout) :: dest
+      real(c_float),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_size_t),intent(in) :: length
+      integer(kind(hipMemcpyHostToHost)) :: myKind
+      type(c_ptr) :: stream
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpyAsync_r4_assumed_rank_c_size_t
+#else
+      integer(kind(hipSuccess)) :: hipMemcpyAsync_r4_assumed_rank_c_size_t
+#endif
+      !
+      hipMemcpyAsync_r4_assumed_rank_c_size_t = hipMemcpyAsync_(c_loc(dest),c_loc(src),length*4_8,myKind,stream)
+    end function
+
+function hipMemcpyAsync_r4_assumed_rank(dest,src,myKind,stream)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      real(c_float),target,contiguous,dimension(..),intent(inout) :: dest
+      real(c_float),target,contiguous,dimension(..),intent(in)    :: src
+      integer(kind(hipMemcpyHostToHost)) :: myKind
+      type(c_ptr) :: stream
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpyAsync_r4_assumed_rank
+#else
+      integer(kind(hipSuccess)) :: hipMemcpyAsync_r4_assumed_rank
+#endif
+      !
+      hipMemcpyAsync_r4_assumed_rank = hipMemcpyAsync_(c_loc(dest),c_loc(src),size(dest)*4_8,myKind,stream)
+    end function
+
+function hipMemcpyAsync_r8_assumed_rank_c_int(dest,src,length,myKind,stream)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      real(c_double),target,contiguous,dimension(..),intent(inout) :: dest
+      real(c_double),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_int),intent(in) :: length
+      integer(kind(hipMemcpyHostToHost)) :: myKind
+      type(c_ptr) :: stream
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpyAsync_r8_assumed_rank_c_int
+#else
+      integer(kind(hipSuccess)) :: hipMemcpyAsync_r8_assumed_rank_c_int
+#endif
+      !
+      hipMemcpyAsync_r8_assumed_rank_c_int = hipMemcpyAsync_(c_loc(dest),c_loc(src),length*8_8,myKind,stream)
+    end function
+
+function hipMemcpyAsync_r8_assumed_rank_c_size_t(dest,src,length,myKind,stream)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      real(c_double),target,contiguous,dimension(..),intent(inout) :: dest
+      real(c_double),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_size_t),intent(in) :: length
+      integer(kind(hipMemcpyHostToHost)) :: myKind
+      type(c_ptr) :: stream
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpyAsync_r8_assumed_rank_c_size_t
+#else
+      integer(kind(hipSuccess)) :: hipMemcpyAsync_r8_assumed_rank_c_size_t
+#endif
+      !
+      hipMemcpyAsync_r8_assumed_rank_c_size_t = hipMemcpyAsync_(c_loc(dest),c_loc(src),length*8_8,myKind,stream)
+    end function
+
+function hipMemcpyAsync_r8_assumed_rank(dest,src,myKind,stream)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      real(c_double),target,contiguous,dimension(..),intent(inout) :: dest
+      real(c_double),target,contiguous,dimension(..),intent(in)    :: src
+      integer(kind(hipMemcpyHostToHost)) :: myKind
+      type(c_ptr) :: stream
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpyAsync_r8_assumed_rank
+#else
+      integer(kind(hipSuccess)) :: hipMemcpyAsync_r8_assumed_rank
+#endif
+      !
+      hipMemcpyAsync_r8_assumed_rank = hipMemcpyAsync_(c_loc(dest),c_loc(src),size(dest)*8_8,myKind,stream)
+    end function
+
+function hipMemcpyAsync_c4_assumed_rank_c_int(dest,src,length,myKind,stream)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      complex(c_float_complex),target,contiguous,dimension(..),intent(inout) :: dest
+      complex(c_float_complex),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_int),intent(in) :: length
+      integer(kind(hipMemcpyHostToHost)) :: myKind
+      type(c_ptr) :: stream
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpyAsync_c4_assumed_rank_c_int
+#else
+      integer(kind(hipSuccess)) :: hipMemcpyAsync_c4_assumed_rank_c_int
+#endif
+      !
+      hipMemcpyAsync_c4_assumed_rank_c_int = hipMemcpyAsync_(c_loc(dest),c_loc(src),length*2*4_8,myKind,stream)
+    end function
+
+function hipMemcpyAsync_c4_assumed_rank_c_size_t(dest,src,length,myKind,stream)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      complex(c_float_complex),target,contiguous,dimension(..),intent(inout) :: dest
+      complex(c_float_complex),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_size_t),intent(in) :: length
+      integer(kind(hipMemcpyHostToHost)) :: myKind
+      type(c_ptr) :: stream
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpyAsync_c4_assumed_rank_c_size_t
+#else
+      integer(kind(hipSuccess)) :: hipMemcpyAsync_c4_assumed_rank_c_size_t
+#endif
+      !
+      hipMemcpyAsync_c4_assumed_rank_c_size_t = hipMemcpyAsync_(c_loc(dest),c_loc(src),length*2*4_8,myKind,stream)
+    end function
+
+function hipMemcpyAsync_c4_assumed_rank(dest,src,myKind,stream)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      complex(c_float_complex),target,contiguous,dimension(..),intent(inout) :: dest
+      complex(c_float_complex),target,contiguous,dimension(..),intent(in)    :: src
+      integer(kind(hipMemcpyHostToHost)) :: myKind
+      type(c_ptr) :: stream
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpyAsync_c4_assumed_rank
+#else
+      integer(kind(hipSuccess)) :: hipMemcpyAsync_c4_assumed_rank
+#endif
+      !
+      hipMemcpyAsync_c4_assumed_rank = hipMemcpyAsync_(c_loc(dest),c_loc(src),size(dest)*2*4_8,myKind,stream)
+    end function
+
+function hipMemcpyAsync_c8_assumed_rank_c_int(dest,src,length,myKind,stream)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      complex(c_double_complex),target,contiguous,dimension(..),intent(inout) :: dest
+      complex(c_double_complex),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_int),intent(in) :: length
+      integer(kind(hipMemcpyHostToHost)) :: myKind
+      type(c_ptr) :: stream
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpyAsync_c8_assumed_rank_c_int
+#else
+      integer(kind(hipSuccess)) :: hipMemcpyAsync_c8_assumed_rank_c_int
+#endif
+      !
+      hipMemcpyAsync_c8_assumed_rank_c_int = hipMemcpyAsync_(c_loc(dest),c_loc(src),length*2*8_8,myKind,stream)
+    end function
+
+function hipMemcpyAsync_c8_assumed_rank_c_size_t(dest,src,length,myKind,stream)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      complex(c_double_complex),target,contiguous,dimension(..),intent(inout) :: dest
+      complex(c_double_complex),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_size_t),intent(in) :: length
+      integer(kind(hipMemcpyHostToHost)) :: myKind
+      type(c_ptr) :: stream
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpyAsync_c8_assumed_rank_c_size_t
+#else
+      integer(kind(hipSuccess)) :: hipMemcpyAsync_c8_assumed_rank_c_size_t
+#endif
+      !
+      hipMemcpyAsync_c8_assumed_rank_c_size_t = hipMemcpyAsync_(c_loc(dest),c_loc(src),length*2*8_8,myKind,stream)
+    end function
+
+function hipMemcpyAsync_c8_assumed_rank(dest,src,myKind,stream)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      complex(c_double_complex),target,contiguous,dimension(..),intent(inout) :: dest
+      complex(c_double_complex),target,contiguous,dimension(..),intent(in)    :: src
+      integer(kind(hipMemcpyHostToHost)) :: myKind
+      type(c_ptr) :: stream
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpyAsync_c8_assumed_rank
+#else
+      integer(kind(hipSuccess)) :: hipMemcpyAsync_c8_assumed_rank
+#endif
+      !
+      hipMemcpyAsync_c8_assumed_rank = hipMemcpyAsync_(c_loc(dest),c_loc(src),size(dest)*2*8_8,myKind,stream)
+    end function
+
+function hipMemcpy2D_l_assumed_rank_c_int(dest,dpitch,src,spitch,width,height,myKind)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      logical(c_bool),target,contiguous,dimension(..),intent(inout) :: dest
+      integer(c_int) :: dpitch
+      logical(c_bool),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_int) :: spitch
+      integer(c_int) :: width
+      integer(c_int) :: height
+      integer(kind(hipMemcpyHostToHost)),value :: myKind
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpy2D_l_assumed_rank_c_int
+#else
+      integer(kind(hipSuccess)) :: hipMemcpy2D_l_assumed_rank_c_int
+#endif
+      !
+      hipMemcpy2D_l_assumed_rank_c_int = hipMemcpy2D_(c_loc(dest),1_8*dpitch,c_loc(src),1_8*spitch,1_8*width,height*1_8,myKind)
+    end function
+
+function hipMemcpy2D_l_assumed_rank_c_size_t(dest,dpitch,src,spitch,width,height,myKind)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      logical(c_bool),target,contiguous,dimension(..),intent(inout) :: dest
+      integer(c_size_t) :: dpitch
+      logical(c_bool),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_size_t) :: spitch
+      integer(c_size_t) :: width
+      integer(c_size_t) :: height
+      integer(kind(hipMemcpyHostToHost)),value :: myKind
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpy2D_l_assumed_rank_c_size_t
+#else
+      integer(kind(hipSuccess)) :: hipMemcpy2D_l_assumed_rank_c_size_t
+#endif
+      !
+      hipMemcpy2D_l_assumed_rank_c_size_t = hipMemcpy2D_(c_loc(dest),1_8*dpitch,c_loc(src),1_8*spitch,1_8*width,height*1_8,myKind)
+    end function
+
+function hipMemcpy2D_i4_assumed_rank_c_int(dest,dpitch,src,spitch,width,height,myKind)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      integer(c_int),target,contiguous,dimension(..),intent(inout) :: dest
+      integer(c_int) :: dpitch
+      integer(c_int),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_int) :: spitch
+      integer(c_int) :: width
+      integer(c_int) :: height
+      integer(kind(hipMemcpyHostToHost)),value :: myKind
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpy2D_i4_assumed_rank_c_int
+#else
+      integer(kind(hipSuccess)) :: hipMemcpy2D_i4_assumed_rank_c_int
+#endif
+      !
+      hipMemcpy2D_i4_assumed_rank_c_int = hipMemcpy2D_(c_loc(dest),4_8*dpitch,c_loc(src),4_8*spitch,4_8*width,height*1_8,myKind)
+    end function
+
+function hipMemcpy2D_i4_assumed_rank_c_size_t(dest,dpitch,src,spitch,width,height,myKind)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      integer(c_int),target,contiguous,dimension(..),intent(inout) :: dest
+      integer(c_size_t) :: dpitch
+      integer(c_int),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_size_t) :: spitch
+      integer(c_size_t) :: width
+      integer(c_size_t) :: height
+      integer(kind(hipMemcpyHostToHost)),value :: myKind
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpy2D_i4_assumed_rank_c_size_t
+#else
+      integer(kind(hipSuccess)) :: hipMemcpy2D_i4_assumed_rank_c_size_t
+#endif
+      !
+      hipMemcpy2D_i4_assumed_rank_c_size_t = hipMemcpy2D_(c_loc(dest),4_8*dpitch,c_loc(src),4_8*spitch,4_8*width,height*1_8,myKind)
+    end function
+
+function hipMemcpy2D_i8_assumed_rank_c_int(dest,dpitch,src,spitch,width,height,myKind)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      integer(c_long),target,contiguous,dimension(..),intent(inout) :: dest
+      integer(c_int) :: dpitch
+      integer(c_long),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_int) :: spitch
+      integer(c_int) :: width
+      integer(c_int) :: height
+      integer(kind(hipMemcpyHostToHost)),value :: myKind
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpy2D_i8_assumed_rank_c_int
+#else
+      integer(kind(hipSuccess)) :: hipMemcpy2D_i8_assumed_rank_c_int
+#endif
+      !
+      hipMemcpy2D_i8_assumed_rank_c_int = hipMemcpy2D_(c_loc(dest),8_8*dpitch,c_loc(src),8_8*spitch,8_8*width,height*1_8,myKind)
+    end function
+
+function hipMemcpy2D_i8_assumed_rank_c_size_t(dest,dpitch,src,spitch,width,height,myKind)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      integer(c_long),target,contiguous,dimension(..),intent(inout) :: dest
+      integer(c_size_t) :: dpitch
+      integer(c_long),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_size_t) :: spitch
+      integer(c_size_t) :: width
+      integer(c_size_t) :: height
+      integer(kind(hipMemcpyHostToHost)),value :: myKind
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpy2D_i8_assumed_rank_c_size_t
+#else
+      integer(kind(hipSuccess)) :: hipMemcpy2D_i8_assumed_rank_c_size_t
+#endif
+      !
+      hipMemcpy2D_i8_assumed_rank_c_size_t = hipMemcpy2D_(c_loc(dest),8_8*dpitch,c_loc(src),8_8*spitch,8_8*width,height*1_8,myKind)
+    end function
+
+function hipMemcpy2D_r4_assumed_rank_c_int(dest,dpitch,src,spitch,width,height,myKind)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      real(c_float),target,contiguous,dimension(..),intent(inout) :: dest
+      integer(c_int) :: dpitch
+      real(c_float),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_int) :: spitch
+      integer(c_int) :: width
+      integer(c_int) :: height
+      integer(kind(hipMemcpyHostToHost)),value :: myKind
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpy2D_r4_assumed_rank_c_int
+#else
+      integer(kind(hipSuccess)) :: hipMemcpy2D_r4_assumed_rank_c_int
+#endif
+      !
+      hipMemcpy2D_r4_assumed_rank_c_int = hipMemcpy2D_(c_loc(dest),4_8*dpitch,c_loc(src),4_8*spitch,4_8*width,height*1_8,myKind)
+    end function
+
+function hipMemcpy2D_r4_assumed_rank_c_size_t(dest,dpitch,src,spitch,width,height,myKind)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      real(c_float),target,contiguous,dimension(..),intent(inout) :: dest
+      integer(c_size_t) :: dpitch
+      real(c_float),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_size_t) :: spitch
+      integer(c_size_t) :: width
+      integer(c_size_t) :: height
+      integer(kind(hipMemcpyHostToHost)),value :: myKind
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpy2D_r4_assumed_rank_c_size_t
+#else
+      integer(kind(hipSuccess)) :: hipMemcpy2D_r4_assumed_rank_c_size_t
+#endif
+      !
+      hipMemcpy2D_r4_assumed_rank_c_size_t = hipMemcpy2D_(c_loc(dest),4_8*dpitch,c_loc(src),4_8*spitch,4_8*width,height*1_8,myKind)
+    end function
+
+function hipMemcpy2D_r8_assumed_rank_c_int(dest,dpitch,src,spitch,width,height,myKind)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      real(c_double),target,contiguous,dimension(..),intent(inout) :: dest
+      integer(c_int) :: dpitch
+      real(c_double),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_int) :: spitch
+      integer(c_int) :: width
+      integer(c_int) :: height
+      integer(kind(hipMemcpyHostToHost)),value :: myKind
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpy2D_r8_assumed_rank_c_int
+#else
+      integer(kind(hipSuccess)) :: hipMemcpy2D_r8_assumed_rank_c_int
+#endif
+      !
+      hipMemcpy2D_r8_assumed_rank_c_int = hipMemcpy2D_(c_loc(dest),8_8*dpitch,c_loc(src),8_8*spitch,8_8*width,height*1_8,myKind)
+    end function
+
+function hipMemcpy2D_r8_assumed_rank_c_size_t(dest,dpitch,src,spitch,width,height,myKind)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      real(c_double),target,contiguous,dimension(..),intent(inout) :: dest
+      integer(c_size_t) :: dpitch
+      real(c_double),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_size_t) :: spitch
+      integer(c_size_t) :: width
+      integer(c_size_t) :: height
+      integer(kind(hipMemcpyHostToHost)),value :: myKind
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpy2D_r8_assumed_rank_c_size_t
+#else
+      integer(kind(hipSuccess)) :: hipMemcpy2D_r8_assumed_rank_c_size_t
+#endif
+      !
+      hipMemcpy2D_r8_assumed_rank_c_size_t = hipMemcpy2D_(c_loc(dest),8_8*dpitch,c_loc(src),8_8*spitch,8_8*width,height*1_8,myKind)
+    end function
+
+function hipMemcpy2D_c4_assumed_rank_c_int(dest,dpitch,src,spitch,width,height,myKind)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      complex(c_float_complex),target,contiguous,dimension(..),intent(inout) :: dest
+      integer(c_int) :: dpitch
+      complex(c_float_complex),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_int) :: spitch
+      integer(c_int) :: width
+      integer(c_int) :: height
+      integer(kind(hipMemcpyHostToHost)),value :: myKind
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpy2D_c4_assumed_rank_c_int
+#else
+      integer(kind(hipSuccess)) :: hipMemcpy2D_c4_assumed_rank_c_int
+#endif
+      !
+      hipMemcpy2D_c4_assumed_rank_c_int = &
+          hipMemcpy2D_(c_loc(dest),2*4_8*dpitch,c_loc(src),2*4_8*spitch,2*4_8*width,height*1_8,myKind)
+    end function
+
+function hipMemcpy2D_c4_assumed_rank_c_size_t(dest,dpitch,src,spitch,width,height,myKind)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      complex(c_float_complex),target,contiguous,dimension(..),intent(inout) :: dest
+      integer(c_size_t) :: dpitch
+      complex(c_float_complex),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_size_t) :: spitch
+      integer(c_size_t) :: width
+      integer(c_size_t) :: height
+      integer(kind(hipMemcpyHostToHost)),value :: myKind
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpy2D_c4_assumed_rank_c_size_t
+#else
+      integer(kind(hipSuccess)) :: hipMemcpy2D_c4_assumed_rank_c_size_t
+#endif
+      !
+      hipMemcpy2D_c4_assumed_rank_c_size_t = &
+          hipMemcpy2D_(c_loc(dest),2*4_8*dpitch,c_loc(src),2*4_8*spitch,2*4_8*width,height*1_8,myKind)
+    end function
+
+function hipMemcpy2D_c8_assumed_rank_c_int(dest,dpitch,src,spitch,width,height,myKind)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      complex(c_double_complex),target,contiguous,dimension(..),intent(inout) :: dest
+      integer(c_int) :: dpitch
+      complex(c_double_complex),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_int) :: spitch
+      integer(c_int) :: width
+      integer(c_int) :: height
+      integer(kind(hipMemcpyHostToHost)),value :: myKind
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpy2D_c8_assumed_rank_c_int
+#else
+      integer(kind(hipSuccess)) :: hipMemcpy2D_c8_assumed_rank_c_int
+#endif
+      !
+      hipMemcpy2D_c8_assumed_rank_c_int = &
+          hipMemcpy2D_(c_loc(dest),2*8_8*dpitch,c_loc(src),2*8_8*spitch,2*8_8*width,height*1_8,myKind)
+    end function
+
+function hipMemcpy2D_c8_assumed_rank_c_size_t(dest,dpitch,src,spitch,width,height,myKind)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      complex(c_double_complex),target,contiguous,dimension(..),intent(inout) :: dest
+      integer(c_size_t) :: dpitch
+      complex(c_double_complex),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_size_t) :: spitch
+      integer(c_size_t) :: width
+      integer(c_size_t) :: height
+      integer(kind(hipMemcpyHostToHost)),value :: myKind
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpy2D_c8_assumed_rank_c_size_t
+#else
+      integer(kind(hipSuccess)) :: hipMemcpy2D_c8_assumed_rank_c_size_t
+#endif
+      !
+      hipMemcpy2D_c8_assumed_rank_c_size_t = &
+          hipMemcpy2D_(c_loc(dest),2*8_8*dpitch,c_loc(src),2*8_8*spitch,2*8_8*width,height*1_8,myKind)
+    end function
+
+function hipMemcpy2DAsync_l_assumed_rank_c_int(dest,dpitch,src,spitch,width,height,myKind,stream)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      logical(c_bool),target,contiguous,dimension(..),intent(inout) :: dest
+      integer(c_int) :: dpitch
+      logical(c_bool),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_int) :: spitch
+      integer(c_int) :: width
+      integer(c_int) :: height
+      integer(kind(hipMemcpyHostToHost)),value :: myKind
+      type(c_ptr),value :: stream
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpy2DAsync_l_assumed_rank_c_int
+#else
+      integer(kind(hipSuccess)) :: hipMemcpy2DAsync_l_assumed_rank_c_int
+#endif
+      !
+      hipMemcpy2DAsync_l_assumed_rank_c_int = &
+          hipMemcpy2DAsync_(c_loc(dest),1_8*dpitch,c_loc(src),1_8*spitch,1_8*width,height*1_8,myKind, &
+          stream)
+    end function
+
+function hipMemcpy2DAsync_l_assumed_rank_c_size_t(dest,dpitch,src,spitch,width,height,myKind,stream)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      logical(c_bool),target,contiguous,dimension(..),intent(inout) :: dest
+      integer(c_size_t) :: dpitch
+      logical(c_bool),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_size_t) :: spitch
+      integer(c_size_t) :: width
+      integer(c_size_t) :: height
+      integer(kind(hipMemcpyHostToHost)),value :: myKind
+      type(c_ptr),value :: stream
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpy2DAsync_l_assumed_rank_c_size_t
+#else
+      integer(kind(hipSuccess)) :: hipMemcpy2DAsync_l_assumed_rank_c_size_t
+#endif
+      !
+      hipMemcpy2DAsync_l_assumed_rank_c_size_t = &
+          hipMemcpy2DAsync_(c_loc(dest),1_8*dpitch,c_loc(src),1_8*spitch,1_8*width,height*1_8,myKind, &
+          stream)
+    end function
+
+function hipMemcpy2DAsync_i4_assumed_rank_c_int(dest,dpitch,src,spitch,width,height,myKind,stream)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      integer(c_int),target,contiguous,dimension(..),intent(inout) :: dest
+      integer(c_int) :: dpitch
+      integer(c_int),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_int) :: spitch
+      integer(c_int) :: width
+      integer(c_int) :: height
+      integer(kind(hipMemcpyHostToHost)),value :: myKind
+      type(c_ptr),value :: stream
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpy2DAsync_i4_assumed_rank_c_int
+#else
+      integer(kind(hipSuccess)) :: hipMemcpy2DAsync_i4_assumed_rank_c_int
+#endif
+      !
+      hipMemcpy2DAsync_i4_assumed_rank_c_int = &
+          hipMemcpy2DAsync_(c_loc(dest),4_8*dpitch,c_loc(src),4_8*spitch,4_8*width,height*1_8,myKind, &
+          stream)
+    end function
+
+function hipMemcpy2DAsync_i4_assumed_rank_c_size_t(dest,dpitch,src,spitch,width,height,myKind,stream)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      integer(c_int),target,contiguous,dimension(..),intent(inout) :: dest
+      integer(c_size_t) :: dpitch
+      integer(c_int),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_size_t) :: spitch
+      integer(c_size_t) :: width
+      integer(c_size_t) :: height
+      integer(kind(hipMemcpyHostToHost)),value :: myKind
+      type(c_ptr),value :: stream
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpy2DAsync_i4_assumed_rank_c_size_t
+#else
+      integer(kind(hipSuccess)) :: hipMemcpy2DAsync_i4_assumed_rank_c_size_t
+#endif
+      !
+      hipMemcpy2DAsync_i4_assumed_rank_c_size_t = &
+          hipMemcpy2DAsync_(c_loc(dest),4_8*dpitch,c_loc(src),4_8*spitch,4_8*width,height*1_8,myKind, &
+          stream)
+    end function
+
+function hipMemcpy2DAsync_i8_assumed_rank_c_int(dest,dpitch,src,spitch,width,height,myKind,stream)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      integer(c_long),target,contiguous,dimension(..),intent(inout) :: dest
+      integer(c_int) :: dpitch
+      integer(c_long),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_int) :: spitch
+      integer(c_int) :: width
+      integer(c_int) :: height
+      integer(kind(hipMemcpyHostToHost)),value :: myKind
+      type(c_ptr),value :: stream
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpy2DAsync_i8_assumed_rank_c_int
+#else
+      integer(kind(hipSuccess)) :: hipMemcpy2DAsync_i8_assumed_rank_c_int
+#endif
+      !
+      hipMemcpy2DAsync_i8_assumed_rank_c_int = &
+          hipMemcpy2DAsync_(c_loc(dest),8_8*dpitch,c_loc(src),8_8*spitch,8_8*width,height*1_8,myKind, &
+          stream)
+    end function
+
+function hipMemcpy2DAsync_i8_assumed_rank_c_size_t(dest,dpitch,src,spitch,width,height,myKind,stream)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      integer(c_long),target,contiguous,dimension(..),intent(inout) :: dest
+      integer(c_size_t) :: dpitch
+      integer(c_long),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_size_t) :: spitch
+      integer(c_size_t) :: width
+      integer(c_size_t) :: height
+      integer(kind(hipMemcpyHostToHost)),value :: myKind
+      type(c_ptr),value :: stream
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpy2DAsync_i8_assumed_rank_c_size_t
+#else
+      integer(kind(hipSuccess)) :: hipMemcpy2DAsync_i8_assumed_rank_c_size_t
+#endif
+      !
+      hipMemcpy2DAsync_i8_assumed_rank_c_size_t = &
+          hipMemcpy2DAsync_(c_loc(dest),8_8*dpitch,c_loc(src),8_8*spitch,8_8*width,height*1_8,myKind, &
+          stream)
+    end function
+
+function hipMemcpy2DAsync_r4_assumed_rank_c_int(dest,dpitch,src,spitch,width,height,myKind,stream)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      real(c_float),target,contiguous,dimension(..),intent(inout) :: dest
+      integer(c_int) :: dpitch
+      real(c_float),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_int) :: spitch
+      integer(c_int) :: width
+      integer(c_int) :: height
+      integer(kind(hipMemcpyHostToHost)),value :: myKind
+      type(c_ptr),value :: stream
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpy2DAsync_r4_assumed_rank_c_int
+#else
+      integer(kind(hipSuccess)) :: hipMemcpy2DAsync_r4_assumed_rank_c_int
+#endif
+      !
+      hipMemcpy2DAsync_r4_assumed_rank_c_int = &
+          hipMemcpy2DAsync_(c_loc(dest),4_8*dpitch,c_loc(src),4_8*spitch,4_8*width,height*1_8,myKind, &
+          stream)
+    end function
+
+function hipMemcpy2DAsync_r4_assumed_rank_c_size_t(dest,dpitch,src,spitch,width,height,myKind,stream)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      real(c_float),target,contiguous,dimension(..),intent(inout) :: dest
+      integer(c_size_t) :: dpitch
+      real(c_float),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_size_t) :: spitch
+      integer(c_size_t) :: width
+      integer(c_size_t) :: height
+      integer(kind(hipMemcpyHostToHost)),value :: myKind
+      type(c_ptr),value :: stream
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpy2DAsync_r4_assumed_rank_c_size_t
+#else
+      integer(kind(hipSuccess)) :: hipMemcpy2DAsync_r4_assumed_rank_c_size_t
+#endif
+      !
+      hipMemcpy2DAsync_r4_assumed_rank_c_size_t = &
+          hipMemcpy2DAsync_(c_loc(dest),4_8*dpitch,c_loc(src),4_8*spitch,4_8*width,height*1_8,myKind, &
+          stream)
+    end function
+
+function hipMemcpy2DAsync_r8_assumed_rank_c_int(dest,dpitch,src,spitch,width,height,myKind,stream)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      real(c_double),target,contiguous,dimension(..),intent(inout) :: dest
+      integer(c_int) :: dpitch
+      real(c_double),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_int) :: spitch
+      integer(c_int) :: width
+      integer(c_int) :: height
+      integer(kind(hipMemcpyHostToHost)),value :: myKind
+      type(c_ptr),value :: stream
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpy2DAsync_r8_assumed_rank_c_int
+#else
+      integer(kind(hipSuccess)) :: hipMemcpy2DAsync_r8_assumed_rank_c_int
+#endif
+      !
+      hipMemcpy2DAsync_r8_assumed_rank_c_int = &
+          hipMemcpy2DAsync_(c_loc(dest),8_8*dpitch,c_loc(src),8_8*spitch,8_8*width,height*1_8,myKind, &
+          stream)
+    end function
+
+function hipMemcpy2DAsync_r8_assumed_rank_c_size_t(dest,dpitch,src,spitch,width,height,myKind,stream)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      real(c_double),target,contiguous,dimension(..),intent(inout) :: dest
+      integer(c_size_t) :: dpitch
+      real(c_double),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_size_t) :: spitch
+      integer(c_size_t) :: width
+      integer(c_size_t) :: height
+      integer(kind(hipMemcpyHostToHost)),value :: myKind
+      type(c_ptr),value :: stream
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpy2DAsync_r8_assumed_rank_c_size_t
+#else
+      integer(kind(hipSuccess)) :: hipMemcpy2DAsync_r8_assumed_rank_c_size_t
+#endif
+      !
+      hipMemcpy2DAsync_r8_assumed_rank_c_size_t = &
+          hipMemcpy2DAsync_(c_loc(dest),8_8*dpitch,c_loc(src),8_8*spitch,8_8*width,height*1_8,myKind, &
+          stream)
+    end function
+
+function hipMemcpy2DAsync_c4_assumed_rank_c_int(dest,dpitch,src,spitch,width,height,myKind,stream)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      complex(c_float_complex),target,contiguous,dimension(..),intent(inout) :: dest
+      integer(c_int) :: dpitch
+      complex(c_float_complex),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_int) :: spitch
+      integer(c_int) :: width
+      integer(c_int) :: height
+      integer(kind(hipMemcpyHostToHost)),value :: myKind
+      type(c_ptr),value :: stream
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpy2DAsync_c4_assumed_rank_c_int
+#else
+      integer(kind(hipSuccess)) :: hipMemcpy2DAsync_c4_assumed_rank_c_int
+#endif
+      !
+      hipMemcpy2DAsync_c4_assumed_rank_c_int = &
+          hipMemcpy2DAsync_(c_loc(dest),2*4_8*dpitch,c_loc(src),2*4_8*spitch,2*4_8*width,height*1_8, &
+          myKind,stream)
+    end function
+
+function hipMemcpy2DAsync_c4_assumed_rank_c_size_t(dest,dpitch,src,spitch,width,height,myKind,stream)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      complex(c_float_complex),target,contiguous,dimension(..),intent(inout) :: dest
+      integer(c_size_t) :: dpitch
+      complex(c_float_complex),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_size_t) :: spitch
+      integer(c_size_t) :: width
+      integer(c_size_t) :: height
+      integer(kind(hipMemcpyHostToHost)),value :: myKind
+      type(c_ptr),value :: stream
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpy2DAsync_c4_assumed_rank_c_size_t
+#else
+      integer(kind(hipSuccess)) :: hipMemcpy2DAsync_c4_assumed_rank_c_size_t
+#endif
+      !
+      hipMemcpy2DAsync_c4_assumed_rank_c_size_t = &
+          hipMemcpy2DAsync_(c_loc(dest),2*4_8*dpitch,c_loc(src),2*4_8*spitch,2*4_8*width,height*1_8, &
+          myKind,stream)
+    end function
+
+function hipMemcpy2DAsync_c8_assumed_rank_c_int(dest,dpitch,src,spitch,width,height,myKind,stream)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      complex(c_double_complex),target,contiguous,dimension(..),intent(inout) :: dest
+      integer(c_int) :: dpitch
+      complex(c_double_complex),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_int) :: spitch
+      integer(c_int) :: width
+      integer(c_int) :: height
+      integer(kind(hipMemcpyHostToHost)),value :: myKind
+      type(c_ptr),value :: stream
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpy2DAsync_c8_assumed_rank_c_int
+#else
+      integer(kind(hipSuccess)) :: hipMemcpy2DAsync_c8_assumed_rank_c_int
+#endif
+      !
+      hipMemcpy2DAsync_c8_assumed_rank_c_int = &
+          hipMemcpy2DAsync_(c_loc(dest),2*8_8*dpitch,c_loc(src),2*8_8*spitch,2*8_8*width,height*1_8, &
+          myKind,stream)
+    end function
+
+function hipMemcpy2DAsync_c8_assumed_rank_c_size_t(dest,dpitch,src,spitch,width,height,myKind,stream)
+      use iso_c_binding
+#ifdef USE_CUDA_NAMES
+      use hipfort_cuda_errors
+#endif
+      use hipfort_enums
+      use hipfort_types
+      implicit none
+      complex(c_double_complex),target,contiguous,dimension(..),intent(inout) :: dest
+      integer(c_size_t) :: dpitch
+      complex(c_double_complex),target,contiguous,dimension(..),intent(in)    :: src
+      integer(c_size_t) :: spitch
+      integer(c_size_t) :: width
+      integer(c_size_t) :: height
+      integer(kind(hipMemcpyHostToHost)),value :: myKind
+      type(c_ptr),value :: stream
+#ifdef USE_CUDA_NAMES
+      integer(kind(cudaSuccess)) :: hipMemcpy2DAsync_c8_assumed_rank_c_size_t
+#else
+      integer(kind(hipSuccess)) :: hipMemcpy2DAsync_c8_assumed_rank_c_size_t
+#endif
+      !
+      hipMemcpy2DAsync_c8_assumed_rank_c_size_t = &
+          hipMemcpy2DAsync_(c_loc(dest),2*8_8*dpitch,c_loc(src),2*8_8*spitch,2*8_8*width,height*1_8, &
+          myKind,stream)
+    end function
+
+#else
     
                                                               
     function hipMemcpy_l_0_c_int(dest,src,length,myKind)
@@ -9681,5 +11376,6 @@ function hipMemcpy2DAsync_c8_2_c_size_t(dest,dpitch,src,spitch,width,height,myKi
           myKind,stream)
     end function
 
+#endif
 #endif
 end module

--- a/lib/hipfort/hipfort_hipsolver.F90
+++ b/lib/hipfort/hipfort_hipsolver.F90
@@ -14450,6 +14450,7 @@ module hipfort_hipsolver
 #ifdef USE_FPOINTER_INTERFACES
   contains
 #ifdef USE_ASSUMED_RANK_INTERFACES
+#ifndef USE_CUDA_NAMES
     function hipsolverSorgbr_bufferSize_assumed_rank(handle,side,m,n,k,A,lda,tau,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -14468,7 +14469,9 @@ module hipfort_hipsolver
       hipsolverSorgbr_bufferSize_assumed_rank = hipsolverSorgbr_bufferSize_(handle,side,m,n,k,c_loc(A), &
         lda,tau,lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverDorgbr_bufferSize_assumed_rank(handle,side,m,n,k,A,lda,tau,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -14487,7 +14490,9 @@ module hipfort_hipsolver
       hipsolverDorgbr_bufferSize_assumed_rank = hipsolverDorgbr_bufferSize_(handle,side,m,n,k,c_loc(A), &
         lda,tau,lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverCungbr_bufferSize_assumed_rank(handle,side,m,n,k,A,lda,tau,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -14506,7 +14511,9 @@ module hipfort_hipsolver
       hipsolverCungbr_bufferSize_assumed_rank = hipsolverCungbr_bufferSize_(handle,side,m,n,k,c_loc(A), &
         lda,tau,lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverZungbr_bufferSize_assumed_rank(handle,side,m,n,k,A,lda,tau,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -14525,7 +14532,9 @@ module hipfort_hipsolver
       hipsolverZungbr_bufferSize_assumed_rank = hipsolverZungbr_bufferSize_(handle,side,m,n,k,c_loc(A), &
         lda,tau,lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverSorgbr_assumed_rank(handle,side,m,n,k,A,lda,tau,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -14546,7 +14555,9 @@ module hipfort_hipsolver
       hipsolverSorgbr_assumed_rank = hipsolverSorgbr_(handle,side,m,n,k,c_loc(A),lda,tau,work,lwork, &
         devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverDorgbr_assumed_rank(handle,side,m,n,k,A,lda,tau,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -14567,7 +14578,9 @@ module hipfort_hipsolver
       hipsolverDorgbr_assumed_rank = hipsolverDorgbr_(handle,side,m,n,k,c_loc(A),lda,tau,work,lwork, &
         devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverCungbr_assumed_rank(handle,side,m,n,k,A,lda,tau,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -14588,7 +14601,9 @@ module hipfort_hipsolver
       hipsolverCungbr_assumed_rank = hipsolverCungbr_(handle,side,m,n,k,c_loc(A),lda,tau,work,lwork, &
         devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverZungbr_assumed_rank(handle,side,m,n,k,A,lda,tau,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -14609,7 +14624,9 @@ module hipfort_hipsolver
       hipsolverZungbr_assumed_rank = hipsolverZungbr_(handle,side,m,n,k,c_loc(A),lda,tau,work,lwork, &
         devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverSorgqr_bufferSize_assumed_rank(handle,m,n,k,A,lda,tau,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -14627,7 +14644,9 @@ module hipfort_hipsolver
       hipsolverSorgqr_bufferSize_assumed_rank = hipsolverSorgqr_bufferSize_(handle,m,n,k,c_loc(A),lda, &
         tau,lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverDorgqr_bufferSize_assumed_rank(handle,m,n,k,A,lda,tau,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -14645,7 +14664,9 @@ module hipfort_hipsolver
       hipsolverDorgqr_bufferSize_assumed_rank = hipsolverDorgqr_bufferSize_(handle,m,n,k,c_loc(A),lda, &
         tau,lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverCungqr_bufferSize_assumed_rank(handle,m,n,k,A,lda,tau,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -14663,7 +14684,9 @@ module hipfort_hipsolver
       hipsolverCungqr_bufferSize_assumed_rank = hipsolverCungqr_bufferSize_(handle,m,n,k,c_loc(A),lda, &
         tau,lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverZungqr_bufferSize_assumed_rank(handle,m,n,k,A,lda,tau,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -14681,7 +14704,9 @@ module hipfort_hipsolver
       hipsolverZungqr_bufferSize_assumed_rank = hipsolverZungqr_bufferSize_(handle,m,n,k,c_loc(A),lda, &
         tau,lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverSorgqr_assumed_rank(handle,m,n,k,A,lda,tau,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -14700,7 +14725,9 @@ module hipfort_hipsolver
       !
       hipsolverSorgqr_assumed_rank = hipsolverSorgqr_(handle,m,n,k,c_loc(A),lda,tau,work,lwork,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverDorgqr_assumed_rank(handle,m,n,k,A,lda,tau,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -14719,7 +14746,9 @@ module hipfort_hipsolver
       !
       hipsolverDorgqr_assumed_rank = hipsolverDorgqr_(handle,m,n,k,c_loc(A),lda,tau,work,lwork,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverCungqr_assumed_rank(handle,m,n,k,A,lda,tau,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -14738,7 +14767,9 @@ module hipfort_hipsolver
       !
       hipsolverCungqr_assumed_rank = hipsolverCungqr_(handle,m,n,k,c_loc(A),lda,tau,work,lwork,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverZungqr_assumed_rank(handle,m,n,k,A,lda,tau,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -14757,7 +14788,9 @@ module hipfort_hipsolver
       !
       hipsolverZungqr_assumed_rank = hipsolverZungqr_(handle,m,n,k,c_loc(A),lda,tau,work,lwork,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverSorgtr_bufferSize_assumed_rank(handle,uplo,n,A,lda,tau,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -14774,7 +14807,9 @@ module hipfort_hipsolver
       hipsolverSorgtr_bufferSize_assumed_rank = hipsolverSorgtr_bufferSize_(handle,uplo,n,c_loc(A),lda, &
         tau,lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverDorgtr_bufferSize_assumed_rank(handle,uplo,n,A,lda,tau,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -14791,7 +14826,9 @@ module hipfort_hipsolver
       hipsolverDorgtr_bufferSize_assumed_rank = hipsolverDorgtr_bufferSize_(handle,uplo,n,c_loc(A),lda, &
         tau,lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverCungtr_bufferSize_assumed_rank(handle,uplo,n,A,lda,tau,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -14808,7 +14845,9 @@ module hipfort_hipsolver
       hipsolverCungtr_bufferSize_assumed_rank = hipsolverCungtr_bufferSize_(handle,uplo,n,c_loc(A),lda, &
         tau,lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverZungtr_bufferSize_assumed_rank(handle,uplo,n,A,lda,tau,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -14825,7 +14864,9 @@ module hipfort_hipsolver
       hipsolverZungtr_bufferSize_assumed_rank = hipsolverZungtr_bufferSize_(handle,uplo,n,c_loc(A),lda, &
         tau,lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverSorgtr_assumed_rank(handle,uplo,n,A,lda,tau,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -14843,7 +14884,9 @@ module hipfort_hipsolver
       !
       hipsolverSorgtr_assumed_rank = hipsolverSorgtr_(handle,uplo,n,c_loc(A),lda,tau,work,lwork,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverDorgtr_assumed_rank(handle,uplo,n,A,lda,tau,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -14861,7 +14904,9 @@ module hipfort_hipsolver
       !
       hipsolverDorgtr_assumed_rank = hipsolverDorgtr_(handle,uplo,n,c_loc(A),lda,tau,work,lwork,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverCungtr_assumed_rank(handle,uplo,n,A,lda,tau,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -14879,7 +14924,9 @@ module hipfort_hipsolver
       !
       hipsolverCungtr_assumed_rank = hipsolverCungtr_(handle,uplo,n,c_loc(A),lda,tau,work,lwork,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverZungtr_assumed_rank(handle,uplo,n,A,lda,tau,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -14897,7 +14944,9 @@ module hipfort_hipsolver
       !
       hipsolverZungtr_assumed_rank = hipsolverZungtr_(handle,uplo,n,c_loc(A),lda,tau,work,lwork,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverSormqr_bufferSize_assumed_rank(handle,side,trans,m,n,k,A,lda,tau,C,ldc,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -14919,7 +14968,9 @@ module hipfort_hipsolver
       hipsolverSormqr_bufferSize_assumed_rank = hipsolverSormqr_bufferSize_(handle,side,trans,m,n,k, &
         c_loc(A),lda,tau,c_loc(C),ldc,lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverDormqr_bufferSize_assumed_rank(handle,side,trans,m,n,k,A,lda,tau,C,ldc,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -14941,7 +14992,9 @@ module hipfort_hipsolver
       hipsolverDormqr_bufferSize_assumed_rank = hipsolverDormqr_bufferSize_(handle,side,trans,m,n,k, &
         c_loc(A),lda,tau,c_loc(C),ldc,lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverCunmqr_bufferSize_assumed_rank(handle,side,trans,m,n,k,A,lda,tau,C,ldc,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -14963,7 +15016,9 @@ module hipfort_hipsolver
       hipsolverCunmqr_bufferSize_assumed_rank = hipsolverCunmqr_bufferSize_(handle,side,trans,m,n,k, &
         c_loc(A),lda,tau,c_loc(C),ldc,lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverZunmqr_bufferSize_assumed_rank(handle,side,trans,m,n,k,A,lda,tau,C,ldc,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -14985,7 +15040,9 @@ module hipfort_hipsolver
       hipsolverZunmqr_bufferSize_assumed_rank = hipsolverZunmqr_bufferSize_(handle,side,trans,m,n,k, &
         c_loc(A),lda,tau,c_loc(C),ldc,lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverSormqr_assumed_rank(handle,side,trans,m,n,k,A,lda,tau,C,ldc,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15009,7 +15066,9 @@ module hipfort_hipsolver
       hipsolverSormqr_assumed_rank = hipsolverSormqr_(handle,side,trans,m,n,k,c_loc(A),lda,tau,c_loc(C), &
         ldc,work,lwork,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverDormqr_assumed_rank(handle,side,trans,m,n,k,A,lda,tau,C,ldc,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15033,7 +15092,9 @@ module hipfort_hipsolver
       hipsolverDormqr_assumed_rank = hipsolverDormqr_(handle,side,trans,m,n,k,c_loc(A),lda,tau,c_loc(C), &
         ldc,work,lwork,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverCunmqr_assumed_rank(handle,side,trans,m,n,k,A,lda,tau,C,ldc,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15057,7 +15118,9 @@ module hipfort_hipsolver
       hipsolverCunmqr_assumed_rank = hipsolverCunmqr_(handle,side,trans,m,n,k,c_loc(A),lda,tau,c_loc(C), &
         ldc,work,lwork,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverZunmqr_assumed_rank(handle,side,trans,m,n,k,A,lda,tau,C,ldc,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15081,7 +15144,9 @@ module hipfort_hipsolver
       hipsolverZunmqr_assumed_rank = hipsolverZunmqr_(handle,side,trans,m,n,k,c_loc(A),lda,tau,c_loc(C), &
         ldc,work,lwork,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverSormtr_bufferSize_assumed_rank(handle,side,uplo,trans,m,n,A,lda,tau,C,ldc,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15103,7 +15168,9 @@ module hipfort_hipsolver
       hipsolverSormtr_bufferSize_assumed_rank = hipsolverSormtr_bufferSize_(handle,side,uplo,trans,m,n, &
         c_loc(A),lda,tau,c_loc(C),ldc,lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverDormtr_bufferSize_assumed_rank(handle,side,uplo,trans,m,n,A,lda,tau,C,ldc,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15125,7 +15192,9 @@ module hipfort_hipsolver
       hipsolverDormtr_bufferSize_assumed_rank = hipsolverDormtr_bufferSize_(handle,side,uplo,trans,m,n, &
         c_loc(A),lda,tau,c_loc(C),ldc,lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverCunmtr_bufferSize_assumed_rank(handle,side,uplo,trans,m,n,A,lda,tau,C,ldc,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15147,7 +15216,9 @@ module hipfort_hipsolver
       hipsolverCunmtr_bufferSize_assumed_rank = hipsolverCunmtr_bufferSize_(handle,side,uplo,trans,m,n, &
         c_loc(A),lda,tau,c_loc(C),ldc,lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverZunmtr_bufferSize_assumed_rank(handle,side,uplo,trans,m,n,A,lda,tau,C,ldc,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15169,7 +15240,9 @@ module hipfort_hipsolver
       hipsolverZunmtr_bufferSize_assumed_rank = hipsolverZunmtr_bufferSize_(handle,side,uplo,trans,m,n, &
         c_loc(A),lda,tau,c_loc(C),ldc,lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverSormtr_assumed_rank(handle,side,uplo,trans,m,n,A,lda,tau,C,ldc,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15193,7 +15266,9 @@ module hipfort_hipsolver
       hipsolverSormtr_assumed_rank = hipsolverSormtr_(handle,side,uplo,trans,m,n,c_loc(A),lda,tau, &
         c_loc(C),ldc,work,lwork,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverDormtr_assumed_rank(handle,side,uplo,trans,m,n,A,lda,tau,C,ldc,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15217,7 +15292,9 @@ module hipfort_hipsolver
       hipsolverDormtr_assumed_rank = hipsolverDormtr_(handle,side,uplo,trans,m,n,c_loc(A),lda,tau, &
         c_loc(C),ldc,work,lwork,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverCunmtr_assumed_rank(handle,side,uplo,trans,m,n,A,lda,tau,C,ldc,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15241,7 +15318,9 @@ module hipfort_hipsolver
       hipsolverCunmtr_assumed_rank = hipsolverCunmtr_(handle,side,uplo,trans,m,n,c_loc(A),lda,tau, &
         c_loc(C),ldc,work,lwork,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverZunmtr_assumed_rank(handle,side,uplo,trans,m,n,A,lda,tau,C,ldc,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15265,7 +15344,9 @@ module hipfort_hipsolver
       hipsolverZunmtr_assumed_rank = hipsolverZunmtr_(handle,side,uplo,trans,m,n,c_loc(A),lda,tau, &
         c_loc(C),ldc,work,lwork,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverSgebrd_assumed_rank(handle,m,n,A,lda,D,E,tauq,taup,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15287,7 +15368,9 @@ module hipfort_hipsolver
       hipsolverSgebrd_assumed_rank = hipsolverSgebrd_(handle,m,n,c_loc(A),lda,c_loc(D),c_loc(E), &
         c_loc(tauq),c_loc(taup),work,lwork,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverDgebrd_assumed_rank(handle,m,n,A,lda,D,E,tauq,taup,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15309,7 +15392,9 @@ module hipfort_hipsolver
       hipsolverDgebrd_assumed_rank = hipsolverDgebrd_(handle,m,n,c_loc(A),lda,c_loc(D),c_loc(E), &
         c_loc(tauq),c_loc(taup),work,lwork,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverCgebrd_assumed_rank(handle,m,n,A,lda,D,E,tauq,taup,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15331,7 +15416,9 @@ module hipfort_hipsolver
       hipsolverCgebrd_assumed_rank = hipsolverCgebrd_(handle,m,n,c_loc(A),lda,c_loc(D),c_loc(E), &
         c_loc(tauq),c_loc(taup),work,lwork,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverZgebrd_assumed_rank(handle,m,n,A,lda,D,E,tauq,taup,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15353,7 +15440,9 @@ module hipfort_hipsolver
       hipsolverZgebrd_assumed_rank = hipsolverZgebrd_(handle,m,n,c_loc(A),lda,c_loc(D),c_loc(E), &
         c_loc(tauq),c_loc(taup),work,lwork,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverSgeqrf_bufferSize_assumed_rank(handle,m,n,A,lda,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15368,7 +15457,9 @@ module hipfort_hipsolver
       !
       hipsolverSgeqrf_bufferSize_assumed_rank = hipsolverSgeqrf_bufferSize_(handle,m,n,c_loc(A),lda,lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverDgeqrf_bufferSize_assumed_rank(handle,m,n,A,lda,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15383,7 +15474,9 @@ module hipfort_hipsolver
       !
       hipsolverDgeqrf_bufferSize_assumed_rank = hipsolverDgeqrf_bufferSize_(handle,m,n,c_loc(A),lda,lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverCgeqrf_bufferSize_assumed_rank(handle,m,n,A,lda,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15398,7 +15491,9 @@ module hipfort_hipsolver
       !
       hipsolverCgeqrf_bufferSize_assumed_rank = hipsolverCgeqrf_bufferSize_(handle,m,n,c_loc(A),lda,lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverZgeqrf_bufferSize_assumed_rank(handle,m,n,A,lda,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15413,7 +15508,9 @@ module hipfort_hipsolver
       !
       hipsolverZgeqrf_bufferSize_assumed_rank = hipsolverZgeqrf_bufferSize_(handle,m,n,c_loc(A),lda,lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverSgeqrf_assumed_rank(handle,m,n,A,lda,tau,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15431,7 +15528,9 @@ module hipfort_hipsolver
       !
       hipsolverSgeqrf_assumed_rank = hipsolverSgeqrf_(handle,m,n,c_loc(A),lda,tau,work,lwork,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverDgeqrf_assumed_rank(handle,m,n,A,lda,tau,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15449,7 +15548,9 @@ module hipfort_hipsolver
       !
       hipsolverDgeqrf_assumed_rank = hipsolverDgeqrf_(handle,m,n,c_loc(A),lda,tau,work,lwork,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverCgeqrf_assumed_rank(handle,m,n,A,lda,tau,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15467,7 +15568,9 @@ module hipfort_hipsolver
       !
       hipsolverCgeqrf_assumed_rank = hipsolverCgeqrf_(handle,m,n,c_loc(A),lda,tau,work,lwork,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverZgeqrf_assumed_rank(handle,m,n,A,lda,tau,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15485,7 +15588,9 @@ module hipfort_hipsolver
       !
       hipsolverZgeqrf_assumed_rank = hipsolverZgeqrf_(handle,m,n,c_loc(A),lda,tau,work,lwork,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverSSgesv_bufferSize_assumed_rank(handle,n,nrhs,A,lda,devIpiv,B,ldb,X,ldx,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15506,7 +15611,9 @@ module hipfort_hipsolver
       hipsolverSSgesv_bufferSize_assumed_rank = hipsolverSSgesv_bufferSize_(handle,n,nrhs,c_loc(A),lda, &
         c_loc(devIpiv),c_loc(B),ldb,c_loc(X),ldx,lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverDDgesv_bufferSize_assumed_rank(handle,n,nrhs,A,lda,devIpiv,B,ldb,X,ldx,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15527,7 +15634,9 @@ module hipfort_hipsolver
       hipsolverDDgesv_bufferSize_assumed_rank = hipsolverDDgesv_bufferSize_(handle,n,nrhs,c_loc(A),lda, &
         c_loc(devIpiv),c_loc(B),ldb,c_loc(X),ldx,lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverCCgesv_bufferSize_assumed_rank(handle,n,nrhs,A,lda,devIpiv,B,ldb,X,ldx,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15548,7 +15657,9 @@ module hipfort_hipsolver
       hipsolverCCgesv_bufferSize_assumed_rank = hipsolverCCgesv_bufferSize_(handle,n,nrhs,c_loc(A),lda, &
         c_loc(devIpiv),c_loc(B),ldb,c_loc(X),ldx,lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverZZgesv_bufferSize_assumed_rank(handle,n,nrhs,A,lda,devIpiv,B,ldb,X,ldx,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15569,7 +15680,9 @@ module hipfort_hipsolver
       hipsolverZZgesv_bufferSize_assumed_rank = hipsolverZZgesv_bufferSize_(handle,n,nrhs,c_loc(A),lda, &
         c_loc(devIpiv),c_loc(B),ldb,c_loc(X),ldx,lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverSSgesv_assumed_rank(handle,n,nrhs,A,lda,devIpiv,B,ldb,X,ldx,work,lwork,niters, &
         devInfo)
       use iso_c_binding
@@ -15594,7 +15707,9 @@ module hipfort_hipsolver
       hipsolverSSgesv_assumed_rank = hipsolverSSgesv_(handle,n,nrhs,c_loc(A),lda,c_loc(devIpiv), &
         c_loc(B),ldb,c_loc(X),ldx,work,lwork,niters,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverDDgesv_assumed_rank(handle,n,nrhs,A,lda,devIpiv,B,ldb,X,ldx,work,lwork,niters, &
         devInfo)
       use iso_c_binding
@@ -15619,7 +15734,9 @@ module hipfort_hipsolver
       hipsolverDDgesv_assumed_rank = hipsolverDDgesv_(handle,n,nrhs,c_loc(A),lda,c_loc(devIpiv), &
         c_loc(B),ldb,c_loc(X),ldx,work,lwork,niters,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverCCgesv_assumed_rank(handle,n,nrhs,A,lda,devIpiv,B,ldb,X,ldx,work,lwork,niters, &
         devInfo)
       use iso_c_binding
@@ -15644,7 +15761,9 @@ module hipfort_hipsolver
       hipsolverCCgesv_assumed_rank = hipsolverCCgesv_(handle,n,nrhs,c_loc(A),lda,c_loc(devIpiv), &
         c_loc(B),ldb,c_loc(X),ldx,work,lwork,niters,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverZZgesv_assumed_rank(handle,n,nrhs,A,lda,devIpiv,B,ldb,X,ldx,work,lwork,niters, &
         devInfo)
       use iso_c_binding
@@ -15669,7 +15788,9 @@ module hipfort_hipsolver
       hipsolverZZgesv_assumed_rank = hipsolverZZgesv_(handle,n,nrhs,c_loc(A),lda,c_loc(devIpiv), &
         c_loc(B),ldb,c_loc(X),ldx,work,lwork,niters,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverSgetrf_bufferSize_assumed_rank(handle,m,n,A,lda,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15684,7 +15805,9 @@ module hipfort_hipsolver
       !
       hipsolverSgetrf_bufferSize_assumed_rank = hipsolverSgetrf_bufferSize_(handle,m,n,c_loc(A),lda,lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverDgetrf_bufferSize_assumed_rank(handle,m,n,A,lda,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15699,7 +15822,9 @@ module hipfort_hipsolver
       !
       hipsolverDgetrf_bufferSize_assumed_rank = hipsolverDgetrf_bufferSize_(handle,m,n,c_loc(A),lda,lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverCgetrf_bufferSize_assumed_rank(handle,m,n,A,lda,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15714,7 +15839,9 @@ module hipfort_hipsolver
       !
       hipsolverCgetrf_bufferSize_assumed_rank = hipsolverCgetrf_bufferSize_(handle,m,n,c_loc(A),lda,lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverZgetrf_bufferSize_assumed_rank(handle,m,n,A,lda,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15729,7 +15856,9 @@ module hipfort_hipsolver
       !
       hipsolverZgetrf_bufferSize_assumed_rank = hipsolverZgetrf_bufferSize_(handle,m,n,c_loc(A),lda,lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverSgetrf_assumed_rank(handle,m,n,A,lda,work,lwork,devIpiv,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15748,7 +15877,9 @@ module hipfort_hipsolver
       hipsolverSgetrf_assumed_rank = hipsolverSgetrf_(handle,m,n,c_loc(A),lda,work,lwork,c_loc(devIpiv), &
         devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverDgetrf_assumed_rank(handle,m,n,A,lda,work,lwork,devIpiv,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15767,7 +15898,9 @@ module hipfort_hipsolver
       hipsolverDgetrf_assumed_rank = hipsolverDgetrf_(handle,m,n,c_loc(A),lda,work,lwork,c_loc(devIpiv), &
         devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverCgetrf_assumed_rank(handle,m,n,A,lda,work,lwork,devIpiv,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15786,7 +15919,9 @@ module hipfort_hipsolver
       hipsolverCgetrf_assumed_rank = hipsolverCgetrf_(handle,m,n,c_loc(A),lda,work,lwork,c_loc(devIpiv), &
         devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverZgetrf_assumed_rank(handle,m,n,A,lda,work,lwork,devIpiv,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15805,7 +15940,9 @@ module hipfort_hipsolver
       hipsolverZgetrf_assumed_rank = hipsolverZgetrf_(handle,m,n,c_loc(A),lda,work,lwork,c_loc(devIpiv), &
         devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverSgetrs_bufferSize_assumed_rank(handle,trans,n,nrhs,A,lda,devIpiv,B,ldb,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15825,7 +15962,9 @@ module hipfort_hipsolver
       hipsolverSgetrs_bufferSize_assumed_rank = hipsolverSgetrs_bufferSize_(handle,trans,n,nrhs, &
         c_loc(A),lda,c_loc(devIpiv),c_loc(B),ldb,lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverDgetrs_bufferSize_assumed_rank(handle,trans,n,nrhs,A,lda,devIpiv,B,ldb,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15845,7 +15984,9 @@ module hipfort_hipsolver
       hipsolverDgetrs_bufferSize_assumed_rank = hipsolverDgetrs_bufferSize_(handle,trans,n,nrhs, &
         c_loc(A),lda,c_loc(devIpiv),c_loc(B),ldb,lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverCgetrs_bufferSize_assumed_rank(handle,trans,n,nrhs,A,lda,devIpiv,B,ldb,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15865,7 +16006,9 @@ module hipfort_hipsolver
       hipsolverCgetrs_bufferSize_assumed_rank = hipsolverCgetrs_bufferSize_(handle,trans,n,nrhs, &
         c_loc(A),lda,c_loc(devIpiv),c_loc(B),ldb,lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverZgetrs_bufferSize_assumed_rank(handle,trans,n,nrhs,A,lda,devIpiv,B,ldb,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15885,7 +16028,9 @@ module hipfort_hipsolver
       hipsolverZgetrs_bufferSize_assumed_rank = hipsolverZgetrs_bufferSize_(handle,trans,n,nrhs, &
         c_loc(A),lda,c_loc(devIpiv),c_loc(B),ldb,lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverSgetrs_assumed_rank(handle,trans,n,nrhs,A,lda,devIpiv,B,ldb,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15907,7 +16052,9 @@ module hipfort_hipsolver
       hipsolverSgetrs_assumed_rank = hipsolverSgetrs_(handle,trans,n,nrhs,c_loc(A),lda,c_loc(devIpiv), &
         c_loc(B),ldb,work,lwork,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverDgetrs_assumed_rank(handle,trans,n,nrhs,A,lda,devIpiv,B,ldb,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15929,7 +16076,9 @@ module hipfort_hipsolver
       hipsolverDgetrs_assumed_rank = hipsolverDgetrs_(handle,trans,n,nrhs,c_loc(A),lda,c_loc(devIpiv), &
         c_loc(B),ldb,work,lwork,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverCgetrs_assumed_rank(handle,trans,n,nrhs,A,lda,devIpiv,B,ldb,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15951,7 +16100,9 @@ module hipfort_hipsolver
       hipsolverCgetrs_assumed_rank = hipsolverCgetrs_(handle,trans,n,nrhs,c_loc(A),lda,c_loc(devIpiv), &
         c_loc(B),ldb,work,lwork,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverZgetrs_assumed_rank(handle,trans,n,nrhs,A,lda,devIpiv,B,ldb,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15973,7 +16124,9 @@ module hipfort_hipsolver
       hipsolverZgetrs_assumed_rank = hipsolverZgetrs_(handle,trans,n,nrhs,c_loc(A),lda,c_loc(devIpiv), &
         c_loc(B),ldb,work,lwork,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverSpotrf_bufferSize_assumed_rank(handle,uplo,n,A,lda,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -15989,7 +16142,9 @@ module hipfort_hipsolver
       hipsolverSpotrf_bufferSize_assumed_rank = hipsolverSpotrf_bufferSize_(handle,uplo,n,c_loc(A),lda, &
         lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverDpotrf_bufferSize_assumed_rank(handle,uplo,n,A,lda,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16005,7 +16160,9 @@ module hipfort_hipsolver
       hipsolverDpotrf_bufferSize_assumed_rank = hipsolverDpotrf_bufferSize_(handle,uplo,n,c_loc(A),lda, &
         lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverCpotrf_bufferSize_assumed_rank(handle,uplo,n,A,lda,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16021,7 +16178,9 @@ module hipfort_hipsolver
       hipsolverCpotrf_bufferSize_assumed_rank = hipsolverCpotrf_bufferSize_(handle,uplo,n,c_loc(A),lda, &
         lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverZpotrf_bufferSize_assumed_rank(handle,uplo,n,A,lda,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16037,7 +16196,9 @@ module hipfort_hipsolver
       hipsolverZpotrf_bufferSize_assumed_rank = hipsolverZpotrf_bufferSize_(handle,uplo,n,c_loc(A),lda, &
         lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverSpotrf_assumed_rank(handle,uplo,n,A,lda,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16054,7 +16215,9 @@ module hipfort_hipsolver
       !
       hipsolverSpotrf_assumed_rank = hipsolverSpotrf_(handle,uplo,n,c_loc(A),lda,work,lwork,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverDpotrf_assumed_rank(handle,uplo,n,A,lda,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16071,7 +16234,9 @@ module hipfort_hipsolver
       !
       hipsolverDpotrf_assumed_rank = hipsolverDpotrf_(handle,uplo,n,c_loc(A),lda,work,lwork,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverCpotrf_assumed_rank(handle,uplo,n,A,lda,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16088,7 +16253,9 @@ module hipfort_hipsolver
       !
       hipsolverCpotrf_assumed_rank = hipsolverCpotrf_(handle,uplo,n,c_loc(A),lda,work,lwork,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverZpotrf_assumed_rank(handle,uplo,n,A,lda,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16105,7 +16272,9 @@ module hipfort_hipsolver
       !
       hipsolverZpotrf_assumed_rank = hipsolverZpotrf_(handle,uplo,n,c_loc(A),lda,work,lwork,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverSpotri_bufferSize_assumed_rank(handle,uplo,n,A,lda,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16121,7 +16290,9 @@ module hipfort_hipsolver
       hipsolverSpotri_bufferSize_assumed_rank = hipsolverSpotri_bufferSize_(handle,uplo,n,c_loc(A),lda, &
         lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverDpotri_bufferSize_assumed_rank(handle,uplo,n,A,lda,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16137,7 +16308,9 @@ module hipfort_hipsolver
       hipsolverDpotri_bufferSize_assumed_rank = hipsolverDpotri_bufferSize_(handle,uplo,n,c_loc(A),lda, &
         lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverCpotri_bufferSize_assumed_rank(handle,uplo,n,A,lda,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16153,7 +16326,9 @@ module hipfort_hipsolver
       hipsolverCpotri_bufferSize_assumed_rank = hipsolverCpotri_bufferSize_(handle,uplo,n,c_loc(A),lda, &
         lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverZpotri_bufferSize_assumed_rank(handle,uplo,n,A,lda,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16169,7 +16344,9 @@ module hipfort_hipsolver
       hipsolverZpotri_bufferSize_assumed_rank = hipsolverZpotri_bufferSize_(handle,uplo,n,c_loc(A),lda, &
         lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverSpotri_assumed_rank(handle,uplo,n,A,lda,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16186,7 +16363,9 @@ module hipfort_hipsolver
       !
       hipsolverSpotri_assumed_rank = hipsolverSpotri_(handle,uplo,n,c_loc(A),lda,work,lwork,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverDpotri_assumed_rank(handle,uplo,n,A,lda,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16203,7 +16382,9 @@ module hipfort_hipsolver
       !
       hipsolverDpotri_assumed_rank = hipsolverDpotri_(handle,uplo,n,c_loc(A),lda,work,lwork,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverCpotri_assumed_rank(handle,uplo,n,A,lda,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16220,7 +16401,9 @@ module hipfort_hipsolver
       !
       hipsolverCpotri_assumed_rank = hipsolverCpotri_(handle,uplo,n,c_loc(A),lda,work,lwork,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverZpotri_assumed_rank(handle,uplo,n,A,lda,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16237,7 +16420,9 @@ module hipfort_hipsolver
       !
       hipsolverZpotri_assumed_rank = hipsolverZpotri_(handle,uplo,n,c_loc(A),lda,work,lwork,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverSpotrs_bufferSize_assumed_rank(handle,uplo,n,nrhs,A,lda,B,ldb,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16256,7 +16441,9 @@ module hipfort_hipsolver
       hipsolverSpotrs_bufferSize_assumed_rank = hipsolverSpotrs_bufferSize_(handle,uplo,n,nrhs,c_loc(A), &
         lda,c_loc(B),ldb,lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverDpotrs_bufferSize_assumed_rank(handle,uplo,n,nrhs,A,lda,B,ldb,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16275,7 +16462,9 @@ module hipfort_hipsolver
       hipsolverDpotrs_bufferSize_assumed_rank = hipsolverDpotrs_bufferSize_(handle,uplo,n,nrhs,c_loc(A), &
         lda,c_loc(B),ldb,lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverCpotrs_bufferSize_assumed_rank(handle,uplo,n,nrhs,A,lda,B,ldb,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16294,7 +16483,9 @@ module hipfort_hipsolver
       hipsolverCpotrs_bufferSize_assumed_rank = hipsolverCpotrs_bufferSize_(handle,uplo,n,nrhs,c_loc(A), &
         lda,c_loc(B),ldb,lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverZpotrs_bufferSize_assumed_rank(handle,uplo,n,nrhs,A,lda,B,ldb,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16313,7 +16504,9 @@ module hipfort_hipsolver
       hipsolverZpotrs_bufferSize_assumed_rank = hipsolverZpotrs_bufferSize_(handle,uplo,n,nrhs,c_loc(A), &
         lda,c_loc(B),ldb,lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverSpotrs_assumed_rank(handle,uplo,n,nrhs,A,lda,B,ldb,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16334,7 +16527,9 @@ module hipfort_hipsolver
       hipsolverSpotrs_assumed_rank = hipsolverSpotrs_(handle,uplo,n,nrhs,c_loc(A),lda,c_loc(B),ldb,work, &
         lwork,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverDpotrs_assumed_rank(handle,uplo,n,nrhs,A,lda,B,ldb,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16355,7 +16550,9 @@ module hipfort_hipsolver
       hipsolverDpotrs_assumed_rank = hipsolverDpotrs_(handle,uplo,n,nrhs,c_loc(A),lda,c_loc(B),ldb,work, &
         lwork,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverCpotrs_assumed_rank(handle,uplo,n,nrhs,A,lda,B,ldb,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16376,7 +16573,9 @@ module hipfort_hipsolver
       hipsolverCpotrs_assumed_rank = hipsolverCpotrs_(handle,uplo,n,nrhs,c_loc(A),lda,c_loc(B),ldb,work, &
         lwork,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverZpotrs_assumed_rank(handle,uplo,n,nrhs,A,lda,B,ldb,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16397,7 +16596,9 @@ module hipfort_hipsolver
       hipsolverZpotrs_assumed_rank = hipsolverZpotrs_(handle,uplo,n,nrhs,c_loc(A),lda,c_loc(B),ldb,work, &
         lwork,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverSsyevd_bufferSize_assumed_rank(handle,jobz,uplo,n,A,lda,D,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16415,7 +16616,9 @@ module hipfort_hipsolver
       hipsolverSsyevd_bufferSize_assumed_rank = hipsolverSsyevd_bufferSize_(handle,jobz,uplo,n,c_loc(A), &
         lda,c_loc(D),lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverDsyevd_bufferSize_assumed_rank(handle,jobz,uplo,n,A,lda,D,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16433,7 +16636,9 @@ module hipfort_hipsolver
       hipsolverDsyevd_bufferSize_assumed_rank = hipsolverDsyevd_bufferSize_(handle,jobz,uplo,n,c_loc(A), &
         lda,c_loc(D),lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverCheevd_bufferSize_assumed_rank(handle,jobz,uplo,n,A,lda,D,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16451,7 +16656,9 @@ module hipfort_hipsolver
       hipsolverCheevd_bufferSize_assumed_rank = hipsolverCheevd_bufferSize_(handle,jobz,uplo,n,c_loc(A), &
         lda,c_loc(D),lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverZheevd_bufferSize_assumed_rank(handle,jobz,uplo,n,A,lda,D,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16469,7 +16676,9 @@ module hipfort_hipsolver
       hipsolverZheevd_bufferSize_assumed_rank = hipsolverZheevd_bufferSize_(handle,jobz,uplo,n,c_loc(A), &
         lda,c_loc(D),lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverSsyevd_assumed_rank(handle,jobz,uplo,n,A,lda,D,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16489,7 +16698,9 @@ module hipfort_hipsolver
       hipsolverSsyevd_assumed_rank = hipsolverSsyevd_(handle,jobz,uplo,n,c_loc(A),lda,c_loc(D),work, &
         lwork,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverDsyevd_assumed_rank(handle,jobz,uplo,n,A,lda,D,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16509,7 +16720,9 @@ module hipfort_hipsolver
       hipsolverDsyevd_assumed_rank = hipsolverDsyevd_(handle,jobz,uplo,n,c_loc(A),lda,c_loc(D),work, &
         lwork,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverCheevd_assumed_rank(handle,jobz,uplo,n,A,lda,D,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16529,7 +16742,9 @@ module hipfort_hipsolver
       hipsolverCheevd_assumed_rank = hipsolverCheevd_(handle,jobz,uplo,n,c_loc(A),lda,c_loc(D),work, &
         lwork,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverZheevd_assumed_rank(handle,jobz,uplo,n,A,lda,D,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16549,7 +16764,9 @@ module hipfort_hipsolver
       hipsolverZheevd_assumed_rank = hipsolverZheevd_(handle,jobz,uplo,n,c_loc(A),lda,c_loc(D),work, &
         lwork,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverSsygvd_bufferSize_assumed_rank(handle,itype,jobz,uplo,n,A,lda,B,ldb,W,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16570,7 +16787,9 @@ module hipfort_hipsolver
       hipsolverSsygvd_bufferSize_assumed_rank = hipsolverSsygvd_bufferSize_(handle,itype,jobz,uplo,n, &
         c_loc(A),lda,c_loc(B),ldb,c_loc(W),lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverDsygvd_bufferSize_assumed_rank(handle,itype,jobz,uplo,n,A,lda,B,ldb,W,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16591,7 +16810,9 @@ module hipfort_hipsolver
       hipsolverDsygvd_bufferSize_assumed_rank = hipsolverDsygvd_bufferSize_(handle,itype,jobz,uplo,n, &
         c_loc(A),lda,c_loc(B),ldb,c_loc(W),lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverChegvd_bufferSize_assumed_rank(handle,itype,jobz,uplo,n,A,lda,B,ldb,W,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16612,7 +16833,9 @@ module hipfort_hipsolver
       hipsolverChegvd_bufferSize_assumed_rank = hipsolverChegvd_bufferSize_(handle,itype,jobz,uplo,n, &
         c_loc(A),lda,c_loc(B),ldb,c_loc(W),lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverZhegvd_bufferSize_assumed_rank(handle,itype,jobz,uplo,n,A,lda,B,ldb,W,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16633,7 +16856,9 @@ module hipfort_hipsolver
       hipsolverZhegvd_bufferSize_assumed_rank = hipsolverZhegvd_bufferSize_(handle,itype,jobz,uplo,n, &
         c_loc(A),lda,c_loc(B),ldb,c_loc(W),lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverSsygvd_assumed_rank(handle,itype,jobz,uplo,n,A,lda,B,ldb,W,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16656,7 +16881,9 @@ module hipfort_hipsolver
       hipsolverSsygvd_assumed_rank = hipsolverSsygvd_(handle,itype,jobz,uplo,n,c_loc(A),lda,c_loc(B), &
         ldb,c_loc(W),work,lwork,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverDsygvd_assumed_rank(handle,itype,jobz,uplo,n,A,lda,B,ldb,W,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16679,7 +16906,9 @@ module hipfort_hipsolver
       hipsolverDsygvd_assumed_rank = hipsolverDsygvd_(handle,itype,jobz,uplo,n,c_loc(A),lda,c_loc(B), &
         ldb,c_loc(W),work,lwork,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverChegvd_assumed_rank(handle,itype,jobz,uplo,n,A,lda,B,ldb,W,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16702,7 +16931,9 @@ module hipfort_hipsolver
       hipsolverChegvd_assumed_rank = hipsolverChegvd_(handle,itype,jobz,uplo,n,c_loc(A),lda,c_loc(B), &
         ldb,c_loc(W),work,lwork,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverZhegvd_assumed_rank(handle,itype,jobz,uplo,n,A,lda,B,ldb,W,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16725,7 +16956,9 @@ module hipfort_hipsolver
       hipsolverZhegvd_assumed_rank = hipsolverZhegvd_(handle,itype,jobz,uplo,n,c_loc(A),lda,c_loc(B), &
         ldb,c_loc(W),work,lwork,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverSsytrd_bufferSize_assumed_rank(handle,uplo,n,A,lda,D,E,tau,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16744,7 +16977,9 @@ module hipfort_hipsolver
       hipsolverSsytrd_bufferSize_assumed_rank = hipsolverSsytrd_bufferSize_(handle,uplo,n,c_loc(A),lda, &
         c_loc(D),c_loc(E),tau,lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverDsytrd_bufferSize_assumed_rank(handle,uplo,n,A,lda,D,E,tau,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16763,7 +16998,9 @@ module hipfort_hipsolver
       hipsolverDsytrd_bufferSize_assumed_rank = hipsolverDsytrd_bufferSize_(handle,uplo,n,c_loc(A),lda, &
         c_loc(D),c_loc(E),tau,lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverChetrd_bufferSize_assumed_rank(handle,uplo,n,A,lda,D,E,tau,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16782,7 +17019,9 @@ module hipfort_hipsolver
       hipsolverChetrd_bufferSize_assumed_rank = hipsolverChetrd_bufferSize_(handle,uplo,n,c_loc(A),lda, &
         c_loc(D),c_loc(E),tau,lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverZhetrd_bufferSize_assumed_rank(handle,uplo,n,A,lda,D,E,tau,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16801,7 +17040,9 @@ module hipfort_hipsolver
       hipsolverZhetrd_bufferSize_assumed_rank = hipsolverZhetrd_bufferSize_(handle,uplo,n,c_loc(A),lda, &
         c_loc(D),c_loc(E),tau,lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverSsytrd_assumed_rank(handle,uplo,n,A,lda,D,E,tau,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16822,7 +17063,9 @@ module hipfort_hipsolver
       hipsolverSsytrd_assumed_rank = hipsolverSsytrd_(handle,uplo,n,c_loc(A),lda,c_loc(D),c_loc(E),tau, &
         work,lwork,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverDsytrd_assumed_rank(handle,uplo,n,A,lda,D,E,tau,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16843,7 +17086,9 @@ module hipfort_hipsolver
       hipsolverDsytrd_assumed_rank = hipsolverDsytrd_(handle,uplo,n,c_loc(A),lda,c_loc(D),c_loc(E),tau, &
         work,lwork,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverChetrd_assumed_rank(handle,uplo,n,A,lda,D,E,tau,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16864,7 +17109,9 @@ module hipfort_hipsolver
       hipsolverChetrd_assumed_rank = hipsolverChetrd_(handle,uplo,n,c_loc(A),lda,c_loc(D),c_loc(E),tau, &
         work,lwork,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverZhetrd_assumed_rank(handle,uplo,n,A,lda,D,E,tau,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16885,7 +17132,9 @@ module hipfort_hipsolver
       hipsolverZhetrd_assumed_rank = hipsolverZhetrd_(handle,uplo,n,c_loc(A),lda,c_loc(D),c_loc(E),tau, &
         work,lwork,devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverSsytrf_bufferSize_assumed_rank(handle,n,A,lda,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16899,7 +17148,9 @@ module hipfort_hipsolver
       !
       hipsolverSsytrf_bufferSize_assumed_rank = hipsolverSsytrf_bufferSize_(handle,n,c_loc(A),lda,lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverDsytrf_bufferSize_assumed_rank(handle,n,A,lda,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16913,7 +17164,9 @@ module hipfort_hipsolver
       !
       hipsolverDsytrf_bufferSize_assumed_rank = hipsolverDsytrf_bufferSize_(handle,n,c_loc(A),lda,lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverCsytrf_bufferSize_assumed_rank(handle,n,A,lda,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16927,7 +17180,9 @@ module hipfort_hipsolver
       !
       hipsolverCsytrf_bufferSize_assumed_rank = hipsolverCsytrf_bufferSize_(handle,n,c_loc(A),lda,lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverZsytrf_bufferSize_assumed_rank(handle,n,A,lda,lwork)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16941,7 +17196,9 @@ module hipfort_hipsolver
       !
       hipsolverZsytrf_bufferSize_assumed_rank = hipsolverZsytrf_bufferSize_(handle,n,c_loc(A),lda,lwork)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverSsytrf_assumed_rank(handle,uplo,n,A,lda,ipiv,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16960,7 +17217,9 @@ module hipfort_hipsolver
       hipsolverSsytrf_assumed_rank = hipsolverSsytrf_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv),work,lwork, &
         devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverDsytrf_assumed_rank(handle,uplo,n,A,lda,ipiv,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16979,7 +17238,9 @@ module hipfort_hipsolver
       hipsolverDsytrf_assumed_rank = hipsolverDsytrf_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv),work,lwork, &
         devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverCsytrf_assumed_rank(handle,uplo,n,A,lda,ipiv,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -16998,7 +17259,9 @@ module hipfort_hipsolver
       hipsolverCsytrf_assumed_rank = hipsolverCsytrf_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv),work,lwork, &
         devInfo)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsolverZsytrf_assumed_rank(handle,uplo,n,A,lda,ipiv,work,lwork,devInfo)
       use iso_c_binding
       use hipfort_hipsolver_enums
@@ -17017,6 +17280,7 @@ module hipfort_hipsolver
       hipsolverZsytrf_assumed_rank = hipsolverZsytrf_(handle,uplo,n,c_loc(A),lda,c_loc(ipiv),work,lwork, &
         devInfo)
     end function
+#endif
 
 #else
 

--- a/lib/hipfort/hipfort_hipsparse.F90
+++ b/lib/hipfort/hipfort_hipsparse.F90
@@ -25471,6 +25471,7 @@ module hipfort_hipsparse
 #ifdef USE_FPOINTER_INTERFACES
   contains
 #ifdef USE_ASSUMED_RANK_INTERFACES
+#ifndef USE_CUDA_NAMES
     function hipsparseSaxpyi_assumed_rank(handle,nnz,alpha,xVal,xInd,y,idxBase)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -25487,7 +25488,9 @@ module hipfort_hipsparse
       hipsparseSaxpyi_assumed_rank = hipsparseSaxpyi_(handle,nnz,alpha,c_loc(xVal),c_loc(xInd),c_loc(y), &
         idxBase)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseDaxpyi_assumed_rank(handle,nnz,alpha,xVal,xInd,y,idxBase)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -25504,7 +25507,9 @@ module hipfort_hipsparse
       hipsparseDaxpyi_assumed_rank = hipsparseDaxpyi_(handle,nnz,alpha,c_loc(xVal),c_loc(xInd),c_loc(y), &
         idxBase)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseCaxpyi_assumed_rank(handle,nnz,alpha,xVal,xInd,y,idxBase)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -25521,7 +25526,9 @@ module hipfort_hipsparse
       hipsparseCaxpyi_assumed_rank = hipsparseCaxpyi_(handle,nnz,alpha,c_loc(xVal),c_loc(xInd),c_loc(y), &
         idxBase)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseZaxpyi_assumed_rank(handle,nnz,alpha,xVal,xInd,y,idxBase)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -25538,7 +25545,9 @@ module hipfort_hipsparse
       hipsparseZaxpyi_assumed_rank = hipsparseZaxpyi_(handle,nnz,alpha,c_loc(xVal),c_loc(xInd),c_loc(y), &
         idxBase)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseCdotci_assumed_rank(handle,nnz,xVal,xInd,y,myResult,idxBase)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -25555,7 +25564,9 @@ module hipfort_hipsparse
       hipsparseCdotci_assumed_rank = hipsparseCdotci_(handle,nnz,c_loc(xVal),c_loc(xInd),c_loc(y), &
         c_loc(myResult),idxBase)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseZdotci_assumed_rank(handle,nnz,xVal,xInd,y,myResult,idxBase)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -25572,7 +25583,9 @@ module hipfort_hipsparse
       hipsparseZdotci_assumed_rank = hipsparseZdotci_(handle,nnz,c_loc(xVal),c_loc(xInd),c_loc(y), &
         c_loc(myResult),idxBase)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseSdoti_assumed_rank(handle,nnz,xVal,xInd,y,myResult,idxBase)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -25589,7 +25602,9 @@ module hipfort_hipsparse
       hipsparseSdoti_assumed_rank = hipsparseSdoti_(handle,nnz,c_loc(xVal),c_loc(xInd),c_loc(y), &
         c_loc(myResult),idxBase)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseDdoti_assumed_rank(handle,nnz,xVal,xInd,y,myResult,idxBase)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -25606,7 +25621,9 @@ module hipfort_hipsparse
       hipsparseDdoti_assumed_rank = hipsparseDdoti_(handle,nnz,c_loc(xVal),c_loc(xInd),c_loc(y), &
         c_loc(myResult),idxBase)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseCdoti_assumed_rank(handle,nnz,xVal,xInd,y,myResult,idxBase)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -25623,7 +25640,9 @@ module hipfort_hipsparse
       hipsparseCdoti_assumed_rank = hipsparseCdoti_(handle,nnz,c_loc(xVal),c_loc(xInd),c_loc(y), &
         c_loc(myResult),idxBase)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseZdoti_assumed_rank(handle,nnz,xVal,xInd,y,myResult,idxBase)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -25640,7 +25659,9 @@ module hipfort_hipsparse
       hipsparseZdoti_assumed_rank = hipsparseZdoti_(handle,nnz,c_loc(xVal),c_loc(xInd),c_loc(y), &
         c_loc(myResult),idxBase)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseSgthr_assumed_rank(handle,nnz,y,xVal,xInd,idxBase)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -25655,7 +25676,9 @@ module hipfort_hipsparse
       !
       hipsparseSgthr_assumed_rank = hipsparseSgthr_(handle,nnz,c_loc(y),c_loc(xVal),c_loc(xInd),idxBase)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseDgthr_assumed_rank(handle,nnz,y,xVal,xInd,idxBase)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -25670,7 +25693,9 @@ module hipfort_hipsparse
       !
       hipsparseDgthr_assumed_rank = hipsparseDgthr_(handle,nnz,c_loc(y),c_loc(xVal),c_loc(xInd),idxBase)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseCgthr_assumed_rank(handle,nnz,y,xVal,xInd,idxBase)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -25685,7 +25710,9 @@ module hipfort_hipsparse
       !
       hipsparseCgthr_assumed_rank = hipsparseCgthr_(handle,nnz,c_loc(y),c_loc(xVal),c_loc(xInd),idxBase)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseZgthr_assumed_rank(handle,nnz,y,xVal,xInd,idxBase)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -25700,7 +25727,9 @@ module hipfort_hipsparse
       !
       hipsparseZgthr_assumed_rank = hipsparseZgthr_(handle,nnz,c_loc(y),c_loc(xVal),c_loc(xInd),idxBase)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseSgthrz_assumed_rank(handle,nnz,y,xVal,xInd,idxBase)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -25715,7 +25744,9 @@ module hipfort_hipsparse
       !
       hipsparseSgthrz_assumed_rank = hipsparseSgthrz_(handle,nnz,c_loc(y),c_loc(xVal),c_loc(xInd),idxBase)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseDgthrz_assumed_rank(handle,nnz,y,xVal,xInd,idxBase)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -25730,7 +25761,9 @@ module hipfort_hipsparse
       !
       hipsparseDgthrz_assumed_rank = hipsparseDgthrz_(handle,nnz,c_loc(y),c_loc(xVal),c_loc(xInd),idxBase)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseCgthrz_assumed_rank(handle,nnz,y,xVal,xInd,idxBase)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -25745,7 +25778,9 @@ module hipfort_hipsparse
       !
       hipsparseCgthrz_assumed_rank = hipsparseCgthrz_(handle,nnz,c_loc(y),c_loc(xVal),c_loc(xInd),idxBase)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseZgthrz_assumed_rank(handle,nnz,y,xVal,xInd,idxBase)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -25760,7 +25795,9 @@ module hipfort_hipsparse
       !
       hipsparseZgthrz_assumed_rank = hipsparseZgthrz_(handle,nnz,c_loc(y),c_loc(xVal),c_loc(xInd),idxBase)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseSroti_assumed_rank(handle,nnz,xVal,xInd,y,c,s,idxBase)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -25778,7 +25815,9 @@ module hipfort_hipsparse
       hipsparseSroti_assumed_rank = hipsparseSroti_(handle,nnz,c_loc(xVal),c_loc(xInd),c_loc(y),c,s, &
         idxBase)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseDroti_assumed_rank(handle,nnz,xVal,xInd,y,c,s,idxBase)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -25796,7 +25835,9 @@ module hipfort_hipsparse
       hipsparseDroti_assumed_rank = hipsparseDroti_(handle,nnz,c_loc(xVal),c_loc(xInd),c_loc(y),c,s, &
         idxBase)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseSsctr_assumed_rank(handle,nnz,xVal,xInd,y,idxBase)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -25811,7 +25852,9 @@ module hipfort_hipsparse
       !
       hipsparseSsctr_assumed_rank = hipsparseSsctr_(handle,nnz,c_loc(xVal),c_loc(xInd),c_loc(y),idxBase)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseDsctr_assumed_rank(handle,nnz,xVal,xInd,y,idxBase)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -25826,7 +25869,9 @@ module hipfort_hipsparse
       !
       hipsparseDsctr_assumed_rank = hipsparseDsctr_(handle,nnz,c_loc(xVal),c_loc(xInd),c_loc(y),idxBase)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseCsctr_assumed_rank(handle,nnz,xVal,xInd,y,idxBase)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -25841,7 +25886,9 @@ module hipfort_hipsparse
       !
       hipsparseCsctr_assumed_rank = hipsparseCsctr_(handle,nnz,c_loc(xVal),c_loc(xInd),c_loc(y),idxBase)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseZsctr_assumed_rank(handle,nnz,xVal,xInd,y,idxBase)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -25856,6 +25903,7 @@ module hipfort_hipsparse
       !
       hipsparseZsctr_assumed_rank = hipsparseZsctr_(handle,nnz,c_loc(xVal),c_loc(xInd),c_loc(y),idxBase)
     end function
+#endif
 
     function hipsparseSbsrmv_assumed_rank(handle,dirA,transA,mb,nb,nnzb,alpha,descrA,bsrSortedValA, &
         bsrSortedRowPtrA,bsrSortedColIndA,blockDim,x,beta,y)
@@ -26061,6 +26109,7 @@ module hipfort_hipsparse
         myInfo,pBufferSizeInBytes)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipsparseSbsrsv2_bufferSizeExt_assumed_rank(handle,dirA,transA,mb,nnzb,descrA, &
         bsrSortedValA,bsrSortedRowPtrA,bsrSortedColIndA,blockDim,myInfo,pBufferSizeInBytes)
       use iso_c_binding
@@ -26084,7 +26133,9 @@ module hipfort_hipsparse
         mb,nnzb,descrA,c_loc(bsrSortedValA),c_loc(bsrSortedRowPtrA),c_loc(bsrSortedColIndA), &
         blockDim,myInfo,pBufferSizeInBytes)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseDbsrsv2_bufferSizeExt_assumed_rank(handle,dirA,transA,mb,nnzb,descrA, &
         bsrSortedValA,bsrSortedRowPtrA,bsrSortedColIndA,blockDim,myInfo,pBufferSizeInBytes)
       use iso_c_binding
@@ -26108,7 +26159,9 @@ module hipfort_hipsparse
         mb,nnzb,descrA,c_loc(bsrSortedValA),c_loc(bsrSortedRowPtrA),c_loc(bsrSortedColIndA), &
         blockDim,myInfo,pBufferSizeInBytes)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseCbsrsv2_bufferSizeExt_assumed_rank(handle,dirA,transA,mb,nnzb,descrA, &
         bsrSortedValA,bsrSortedRowPtrA,bsrSortedColIndA,blockDim,myInfo,pBufferSizeInBytes)
       use iso_c_binding
@@ -26132,7 +26185,9 @@ module hipfort_hipsparse
         mb,nnzb,descrA,c_loc(bsrSortedValA),c_loc(bsrSortedRowPtrA),c_loc(bsrSortedColIndA), &
         blockDim,myInfo,pBufferSizeInBytes)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseZbsrsv2_bufferSizeExt_assumed_rank(handle,dirA,transA,mb,nnzb,descrA, &
         bsrSortedValA,bsrSortedRowPtrA,bsrSortedColIndA,blockDim,myInfo,pBufferSizeInBytes)
       use iso_c_binding
@@ -26156,6 +26211,7 @@ module hipfort_hipsparse
         mb,nnzb,descrA,c_loc(bsrSortedValA),c_loc(bsrSortedRowPtrA),c_loc(bsrSortedColIndA), &
         blockDim,myInfo,pBufferSizeInBytes)
     end function
+#endif
 
     function hipsparseSbsrsv2_analysis_assumed_rank(handle,dirA,transA,mb,nnzb,descrA,bsrSortedValA, &
         bsrSortedRowPtrA,bsrSortedColIndA,blockDim,myInfo,policy,pBuffer)
@@ -26489,6 +26545,7 @@ module hipfort_hipsparse
         blockDim,c_loc(x),beta,c_loc(y))
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipsparseScsrmv_assumed_rank(handle,transA,m,n,nnz,alpha,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,x,beta,y)
       use iso_c_binding
@@ -26512,7 +26569,9 @@ module hipfort_hipsparse
       hipsparseScsrmv_assumed_rank = hipsparseScsrmv_(handle,transA,m,n,nnz,alpha,descrA, &
         c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),c_loc(x),beta,c_loc(y))
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseDcsrmv_assumed_rank(handle,transA,m,n,nnz,alpha,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,x,beta,y)
       use iso_c_binding
@@ -26536,7 +26595,9 @@ module hipfort_hipsparse
       hipsparseDcsrmv_assumed_rank = hipsparseDcsrmv_(handle,transA,m,n,nnz,alpha,descrA, &
         c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),c_loc(x),beta,c_loc(y))
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseCcsrmv_assumed_rank(handle,transA,m,n,nnz,alpha,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,x,beta,y)
       use iso_c_binding
@@ -26560,7 +26621,9 @@ module hipfort_hipsparse
       hipsparseCcsrmv_assumed_rank = hipsparseCcsrmv_(handle,transA,m,n,nnz,alpha,descrA, &
         c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),c_loc(x),beta,c_loc(y))
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseZcsrmv_assumed_rank(handle,transA,m,n,nnz,alpha,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,x,beta,y)
       use iso_c_binding
@@ -26584,7 +26647,9 @@ module hipfort_hipsparse
       hipsparseZcsrmv_assumed_rank = hipsparseZcsrmv_(handle,transA,m,n,nnz,alpha,descrA, &
         c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),c_loc(x),beta,c_loc(y))
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseScsrsv2_bufferSize_assumed_rank(handle,transA,m,nnz,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,pBufferSizeInBytes)
       use iso_c_binding
@@ -26606,7 +26671,9 @@ module hipfort_hipsparse
         descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),myInfo, &
         pBufferSizeInBytes)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseDcsrsv2_bufferSize_assumed_rank(handle,transA,m,nnz,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,pBufferSizeInBytes)
       use iso_c_binding
@@ -26628,7 +26695,9 @@ module hipfort_hipsparse
         descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),myInfo, &
         pBufferSizeInBytes)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseCcsrsv2_bufferSize_assumed_rank(handle,transA,m,nnz,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,pBufferSizeInBytes)
       use iso_c_binding
@@ -26650,7 +26719,9 @@ module hipfort_hipsparse
         descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),myInfo, &
         pBufferSizeInBytes)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseZcsrsv2_bufferSize_assumed_rank(handle,transA,m,nnz,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,pBufferSizeInBytes)
       use iso_c_binding
@@ -26672,7 +26743,9 @@ module hipfort_hipsparse
         descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),myInfo, &
         pBufferSizeInBytes)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseScsrsv2_bufferSizeExt_assumed_rank(handle,transA,m,nnz,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,pBufferSizeInBytes)
       use iso_c_binding
@@ -26694,7 +26767,9 @@ module hipfort_hipsparse
         descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),myInfo, &
         pBufferSizeInBytes)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseDcsrsv2_bufferSizeExt_assumed_rank(handle,transA,m,nnz,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,pBufferSizeInBytes)
       use iso_c_binding
@@ -26716,7 +26791,9 @@ module hipfort_hipsparse
         descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),myInfo, &
         pBufferSizeInBytes)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseCcsrsv2_bufferSizeExt_assumed_rank(handle,transA,m,nnz,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,pBufferSizeInBytes)
       use iso_c_binding
@@ -26738,7 +26815,9 @@ module hipfort_hipsparse
         descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),myInfo, &
         pBufferSizeInBytes)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseZcsrsv2_bufferSizeExt_assumed_rank(handle,transA,m,nnz,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,pBufferSizeInBytes)
       use iso_c_binding
@@ -26760,7 +26839,9 @@ module hipfort_hipsparse
         descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),myInfo, &
         pBufferSizeInBytes)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseScsrsv2_analysis_assumed_rank(handle,transA,m,nnz,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,policy,pBuffer)
       use iso_c_binding
@@ -26782,7 +26863,9 @@ module hipfort_hipsparse
       hipsparseScsrsv2_analysis_assumed_rank = hipsparseScsrsv2_analysis_(handle,transA,m,nnz,descrA, &
         c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),myInfo,policy,pBuffer)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseDcsrsv2_analysis_assumed_rank(handle,transA,m,nnz,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,policy,pBuffer)
       use iso_c_binding
@@ -26804,7 +26887,9 @@ module hipfort_hipsparse
       hipsparseDcsrsv2_analysis_assumed_rank = hipsparseDcsrsv2_analysis_(handle,transA,m,nnz,descrA, &
         c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),myInfo,policy,pBuffer)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseCcsrsv2_analysis_assumed_rank(handle,transA,m,nnz,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,policy,pBuffer)
       use iso_c_binding
@@ -26826,7 +26911,9 @@ module hipfort_hipsparse
       hipsparseCcsrsv2_analysis_assumed_rank = hipsparseCcsrsv2_analysis_(handle,transA,m,nnz,descrA, &
         c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),myInfo,policy,pBuffer)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseZcsrsv2_analysis_assumed_rank(handle,transA,m,nnz,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,policy,pBuffer)
       use iso_c_binding
@@ -26848,7 +26935,9 @@ module hipfort_hipsparse
       hipsparseZcsrsv2_analysis_assumed_rank = hipsparseZcsrsv2_analysis_(handle,transA,m,nnz,descrA, &
         c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),myInfo,policy,pBuffer)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseScsrsv2_solve_assumed_rank(handle,transA,m,nnz,alpha,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,f,x,policy,pBuffer)
       use iso_c_binding
@@ -26874,7 +26963,9 @@ module hipfort_hipsparse
         c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),myInfo,c_loc(f), &
         c_loc(x),policy,pBuffer)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseDcsrsv2_solve_assumed_rank(handle,transA,m,nnz,alpha,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,f,x,policy,pBuffer)
       use iso_c_binding
@@ -26900,7 +26991,9 @@ module hipfort_hipsparse
         c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),myInfo,c_loc(f), &
         c_loc(x),policy,pBuffer)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseCcsrsv2_solve_assumed_rank(handle,transA,m,nnz,alpha,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,f,x,policy,pBuffer)
       use iso_c_binding
@@ -26926,7 +27019,9 @@ module hipfort_hipsparse
         c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),myInfo,c_loc(f), &
         c_loc(x),policy,pBuffer)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseZcsrsv2_solve_assumed_rank(handle,transA,m,nnz,alpha,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,f,x,policy,pBuffer)
       use iso_c_binding
@@ -26952,6 +27047,7 @@ module hipfort_hipsparse
         c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),myInfo,c_loc(f), &
         c_loc(x),policy,pBuffer)
     end function
+#endif
 
     function hipsparseSgemvi_assumed_rank(handle,transA,m,n,alpha,A,lda,nnz,x,xInd,beta,y,idxBase,pBuffer)
       use iso_c_binding
@@ -27049,6 +27145,7 @@ module hipfort_hipsparse
         c_loc(xInd),beta,c_loc(y),idxBase,pBuffer)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipsparseShybmv_assumed_rank(handle,transA,alpha,descrA,hybA,x,beta,y)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -27066,7 +27163,9 @@ module hipfort_hipsparse
       hipsparseShybmv_assumed_rank = hipsparseShybmv_(handle,transA,alpha,descrA,hybA,c_loc(x),beta, &
         c_loc(y))
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseDhybmv_assumed_rank(handle,transA,alpha,descrA,hybA,x,beta,y)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -27084,7 +27183,9 @@ module hipfort_hipsparse
       hipsparseDhybmv_assumed_rank = hipsparseDhybmv_(handle,transA,alpha,descrA,hybA,c_loc(x),beta, &
         c_loc(y))
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseChybmv_assumed_rank(handle,transA,alpha,descrA,hybA,x,beta,y)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -27102,7 +27203,9 @@ module hipfort_hipsparse
       hipsparseChybmv_assumed_rank = hipsparseChybmv_(handle,transA,alpha,descrA,hybA,c_loc(x),beta, &
         c_loc(y))
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseZhybmv_assumed_rank(handle,transA,alpha,descrA,hybA,x,beta,y)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -27120,6 +27223,7 @@ module hipfort_hipsparse
       hipsparseZhybmv_assumed_rank = hipsparseZhybmv_(handle,transA,alpha,descrA,hybA,c_loc(x),beta, &
         c_loc(y))
     end function
+#endif
 
     function hipsparseSbsrmm_assumed_rank(handle,dirA,transA,transB,mb,n,kb,nnzb,alpha,descrA,bsrValA, &
         bsrRowPtrA,bsrColIndA,blockDim,B,ldb,beta,C,ldc)
@@ -27585,6 +27689,7 @@ module hipfort_hipsparse
         blockDim,myInfo,c_loc(B),ldb,c_loc(X),ldx,policy,pBuffer)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipsparseScsrmm_assumed_rank(handle,transA,m,n,k,nnz,alpha,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,B,ldb,beta,C,ldc)
       use iso_c_binding
@@ -27612,7 +27717,9 @@ module hipfort_hipsparse
         c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),c_loc(B),ldb,beta, &
         c_loc(C),ldc)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseDcsrmm_assumed_rank(handle,transA,m,n,k,nnz,alpha,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,B,ldb,beta,C,ldc)
       use iso_c_binding
@@ -27640,7 +27747,9 @@ module hipfort_hipsparse
         c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),c_loc(B),ldb,beta, &
         c_loc(C),ldc)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseCcsrmm_assumed_rank(handle,transA,m,n,k,nnz,alpha,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,B,ldb,beta,C,ldc)
       use iso_c_binding
@@ -27668,7 +27777,9 @@ module hipfort_hipsparse
         c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),c_loc(B),ldb,beta, &
         c_loc(C),ldc)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseZcsrmm_assumed_rank(handle,transA,m,n,k,nnz,alpha,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,B,ldb,beta,C,ldc)
       use iso_c_binding
@@ -27696,7 +27807,9 @@ module hipfort_hipsparse
         c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),c_loc(B),ldb,beta, &
         c_loc(C),ldc)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseScsrmm2_assumed_rank(handle,transA,transB,m,n,k,nnz,alpha,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,B,ldb,beta,C,ldc)
       use iso_c_binding
@@ -27725,7 +27838,9 @@ module hipfort_hipsparse
         c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),c_loc(B),ldb,beta, &
         c_loc(C),ldc)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseDcsrmm2_assumed_rank(handle,transA,transB,m,n,k,nnz,alpha,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,B,ldb,beta,C,ldc)
       use iso_c_binding
@@ -27754,7 +27869,9 @@ module hipfort_hipsparse
         c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),c_loc(B),ldb,beta, &
         c_loc(C),ldc)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseCcsrmm2_assumed_rank(handle,transA,transB,m,n,k,nnz,alpha,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,B,ldb,beta,C,ldc)
       use iso_c_binding
@@ -27783,7 +27900,9 @@ module hipfort_hipsparse
         c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),c_loc(B),ldb,beta, &
         c_loc(C),ldc)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseZcsrmm2_assumed_rank(handle,transA,transB,m,n,k,nnz,alpha,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,B,ldb,beta,C,ldc)
       use iso_c_binding
@@ -27812,7 +27931,9 @@ module hipfort_hipsparse
         c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),c_loc(B),ldb,beta, &
         c_loc(C),ldc)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseScsrsm2_bufferSizeExt_assumed_rank(handle,algo,transA,transB,m,nrhs,nnz,alpha, &
         descrA,csrSortedValA,csrSortedRowPtrA,csrSortedColIndA,B,ldb,myInfo,policy, &
         pBufferSizeInBytes)
@@ -27842,7 +27963,9 @@ module hipfort_hipsparse
         transB,m,nrhs,nnz,c_loc(alpha),descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA), &
         c_loc(csrSortedColIndA),c_loc(B),ldb,myInfo,policy,pBufferSizeInBytes)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseDcsrsm2_bufferSizeExt_assumed_rank(handle,algo,transA,transB,m,nrhs,nnz,alpha, &
         descrA,csrSortedValA,csrSortedRowPtrA,csrSortedColIndA,B,ldb,myInfo,policy, &
         pBufferSizeInBytes)
@@ -27872,7 +27995,9 @@ module hipfort_hipsparse
         transB,m,nrhs,nnz,c_loc(alpha),descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA), &
         c_loc(csrSortedColIndA),c_loc(B),ldb,myInfo,policy,pBufferSizeInBytes)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseCcsrsm2_bufferSizeExt_assumed_rank(handle,algo,transA,transB,m,nrhs,nnz,alpha, &
         descrA,csrSortedValA,csrSortedRowPtrA,csrSortedColIndA,B,ldb,myInfo,policy, &
         pBufferSizeInBytes)
@@ -27902,7 +28027,9 @@ module hipfort_hipsparse
         transB,m,nrhs,nnz,c_loc(alpha),descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA), &
         c_loc(csrSortedColIndA),c_loc(B),ldb,myInfo,policy,pBufferSizeInBytes)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseZcsrsm2_bufferSizeExt_assumed_rank(handle,algo,transA,transB,m,nrhs,nnz,alpha, &
         descrA,csrSortedValA,csrSortedRowPtrA,csrSortedColIndA,B,ldb,myInfo,policy, &
         pBufferSizeInBytes)
@@ -27932,7 +28059,9 @@ module hipfort_hipsparse
         transB,m,nrhs,nnz,c_loc(alpha),descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA), &
         c_loc(csrSortedColIndA),c_loc(B),ldb,myInfo,policy,pBufferSizeInBytes)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseScsrsm2_analysis_assumed_rank(handle,algo,transA,transB,m,nrhs,nnz,alpha,descrA, &
         csrSortedValA,csrSortedRowPtrA,csrSortedColIndA,B,ldb,myInfo,policy,pBuffer)
       use iso_c_binding
@@ -27961,7 +28090,9 @@ module hipfort_hipsparse
         nrhs,nnz,alpha,descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA), &
         c_loc(csrSortedColIndA),c_loc(B),ldb,myInfo,policy,pBuffer)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseDcsrsm2_analysis_assumed_rank(handle,algo,transA,transB,m,nrhs,nnz,alpha,descrA, &
         csrSortedValA,csrSortedRowPtrA,csrSortedColIndA,B,ldb,myInfo,policy,pBuffer)
       use iso_c_binding
@@ -27990,7 +28121,9 @@ module hipfort_hipsparse
         nrhs,nnz,alpha,descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA), &
         c_loc(csrSortedColIndA),c_loc(B),ldb,myInfo,policy,pBuffer)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseCcsrsm2_analysis_assumed_rank(handle,algo,transA,transB,m,nrhs,nnz,alpha,descrA, &
         csrSortedValA,csrSortedRowPtrA,csrSortedColIndA,B,ldb,myInfo,policy,pBuffer)
       use iso_c_binding
@@ -28019,7 +28152,9 @@ module hipfort_hipsparse
         nrhs,nnz,alpha,descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA), &
         c_loc(csrSortedColIndA),c_loc(B),ldb,myInfo,policy,pBuffer)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseZcsrsm2_analysis_assumed_rank(handle,algo,transA,transB,m,nrhs,nnz,alpha,descrA, &
         csrSortedValA,csrSortedRowPtrA,csrSortedColIndA,B,ldb,myInfo,policy,pBuffer)
       use iso_c_binding
@@ -28048,7 +28183,9 @@ module hipfort_hipsparse
         nrhs,nnz,alpha,descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA), &
         c_loc(csrSortedColIndA),c_loc(B),ldb,myInfo,policy,pBuffer)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseScsrsm2_solve_assumed_rank(handle,algo,transA,transB,m,nrhs,nnz,alpha,descrA, &
         csrSortedValA,csrSortedRowPtrA,csrSortedColIndA,B,ldb,myInfo,policy,pBuffer)
       use iso_c_binding
@@ -28077,7 +28214,9 @@ module hipfort_hipsparse
         nnz,alpha,descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA), &
         c_loc(B),ldb,myInfo,policy,pBuffer)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseDcsrsm2_solve_assumed_rank(handle,algo,transA,transB,m,nrhs,nnz,alpha,descrA, &
         csrSortedValA,csrSortedRowPtrA,csrSortedColIndA,B,ldb,myInfo,policy,pBuffer)
       use iso_c_binding
@@ -28106,7 +28245,9 @@ module hipfort_hipsparse
         nnz,alpha,descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA), &
         c_loc(B),ldb,myInfo,policy,pBuffer)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseCcsrsm2_solve_assumed_rank(handle,algo,transA,transB,m,nrhs,nnz,alpha,descrA, &
         csrSortedValA,csrSortedRowPtrA,csrSortedColIndA,B,ldb,myInfo,policy,pBuffer)
       use iso_c_binding
@@ -28135,7 +28276,9 @@ module hipfort_hipsparse
         nnz,alpha,descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA), &
         c_loc(B),ldb,myInfo,policy,pBuffer)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseZcsrsm2_solve_assumed_rank(handle,algo,transA,transB,m,nrhs,nnz,alpha,descrA, &
         csrSortedValA,csrSortedRowPtrA,csrSortedColIndA,B,ldb,myInfo,policy,pBuffer)
       use iso_c_binding
@@ -28164,7 +28307,9 @@ module hipfort_hipsparse
         nnz,alpha,descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA), &
         c_loc(B),ldb,myInfo,policy,pBuffer)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseSgemmi_assumed_rank(handle,m,n,k,nnz,alpha,A,lda,cscValB,cscColPtrB,cscRowIndB, &
         beta,C,ldc)
       use iso_c_binding
@@ -28189,7 +28334,9 @@ module hipfort_hipsparse
       hipsparseSgemmi_assumed_rank = hipsparseSgemmi_(handle,m,n,k,nnz,alpha,c_loc(A),lda, &
         c_loc(cscValB),c_loc(cscColPtrB),c_loc(cscRowIndB),beta,c_loc(C),ldc)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseDgemmi_assumed_rank(handle,m,n,k,nnz,alpha,A,lda,cscValB,cscColPtrB,cscRowIndB, &
         beta,C,ldc)
       use iso_c_binding
@@ -28214,7 +28361,9 @@ module hipfort_hipsparse
       hipsparseDgemmi_assumed_rank = hipsparseDgemmi_(handle,m,n,k,nnz,alpha,c_loc(A),lda, &
         c_loc(cscValB),c_loc(cscColPtrB),c_loc(cscRowIndB),beta,c_loc(C),ldc)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseCgemmi_assumed_rank(handle,m,n,k,nnz,alpha,A,lda,cscValB,cscColPtrB,cscRowIndB, &
         beta,C,ldc)
       use iso_c_binding
@@ -28239,7 +28388,9 @@ module hipfort_hipsparse
       hipsparseCgemmi_assumed_rank = hipsparseCgemmi_(handle,m,n,k,nnz,alpha,c_loc(A),lda, &
         c_loc(cscValB),c_loc(cscColPtrB),c_loc(cscRowIndB),beta,c_loc(C),ldc)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseZgemmi_assumed_rank(handle,m,n,k,nnz,alpha,A,lda,cscValB,cscColPtrB,cscRowIndB, &
         beta,C,ldc)
       use iso_c_binding
@@ -28264,7 +28415,9 @@ module hipfort_hipsparse
       hipsparseZgemmi_assumed_rank = hipsparseZgemmi_(handle,m,n,k,nnz,alpha,c_loc(A),lda, &
         c_loc(cscValB),c_loc(cscColPtrB),c_loc(cscRowIndB),beta,c_loc(C),ldc)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseXcsrgeamNnz_assumed_rank(handle,m,n,descrA,nnzA,csrRowPtrA,csrColIndA,descrB,nnzB, &
         csrRowPtrB,csrColIndB,descrC,csrRowPtrC,nnzTotalDevHostPtr)
       use iso_c_binding
@@ -28290,7 +28443,9 @@ module hipfort_hipsparse
         c_loc(csrRowPtrA),c_loc(csrColIndA),descrB,nnzB,c_loc(csrRowPtrB),c_loc(csrColIndB), &
         descrC,c_loc(csrRowPtrC),nnzTotalDevHostPtr)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseScsrgeam_assumed_rank(handle,m,n,alpha,descrA,nnzA,csrValA,csrRowPtrA,csrColIndA, &
         beta,descrB,nnzB,csrValB,csrRowPtrB,csrColIndB,descrC,csrValC,csrRowPtrC,csrColIndC)
       use iso_c_binding
@@ -28321,7 +28476,9 @@ module hipfort_hipsparse
         c_loc(csrRowPtrA),c_loc(csrColIndA),beta,descrB,nnzB,c_loc(csrValB),c_loc(csrRowPtrB), &
         c_loc(csrColIndB),descrC,c_loc(csrValC),c_loc(csrRowPtrC),c_loc(csrColIndC))
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseDcsrgeam_assumed_rank(handle,m,n,alpha,descrA,nnzA,csrValA,csrRowPtrA,csrColIndA, &
         beta,descrB,nnzB,csrValB,csrRowPtrB,csrColIndB,descrC,csrValC,csrRowPtrC,csrColIndC)
       use iso_c_binding
@@ -28352,7 +28509,9 @@ module hipfort_hipsparse
         c_loc(csrRowPtrA),c_loc(csrColIndA),beta,descrB,nnzB,c_loc(csrValB),c_loc(csrRowPtrB), &
         c_loc(csrColIndB),descrC,c_loc(csrValC),c_loc(csrRowPtrC),c_loc(csrColIndC))
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseCcsrgeam_assumed_rank(handle,m,n,alpha,descrA,nnzA,csrValA,csrRowPtrA,csrColIndA, &
         beta,descrB,nnzB,csrValB,csrRowPtrB,csrColIndB,descrC,csrValC,csrRowPtrC,csrColIndC)
       use iso_c_binding
@@ -28383,7 +28542,9 @@ module hipfort_hipsparse
         c_loc(csrRowPtrA),c_loc(csrColIndA),beta,descrB,nnzB,c_loc(csrValB),c_loc(csrRowPtrB), &
         c_loc(csrColIndB),descrC,c_loc(csrValC),c_loc(csrRowPtrC),c_loc(csrColIndC))
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseZcsrgeam_assumed_rank(handle,m,n,alpha,descrA,nnzA,csrValA,csrRowPtrA,csrColIndA, &
         beta,descrB,nnzB,csrValB,csrRowPtrB,csrColIndB,descrC,csrValC,csrRowPtrC,csrColIndC)
       use iso_c_binding
@@ -28414,6 +28575,7 @@ module hipfort_hipsparse
         c_loc(csrRowPtrA),c_loc(csrColIndA),beta,descrB,nnzB,c_loc(csrValB),c_loc(csrRowPtrB), &
         c_loc(csrColIndB),descrC,c_loc(csrValC),c_loc(csrRowPtrC),c_loc(csrColIndC))
     end function
+#endif
 
     function hipsparseScsrgeam2_bufferSizeExt_assumed_rank(handle,m,n,alpha,descrA,nnzA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,beta,descrB,nnzB,csrSortedValB,csrSortedRowPtrB, &
@@ -28719,6 +28881,7 @@ module hipfort_hipsparse
         c_loc(csrSortedValC),c_loc(csrSortedRowPtrC),c_loc(csrSortedColIndC),pBuffer)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipsparseXcsrgemmNnz_assumed_rank(handle,transA,transB,m,n,k,descrA,nnzA,csrRowPtrA, &
         csrColIndA,descrB,nnzB,csrRowPtrB,csrColIndB,descrC,csrRowPtrC,nnzTotalDevHostPtr)
       use iso_c_binding
@@ -28747,7 +28910,9 @@ module hipfort_hipsparse
         c_loc(csrRowPtrA),c_loc(csrColIndA),descrB,nnzB,c_loc(csrRowPtrB),c_loc(csrColIndB), &
         descrC,c_loc(csrRowPtrC),nnzTotalDevHostPtr)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseScsrgemm_assumed_rank(handle,transA,transB,m,n,k,descrA,nnzA,csrValA,csrRowPtrA, &
         csrColIndA,descrB,nnzB,csrValB,csrRowPtrB,csrColIndB,descrC,csrValC,csrRowPtrC,csrColIndC)
       use iso_c_binding
@@ -28780,7 +28945,9 @@ module hipfort_hipsparse
         c_loc(csrRowPtrB),c_loc(csrColIndB),descrC,c_loc(csrValC),c_loc(csrRowPtrC), &
         c_loc(csrColIndC))
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseDcsrgemm_assumed_rank(handle,transA,transB,m,n,k,descrA,nnzA,csrValA,csrRowPtrA, &
         csrColIndA,descrB,nnzB,csrValB,csrRowPtrB,csrColIndB,descrC,csrValC,csrRowPtrC,csrColIndC)
       use iso_c_binding
@@ -28813,7 +28980,9 @@ module hipfort_hipsparse
         c_loc(csrRowPtrB),c_loc(csrColIndB),descrC,c_loc(csrValC),c_loc(csrRowPtrC), &
         c_loc(csrColIndC))
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseCcsrgemm_assumed_rank(handle,transA,transB,m,n,k,descrA,nnzA,csrValA,csrRowPtrA, &
         csrColIndA,descrB,nnzB,csrValB,csrRowPtrB,csrColIndB,descrC,csrValC,csrRowPtrC,csrColIndC)
       use iso_c_binding
@@ -28846,7 +29015,9 @@ module hipfort_hipsparse
         c_loc(csrRowPtrB),c_loc(csrColIndB),descrC,c_loc(csrValC),c_loc(csrRowPtrC), &
         c_loc(csrColIndC))
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseZcsrgemm_assumed_rank(handle,transA,transB,m,n,k,descrA,nnzA,csrValA,csrRowPtrA, &
         csrColIndA,descrB,nnzB,csrValB,csrRowPtrB,csrColIndB,descrC,csrValC,csrRowPtrC,csrColIndC)
       use iso_c_binding
@@ -28879,7 +29050,9 @@ module hipfort_hipsparse
         c_loc(csrRowPtrB),c_loc(csrColIndB),descrC,c_loc(csrValC),c_loc(csrRowPtrC), &
         c_loc(csrColIndC))
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseScsrgemm2_bufferSizeExt_assumed_rank(handle,m,n,k,alpha,descrA,nnzA,csrRowPtrA, &
         csrColIndA,descrB,nnzB,csrRowPtrB,csrColIndB,beta,descrD,nnzD,csrRowPtrD,csrColIndD, &
         myInfo,pBufferSizeInBytes)
@@ -28913,7 +29086,9 @@ module hipfort_hipsparse
         c_loc(csrColIndB),beta,descrD,nnzD,c_loc(csrRowPtrD),c_loc(csrColIndD),myInfo, &
         pBufferSizeInBytes)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseDcsrgemm2_bufferSizeExt_assumed_rank(handle,m,n,k,alpha,descrA,nnzA,csrRowPtrA, &
         csrColIndA,descrB,nnzB,csrRowPtrB,csrColIndB,beta,descrD,nnzD,csrRowPtrD,csrColIndD, &
         myInfo,pBufferSizeInBytes)
@@ -28947,7 +29122,9 @@ module hipfort_hipsparse
         c_loc(csrColIndB),beta,descrD,nnzD,c_loc(csrRowPtrD),c_loc(csrColIndD),myInfo, &
         pBufferSizeInBytes)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseCcsrgemm2_bufferSizeExt_assumed_rank(handle,m,n,k,alpha,descrA,nnzA,csrRowPtrA, &
         csrColIndA,descrB,nnzB,csrRowPtrB,csrColIndB,beta,descrD,nnzD,csrRowPtrD,csrColIndD, &
         myInfo,pBufferSizeInBytes)
@@ -28981,7 +29158,9 @@ module hipfort_hipsparse
         c_loc(csrColIndB),beta,descrD,nnzD,c_loc(csrRowPtrD),c_loc(csrColIndD),myInfo, &
         pBufferSizeInBytes)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseZcsrgemm2_bufferSizeExt_assumed_rank(handle,m,n,k,alpha,descrA,nnzA,csrRowPtrA, &
         csrColIndA,descrB,nnzB,csrRowPtrB,csrColIndB,beta,descrD,nnzD,csrRowPtrD,csrColIndD, &
         myInfo,pBufferSizeInBytes)
@@ -29015,7 +29194,9 @@ module hipfort_hipsparse
         c_loc(csrColIndB),beta,descrD,nnzD,c_loc(csrRowPtrD),c_loc(csrColIndD),myInfo, &
         pBufferSizeInBytes)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseXcsrgemm2Nnz_assumed_rank(handle,m,n,k,descrA,nnzA,csrRowPtrA,csrColIndA,descrB, &
         nnzB,csrRowPtrB,csrColIndB,descrD,nnzD,csrRowPtrD,csrColIndD,descrC,csrRowPtrC, &
         nnzTotalDevHostPtr,myInfo,pBuffer)
@@ -29050,7 +29231,9 @@ module hipfort_hipsparse
         descrD,nnzD,c_loc(csrRowPtrD),c_loc(csrColIndD),descrC,c_loc(csrRowPtrC), &
         nnzTotalDevHostPtr,myInfo,pBuffer)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseScsrgemm2_assumed_rank(handle,m,n,k,alpha,descrA,nnzA,csrValA,csrRowPtrA, &
         csrColIndA,descrB,nnzB,csrValB,csrRowPtrB,csrColIndB,beta,descrD,nnzD,csrValD,csrRowPtrD, &
         csrColIndD,descrC,csrValC,csrRowPtrC,csrColIndC,myInfo,pBuffer)
@@ -29091,7 +29274,9 @@ module hipfort_hipsparse
         c_loc(csrRowPtrB),c_loc(csrColIndB),beta,descrD,nnzD,c_loc(csrValD),c_loc(csrRowPtrD), &
         c_loc(csrColIndD),descrC,c_loc(csrValC),c_loc(csrRowPtrC),c_loc(csrColIndC),myInfo,pBuffer)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseDcsrgemm2_assumed_rank(handle,m,n,k,alpha,descrA,nnzA,csrValA,csrRowPtrA, &
         csrColIndA,descrB,nnzB,csrValB,csrRowPtrB,csrColIndB,beta,descrD,nnzD,csrValD,csrRowPtrD, &
         csrColIndD,descrC,csrValC,csrRowPtrC,csrColIndC,myInfo,pBuffer)
@@ -29132,7 +29317,9 @@ module hipfort_hipsparse
         c_loc(csrRowPtrB),c_loc(csrColIndB),beta,descrD,nnzD,c_loc(csrValD),c_loc(csrRowPtrD), &
         c_loc(csrColIndD),descrC,c_loc(csrValC),c_loc(csrRowPtrC),c_loc(csrColIndC),myInfo,pBuffer)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseCcsrgemm2_assumed_rank(handle,m,n,k,alpha,descrA,nnzA,csrValA,csrRowPtrA, &
         csrColIndA,descrB,nnzB,csrValB,csrRowPtrB,csrColIndB,beta,descrD,nnzD,csrValD,csrRowPtrD, &
         csrColIndD,descrC,csrValC,csrRowPtrC,csrColIndC,myInfo,pBuffer)
@@ -29173,7 +29360,9 @@ module hipfort_hipsparse
         c_loc(csrRowPtrB),c_loc(csrColIndB),beta,descrD,nnzD,c_loc(csrValD),c_loc(csrRowPtrD), &
         c_loc(csrColIndD),descrC,c_loc(csrValC),c_loc(csrRowPtrC),c_loc(csrColIndC),myInfo,pBuffer)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseZcsrgemm2_assumed_rank(handle,m,n,k,alpha,descrA,nnzA,csrValA,csrRowPtrA, &
         csrColIndA,descrB,nnzB,csrValB,csrRowPtrB,csrColIndB,beta,descrD,nnzD,csrValD,csrRowPtrD, &
         csrColIndD,descrC,csrValC,csrRowPtrC,csrColIndC,myInfo,pBuffer)
@@ -29214,6 +29403,7 @@ module hipfort_hipsparse
         c_loc(csrRowPtrB),c_loc(csrColIndB),beta,descrD,nnzD,c_loc(csrValD),c_loc(csrRowPtrD), &
         c_loc(csrColIndD),descrC,c_loc(csrValC),c_loc(csrRowPtrC),c_loc(csrColIndC),myInfo,pBuffer)
     end function
+#endif
 
     function hipsparseSbsric02_bufferSize_assumed_rank(handle,dirA,mb,nnzb,descrA,bsrValA,bsrRowPtrA, &
         bsrColIndA,blockDim,myInfo,pBufferSizeInBytes)
@@ -29859,6 +30049,7 @@ module hipfort_hipsparse
         pBufferSizeInBytes)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipsparseScsric02_bufferSizeExt_assumed_rank(handle,m,nnz,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,pBufferSizeInBytes)
       use iso_c_binding
@@ -29879,7 +30070,9 @@ module hipfort_hipsparse
         descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),myInfo, &
         pBufferSizeInBytes)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseDcsric02_bufferSizeExt_assumed_rank(handle,m,nnz,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,pBufferSizeInBytes)
       use iso_c_binding
@@ -29900,7 +30093,9 @@ module hipfort_hipsparse
         descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),myInfo, &
         pBufferSizeInBytes)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseCcsric02_bufferSizeExt_assumed_rank(handle,m,nnz,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,pBufferSizeInBytes)
       use iso_c_binding
@@ -29921,7 +30116,9 @@ module hipfort_hipsparse
         descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),myInfo, &
         pBufferSizeInBytes)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseZcsric02_bufferSizeExt_assumed_rank(handle,m,nnz,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,pBufferSizeInBytes)
       use iso_c_binding
@@ -29942,6 +30139,7 @@ module hipfort_hipsparse
         descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),myInfo, &
         pBufferSizeInBytes)
     end function
+#endif
 
     function hipsparseScsric02_analysis_assumed_rank(handle,m,nnz,descrA,csrSortedValA,csrSortedRowPtrA, &
         csrSortedColIndA,myInfo,policy,pBuffer)
@@ -30195,6 +30393,7 @@ module hipfort_hipsparse
         pBufferSizeInBytes)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipsparseScsrilu02_bufferSizeExt_assumed_rank(handle,m,nnz,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,pBufferSizeInBytes)
       use iso_c_binding
@@ -30215,7 +30414,9 @@ module hipfort_hipsparse
         descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),myInfo, &
         pBufferSizeInBytes)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseDcsrilu02_bufferSizeExt_assumed_rank(handle,m,nnz,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,pBufferSizeInBytes)
       use iso_c_binding
@@ -30236,7 +30437,9 @@ module hipfort_hipsparse
         descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),myInfo, &
         pBufferSizeInBytes)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseCcsrilu02_bufferSizeExt_assumed_rank(handle,m,nnz,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,pBufferSizeInBytes)
       use iso_c_binding
@@ -30257,7 +30460,9 @@ module hipfort_hipsparse
         descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),myInfo, &
         pBufferSizeInBytes)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseZcsrilu02_bufferSizeExt_assumed_rank(handle,m,nnz,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,pBufferSizeInBytes)
       use iso_c_binding
@@ -30278,6 +30483,7 @@ module hipfort_hipsparse
         descrA,c_loc(csrSortedValA),c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),myInfo, &
         pBufferSizeInBytes)
     end function
+#endif
 
     function hipsparseScsrilu02_analysis_assumed_rank(handle,m,nnz,descrA,csrSortedValA, &
         csrSortedRowPtrA,csrSortedColIndA,myInfo,policy,pBuffer)
@@ -31278,6 +31484,7 @@ module hipfort_hipsparse
         c_loc(p))
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipsparseScsc2dense_assumed_rank(handle,m,n,descr,cscVal,cscRowInd,cscColPtr,A,ld)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -31296,7 +31503,9 @@ module hipfort_hipsparse
       hipsparseScsc2dense_assumed_rank = hipsparseScsc2dense_(handle,m,n,descr,c_loc(cscVal), &
         c_loc(cscRowInd),c_loc(cscColPtr),c_loc(A),ld)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseDcsc2dense_assumed_rank(handle,m,n,descr,cscVal,cscRowInd,cscColPtr,A,ld)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -31315,7 +31524,9 @@ module hipfort_hipsparse
       hipsparseDcsc2dense_assumed_rank = hipsparseDcsc2dense_(handle,m,n,descr,c_loc(cscVal), &
         c_loc(cscRowInd),c_loc(cscColPtr),c_loc(A),ld)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseCcsc2dense_assumed_rank(handle,m,n,descr,cscVal,cscRowInd,cscColPtr,A,ld)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -31334,7 +31545,9 @@ module hipfort_hipsparse
       hipsparseCcsc2dense_assumed_rank = hipsparseCcsc2dense_(handle,m,n,descr,c_loc(cscVal), &
         c_loc(cscRowInd),c_loc(cscColPtr),c_loc(A),ld)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseZcsc2dense_assumed_rank(handle,m,n,descr,cscVal,cscRowInd,cscColPtr,A,ld)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -31353,6 +31566,7 @@ module hipfort_hipsparse
       hipsparseZcsc2dense_assumed_rank = hipsparseZcsc2dense_(handle,m,n,descr,c_loc(cscVal), &
         c_loc(cscRowInd),c_loc(cscColPtr),c_loc(A),ld)
     end function
+#endif
 
     function hipsparseXcscsort_bufferSizeExt_assumed_rank(handle,m,n,nnz,cscColPtr,cscRowInd, &
         pBufferSizeInBytes)
@@ -31529,6 +31743,7 @@ module hipfort_hipsparse
         c_loc(cooRowInd),idxBase)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipsparseScsr2csc_assumed_rank(handle,m,n,nnz,csrSortedVal,csrSortedRowPtr,csrSortedColInd, &
         cscSortedVal,cscSortedRowInd,cscSortedColPtr,copyValues,idxBase)
       use iso_c_binding
@@ -31552,7 +31767,9 @@ module hipfort_hipsparse
         c_loc(csrSortedRowPtr),c_loc(csrSortedColInd),c_loc(cscSortedVal),c_loc(cscSortedRowInd), &
         c_loc(cscSortedColPtr),copyValues,idxBase)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseDcsr2csc_assumed_rank(handle,m,n,nnz,csrSortedVal,csrSortedRowPtr,csrSortedColInd, &
         cscSortedVal,cscSortedRowInd,cscSortedColPtr,copyValues,idxBase)
       use iso_c_binding
@@ -31576,7 +31793,9 @@ module hipfort_hipsparse
         c_loc(csrSortedRowPtr),c_loc(csrSortedColInd),c_loc(cscSortedVal),c_loc(cscSortedRowInd), &
         c_loc(cscSortedColPtr),copyValues,idxBase)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseCcsr2csc_assumed_rank(handle,m,n,nnz,csrSortedVal,csrSortedRowPtr,csrSortedColInd, &
         cscSortedVal,cscSortedRowInd,cscSortedColPtr,copyValues,idxBase)
       use iso_c_binding
@@ -31600,7 +31819,9 @@ module hipfort_hipsparse
         c_loc(csrSortedRowPtr),c_loc(csrSortedColInd),c_loc(cscSortedVal),c_loc(cscSortedRowInd), &
         c_loc(cscSortedColPtr),copyValues,idxBase)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseZcsr2csc_assumed_rank(handle,m,n,nnz,csrSortedVal,csrSortedRowPtr,csrSortedColInd, &
         cscSortedVal,cscSortedRowInd,cscSortedColPtr,copyValues,idxBase)
       use iso_c_binding
@@ -31624,6 +31845,7 @@ module hipfort_hipsparse
         c_loc(csrSortedRowPtr),c_loc(csrSortedColInd),c_loc(cscSortedVal),c_loc(cscSortedRowInd), &
         c_loc(cscSortedColPtr),copyValues,idxBase)
     end function
+#endif
 
     function hipsparseScsr2csr_compress_assumed_rank(handle,m,n,descrA,csrValA,csrColIndA,csrRowPtrA, &
         nnzA,nnzPerRow,csrValC,csrColIndC,csrRowPtrC,tol)
@@ -31809,6 +32031,7 @@ module hipfort_hipsparse
         c_loc(csrRowPtr),c_loc(csrColInd),myInfo,pBuffer)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipsparseScsr2dense_assumed_rank(handle,m,n,descr,csrVal,csrRowPtr,csrColInd,A,ld)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -31827,7 +32050,9 @@ module hipfort_hipsparse
       hipsparseScsr2dense_assumed_rank = hipsparseScsr2dense_(handle,m,n,descr,c_loc(csrVal), &
         c_loc(csrRowPtr),c_loc(csrColInd),c_loc(A),ld)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseDcsr2dense_assumed_rank(handle,m,n,descr,csrVal,csrRowPtr,csrColInd,A,ld)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -31846,7 +32071,9 @@ module hipfort_hipsparse
       hipsparseDcsr2dense_assumed_rank = hipsparseDcsr2dense_(handle,m,n,descr,c_loc(csrVal), &
         c_loc(csrRowPtr),c_loc(csrColInd),c_loc(A),ld)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseCcsr2dense_assumed_rank(handle,m,n,descr,csrVal,csrRowPtr,csrColInd,A,ld)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -31865,7 +32092,9 @@ module hipfort_hipsparse
       hipsparseCcsr2dense_assumed_rank = hipsparseCcsr2dense_(handle,m,n,descr,c_loc(csrVal), &
         c_loc(csrRowPtr),c_loc(csrColInd),c_loc(A),ld)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseZcsr2dense_assumed_rank(handle,m,n,descr,csrVal,csrRowPtr,csrColInd,A,ld)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -31884,6 +32113,7 @@ module hipfort_hipsparse
       hipsparseZcsr2dense_assumed_rank = hipsparseZcsr2dense_(handle,m,n,descr,c_loc(csrVal), &
         c_loc(csrRowPtr),c_loc(csrColInd),c_loc(A),ld)
     end function
+#endif
 
     function hipsparseScsr2gebsr_bufferSize_assumed_rank(handle,dir,m,n,csr_descr,csrVal,csrRowPtr, &
         csrColInd,rowBlockDim,colBlockDim,pBufferSizeInBytes)
@@ -32110,6 +32340,7 @@ module hipfort_hipsparse
         c_loc(bsrColInd),rowBlockDim,colBlockDim,pbuffer)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipsparseScsr2hyb_assumed_rank(handle,m,n,descrA,csrSortedValA,csrSortedRowPtrA, &
         csrSortedColIndA,hybA,userEllWidth,partitionType)
       use iso_c_binding
@@ -32130,7 +32361,9 @@ module hipfort_hipsparse
       hipsparseScsr2hyb_assumed_rank = hipsparseScsr2hyb_(handle,m,n,descrA,c_loc(csrSortedValA), &
         c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),hybA,userEllWidth,partitionType)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseDcsr2hyb_assumed_rank(handle,m,n,descrA,csrSortedValA,csrSortedRowPtrA, &
         csrSortedColIndA,hybA,userEllWidth,partitionType)
       use iso_c_binding
@@ -32151,7 +32384,9 @@ module hipfort_hipsparse
       hipsparseDcsr2hyb_assumed_rank = hipsparseDcsr2hyb_(handle,m,n,descrA,c_loc(csrSortedValA), &
         c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),hybA,userEllWidth,partitionType)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseCcsr2hyb_assumed_rank(handle,m,n,descrA,csrSortedValA,csrSortedRowPtrA, &
         csrSortedColIndA,hybA,userEllWidth,partitionType)
       use iso_c_binding
@@ -32172,7 +32407,9 @@ module hipfort_hipsparse
       hipsparseCcsr2hyb_assumed_rank = hipsparseCcsr2hyb_(handle,m,n,descrA,c_loc(csrSortedValA), &
         c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),hybA,userEllWidth,partitionType)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseZcsr2hyb_assumed_rank(handle,m,n,descrA,csrSortedValA,csrSortedRowPtrA, &
         csrSortedColIndA,hybA,userEllWidth,partitionType)
       use iso_c_binding
@@ -32193,6 +32430,7 @@ module hipfort_hipsparse
       hipsparseZcsr2hyb_assumed_rank = hipsparseZcsr2hyb_(handle,m,n,descrA,c_loc(csrSortedValA), &
         c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA),hybA,userEllWidth,partitionType)
     end function
+#endif
 
     function hipsparseXcsrsort_bufferSizeExt_assumed_rank(handle,m,n,nnz,csrRowPtr,csrColInd, &
         pBufferSizeInBytes)
@@ -32395,6 +32633,7 @@ module hipfort_hipsparse
         c_loc(csrRowPtr),c_loc(csrColInd),myInfo,pBuffer)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipsparseSdense2csc_assumed_rank(handle,m,n,descr,A,ld,nnzPerColumn,cscVal,cscRowInd, &
         cscColPtr)
       use iso_c_binding
@@ -32415,7 +32654,9 @@ module hipfort_hipsparse
       hipsparseSdense2csc_assumed_rank = hipsparseSdense2csc_(handle,m,n,descr,c_loc(A),ld, &
         c_loc(nnzPerColumn),c_loc(cscVal),c_loc(cscRowInd),c_loc(cscColPtr))
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseDdense2csc_assumed_rank(handle,m,n,descr,A,ld,nnzPerColumn,cscVal,cscRowInd, &
         cscColPtr)
       use iso_c_binding
@@ -32436,7 +32677,9 @@ module hipfort_hipsparse
       hipsparseDdense2csc_assumed_rank = hipsparseDdense2csc_(handle,m,n,descr,c_loc(A),ld, &
         c_loc(nnzPerColumn),c_loc(cscVal),c_loc(cscRowInd),c_loc(cscColPtr))
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseCdense2csc_assumed_rank(handle,m,n,descr,A,ld,nnzPerColumn,cscVal,cscRowInd, &
         cscColPtr)
       use iso_c_binding
@@ -32457,7 +32700,9 @@ module hipfort_hipsparse
       hipsparseCdense2csc_assumed_rank = hipsparseCdense2csc_(handle,m,n,descr,c_loc(A),ld, &
         c_loc(nnzPerColumn),c_loc(cscVal),c_loc(cscRowInd),c_loc(cscColPtr))
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseZdense2csc_assumed_rank(handle,m,n,descr,A,ld,nnzPerColumn,cscVal,cscRowInd, &
         cscColPtr)
       use iso_c_binding
@@ -32478,7 +32723,9 @@ module hipfort_hipsparse
       hipsparseZdense2csc_assumed_rank = hipsparseZdense2csc_(handle,m,n,descr,c_loc(A),ld, &
         c_loc(nnzPerColumn),c_loc(cscVal),c_loc(cscRowInd),c_loc(cscColPtr))
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseSdense2csr_assumed_rank(handle,m,n,descr,A,ld,nnzPerRow,csrVal,csrRowPtr,csrColInd)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -32498,7 +32745,9 @@ module hipfort_hipsparse
       hipsparseSdense2csr_assumed_rank = hipsparseSdense2csr_(handle,m,n,descr,c_loc(A),ld, &
         c_loc(nnzPerRow),c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd))
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseDdense2csr_assumed_rank(handle,m,n,descr,A,ld,nnzPerRow,csrVal,csrRowPtr,csrColInd)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -32518,7 +32767,9 @@ module hipfort_hipsparse
       hipsparseDdense2csr_assumed_rank = hipsparseDdense2csr_(handle,m,n,descr,c_loc(A),ld, &
         c_loc(nnzPerRow),c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd))
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseCdense2csr_assumed_rank(handle,m,n,descr,A,ld,nnzPerRow,csrVal,csrRowPtr,csrColInd)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -32538,7 +32789,9 @@ module hipfort_hipsparse
       hipsparseCdense2csr_assumed_rank = hipsparseCdense2csr_(handle,m,n,descr,c_loc(A),ld, &
         c_loc(nnzPerRow),c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd))
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseZdense2csr_assumed_rank(handle,m,n,descr,A,ld,nnzPerRow,csrVal,csrRowPtr,csrColInd)
       use iso_c_binding
       use hipfort_hipsparse_enums
@@ -32558,6 +32811,7 @@ module hipfort_hipsparse
       hipsparseZdense2csr_assumed_rank = hipsparseZdense2csr_(handle,m,n,descr,c_loc(A),ld, &
         c_loc(nnzPerRow),c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd))
     end function
+#endif
 
     function hipsparseSgebsr2csr_assumed_rank(handle,dirA,mb,nb,descrA,bsrValA,bsrRowPtrA,bsrColIndA, &
         rowBlockDim,colBlockDim,descrC,csrValC,csrRowPtrC,csrColIndC)
@@ -32924,6 +33178,7 @@ module hipfort_hipsparse
         c_loc(bsrValC),c_loc(bsrRowPtrC),c_loc(bsrColIndC),rowBlockDimC,colBlockDimC,buffer)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipsparseShyb2csr_assumed_rank(handle,descrA,hybA,csrSortedValA,csrSortedRowPtrA, &
         csrSortedColIndA)
       use iso_c_binding
@@ -32940,7 +33195,9 @@ module hipfort_hipsparse
       hipsparseShyb2csr_assumed_rank = hipsparseShyb2csr_(handle,descrA,hybA,c_loc(csrSortedValA), &
         c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA))
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseDhyb2csr_assumed_rank(handle,descrA,hybA,csrSortedValA,csrSortedRowPtrA, &
         csrSortedColIndA)
       use iso_c_binding
@@ -32957,7 +33214,9 @@ module hipfort_hipsparse
       hipsparseDhyb2csr_assumed_rank = hipsparseDhyb2csr_(handle,descrA,hybA,c_loc(csrSortedValA), &
         c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA))
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseChyb2csr_assumed_rank(handle,descrA,hybA,csrSortedValA,csrSortedRowPtrA, &
         csrSortedColIndA)
       use iso_c_binding
@@ -32974,7 +33233,9 @@ module hipfort_hipsparse
       hipsparseChyb2csr_assumed_rank = hipsparseChyb2csr_(handle,descrA,hybA,c_loc(csrSortedValA), &
         c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA))
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseZhyb2csr_assumed_rank(handle,descrA,hybA,csrSortedValA,csrSortedRowPtrA, &
         csrSortedColIndA)
       use iso_c_binding
@@ -32991,6 +33252,7 @@ module hipfort_hipsparse
       hipsparseZhyb2csr_assumed_rank = hipsparseZhyb2csr_(handle,descrA,hybA,c_loc(csrSortedValA), &
         c_loc(csrSortedRowPtrA),c_loc(csrSortedColIndA))
     end function
+#endif
 
     function hipsparseSnnz_assumed_rank(handle,dirA,m,n,descrA,A,lda,nnzPerRowColumn,nnzTotalDevHostPtr)
       use iso_c_binding
@@ -33140,6 +33402,7 @@ module hipfort_hipsparse
         c_loc(csrRowPtrA),c_loc(nnzPerRow),c_loc(nnzC),tol)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipsparseSpruneCsr2csr_bufferSize_assumed_rank(handle,m,n,nnzA,descrA,csrValA,csrRowPtrA, &
         csrColIndA,threshold,descrC,csrValC,csrRowPtrC,csrColIndC,pBufferSizeInBytes)
       use iso_c_binding
@@ -33165,7 +33428,9 @@ module hipfort_hipsparse
         nnzA,descrA,c_loc(csrValA),c_loc(csrRowPtrA),c_loc(csrColIndA),c_loc(threshold),descrC, &
         c_loc(csrValC),c_loc(csrRowPtrC),c_loc(csrColIndC),pBufferSizeInBytes)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseDpruneCsr2csr_bufferSize_assumed_rank(handle,m,n,nnzA,descrA,csrValA,csrRowPtrA, &
         csrColIndA,threshold,descrC,csrValC,csrRowPtrC,csrColIndC,pBufferSizeInBytes)
       use iso_c_binding
@@ -33191,6 +33456,7 @@ module hipfort_hipsparse
         nnzA,descrA,c_loc(csrValA),c_loc(csrRowPtrA),c_loc(csrColIndA),c_loc(threshold),descrC, &
         c_loc(csrValC),c_loc(csrRowPtrC),c_loc(csrColIndC),pBufferSizeInBytes)
     end function
+#endif
 
     function hipsparseSpruneCsr2csr_bufferSizeExt_assumed_rank(handle,m,n,nnzA,descrA,csrValA, &
         csrRowPtrA,csrColIndA,threshold,descrC,csrValC,csrRowPtrC,csrColIndC,pBufferSizeInBytes)
@@ -33346,6 +33612,7 @@ module hipfort_hipsparse
         c_loc(csrRowPtrC),c_loc(csrColIndC),buffer)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipsparseSpruneCsr2csrByPercentage_bufferSize_assumed_rank(handle,m,n,nnzA,descrA,csrValA, &
         csrRowPtrA,csrColIndA,percentage,descrC,csrValC,csrRowPtrC,csrColIndC,myInfo, &
         pBufferSizeInBytes)
@@ -33374,7 +33641,9 @@ module hipfort_hipsparse
         c_loc(csrRowPtrA),c_loc(csrColIndA),percentage,descrC,c_loc(csrValC),c_loc(csrRowPtrC), &
         c_loc(csrColIndC),myInfo,pBufferSizeInBytes)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseDpruneCsr2csrByPercentage_bufferSize_assumed_rank(handle,m,n,nnzA,descrA,csrValA, &
         csrRowPtrA,csrColIndA,percentage,descrC,csrValC,csrRowPtrC,csrColIndC,myInfo, &
         pBufferSizeInBytes)
@@ -33403,6 +33672,7 @@ module hipfort_hipsparse
         c_loc(csrRowPtrA),c_loc(csrColIndA),percentage,descrC,c_loc(csrValC),c_loc(csrRowPtrC), &
         c_loc(csrColIndC),myInfo,pBufferSizeInBytes)
     end function
+#endif
 
     function hipsparseSpruneCsr2csrByPercentage_bufferSizeExt_assumed_rank(handle,m,n,nnzA,descrA, &
         csrValA,csrRowPtrA,csrColIndA,percentage,descrC,csrValC,csrRowPtrC,csrColIndC,myInfo, &
@@ -33568,6 +33838,7 @@ module hipfort_hipsparse
         c_loc(csrValC),c_loc(csrRowPtrC),c_loc(csrColIndC),myInfo,buffer)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipsparseSpruneDense2csr_bufferSize_assumed_rank(handle,m,n,A,lda,threshold,descr,csrVal, &
         csrRowPtr,csrColInd,pBufferSizeInBytes)
       use iso_c_binding
@@ -33590,7 +33861,9 @@ module hipfort_hipsparse
         n,c_loc(A),lda,c_loc(threshold),descr,c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd), &
         pBufferSizeInBytes)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseDpruneDense2csr_bufferSize_assumed_rank(handle,m,n,A,lda,threshold,descr,csrVal, &
         csrRowPtr,csrColInd,pBufferSizeInBytes)
       use iso_c_binding
@@ -33613,6 +33886,7 @@ module hipfort_hipsparse
         n,c_loc(A),lda,c_loc(threshold),descr,c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd), &
         pBufferSizeInBytes)
     end function
+#endif
 
     function hipsparseSpruneDense2csr_bufferSizeExt_assumed_rank(handle,m,n,A,lda,threshold,descr, &
         csrVal,csrRowPtr,csrColInd,pBufferSizeInBytes)
@@ -33746,6 +34020,7 @@ module hipfort_hipsparse
         threshold,descr,c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd),buffer)
     end function
 
+#ifndef USE_CUDA_NAMES
     function hipsparseSpruneDense2csrByPercentage_bufferSize_assumed_rank(handle,m,n,A,lda,percentage, &
         descr,csrVal,csrRowPtr,csrColInd,myInfo,pBufferSizeInBytes)
       use iso_c_binding
@@ -33769,7 +34044,9 @@ module hipfort_hipsparse
         hipsparseSpruneDense2csrByPercentage_bufferSize_(handle,m,n,c_loc(A),lda,percentage,descr, &
         c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd),myInfo,pBufferSizeInBytes)
     end function
+#endif
 
+#ifndef USE_CUDA_NAMES
     function hipsparseDpruneDense2csrByPercentage_bufferSize_assumed_rank(handle,m,n,A,lda,percentage, &
         descr,csrVal,csrRowPtr,csrColInd,myInfo,pBufferSizeInBytes)
       use iso_c_binding
@@ -33793,6 +34070,7 @@ module hipfort_hipsparse
         hipsparseDpruneDense2csrByPercentage_bufferSize_(handle,m,n,c_loc(A),lda,percentage,descr, &
         c_loc(csrVal),c_loc(csrRowPtr),c_loc(csrColInd),myInfo,pBufferSizeInBytes)
     end function
+#endif
 
     function hipsparseSpruneDense2csrByPercentage_bufferSizeExt_assumed_rank(handle,m,n,A,lda, &
         percentage,descr,csrVal,csrRowPtr,csrColInd,myInfo,pBufferSizeInBytes)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,12 +23,9 @@ if(BUILD_TESTING)
   endif()
 
   function(hipfort_add_test lib func dir)
-    # f2018 tests exercise the experimental assumed-rank interfaces (dimension(..)),
-    # which are only compiled into the library when HIPFORT_ASSUMED_RANK is ON.
     if(dir STREQUAL "f2018" AND NOT HIPFORT_ASSUMED_RANK)
       return()
     endif()
-    # f2003 tests use .f03, f2008 use .f08, f2018 use .f18 (matching the standard).
     if(dir STREQUAL "f2008")
       set(ext "f08")
     elseif(dir STREQUAL "f2018")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,9 +23,16 @@ if(BUILD_TESTING)
   endif()
 
   function(hipfort_add_test lib func dir)
-    # f2003 tests use .f03, f2008 tests use .f08 to match the target standard.
+    # f2018 tests exercise the experimental assumed-rank interfaces (dimension(..)),
+    # which are only compiled into the library when HIPFORT_ASSUMED_RANK is ON.
+    if(dir STREQUAL "f2018" AND NOT HIPFORT_ASSUMED_RANK)
+      return()
+    endif()
+    # f2003 tests use .f03, f2008 use .f08, f2018 use .f18 (matching the standard).
     if(dir STREQUAL "f2008")
       set(ext "f08")
+    elseif(dir STREQUAL "f2018")
+      set(ext "f18")
     else()
       set(ext "f03")
     endif()
@@ -238,6 +245,7 @@ if(BUILD_TESTING)
     hipfort_add_test(rocblas dtrmm f2003)
     hipfort_add_test(rocblas saxpy f2008)
     hipfort_add_test(rocblas daxpy f2008)
+    hipfort_add_test(rocblas saxpy f2018)
     hipfort_add_test(rocblas caxpy f2008)
     hipfort_add_test(rocblas zaxpy f2008)
     hipfort_add_test(rocblas dtrmm f2008)

--- a/test/f2018/rocblas/saxpy.f18
+++ b/test/f2018/rocblas/saxpy.f18
@@ -1,0 +1,89 @@
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Copyright (c) 2026 Advanced Micro Devices, Inc.
+!
+! Permission is hereby granted, free of charge, to any person obtaining a copy
+! of this software and associated documentation files (the "Software"), to deal
+! in the Software without restriction, including without limitation the rights
+! to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+! copies of the Software, and to permit persons to whom the Software is
+! furnished to do so, subject to the following conditions:
+!
+! The above copyright notice and this permission notice shall be included in
+! all copies or substantial portions of the Software.
+!
+! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+! IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+! AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+! OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+! THE SOFTWARE.
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+
+! Exercises the experimental F2018 assumed-rank interfaces: a rank-3 array is
+! passed to the rocblas_saxpy generic. The classic rank-specific overloads only
+! cover up to rank 1, so this compiles/resolves ONLY with HIPFORT_ASSUMED_RANK
+! (a single dimension(..) wrapper accepts any rank). Demonstrates the rank > 2
+! support requested in https://github.com/ROCm/hipfort/issues/175.
+
+program rocblas_saxpy_rank3_test
+
+  use iso_c_binding
+  use hipfort
+  use hipfort_check
+  use hipfort_rocblas
+
+  implicit none
+
+  integer, parameter :: nx = 2, ny = 3, nz = 4, n = nx*ny*nz
+
+  real(c_float), allocatable, dimension(:,:,:) :: hx, hy
+  real(c_float), pointer, dimension(:,:,:) :: dx => null(), dy => null()
+  real(c_float) :: alpha = 2.0
+  real(c_float), parameter :: y_exact = 5.0   ! alpha*1 + 3 = 5
+  type(c_ptr) :: handle = c_null_ptr
+
+  integer :: i, j, k
+  real(c_float) :: error
+  real(c_float), parameter :: error_max = 10*epsilon(error)
+
+  write(*,"(a)",advance="no") "-- Running test 'SAXPY rank-3' (Fortran 2018 assumed-rank interfaces) - "
+
+  call rocblasCheck(rocblas_create_handle(handle))
+
+  allocate(hx(nx,ny,nz), hy(nx,ny,nz))
+  hx = 1.0
+  hy = 3.0
+
+  call hipCheck(hipMalloc(dx, source=hx))
+  call hipCheck(hipMalloc(dy, source=hy))
+
+  ! Rank-3 dx/dy passed directly to the generic; n counts all elements. Resolves
+  ! to the assumed-rank specific (rank > 1 is impossible with the classic form).
+  call rocblasCheck(rocblas_saxpy(handle, n, alpha, dx, 1, dy, 1))
+
+  call hipCheck(hipDeviceSynchronize())
+  call hipCheck(hipMemcpy(hy, dy, hipMemcpyDeviceToHost))
+
+  do k = 1, nz
+    do j = 1, ny
+      do i = 1, nx
+        error = abs((y_exact - hy(i,j,k))/y_exact)
+        if( error > error_max )then
+          write(*,*) "FAILED! Error bigger than max! Error = ", error, " hy = ", hy(i,j,k)
+          call exit(1)
+        end if
+      end do
+    end do
+  end do
+
+  call hipCheck(hipFree(dx))
+  call hipCheck(hipFree(dy))
+  call rocblasCheck(rocblas_destroy_handle(handle))
+  deallocate(hx, hy)
+
+  write(*,*) "PASSED!"
+
+end program rocblas_saxpy_rank3_test


### PR DESCRIPTION
## What

Adds an **experimental, opt-in** F2018 assumed-rank form of the array (`f2008`) interfaces. With `-DHIPFORT_ASSUMED_RANK=ON`, each array generic is backed by a single assumed-rank (`dimension(..)`) wrapper instead of the rank-specific overloads (`rank_0`, `rank_1`, ...):

```fortran
#ifdef USE_FPOINTER_INTERFACES
#ifdef USE_ASSUMED_RANK_INTERFACES
    module procedure hipfftExecC2C_assumed_rank      ! one wrapper, any rank
#else
    module procedure hipfftExecC2C_rank_0, ..._rank_1, ..._rank_2, ..._rank_3
#endif
#endif
```

The single wrapper declares every buffer `dimension(..)` and forwards the base address to the raw `bind(C)` specific via `c_loc`.

## Why

- Same generic call, any rank (including mixed ranks across buffers).
- Much smaller generated modules, one wrapper per routine instead of N (helps the long-line / large-file pressure).

## Design

- Guarded by `USE_ASSUMED_RANK_INTERFACES`, nested inside `USE_FPOINTER_INTERFACES` (assumed-rank is F2018 ⊃ F2008).
The two forms are mutually exclusive `#ifdef` branches, an assumed-rank dummy matches every rank, so it cannot coexist with the rank-specific specifics in one generic.
- `OFF` by default and purely additive: without the macro the classic rank-specific path is emitted unchanged (only the surrounding `#ifdef/#else/#endif` lines are added). The regenerated files gain guards + the new `*_assumed_rank` wrappers and nothing else (no functions removed).
- New CMake option `HIPFORT_ASSUMED_RANK` (only takes effect when the `f2008` interfaces are enabled).

## Requirements

F2018 assumed-rank + `c_loc` support.

## Verification (amdflang)

- The regenerated modules compile in both modes with no new generic ambiguity.
- The same generic call resolves for rank-0/1/2 actuals in either mode.