### PR TITLE
Enable the Fortran 2008 array interfaces for every Fortran 2008 compiler

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -22,17 +22,11 @@ file(GLOB HIPFORT_SRC_HIP_F90 "${CMAKE_CURRENT_SOURCE_DIR}/hipfort/*.f90")
 file(GLOB HIPFORT_SRC_HIP_F90_UPPER "${CMAKE_CURRENT_SOURCE_DIR}/hipfort/*.F90")
 set(HIPFORT_SRC_HIP ${HIPFORT_SRC_HIP_F90} ${HIPFORT_SRC_HIP_F90_UPPER})
 
-# The Fortran 2008 array interfaces (USE_FPOINTER_INTERFACES) rely on generic
-# interfaces that the Intel compilers (ifx/ifort) reject as ambiguous. Build the
-# Fortran 2003 (type(c_ptr)) interfaces there instead.
+# The Fortran 2008 array interfaces (USE_FPOINTER_INTERFACES) are enabled whenever
+# the Fortran compiler supports the Fortran 2008 standard.
 set(HIPFORT_USE_FPOINTER_INTERFACES OFF)
-if(CMAKE_Fortran_COMPILER_SUPPORTS_F08 AND NOT CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
+if(CMAKE_Fortran_COMPILER_SUPPORTS_F08)
   set(HIPFORT_USE_FPOINTER_INTERFACES ON)
-elseif(CMAKE_Fortran_COMPILER_SUPPORTS_F08)
-  message(STATUS "Intel Fortran (${CMAKE_Fortran_COMPILER_ID}) detected: building the "
-                 "Fortran 2003 (type(c_ptr)) interfaces; the Fortran 2008 array "
-                 "interfaces are disabled to avoid a generic-interface ambiguity "
-                 "rejected by ifx/ifort.")
 endif()
 
 set(HIPFORT_ARCH "amdgcn")

--- a/lib/hipfort/hipfort_hipmalloc.F90
+++ b/lib/hipfort/hipfort_hipmalloc.F90
@@ -26,13 +26,6 @@
 
 module hipfort_hipmalloc
 
-! ifx/ifort cannot compile the higher-rank allocate-from-source overloads of
-! hipMalloc/hipMallocManaged/hipHostMalloc (a generic-resolution/capacity limit:
-! the SHAPE intrinsic is dropped in some of them above rank 2), so the rank 3-7
-! *_source routines are excluded below when __INTEL_COMPILER is defined (both ifx
-! and ifort predefine it). The rank 0-2 *_source routines and every other overload
-! are unaffected.
-
   use, intrinsic :: iso_fortran_env , only : int32, int64, real32, real64
 
   integer(int32) :: elem_int32

--- a/lib/hipfort/hipfort_hipmalloc.F90
+++ b/lib/hipfort/hipfort_hipmalloc.F90
@@ -26,6 +26,13 @@
 
 module hipfort_hipmalloc
 
+! ifx/ifort cannot compile the higher-rank allocate-from-source overloads of
+! hipMalloc/hipMallocManaged/hipHostMalloc (a generic-resolution/capacity limit:
+! the SHAPE intrinsic is dropped in some of them above rank 2), so the rank 3-7
+! *_source routines are excluded below when __INTEL_COMPILER is defined (both ifx
+! and ifort predefine it). The rank 0-2 *_source routines and every other overload
+! are unaffected.
+
   use, intrinsic :: iso_fortran_env , only : int32, int64, real32, real64
 
   integer(int32) :: elem_int32
@@ -80,160 +87,230 @@ module hipfort_hipmalloc
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
-    module procedure hipMalloc_l_0_source,&
-      hipMalloc_l_1_source,&
-      hipMalloc_l_1_c_int,&
-      hipMalloc_l_1_c_size_t,&
-      hipMalloc_l_2_source,&
-      hipMalloc_l_2_c_int,&
-      hipMalloc_l_2_c_size_t,&
-      hipMalloc_l_3_source,&
-      hipMalloc_l_3_c_int,&
-      hipMalloc_l_3_c_size_t,&
-      hipMalloc_l_4_source,&
-      hipMalloc_l_4_c_int,&
-      hipMalloc_l_4_c_size_t,&
-      hipMalloc_l_5_source,&
-      hipMalloc_l_5_c_int,&
-      hipMalloc_l_5_c_size_t,&
-      hipMalloc_l_6_source,&
-      hipMalloc_l_6_c_int,&
-      hipMalloc_l_6_c_size_t,&
-      hipMalloc_l_7_source,&
-      hipMalloc_l_7_c_int,&
-      hipMalloc_l_7_c_size_t,&
-      hipMalloc_i4_0_source,&
-      hipMalloc_i4_1_source,&
-      hipMalloc_i4_1_c_int,&
-      hipMalloc_i4_1_c_size_t,&
-      hipMalloc_i4_2_source,&
-      hipMalloc_i4_2_c_int,&
-      hipMalloc_i4_2_c_size_t,&
-      hipMalloc_i4_3_source,&
-      hipMalloc_i4_3_c_int,&
-      hipMalloc_i4_3_c_size_t,&
-      hipMalloc_i4_4_source,&
-      hipMalloc_i4_4_c_int,&
-      hipMalloc_i4_4_c_size_t,&
-      hipMalloc_i4_5_source,&
-      hipMalloc_i4_5_c_int,&
-      hipMalloc_i4_5_c_size_t,&
-      hipMalloc_i4_6_source,&
-      hipMalloc_i4_6_c_int,&
-      hipMalloc_i4_6_c_size_t,&
-      hipMalloc_i4_7_source,&
-      hipMalloc_i4_7_c_int,&
-      hipMalloc_i4_7_c_size_t,&
-      hipMalloc_i8_0_source,&
-      hipMalloc_i8_1_source,&
-      hipMalloc_i8_1_c_int,&
-      hipMalloc_i8_1_c_size_t,&
-      hipMalloc_i8_2_source,&
-      hipMalloc_i8_2_c_int,&
-      hipMalloc_i8_2_c_size_t,&
-      hipMalloc_i8_3_source,&
-      hipMalloc_i8_3_c_int,&
-      hipMalloc_i8_3_c_size_t,&
-      hipMalloc_i8_4_source,&
-      hipMalloc_i8_4_c_int,&
-      hipMalloc_i8_4_c_size_t,&
-      hipMalloc_i8_5_source,&
-      hipMalloc_i8_5_c_int,&
-      hipMalloc_i8_5_c_size_t,&
-      hipMalloc_i8_6_source,&
-      hipMalloc_i8_6_c_int,&
-      hipMalloc_i8_6_c_size_t,&
-      hipMalloc_i8_7_source,&
-      hipMalloc_i8_7_c_int,&
-      hipMalloc_i8_7_c_size_t,&
-      hipMalloc_r4_0_source,&
-      hipMalloc_r4_1_source,&
-      hipMalloc_r4_1_c_int,&
-      hipMalloc_r4_1_c_size_t,&
-      hipMalloc_r4_2_source,&
-      hipMalloc_r4_2_c_int,&
-      hipMalloc_r4_2_c_size_t,&
-      hipMalloc_r4_3_source,&
-      hipMalloc_r4_3_c_int,&
-      hipMalloc_r4_3_c_size_t,&
-      hipMalloc_r4_4_source,&
-      hipMalloc_r4_4_c_int,&
-      hipMalloc_r4_4_c_size_t,&
-      hipMalloc_r4_5_source,&
-      hipMalloc_r4_5_c_int,&
-      hipMalloc_r4_5_c_size_t,&
-      hipMalloc_r4_6_source,&
-      hipMalloc_r4_6_c_int,&
-      hipMalloc_r4_6_c_size_t,&
-      hipMalloc_r4_7_source,&
-      hipMalloc_r4_7_c_int,&
-      hipMalloc_r4_7_c_size_t,&
-      hipMalloc_r8_0_source,&
-      hipMalloc_r8_1_source,&
-      hipMalloc_r8_1_c_int,&
-      hipMalloc_r8_1_c_size_t,&
-      hipMalloc_r8_2_source,&
-      hipMalloc_r8_2_c_int,&
-      hipMalloc_r8_2_c_size_t,&
-      hipMalloc_r8_3_source,&
-      hipMalloc_r8_3_c_int,&
-      hipMalloc_r8_3_c_size_t,&
-      hipMalloc_r8_4_source,&
-      hipMalloc_r8_4_c_int,&
-      hipMalloc_r8_4_c_size_t,&
-      hipMalloc_r8_5_source,&
-      hipMalloc_r8_5_c_int,&
-      hipMalloc_r8_5_c_size_t,&
-      hipMalloc_r8_6_source,&
-      hipMalloc_r8_6_c_int,&
-      hipMalloc_r8_6_c_size_t,&
-      hipMalloc_r8_7_source,&
-      hipMalloc_r8_7_c_int,&
-      hipMalloc_r8_7_c_size_t,&
-      hipMalloc_c4_0_source,&
-      hipMalloc_c4_1_source,&
-      hipMalloc_c4_1_c_int,&
-      hipMalloc_c4_1_c_size_t,&
-      hipMalloc_c4_2_source,&
-      hipMalloc_c4_2_c_int,&
-      hipMalloc_c4_2_c_size_t,&
-      hipMalloc_c4_3_source,&
-      hipMalloc_c4_3_c_int,&
-      hipMalloc_c4_3_c_size_t,&
-      hipMalloc_c4_4_source,&
-      hipMalloc_c4_4_c_int,&
-      hipMalloc_c4_4_c_size_t,&
-      hipMalloc_c4_5_source,&
-      hipMalloc_c4_5_c_int,&
-      hipMalloc_c4_5_c_size_t,&
-      hipMalloc_c4_6_source,&
-      hipMalloc_c4_6_c_int,&
-      hipMalloc_c4_6_c_size_t,&
-      hipMalloc_c4_7_source,&
-      hipMalloc_c4_7_c_int,&
-      hipMalloc_c4_7_c_size_t,&
-      hipMalloc_c8_0_source,&
-      hipMalloc_c8_1_source,&
-      hipMalloc_c8_1_c_int,&
-      hipMalloc_c8_1_c_size_t,&
-      hipMalloc_c8_2_source,&
-      hipMalloc_c8_2_c_int,&
-      hipMalloc_c8_2_c_size_t,&
-      hipMalloc_c8_3_source,&
-      hipMalloc_c8_3_c_int,&
-      hipMalloc_c8_3_c_size_t,&
-      hipMalloc_c8_4_source,&
-      hipMalloc_c8_4_c_int,&
-      hipMalloc_c8_4_c_size_t,&
-      hipMalloc_c8_5_source,&
-      hipMalloc_c8_5_c_int,&
-      hipMalloc_c8_5_c_size_t,&
-      hipMalloc_c8_6_source,&
-      hipMalloc_c8_6_c_int,&
-      hipMalloc_c8_6_c_size_t,&
-      hipMalloc_c8_7_source,&
-      hipMalloc_c8_7_c_int,&
-      hipMalloc_c8_7_c_size_t 
+    module procedure hipMalloc_l_0_source
+    module procedure hipMalloc_l_1_source
+    module procedure hipMalloc_l_1_c_int
+    module procedure hipMalloc_l_1_c_size_t
+    module procedure hipMalloc_l_2_source
+    module procedure hipMalloc_l_2_c_int
+    module procedure hipMalloc_l_2_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMalloc_l_3_source
+#endif
+    module procedure hipMalloc_l_3_c_int
+    module procedure hipMalloc_l_3_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMalloc_l_4_source
+#endif
+    module procedure hipMalloc_l_4_c_int
+    module procedure hipMalloc_l_4_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMalloc_l_5_source
+#endif
+    module procedure hipMalloc_l_5_c_int
+    module procedure hipMalloc_l_5_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMalloc_l_6_source
+#endif
+    module procedure hipMalloc_l_6_c_int
+    module procedure hipMalloc_l_6_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMalloc_l_7_source
+#endif
+    module procedure hipMalloc_l_7_c_int
+    module procedure hipMalloc_l_7_c_size_t
+    module procedure hipMalloc_i4_0_source
+    module procedure hipMalloc_i4_1_source
+    module procedure hipMalloc_i4_1_c_int
+    module procedure hipMalloc_i4_1_c_size_t
+    module procedure hipMalloc_i4_2_source
+    module procedure hipMalloc_i4_2_c_int
+    module procedure hipMalloc_i4_2_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMalloc_i4_3_source
+#endif
+    module procedure hipMalloc_i4_3_c_int
+    module procedure hipMalloc_i4_3_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMalloc_i4_4_source
+#endif
+    module procedure hipMalloc_i4_4_c_int
+    module procedure hipMalloc_i4_4_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMalloc_i4_5_source
+#endif
+    module procedure hipMalloc_i4_5_c_int
+    module procedure hipMalloc_i4_5_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMalloc_i4_6_source
+#endif
+    module procedure hipMalloc_i4_6_c_int
+    module procedure hipMalloc_i4_6_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMalloc_i4_7_source
+#endif
+    module procedure hipMalloc_i4_7_c_int
+    module procedure hipMalloc_i4_7_c_size_t
+    module procedure hipMalloc_i8_0_source
+    module procedure hipMalloc_i8_1_source
+    module procedure hipMalloc_i8_1_c_int
+    module procedure hipMalloc_i8_1_c_size_t
+    module procedure hipMalloc_i8_2_source
+    module procedure hipMalloc_i8_2_c_int
+    module procedure hipMalloc_i8_2_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMalloc_i8_3_source
+#endif
+    module procedure hipMalloc_i8_3_c_int
+    module procedure hipMalloc_i8_3_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMalloc_i8_4_source
+#endif
+    module procedure hipMalloc_i8_4_c_int
+    module procedure hipMalloc_i8_4_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMalloc_i8_5_source
+#endif
+    module procedure hipMalloc_i8_5_c_int
+    module procedure hipMalloc_i8_5_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMalloc_i8_6_source
+#endif
+    module procedure hipMalloc_i8_6_c_int
+    module procedure hipMalloc_i8_6_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMalloc_i8_7_source
+#endif
+    module procedure hipMalloc_i8_7_c_int
+    module procedure hipMalloc_i8_7_c_size_t
+    module procedure hipMalloc_r4_0_source
+    module procedure hipMalloc_r4_1_source
+    module procedure hipMalloc_r4_1_c_int
+    module procedure hipMalloc_r4_1_c_size_t
+    module procedure hipMalloc_r4_2_source
+    module procedure hipMalloc_r4_2_c_int
+    module procedure hipMalloc_r4_2_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMalloc_r4_3_source
+#endif
+    module procedure hipMalloc_r4_3_c_int
+    module procedure hipMalloc_r4_3_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMalloc_r4_4_source
+#endif
+    module procedure hipMalloc_r4_4_c_int
+    module procedure hipMalloc_r4_4_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMalloc_r4_5_source
+#endif
+    module procedure hipMalloc_r4_5_c_int
+    module procedure hipMalloc_r4_5_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMalloc_r4_6_source
+#endif
+    module procedure hipMalloc_r4_6_c_int
+    module procedure hipMalloc_r4_6_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMalloc_r4_7_source
+#endif
+    module procedure hipMalloc_r4_7_c_int
+    module procedure hipMalloc_r4_7_c_size_t
+    module procedure hipMalloc_r8_0_source
+    module procedure hipMalloc_r8_1_source
+    module procedure hipMalloc_r8_1_c_int
+    module procedure hipMalloc_r8_1_c_size_t
+    module procedure hipMalloc_r8_2_source
+    module procedure hipMalloc_r8_2_c_int
+    module procedure hipMalloc_r8_2_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMalloc_r8_3_source
+#endif
+    module procedure hipMalloc_r8_3_c_int
+    module procedure hipMalloc_r8_3_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMalloc_r8_4_source
+#endif
+    module procedure hipMalloc_r8_4_c_int
+    module procedure hipMalloc_r8_4_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMalloc_r8_5_source
+#endif
+    module procedure hipMalloc_r8_5_c_int
+    module procedure hipMalloc_r8_5_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMalloc_r8_6_source
+#endif
+    module procedure hipMalloc_r8_6_c_int
+    module procedure hipMalloc_r8_6_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMalloc_r8_7_source
+#endif
+    module procedure hipMalloc_r8_7_c_int
+    module procedure hipMalloc_r8_7_c_size_t
+    module procedure hipMalloc_c4_0_source
+    module procedure hipMalloc_c4_1_source
+    module procedure hipMalloc_c4_1_c_int
+    module procedure hipMalloc_c4_1_c_size_t
+    module procedure hipMalloc_c4_2_source
+    module procedure hipMalloc_c4_2_c_int
+    module procedure hipMalloc_c4_2_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMalloc_c4_3_source
+#endif
+    module procedure hipMalloc_c4_3_c_int
+    module procedure hipMalloc_c4_3_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMalloc_c4_4_source
+#endif
+    module procedure hipMalloc_c4_4_c_int
+    module procedure hipMalloc_c4_4_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMalloc_c4_5_source
+#endif
+    module procedure hipMalloc_c4_5_c_int
+    module procedure hipMalloc_c4_5_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMalloc_c4_6_source
+#endif
+    module procedure hipMalloc_c4_6_c_int
+    module procedure hipMalloc_c4_6_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMalloc_c4_7_source
+#endif
+    module procedure hipMalloc_c4_7_c_int
+    module procedure hipMalloc_c4_7_c_size_t
+    module procedure hipMalloc_c8_0_source
+    module procedure hipMalloc_c8_1_source
+    module procedure hipMalloc_c8_1_c_int
+    module procedure hipMalloc_c8_1_c_size_t
+    module procedure hipMalloc_c8_2_source
+    module procedure hipMalloc_c8_2_c_int
+    module procedure hipMalloc_c8_2_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMalloc_c8_3_source
+#endif
+    module procedure hipMalloc_c8_3_c_int
+    module procedure hipMalloc_c8_3_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMalloc_c8_4_source
+#endif
+    module procedure hipMalloc_c8_4_c_int
+    module procedure hipMalloc_c8_4_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMalloc_c8_5_source
+#endif
+    module procedure hipMalloc_c8_5_c_int
+    module procedure hipMalloc_c8_5_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMalloc_c8_6_source
+#endif
+    module procedure hipMalloc_c8_6_c_int
+    module procedure hipMalloc_c8_6_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMalloc_c8_7_source
+#endif
+    module procedure hipMalloc_c8_7_c_int
+    module procedure hipMalloc_c8_7_c_size_t
 #endif
   end interface
 
@@ -271,160 +348,230 @@ module hipfort_hipmalloc
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
-    module procedure hipMallocManaged_l_0_source,&
-      hipMallocManaged_l_1_source,&
-      hipMallocManaged_l_1_c_int,&
-      hipMallocManaged_l_1_c_size_t,&
-      hipMallocManaged_l_2_source,&
-      hipMallocManaged_l_2_c_int,&
-      hipMallocManaged_l_2_c_size_t,&
-      hipMallocManaged_l_3_source,&
-      hipMallocManaged_l_3_c_int,&
-      hipMallocManaged_l_3_c_size_t,&
-      hipMallocManaged_l_4_source,&
-      hipMallocManaged_l_4_c_int,&
-      hipMallocManaged_l_4_c_size_t,&
-      hipMallocManaged_l_5_source,&
-      hipMallocManaged_l_5_c_int,&
-      hipMallocManaged_l_5_c_size_t,&
-      hipMallocManaged_l_6_source,&
-      hipMallocManaged_l_6_c_int,&
-      hipMallocManaged_l_6_c_size_t,&
-      hipMallocManaged_l_7_source,&
-      hipMallocManaged_l_7_c_int,&
-      hipMallocManaged_l_7_c_size_t,&
-      hipMallocManaged_i4_0_source,&
-      hipMallocManaged_i4_1_source,&
-      hipMallocManaged_i4_1_c_int,&
-      hipMallocManaged_i4_1_c_size_t,&
-      hipMallocManaged_i4_2_source,&
-      hipMallocManaged_i4_2_c_int,&
-      hipMallocManaged_i4_2_c_size_t,&
-      hipMallocManaged_i4_3_source,&
-      hipMallocManaged_i4_3_c_int,&
-      hipMallocManaged_i4_3_c_size_t,&
-      hipMallocManaged_i4_4_source,&
-      hipMallocManaged_i4_4_c_int,&
-      hipMallocManaged_i4_4_c_size_t,&
-      hipMallocManaged_i4_5_source,&
-      hipMallocManaged_i4_5_c_int,&
-      hipMallocManaged_i4_5_c_size_t,&
-      hipMallocManaged_i4_6_source,&
-      hipMallocManaged_i4_6_c_int,&
-      hipMallocManaged_i4_6_c_size_t,&
-      hipMallocManaged_i4_7_source,&
-      hipMallocManaged_i4_7_c_int,&
-      hipMallocManaged_i4_7_c_size_t,&
-      hipMallocManaged_i8_0_source,&
-      hipMallocManaged_i8_1_source,&
-      hipMallocManaged_i8_1_c_int,&
-      hipMallocManaged_i8_1_c_size_t,&
-      hipMallocManaged_i8_2_source,&
-      hipMallocManaged_i8_2_c_int,&
-      hipMallocManaged_i8_2_c_size_t,&
-      hipMallocManaged_i8_3_source,&
-      hipMallocManaged_i8_3_c_int,&
-      hipMallocManaged_i8_3_c_size_t,&
-      hipMallocManaged_i8_4_source,&
-      hipMallocManaged_i8_4_c_int,&
-      hipMallocManaged_i8_4_c_size_t,&
-      hipMallocManaged_i8_5_source,&
-      hipMallocManaged_i8_5_c_int,&
-      hipMallocManaged_i8_5_c_size_t,&
-      hipMallocManaged_i8_6_source,&
-      hipMallocManaged_i8_6_c_int,&
-      hipMallocManaged_i8_6_c_size_t,&
-      hipMallocManaged_i8_7_source,&
-      hipMallocManaged_i8_7_c_int,&
-      hipMallocManaged_i8_7_c_size_t,&
-      hipMallocManaged_r4_0_source,&
-      hipMallocManaged_r4_1_source,&
-      hipMallocManaged_r4_1_c_int,&
-      hipMallocManaged_r4_1_c_size_t,&
-      hipMallocManaged_r4_2_source,&
-      hipMallocManaged_r4_2_c_int,&
-      hipMallocManaged_r4_2_c_size_t,&
-      hipMallocManaged_r4_3_source,&
-      hipMallocManaged_r4_3_c_int,&
-      hipMallocManaged_r4_3_c_size_t,&
-      hipMallocManaged_r4_4_source,&
-      hipMallocManaged_r4_4_c_int,&
-      hipMallocManaged_r4_4_c_size_t,&
-      hipMallocManaged_r4_5_source,&
-      hipMallocManaged_r4_5_c_int,&
-      hipMallocManaged_r4_5_c_size_t,&
-      hipMallocManaged_r4_6_source,&
-      hipMallocManaged_r4_6_c_int,&
-      hipMallocManaged_r4_6_c_size_t,&
-      hipMallocManaged_r4_7_source,&
-      hipMallocManaged_r4_7_c_int,&
-      hipMallocManaged_r4_7_c_size_t,&
-      hipMallocManaged_r8_0_source,&
-      hipMallocManaged_r8_1_source,&
-      hipMallocManaged_r8_1_c_int,&
-      hipMallocManaged_r8_1_c_size_t,&
-      hipMallocManaged_r8_2_source,&
-      hipMallocManaged_r8_2_c_int,&
-      hipMallocManaged_r8_2_c_size_t,&
-      hipMallocManaged_r8_3_source,&
-      hipMallocManaged_r8_3_c_int,&
-      hipMallocManaged_r8_3_c_size_t,&
-      hipMallocManaged_r8_4_source,&
-      hipMallocManaged_r8_4_c_int,&
-      hipMallocManaged_r8_4_c_size_t,&
-      hipMallocManaged_r8_5_source,&
-      hipMallocManaged_r8_5_c_int,&
-      hipMallocManaged_r8_5_c_size_t,&
-      hipMallocManaged_r8_6_source,&
-      hipMallocManaged_r8_6_c_int,&
-      hipMallocManaged_r8_6_c_size_t,&
-      hipMallocManaged_r8_7_source,&
-      hipMallocManaged_r8_7_c_int,&
-      hipMallocManaged_r8_7_c_size_t,&
-      hipMallocManaged_c4_0_source,&
-      hipMallocManaged_c4_1_source,&
-      hipMallocManaged_c4_1_c_int,&
-      hipMallocManaged_c4_1_c_size_t,&
-      hipMallocManaged_c4_2_source,&
-      hipMallocManaged_c4_2_c_int,&
-      hipMallocManaged_c4_2_c_size_t,&
-      hipMallocManaged_c4_3_source,&
-      hipMallocManaged_c4_3_c_int,&
-      hipMallocManaged_c4_3_c_size_t,&
-      hipMallocManaged_c4_4_source,&
-      hipMallocManaged_c4_4_c_int,&
-      hipMallocManaged_c4_4_c_size_t,&
-      hipMallocManaged_c4_5_source,&
-      hipMallocManaged_c4_5_c_int,&
-      hipMallocManaged_c4_5_c_size_t,&
-      hipMallocManaged_c4_6_source,&
-      hipMallocManaged_c4_6_c_int,&
-      hipMallocManaged_c4_6_c_size_t,&
-      hipMallocManaged_c4_7_source,&
-      hipMallocManaged_c4_7_c_int,&
-      hipMallocManaged_c4_7_c_size_t,&
-      hipMallocManaged_c8_0_source,&
-      hipMallocManaged_c8_1_source,&
-      hipMallocManaged_c8_1_c_int,&
-      hipMallocManaged_c8_1_c_size_t,&
-      hipMallocManaged_c8_2_source,&
-      hipMallocManaged_c8_2_c_int,&
-      hipMallocManaged_c8_2_c_size_t,&
-      hipMallocManaged_c8_3_source,&
-      hipMallocManaged_c8_3_c_int,&
-      hipMallocManaged_c8_3_c_size_t,&
-      hipMallocManaged_c8_4_source,&
-      hipMallocManaged_c8_4_c_int,&
-      hipMallocManaged_c8_4_c_size_t,&
-      hipMallocManaged_c8_5_source,&
-      hipMallocManaged_c8_5_c_int,&
-      hipMallocManaged_c8_5_c_size_t,&
-      hipMallocManaged_c8_6_source,&
-      hipMallocManaged_c8_6_c_int,&
-      hipMallocManaged_c8_6_c_size_t,&
-      hipMallocManaged_c8_7_source,&
-      hipMallocManaged_c8_7_c_int,&
-      hipMallocManaged_c8_7_c_size_t 
+    module procedure hipMallocManaged_l_0_source
+    module procedure hipMallocManaged_l_1_source
+    module procedure hipMallocManaged_l_1_c_int
+    module procedure hipMallocManaged_l_1_c_size_t
+    module procedure hipMallocManaged_l_2_source
+    module procedure hipMallocManaged_l_2_c_int
+    module procedure hipMallocManaged_l_2_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMallocManaged_l_3_source
+#endif
+    module procedure hipMallocManaged_l_3_c_int
+    module procedure hipMallocManaged_l_3_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMallocManaged_l_4_source
+#endif
+    module procedure hipMallocManaged_l_4_c_int
+    module procedure hipMallocManaged_l_4_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMallocManaged_l_5_source
+#endif
+    module procedure hipMallocManaged_l_5_c_int
+    module procedure hipMallocManaged_l_5_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMallocManaged_l_6_source
+#endif
+    module procedure hipMallocManaged_l_6_c_int
+    module procedure hipMallocManaged_l_6_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMallocManaged_l_7_source
+#endif
+    module procedure hipMallocManaged_l_7_c_int
+    module procedure hipMallocManaged_l_7_c_size_t
+    module procedure hipMallocManaged_i4_0_source
+    module procedure hipMallocManaged_i4_1_source
+    module procedure hipMallocManaged_i4_1_c_int
+    module procedure hipMallocManaged_i4_1_c_size_t
+    module procedure hipMallocManaged_i4_2_source
+    module procedure hipMallocManaged_i4_2_c_int
+    module procedure hipMallocManaged_i4_2_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMallocManaged_i4_3_source
+#endif
+    module procedure hipMallocManaged_i4_3_c_int
+    module procedure hipMallocManaged_i4_3_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMallocManaged_i4_4_source
+#endif
+    module procedure hipMallocManaged_i4_4_c_int
+    module procedure hipMallocManaged_i4_4_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMallocManaged_i4_5_source
+#endif
+    module procedure hipMallocManaged_i4_5_c_int
+    module procedure hipMallocManaged_i4_5_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMallocManaged_i4_6_source
+#endif
+    module procedure hipMallocManaged_i4_6_c_int
+    module procedure hipMallocManaged_i4_6_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMallocManaged_i4_7_source
+#endif
+    module procedure hipMallocManaged_i4_7_c_int
+    module procedure hipMallocManaged_i4_7_c_size_t
+    module procedure hipMallocManaged_i8_0_source
+    module procedure hipMallocManaged_i8_1_source
+    module procedure hipMallocManaged_i8_1_c_int
+    module procedure hipMallocManaged_i8_1_c_size_t
+    module procedure hipMallocManaged_i8_2_source
+    module procedure hipMallocManaged_i8_2_c_int
+    module procedure hipMallocManaged_i8_2_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMallocManaged_i8_3_source
+#endif
+    module procedure hipMallocManaged_i8_3_c_int
+    module procedure hipMallocManaged_i8_3_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMallocManaged_i8_4_source
+#endif
+    module procedure hipMallocManaged_i8_4_c_int
+    module procedure hipMallocManaged_i8_4_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMallocManaged_i8_5_source
+#endif
+    module procedure hipMallocManaged_i8_5_c_int
+    module procedure hipMallocManaged_i8_5_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMallocManaged_i8_6_source
+#endif
+    module procedure hipMallocManaged_i8_6_c_int
+    module procedure hipMallocManaged_i8_6_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMallocManaged_i8_7_source
+#endif
+    module procedure hipMallocManaged_i8_7_c_int
+    module procedure hipMallocManaged_i8_7_c_size_t
+    module procedure hipMallocManaged_r4_0_source
+    module procedure hipMallocManaged_r4_1_source
+    module procedure hipMallocManaged_r4_1_c_int
+    module procedure hipMallocManaged_r4_1_c_size_t
+    module procedure hipMallocManaged_r4_2_source
+    module procedure hipMallocManaged_r4_2_c_int
+    module procedure hipMallocManaged_r4_2_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMallocManaged_r4_3_source
+#endif
+    module procedure hipMallocManaged_r4_3_c_int
+    module procedure hipMallocManaged_r4_3_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMallocManaged_r4_4_source
+#endif
+    module procedure hipMallocManaged_r4_4_c_int
+    module procedure hipMallocManaged_r4_4_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMallocManaged_r4_5_source
+#endif
+    module procedure hipMallocManaged_r4_5_c_int
+    module procedure hipMallocManaged_r4_5_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMallocManaged_r4_6_source
+#endif
+    module procedure hipMallocManaged_r4_6_c_int
+    module procedure hipMallocManaged_r4_6_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMallocManaged_r4_7_source
+#endif
+    module procedure hipMallocManaged_r4_7_c_int
+    module procedure hipMallocManaged_r4_7_c_size_t
+    module procedure hipMallocManaged_r8_0_source
+    module procedure hipMallocManaged_r8_1_source
+    module procedure hipMallocManaged_r8_1_c_int
+    module procedure hipMallocManaged_r8_1_c_size_t
+    module procedure hipMallocManaged_r8_2_source
+    module procedure hipMallocManaged_r8_2_c_int
+    module procedure hipMallocManaged_r8_2_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMallocManaged_r8_3_source
+#endif
+    module procedure hipMallocManaged_r8_3_c_int
+    module procedure hipMallocManaged_r8_3_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMallocManaged_r8_4_source
+#endif
+    module procedure hipMallocManaged_r8_4_c_int
+    module procedure hipMallocManaged_r8_4_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMallocManaged_r8_5_source
+#endif
+    module procedure hipMallocManaged_r8_5_c_int
+    module procedure hipMallocManaged_r8_5_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMallocManaged_r8_6_source
+#endif
+    module procedure hipMallocManaged_r8_6_c_int
+    module procedure hipMallocManaged_r8_6_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMallocManaged_r8_7_source
+#endif
+    module procedure hipMallocManaged_r8_7_c_int
+    module procedure hipMallocManaged_r8_7_c_size_t
+    module procedure hipMallocManaged_c4_0_source
+    module procedure hipMallocManaged_c4_1_source
+    module procedure hipMallocManaged_c4_1_c_int
+    module procedure hipMallocManaged_c4_1_c_size_t
+    module procedure hipMallocManaged_c4_2_source
+    module procedure hipMallocManaged_c4_2_c_int
+    module procedure hipMallocManaged_c4_2_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMallocManaged_c4_3_source
+#endif
+    module procedure hipMallocManaged_c4_3_c_int
+    module procedure hipMallocManaged_c4_3_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMallocManaged_c4_4_source
+#endif
+    module procedure hipMallocManaged_c4_4_c_int
+    module procedure hipMallocManaged_c4_4_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMallocManaged_c4_5_source
+#endif
+    module procedure hipMallocManaged_c4_5_c_int
+    module procedure hipMallocManaged_c4_5_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMallocManaged_c4_6_source
+#endif
+    module procedure hipMallocManaged_c4_6_c_int
+    module procedure hipMallocManaged_c4_6_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMallocManaged_c4_7_source
+#endif
+    module procedure hipMallocManaged_c4_7_c_int
+    module procedure hipMallocManaged_c4_7_c_size_t
+    module procedure hipMallocManaged_c8_0_source
+    module procedure hipMallocManaged_c8_1_source
+    module procedure hipMallocManaged_c8_1_c_int
+    module procedure hipMallocManaged_c8_1_c_size_t
+    module procedure hipMallocManaged_c8_2_source
+    module procedure hipMallocManaged_c8_2_c_int
+    module procedure hipMallocManaged_c8_2_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMallocManaged_c8_3_source
+#endif
+    module procedure hipMallocManaged_c8_3_c_int
+    module procedure hipMallocManaged_c8_3_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMallocManaged_c8_4_source
+#endif
+    module procedure hipMallocManaged_c8_4_c_int
+    module procedure hipMallocManaged_c8_4_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMallocManaged_c8_5_source
+#endif
+    module procedure hipMallocManaged_c8_5_c_int
+    module procedure hipMallocManaged_c8_5_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMallocManaged_c8_6_source
+#endif
+    module procedure hipMallocManaged_c8_6_c_int
+    module procedure hipMallocManaged_c8_6_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipMallocManaged_c8_7_source
+#endif
+    module procedure hipMallocManaged_c8_7_c_int
+    module procedure hipMallocManaged_c8_7_c_size_t
 #endif
 
   end interface
@@ -466,160 +613,230 @@ module hipfort_hipmalloc
     end function
 
 #ifdef USE_FPOINTER_INTERFACES
-    module procedure hipHostMalloc_l_0_source,&
-      hipHostMalloc_l_1_source,&
-      hipHostMalloc_l_1_c_int,&
-      hipHostMalloc_l_1_c_size_t,&
-      hipHostMalloc_l_2_source,&
-      hipHostMalloc_l_2_c_int,&
-      hipHostMalloc_l_2_c_size_t,&
-      hipHostMalloc_l_3_source,&
-      hipHostMalloc_l_3_c_int,&
-      hipHostMalloc_l_3_c_size_t,&
-      hipHostMalloc_l_4_source,&
-      hipHostMalloc_l_4_c_int,&
-      hipHostMalloc_l_4_c_size_t,&
-      hipHostMalloc_l_5_source,&
-      hipHostMalloc_l_5_c_int,&
-      hipHostMalloc_l_5_c_size_t,&
-      hipHostMalloc_l_6_source,&
-      hipHostMalloc_l_6_c_int,&
-      hipHostMalloc_l_6_c_size_t,&
-      hipHostMalloc_l_7_source,&
-      hipHostMalloc_l_7_c_int,&
-      hipHostMalloc_l_7_c_size_t,&
-      hipHostMalloc_i4_0_source,&
-      hipHostMalloc_i4_1_source,&
-      hipHostMalloc_i4_1_c_int,&
-      hipHostMalloc_i4_1_c_size_t,&
-      hipHostMalloc_i4_2_source,&
-      hipHostMalloc_i4_2_c_int,&
-      hipHostMalloc_i4_2_c_size_t,&
-      hipHostMalloc_i4_3_source,&
-      hipHostMalloc_i4_3_c_int,&
-      hipHostMalloc_i4_3_c_size_t,&
-      hipHostMalloc_i4_4_source,&
-      hipHostMalloc_i4_4_c_int,&
-      hipHostMalloc_i4_4_c_size_t,&
-      hipHostMalloc_i4_5_source,&
-      hipHostMalloc_i4_5_c_int,&
-      hipHostMalloc_i4_5_c_size_t,&
-      hipHostMalloc_i4_6_source,&
-      hipHostMalloc_i4_6_c_int,&
-      hipHostMalloc_i4_6_c_size_t,&
-      hipHostMalloc_i4_7_source,&
-      hipHostMalloc_i4_7_c_int,&
-      hipHostMalloc_i4_7_c_size_t,&
-      hipHostMalloc_i8_0_source,&
-      hipHostMalloc_i8_1_source,&
-      hipHostMalloc_i8_1_c_int,&
-      hipHostMalloc_i8_1_c_size_t,&
-      hipHostMalloc_i8_2_source,&
-      hipHostMalloc_i8_2_c_int,&
-      hipHostMalloc_i8_2_c_size_t,&
-      hipHostMalloc_i8_3_source,&
-      hipHostMalloc_i8_3_c_int,&
-      hipHostMalloc_i8_3_c_size_t,&
-      hipHostMalloc_i8_4_source,&
-      hipHostMalloc_i8_4_c_int,&
-      hipHostMalloc_i8_4_c_size_t,&
-      hipHostMalloc_i8_5_source,&
-      hipHostMalloc_i8_5_c_int,&
-      hipHostMalloc_i8_5_c_size_t,&
-      hipHostMalloc_i8_6_source,&
-      hipHostMalloc_i8_6_c_int,&
-      hipHostMalloc_i8_6_c_size_t,&
-      hipHostMalloc_i8_7_source,&
-      hipHostMalloc_i8_7_c_int,&
-      hipHostMalloc_i8_7_c_size_t,&
-      hipHostMalloc_r4_0_source,&
-      hipHostMalloc_r4_1_source,&
-      hipHostMalloc_r4_1_c_int,&
-      hipHostMalloc_r4_1_c_size_t,&
-      hipHostMalloc_r4_2_source,&
-      hipHostMalloc_r4_2_c_int,&
-      hipHostMalloc_r4_2_c_size_t,&
-      hipHostMalloc_r4_3_source,&
-      hipHostMalloc_r4_3_c_int,&
-      hipHostMalloc_r4_3_c_size_t,&
-      hipHostMalloc_r4_4_source,&
-      hipHostMalloc_r4_4_c_int,&
-      hipHostMalloc_r4_4_c_size_t,&
-      hipHostMalloc_r4_5_source,&
-      hipHostMalloc_r4_5_c_int,&
-      hipHostMalloc_r4_5_c_size_t,&
-      hipHostMalloc_r4_6_source,&
-      hipHostMalloc_r4_6_c_int,&
-      hipHostMalloc_r4_6_c_size_t,&
-      hipHostMalloc_r4_7_source,&
-      hipHostMalloc_r4_7_c_int,&
-      hipHostMalloc_r4_7_c_size_t,&
-      hipHostMalloc_r8_0_source,&
-      hipHostMalloc_r8_1_source,&
-      hipHostMalloc_r8_1_c_int,&
-      hipHostMalloc_r8_1_c_size_t,&
-      hipHostMalloc_r8_2_source,&
-      hipHostMalloc_r8_2_c_int,&
-      hipHostMalloc_r8_2_c_size_t,&
-      hipHostMalloc_r8_3_source,&
-      hipHostMalloc_r8_3_c_int,&
-      hipHostMalloc_r8_3_c_size_t,&
-      hipHostMalloc_r8_4_source,&
-      hipHostMalloc_r8_4_c_int,&
-      hipHostMalloc_r8_4_c_size_t,&
-      hipHostMalloc_r8_5_source,&
-      hipHostMalloc_r8_5_c_int,&
-      hipHostMalloc_r8_5_c_size_t,&
-      hipHostMalloc_r8_6_source,&
-      hipHostMalloc_r8_6_c_int,&
-      hipHostMalloc_r8_6_c_size_t,&
-      hipHostMalloc_r8_7_source,&
-      hipHostMalloc_r8_7_c_int,&
-      hipHostMalloc_r8_7_c_size_t,&
-      hipHostMalloc_c4_0_source,&
-      hipHostMalloc_c4_1_source,&
-      hipHostMalloc_c4_1_c_int,&
-      hipHostMalloc_c4_1_c_size_t,&
-      hipHostMalloc_c4_2_source,&
-      hipHostMalloc_c4_2_c_int,&
-      hipHostMalloc_c4_2_c_size_t,&
-      hipHostMalloc_c4_3_source,&
-      hipHostMalloc_c4_3_c_int,&
-      hipHostMalloc_c4_3_c_size_t,&
-      hipHostMalloc_c4_4_source,&
-      hipHostMalloc_c4_4_c_int,&
-      hipHostMalloc_c4_4_c_size_t,&
-      hipHostMalloc_c4_5_source,&
-      hipHostMalloc_c4_5_c_int,&
-      hipHostMalloc_c4_5_c_size_t,&
-      hipHostMalloc_c4_6_source,&
-      hipHostMalloc_c4_6_c_int,&
-      hipHostMalloc_c4_6_c_size_t,&
-      hipHostMalloc_c4_7_source,&
-      hipHostMalloc_c4_7_c_int,&
-      hipHostMalloc_c4_7_c_size_t,&
-      hipHostMalloc_c8_0_source,&
-      hipHostMalloc_c8_1_source,&
-      hipHostMalloc_c8_1_c_int,&
-      hipHostMalloc_c8_1_c_size_t,&
-      hipHostMalloc_c8_2_source,&
-      hipHostMalloc_c8_2_c_int,&
-      hipHostMalloc_c8_2_c_size_t,&
-      hipHostMalloc_c8_3_source,&
-      hipHostMalloc_c8_3_c_int,&
-      hipHostMalloc_c8_3_c_size_t,&
-      hipHostMalloc_c8_4_source,&
-      hipHostMalloc_c8_4_c_int,&
-      hipHostMalloc_c8_4_c_size_t,&
-      hipHostMalloc_c8_5_source,&
-      hipHostMalloc_c8_5_c_int,&
-      hipHostMalloc_c8_5_c_size_t,&
-      hipHostMalloc_c8_6_source,&
-      hipHostMalloc_c8_6_c_int,&
-      hipHostMalloc_c8_6_c_size_t,&
-      hipHostMalloc_c8_7_source,&
-      hipHostMalloc_c8_7_c_int,&
-      hipHostMalloc_c8_7_c_size_t 
+    module procedure hipHostMalloc_l_0_source
+    module procedure hipHostMalloc_l_1_source
+    module procedure hipHostMalloc_l_1_c_int
+    module procedure hipHostMalloc_l_1_c_size_t
+    module procedure hipHostMalloc_l_2_source
+    module procedure hipHostMalloc_l_2_c_int
+    module procedure hipHostMalloc_l_2_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipHostMalloc_l_3_source
+#endif
+    module procedure hipHostMalloc_l_3_c_int
+    module procedure hipHostMalloc_l_3_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipHostMalloc_l_4_source
+#endif
+    module procedure hipHostMalloc_l_4_c_int
+    module procedure hipHostMalloc_l_4_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipHostMalloc_l_5_source
+#endif
+    module procedure hipHostMalloc_l_5_c_int
+    module procedure hipHostMalloc_l_5_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipHostMalloc_l_6_source
+#endif
+    module procedure hipHostMalloc_l_6_c_int
+    module procedure hipHostMalloc_l_6_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipHostMalloc_l_7_source
+#endif
+    module procedure hipHostMalloc_l_7_c_int
+    module procedure hipHostMalloc_l_7_c_size_t
+    module procedure hipHostMalloc_i4_0_source
+    module procedure hipHostMalloc_i4_1_source
+    module procedure hipHostMalloc_i4_1_c_int
+    module procedure hipHostMalloc_i4_1_c_size_t
+    module procedure hipHostMalloc_i4_2_source
+    module procedure hipHostMalloc_i4_2_c_int
+    module procedure hipHostMalloc_i4_2_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipHostMalloc_i4_3_source
+#endif
+    module procedure hipHostMalloc_i4_3_c_int
+    module procedure hipHostMalloc_i4_3_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipHostMalloc_i4_4_source
+#endif
+    module procedure hipHostMalloc_i4_4_c_int
+    module procedure hipHostMalloc_i4_4_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipHostMalloc_i4_5_source
+#endif
+    module procedure hipHostMalloc_i4_5_c_int
+    module procedure hipHostMalloc_i4_5_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipHostMalloc_i4_6_source
+#endif
+    module procedure hipHostMalloc_i4_6_c_int
+    module procedure hipHostMalloc_i4_6_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipHostMalloc_i4_7_source
+#endif
+    module procedure hipHostMalloc_i4_7_c_int
+    module procedure hipHostMalloc_i4_7_c_size_t
+    module procedure hipHostMalloc_i8_0_source
+    module procedure hipHostMalloc_i8_1_source
+    module procedure hipHostMalloc_i8_1_c_int
+    module procedure hipHostMalloc_i8_1_c_size_t
+    module procedure hipHostMalloc_i8_2_source
+    module procedure hipHostMalloc_i8_2_c_int
+    module procedure hipHostMalloc_i8_2_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipHostMalloc_i8_3_source
+#endif
+    module procedure hipHostMalloc_i8_3_c_int
+    module procedure hipHostMalloc_i8_3_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipHostMalloc_i8_4_source
+#endif
+    module procedure hipHostMalloc_i8_4_c_int
+    module procedure hipHostMalloc_i8_4_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipHostMalloc_i8_5_source
+#endif
+    module procedure hipHostMalloc_i8_5_c_int
+    module procedure hipHostMalloc_i8_5_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipHostMalloc_i8_6_source
+#endif
+    module procedure hipHostMalloc_i8_6_c_int
+    module procedure hipHostMalloc_i8_6_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipHostMalloc_i8_7_source
+#endif
+    module procedure hipHostMalloc_i8_7_c_int
+    module procedure hipHostMalloc_i8_7_c_size_t
+    module procedure hipHostMalloc_r4_0_source
+    module procedure hipHostMalloc_r4_1_source
+    module procedure hipHostMalloc_r4_1_c_int
+    module procedure hipHostMalloc_r4_1_c_size_t
+    module procedure hipHostMalloc_r4_2_source
+    module procedure hipHostMalloc_r4_2_c_int
+    module procedure hipHostMalloc_r4_2_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipHostMalloc_r4_3_source
+#endif
+    module procedure hipHostMalloc_r4_3_c_int
+    module procedure hipHostMalloc_r4_3_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipHostMalloc_r4_4_source
+#endif
+    module procedure hipHostMalloc_r4_4_c_int
+    module procedure hipHostMalloc_r4_4_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipHostMalloc_r4_5_source
+#endif
+    module procedure hipHostMalloc_r4_5_c_int
+    module procedure hipHostMalloc_r4_5_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipHostMalloc_r4_6_source
+#endif
+    module procedure hipHostMalloc_r4_6_c_int
+    module procedure hipHostMalloc_r4_6_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipHostMalloc_r4_7_source
+#endif
+    module procedure hipHostMalloc_r4_7_c_int
+    module procedure hipHostMalloc_r4_7_c_size_t
+    module procedure hipHostMalloc_r8_0_source
+    module procedure hipHostMalloc_r8_1_source
+    module procedure hipHostMalloc_r8_1_c_int
+    module procedure hipHostMalloc_r8_1_c_size_t
+    module procedure hipHostMalloc_r8_2_source
+    module procedure hipHostMalloc_r8_2_c_int
+    module procedure hipHostMalloc_r8_2_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipHostMalloc_r8_3_source
+#endif
+    module procedure hipHostMalloc_r8_3_c_int
+    module procedure hipHostMalloc_r8_3_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipHostMalloc_r8_4_source
+#endif
+    module procedure hipHostMalloc_r8_4_c_int
+    module procedure hipHostMalloc_r8_4_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipHostMalloc_r8_5_source
+#endif
+    module procedure hipHostMalloc_r8_5_c_int
+    module procedure hipHostMalloc_r8_5_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipHostMalloc_r8_6_source
+#endif
+    module procedure hipHostMalloc_r8_6_c_int
+    module procedure hipHostMalloc_r8_6_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipHostMalloc_r8_7_source
+#endif
+    module procedure hipHostMalloc_r8_7_c_int
+    module procedure hipHostMalloc_r8_7_c_size_t
+    module procedure hipHostMalloc_c4_0_source
+    module procedure hipHostMalloc_c4_1_source
+    module procedure hipHostMalloc_c4_1_c_int
+    module procedure hipHostMalloc_c4_1_c_size_t
+    module procedure hipHostMalloc_c4_2_source
+    module procedure hipHostMalloc_c4_2_c_int
+    module procedure hipHostMalloc_c4_2_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipHostMalloc_c4_3_source
+#endif
+    module procedure hipHostMalloc_c4_3_c_int
+    module procedure hipHostMalloc_c4_3_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipHostMalloc_c4_4_source
+#endif
+    module procedure hipHostMalloc_c4_4_c_int
+    module procedure hipHostMalloc_c4_4_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipHostMalloc_c4_5_source
+#endif
+    module procedure hipHostMalloc_c4_5_c_int
+    module procedure hipHostMalloc_c4_5_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipHostMalloc_c4_6_source
+#endif
+    module procedure hipHostMalloc_c4_6_c_int
+    module procedure hipHostMalloc_c4_6_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipHostMalloc_c4_7_source
+#endif
+    module procedure hipHostMalloc_c4_7_c_int
+    module procedure hipHostMalloc_c4_7_c_size_t
+    module procedure hipHostMalloc_c8_0_source
+    module procedure hipHostMalloc_c8_1_source
+    module procedure hipHostMalloc_c8_1_c_int
+    module procedure hipHostMalloc_c8_1_c_size_t
+    module procedure hipHostMalloc_c8_2_source
+    module procedure hipHostMalloc_c8_2_c_int
+    module procedure hipHostMalloc_c8_2_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipHostMalloc_c8_3_source
+#endif
+    module procedure hipHostMalloc_c8_3_c_int
+    module procedure hipHostMalloc_c8_3_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipHostMalloc_c8_4_source
+#endif
+    module procedure hipHostMalloc_c8_4_c_int
+    module procedure hipHostMalloc_c8_4_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipHostMalloc_c8_5_source
+#endif
+    module procedure hipHostMalloc_c8_5_c_int
+    module procedure hipHostMalloc_c8_5_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipHostMalloc_c8_6_source
+#endif
+    module procedure hipHostMalloc_c8_6_c_int
+    module procedure hipHostMalloc_c8_6_c_size_t
+#ifndef __INTEL_COMPILER
+    module procedure hipHostMalloc_c8_7_source
+#endif
+    module procedure hipHostMalloc_c8_7_c_int
+    module procedure hipHostMalloc_c8_7_c_size_t
 #endif
   end interface
   
@@ -1133,6 +1350,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMalloc_l_3_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -1206,6 +1424,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMalloc_l_3_c_int(ptr,length1,length2,length3)
@@ -1256,6 +1475,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMalloc_l_4_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -1329,6 +1549,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMalloc_l_4_c_int(ptr,length1,length2,length3,length4)
@@ -1381,6 +1602,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMalloc_l_5_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -1454,6 +1676,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMalloc_l_5_c_int(ptr,length1,length2,length3,length4,length5)
@@ -1506,6 +1729,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMalloc_l_6_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -1580,6 +1804,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMalloc_l_6_c_int(ptr,length1,length2,length3,length4,length5,length6)
@@ -1632,6 +1857,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMalloc_l_7_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -1707,6 +1933,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMalloc_l_7_c_int(ptr,length1,length2,length3,length4,length5,length6,length7)
@@ -2053,6 +2280,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMalloc_i4_3_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -2127,6 +2355,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMalloc_i4_3_c_int(ptr,length1,length2,length3)
@@ -2179,6 +2408,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMalloc_i4_4_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -2253,6 +2483,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMalloc_i4_4_c_int(ptr,length1,length2,length3,length4)
@@ -2305,6 +2536,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMalloc_i4_5_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -2379,6 +2611,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMalloc_i4_5_c_int(ptr,length1,length2,length3,length4,length5)
@@ -2431,6 +2664,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMalloc_i4_6_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -2506,6 +2740,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMalloc_i4_6_c_int(ptr,length1,length2,length3,length4,length5,length6)
@@ -2560,6 +2795,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMalloc_i4_7_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -2636,6 +2872,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMalloc_i4_7_c_int(ptr,length1,length2,length3,length4,length5,length6,length7)
@@ -2982,6 +3219,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMalloc_i8_3_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -3056,6 +3294,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMalloc_i8_3_c_int(ptr,length1,length2,length3)
@@ -3108,6 +3347,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMalloc_i8_4_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -3182,6 +3422,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMalloc_i8_4_c_int(ptr,length1,length2,length3,length4)
@@ -3234,6 +3475,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMalloc_i8_5_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -3308,6 +3550,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMalloc_i8_5_c_int(ptr,length1,length2,length3,length4,length5)
@@ -3360,6 +3603,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMalloc_i8_6_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -3435,6 +3679,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMalloc_i8_6_c_int(ptr,length1,length2,length3,length4,length5,length6)
@@ -3489,6 +3734,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMalloc_i8_7_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -3565,6 +3811,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMalloc_i8_7_c_int(ptr,length1,length2,length3,length4,length5,length6,length7)
@@ -3911,6 +4158,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMalloc_r4_3_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -3985,6 +4233,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMalloc_r4_3_c_int(ptr,length1,length2,length3)
@@ -4037,6 +4286,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMalloc_r4_4_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -4111,6 +4361,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMalloc_r4_4_c_int(ptr,length1,length2,length3,length4)
@@ -4163,6 +4414,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMalloc_r4_5_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -4237,6 +4489,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMalloc_r4_5_c_int(ptr,length1,length2,length3,length4,length5)
@@ -4289,6 +4542,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMalloc_r4_6_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -4364,6 +4618,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMalloc_r4_6_c_int(ptr,length1,length2,length3,length4,length5,length6)
@@ -4418,6 +4673,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMalloc_r4_7_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -4494,6 +4750,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMalloc_r4_7_c_int(ptr,length1,length2,length3,length4,length5,length6,length7)
@@ -4838,6 +5095,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMalloc_r8_3_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -4911,6 +5169,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMalloc_r8_3_c_int(ptr,length1,length2,length3)
@@ -4963,6 +5222,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMalloc_r8_4_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -5036,6 +5296,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMalloc_r8_4_c_int(ptr,length1,length2,length3,length4)
@@ -5088,6 +5349,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMalloc_r8_5_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -5161,6 +5423,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMalloc_r8_5_c_int(ptr,length1,length2,length3,length4,length5)
@@ -5213,6 +5476,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMalloc_r8_6_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -5287,6 +5551,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMalloc_r8_6_c_int(ptr,length1,length2,length3,length4,length5,length6)
@@ -5341,6 +5606,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMalloc_r8_7_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -5416,6 +5682,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMalloc_r8_7_c_int(ptr,length1,length2,length3,length4,length5,length6,length7)
@@ -5764,6 +6031,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMalloc_c4_3_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -5839,6 +6107,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMalloc_c4_3_c_int(ptr,length1,length2,length3)
@@ -5891,6 +6160,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMalloc_c4_4_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -5966,6 +6236,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMalloc_c4_4_c_int(ptr,length1,length2,length3,length4)
@@ -6018,6 +6289,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMalloc_c4_5_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -6093,6 +6365,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMalloc_c4_5_c_int(ptr,length1,length2,length3,length4,length5)
@@ -6145,6 +6418,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMalloc_c4_6_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -6221,6 +6495,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMalloc_c4_6_c_int(ptr,length1,length2,length3,length4,length5,length6)
@@ -6275,6 +6550,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMalloc_c4_7_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -6352,6 +6628,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMalloc_c4_7_c_int(ptr,length1,length2,length3,length4,length5,length6,length7)
@@ -6700,6 +6977,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMalloc_c8_3_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -6775,6 +7053,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMalloc_c8_3_c_int(ptr,length1,length2,length3)
@@ -6827,6 +7106,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMalloc_c8_4_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -6902,6 +7182,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMalloc_c8_4_c_int(ptr,length1,length2,length3,length4)
@@ -6954,6 +7235,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMalloc_c8_5_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -7029,6 +7311,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMalloc_c8_5_c_int(ptr,length1,length2,length3,length4,length5)
@@ -7081,6 +7364,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMalloc_c8_6_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -7157,6 +7441,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMalloc_c8_6_c_int(ptr,length1,length2,length3,length4,length5,length6)
@@ -7211,6 +7496,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMalloc_c8_7_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -7288,6 +7574,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMalloc_c8_7_c_int(ptr,length1,length2,length3,length4,length5,length6,length7)
@@ -7632,6 +7919,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMallocManaged_l_3_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -7705,6 +7993,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMallocManaged_l_3_c_int(ptr,length1,length2,length3,flags)
@@ -7755,6 +8044,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMallocManaged_l_4_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -7828,6 +8118,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMallocManaged_l_4_c_int(ptr,length1,length2,length3,length4,flags)
@@ -7878,6 +8169,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMallocManaged_l_5_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -7951,6 +8243,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMallocManaged_l_5_c_int(ptr,length1,length2,length3,length4,length5,flags)
@@ -8001,6 +8294,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMallocManaged_l_6_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -8075,6 +8369,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMallocManaged_l_6_c_int(ptr,length1,length2,length3,length4,length5,length6,flags)
@@ -8125,6 +8420,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMallocManaged_l_7_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -8200,6 +8496,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMallocManaged_l_7_c_int(ptr,length1,length2,length3,length4,length5,length6,length7,flags)
@@ -8546,6 +8843,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMallocManaged_i4_3_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -8621,6 +8919,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMallocManaged_i4_3_c_int(ptr,length1,length2,length3,flags)
@@ -8673,6 +8972,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMallocManaged_i4_4_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -8748,6 +9048,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMallocManaged_i4_4_c_int(ptr,length1,length2,length3,length4,flags)
@@ -8801,6 +9102,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMallocManaged_i4_5_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -8876,6 +9178,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMallocManaged_i4_5_c_int(ptr,length1,length2,length3,length4,length5,flags)
@@ -8931,6 +9234,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMallocManaged_i4_6_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -9007,6 +9311,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMallocManaged_i4_6_c_int(ptr,length1,length2,length3,length4,length5,length6,flags)
@@ -9062,6 +9367,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMallocManaged_i4_7_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -9139,6 +9445,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMallocManaged_i4_7_c_int(ptr,length1,length2,length3,length4,length5,length6,length7,flags)
@@ -9491,6 +9798,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMallocManaged_i8_3_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -9566,6 +9874,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMallocManaged_i8_3_c_int(ptr,length1,length2,length3,flags)
@@ -9618,6 +9927,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMallocManaged_i8_4_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -9693,6 +10003,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMallocManaged_i8_4_c_int(ptr,length1,length2,length3,length4,flags)
@@ -9746,6 +10057,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMallocManaged_i8_5_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -9821,6 +10133,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMallocManaged_i8_5_c_int(ptr,length1,length2,length3,length4,length5,flags)
@@ -9876,6 +10189,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMallocManaged_i8_6_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -9952,6 +10266,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMallocManaged_i8_6_c_int(ptr,length1,length2,length3,length4,length5,length6,flags)
@@ -10007,6 +10322,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMallocManaged_i8_7_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -10084,6 +10400,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMallocManaged_i8_7_c_int(ptr,length1,length2,length3,length4,length5,length6,length7,flags)
@@ -10436,6 +10753,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMallocManaged_r4_3_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -10511,6 +10829,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMallocManaged_r4_3_c_int(ptr,length1,length2,length3,flags)
@@ -10563,6 +10882,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMallocManaged_r4_4_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -10638,6 +10958,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMallocManaged_r4_4_c_int(ptr,length1,length2,length3,length4,flags)
@@ -10690,6 +11011,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMallocManaged_r4_5_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -10765,6 +11087,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMallocManaged_r4_5_c_int(ptr,length1,length2,length3,length4,length5,flags)
@@ -10817,6 +11140,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMallocManaged_r4_6_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -10893,6 +11217,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMallocManaged_r4_6_c_int(ptr,length1,length2,length3,length4,length5,length6,flags)
@@ -10945,6 +11270,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMallocManaged_r4_7_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -11022,6 +11348,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMallocManaged_r4_7_c_int(ptr,length1,length2,length3,length4,length5,length6,length7,flags)
@@ -11372,6 +11699,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMallocManaged_r8_3_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -11447,6 +11775,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMallocManaged_r8_3_c_int(ptr,length1,length2,length3,flags)
@@ -11499,6 +11828,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMallocManaged_r8_4_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -11574,6 +11904,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMallocManaged_r8_4_c_int(ptr,length1,length2,length3,length4,flags)
@@ -11626,6 +11957,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMallocManaged_r8_5_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -11701,6 +12033,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMallocManaged_r8_5_c_int(ptr,length1,length2,length3,length4,length5,flags)
@@ -11753,6 +12086,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMallocManaged_r8_6_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -11829,6 +12163,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMallocManaged_r8_6_c_int(ptr,length1,length2,length3,length4,length5,length6,flags)
@@ -11881,6 +12216,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMallocManaged_r8_7_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -11958,6 +12294,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMallocManaged_r8_7_c_int(ptr,length1,length2,length3,length4,length5,length6,length7,flags)
@@ -12308,6 +12645,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMallocManaged_c4_3_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -12383,6 +12721,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMallocManaged_c4_3_c_int(ptr,length1,length2,length3,flags)
@@ -12435,6 +12774,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMallocManaged_c4_4_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -12510,6 +12850,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMallocManaged_c4_4_c_int(ptr,length1,length2,length3,length4,flags)
@@ -12563,6 +12904,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMallocManaged_c4_5_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -12638,6 +12980,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMallocManaged_c4_5_c_int(ptr,length1,length2,length3,length4,length5,flags)
@@ -12693,6 +13036,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMallocManaged_c4_6_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -12769,6 +13113,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMallocManaged_c4_6_c_int(ptr,length1,length2,length3,length4,length5,length6,flags)
@@ -12824,6 +13169,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMallocManaged_c4_7_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -12901,6 +13247,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMallocManaged_c4_7_c_int(ptr,length1,length2,length3,length4,length5,length6,length7,flags)
@@ -13253,6 +13600,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMallocManaged_c8_3_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -13328,6 +13676,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMallocManaged_c8_3_c_int(ptr,length1,length2,length3,flags)
@@ -13380,6 +13729,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMallocManaged_c8_4_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -13455,6 +13805,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMallocManaged_c8_4_c_int(ptr,length1,length2,length3,length4,flags)
@@ -13508,6 +13859,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMallocManaged_c8_5_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -13583,6 +13935,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMallocManaged_c8_5_c_int(ptr,length1,length2,length3,length4,length5,flags)
@@ -13638,6 +13991,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMallocManaged_c8_6_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -13714,6 +14068,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMallocManaged_c8_6_c_int(ptr,length1,length2,length3,length4,length5,length6,flags)
@@ -13769,6 +14124,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipMallocManaged_c8_7_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -13846,6 +14202,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
 
                                                               
     function hipMallocManaged_c8_7_c_int(ptr,length1,length2,length3,length4,length5,length6,length7,flags)
@@ -14189,6 +14546,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipHostMalloc_l_3_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -14262,6 +14620,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
     
                                                               
     function hipHostMalloc_l_3_c_int(ptr,length1,length2,length3,flags)
@@ -14311,6 +14670,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipHostMalloc_l_4_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -14384,6 +14744,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
     
                                                               
     function hipHostMalloc_l_4_c_int(ptr,length1,length2,length3,length4,flags)
@@ -14434,6 +14795,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipHostMalloc_l_5_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -14507,6 +14869,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
     
                                                               
     function hipHostMalloc_l_5_c_int(ptr,length1,length2,length3,length4,length5,flags)
@@ -14557,6 +14920,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipHostMalloc_l_6_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -14631,6 +14995,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
     
                                                               
     function hipHostMalloc_l_6_c_int(ptr,length1,length2,length3,length4,length5,length6,flags)
@@ -14682,6 +15047,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipHostMalloc_l_7_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -14757,6 +15123,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
     
                                                               
     function hipHostMalloc_l_7_c_int(ptr,length1,length2,length3,length4,length5,length6,length7,flags)
@@ -15097,6 +15464,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipHostMalloc_i4_3_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -15171,6 +15539,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
     
                                                               
     function hipHostMalloc_i4_3_c_int(ptr,length1,length2,length3,flags)
@@ -15221,6 +15590,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipHostMalloc_i4_4_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -15295,6 +15665,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
     
                                                               
     function hipHostMalloc_i4_4_c_int(ptr,length1,length2,length3,length4,flags)
@@ -15345,6 +15716,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipHostMalloc_i4_5_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -15419,6 +15791,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
     
                                                               
     function hipHostMalloc_i4_5_c_int(ptr,length1,length2,length3,length4,length5,flags)
@@ -15469,6 +15842,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipHostMalloc_i4_6_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -15544,6 +15918,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
     
                                                               
     function hipHostMalloc_i4_6_c_int(ptr,length1,length2,length3,length4,length5,length6,flags)
@@ -15596,6 +15971,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipHostMalloc_i4_7_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -15672,6 +16048,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
     
                                                               
     function hipHostMalloc_i4_7_c_int(ptr,length1,length2,length3,length4,length5,length6,length7,flags)
@@ -16012,6 +16389,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipHostMalloc_i8_3_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -16086,6 +16464,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
     
                                                               
     function hipHostMalloc_i8_3_c_int(ptr,length1,length2,length3,flags)
@@ -16136,6 +16515,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipHostMalloc_i8_4_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -16210,6 +16590,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
     
                                                               
     function hipHostMalloc_i8_4_c_int(ptr,length1,length2,length3,length4,flags)
@@ -16260,6 +16641,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipHostMalloc_i8_5_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -16334,6 +16716,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
     
                                                               
     function hipHostMalloc_i8_5_c_int(ptr,length1,length2,length3,length4,length5,flags)
@@ -16384,6 +16767,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipHostMalloc_i8_6_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -16459,6 +16843,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
     
                                                               
     function hipHostMalloc_i8_6_c_int(ptr,length1,length2,length3,length4,length5,length6,flags)
@@ -16511,6 +16896,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipHostMalloc_i8_7_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -16587,6 +16973,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
     
                                                               
     function hipHostMalloc_i8_7_c_int(ptr,length1,length2,length3,length4,length5,length6,length7,flags)
@@ -16928,6 +17315,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipHostMalloc_r4_3_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -17002,6 +17390,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
     
                                                               
     function hipHostMalloc_r4_3_c_int(ptr,length1,length2,length3,flags)
@@ -17052,6 +17441,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipHostMalloc_r4_4_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -17126,6 +17516,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
     
                                                               
     function hipHostMalloc_r4_4_c_int(ptr,length1,length2,length3,length4,flags)
@@ -17176,6 +17567,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipHostMalloc_r4_5_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -17250,6 +17642,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
     
                                                               
     function hipHostMalloc_r4_5_c_int(ptr,length1,length2,length3,length4,length5,flags)
@@ -17301,6 +17694,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipHostMalloc_r4_6_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -17376,6 +17770,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
     
                                                               
     function hipHostMalloc_r4_6_c_int(ptr,length1,length2,length3,length4,length5,length6,flags)
@@ -17428,6 +17823,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipHostMalloc_r4_7_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -17504,6 +17900,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
     
                                                               
     function hipHostMalloc_r4_7_c_int(ptr,length1,length2,length3,length4,length5,length6,length7,flags)
@@ -17845,6 +18242,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipHostMalloc_r8_3_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -17919,6 +18317,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
     
                                                               
     function hipHostMalloc_r8_3_c_int(ptr,length1,length2,length3,flags)
@@ -17969,6 +18368,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipHostMalloc_r8_4_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -18043,6 +18443,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
     
                                                               
     function hipHostMalloc_r8_4_c_int(ptr,length1,length2,length3,length4,flags)
@@ -18093,6 +18494,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipHostMalloc_r8_5_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -18167,6 +18569,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
     
                                                               
     function hipHostMalloc_r8_5_c_int(ptr,length1,length2,length3,length4,length5,flags)
@@ -18218,6 +18621,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipHostMalloc_r8_6_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -18293,6 +18697,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
     
                                                               
     function hipHostMalloc_r8_6_c_int(ptr,length1,length2,length3,length4,length5,length6,flags)
@@ -18345,6 +18750,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipHostMalloc_r8_7_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -18421,6 +18827,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
     
                                                               
     function hipHostMalloc_r8_7_c_int(ptr,length1,length2,length3,length4,length5,length6,length7,flags)
@@ -18765,6 +19172,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipHostMalloc_c4_3_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -18840,6 +19248,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
     
                                                               
     function hipHostMalloc_c4_3_c_int(ptr,length1,length2,length3,flags)
@@ -18890,6 +19299,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipHostMalloc_c4_4_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -18965,6 +19375,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
     
                                                               
     function hipHostMalloc_c4_4_c_int(ptr,length1,length2,length3,length4,flags)
@@ -19015,6 +19426,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipHostMalloc_c4_5_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -19090,6 +19502,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
     
                                                               
     function hipHostMalloc_c4_5_c_int(ptr,length1,length2,length3,length4,length5,flags)
@@ -19142,6 +19555,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipHostMalloc_c4_6_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -19218,6 +19632,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
     
                                                               
     function hipHostMalloc_c4_6_c_int(ptr,length1,length2,length3,length4,length5,length6,flags)
@@ -19270,6 +19685,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipHostMalloc_c4_7_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -19347,6 +19763,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
     
                                                               
     function hipHostMalloc_c4_7_c_int(ptr,length1,length2,length3,length4,length5,length6,length7,flags)
@@ -19691,6 +20108,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipHostMalloc_c8_3_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -19766,6 +20184,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
     
                                                               
     function hipHostMalloc_c8_3_c_int(ptr,length1,length2,length3,flags)
@@ -19816,6 +20235,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipHostMalloc_c8_4_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -19891,6 +20311,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
     
                                                               
     function hipHostMalloc_c8_4_c_int(ptr,length1,length2,length3,length4,flags)
@@ -19941,6 +20362,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipHostMalloc_c8_5_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -20016,6 +20438,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
     
                                                               
     function hipHostMalloc_c8_5_c_int(ptr,length1,length2,length3,length4,length5,flags)
@@ -20068,6 +20491,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipHostMalloc_c8_6_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -20144,6 +20568,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
     
                                                               
     function hipHostMalloc_c8_6_c_int(ptr,length1,length2,length3,length4,length5,length6,flags)
@@ -20196,6 +20621,7 @@ module hipfort_hipmalloc
     end function
 
                                                               
+#ifndef __INTEL_COMPILER
     function hipHostMalloc_c8_7_source(ptr,dims,dims8,lbounds,lbounds8,dsource,source,mold,flags)
       use iso_c_binding
 #ifdef USE_CUDA_NAMES
@@ -20273,6 +20699,7 @@ module hipfort_hipmalloc
         end if
       end if
     end function
+#endif
     
                                                               
     function hipHostMalloc_c8_7_c_int(ptr,length1,length2,length3,length4,length5,length6,length7,flags)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,12 +23,6 @@ if(BUILD_TESTING)
   endif()
 
   function(hipfort_add_test lib func dir)
-    # The Fortran 2008 array interfaces are disabled on the Intel compilers
-    # (see USE_FPOINTER_INTERFACES in lib/CMakeLists.txt), so the f2008 tests
-    # cannot be built there; skip them.
-    if(dir STREQUAL "f2008" AND CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
-      return()
-    endif()
     # f2003 tests use .f03, f2008 tests use .f08 to match the target standard.
     if(dir STREQUAL "f2008")
       set(ext "f08")
@@ -519,6 +513,7 @@ if(BUILD_TESTING)
     hipfort_add_test(rocsparse rocsparse_dsptrsm f2008)
     hipfort_add_test(rocsparse rocsparse_csptrsm f2008)
     hipfort_add_test(rocsparse rocsparse_zsptrsm f2008)
+    hipfort_add_test(rocsparse zgpsv_interleaved_batch f2008)
     hipfort_add_test(rocsparse rocsparse_csr2coo f2003)
     hipfort_add_test(rocsparse rocsparse_scsr2csc f2003)
     hipfort_add_test(rocsparse rocsparse_dcsr2csc f2003)

--- a/test/f2008/rocsparse/zgpsv_interleaved_batch.f08
+++ b/test/f2008/rocsparse/zgpsv_interleaved_batch.f08
@@ -109,8 +109,8 @@ program rocsparse_zgpsv_interleaved_batch_test
     call rocsparseCheck(rocsparse_zgpsv_interleaved_batch_buffer_size(handle, &
                                                                       rocsparse_gpsv_interleaved_alg_qr, &
                                                                       M, &
-                                                                      c_loc(d_ds(1)), c_loc(d_dl(1)), c_loc(d_d(1)), &
-                                                                      c_loc(d_du(1)), c_loc(d_dw(1)), &
+                                                                      d_ds, d_dl, d_d, &
+                                                                      d_du, d_dw, &
                                                                       d_x, &
                                                                       batch_count, &
                                                                       batch_stride, &
@@ -122,8 +122,8 @@ program rocsparse_zgpsv_interleaved_batch_test
     call rocsparseCheck(rocsparse_zgpsv_interleaved_batch(handle, &
                                                           rocsparse_gpsv_interleaved_alg_qr, &
                                                           M, &
-                                                          c_loc(d_ds(1)), c_loc(d_dl(1)), c_loc(d_d(1)), &
-                                                          c_loc(d_du(1)), c_loc(d_dw(1)), &
+                                                          d_ds, d_dl, d_d, &
+                                                          d_du, d_dw, &
                                                           d_x, &
                                                           batch_count, &
                                                           batch_stride, &


### PR DESCRIPTION
## Summary

`USE_FPOINTER_INTERFACES` is now enabled whenever the Fortran compiler supports Fortran 2008, instead of being restricted to a subset of compilers. This exposes the array (Fortran-pointer) interfaces of all the generated `hip*`/`roc*` bindings and of the hand-written `hipMemcpy` / `hipHostRegister` / `hipMalloc` families to every Fortran 2008 compiler, and lets the `f2008` test suite build with any of them.

## Change

- `lib/CMakeLists.txt`: enable `USE_FPOINTER_INTERFACES` for any Fortran-2008-capable compiler (no compiler-specific logic in CMake).
- The only overloads that cannot be built everywhere are the higher-rank allocate-from-source forms of `hipMalloc`/`hipMallocManaged`/`hipHostMalloc` (`dims=`/`dsource=`/`source=`/`mold=`): `ifx`/`ifort` hit a generic-resolution/capacity limit on them above rank 2. The rank 3-7 `*_source` routines are excluded via a source guard (`__INTEL_COMPILER`); the rank 0-2 source forms, the explicit-extent `hipMalloc(ptr, n1, ..., nR)` forms, and every other interface are unaffected.
- `test/CMakeLists.txt`: drop the compiler restriction that skipped the `f2008` tests.
- Fix and register `rocsparse/zgpsv_interleaved_batch` (it passed its diagonals via `c_loc(...)` instead of as arrays, so the generic never resolved — on any compiler).
