### PR TITLE
Fix Doxygen @param names in the generated HIP memory-family modules

### DIFF
--- a/lib/hipfort/hipfort_hiphostregister.F90
+++ b/lib/hipfort/hipfort_hiphostregister.F90
@@ -401,14 +401,14 @@ module hipfort_hiphostregister
   !>
   !>   @see hipHostMalloc
 #ifdef USE_CUDA_NAMES
-    function hipHostGetFlags_(flags, hostPtr) bind(c, name="cudaHostGetFlags")
+    function hipHostGetFlags_(flagsPtr, hostPtr) bind(c, name="cudaHostGetFlags")
 #else
-    function hipHostGetFlags_(flags, hostPtr) bind(c, name="hipHostGetFlags")
+    function hipHostGetFlags_(flagsPtr, hostPtr) bind(c, name="hipHostGetFlags")
 #endif
       use iso_c_binding
       implicit none
       integer(c_int) :: hipHostGetFlags_
-      integer(c_int) :: flags
+      integer(c_int) :: flagsPtr
       type(c_ptr), value :: hostPtr
     end function hipHostGetFlags_
     module procedure hipHostGetFlags_i4_0

--- a/lib/hipfort/hipfort_hipmalloc.F90
+++ b/lib/hipfort/hipfort_hipmalloc.F90
@@ -33,7 +33,7 @@ module hipfort_hipmalloc
   !>   @brief Allocate memory on the default accelerator
   !>
   !>   @param[out] ptr Pointer to the allocated memory
-  !>   @param[in]  size Requested memory size
+  !>   @param[in]  sizeBytes Requested memory size
   !>
   !>   If size is 0, no memory is allocated, *ptr returns nullptr, and hipSuccess is returned.
   !>
@@ -234,8 +234,8 @@ module hipfort_hipmalloc
   !>
   !>  @note   It is recommend to do the capability check before call this API.
   !>
-  !>  @param [out] dev_ptr - pointer to allocated device memory
-  !>  @param [in]  size    - requested allocation size in bytes, it should be granularity of 4KB
+  !>  @param [out] ptr - pointer to allocated device memory
+  !>  @param [in] sizeBytes - requested allocation size in bytes, it should be granularity of 4KB
   !>  @param [in]  flags   - must be either hipMemAttachGlobal or hipMemAttachHost
   !>                         (defaults to hipMemAttachGlobal)
   !>
@@ -432,7 +432,7 @@ module hipfort_hipmalloc
   !>   Developers need to choose proper allocation flag with consideration of synchronization.
   !>
   !>   @param[out] ptr Pointer to the allocated host pinned memory
-  !>   @param[in]  size Requested memory size in bytes
+  !>   @param[in]  sizeBytes Requested memory size in bytes
   !>   If size is 0, no memory is allocated, *ptr returns nullptr, and hipSuccess is returned.
   !>   @param[in]  flags Type of host memory allocation. See the description of flags in
   !>   hipSetDeviceFlags.

--- a/lib/hipfort/hipfort_hipmemcpy.F90
+++ b/lib/hipfort/hipfort_hipmemcpy.F90
@@ -46,10 +46,10 @@ module hipfort_hipmemcpy
   !>   Calling hipMemcpy with dst and src pointers that do not match the hipMemcpyKind results in
   !>   undefined behavior.
   !>
-  !>   @param[out]  dst Data being copy to
+  !>   @param[out]  dest Data being copy to
   !>   @param[in]  src Data being copy from
   !>   @param[in]  sizeBytes Data size in bytes
-  !>   @param[in]  kind Kind of transfer
+  !>   @param[in]  myKind Kind of transfer
   !>   @returns `hipSuccess`, `hipErrorInvalidValue`, `hipErrorUnknown`
   !>
   !>   @see hipArrayCreate, hipArrayDestroy, hipArrayGetDescriptor, hipMemAlloc, hipMemAllocHost,
@@ -282,10 +282,10 @@ module hipfort_hipmemcpy
   !>  best performance, use hipHostMalloc to allocate host memory that is transferred
   !>  asynchronously.
   !>
-  !>   @param[out] dst Data being copy to
+  !>   @param[out] dest Data being copy to
   !>   @param[in]  src Data being copy from
   !>   @param[in]  sizeBytes Data size in bytes
-  !>   @param[in]  kind  Type of memory transfer
+  !>   @param[in]  myKind  Type of memory transfer
   !>   @param[in]  stream  Stream identifier
   !>   @returns `hipSuccess`, `hipErrorInvalidValue`, `hipErrorUnknown`
   !>
@@ -527,13 +527,13 @@ module hipfort_hipmemcpy
   !>   @warning  Calling hipMemcpy2D with dst and src pointers that do not match the hipMemcpyKind
   !>  results in undefined behavior.
   !>
-  !>   @param[in]   dst    Destination memory address
+  !>   @param[in]   dest    Destination memory address
   !>   @param[in]   dpitch Pitch size in bytes of destination memory
   !>   @param[in]   src    Source memory address
   !>   @param[in]   spitch Pitch size in bytes of source memory
   !>   @param[in]   width  Width size in bytes of matrix transfer (columns)
   !>   @param[in]   height Height size in bytes of matrix transfer (rows)
-  !>   @param[in]   kind   Type of transfer
+  !>   @param[in]   myKind   Type of transfer
   !>   @returns     `hipSuccess`, `hipErrorInvalidValue`, `hipErrorInvalidPitchValue`,
   !>  `hipErrorInvalidDevicePointer`, `hipErrorInvalidMemcpyDirection`
   !>
@@ -718,13 +718,13 @@ module hipfort_hipmemcpy
   !>  best performance, use hipHostMalloc to allocate host memory that is transferred
   !>  asynchronously.
   !>
-  !>   @param[in]   dst    Pointer to destination memory address
+  !>   @param[in]   dest    Pointer to destination memory address
   !>   @param[in]   dpitch Pitch size in bytes of destination memory
   !>   @param[in]   src    Pointer to source memory address
   !>   @param[in]   spitch Pitch size in bytes of source memory
   !>   @param[in]   width  Width of matrix transfer (columns in bytes)
   !>   @param[in]   height Height of matrix transfer (rows)
-  !>   @param[in]   kind   Type of transfer
+  !>   @param[in]   myKind   Type of transfer
   !>   @param[in]   stream Stream to use
   !>   @returns     `hipSuccess`, `hipErrorInvalidValue`, `hipErrorInvalidPitchValue`,
   !>  `hipErrorInvalidDevicePointer`, `hipErrorInvalidMemcpyDirection`


### PR DESCRIPTION
## Problem

The docs build (readthedocs, Doxygen with `WARN_AS_ERROR`) fails after #462 with:

```
hipfort_hiphostregister.F90:400: error: argument 'flagsptr' of command @param is not
found in the argument list of ...hiphostgetflags_(integer(c_int) flags, ...) (warning treated as error, aborting now)
```

#462 regenerated `hipfort_hipmalloc/hipmemcpy/hiphostregister.F90` from the generator. Those modules carry the Doxygen docs captured from the C headers, which spell parameters with the **C names**, while the typed Fortran binds rename several dummies. Doxygen then rejects every `@param` whose name is absent from the Fortran argument list. There are 13 such mismatches; Doxygen aborts on the first.

## Fix

Regenerated the three modules after fixing the generator (`rocm-fortran` `hip_generics.jl`) so each `@param` matches its Fortran dummy:

| Family | change |
|---|---|
| hipMemcpy / Async / 2D / 2DAsync | `@param` `dst`→`dest`, `kind`→`myKind` |
| hipMalloc / hipHostMalloc | `@param` `size`→`sizeBytes` |
| hipMallocManaged | `@param` `dev_ptr`→`ptr`, `size`→`sizeBytes` |
| hipHostGetFlags | dummy `flags`→`flagsPtr` (matches the C API, the doc, and the former hand-written binding) |

Doc-only apart from the `hipHostGetFlags` dummy rename — no procedure bodies, signatures, or generic surfaces change (15 insertions / 15 deletions).

## Verification

- `@param`/argument mismatch scan over the three files: **13 → 0**
- Diff is limited to `!> @param` lines plus the `flagsPtr` dummy rename
- All three modules compile with `gfortran -cpp -fsyntax-only` in both the default (per-rank) and `-DUSE_FPOINTER_INTERFACES` layouts
