### PR TITLE
test: wrap the over-long lines in dgemv_batched.f08

### DIFF
--- a/test/f2008/rocblas/dgemv_batched.f08
+++ b/test/f2008/rocblas/dgemv_batched.f08
@@ -46,9 +46,12 @@ program dgemv_batched
   hAp(1) = dA1; hAp(2) = dA2
   hxp(1) = dx1; hxp(2) = dx2
   hyp(1) = dy1; hyp(2) = dy2
-  call hipCheck(hipMalloc(dAp, int(batch,c_size_t)*psize)); call hipCheck(hipMemcpy(dAp, c_loc(hAp(1)), int(batch,c_size_t)*psize, hipMemcpyHostToDevice))
-  call hipCheck(hipMalloc(dxp, int(batch,c_size_t)*psize)); call hipCheck(hipMemcpy(dxp, c_loc(hxp(1)), int(batch,c_size_t)*psize, hipMemcpyHostToDevice))
-  call hipCheck(hipMalloc(dyp, int(batch,c_size_t)*psize)); call hipCheck(hipMemcpy(dyp, c_loc(hyp(1)), int(batch,c_size_t)*psize, hipMemcpyHostToDevice))
+  call hipCheck(hipMalloc(dAp, int(batch,c_size_t)*psize))
+  call hipCheck(hipMemcpy(dAp, c_loc(hAp(1)), int(batch,c_size_t)*psize, hipMemcpyHostToDevice))
+  call hipCheck(hipMalloc(dxp, int(batch,c_size_t)*psize))
+  call hipCheck(hipMemcpy(dxp, c_loc(hxp(1)), int(batch,c_size_t)*psize, hipMemcpyHostToDevice))
+  call hipCheck(hipMalloc(dyp, int(batch,c_size_t)*psize))
+  call hipCheck(hipMemcpy(dyp, c_loc(hyp(1)), int(batch,c_size_t)*psize, hipMemcpyHostToDevice))
 
   call hipCheck(rocblas_create_handle(handle))
   call hipCheck(rocblas_dgemv_batched(handle, rocblas_operation_none, M, N, alpha, dAp, lda, &


### PR DESCRIPTION
## Summary

`test/f2008/rocblas/dgemv_batched.f08` failed to build with gfortran: two of the batched-pointer setup statements packed a `hipMalloc` and a `hipMemcpy` call onto a single line with `;`, pushing them to **154 columns** — past gfortran's 132-column free-form default, so gfortran truncated the line.

## Change

Split each of the three affected lines so a `hipMalloc` and its `hipMemcpy` sit on separate lines. The source now stays within the standard 132-column free-form limit (longest line: 111 columns), so **no compiler-specific flag** is needed.

## Verification

`dgemv_batched.f08` now compiles with `gfortran -std=gnu` **without** `-ffree-line-length-none`, with no truncation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)