### PR TITLE
Fix two binding type mistakes: fftw_alloc_real return, spVecGet size

### DIFF
--- a/lib/hipfort/hipfort_hipfftw.F90
+++ b/lib/hipfort/hipfort_hipfftw.F90
@@ -62,7 +62,7 @@ module hipfort_hipfftw
       use iso_c_binding
       use hipfort_hipfftw_enums
       implicit none
-      real(c_double) :: fftw_alloc_real_
+      type(c_ptr) :: fftw_alloc_real_
       integer(c_size_t),value :: n
     end function
   end interface
@@ -73,7 +73,7 @@ module hipfort_hipfftw
       use iso_c_binding
       use hipfort_hipfftw_enums
       implicit none
-      real(c_float) :: fftwf_alloc_real_
+      type(c_ptr) :: fftwf_alloc_real_
       integer(c_size_t),value :: n
     end function
   end interface

--- a/lib/hipfort/hipfort_hipsparse.F90
+++ b/lib/hipfort/hipfort_hipsparse.F90
@@ -23187,7 +23187,7 @@ module hipfort_hipsparse
       implicit none
       integer(kind(HIPSPARSE_STATUS_SUCCESS)) :: hipsparseSpVecGet_
       type(c_ptr),value :: spVecDescr
-      type(c_ptr),value :: mySize
+      integer(c_int64_t) :: mySize
       integer(c_int64_t) :: nnz
       type(c_ptr) :: indices
       type(c_ptr) :: values
@@ -23212,7 +23212,7 @@ module hipfort_hipsparse
       implicit none
       integer(kind(HIPSPARSE_STATUS_SUCCESS)) :: hipsparseConstSpVecGet_
       type(c_ptr),value :: spVecDescr
-      type(c_ptr),value :: mySize
+      integer(c_int64_t) :: mySize
       integer(c_int64_t) :: nnz
       type(c_ptr) :: indices
       type(c_ptr) :: values
@@ -24257,7 +24257,7 @@ module hipfort_hipsparse
       implicit none
       integer(kind(HIPSPARSE_STATUS_SUCCESS)) :: hipsparseDnVecGet_
       type(c_ptr),value :: dnVecDescr
-      type(c_ptr),value :: mySize
+      integer(c_int64_t) :: mySize
       type(c_ptr) :: values
       type(c_ptr),value :: valueType
     end function
@@ -24276,7 +24276,7 @@ module hipfort_hipsparse
       implicit none
       integer(kind(HIPSPARSE_STATUS_SUCCESS)) :: hipsparseConstDnVecGet_
       type(c_ptr),value :: dnVecDescr
-      type(c_ptr),value :: mySize
+      integer(c_int64_t) :: mySize
       type(c_ptr) :: values
       type(c_ptr),value :: valueType
     end function

--- a/lib/hipfort/hipfort_rocsparse.F90
+++ b/lib/hipfort/hipfort_rocsparse.F90
@@ -1018,7 +1018,7 @@ module hipfort_rocsparse
       implicit none
       integer(kind(rocsparse_status_success)) :: rocsparse_spvec_get_
       type(c_ptr),value :: descr
-      type(c_ptr),value :: mySize
+      integer(c_int64_t) :: mySize
       integer(c_int64_t) :: nnz
       type(c_ptr) :: indices
       type(c_ptr) :: values
@@ -1037,7 +1037,7 @@ module hipfort_rocsparse
       implicit none
       integer(kind(rocsparse_status_success)) :: rocsparse_const_spvec_get_
       type(c_ptr),value :: descr
-      type(c_ptr),value :: mySize
+      integer(c_int64_t) :: mySize
       integer(c_int64_t) :: nnz
       type(c_ptr) :: indices
       type(c_ptr) :: values
@@ -3836,7 +3836,7 @@ module hipfort_rocsparse
       implicit none
       integer(kind(rocsparse_status_success)) :: rocsparse_dnvec_get_
       type(c_ptr),value :: descr
-      type(c_ptr),value :: mySize
+      integer(c_int64_t) :: mySize
       type(c_ptr) :: values
       type(c_ptr),value :: data_type
     end function
@@ -3850,7 +3850,7 @@ module hipfort_rocsparse
       implicit none
       integer(kind(rocsparse_status_success)) :: rocsparse_const_dnvec_get_
       type(c_ptr),value :: descr
-      type(c_ptr),value :: mySize
+      integer(c_int64_t) :: mySize
       type(c_ptr) :: values
       type(c_ptr),value :: data_type
     end function


### PR DESCRIPTION
Two generated-binding typos caught by an interface audit. Both are minimal, surgical fixes.

## 1. `fftw_alloc_real` / `fftwf_alloc_real` — wrong return type (HIGH)

`lib/hipfort/hipfort_hipfftw.F90`

The C functions return a **pointer**:
```c
double* fftw_alloc_real(size_t n);
float*  fftwf_alloc_real(size_t n);
```
but the bindings declared a **scalar** return (`real(c_double)` / `real(c_float)`).
The returned allocation address is reinterpreted as a floating-point value, so the
buffer is lost. The sibling `fftw_alloc_complex` / `fftw_malloc` bindings already
return `type(c_ptr)` correctly; this makes `fftw_alloc_real` match.

## 2. `*SpVecGet` / `*DnVecGet` — `size` output passed by value (MEDIUM)

`lib/hipfort/hipfort_rocsparse.F90`, `lib/hipfort/hipfort_hipsparse.F90` (8 accessors)

The `size` output argument (C `int64_t*`) was declared `type(c_ptr), value`,
while the adjacent `nnz` output of the **same** C type (`int64_t*`) is declared
`integer(c_int64_t)` by reference. This fixes `size` to be by reference like
`nnz`, so the two outputs share one calling convention.

## Testing

The full library builds for both the amdgcn and nvptx backends. Changes are
type-declaration-only (10 lines), no behavioural change beyond the corrected
calling conventions.