### PR TITLE
Refresh supported_api tables for the hipBLAS/rocBLAS ILP64 array overloads

### DIFF
--- a/docs/doxygen/input/supported_api_hipblas.md
+++ b/docs/doxygen/input/supported_api_hipblas.md
@@ -5,1199 +5,1199 @@
 1 | [hipblasCreate](interfacehipfort__hipblas_1_1hipblascreate.html "Interface documentation") | C binding
 2 | [hipblasDestroy](interfacehipfort__hipblas_1_1hipblasdestroy.html "Interface documentation") | C binding
 3 | [hipblasGetVersion](interfacehipfort__hipblas_1_1hipblasgetversion.html "Interface documentation") | C binding
-4 | [hipblasGetProperty](interfacehipfort__hipblas_1_1hipblasgetproperty.html "Interface documentation") | C binding
+4 | [hipblasGetProperty](interfacehipfort__hipblas_1_1hipblasgetproperty.html "Interface documentation") | C binding, rank_0, rank_1
 5 | [hipblasSetStream](interfacehipfort__hipblas_1_1hipblassetstream.html "Interface documentation") | C binding
 6 | [hipblasGetStream](interfacehipfort__hipblas_1_1hipblasgetstream.html "Interface documentation") | C binding
 7 | [hipblasSetPointerMode](interfacehipfort__hipblas_1_1hipblassetpointermode.html "Interface documentation") | C binding
-8 | [hipblasGetPointerMode](interfacehipfort__hipblas_1_1hipblasgetpointermode.html "Interface documentation") | C binding
+8 | [hipblasGetPointerMode](interfacehipfort__hipblas_1_1hipblasgetpointermode.html "Interface documentation") | C binding, rank_0, rank_1
 9 | [hipblasSetMathMode](interfacehipfort__hipblas_1_1hipblassetmathmode.html "Interface documentation") | C binding
-10 | [hipblasGetMathMode](interfacehipfort__hipblas_1_1hipblasgetmathmode.html "Interface documentation") | C binding
+10 | [hipblasGetMathMode](interfacehipfort__hipblas_1_1hipblasgetmathmode.html "Interface documentation") | C binding, rank_0, rank_1
 11 | [hipblasSetWorkspace](interfacehipfort__hipblas_1_1hipblassetworkspace.html "Interface documentation") | C binding
-12 | [hipblasSetVector](interfacehipfort__hipblas_1_1hipblassetvector.html "Interface documentation") | C binding, full_rank, rank_0
-13 | [hipblasGetVector](interfacehipfort__hipblas_1_1hipblasgetvector.html "Interface documentation") | C binding, full_rank, rank_0
-14 | [hipblasSetMatrix](interfacehipfort__hipblas_1_1hipblassetmatrix.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-15 | [hipblasGetMatrix](interfacehipfort__hipblas_1_1hipblasgetmatrix.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-16 | [hipblasSetVectorAsync](interfacehipfort__hipblas_1_1hipblassetvectorasync.html "Interface documentation") | C binding, full_rank, rank_0
-17 | [hipblasGetVectorAsync](interfacehipfort__hipblas_1_1hipblasgetvectorasync.html "Interface documentation") | C binding, full_rank, rank_0
-18 | [hipblasSetMatrixAsync](interfacehipfort__hipblas_1_1hipblassetmatrixasync.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-19 | [hipblasGetMatrixAsync](interfacehipfort__hipblas_1_1hipblasgetmatrixasync.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-20 | [hipblasSetAtomicsMode](interfacehipfort__hipblas_1_1hipblassetatomicsmode.html "Interface documentation") | C binding
-21 | [hipblasGetAtomicsMode](interfacehipfort__hipblas_1_1hipblasgetatomicsmode.html "Interface documentation") | C binding
-22 | [hipblasSetBatchAlphaStride](interfacehipfort__hipblas_1_1hipblassetbatchalphastride.html "Interface documentation") | C binding
-23 | [hipblasGetBatchAlphaStride](interfacehipfort__hipblas_1_1hipblasgetbatchalphastride.html "Interface documentation") | C binding
-24 | [hipblasSetBatchBetaStride](interfacehipfort__hipblas_1_1hipblassetbatchbetastride.html "Interface documentation") | C binding
-25 | [hipblasGetBatchBetaStride](interfacehipfort__hipblas_1_1hipblasgetbatchbetastride.html "Interface documentation") | C binding
-26 | [hipblasIsamax](interfacehipfort__hipblas_1_1hipblasisamax.html "Interface documentation") | C binding, rank_0, rank_1
-27 | [hipblasIdamax](interfacehipfort__hipblas_1_1hipblasidamax.html "Interface documentation") | C binding, rank_0, rank_1
-28 | [hipblasIcamax](interfacehipfort__hipblas_1_1hipblasicamax.html "Interface documentation") | C binding, rank_0, rank_1
-29 | [hipblasIzamax](interfacehipfort__hipblas_1_1hipblasizamax.html "Interface documentation") | C binding, rank_0, rank_1
-30 | [hipblasIsamax_64](interfacehipfort__hipblas_1_1hipblasisamax__64.html "Interface documentation") | C binding
-31 | [hipblasIdamax_64](interfacehipfort__hipblas_1_1hipblasidamax__64.html "Interface documentation") | C binding
-32 | [hipblasIcamax_64](interfacehipfort__hipblas_1_1hipblasicamax__64.html "Interface documentation") | C binding
-33 | [hipblasIzamax_64](interfacehipfort__hipblas_1_1hipblasizamax__64.html "Interface documentation") | C binding
-34 | [hipblasIsamaxBatched](interfacehipfort__hipblas_1_1hipblasisamaxbatched.html "Interface documentation") | C binding
-35 | [hipblasIdamaxBatched](interfacehipfort__hipblas_1_1hipblasidamaxbatched.html "Interface documentation") | C binding
-36 | [hipblasIcamaxBatched](interfacehipfort__hipblas_1_1hipblasicamaxbatched.html "Interface documentation") | C binding
-37 | [hipblasIzamaxBatched](interfacehipfort__hipblas_1_1hipblasizamaxbatched.html "Interface documentation") | C binding
-38 | [hipblasIsamaxBatched_64](interfacehipfort__hipblas_1_1hipblasisamaxbatched__64.html "Interface documentation") | C binding
-39 | [hipblasIdamaxBatched_64](interfacehipfort__hipblas_1_1hipblasidamaxbatched__64.html "Interface documentation") | C binding
-40 | [hipblasIcamaxBatched_64](interfacehipfort__hipblas_1_1hipblasicamaxbatched__64.html "Interface documentation") | C binding
-41 | [hipblasIzamaxBatched_64](interfacehipfort__hipblas_1_1hipblasizamaxbatched__64.html "Interface documentation") | C binding
-42 | [hipblasIsamaxStridedBatched](interfacehipfort__hipblas_1_1hipblasisamaxstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-43 | [hipblasIdamaxStridedBatched](interfacehipfort__hipblas_1_1hipblasidamaxstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-44 | [hipblasIcamaxStridedBatched](interfacehipfort__hipblas_1_1hipblasicamaxstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-45 | [hipblasIzamaxStridedBatched](interfacehipfort__hipblas_1_1hipblasizamaxstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-46 | [hipblasIsamaxStridedBatched_64](interfacehipfort__hipblas_1_1hipblasisamaxstridedbatched__64.html "Interface documentation") | C binding
-47 | [hipblasIdamaxStridedBatched_64](interfacehipfort__hipblas_1_1hipblasidamaxstridedbatched__64.html "Interface documentation") | C binding
-48 | [hipblasIcamaxStridedBatched_64](interfacehipfort__hipblas_1_1hipblasicamaxstridedbatched__64.html "Interface documentation") | C binding
-49 | [hipblasIzamaxStridedBatched_64](interfacehipfort__hipblas_1_1hipblasizamaxstridedbatched__64.html "Interface documentation") | C binding
-50 | [hipblasIsamin](interfacehipfort__hipblas_1_1hipblasisamin.html "Interface documentation") | C binding, rank_0, rank_1
-51 | [hipblasIdamin](interfacehipfort__hipblas_1_1hipblasidamin.html "Interface documentation") | C binding, rank_0, rank_1
-52 | [hipblasIcamin](interfacehipfort__hipblas_1_1hipblasicamin.html "Interface documentation") | C binding, rank_0, rank_1
-53 | [hipblasIzamin](interfacehipfort__hipblas_1_1hipblasizamin.html "Interface documentation") | C binding, rank_0, rank_1
-54 | [hipblasIsamin_64](interfacehipfort__hipblas_1_1hipblasisamin__64.html "Interface documentation") | C binding
-55 | [hipblasIdamin_64](interfacehipfort__hipblas_1_1hipblasidamin__64.html "Interface documentation") | C binding
-56 | [hipblasIcamin_64](interfacehipfort__hipblas_1_1hipblasicamin__64.html "Interface documentation") | C binding
-57 | [hipblasIzamin_64](interfacehipfort__hipblas_1_1hipblasizamin__64.html "Interface documentation") | C binding
-58 | [hipblasIsaminBatched](interfacehipfort__hipblas_1_1hipblasisaminbatched.html "Interface documentation") | C binding
-59 | [hipblasIdaminBatched](interfacehipfort__hipblas_1_1hipblasidaminbatched.html "Interface documentation") | C binding
-60 | [hipblasIcaminBatched](interfacehipfort__hipblas_1_1hipblasicaminbatched.html "Interface documentation") | C binding
-61 | [hipblasIzaminBatched](interfacehipfort__hipblas_1_1hipblasizaminbatched.html "Interface documentation") | C binding
-62 | [hipblasIsaminBatched_64](interfacehipfort__hipblas_1_1hipblasisaminbatched__64.html "Interface documentation") | C binding
-63 | [hipblasIdaminBatched_64](interfacehipfort__hipblas_1_1hipblasidaminbatched__64.html "Interface documentation") | C binding
-64 | [hipblasIcaminBatched_64](interfacehipfort__hipblas_1_1hipblasicaminbatched__64.html "Interface documentation") | C binding
-65 | [hipblasIzaminBatched_64](interfacehipfort__hipblas_1_1hipblasizaminbatched__64.html "Interface documentation") | C binding
-66 | [hipblasIsaminStridedBatched](interfacehipfort__hipblas_1_1hipblasisaminstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-67 | [hipblasIdaminStridedBatched](interfacehipfort__hipblas_1_1hipblasidaminstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-68 | [hipblasIcaminStridedBatched](interfacehipfort__hipblas_1_1hipblasicaminstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-69 | [hipblasIzaminStridedBatched](interfacehipfort__hipblas_1_1hipblasizaminstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-70 | [hipblasIsaminStridedBatched_64](interfacehipfort__hipblas_1_1hipblasisaminstridedbatched__64.html "Interface documentation") | C binding
-71 | [hipblasIdaminStridedBatched_64](interfacehipfort__hipblas_1_1hipblasidaminstridedbatched__64.html "Interface documentation") | C binding
-72 | [hipblasIcaminStridedBatched_64](interfacehipfort__hipblas_1_1hipblasicaminstridedbatched__64.html "Interface documentation") | C binding
-73 | [hipblasIzaminStridedBatched_64](interfacehipfort__hipblas_1_1hipblasizaminstridedbatched__64.html "Interface documentation") | C binding
-74 | [hipblasSasum](interfacehipfort__hipblas_1_1hipblassasum.html "Interface documentation") | C binding, rank_0, rank_1
-75 | [hipblasDasum](interfacehipfort__hipblas_1_1hipblasdasum.html "Interface documentation") | C binding, rank_0, rank_1
-76 | [hipblasScasum](interfacehipfort__hipblas_1_1hipblasscasum.html "Interface documentation") | C binding, rank_0, rank_1
-77 | [hipblasDzasum](interfacehipfort__hipblas_1_1hipblasdzasum.html "Interface documentation") | C binding, rank_0, rank_1
-78 | [hipblasSasum_64](interfacehipfort__hipblas_1_1hipblassasum__64.html "Interface documentation") | C binding
-79 | [hipblasDasum_64](interfacehipfort__hipblas_1_1hipblasdasum__64.html "Interface documentation") | C binding
-80 | [hipblasScasum_64](interfacehipfort__hipblas_1_1hipblasscasum__64.html "Interface documentation") | C binding
-81 | [hipblasDzasum_64](interfacehipfort__hipblas_1_1hipblasdzasum__64.html "Interface documentation") | C binding
-82 | [hipblasSasumBatched](interfacehipfort__hipblas_1_1hipblassasumbatched.html "Interface documentation") | C binding
-83 | [hipblasDasumBatched](interfacehipfort__hipblas_1_1hipblasdasumbatched.html "Interface documentation") | C binding
-84 | [hipblasScasumBatched](interfacehipfort__hipblas_1_1hipblasscasumbatched.html "Interface documentation") | C binding
-85 | [hipblasDzasumBatched](interfacehipfort__hipblas_1_1hipblasdzasumbatched.html "Interface documentation") | C binding
-86 | [hipblasSasumBatched_64](interfacehipfort__hipblas_1_1hipblassasumbatched__64.html "Interface documentation") | C binding
-87 | [hipblasDasumBatched_64](interfacehipfort__hipblas_1_1hipblasdasumbatched__64.html "Interface documentation") | C binding
-88 | [hipblasScasumBatched_64](interfacehipfort__hipblas_1_1hipblasscasumbatched__64.html "Interface documentation") | C binding
-89 | [hipblasDzasumBatched_64](interfacehipfort__hipblas_1_1hipblasdzasumbatched__64.html "Interface documentation") | C binding
-90 | [hipblasSasumStridedBatched](interfacehipfort__hipblas_1_1hipblassasumstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-91 | [hipblasDasumStridedBatched](interfacehipfort__hipblas_1_1hipblasdasumstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-92 | [hipblasScasumStridedBatched](interfacehipfort__hipblas_1_1hipblasscasumstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-93 | [hipblasDzasumStridedBatched](interfacehipfort__hipblas_1_1hipblasdzasumstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-94 | [hipblasSasumStridedBatched_64](interfacehipfort__hipblas_1_1hipblassasumstridedbatched__64.html "Interface documentation") | C binding
-95 | [hipblasDasumStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdasumstridedbatched__64.html "Interface documentation") | C binding
-96 | [hipblasScasumStridedBatched_64](interfacehipfort__hipblas_1_1hipblasscasumstridedbatched__64.html "Interface documentation") | C binding
-97 | [hipblasDzasumStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdzasumstridedbatched__64.html "Interface documentation") | C binding
-98 | [hipblasHaxpy](interfacehipfort__hipblas_1_1hipblashaxpy.html "Interface documentation") | C binding
-99 | [hipblasSaxpy](interfacehipfort__hipblas_1_1hipblassaxpy.html "Interface documentation") | C binding, rank_0, rank_1
-100 | [hipblasDaxpy](interfacehipfort__hipblas_1_1hipblasdaxpy.html "Interface documentation") | C binding, rank_0, rank_1
-101 | [hipblasCaxpy](interfacehipfort__hipblas_1_1hipblascaxpy.html "Interface documentation") | C binding, rank_0, rank_1
-102 | [hipblasZaxpy](interfacehipfort__hipblas_1_1hipblaszaxpy.html "Interface documentation") | C binding, rank_0, rank_1
-103 | [hipblasHaxpy_64](interfacehipfort__hipblas_1_1hipblashaxpy__64.html "Interface documentation") | C binding
-104 | [hipblasSaxpy_64](interfacehipfort__hipblas_1_1hipblassaxpy__64.html "Interface documentation") | C binding
-105 | [hipblasDaxpy_64](interfacehipfort__hipblas_1_1hipblasdaxpy__64.html "Interface documentation") | C binding
-106 | [hipblasCaxpy_64](interfacehipfort__hipblas_1_1hipblascaxpy__64.html "Interface documentation") | C binding
-107 | [hipblasZaxpy_64](interfacehipfort__hipblas_1_1hipblaszaxpy__64.html "Interface documentation") | C binding
-108 | [hipblasHaxpyBatched](interfacehipfort__hipblas_1_1hipblashaxpybatched.html "Interface documentation") | C binding
-109 | [hipblasSaxpyBatched](interfacehipfort__hipblas_1_1hipblassaxpybatched.html "Interface documentation") | C binding
-110 | [hipblasDaxpyBatched](interfacehipfort__hipblas_1_1hipblasdaxpybatched.html "Interface documentation") | C binding
-111 | [hipblasCaxpyBatched](interfacehipfort__hipblas_1_1hipblascaxpybatched.html "Interface documentation") | C binding
-112 | [hipblasZaxpyBatched](interfacehipfort__hipblas_1_1hipblaszaxpybatched.html "Interface documentation") | C binding
-113 | [hipblasHaxpyBatched_64](interfacehipfort__hipblas_1_1hipblashaxpybatched__64.html "Interface documentation") | C binding
-114 | [hipblasSaxpyBatched_64](interfacehipfort__hipblas_1_1hipblassaxpybatched__64.html "Interface documentation") | C binding
-115 | [hipblasDaxpyBatched_64](interfacehipfort__hipblas_1_1hipblasdaxpybatched__64.html "Interface documentation") | C binding
-116 | [hipblasCaxpyBatched_64](interfacehipfort__hipblas_1_1hipblascaxpybatched__64.html "Interface documentation") | C binding
-117 | [hipblasZaxpyBatched_64](interfacehipfort__hipblas_1_1hipblaszaxpybatched__64.html "Interface documentation") | C binding
-118 | [hipblasHaxpyStridedBatched](interfacehipfort__hipblas_1_1hipblashaxpystridedbatched.html "Interface documentation") | C binding
-119 | [hipblasSaxpyStridedBatched](interfacehipfort__hipblas_1_1hipblassaxpystridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-120 | [hipblasDaxpyStridedBatched](interfacehipfort__hipblas_1_1hipblasdaxpystridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-121 | [hipblasCaxpyStridedBatched](interfacehipfort__hipblas_1_1hipblascaxpystridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-122 | [hipblasZaxpyStridedBatched](interfacehipfort__hipblas_1_1hipblaszaxpystridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-123 | [hipblasHaxpyStridedBatched_64](interfacehipfort__hipblas_1_1hipblashaxpystridedbatched__64.html "Interface documentation") | C binding
-124 | [hipblasSaxpyStridedBatched_64](interfacehipfort__hipblas_1_1hipblassaxpystridedbatched__64.html "Interface documentation") | C binding
-125 | [hipblasDaxpyStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdaxpystridedbatched__64.html "Interface documentation") | C binding
-126 | [hipblasCaxpyStridedBatched_64](interfacehipfort__hipblas_1_1hipblascaxpystridedbatched__64.html "Interface documentation") | C binding
-127 | [hipblasZaxpyStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszaxpystridedbatched__64.html "Interface documentation") | C binding
-128 | [hipblasScopy](interfacehipfort__hipblas_1_1hipblasscopy.html "Interface documentation") | C binding, rank_0, rank_1
-129 | [hipblasDcopy](interfacehipfort__hipblas_1_1hipblasdcopy.html "Interface documentation") | C binding, rank_0, rank_1
-130 | [hipblasCcopy](interfacehipfort__hipblas_1_1hipblasccopy.html "Interface documentation") | C binding, rank_0, rank_1
-131 | [hipblasZcopy](interfacehipfort__hipblas_1_1hipblaszcopy.html "Interface documentation") | C binding, rank_0, rank_1
-132 | [hipblasScopy_64](interfacehipfort__hipblas_1_1hipblasscopy__64.html "Interface documentation") | C binding
-133 | [hipblasDcopy_64](interfacehipfort__hipblas_1_1hipblasdcopy__64.html "Interface documentation") | C binding
-134 | [hipblasCcopy_64](interfacehipfort__hipblas_1_1hipblasccopy__64.html "Interface documentation") | C binding
-135 | [hipblasZcopy_64](interfacehipfort__hipblas_1_1hipblaszcopy__64.html "Interface documentation") | C binding
-136 | [hipblasScopyBatched](interfacehipfort__hipblas_1_1hipblasscopybatched.html "Interface documentation") | C binding
-137 | [hipblasDcopyBatched](interfacehipfort__hipblas_1_1hipblasdcopybatched.html "Interface documentation") | C binding
-138 | [hipblasCcopyBatched](interfacehipfort__hipblas_1_1hipblasccopybatched.html "Interface documentation") | C binding
-139 | [hipblasZcopyBatched](interfacehipfort__hipblas_1_1hipblaszcopybatched.html "Interface documentation") | C binding
-140 | [hipblasScopyBatched_64](interfacehipfort__hipblas_1_1hipblasscopybatched__64.html "Interface documentation") | C binding
-141 | [hipblasDcopyBatched_64](interfacehipfort__hipblas_1_1hipblasdcopybatched__64.html "Interface documentation") | C binding
-142 | [hipblasCcopyBatched_64](interfacehipfort__hipblas_1_1hipblasccopybatched__64.html "Interface documentation") | C binding
-143 | [hipblasZcopyBatched_64](interfacehipfort__hipblas_1_1hipblaszcopybatched__64.html "Interface documentation") | C binding
-144 | [hipblasScopyStridedBatched](interfacehipfort__hipblas_1_1hipblasscopystridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-145 | [hipblasDcopyStridedBatched](interfacehipfort__hipblas_1_1hipblasdcopystridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-146 | [hipblasCcopyStridedBatched](interfacehipfort__hipblas_1_1hipblasccopystridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-147 | [hipblasZcopyStridedBatched](interfacehipfort__hipblas_1_1hipblaszcopystridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-148 | [hipblasScopyStridedBatched_64](interfacehipfort__hipblas_1_1hipblasscopystridedbatched__64.html "Interface documentation") | C binding
-149 | [hipblasDcopyStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdcopystridedbatched__64.html "Interface documentation") | C binding
-150 | [hipblasCcopyStridedBatched_64](interfacehipfort__hipblas_1_1hipblasccopystridedbatched__64.html "Interface documentation") | C binding
-151 | [hipblasZcopyStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszcopystridedbatched__64.html "Interface documentation") | C binding
-152 | [hipblasHdot](interfacehipfort__hipblas_1_1hipblashdot.html "Interface documentation") | C binding
-153 | [hipblasBfdot](interfacehipfort__hipblas_1_1hipblasbfdot.html "Interface documentation") | C binding
-154 | [hipblasSdot](interfacehipfort__hipblas_1_1hipblassdot.html "Interface documentation") | C binding, rank_0, rank_1
-155 | [hipblasDdot](interfacehipfort__hipblas_1_1hipblasddot.html "Interface documentation") | C binding, rank_0, rank_1
-156 | [hipblasCdotc](interfacehipfort__hipblas_1_1hipblascdotc.html "Interface documentation") | C binding, rank_0, rank_1
-157 | [hipblasCdotu](interfacehipfort__hipblas_1_1hipblascdotu.html "Interface documentation") | C binding, rank_0, rank_1
-158 | [hipblasZdotc](interfacehipfort__hipblas_1_1hipblaszdotc.html "Interface documentation") | C binding, rank_0, rank_1
-159 | [hipblasZdotu](interfacehipfort__hipblas_1_1hipblaszdotu.html "Interface documentation") | C binding, rank_0, rank_1
-160 | [hipblasHdot_64](interfacehipfort__hipblas_1_1hipblashdot__64.html "Interface documentation") | C binding
-161 | [hipblasBfdot_64](interfacehipfort__hipblas_1_1hipblasbfdot__64.html "Interface documentation") | C binding
-162 | [hipblasSdot_64](interfacehipfort__hipblas_1_1hipblassdot__64.html "Interface documentation") | C binding
-163 | [hipblasDdot_64](interfacehipfort__hipblas_1_1hipblasddot__64.html "Interface documentation") | C binding
-164 | [hipblasCdotc_64](interfacehipfort__hipblas_1_1hipblascdotc__64.html "Interface documentation") | C binding
-165 | [hipblasCdotu_64](interfacehipfort__hipblas_1_1hipblascdotu__64.html "Interface documentation") | C binding
-166 | [hipblasZdotc_64](interfacehipfort__hipblas_1_1hipblaszdotc__64.html "Interface documentation") | C binding
-167 | [hipblasZdotu_64](interfacehipfort__hipblas_1_1hipblaszdotu__64.html "Interface documentation") | C binding
-168 | [hipblasHdotBatched](interfacehipfort__hipblas_1_1hipblashdotbatched.html "Interface documentation") | C binding
-169 | [hipblasBfdotBatched](interfacehipfort__hipblas_1_1hipblasbfdotbatched.html "Interface documentation") | C binding
-170 | [hipblasSdotBatched](interfacehipfort__hipblas_1_1hipblassdotbatched.html "Interface documentation") | C binding
-171 | [hipblasDdotBatched](interfacehipfort__hipblas_1_1hipblasddotbatched.html "Interface documentation") | C binding
-172 | [hipblasCdotcBatched](interfacehipfort__hipblas_1_1hipblascdotcbatched.html "Interface documentation") | C binding
-173 | [hipblasCdotuBatched](interfacehipfort__hipblas_1_1hipblascdotubatched.html "Interface documentation") | C binding
-174 | [hipblasZdotcBatched](interfacehipfort__hipblas_1_1hipblaszdotcbatched.html "Interface documentation") | C binding
-175 | [hipblasZdotuBatched](interfacehipfort__hipblas_1_1hipblaszdotubatched.html "Interface documentation") | C binding
-176 | [hipblasHdotBatched_64](interfacehipfort__hipblas_1_1hipblashdotbatched__64.html "Interface documentation") | C binding
-177 | [hipblasBfdotBatched_64](interfacehipfort__hipblas_1_1hipblasbfdotbatched__64.html "Interface documentation") | C binding
-178 | [hipblasSdotBatched_64](interfacehipfort__hipblas_1_1hipblassdotbatched__64.html "Interface documentation") | C binding
-179 | [hipblasDdotBatched_64](interfacehipfort__hipblas_1_1hipblasddotbatched__64.html "Interface documentation") | C binding
-180 | [hipblasCdotcBatched_64](interfacehipfort__hipblas_1_1hipblascdotcbatched__64.html "Interface documentation") | C binding
-181 | [hipblasCdotuBatched_64](interfacehipfort__hipblas_1_1hipblascdotubatched__64.html "Interface documentation") | C binding
-182 | [hipblasZdotcBatched_64](interfacehipfort__hipblas_1_1hipblaszdotcbatched__64.html "Interface documentation") | C binding
-183 | [hipblasZdotuBatched_64](interfacehipfort__hipblas_1_1hipblaszdotubatched__64.html "Interface documentation") | C binding
-184 | [hipblasHdotStridedBatched](interfacehipfort__hipblas_1_1hipblashdotstridedbatched.html "Interface documentation") | C binding
-185 | [hipblasBfdotStridedBatched](interfacehipfort__hipblas_1_1hipblasbfdotstridedbatched.html "Interface documentation") | C binding
-186 | [hipblasSdotStridedBatched](interfacehipfort__hipblas_1_1hipblassdotstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-187 | [hipblasDdotStridedBatched](interfacehipfort__hipblas_1_1hipblasddotstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-188 | [hipblasCdotcStridedBatched](interfacehipfort__hipblas_1_1hipblascdotcstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-189 | [hipblasCdotuStridedBatched](interfacehipfort__hipblas_1_1hipblascdotustridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-190 | [hipblasZdotcStridedBatched](interfacehipfort__hipblas_1_1hipblaszdotcstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-191 | [hipblasZdotuStridedBatched](interfacehipfort__hipblas_1_1hipblaszdotustridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-192 | [hipblasHdotStridedBatched_64](interfacehipfort__hipblas_1_1hipblashdotstridedbatched__64.html "Interface documentation") | C binding
-193 | [hipblasBfdotStridedBatched_64](interfacehipfort__hipblas_1_1hipblasbfdotstridedbatched__64.html "Interface documentation") | C binding
-194 | [hipblasSdotStridedBatched_64](interfacehipfort__hipblas_1_1hipblassdotstridedbatched__64.html "Interface documentation") | C binding
-195 | [hipblasDdotStridedBatched_64](interfacehipfort__hipblas_1_1hipblasddotstridedbatched__64.html "Interface documentation") | C binding
-196 | [hipblasCdotcStridedBatched_64](interfacehipfort__hipblas_1_1hipblascdotcstridedbatched__64.html "Interface documentation") | C binding
-197 | [hipblasCdotuStridedBatched_64](interfacehipfort__hipblas_1_1hipblascdotustridedbatched__64.html "Interface documentation") | C binding
-198 | [hipblasZdotcStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszdotcstridedbatched__64.html "Interface documentation") | C binding
-199 | [hipblasZdotuStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszdotustridedbatched__64.html "Interface documentation") | C binding
-200 | [hipblasSnrm2](interfacehipfort__hipblas_1_1hipblassnrm2.html "Interface documentation") | C binding, rank_0, rank_1
-201 | [hipblasDnrm2](interfacehipfort__hipblas_1_1hipblasdnrm2.html "Interface documentation") | C binding, rank_0, rank_1
-202 | [hipblasScnrm2](interfacehipfort__hipblas_1_1hipblasscnrm2.html "Interface documentation") | C binding, rank_0, rank_1
-203 | [hipblasDznrm2](interfacehipfort__hipblas_1_1hipblasdznrm2.html "Interface documentation") | C binding, rank_0, rank_1
-204 | [hipblasSnrm2_64](interfacehipfort__hipblas_1_1hipblassnrm2__64.html "Interface documentation") | C binding
-205 | [hipblasDnrm2_64](interfacehipfort__hipblas_1_1hipblasdnrm2__64.html "Interface documentation") | C binding
-206 | [hipblasScnrm2_64](interfacehipfort__hipblas_1_1hipblasscnrm2__64.html "Interface documentation") | C binding
-207 | [hipblasDznrm2_64](interfacehipfort__hipblas_1_1hipblasdznrm2__64.html "Interface documentation") | C binding
-208 | [hipblasSnrm2Batched](interfacehipfort__hipblas_1_1hipblassnrm2batched.html "Interface documentation") | C binding
-209 | [hipblasDnrm2Batched](interfacehipfort__hipblas_1_1hipblasdnrm2batched.html "Interface documentation") | C binding
-210 | [hipblasScnrm2Batched](interfacehipfort__hipblas_1_1hipblasscnrm2batched.html "Interface documentation") | C binding
-211 | [hipblasDznrm2Batched](interfacehipfort__hipblas_1_1hipblasdznrm2batched.html "Interface documentation") | C binding
-212 | [hipblasSnrm2Batched_64](interfacehipfort__hipblas_1_1hipblassnrm2batched__64.html "Interface documentation") | C binding
-213 | [hipblasDnrm2Batched_64](interfacehipfort__hipblas_1_1hipblasdnrm2batched__64.html "Interface documentation") | C binding
-214 | [hipblasScnrm2Batched_64](interfacehipfort__hipblas_1_1hipblasscnrm2batched__64.html "Interface documentation") | C binding
-215 | [hipblasDznrm2Batched_64](interfacehipfort__hipblas_1_1hipblasdznrm2batched__64.html "Interface documentation") | C binding
-216 | [hipblasSnrm2StridedBatched](interfacehipfort__hipblas_1_1hipblassnrm2stridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-217 | [hipblasDnrm2StridedBatched](interfacehipfort__hipblas_1_1hipblasdnrm2stridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-218 | [hipblasScnrm2StridedBatched](interfacehipfort__hipblas_1_1hipblasscnrm2stridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-219 | [hipblasDznrm2StridedBatched](interfacehipfort__hipblas_1_1hipblasdznrm2stridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-220 | [hipblasSnrm2StridedBatched_64](interfacehipfort__hipblas_1_1hipblassnrm2stridedbatched__64.html "Interface documentation") | C binding
-221 | [hipblasDnrm2StridedBatched_64](interfacehipfort__hipblas_1_1hipblasdnrm2stridedbatched__64.html "Interface documentation") | C binding
-222 | [hipblasScnrm2StridedBatched_64](interfacehipfort__hipblas_1_1hipblasscnrm2stridedbatched__64.html "Interface documentation") | C binding
-223 | [hipblasDznrm2StridedBatched_64](interfacehipfort__hipblas_1_1hipblasdznrm2stridedbatched__64.html "Interface documentation") | C binding
-224 | [hipblasSrot](interfacehipfort__hipblas_1_1hipblassrot.html "Interface documentation") | C binding, rank_0, rank_1
-225 | [hipblasDrot](interfacehipfort__hipblas_1_1hipblasdrot.html "Interface documentation") | C binding, rank_0, rank_1
-226 | [hipblasCrot](interfacehipfort__hipblas_1_1hipblascrot.html "Interface documentation") | C binding, rank_0, rank_1
-227 | [hipblasCsrot](interfacehipfort__hipblas_1_1hipblascsrot.html "Interface documentation") | C binding, rank_0, rank_1
-228 | [hipblasZrot](interfacehipfort__hipblas_1_1hipblaszrot.html "Interface documentation") | C binding, rank_0, rank_1
-229 | [hipblasZdrot](interfacehipfort__hipblas_1_1hipblaszdrot.html "Interface documentation") | C binding, rank_0, rank_1
-230 | [hipblasSrot_64](interfacehipfort__hipblas_1_1hipblassrot__64.html "Interface documentation") | C binding
-231 | [hipblasDrot_64](interfacehipfort__hipblas_1_1hipblasdrot__64.html "Interface documentation") | C binding
-232 | [hipblasCrot_64](interfacehipfort__hipblas_1_1hipblascrot__64.html "Interface documentation") | C binding
-233 | [hipblasCsrot_64](interfacehipfort__hipblas_1_1hipblascsrot__64.html "Interface documentation") | C binding
-234 | [hipblasZrot_64](interfacehipfort__hipblas_1_1hipblaszrot__64.html "Interface documentation") | C binding
-235 | [hipblasZdrot_64](interfacehipfort__hipblas_1_1hipblaszdrot__64.html "Interface documentation") | C binding
-236 | [hipblasSrotBatched](interfacehipfort__hipblas_1_1hipblassrotbatched.html "Interface documentation") | C binding
-237 | [hipblasDrotBatched](interfacehipfort__hipblas_1_1hipblasdrotbatched.html "Interface documentation") | C binding
-238 | [hipblasCrotBatched](interfacehipfort__hipblas_1_1hipblascrotbatched.html "Interface documentation") | C binding
-239 | [hipblasCsrotBatched](interfacehipfort__hipblas_1_1hipblascsrotbatched.html "Interface documentation") | C binding
-240 | [hipblasZrotBatched](interfacehipfort__hipblas_1_1hipblaszrotbatched.html "Interface documentation") | C binding
-241 | [hipblasZdrotBatched](interfacehipfort__hipblas_1_1hipblaszdrotbatched.html "Interface documentation") | C binding
-242 | [hipblasSrotBatched_64](interfacehipfort__hipblas_1_1hipblassrotbatched__64.html "Interface documentation") | C binding
-243 | [hipblasDrotBatched_64](interfacehipfort__hipblas_1_1hipblasdrotbatched__64.html "Interface documentation") | C binding
-244 | [hipblasCrotBatched_64](interfacehipfort__hipblas_1_1hipblascrotbatched__64.html "Interface documentation") | C binding
-245 | [hipblasCsrotBatched_64](interfacehipfort__hipblas_1_1hipblascsrotbatched__64.html "Interface documentation") | C binding
-246 | [hipblasZrotBatched_64](interfacehipfort__hipblas_1_1hipblaszrotbatched__64.html "Interface documentation") | C binding
-247 | [hipblasZdrotBatched_64](interfacehipfort__hipblas_1_1hipblaszdrotbatched__64.html "Interface documentation") | C binding
-248 | [hipblasSrotStridedBatched](interfacehipfort__hipblas_1_1hipblassrotstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-249 | [hipblasDrotStridedBatched](interfacehipfort__hipblas_1_1hipblasdrotstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-250 | [hipblasCrotStridedBatched](interfacehipfort__hipblas_1_1hipblascrotstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-251 | [hipblasCsrotStridedBatched](interfacehipfort__hipblas_1_1hipblascsrotstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-252 | [hipblasZrotStridedBatched](interfacehipfort__hipblas_1_1hipblaszrotstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-253 | [hipblasZdrotStridedBatched](interfacehipfort__hipblas_1_1hipblaszdrotstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-254 | [hipblasSrotStridedBatched_64](interfacehipfort__hipblas_1_1hipblassrotstridedbatched__64.html "Interface documentation") | C binding
-255 | [hipblasDrotStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdrotstridedbatched__64.html "Interface documentation") | C binding
-256 | [hipblasCrotStridedBatched_64](interfacehipfort__hipblas_1_1hipblascrotstridedbatched__64.html "Interface documentation") | C binding
-257 | [hipblasCsrotStridedBatched_64](interfacehipfort__hipblas_1_1hipblascsrotstridedbatched__64.html "Interface documentation") | C binding
-258 | [hipblasZrotStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszrotstridedbatched__64.html "Interface documentation") | C binding
-259 | [hipblasZdrotStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszdrotstridedbatched__64.html "Interface documentation") | C binding
-260 | [hipblasSrotg](interfacehipfort__hipblas_1_1hipblassrotg.html "Interface documentation") | C binding
-261 | [hipblasDrotg](interfacehipfort__hipblas_1_1hipblasdrotg.html "Interface documentation") | C binding
-262 | [hipblasCrotg](interfacehipfort__hipblas_1_1hipblascrotg.html "Interface documentation") | C binding
-263 | [hipblasZrotg](interfacehipfort__hipblas_1_1hipblaszrotg.html "Interface documentation") | C binding
-264 | [hipblasSrotg_64](interfacehipfort__hipblas_1_1hipblassrotg__64.html "Interface documentation") | C binding
-265 | [hipblasDrotg_64](interfacehipfort__hipblas_1_1hipblasdrotg__64.html "Interface documentation") | C binding
-266 | [hipblasCrotg_64](interfacehipfort__hipblas_1_1hipblascrotg__64.html "Interface documentation") | C binding
-267 | [hipblasZrotg_64](interfacehipfort__hipblas_1_1hipblaszrotg__64.html "Interface documentation") | C binding
-268 | [hipblasSrotgBatched](interfacehipfort__hipblas_1_1hipblassrotgbatched.html "Interface documentation") | C binding
-269 | [hipblasDrotgBatched](interfacehipfort__hipblas_1_1hipblasdrotgbatched.html "Interface documentation") | C binding
-270 | [hipblasCrotgBatched](interfacehipfort__hipblas_1_1hipblascrotgbatched.html "Interface documentation") | C binding
-271 | [hipblasZrotgBatched](interfacehipfort__hipblas_1_1hipblaszrotgbatched.html "Interface documentation") | C binding
-272 | [hipblasSrotgBatched_64](interfacehipfort__hipblas_1_1hipblassrotgbatched__64.html "Interface documentation") | C binding
-273 | [hipblasDrotgBatched_64](interfacehipfort__hipblas_1_1hipblasdrotgbatched__64.html "Interface documentation") | C binding
-274 | [hipblasCrotgBatched_64](interfacehipfort__hipblas_1_1hipblascrotgbatched__64.html "Interface documentation") | C binding
-275 | [hipblasZrotgBatched_64](interfacehipfort__hipblas_1_1hipblaszrotgbatched__64.html "Interface documentation") | C binding
-276 | [hipblasSrotgStridedBatched](interfacehipfort__hipblas_1_1hipblassrotgstridedbatched.html "Interface documentation") | C binding
-277 | [hipblasDrotgStridedBatched](interfacehipfort__hipblas_1_1hipblasdrotgstridedbatched.html "Interface documentation") | C binding
-278 | [hipblasCrotgStridedBatched](interfacehipfort__hipblas_1_1hipblascrotgstridedbatched.html "Interface documentation") | C binding
-279 | [hipblasZrotgStridedBatched](interfacehipfort__hipblas_1_1hipblaszrotgstridedbatched.html "Interface documentation") | C binding
-280 | [hipblasSrotgStridedBatched_64](interfacehipfort__hipblas_1_1hipblassrotgstridedbatched__64.html "Interface documentation") | C binding
-281 | [hipblasDrotgStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdrotgstridedbatched__64.html "Interface documentation") | C binding
-282 | [hipblasCrotgStridedBatched_64](interfacehipfort__hipblas_1_1hipblascrotgstridedbatched__64.html "Interface documentation") | C binding
-283 | [hipblasZrotgStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszrotgstridedbatched__64.html "Interface documentation") | C binding
-284 | [hipblasSrotm](interfacehipfort__hipblas_1_1hipblassrotm.html "Interface documentation") | C binding, rank_0, rank_1
-285 | [hipblasDrotm](interfacehipfort__hipblas_1_1hipblasdrotm.html "Interface documentation") | C binding, rank_0, rank_1
-286 | [hipblasSrotm_64](interfacehipfort__hipblas_1_1hipblassrotm__64.html "Interface documentation") | C binding
-287 | [hipblasDrotm_64](interfacehipfort__hipblas_1_1hipblasdrotm__64.html "Interface documentation") | C binding
-288 | [hipblasSrotmBatched](interfacehipfort__hipblas_1_1hipblassrotmbatched.html "Interface documentation") | C binding
-289 | [hipblasDrotmBatched](interfacehipfort__hipblas_1_1hipblasdrotmbatched.html "Interface documentation") | C binding
-290 | [hipblasSrotmBatched_64](interfacehipfort__hipblas_1_1hipblassrotmbatched__64.html "Interface documentation") | C binding
-291 | [hipblasDrotmBatched_64](interfacehipfort__hipblas_1_1hipblasdrotmbatched__64.html "Interface documentation") | C binding
-292 | [hipblasSrotmStridedBatched](interfacehipfort__hipblas_1_1hipblassrotmstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-293 | [hipblasDrotmStridedBatched](interfacehipfort__hipblas_1_1hipblasdrotmstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-294 | [hipblasSrotmStridedBatched_64](interfacehipfort__hipblas_1_1hipblassrotmstridedbatched__64.html "Interface documentation") | C binding
-295 | [hipblasDrotmStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdrotmstridedbatched__64.html "Interface documentation") | C binding
-296 | [hipblasSrotmg](interfacehipfort__hipblas_1_1hipblassrotmg.html "Interface documentation") | C binding
-297 | [hipblasDrotmg](interfacehipfort__hipblas_1_1hipblasdrotmg.html "Interface documentation") | C binding
-298 | [hipblasSrotmg_64](interfacehipfort__hipblas_1_1hipblassrotmg__64.html "Interface documentation") | C binding
-299 | [hipblasDrotmg_64](interfacehipfort__hipblas_1_1hipblasdrotmg__64.html "Interface documentation") | C binding
-300 | [hipblasSrotmgBatched](interfacehipfort__hipblas_1_1hipblassrotmgbatched.html "Interface documentation") | C binding
-301 | [hipblasDrotmgBatched](interfacehipfort__hipblas_1_1hipblasdrotmgbatched.html "Interface documentation") | C binding
-302 | [hipblasSrotmgBatched_64](interfacehipfort__hipblas_1_1hipblassrotmgbatched__64.html "Interface documentation") | C binding
-303 | [hipblasDrotmgBatched_64](interfacehipfort__hipblas_1_1hipblasdrotmgbatched__64.html "Interface documentation") | C binding
-304 | [hipblasSrotmgStridedBatched](interfacehipfort__hipblas_1_1hipblassrotmgstridedbatched.html "Interface documentation") | C binding
-305 | [hipblasDrotmgStridedBatched](interfacehipfort__hipblas_1_1hipblasdrotmgstridedbatched.html "Interface documentation") | C binding
-306 | [hipblasSrotmgStridedBatched_64](interfacehipfort__hipblas_1_1hipblassrotmgstridedbatched__64.html "Interface documentation") | C binding
-307 | [hipblasDrotmgStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdrotmgstridedbatched__64.html "Interface documentation") | C binding
-308 | [hipblasSscal](interfacehipfort__hipblas_1_1hipblassscal.html "Interface documentation") | C binding, rank_0, rank_1
-309 | [hipblasDscal](interfacehipfort__hipblas_1_1hipblasdscal.html "Interface documentation") | C binding, rank_0, rank_1
-310 | [hipblasCscal](interfacehipfort__hipblas_1_1hipblascscal.html "Interface documentation") | C binding, rank_0, rank_1
-311 | [hipblasCsscal](interfacehipfort__hipblas_1_1hipblascsscal.html "Interface documentation") | C binding, rank_0, rank_1
-312 | [hipblasZscal](interfacehipfort__hipblas_1_1hipblaszscal.html "Interface documentation") | C binding, rank_0, rank_1
-313 | [hipblasZdscal](interfacehipfort__hipblas_1_1hipblaszdscal.html "Interface documentation") | C binding, rank_0, rank_1
-314 | [hipblasSscal_64](interfacehipfort__hipblas_1_1hipblassscal__64.html "Interface documentation") | C binding
-315 | [hipblasDscal_64](interfacehipfort__hipblas_1_1hipblasdscal__64.html "Interface documentation") | C binding
-316 | [hipblasCscal_64](interfacehipfort__hipblas_1_1hipblascscal__64.html "Interface documentation") | C binding
-317 | [hipblasCsscal_64](interfacehipfort__hipblas_1_1hipblascsscal__64.html "Interface documentation") | C binding
-318 | [hipblasZscal_64](interfacehipfort__hipblas_1_1hipblaszscal__64.html "Interface documentation") | C binding
-319 | [hipblasZdscal_64](interfacehipfort__hipblas_1_1hipblaszdscal__64.html "Interface documentation") | C binding
-320 | [hipblasSscalBatched](interfacehipfort__hipblas_1_1hipblassscalbatched.html "Interface documentation") | C binding
-321 | [hipblasDscalBatched](interfacehipfort__hipblas_1_1hipblasdscalbatched.html "Interface documentation") | C binding
-322 | [hipblasCscalBatched](interfacehipfort__hipblas_1_1hipblascscalbatched.html "Interface documentation") | C binding
-323 | [hipblasZscalBatched](interfacehipfort__hipblas_1_1hipblaszscalbatched.html "Interface documentation") | C binding
-324 | [hipblasCsscalBatched](interfacehipfort__hipblas_1_1hipblascsscalbatched.html "Interface documentation") | C binding
-325 | [hipblasZdscalBatched](interfacehipfort__hipblas_1_1hipblaszdscalbatched.html "Interface documentation") | C binding
-326 | [hipblasSscalBatched_64](interfacehipfort__hipblas_1_1hipblassscalbatched__64.html "Interface documentation") | C binding
-327 | [hipblasDscalBatched_64](interfacehipfort__hipblas_1_1hipblasdscalbatched__64.html "Interface documentation") | C binding
-328 | [hipblasCscalBatched_64](interfacehipfort__hipblas_1_1hipblascscalbatched__64.html "Interface documentation") | C binding
-329 | [hipblasZscalBatched_64](interfacehipfort__hipblas_1_1hipblaszscalbatched__64.html "Interface documentation") | C binding
-330 | [hipblasCsscalBatched_64](interfacehipfort__hipblas_1_1hipblascsscalbatched__64.html "Interface documentation") | C binding
-331 | [hipblasZdscalBatched_64](interfacehipfort__hipblas_1_1hipblaszdscalbatched__64.html "Interface documentation") | C binding
-332 | [hipblasSscalStridedBatched](interfacehipfort__hipblas_1_1hipblassscalstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-333 | [hipblasDscalStridedBatched](interfacehipfort__hipblas_1_1hipblasdscalstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-334 | [hipblasCscalStridedBatched](interfacehipfort__hipblas_1_1hipblascscalstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-335 | [hipblasZscalStridedBatched](interfacehipfort__hipblas_1_1hipblaszscalstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-336 | [hipblasCsscalStridedBatched](interfacehipfort__hipblas_1_1hipblascsscalstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-337 | [hipblasZdscalStridedBatched](interfacehipfort__hipblas_1_1hipblaszdscalstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-338 | [hipblasSscalStridedBatched_64](interfacehipfort__hipblas_1_1hipblassscalstridedbatched__64.html "Interface documentation") | C binding
-339 | [hipblasDscalStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdscalstridedbatched__64.html "Interface documentation") | C binding
-340 | [hipblasCscalStridedBatched_64](interfacehipfort__hipblas_1_1hipblascscalstridedbatched__64.html "Interface documentation") | C binding
-341 | [hipblasZscalStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszscalstridedbatched__64.html "Interface documentation") | C binding
-342 | [hipblasCsscalStridedBatched_64](interfacehipfort__hipblas_1_1hipblascsscalstridedbatched__64.html "Interface documentation") | C binding
-343 | [hipblasZdscalStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszdscalstridedbatched__64.html "Interface documentation") | C binding
-344 | [hipblasSswap](interfacehipfort__hipblas_1_1hipblassswap.html "Interface documentation") | C binding, rank_0, rank_1
-345 | [hipblasDswap](interfacehipfort__hipblas_1_1hipblasdswap.html "Interface documentation") | C binding, rank_0, rank_1
-346 | [hipblasCswap](interfacehipfort__hipblas_1_1hipblascswap.html "Interface documentation") | C binding, rank_0, rank_1
-347 | [hipblasZswap](interfacehipfort__hipblas_1_1hipblaszswap.html "Interface documentation") | C binding, rank_0, rank_1
-348 | [hipblasSswap_64](interfacehipfort__hipblas_1_1hipblassswap__64.html "Interface documentation") | C binding
-349 | [hipblasDswap_64](interfacehipfort__hipblas_1_1hipblasdswap__64.html "Interface documentation") | C binding
-350 | [hipblasCswap_64](interfacehipfort__hipblas_1_1hipblascswap__64.html "Interface documentation") | C binding
-351 | [hipblasZswap_64](interfacehipfort__hipblas_1_1hipblaszswap__64.html "Interface documentation") | C binding
-352 | [hipblasSswapBatched](interfacehipfort__hipblas_1_1hipblassswapbatched.html "Interface documentation") | C binding
-353 | [hipblasDswapBatched](interfacehipfort__hipblas_1_1hipblasdswapbatched.html "Interface documentation") | C binding
-354 | [hipblasCswapBatched](interfacehipfort__hipblas_1_1hipblascswapbatched.html "Interface documentation") | C binding
-355 | [hipblasZswapBatched](interfacehipfort__hipblas_1_1hipblaszswapbatched.html "Interface documentation") | C binding
-356 | [hipblasSswapBatched_64](interfacehipfort__hipblas_1_1hipblassswapbatched__64.html "Interface documentation") | C binding
-357 | [hipblasDswapBatched_64](interfacehipfort__hipblas_1_1hipblasdswapbatched__64.html "Interface documentation") | C binding
-358 | [hipblasCswapBatched_64](interfacehipfort__hipblas_1_1hipblascswapbatched__64.html "Interface documentation") | C binding
-359 | [hipblasZswapBatched_64](interfacehipfort__hipblas_1_1hipblaszswapbatched__64.html "Interface documentation") | C binding
-360 | [hipblasSswapStridedBatched](interfacehipfort__hipblas_1_1hipblassswapstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-361 | [hipblasDswapStridedBatched](interfacehipfort__hipblas_1_1hipblasdswapstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-362 | [hipblasCswapStridedBatched](interfacehipfort__hipblas_1_1hipblascswapstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-363 | [hipblasZswapStridedBatched](interfacehipfort__hipblas_1_1hipblaszswapstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-364 | [hipblasSswapStridedBatched_64](interfacehipfort__hipblas_1_1hipblassswapstridedbatched__64.html "Interface documentation") | C binding
-365 | [hipblasDswapStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdswapstridedbatched__64.html "Interface documentation") | C binding
-366 | [hipblasCswapStridedBatched_64](interfacehipfort__hipblas_1_1hipblascswapstridedbatched__64.html "Interface documentation") | C binding
-367 | [hipblasZswapStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszswapstridedbatched__64.html "Interface documentation") | C binding
-368 | [hipblasSgbmv](interfacehipfort__hipblas_1_1hipblassgbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-369 | [hipblasDgbmv](interfacehipfort__hipblas_1_1hipblasdgbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-370 | [hipblasCgbmv](interfacehipfort__hipblas_1_1hipblascgbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-371 | [hipblasZgbmv](interfacehipfort__hipblas_1_1hipblaszgbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-372 | [hipblasSgbmv_64](interfacehipfort__hipblas_1_1hipblassgbmv__64.html "Interface documentation") | C binding
-373 | [hipblasDgbmv_64](interfacehipfort__hipblas_1_1hipblasdgbmv__64.html "Interface documentation") | C binding
-374 | [hipblasCgbmv_64](interfacehipfort__hipblas_1_1hipblascgbmv__64.html "Interface documentation") | C binding
-375 | [hipblasZgbmv_64](interfacehipfort__hipblas_1_1hipblaszgbmv__64.html "Interface documentation") | C binding
-376 | [hipblasSgbmvBatched](interfacehipfort__hipblas_1_1hipblassgbmvbatched.html "Interface documentation") | C binding
-377 | [hipblasDgbmvBatched](interfacehipfort__hipblas_1_1hipblasdgbmvbatched.html "Interface documentation") | C binding
-378 | [hipblasCgbmvBatched](interfacehipfort__hipblas_1_1hipblascgbmvbatched.html "Interface documentation") | C binding
-379 | [hipblasZgbmvBatched](interfacehipfort__hipblas_1_1hipblaszgbmvbatched.html "Interface documentation") | C binding
-380 | [hipblasSgbmvBatched_64](interfacehipfort__hipblas_1_1hipblassgbmvbatched__64.html "Interface documentation") | C binding
-381 | [hipblasDgbmvBatched_64](interfacehipfort__hipblas_1_1hipblasdgbmvbatched__64.html "Interface documentation") | C binding
-382 | [hipblasCgbmvBatched_64](interfacehipfort__hipblas_1_1hipblascgbmvbatched__64.html "Interface documentation") | C binding
-383 | [hipblasZgbmvBatched_64](interfacehipfort__hipblas_1_1hipblaszgbmvbatched__64.html "Interface documentation") | C binding
-384 | [hipblasSgbmvStridedBatched](interfacehipfort__hipblas_1_1hipblassgbmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-385 | [hipblasDgbmvStridedBatched](interfacehipfort__hipblas_1_1hipblasdgbmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-386 | [hipblasCgbmvStridedBatched](interfacehipfort__hipblas_1_1hipblascgbmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-387 | [hipblasZgbmvStridedBatched](interfacehipfort__hipblas_1_1hipblaszgbmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-388 | [hipblasSgbmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblassgbmvstridedbatched__64.html "Interface documentation") | C binding
-389 | [hipblasDgbmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdgbmvstridedbatched__64.html "Interface documentation") | C binding
-390 | [hipblasCgbmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblascgbmvstridedbatched__64.html "Interface documentation") | C binding
-391 | [hipblasZgbmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszgbmvstridedbatched__64.html "Interface documentation") | C binding
-392 | [hipblasSgemv](interfacehipfort__hipblas_1_1hipblassgemv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-393 | [hipblasDgemv](interfacehipfort__hipblas_1_1hipblasdgemv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-394 | [hipblasCgemv](interfacehipfort__hipblas_1_1hipblascgemv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-395 | [hipblasZgemv](interfacehipfort__hipblas_1_1hipblaszgemv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-396 | [hipblasSgemv_64](interfacehipfort__hipblas_1_1hipblassgemv__64.html "Interface documentation") | C binding
-397 | [hipblasDgemv_64](interfacehipfort__hipblas_1_1hipblasdgemv__64.html "Interface documentation") | C binding
-398 | [hipblasCgemv_64](interfacehipfort__hipblas_1_1hipblascgemv__64.html "Interface documentation") | C binding
-399 | [hipblasZgemv_64](interfacehipfort__hipblas_1_1hipblaszgemv__64.html "Interface documentation") | C binding
-400 | [hipblasSgemvBatched](interfacehipfort__hipblas_1_1hipblassgemvbatched.html "Interface documentation") | C binding
-401 | [hipblasDgemvBatched](interfacehipfort__hipblas_1_1hipblasdgemvbatched.html "Interface documentation") | C binding
-402 | [hipblasCgemvBatched](interfacehipfort__hipblas_1_1hipblascgemvbatched.html "Interface documentation") | C binding
-403 | [hipblasZgemvBatched](interfacehipfort__hipblas_1_1hipblaszgemvbatched.html "Interface documentation") | C binding
-404 | [hipblasSgemvBatched_64](interfacehipfort__hipblas_1_1hipblassgemvbatched__64.html "Interface documentation") | C binding
-405 | [hipblasDgemvBatched_64](interfacehipfort__hipblas_1_1hipblasdgemvbatched__64.html "Interface documentation") | C binding
-406 | [hipblasCgemvBatched_64](interfacehipfort__hipblas_1_1hipblascgemvbatched__64.html "Interface documentation") | C binding
-407 | [hipblasZgemvBatched_64](interfacehipfort__hipblas_1_1hipblaszgemvbatched__64.html "Interface documentation") | C binding
-408 | [hipblasSgemvStridedBatched](interfacehipfort__hipblas_1_1hipblassgemvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-409 | [hipblasDgemvStridedBatched](interfacehipfort__hipblas_1_1hipblasdgemvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-410 | [hipblasCgemvStridedBatched](interfacehipfort__hipblas_1_1hipblascgemvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-411 | [hipblasZgemvStridedBatched](interfacehipfort__hipblas_1_1hipblaszgemvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-412 | [hipblasSgemvStridedBatched_64](interfacehipfort__hipblas_1_1hipblassgemvstridedbatched__64.html "Interface documentation") | C binding
-413 | [hipblasDgemvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdgemvstridedbatched__64.html "Interface documentation") | C binding
-414 | [hipblasCgemvStridedBatched_64](interfacehipfort__hipblas_1_1hipblascgemvstridedbatched__64.html "Interface documentation") | C binding
-415 | [hipblasZgemvStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszgemvstridedbatched__64.html "Interface documentation") | C binding
-416 | [hipblasSger](interfacehipfort__hipblas_1_1hipblassger.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-417 | [hipblasDger](interfacehipfort__hipblas_1_1hipblasdger.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-418 | [hipblasCgeru](interfacehipfort__hipblas_1_1hipblascgeru.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-419 | [hipblasCgerc](interfacehipfort__hipblas_1_1hipblascgerc.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-420 | [hipblasZgeru](interfacehipfort__hipblas_1_1hipblaszgeru.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-421 | [hipblasZgerc](interfacehipfort__hipblas_1_1hipblaszgerc.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-422 | [hipblasSger_64](interfacehipfort__hipblas_1_1hipblassger__64.html "Interface documentation") | C binding
-423 | [hipblasDger_64](interfacehipfort__hipblas_1_1hipblasdger__64.html "Interface documentation") | C binding
-424 | [hipblasCgeru_64](interfacehipfort__hipblas_1_1hipblascgeru__64.html "Interface documentation") | C binding
-425 | [hipblasCgerc_64](interfacehipfort__hipblas_1_1hipblascgerc__64.html "Interface documentation") | C binding
-426 | [hipblasZgeru_64](interfacehipfort__hipblas_1_1hipblaszgeru__64.html "Interface documentation") | C binding
-427 | [hipblasZgerc_64](interfacehipfort__hipblas_1_1hipblaszgerc__64.html "Interface documentation") | C binding
-428 | [hipblasSgerBatched](interfacehipfort__hipblas_1_1hipblassgerbatched.html "Interface documentation") | C binding
-429 | [hipblasDgerBatched](interfacehipfort__hipblas_1_1hipblasdgerbatched.html "Interface documentation") | C binding
-430 | [hipblasCgeruBatched](interfacehipfort__hipblas_1_1hipblascgerubatched.html "Interface documentation") | C binding
-431 | [hipblasCgercBatched](interfacehipfort__hipblas_1_1hipblascgercbatched.html "Interface documentation") | C binding
-432 | [hipblasZgeruBatched](interfacehipfort__hipblas_1_1hipblaszgerubatched.html "Interface documentation") | C binding
-433 | [hipblasZgercBatched](interfacehipfort__hipblas_1_1hipblaszgercbatched.html "Interface documentation") | C binding
-434 | [hipblasSgerBatched_64](interfacehipfort__hipblas_1_1hipblassgerbatched__64.html "Interface documentation") | C binding
-435 | [hipblasDgerBatched_64](interfacehipfort__hipblas_1_1hipblasdgerbatched__64.html "Interface documentation") | C binding
-436 | [hipblasCgeruBatched_64](interfacehipfort__hipblas_1_1hipblascgerubatched__64.html "Interface documentation") | C binding
-437 | [hipblasCgercBatched_64](interfacehipfort__hipblas_1_1hipblascgercbatched__64.html "Interface documentation") | C binding
-438 | [hipblasZgeruBatched_64](interfacehipfort__hipblas_1_1hipblaszgerubatched__64.html "Interface documentation") | C binding
-439 | [hipblasZgercBatched_64](interfacehipfort__hipblas_1_1hipblaszgercbatched__64.html "Interface documentation") | C binding
-440 | [hipblasSgerStridedBatched](interfacehipfort__hipblas_1_1hipblassgerstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-441 | [hipblasDgerStridedBatched](interfacehipfort__hipblas_1_1hipblasdgerstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-442 | [hipblasCgeruStridedBatched](interfacehipfort__hipblas_1_1hipblascgerustridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-443 | [hipblasCgercStridedBatched](interfacehipfort__hipblas_1_1hipblascgercstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-444 | [hipblasZgeruStridedBatched](interfacehipfort__hipblas_1_1hipblaszgerustridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-445 | [hipblasZgercStridedBatched](interfacehipfort__hipblas_1_1hipblaszgercstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-446 | [hipblasSgerStridedBatched_64](interfacehipfort__hipblas_1_1hipblassgerstridedbatched__64.html "Interface documentation") | C binding
-447 | [hipblasDgerStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdgerstridedbatched__64.html "Interface documentation") | C binding
-448 | [hipblasCgeruStridedBatched_64](interfacehipfort__hipblas_1_1hipblascgerustridedbatched__64.html "Interface documentation") | C binding
-449 | [hipblasCgercStridedBatched_64](interfacehipfort__hipblas_1_1hipblascgercstridedbatched__64.html "Interface documentation") | C binding
-450 | [hipblasZgeruStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszgerustridedbatched__64.html "Interface documentation") | C binding
-451 | [hipblasZgercStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszgercstridedbatched__64.html "Interface documentation") | C binding
-452 | [hipblasChbmv](interfacehipfort__hipblas_1_1hipblaschbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-453 | [hipblasZhbmv](interfacehipfort__hipblas_1_1hipblaszhbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-454 | [hipblasChbmv_64](interfacehipfort__hipblas_1_1hipblaschbmv__64.html "Interface documentation") | C binding
-455 | [hipblasZhbmv_64](interfacehipfort__hipblas_1_1hipblaszhbmv__64.html "Interface documentation") | C binding
-456 | [hipblasChbmvBatched](interfacehipfort__hipblas_1_1hipblaschbmvbatched.html "Interface documentation") | C binding
-457 | [hipblasZhbmvBatched](interfacehipfort__hipblas_1_1hipblaszhbmvbatched.html "Interface documentation") | C binding
-458 | [hipblasChbmvBatched_64](interfacehipfort__hipblas_1_1hipblaschbmvbatched__64.html "Interface documentation") | C binding
-459 | [hipblasZhbmvBatched_64](interfacehipfort__hipblas_1_1hipblaszhbmvbatched__64.html "Interface documentation") | C binding
-460 | [hipblasChbmvStridedBatched](interfacehipfort__hipblas_1_1hipblaschbmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-461 | [hipblasZhbmvStridedBatched](interfacehipfort__hipblas_1_1hipblaszhbmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-462 | [hipblasChbmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblaschbmvstridedbatched__64.html "Interface documentation") | C binding
-463 | [hipblasZhbmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszhbmvstridedbatched__64.html "Interface documentation") | C binding
-464 | [hipblasChemv](interfacehipfort__hipblas_1_1hipblaschemv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-465 | [hipblasZhemv](interfacehipfort__hipblas_1_1hipblaszhemv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-466 | [hipblasChemv_64](interfacehipfort__hipblas_1_1hipblaschemv__64.html "Interface documentation") | C binding
-467 | [hipblasZhemv_64](interfacehipfort__hipblas_1_1hipblaszhemv__64.html "Interface documentation") | C binding
-468 | [hipblasChemvBatched](interfacehipfort__hipblas_1_1hipblaschemvbatched.html "Interface documentation") | C binding
-469 | [hipblasZhemvBatched](interfacehipfort__hipblas_1_1hipblaszhemvbatched.html "Interface documentation") | C binding
-470 | [hipblasChemvBatched_64](interfacehipfort__hipblas_1_1hipblaschemvbatched__64.html "Interface documentation") | C binding
-471 | [hipblasZhemvBatched_64](interfacehipfort__hipblas_1_1hipblaszhemvbatched__64.html "Interface documentation") | C binding
-472 | [hipblasChemvStridedBatched](interfacehipfort__hipblas_1_1hipblaschemvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-473 | [hipblasZhemvStridedBatched](interfacehipfort__hipblas_1_1hipblaszhemvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-474 | [hipblasChemvStridedBatched_64](interfacehipfort__hipblas_1_1hipblaschemvstridedbatched__64.html "Interface documentation") | C binding
-475 | [hipblasZhemvStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszhemvstridedbatched__64.html "Interface documentation") | C binding
-476 | [hipblasCher](interfacehipfort__hipblas_1_1hipblascher.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-477 | [hipblasZher](interfacehipfort__hipblas_1_1hipblaszher.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-478 | [hipblasCher_64](interfacehipfort__hipblas_1_1hipblascher__64.html "Interface documentation") | C binding
-479 | [hipblasZher_64](interfacehipfort__hipblas_1_1hipblaszher__64.html "Interface documentation") | C binding
-480 | [hipblasCherBatched](interfacehipfort__hipblas_1_1hipblascherbatched.html "Interface documentation") | C binding
-481 | [hipblasZherBatched](interfacehipfort__hipblas_1_1hipblaszherbatched.html "Interface documentation") | C binding
-482 | [hipblasCherBatched_64](interfacehipfort__hipblas_1_1hipblascherbatched__64.html "Interface documentation") | C binding
-483 | [hipblasZherBatched_64](interfacehipfort__hipblas_1_1hipblaszherbatched__64.html "Interface documentation") | C binding
-484 | [hipblasCherStridedBatched](interfacehipfort__hipblas_1_1hipblascherstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-485 | [hipblasZherStridedBatched](interfacehipfort__hipblas_1_1hipblaszherstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-486 | [hipblasCherStridedBatched_64](interfacehipfort__hipblas_1_1hipblascherstridedbatched__64.html "Interface documentation") | C binding
-487 | [hipblasZherStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszherstridedbatched__64.html "Interface documentation") | C binding
-488 | [hipblasCher2](interfacehipfort__hipblas_1_1hipblascher2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-489 | [hipblasZher2](interfacehipfort__hipblas_1_1hipblaszher2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-490 | [hipblasCher2_64](interfacehipfort__hipblas_1_1hipblascher2__64.html "Interface documentation") | C binding
-491 | [hipblasZher2_64](interfacehipfort__hipblas_1_1hipblaszher2__64.html "Interface documentation") | C binding
-492 | [hipblasCher2Batched](interfacehipfort__hipblas_1_1hipblascher2batched.html "Interface documentation") | C binding
-493 | [hipblasZher2Batched](interfacehipfort__hipblas_1_1hipblaszher2batched.html "Interface documentation") | C binding
-494 | [hipblasCher2Batched_64](interfacehipfort__hipblas_1_1hipblascher2batched__64.html "Interface documentation") | C binding
-495 | [hipblasZher2Batched_64](interfacehipfort__hipblas_1_1hipblaszher2batched__64.html "Interface documentation") | C binding
-496 | [hipblasCher2StridedBatched](interfacehipfort__hipblas_1_1hipblascher2stridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-497 | [hipblasZher2StridedBatched](interfacehipfort__hipblas_1_1hipblaszher2stridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-498 | [hipblasCher2StridedBatched_64](interfacehipfort__hipblas_1_1hipblascher2stridedbatched__64.html "Interface documentation") | C binding
-499 | [hipblasZher2StridedBatched_64](interfacehipfort__hipblas_1_1hipblaszher2stridedbatched__64.html "Interface documentation") | C binding
-500 | [hipblasChpmv](interfacehipfort__hipblas_1_1hipblaschpmv.html "Interface documentation") | C binding, rank_0, rank_1
-501 | [hipblasZhpmv](interfacehipfort__hipblas_1_1hipblaszhpmv.html "Interface documentation") | C binding, rank_0, rank_1
-502 | [hipblasChpmv_64](interfacehipfort__hipblas_1_1hipblaschpmv__64.html "Interface documentation") | C binding
-503 | [hipblasZhpmv_64](interfacehipfort__hipblas_1_1hipblaszhpmv__64.html "Interface documentation") | C binding
-504 | [hipblasChpmvBatched](interfacehipfort__hipblas_1_1hipblaschpmvbatched.html "Interface documentation") | C binding
-505 | [hipblasZhpmvBatched](interfacehipfort__hipblas_1_1hipblaszhpmvbatched.html "Interface documentation") | C binding
-506 | [hipblasChpmvBatched_64](interfacehipfort__hipblas_1_1hipblaschpmvbatched__64.html "Interface documentation") | C binding
-507 | [hipblasZhpmvBatched_64](interfacehipfort__hipblas_1_1hipblaszhpmvbatched__64.html "Interface documentation") | C binding
-508 | [hipblasChpmvStridedBatched](interfacehipfort__hipblas_1_1hipblaschpmvstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-509 | [hipblasZhpmvStridedBatched](interfacehipfort__hipblas_1_1hipblaszhpmvstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-510 | [hipblasChpmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblaschpmvstridedbatched__64.html "Interface documentation") | C binding
-511 | [hipblasZhpmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszhpmvstridedbatched__64.html "Interface documentation") | C binding
-512 | [hipblasChpr](interfacehipfort__hipblas_1_1hipblaschpr.html "Interface documentation") | C binding, rank_0, rank_1
-513 | [hipblasZhpr](interfacehipfort__hipblas_1_1hipblaszhpr.html "Interface documentation") | C binding, rank_0, rank_1
-514 | [hipblasChpr_64](interfacehipfort__hipblas_1_1hipblaschpr__64.html "Interface documentation") | C binding
-515 | [hipblasZhpr_64](interfacehipfort__hipblas_1_1hipblaszhpr__64.html "Interface documentation") | C binding
-516 | [hipblasChprBatched](interfacehipfort__hipblas_1_1hipblaschprbatched.html "Interface documentation") | C binding
-517 | [hipblasZhprBatched](interfacehipfort__hipblas_1_1hipblaszhprbatched.html "Interface documentation") | C binding
-518 | [hipblasChprBatched_64](interfacehipfort__hipblas_1_1hipblaschprbatched__64.html "Interface documentation") | C binding
-519 | [hipblasZhprBatched_64](interfacehipfort__hipblas_1_1hipblaszhprbatched__64.html "Interface documentation") | C binding
-520 | [hipblasChprStridedBatched](interfacehipfort__hipblas_1_1hipblaschprstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-521 | [hipblasZhprStridedBatched](interfacehipfort__hipblas_1_1hipblaszhprstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-522 | [hipblasChprStridedBatched_64](interfacehipfort__hipblas_1_1hipblaschprstridedbatched__64.html "Interface documentation") | C binding
-523 | [hipblasZhprStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszhprstridedbatched__64.html "Interface documentation") | C binding
-524 | [hipblasChpr2](interfacehipfort__hipblas_1_1hipblaschpr2.html "Interface documentation") | C binding, rank_0, rank_1
-525 | [hipblasZhpr2](interfacehipfort__hipblas_1_1hipblaszhpr2.html "Interface documentation") | C binding, rank_0, rank_1
-526 | [hipblasChpr2_64](interfacehipfort__hipblas_1_1hipblaschpr2__64.html "Interface documentation") | C binding
-527 | [hipblasZhpr2_64](interfacehipfort__hipblas_1_1hipblaszhpr2__64.html "Interface documentation") | C binding
-528 | [hipblasChpr2Batched](interfacehipfort__hipblas_1_1hipblaschpr2batched.html "Interface documentation") | C binding
-529 | [hipblasZhpr2Batched](interfacehipfort__hipblas_1_1hipblaszhpr2batched.html "Interface documentation") | C binding
-530 | [hipblasChpr2Batched_64](interfacehipfort__hipblas_1_1hipblaschpr2batched__64.html "Interface documentation") | C binding
-531 | [hipblasZhpr2Batched_64](interfacehipfort__hipblas_1_1hipblaszhpr2batched__64.html "Interface documentation") | C binding
-532 | [hipblasChpr2StridedBatched](interfacehipfort__hipblas_1_1hipblaschpr2stridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-533 | [hipblasZhpr2StridedBatched](interfacehipfort__hipblas_1_1hipblaszhpr2stridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-534 | [hipblasChpr2StridedBatched_64](interfacehipfort__hipblas_1_1hipblaschpr2stridedbatched__64.html "Interface documentation") | C binding
-535 | [hipblasZhpr2StridedBatched_64](interfacehipfort__hipblas_1_1hipblaszhpr2stridedbatched__64.html "Interface documentation") | C binding
-536 | [hipblasSsbmv](interfacehipfort__hipblas_1_1hipblasssbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-537 | [hipblasDsbmv](interfacehipfort__hipblas_1_1hipblasdsbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-538 | [hipblasSsbmv_64](interfacehipfort__hipblas_1_1hipblasssbmv__64.html "Interface documentation") | C binding
-539 | [hipblasDsbmv_64](interfacehipfort__hipblas_1_1hipblasdsbmv__64.html "Interface documentation") | C binding
-540 | [hipblasSsbmvBatched](interfacehipfort__hipblas_1_1hipblasssbmvbatched.html "Interface documentation") | C binding
-541 | [hipblasDsbmvBatched](interfacehipfort__hipblas_1_1hipblasdsbmvbatched.html "Interface documentation") | C binding
-542 | [hipblasSsbmvBatched_64](interfacehipfort__hipblas_1_1hipblasssbmvbatched__64.html "Interface documentation") | C binding
-543 | [hipblasDsbmvBatched_64](interfacehipfort__hipblas_1_1hipblasdsbmvbatched__64.html "Interface documentation") | C binding
-544 | [hipblasSsbmvStridedBatched](interfacehipfort__hipblas_1_1hipblasssbmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-545 | [hipblasDsbmvStridedBatched](interfacehipfort__hipblas_1_1hipblasdsbmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-546 | [hipblasSsbmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasssbmvstridedbatched__64.html "Interface documentation") | C binding
-547 | [hipblasDsbmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdsbmvstridedbatched__64.html "Interface documentation") | C binding
-548 | [hipblasSspmv](interfacehipfort__hipblas_1_1hipblassspmv.html "Interface documentation") | C binding, rank_0, rank_1
-549 | [hipblasDspmv](interfacehipfort__hipblas_1_1hipblasdspmv.html "Interface documentation") | C binding, rank_0, rank_1
-550 | [hipblasSspmv_64](interfacehipfort__hipblas_1_1hipblassspmv__64.html "Interface documentation") | C binding
-551 | [hipblasDspmv_64](interfacehipfort__hipblas_1_1hipblasdspmv__64.html "Interface documentation") | C binding
-552 | [hipblasSspmvBatched](interfacehipfort__hipblas_1_1hipblassspmvbatched.html "Interface documentation") | C binding
-553 | [hipblasDspmvBatched](interfacehipfort__hipblas_1_1hipblasdspmvbatched.html "Interface documentation") | C binding
-554 | [hipblasSspmvBatched_64](interfacehipfort__hipblas_1_1hipblassspmvbatched__64.html "Interface documentation") | C binding
-555 | [hipblasDspmvBatched_64](interfacehipfort__hipblas_1_1hipblasdspmvbatched__64.html "Interface documentation") | C binding
-556 | [hipblasSspmvStridedBatched](interfacehipfort__hipblas_1_1hipblassspmvstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-557 | [hipblasDspmvStridedBatched](interfacehipfort__hipblas_1_1hipblasdspmvstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-558 | [hipblasSspmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblassspmvstridedbatched__64.html "Interface documentation") | C binding
-559 | [hipblasDspmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdspmvstridedbatched__64.html "Interface documentation") | C binding
-560 | [hipblasSspr](interfacehipfort__hipblas_1_1hipblassspr.html "Interface documentation") | C binding, rank_0, rank_1
-561 | [hipblasDspr](interfacehipfort__hipblas_1_1hipblasdspr.html "Interface documentation") | C binding, rank_0, rank_1
-562 | [hipblasCspr](interfacehipfort__hipblas_1_1hipblascspr.html "Interface documentation") | C binding, rank_0, rank_1
-563 | [hipblasZspr](interfacehipfort__hipblas_1_1hipblaszspr.html "Interface documentation") | C binding, rank_0, rank_1
-564 | [hipblasSspr_64](interfacehipfort__hipblas_1_1hipblassspr__64.html "Interface documentation") | C binding
-565 | [hipblasDspr_64](interfacehipfort__hipblas_1_1hipblasdspr__64.html "Interface documentation") | C binding
-566 | [hipblasCspr_64](interfacehipfort__hipblas_1_1hipblascspr__64.html "Interface documentation") | C binding
-567 | [hipblasZspr_64](interfacehipfort__hipblas_1_1hipblaszspr__64.html "Interface documentation") | C binding
-568 | [hipblasSsprBatched](interfacehipfort__hipblas_1_1hipblasssprbatched.html "Interface documentation") | C binding
-569 | [hipblasDsprBatched](interfacehipfort__hipblas_1_1hipblasdsprbatched.html "Interface documentation") | C binding
-570 | [hipblasCsprBatched](interfacehipfort__hipblas_1_1hipblascsprbatched.html "Interface documentation") | C binding
-571 | [hipblasZsprBatched](interfacehipfort__hipblas_1_1hipblaszsprbatched.html "Interface documentation") | C binding
-572 | [hipblasSsprBatched_64](interfacehipfort__hipblas_1_1hipblasssprbatched__64.html "Interface documentation") | C binding
-573 | [hipblasDsprBatched_64](interfacehipfort__hipblas_1_1hipblasdsprbatched__64.html "Interface documentation") | C binding
-574 | [hipblasCsprBatched_64](interfacehipfort__hipblas_1_1hipblascsprbatched__64.html "Interface documentation") | C binding
-575 | [hipblasZsprBatched_64](interfacehipfort__hipblas_1_1hipblaszsprbatched__64.html "Interface documentation") | C binding
-576 | [hipblasSsprStridedBatched](interfacehipfort__hipblas_1_1hipblasssprstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-577 | [hipblasDsprStridedBatched](interfacehipfort__hipblas_1_1hipblasdsprstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-578 | [hipblasCsprStridedBatched](interfacehipfort__hipblas_1_1hipblascsprstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-579 | [hipblasZsprStridedBatched](interfacehipfort__hipblas_1_1hipblaszsprstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-580 | [hipblasSsprStridedBatched_64](interfacehipfort__hipblas_1_1hipblasssprstridedbatched__64.html "Interface documentation") | C binding
-581 | [hipblasDsprStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdsprstridedbatched__64.html "Interface documentation") | C binding
-582 | [hipblasCsprStridedBatched_64](interfacehipfort__hipblas_1_1hipblascsprstridedbatched__64.html "Interface documentation") | C binding
-583 | [hipblasZsprStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszsprstridedbatched__64.html "Interface documentation") | C binding
-584 | [hipblasSspr2](interfacehipfort__hipblas_1_1hipblassspr2.html "Interface documentation") | C binding, rank_0, rank_1
-585 | [hipblasDspr2](interfacehipfort__hipblas_1_1hipblasdspr2.html "Interface documentation") | C binding, rank_0, rank_1
-586 | [hipblasSspr2_64](interfacehipfort__hipblas_1_1hipblassspr2__64.html "Interface documentation") | C binding
-587 | [hipblasDspr2_64](interfacehipfort__hipblas_1_1hipblasdspr2__64.html "Interface documentation") | C binding
-588 | [hipblasSspr2Batched](interfacehipfort__hipblas_1_1hipblassspr2batched.html "Interface documentation") | C binding
-589 | [hipblasDspr2Batched](interfacehipfort__hipblas_1_1hipblasdspr2batched.html "Interface documentation") | C binding
-590 | [hipblasSspr2Batched_64](interfacehipfort__hipblas_1_1hipblassspr2batched__64.html "Interface documentation") | C binding
-591 | [hipblasDspr2Batched_64](interfacehipfort__hipblas_1_1hipblasdspr2batched__64.html "Interface documentation") | C binding
-592 | [hipblasSspr2StridedBatched](interfacehipfort__hipblas_1_1hipblassspr2stridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-593 | [hipblasDspr2StridedBatched](interfacehipfort__hipblas_1_1hipblasdspr2stridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-594 | [hipblasSspr2StridedBatched_64](interfacehipfort__hipblas_1_1hipblassspr2stridedbatched__64.html "Interface documentation") | C binding
-595 | [hipblasDspr2StridedBatched_64](interfacehipfort__hipblas_1_1hipblasdspr2stridedbatched__64.html "Interface documentation") | C binding
-596 | [hipblasSsymv](interfacehipfort__hipblas_1_1hipblasssymv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-597 | [hipblasDsymv](interfacehipfort__hipblas_1_1hipblasdsymv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-598 | [hipblasCsymv](interfacehipfort__hipblas_1_1hipblascsymv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-599 | [hipblasZsymv](interfacehipfort__hipblas_1_1hipblaszsymv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-600 | [hipblasSsymv_64](interfacehipfort__hipblas_1_1hipblasssymv__64.html "Interface documentation") | C binding
-601 | [hipblasDsymv_64](interfacehipfort__hipblas_1_1hipblasdsymv__64.html "Interface documentation") | C binding
-602 | [hipblasCsymv_64](interfacehipfort__hipblas_1_1hipblascsymv__64.html "Interface documentation") | C binding
-603 | [hipblasZsymv_64](interfacehipfort__hipblas_1_1hipblaszsymv__64.html "Interface documentation") | C binding
-604 | [hipblasSsymvBatched](interfacehipfort__hipblas_1_1hipblasssymvbatched.html "Interface documentation") | C binding
-605 | [hipblasDsymvBatched](interfacehipfort__hipblas_1_1hipblasdsymvbatched.html "Interface documentation") | C binding
-606 | [hipblasCsymvBatched](interfacehipfort__hipblas_1_1hipblascsymvbatched.html "Interface documentation") | C binding
-607 | [hipblasZsymvBatched](interfacehipfort__hipblas_1_1hipblaszsymvbatched.html "Interface documentation") | C binding
-608 | [hipblasSsymvBatched_64](interfacehipfort__hipblas_1_1hipblasssymvbatched__64.html "Interface documentation") | C binding
-609 | [hipblasDsymvBatched_64](interfacehipfort__hipblas_1_1hipblasdsymvbatched__64.html "Interface documentation") | C binding
-610 | [hipblasCsymvBatched_64](interfacehipfort__hipblas_1_1hipblascsymvbatched__64.html "Interface documentation") | C binding
-611 | [hipblasZsymvBatched_64](interfacehipfort__hipblas_1_1hipblaszsymvbatched__64.html "Interface documentation") | C binding
-612 | [hipblasSsymvStridedBatched](interfacehipfort__hipblas_1_1hipblasssymvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-613 | [hipblasDsymvStridedBatched](interfacehipfort__hipblas_1_1hipblasdsymvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-614 | [hipblasCsymvStridedBatched](interfacehipfort__hipblas_1_1hipblascsymvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-615 | [hipblasZsymvStridedBatched](interfacehipfort__hipblas_1_1hipblaszsymvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-616 | [hipblasSsymvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasssymvstridedbatched__64.html "Interface documentation") | C binding
-617 | [hipblasDsymvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdsymvstridedbatched__64.html "Interface documentation") | C binding
-618 | [hipblasCsymvStridedBatched_64](interfacehipfort__hipblas_1_1hipblascsymvstridedbatched__64.html "Interface documentation") | C binding
-619 | [hipblasZsymvStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszsymvstridedbatched__64.html "Interface documentation") | C binding
-620 | [hipblasSsyr](interfacehipfort__hipblas_1_1hipblasssyr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-621 | [hipblasDsyr](interfacehipfort__hipblas_1_1hipblasdsyr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-622 | [hipblasCsyr](interfacehipfort__hipblas_1_1hipblascsyr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-623 | [hipblasZsyr](interfacehipfort__hipblas_1_1hipblaszsyr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-624 | [hipblasSsyr_64](interfacehipfort__hipblas_1_1hipblasssyr__64.html "Interface documentation") | C binding
-625 | [hipblasDsyr_64](interfacehipfort__hipblas_1_1hipblasdsyr__64.html "Interface documentation") | C binding
-626 | [hipblasCsyr_64](interfacehipfort__hipblas_1_1hipblascsyr__64.html "Interface documentation") | C binding
-627 | [hipblasZsyr_64](interfacehipfort__hipblas_1_1hipblaszsyr__64.html "Interface documentation") | C binding
-628 | [hipblasSsyrBatched](interfacehipfort__hipblas_1_1hipblasssyrbatched.html "Interface documentation") | C binding
-629 | [hipblasDsyrBatched](interfacehipfort__hipblas_1_1hipblasdsyrbatched.html "Interface documentation") | C binding
-630 | [hipblasCsyrBatched](interfacehipfort__hipblas_1_1hipblascsyrbatched.html "Interface documentation") | C binding
-631 | [hipblasZsyrBatched](interfacehipfort__hipblas_1_1hipblaszsyrbatched.html "Interface documentation") | C binding
-632 | [hipblasSsyrBatched_64](interfacehipfort__hipblas_1_1hipblasssyrbatched__64.html "Interface documentation") | C binding
-633 | [hipblasDsyrBatched_64](interfacehipfort__hipblas_1_1hipblasdsyrbatched__64.html "Interface documentation") | C binding
-634 | [hipblasCsyrBatched_64](interfacehipfort__hipblas_1_1hipblascsyrbatched__64.html "Interface documentation") | C binding
-635 | [hipblasZsyrBatched_64](interfacehipfort__hipblas_1_1hipblaszsyrbatched__64.html "Interface documentation") | C binding
-636 | [hipblasSsyrStridedBatched](interfacehipfort__hipblas_1_1hipblasssyrstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-637 | [hipblasDsyrStridedBatched](interfacehipfort__hipblas_1_1hipblasdsyrstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-638 | [hipblasCsyrStridedBatched](interfacehipfort__hipblas_1_1hipblascsyrstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-639 | [hipblasZsyrStridedBatched](interfacehipfort__hipblas_1_1hipblaszsyrstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-640 | [hipblasSsyrStridedBatched_64](interfacehipfort__hipblas_1_1hipblasssyrstridedbatched__64.html "Interface documentation") | C binding
-641 | [hipblasDsyrStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdsyrstridedbatched__64.html "Interface documentation") | C binding
-642 | [hipblasCsyrStridedBatched_64](interfacehipfort__hipblas_1_1hipblascsyrstridedbatched__64.html "Interface documentation") | C binding
-643 | [hipblasZsyrStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszsyrstridedbatched__64.html "Interface documentation") | C binding
-644 | [hipblasSsyr2](interfacehipfort__hipblas_1_1hipblasssyr2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-645 | [hipblasDsyr2](interfacehipfort__hipblas_1_1hipblasdsyr2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-646 | [hipblasCsyr2](interfacehipfort__hipblas_1_1hipblascsyr2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-647 | [hipblasZsyr2](interfacehipfort__hipblas_1_1hipblaszsyr2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-648 | [hipblasSsyr2_64](interfacehipfort__hipblas_1_1hipblasssyr2__64.html "Interface documentation") | C binding
-649 | [hipblasDsyr2_64](interfacehipfort__hipblas_1_1hipblasdsyr2__64.html "Interface documentation") | C binding
-650 | [hipblasCsyr2_64](interfacehipfort__hipblas_1_1hipblascsyr2__64.html "Interface documentation") | C binding
-651 | [hipblasZsyr2_64](interfacehipfort__hipblas_1_1hipblaszsyr2__64.html "Interface documentation") | C binding
-652 | [hipblasSsyr2Batched](interfacehipfort__hipblas_1_1hipblasssyr2batched.html "Interface documentation") | C binding
-653 | [hipblasDsyr2Batched](interfacehipfort__hipblas_1_1hipblasdsyr2batched.html "Interface documentation") | C binding
-654 | [hipblasCsyr2Batched](interfacehipfort__hipblas_1_1hipblascsyr2batched.html "Interface documentation") | C binding
-655 | [hipblasZsyr2Batched](interfacehipfort__hipblas_1_1hipblaszsyr2batched.html "Interface documentation") | C binding
-656 | [hipblasSsyr2Batched_64](interfacehipfort__hipblas_1_1hipblasssyr2batched__64.html "Interface documentation") | C binding
-657 | [hipblasDsyr2Batched_64](interfacehipfort__hipblas_1_1hipblasdsyr2batched__64.html "Interface documentation") | C binding
-658 | [hipblasCsyr2Batched_64](interfacehipfort__hipblas_1_1hipblascsyr2batched__64.html "Interface documentation") | C binding
-659 | [hipblasZsyr2Batched_64](interfacehipfort__hipblas_1_1hipblaszsyr2batched__64.html "Interface documentation") | C binding
-660 | [hipblasSsyr2StridedBatched](interfacehipfort__hipblas_1_1hipblasssyr2stridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-661 | [hipblasDsyr2StridedBatched](interfacehipfort__hipblas_1_1hipblasdsyr2stridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-662 | [hipblasCsyr2StridedBatched](interfacehipfort__hipblas_1_1hipblascsyr2stridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-663 | [hipblasZsyr2StridedBatched](interfacehipfort__hipblas_1_1hipblaszsyr2stridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-664 | [hipblasSsyr2StridedBatched_64](interfacehipfort__hipblas_1_1hipblasssyr2stridedbatched__64.html "Interface documentation") | C binding
-665 | [hipblasDsyr2StridedBatched_64](interfacehipfort__hipblas_1_1hipblasdsyr2stridedbatched__64.html "Interface documentation") | C binding
-666 | [hipblasCsyr2StridedBatched_64](interfacehipfort__hipblas_1_1hipblascsyr2stridedbatched__64.html "Interface documentation") | C binding
-667 | [hipblasZsyr2StridedBatched_64](interfacehipfort__hipblas_1_1hipblaszsyr2stridedbatched__64.html "Interface documentation") | C binding
-668 | [hipblasStbmv](interfacehipfort__hipblas_1_1hipblasstbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-669 | [hipblasDtbmv](interfacehipfort__hipblas_1_1hipblasdtbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-670 | [hipblasCtbmv](interfacehipfort__hipblas_1_1hipblasctbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-671 | [hipblasZtbmv](interfacehipfort__hipblas_1_1hipblasztbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-672 | [hipblasStbmv_64](interfacehipfort__hipblas_1_1hipblasstbmv__64.html "Interface documentation") | C binding
-673 | [hipblasDtbmv_64](interfacehipfort__hipblas_1_1hipblasdtbmv__64.html "Interface documentation") | C binding
-674 | [hipblasCtbmv_64](interfacehipfort__hipblas_1_1hipblasctbmv__64.html "Interface documentation") | C binding
-675 | [hipblasZtbmv_64](interfacehipfort__hipblas_1_1hipblasztbmv__64.html "Interface documentation") | C binding
-676 | [hipblasStbmvBatched](interfacehipfort__hipblas_1_1hipblasstbmvbatched.html "Interface documentation") | C binding
-677 | [hipblasDtbmvBatched](interfacehipfort__hipblas_1_1hipblasdtbmvbatched.html "Interface documentation") | C binding
-678 | [hipblasCtbmvBatched](interfacehipfort__hipblas_1_1hipblasctbmvbatched.html "Interface documentation") | C binding
-679 | [hipblasZtbmvBatched](interfacehipfort__hipblas_1_1hipblasztbmvbatched.html "Interface documentation") | C binding
-680 | [hipblasStbmvBatched_64](interfacehipfort__hipblas_1_1hipblasstbmvbatched__64.html "Interface documentation") | C binding
-681 | [hipblasDtbmvBatched_64](interfacehipfort__hipblas_1_1hipblasdtbmvbatched__64.html "Interface documentation") | C binding
-682 | [hipblasCtbmvBatched_64](interfacehipfort__hipblas_1_1hipblasctbmvbatched__64.html "Interface documentation") | C binding
-683 | [hipblasZtbmvBatched_64](interfacehipfort__hipblas_1_1hipblasztbmvbatched__64.html "Interface documentation") | C binding
-684 | [hipblasStbmvStridedBatched](interfacehipfort__hipblas_1_1hipblasstbmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-685 | [hipblasDtbmvStridedBatched](interfacehipfort__hipblas_1_1hipblasdtbmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-686 | [hipblasCtbmvStridedBatched](interfacehipfort__hipblas_1_1hipblasctbmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-687 | [hipblasZtbmvStridedBatched](interfacehipfort__hipblas_1_1hipblasztbmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-688 | [hipblasStbmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasstbmvstridedbatched__64.html "Interface documentation") | C binding
-689 | [hipblasDtbmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdtbmvstridedbatched__64.html "Interface documentation") | C binding
-690 | [hipblasCtbmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasctbmvstridedbatched__64.html "Interface documentation") | C binding
-691 | [hipblasZtbmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasztbmvstridedbatched__64.html "Interface documentation") | C binding
-692 | [hipblasStbsv](interfacehipfort__hipblas_1_1hipblasstbsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-693 | [hipblasDtbsv](interfacehipfort__hipblas_1_1hipblasdtbsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-694 | [hipblasCtbsv](interfacehipfort__hipblas_1_1hipblasctbsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-695 | [hipblasZtbsv](interfacehipfort__hipblas_1_1hipblasztbsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-696 | [hipblasStbsv_64](interfacehipfort__hipblas_1_1hipblasstbsv__64.html "Interface documentation") | C binding
-697 | [hipblasDtbsv_64](interfacehipfort__hipblas_1_1hipblasdtbsv__64.html "Interface documentation") | C binding
-698 | [hipblasCtbsv_64](interfacehipfort__hipblas_1_1hipblasctbsv__64.html "Interface documentation") | C binding
-699 | [hipblasZtbsv_64](interfacehipfort__hipblas_1_1hipblasztbsv__64.html "Interface documentation") | C binding
-700 | [hipblasStbsvBatched](interfacehipfort__hipblas_1_1hipblasstbsvbatched.html "Interface documentation") | C binding
-701 | [hipblasDtbsvBatched](interfacehipfort__hipblas_1_1hipblasdtbsvbatched.html "Interface documentation") | C binding
-702 | [hipblasCtbsvBatched](interfacehipfort__hipblas_1_1hipblasctbsvbatched.html "Interface documentation") | C binding
-703 | [hipblasZtbsvBatched](interfacehipfort__hipblas_1_1hipblasztbsvbatched.html "Interface documentation") | C binding
-704 | [hipblasStbsvBatched_64](interfacehipfort__hipblas_1_1hipblasstbsvbatched__64.html "Interface documentation") | C binding
-705 | [hipblasDtbsvBatched_64](interfacehipfort__hipblas_1_1hipblasdtbsvbatched__64.html "Interface documentation") | C binding
-706 | [hipblasCtbsvBatched_64](interfacehipfort__hipblas_1_1hipblasctbsvbatched__64.html "Interface documentation") | C binding
-707 | [hipblasZtbsvBatched_64](interfacehipfort__hipblas_1_1hipblasztbsvbatched__64.html "Interface documentation") | C binding
-708 | [hipblasStbsvStridedBatched](interfacehipfort__hipblas_1_1hipblasstbsvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-709 | [hipblasDtbsvStridedBatched](interfacehipfort__hipblas_1_1hipblasdtbsvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-710 | [hipblasCtbsvStridedBatched](interfacehipfort__hipblas_1_1hipblasctbsvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-711 | [hipblasZtbsvStridedBatched](interfacehipfort__hipblas_1_1hipblasztbsvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-712 | [hipblasStbsvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasstbsvstridedbatched__64.html "Interface documentation") | C binding
-713 | [hipblasDtbsvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdtbsvstridedbatched__64.html "Interface documentation") | C binding
-714 | [hipblasCtbsvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasctbsvstridedbatched__64.html "Interface documentation") | C binding
-715 | [hipblasZtbsvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasztbsvstridedbatched__64.html "Interface documentation") | C binding
-716 | [hipblasStpmv](interfacehipfort__hipblas_1_1hipblasstpmv.html "Interface documentation") | C binding, rank_0, rank_1
-717 | [hipblasDtpmv](interfacehipfort__hipblas_1_1hipblasdtpmv.html "Interface documentation") | C binding, rank_0, rank_1
-718 | [hipblasCtpmv](interfacehipfort__hipblas_1_1hipblasctpmv.html "Interface documentation") | C binding, rank_0, rank_1
-719 | [hipblasZtpmv](interfacehipfort__hipblas_1_1hipblasztpmv.html "Interface documentation") | C binding, rank_0, rank_1
-720 | [hipblasStpmv_64](interfacehipfort__hipblas_1_1hipblasstpmv__64.html "Interface documentation") | C binding
-721 | [hipblasDtpmv_64](interfacehipfort__hipblas_1_1hipblasdtpmv__64.html "Interface documentation") | C binding
-722 | [hipblasCtpmv_64](interfacehipfort__hipblas_1_1hipblasctpmv__64.html "Interface documentation") | C binding
-723 | [hipblasZtpmv_64](interfacehipfort__hipblas_1_1hipblasztpmv__64.html "Interface documentation") | C binding
-724 | [hipblasStpmvBatched](interfacehipfort__hipblas_1_1hipblasstpmvbatched.html "Interface documentation") | C binding
-725 | [hipblasDtpmvBatched](interfacehipfort__hipblas_1_1hipblasdtpmvbatched.html "Interface documentation") | C binding
-726 | [hipblasCtpmvBatched](interfacehipfort__hipblas_1_1hipblasctpmvbatched.html "Interface documentation") | C binding
-727 | [hipblasZtpmvBatched](interfacehipfort__hipblas_1_1hipblasztpmvbatched.html "Interface documentation") | C binding
-728 | [hipblasStpmvBatched_64](interfacehipfort__hipblas_1_1hipblasstpmvbatched__64.html "Interface documentation") | C binding
-729 | [hipblasDtpmvBatched_64](interfacehipfort__hipblas_1_1hipblasdtpmvbatched__64.html "Interface documentation") | C binding
-730 | [hipblasCtpmvBatched_64](interfacehipfort__hipblas_1_1hipblasctpmvbatched__64.html "Interface documentation") | C binding
-731 | [hipblasZtpmvBatched_64](interfacehipfort__hipblas_1_1hipblasztpmvbatched__64.html "Interface documentation") | C binding
-732 | [hipblasStpmvStridedBatched](interfacehipfort__hipblas_1_1hipblasstpmvstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-733 | [hipblasDtpmvStridedBatched](interfacehipfort__hipblas_1_1hipblasdtpmvstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-734 | [hipblasCtpmvStridedBatched](interfacehipfort__hipblas_1_1hipblasctpmvstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-735 | [hipblasZtpmvStridedBatched](interfacehipfort__hipblas_1_1hipblasztpmvstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-736 | [hipblasStpmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasstpmvstridedbatched__64.html "Interface documentation") | C binding
-737 | [hipblasDtpmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdtpmvstridedbatched__64.html "Interface documentation") | C binding
-738 | [hipblasCtpmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasctpmvstridedbatched__64.html "Interface documentation") | C binding
-739 | [hipblasZtpmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasztpmvstridedbatched__64.html "Interface documentation") | C binding
-740 | [hipblasStpsv](interfacehipfort__hipblas_1_1hipblasstpsv.html "Interface documentation") | C binding, rank_0, rank_1
-741 | [hipblasDtpsv](interfacehipfort__hipblas_1_1hipblasdtpsv.html "Interface documentation") | C binding, rank_0, rank_1
-742 | [hipblasCtpsv](interfacehipfort__hipblas_1_1hipblasctpsv.html "Interface documentation") | C binding, rank_0, rank_1
-743 | [hipblasZtpsv](interfacehipfort__hipblas_1_1hipblasztpsv.html "Interface documentation") | C binding, rank_0, rank_1
-744 | [hipblasStpsv_64](interfacehipfort__hipblas_1_1hipblasstpsv__64.html "Interface documentation") | C binding
-745 | [hipblasDtpsv_64](interfacehipfort__hipblas_1_1hipblasdtpsv__64.html "Interface documentation") | C binding
-746 | [hipblasCtpsv_64](interfacehipfort__hipblas_1_1hipblasctpsv__64.html "Interface documentation") | C binding
-747 | [hipblasZtpsv_64](interfacehipfort__hipblas_1_1hipblasztpsv__64.html "Interface documentation") | C binding
-748 | [hipblasStpsvBatched](interfacehipfort__hipblas_1_1hipblasstpsvbatched.html "Interface documentation") | C binding
-749 | [hipblasDtpsvBatched](interfacehipfort__hipblas_1_1hipblasdtpsvbatched.html "Interface documentation") | C binding
-750 | [hipblasCtpsvBatched](interfacehipfort__hipblas_1_1hipblasctpsvbatched.html "Interface documentation") | C binding
-751 | [hipblasZtpsvBatched](interfacehipfort__hipblas_1_1hipblasztpsvbatched.html "Interface documentation") | C binding
-752 | [hipblasStpsvBatched_64](interfacehipfort__hipblas_1_1hipblasstpsvbatched__64.html "Interface documentation") | C binding
-753 | [hipblasDtpsvBatched_64](interfacehipfort__hipblas_1_1hipblasdtpsvbatched__64.html "Interface documentation") | C binding
-754 | [hipblasCtpsvBatched_64](interfacehipfort__hipblas_1_1hipblasctpsvbatched__64.html "Interface documentation") | C binding
-755 | [hipblasZtpsvBatched_64](interfacehipfort__hipblas_1_1hipblasztpsvbatched__64.html "Interface documentation") | C binding
-756 | [hipblasStpsvStridedBatched](interfacehipfort__hipblas_1_1hipblasstpsvstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-757 | [hipblasDtpsvStridedBatched](interfacehipfort__hipblas_1_1hipblasdtpsvstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-758 | [hipblasCtpsvStridedBatched](interfacehipfort__hipblas_1_1hipblasctpsvstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-759 | [hipblasZtpsvStridedBatched](interfacehipfort__hipblas_1_1hipblasztpsvstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-760 | [hipblasStpsvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasstpsvstridedbatched__64.html "Interface documentation") | C binding
-761 | [hipblasDtpsvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdtpsvstridedbatched__64.html "Interface documentation") | C binding
-762 | [hipblasCtpsvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasctpsvstridedbatched__64.html "Interface documentation") | C binding
-763 | [hipblasZtpsvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasztpsvstridedbatched__64.html "Interface documentation") | C binding
-764 | [hipblasStrmv](interfacehipfort__hipblas_1_1hipblasstrmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-765 | [hipblasDtrmv](interfacehipfort__hipblas_1_1hipblasdtrmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-766 | [hipblasCtrmv](interfacehipfort__hipblas_1_1hipblasctrmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-767 | [hipblasZtrmv](interfacehipfort__hipblas_1_1hipblasztrmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-768 | [hipblasStrmv_64](interfacehipfort__hipblas_1_1hipblasstrmv__64.html "Interface documentation") | C binding
-769 | [hipblasDtrmv_64](interfacehipfort__hipblas_1_1hipblasdtrmv__64.html "Interface documentation") | C binding
-770 | [hipblasCtrmv_64](interfacehipfort__hipblas_1_1hipblasctrmv__64.html "Interface documentation") | C binding
-771 | [hipblasZtrmv_64](interfacehipfort__hipblas_1_1hipblasztrmv__64.html "Interface documentation") | C binding
-772 | [hipblasStrmvBatched](interfacehipfort__hipblas_1_1hipblasstrmvbatched.html "Interface documentation") | C binding
-773 | [hipblasDtrmvBatched](interfacehipfort__hipblas_1_1hipblasdtrmvbatched.html "Interface documentation") | C binding
-774 | [hipblasCtrmvBatched](interfacehipfort__hipblas_1_1hipblasctrmvbatched.html "Interface documentation") | C binding
-775 | [hipblasZtrmvBatched](interfacehipfort__hipblas_1_1hipblasztrmvbatched.html "Interface documentation") | C binding
-776 | [hipblasStrmvBatched_64](interfacehipfort__hipblas_1_1hipblasstrmvbatched__64.html "Interface documentation") | C binding
-777 | [hipblasDtrmvBatched_64](interfacehipfort__hipblas_1_1hipblasdtrmvbatched__64.html "Interface documentation") | C binding
-778 | [hipblasCtrmvBatched_64](interfacehipfort__hipblas_1_1hipblasctrmvbatched__64.html "Interface documentation") | C binding
-779 | [hipblasZtrmvBatched_64](interfacehipfort__hipblas_1_1hipblasztrmvbatched__64.html "Interface documentation") | C binding
-780 | [hipblasStrmvStridedBatched](interfacehipfort__hipblas_1_1hipblasstrmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-781 | [hipblasDtrmvStridedBatched](interfacehipfort__hipblas_1_1hipblasdtrmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-782 | [hipblasCtrmvStridedBatched](interfacehipfort__hipblas_1_1hipblasctrmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-783 | [hipblasZtrmvStridedBatched](interfacehipfort__hipblas_1_1hipblasztrmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-784 | [hipblasStrmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasstrmvstridedbatched__64.html "Interface documentation") | C binding
-785 | [hipblasDtrmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdtrmvstridedbatched__64.html "Interface documentation") | C binding
-786 | [hipblasCtrmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasctrmvstridedbatched__64.html "Interface documentation") | C binding
-787 | [hipblasZtrmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasztrmvstridedbatched__64.html "Interface documentation") | C binding
-788 | [hipblasStrsv](interfacehipfort__hipblas_1_1hipblasstrsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-789 | [hipblasDtrsv](interfacehipfort__hipblas_1_1hipblasdtrsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-790 | [hipblasCtrsv](interfacehipfort__hipblas_1_1hipblasctrsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-791 | [hipblasZtrsv](interfacehipfort__hipblas_1_1hipblasztrsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-792 | [hipblasStrsv_64](interfacehipfort__hipblas_1_1hipblasstrsv__64.html "Interface documentation") | C binding
-793 | [hipblasDtrsv_64](interfacehipfort__hipblas_1_1hipblasdtrsv__64.html "Interface documentation") | C binding
-794 | [hipblasCtrsv_64](interfacehipfort__hipblas_1_1hipblasctrsv__64.html "Interface documentation") | C binding
-795 | [hipblasZtrsv_64](interfacehipfort__hipblas_1_1hipblasztrsv__64.html "Interface documentation") | C binding
-796 | [hipblasStrsvBatched](interfacehipfort__hipblas_1_1hipblasstrsvbatched.html "Interface documentation") | C binding
-797 | [hipblasDtrsvBatched](interfacehipfort__hipblas_1_1hipblasdtrsvbatched.html "Interface documentation") | C binding
-798 | [hipblasCtrsvBatched](interfacehipfort__hipblas_1_1hipblasctrsvbatched.html "Interface documentation") | C binding
-799 | [hipblasZtrsvBatched](interfacehipfort__hipblas_1_1hipblasztrsvbatched.html "Interface documentation") | C binding
-800 | [hipblasStrsvBatched_64](interfacehipfort__hipblas_1_1hipblasstrsvbatched__64.html "Interface documentation") | C binding
-801 | [hipblasDtrsvBatched_64](interfacehipfort__hipblas_1_1hipblasdtrsvbatched__64.html "Interface documentation") | C binding
-802 | [hipblasCtrsvBatched_64](interfacehipfort__hipblas_1_1hipblasctrsvbatched__64.html "Interface documentation") | C binding
-803 | [hipblasZtrsvBatched_64](interfacehipfort__hipblas_1_1hipblasztrsvbatched__64.html "Interface documentation") | C binding
-804 | [hipblasStrsvStridedBatched](interfacehipfort__hipblas_1_1hipblasstrsvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-805 | [hipblasDtrsvStridedBatched](interfacehipfort__hipblas_1_1hipblasdtrsvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-806 | [hipblasCtrsvStridedBatched](interfacehipfort__hipblas_1_1hipblasctrsvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-807 | [hipblasZtrsvStridedBatched](interfacehipfort__hipblas_1_1hipblasztrsvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-808 | [hipblasStrsvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasstrsvstridedbatched__64.html "Interface documentation") | C binding
-809 | [hipblasDtrsvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdtrsvstridedbatched__64.html "Interface documentation") | C binding
-810 | [hipblasCtrsvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasctrsvstridedbatched__64.html "Interface documentation") | C binding
-811 | [hipblasZtrsvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasztrsvstridedbatched__64.html "Interface documentation") | C binding
-812 | [hipblasHgemm](interfacehipfort__hipblas_1_1hipblashgemm.html "Interface documentation") | C binding
-813 | [hipblasSgemm](interfacehipfort__hipblas_1_1hipblassgemm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-814 | [hipblasDgemm](interfacehipfort__hipblas_1_1hipblasdgemm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-815 | [hipblasCgemm](interfacehipfort__hipblas_1_1hipblascgemm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-816 | [hipblasZgemm](interfacehipfort__hipblas_1_1hipblaszgemm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-817 | [hipblasHgemm_64](interfacehipfort__hipblas_1_1hipblashgemm__64.html "Interface documentation") | C binding
-818 | [hipblasSgemm_64](interfacehipfort__hipblas_1_1hipblassgemm__64.html "Interface documentation") | C binding
-819 | [hipblasDgemm_64](interfacehipfort__hipblas_1_1hipblasdgemm__64.html "Interface documentation") | C binding
-820 | [hipblasCgemm_64](interfacehipfort__hipblas_1_1hipblascgemm__64.html "Interface documentation") | C binding
-821 | [hipblasZgemm_64](interfacehipfort__hipblas_1_1hipblaszgemm__64.html "Interface documentation") | C binding
-822 | [hipblasHgemmBatched](interfacehipfort__hipblas_1_1hipblashgemmbatched.html "Interface documentation") | C binding
-823 | [hipblasSgemmBatched](interfacehipfort__hipblas_1_1hipblassgemmbatched.html "Interface documentation") | C binding
-824 | [hipblasDgemmBatched](interfacehipfort__hipblas_1_1hipblasdgemmbatched.html "Interface documentation") | C binding
-825 | [hipblasCgemmBatched](interfacehipfort__hipblas_1_1hipblascgemmbatched.html "Interface documentation") | C binding
-826 | [hipblasZgemmBatched](interfacehipfort__hipblas_1_1hipblaszgemmbatched.html "Interface documentation") | C binding
-827 | [hipblasHgemmBatched_64](interfacehipfort__hipblas_1_1hipblashgemmbatched__64.html "Interface documentation") | C binding
-828 | [hipblasSgemmBatched_64](interfacehipfort__hipblas_1_1hipblassgemmbatched__64.html "Interface documentation") | C binding
-829 | [hipblasDgemmBatched_64](interfacehipfort__hipblas_1_1hipblasdgemmbatched__64.html "Interface documentation") | C binding
-830 | [hipblasCgemmBatched_64](interfacehipfort__hipblas_1_1hipblascgemmbatched__64.html "Interface documentation") | C binding
-831 | [hipblasZgemmBatched_64](interfacehipfort__hipblas_1_1hipblaszgemmbatched__64.html "Interface documentation") | C binding
-832 | [hipblasHgemmStridedBatched](interfacehipfort__hipblas_1_1hipblashgemmstridedbatched.html "Interface documentation") | C binding
-833 | [hipblasSgemmStridedBatched](interfacehipfort__hipblas_1_1hipblassgemmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-834 | [hipblasDgemmStridedBatched](interfacehipfort__hipblas_1_1hipblasdgemmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-835 | [hipblasCgemmStridedBatched](interfacehipfort__hipblas_1_1hipblascgemmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-836 | [hipblasZgemmStridedBatched](interfacehipfort__hipblas_1_1hipblaszgemmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-837 | [hipblasHgemmStridedBatched_64](interfacehipfort__hipblas_1_1hipblashgemmstridedbatched__64.html "Interface documentation") | C binding
-838 | [hipblasSgemmStridedBatched_64](interfacehipfort__hipblas_1_1hipblassgemmstridedbatched__64.html "Interface documentation") | C binding
-839 | [hipblasDgemmStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdgemmstridedbatched__64.html "Interface documentation") | C binding
-840 | [hipblasCgemmStridedBatched_64](interfacehipfort__hipblas_1_1hipblascgemmstridedbatched__64.html "Interface documentation") | C binding
-841 | [hipblasZgemmStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszgemmstridedbatched__64.html "Interface documentation") | C binding
-842 | [hipblasCherk](interfacehipfort__hipblas_1_1hipblascherk.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-843 | [hipblasZherk](interfacehipfort__hipblas_1_1hipblaszherk.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-844 | [hipblasCherk_64](interfacehipfort__hipblas_1_1hipblascherk__64.html "Interface documentation") | C binding
-845 | [hipblasZherk_64](interfacehipfort__hipblas_1_1hipblaszherk__64.html "Interface documentation") | C binding
-846 | [hipblasCherkBatched](interfacehipfort__hipblas_1_1hipblascherkbatched.html "Interface documentation") | C binding
-847 | [hipblasZherkBatched](interfacehipfort__hipblas_1_1hipblaszherkbatched.html "Interface documentation") | C binding
-848 | [hipblasCherkBatched_64](interfacehipfort__hipblas_1_1hipblascherkbatched__64.html "Interface documentation") | C binding
-849 | [hipblasZherkBatched_64](interfacehipfort__hipblas_1_1hipblaszherkbatched__64.html "Interface documentation") | C binding
-850 | [hipblasCherkStridedBatched](interfacehipfort__hipblas_1_1hipblascherkstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-851 | [hipblasZherkStridedBatched](interfacehipfort__hipblas_1_1hipblaszherkstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-852 | [hipblasCherkStridedBatched_64](interfacehipfort__hipblas_1_1hipblascherkstridedbatched__64.html "Interface documentation") | C binding
-853 | [hipblasZherkStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszherkstridedbatched__64.html "Interface documentation") | C binding
-854 | [hipblasCherkx](interfacehipfort__hipblas_1_1hipblascherkx.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-855 | [hipblasZherkx](interfacehipfort__hipblas_1_1hipblaszherkx.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-856 | [hipblasCherkx_64](interfacehipfort__hipblas_1_1hipblascherkx__64.html "Interface documentation") | C binding
-857 | [hipblasZherkx_64](interfacehipfort__hipblas_1_1hipblaszherkx__64.html "Interface documentation") | C binding
-858 | [hipblasCherkxBatched](interfacehipfort__hipblas_1_1hipblascherkxbatched.html "Interface documentation") | C binding
-859 | [hipblasZherkxBatched](interfacehipfort__hipblas_1_1hipblaszherkxbatched.html "Interface documentation") | C binding
-860 | [hipblasCherkxBatched_64](interfacehipfort__hipblas_1_1hipblascherkxbatched__64.html "Interface documentation") | C binding
-861 | [hipblasZherkxBatched_64](interfacehipfort__hipblas_1_1hipblaszherkxbatched__64.html "Interface documentation") | C binding
-862 | [hipblasCherkxStridedBatched](interfacehipfort__hipblas_1_1hipblascherkxstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-863 | [hipblasZherkxStridedBatched](interfacehipfort__hipblas_1_1hipblaszherkxstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-864 | [hipblasCherkxStridedBatched_64](interfacehipfort__hipblas_1_1hipblascherkxstridedbatched__64.html "Interface documentation") | C binding
-865 | [hipblasZherkxStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszherkxstridedbatched__64.html "Interface documentation") | C binding
-866 | [hipblasCher2k](interfacehipfort__hipblas_1_1hipblascher2k.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-867 | [hipblasZher2k](interfacehipfort__hipblas_1_1hipblaszher2k.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-868 | [hipblasCher2k_64](interfacehipfort__hipblas_1_1hipblascher2k__64.html "Interface documentation") | C binding
-869 | [hipblasZher2k_64](interfacehipfort__hipblas_1_1hipblaszher2k__64.html "Interface documentation") | C binding
-870 | [hipblasCher2kBatched](interfacehipfort__hipblas_1_1hipblascher2kbatched.html "Interface documentation") | C binding
-871 | [hipblasZher2kBatched](interfacehipfort__hipblas_1_1hipblaszher2kbatched.html "Interface documentation") | C binding
-872 | [hipblasCher2kBatched_64](interfacehipfort__hipblas_1_1hipblascher2kbatched__64.html "Interface documentation") | C binding
-873 | [hipblasZher2kBatched_64](interfacehipfort__hipblas_1_1hipblaszher2kbatched__64.html "Interface documentation") | C binding
-874 | [hipblasCher2kStridedBatched](interfacehipfort__hipblas_1_1hipblascher2kstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-875 | [hipblasZher2kStridedBatched](interfacehipfort__hipblas_1_1hipblaszher2kstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-876 | [hipblasCher2kStridedBatched_64](interfacehipfort__hipblas_1_1hipblascher2kstridedbatched__64.html "Interface documentation") | C binding
-877 | [hipblasZher2kStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszher2kstridedbatched__64.html "Interface documentation") | C binding
-878 | [hipblasSsymm](interfacehipfort__hipblas_1_1hipblasssymm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-879 | [hipblasDsymm](interfacehipfort__hipblas_1_1hipblasdsymm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-880 | [hipblasCsymm](interfacehipfort__hipblas_1_1hipblascsymm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-881 | [hipblasZsymm](interfacehipfort__hipblas_1_1hipblaszsymm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-882 | [hipblasSsymm_64](interfacehipfort__hipblas_1_1hipblasssymm__64.html "Interface documentation") | C binding
-883 | [hipblasDsymm_64](interfacehipfort__hipblas_1_1hipblasdsymm__64.html "Interface documentation") | C binding
-884 | [hipblasCsymm_64](interfacehipfort__hipblas_1_1hipblascsymm__64.html "Interface documentation") | C binding
-885 | [hipblasZsymm_64](interfacehipfort__hipblas_1_1hipblaszsymm__64.html "Interface documentation") | C binding
-886 | [hipblasSsymmBatched](interfacehipfort__hipblas_1_1hipblasssymmbatched.html "Interface documentation") | C binding
-887 | [hipblasDsymmBatched](interfacehipfort__hipblas_1_1hipblasdsymmbatched.html "Interface documentation") | C binding
-888 | [hipblasCsymmBatched](interfacehipfort__hipblas_1_1hipblascsymmbatched.html "Interface documentation") | C binding
-889 | [hipblasZsymmBatched](interfacehipfort__hipblas_1_1hipblaszsymmbatched.html "Interface documentation") | C binding
-890 | [hipblasSsymmBatched_64](interfacehipfort__hipblas_1_1hipblasssymmbatched__64.html "Interface documentation") | C binding
-891 | [hipblasDsymmBatched_64](interfacehipfort__hipblas_1_1hipblasdsymmbatched__64.html "Interface documentation") | C binding
-892 | [hipblasCsymmBatched_64](interfacehipfort__hipblas_1_1hipblascsymmbatched__64.html "Interface documentation") | C binding
-893 | [hipblasZsymmBatched_64](interfacehipfort__hipblas_1_1hipblaszsymmbatched__64.html "Interface documentation") | C binding
-894 | [hipblasSsymmStridedBatched](interfacehipfort__hipblas_1_1hipblasssymmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-895 | [hipblasDsymmStridedBatched](interfacehipfort__hipblas_1_1hipblasdsymmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-896 | [hipblasCsymmStridedBatched](interfacehipfort__hipblas_1_1hipblascsymmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-897 | [hipblasZsymmStridedBatched](interfacehipfort__hipblas_1_1hipblaszsymmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-898 | [hipblasSsymmStridedBatched_64](interfacehipfort__hipblas_1_1hipblasssymmstridedbatched__64.html "Interface documentation") | C binding
-899 | [hipblasDsymmStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdsymmstridedbatched__64.html "Interface documentation") | C binding
-900 | [hipblasCsymmStridedBatched_64](interfacehipfort__hipblas_1_1hipblascsymmstridedbatched__64.html "Interface documentation") | C binding
-901 | [hipblasZsymmStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszsymmstridedbatched__64.html "Interface documentation") | C binding
-902 | [hipblasSsyrk](interfacehipfort__hipblas_1_1hipblasssyrk.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-903 | [hipblasDsyrk](interfacehipfort__hipblas_1_1hipblasdsyrk.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-904 | [hipblasCsyrk](interfacehipfort__hipblas_1_1hipblascsyrk.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-905 | [hipblasZsyrk](interfacehipfort__hipblas_1_1hipblaszsyrk.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-906 | [hipblasSsyrk_64](interfacehipfort__hipblas_1_1hipblasssyrk__64.html "Interface documentation") | C binding
-907 | [hipblasDsyrk_64](interfacehipfort__hipblas_1_1hipblasdsyrk__64.html "Interface documentation") | C binding
-908 | [hipblasCsyrk_64](interfacehipfort__hipblas_1_1hipblascsyrk__64.html "Interface documentation") | C binding
-909 | [hipblasZsyrk_64](interfacehipfort__hipblas_1_1hipblaszsyrk__64.html "Interface documentation") | C binding
-910 | [hipblasSsyrkBatched](interfacehipfort__hipblas_1_1hipblasssyrkbatched.html "Interface documentation") | C binding
-911 | [hipblasDsyrkBatched](interfacehipfort__hipblas_1_1hipblasdsyrkbatched.html "Interface documentation") | C binding
-912 | [hipblasCsyrkBatched](interfacehipfort__hipblas_1_1hipblascsyrkbatched.html "Interface documentation") | C binding
-913 | [hipblasZsyrkBatched](interfacehipfort__hipblas_1_1hipblaszsyrkbatched.html "Interface documentation") | C binding
-914 | [hipblasSsyrkBatched_64](interfacehipfort__hipblas_1_1hipblasssyrkbatched__64.html "Interface documentation") | C binding
-915 | [hipblasDsyrkBatched_64](interfacehipfort__hipblas_1_1hipblasdsyrkbatched__64.html "Interface documentation") | C binding
-916 | [hipblasCsyrkBatched_64](interfacehipfort__hipblas_1_1hipblascsyrkbatched__64.html "Interface documentation") | C binding
-917 | [hipblasZsyrkBatched_64](interfacehipfort__hipblas_1_1hipblaszsyrkbatched__64.html "Interface documentation") | C binding
-918 | [hipblasSsyrkStridedBatched](interfacehipfort__hipblas_1_1hipblasssyrkstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-919 | [hipblasDsyrkStridedBatched](interfacehipfort__hipblas_1_1hipblasdsyrkstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-920 | [hipblasCsyrkStridedBatched](interfacehipfort__hipblas_1_1hipblascsyrkstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-921 | [hipblasZsyrkStridedBatched](interfacehipfort__hipblas_1_1hipblaszsyrkstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-922 | [hipblasSsyrkStridedBatched_64](interfacehipfort__hipblas_1_1hipblasssyrkstridedbatched__64.html "Interface documentation") | C binding
-923 | [hipblasDsyrkStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdsyrkstridedbatched__64.html "Interface documentation") | C binding
-924 | [hipblasCsyrkStridedBatched_64](interfacehipfort__hipblas_1_1hipblascsyrkstridedbatched__64.html "Interface documentation") | C binding
-925 | [hipblasZsyrkStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszsyrkstridedbatched__64.html "Interface documentation") | C binding
-926 | [hipblasSsyr2k](interfacehipfort__hipblas_1_1hipblasssyr2k.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-927 | [hipblasDsyr2k](interfacehipfort__hipblas_1_1hipblasdsyr2k.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-928 | [hipblasCsyr2k](interfacehipfort__hipblas_1_1hipblascsyr2k.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-929 | [hipblasZsyr2k](interfacehipfort__hipblas_1_1hipblaszsyr2k.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-930 | [hipblasSsyr2k_64](interfacehipfort__hipblas_1_1hipblasssyr2k__64.html "Interface documentation") | C binding
-931 | [hipblasDsyr2k_64](interfacehipfort__hipblas_1_1hipblasdsyr2k__64.html "Interface documentation") | C binding
-932 | [hipblasCsyr2k_64](interfacehipfort__hipblas_1_1hipblascsyr2k__64.html "Interface documentation") | C binding
-933 | [hipblasZsyr2k_64](interfacehipfort__hipblas_1_1hipblaszsyr2k__64.html "Interface documentation") | C binding
-934 | [hipblasSsyr2kBatched](interfacehipfort__hipblas_1_1hipblasssyr2kbatched.html "Interface documentation") | C binding
-935 | [hipblasDsyr2kBatched](interfacehipfort__hipblas_1_1hipblasdsyr2kbatched.html "Interface documentation") | C binding
-936 | [hipblasCsyr2kBatched](interfacehipfort__hipblas_1_1hipblascsyr2kbatched.html "Interface documentation") | C binding
-937 | [hipblasZsyr2kBatched](interfacehipfort__hipblas_1_1hipblaszsyr2kbatched.html "Interface documentation") | C binding
-938 | [hipblasSsyr2kBatched_64](interfacehipfort__hipblas_1_1hipblasssyr2kbatched__64.html "Interface documentation") | C binding
-939 | [hipblasDsyr2kBatched_64](interfacehipfort__hipblas_1_1hipblasdsyr2kbatched__64.html "Interface documentation") | C binding
-940 | [hipblasCsyr2kBatched_64](interfacehipfort__hipblas_1_1hipblascsyr2kbatched__64.html "Interface documentation") | C binding
-941 | [hipblasZsyr2kBatched_64](interfacehipfort__hipblas_1_1hipblaszsyr2kbatched__64.html "Interface documentation") | C binding
-942 | [hipblasSsyr2kStridedBatched](interfacehipfort__hipblas_1_1hipblasssyr2kstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-943 | [hipblasDsyr2kStridedBatched](interfacehipfort__hipblas_1_1hipblasdsyr2kstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-944 | [hipblasCsyr2kStridedBatched](interfacehipfort__hipblas_1_1hipblascsyr2kstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-945 | [hipblasZsyr2kStridedBatched](interfacehipfort__hipblas_1_1hipblaszsyr2kstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-946 | [hipblasSsyr2kStridedBatched_64](interfacehipfort__hipblas_1_1hipblasssyr2kstridedbatched__64.html "Interface documentation") | C binding
-947 | [hipblasDsyr2kStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdsyr2kstridedbatched__64.html "Interface documentation") | C binding
-948 | [hipblasCsyr2kStridedBatched_64](interfacehipfort__hipblas_1_1hipblascsyr2kstridedbatched__64.html "Interface documentation") | C binding
-949 | [hipblasZsyr2kStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszsyr2kstridedbatched__64.html "Interface documentation") | C binding
-950 | [hipblasSsyrkx](interfacehipfort__hipblas_1_1hipblasssyrkx.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-951 | [hipblasDsyrkx](interfacehipfort__hipblas_1_1hipblasdsyrkx.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-952 | [hipblasCsyrkx](interfacehipfort__hipblas_1_1hipblascsyrkx.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-953 | [hipblasZsyrkx](interfacehipfort__hipblas_1_1hipblaszsyrkx.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-954 | [hipblasSsyrkx_64](interfacehipfort__hipblas_1_1hipblasssyrkx__64.html "Interface documentation") | C binding
-955 | [hipblasDsyrkx_64](interfacehipfort__hipblas_1_1hipblasdsyrkx__64.html "Interface documentation") | C binding
-956 | [hipblasCsyrkx_64](interfacehipfort__hipblas_1_1hipblascsyrkx__64.html "Interface documentation") | C binding
-957 | [hipblasZsyrkx_64](interfacehipfort__hipblas_1_1hipblaszsyrkx__64.html "Interface documentation") | C binding
-958 | [hipblasSsyrkxBatched](interfacehipfort__hipblas_1_1hipblasssyrkxbatched.html "Interface documentation") | C binding
-959 | [hipblasDsyrkxBatched](interfacehipfort__hipblas_1_1hipblasdsyrkxbatched.html "Interface documentation") | C binding
-960 | [hipblasCsyrkxBatched](interfacehipfort__hipblas_1_1hipblascsyrkxbatched.html "Interface documentation") | C binding
-961 | [hipblasZsyrkxBatched](interfacehipfort__hipblas_1_1hipblaszsyrkxbatched.html "Interface documentation") | C binding
-962 | [hipblasSsyrkxBatched_64](interfacehipfort__hipblas_1_1hipblasssyrkxbatched__64.html "Interface documentation") | C binding
-963 | [hipblasDsyrkxBatched_64](interfacehipfort__hipblas_1_1hipblasdsyrkxbatched__64.html "Interface documentation") | C binding
-964 | [hipblasCsyrkxBatched_64](interfacehipfort__hipblas_1_1hipblascsyrkxbatched__64.html "Interface documentation") | C binding
-965 | [hipblasZsyrkxBatched_64](interfacehipfort__hipblas_1_1hipblaszsyrkxbatched__64.html "Interface documentation") | C binding
-966 | [hipblasSsyrkxStridedBatched](interfacehipfort__hipblas_1_1hipblasssyrkxstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-967 | [hipblasDsyrkxStridedBatched](interfacehipfort__hipblas_1_1hipblasdsyrkxstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-968 | [hipblasCsyrkxStridedBatched](interfacehipfort__hipblas_1_1hipblascsyrkxstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-969 | [hipblasZsyrkxStridedBatched](interfacehipfort__hipblas_1_1hipblaszsyrkxstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-970 | [hipblasSsyrkxStridedBatched_64](interfacehipfort__hipblas_1_1hipblasssyrkxstridedbatched__64.html "Interface documentation") | C binding
-971 | [hipblasDsyrkxStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdsyrkxstridedbatched__64.html "Interface documentation") | C binding
-972 | [hipblasCsyrkxStridedBatched_64](interfacehipfort__hipblas_1_1hipblascsyrkxstridedbatched__64.html "Interface documentation") | C binding
-973 | [hipblasZsyrkxStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszsyrkxstridedbatched__64.html "Interface documentation") | C binding
-974 | [hipblasSgeam](interfacehipfort__hipblas_1_1hipblassgeam.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-975 | [hipblasDgeam](interfacehipfort__hipblas_1_1hipblasdgeam.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-976 | [hipblasCgeam](interfacehipfort__hipblas_1_1hipblascgeam.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-977 | [hipblasZgeam](interfacehipfort__hipblas_1_1hipblaszgeam.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-978 | [hipblasSgeam_64](interfacehipfort__hipblas_1_1hipblassgeam__64.html "Interface documentation") | C binding
-979 | [hipblasDgeam_64](interfacehipfort__hipblas_1_1hipblasdgeam__64.html "Interface documentation") | C binding
-980 | [hipblasCgeam_64](interfacehipfort__hipblas_1_1hipblascgeam__64.html "Interface documentation") | C binding
-981 | [hipblasZgeam_64](interfacehipfort__hipblas_1_1hipblaszgeam__64.html "Interface documentation") | C binding
-982 | [hipblasSgeamBatched](interfacehipfort__hipblas_1_1hipblassgeambatched.html "Interface documentation") | C binding
-983 | [hipblasDgeamBatched](interfacehipfort__hipblas_1_1hipblasdgeambatched.html "Interface documentation") | C binding
-984 | [hipblasCgeamBatched](interfacehipfort__hipblas_1_1hipblascgeambatched.html "Interface documentation") | C binding
-985 | [hipblasZgeamBatched](interfacehipfort__hipblas_1_1hipblaszgeambatched.html "Interface documentation") | C binding
-986 | [hipblasSgeamBatched_64](interfacehipfort__hipblas_1_1hipblassgeambatched__64.html "Interface documentation") | C binding
-987 | [hipblasDgeamBatched_64](interfacehipfort__hipblas_1_1hipblasdgeambatched__64.html "Interface documentation") | C binding
-988 | [hipblasCgeamBatched_64](interfacehipfort__hipblas_1_1hipblascgeambatched__64.html "Interface documentation") | C binding
-989 | [hipblasZgeamBatched_64](interfacehipfort__hipblas_1_1hipblaszgeambatched__64.html "Interface documentation") | C binding
-990 | [hipblasSgeamStridedBatched](interfacehipfort__hipblas_1_1hipblassgeamstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-991 | [hipblasDgeamStridedBatched](interfacehipfort__hipblas_1_1hipblasdgeamstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-992 | [hipblasCgeamStridedBatched](interfacehipfort__hipblas_1_1hipblascgeamstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-993 | [hipblasZgeamStridedBatched](interfacehipfort__hipblas_1_1hipblaszgeamstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-994 | [hipblasSgeamStridedBatched_64](interfacehipfort__hipblas_1_1hipblassgeamstridedbatched__64.html "Interface documentation") | C binding
-995 | [hipblasDgeamStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdgeamstridedbatched__64.html "Interface documentation") | C binding
-996 | [hipblasCgeamStridedBatched_64](interfacehipfort__hipblas_1_1hipblascgeamstridedbatched__64.html "Interface documentation") | C binding
-997 | [hipblasZgeamStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszgeamstridedbatched__64.html "Interface documentation") | C binding
-998 | [hipblasChemm](interfacehipfort__hipblas_1_1hipblaschemm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-999 | [hipblasZhemm](interfacehipfort__hipblas_1_1hipblaszhemm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1000 | [hipblasChemm_64](interfacehipfort__hipblas_1_1hipblaschemm__64.html "Interface documentation") | C binding
-1001 | [hipblasZhemm_64](interfacehipfort__hipblas_1_1hipblaszhemm__64.html "Interface documentation") | C binding
-1002 | [hipblasChemmBatched](interfacehipfort__hipblas_1_1hipblaschemmbatched.html "Interface documentation") | C binding
-1003 | [hipblasZhemmBatched](interfacehipfort__hipblas_1_1hipblaszhemmbatched.html "Interface documentation") | C binding
-1004 | [hipblasChemmBatched_64](interfacehipfort__hipblas_1_1hipblaschemmbatched__64.html "Interface documentation") | C binding
-1005 | [hipblasZhemmBatched_64](interfacehipfort__hipblas_1_1hipblaszhemmbatched__64.html "Interface documentation") | C binding
-1006 | [hipblasChemmStridedBatched](interfacehipfort__hipblas_1_1hipblaschemmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1007 | [hipblasZhemmStridedBatched](interfacehipfort__hipblas_1_1hipblaszhemmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1008 | [hipblasChemmStridedBatched_64](interfacehipfort__hipblas_1_1hipblaschemmstridedbatched__64.html "Interface documentation") | C binding
-1009 | [hipblasZhemmStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszhemmstridedbatched__64.html "Interface documentation") | C binding
-1010 | [hipblasStrmm](interfacehipfort__hipblas_1_1hipblasstrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1011 | [hipblasDtrmm](interfacehipfort__hipblas_1_1hipblasdtrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1012 | [hipblasCtrmm](interfacehipfort__hipblas_1_1hipblasctrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1013 | [hipblasZtrmm](interfacehipfort__hipblas_1_1hipblasztrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1014 | [hipblasStrmm_64](interfacehipfort__hipblas_1_1hipblasstrmm__64.html "Interface documentation") | C binding
-1015 | [hipblasDtrmm_64](interfacehipfort__hipblas_1_1hipblasdtrmm__64.html "Interface documentation") | C binding
-1016 | [hipblasCtrmm_64](interfacehipfort__hipblas_1_1hipblasctrmm__64.html "Interface documentation") | C binding
-1017 | [hipblasZtrmm_64](interfacehipfort__hipblas_1_1hipblasztrmm__64.html "Interface documentation") | C binding
-1018 | [hipblasStrmmBatched](interfacehipfort__hipblas_1_1hipblasstrmmbatched.html "Interface documentation") | C binding
-1019 | [hipblasDtrmmBatched](interfacehipfort__hipblas_1_1hipblasdtrmmbatched.html "Interface documentation") | C binding
-1020 | [hipblasCtrmmBatched](interfacehipfort__hipblas_1_1hipblasctrmmbatched.html "Interface documentation") | C binding
-1021 | [hipblasZtrmmBatched](interfacehipfort__hipblas_1_1hipblasztrmmbatched.html "Interface documentation") | C binding
-1022 | [hipblasStrmmBatched_64](interfacehipfort__hipblas_1_1hipblasstrmmbatched__64.html "Interface documentation") | C binding
-1023 | [hipblasDtrmmBatched_64](interfacehipfort__hipblas_1_1hipblasdtrmmbatched__64.html "Interface documentation") | C binding
-1024 | [hipblasCtrmmBatched_64](interfacehipfort__hipblas_1_1hipblasctrmmbatched__64.html "Interface documentation") | C binding
-1025 | [hipblasZtrmmBatched_64](interfacehipfort__hipblas_1_1hipblasztrmmbatched__64.html "Interface documentation") | C binding
-1026 | [hipblasStrmmStridedBatched](interfacehipfort__hipblas_1_1hipblasstrmmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1027 | [hipblasDtrmmStridedBatched](interfacehipfort__hipblas_1_1hipblasdtrmmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1028 | [hipblasCtrmmStridedBatched](interfacehipfort__hipblas_1_1hipblasctrmmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1029 | [hipblasZtrmmStridedBatched](interfacehipfort__hipblas_1_1hipblasztrmmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1030 | [hipblasStrmmStridedBatched_64](interfacehipfort__hipblas_1_1hipblasstrmmstridedbatched__64.html "Interface documentation") | C binding
-1031 | [hipblasDtrmmStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdtrmmstridedbatched__64.html "Interface documentation") | C binding
-1032 | [hipblasCtrmmStridedBatched_64](interfacehipfort__hipblas_1_1hipblasctrmmstridedbatched__64.html "Interface documentation") | C binding
-1033 | [hipblasZtrmmStridedBatched_64](interfacehipfort__hipblas_1_1hipblasztrmmstridedbatched__64.html "Interface documentation") | C binding
-1034 | [hipblasStrsm](interfacehipfort__hipblas_1_1hipblasstrsm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1035 | [hipblasDtrsm](interfacehipfort__hipblas_1_1hipblasdtrsm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1036 | [hipblasCtrsm](interfacehipfort__hipblas_1_1hipblasctrsm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1037 | [hipblasZtrsm](interfacehipfort__hipblas_1_1hipblasztrsm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1038 | [hipblasStrsm_64](interfacehipfort__hipblas_1_1hipblasstrsm__64.html "Interface documentation") | C binding
-1039 | [hipblasDtrsm_64](interfacehipfort__hipblas_1_1hipblasdtrsm__64.html "Interface documentation") | C binding
-1040 | [hipblasCtrsm_64](interfacehipfort__hipblas_1_1hipblasctrsm__64.html "Interface documentation") | C binding
-1041 | [hipblasZtrsm_64](interfacehipfort__hipblas_1_1hipblasztrsm__64.html "Interface documentation") | C binding
-1042 | [hipblasStrsmBatched](interfacehipfort__hipblas_1_1hipblasstrsmbatched.html "Interface documentation") | C binding
-1043 | [hipblasDtrsmBatched](interfacehipfort__hipblas_1_1hipblasdtrsmbatched.html "Interface documentation") | C binding
-1044 | [hipblasCtrsmBatched](interfacehipfort__hipblas_1_1hipblasctrsmbatched.html "Interface documentation") | C binding
-1045 | [hipblasZtrsmBatched](interfacehipfort__hipblas_1_1hipblasztrsmbatched.html "Interface documentation") | C binding
-1046 | [hipblasStrsmBatched_64](interfacehipfort__hipblas_1_1hipblasstrsmbatched__64.html "Interface documentation") | C binding
-1047 | [hipblasDtrsmBatched_64](interfacehipfort__hipblas_1_1hipblasdtrsmbatched__64.html "Interface documentation") | C binding
-1048 | [hipblasCtrsmBatched_64](interfacehipfort__hipblas_1_1hipblasctrsmbatched__64.html "Interface documentation") | C binding
-1049 | [hipblasZtrsmBatched_64](interfacehipfort__hipblas_1_1hipblasztrsmbatched__64.html "Interface documentation") | C binding
-1050 | [hipblasStrsmStridedBatched](interfacehipfort__hipblas_1_1hipblasstrsmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1051 | [hipblasDtrsmStridedBatched](interfacehipfort__hipblas_1_1hipblasdtrsmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1052 | [hipblasCtrsmStridedBatched](interfacehipfort__hipblas_1_1hipblasctrsmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1053 | [hipblasZtrsmStridedBatched](interfacehipfort__hipblas_1_1hipblasztrsmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1054 | [hipblasStrsmStridedBatched_64](interfacehipfort__hipblas_1_1hipblasstrsmstridedbatched__64.html "Interface documentation") | C binding
-1055 | [hipblasDtrsmStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdtrsmstridedbatched__64.html "Interface documentation") | C binding
-1056 | [hipblasCtrsmStridedBatched_64](interfacehipfort__hipblas_1_1hipblasctrsmstridedbatched__64.html "Interface documentation") | C binding
-1057 | [hipblasZtrsmStridedBatched_64](interfacehipfort__hipblas_1_1hipblasztrsmstridedbatched__64.html "Interface documentation") | C binding
-1058 | [hipblasStrtri](interfacehipfort__hipblas_1_1hipblasstrtri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1059 | [hipblasDtrtri](interfacehipfort__hipblas_1_1hipblasdtrtri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1060 | [hipblasCtrtri](interfacehipfort__hipblas_1_1hipblasctrtri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1061 | [hipblasZtrtri](interfacehipfort__hipblas_1_1hipblasztrtri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1062 | [hipblasStrtriBatched](interfacehipfort__hipblas_1_1hipblasstrtribatched.html "Interface documentation") | C binding
-1063 | [hipblasDtrtriBatched](interfacehipfort__hipblas_1_1hipblasdtrtribatched.html "Interface documentation") | C binding
-1064 | [hipblasCtrtriBatched](interfacehipfort__hipblas_1_1hipblasctrtribatched.html "Interface documentation") | C binding
-1065 | [hipblasZtrtriBatched](interfacehipfort__hipblas_1_1hipblasztrtribatched.html "Interface documentation") | C binding
-1066 | [hipblasStrtriStridedBatched](interfacehipfort__hipblas_1_1hipblasstrtristridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1067 | [hipblasDtrtriStridedBatched](interfacehipfort__hipblas_1_1hipblasdtrtristridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1068 | [hipblasCtrtriStridedBatched](interfacehipfort__hipblas_1_1hipblasctrtristridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1069 | [hipblasZtrtriStridedBatched](interfacehipfort__hipblas_1_1hipblasztrtristridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1070 | [hipblasSdgmm](interfacehipfort__hipblas_1_1hipblassdgmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1071 | [hipblasDdgmm](interfacehipfort__hipblas_1_1hipblasddgmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1072 | [hipblasCdgmm](interfacehipfort__hipblas_1_1hipblascdgmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1073 | [hipblasZdgmm](interfacehipfort__hipblas_1_1hipblaszdgmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1074 | [hipblasSdgmm_64](interfacehipfort__hipblas_1_1hipblassdgmm__64.html "Interface documentation") | C binding
-1075 | [hipblasDdgmm_64](interfacehipfort__hipblas_1_1hipblasddgmm__64.html "Interface documentation") | C binding
-1076 | [hipblasCdgmm_64](interfacehipfort__hipblas_1_1hipblascdgmm__64.html "Interface documentation") | C binding
-1077 | [hipblasZdgmm_64](interfacehipfort__hipblas_1_1hipblaszdgmm__64.html "Interface documentation") | C binding
-1078 | [hipblasSdgmmBatched](interfacehipfort__hipblas_1_1hipblassdgmmbatched.html "Interface documentation") | C binding
-1079 | [hipblasDdgmmBatched](interfacehipfort__hipblas_1_1hipblasddgmmbatched.html "Interface documentation") | C binding
-1080 | [hipblasCdgmmBatched](interfacehipfort__hipblas_1_1hipblascdgmmbatched.html "Interface documentation") | C binding
-1081 | [hipblasZdgmmBatched](interfacehipfort__hipblas_1_1hipblaszdgmmbatched.html "Interface documentation") | C binding
-1082 | [hipblasSdgmmBatched_64](interfacehipfort__hipblas_1_1hipblassdgmmbatched__64.html "Interface documentation") | C binding
-1083 | [hipblasDdgmmBatched_64](interfacehipfort__hipblas_1_1hipblasddgmmbatched__64.html "Interface documentation") | C binding
-1084 | [hipblasCdgmmBatched_64](interfacehipfort__hipblas_1_1hipblascdgmmbatched__64.html "Interface documentation") | C binding
-1085 | [hipblasZdgmmBatched_64](interfacehipfort__hipblas_1_1hipblaszdgmmbatched__64.html "Interface documentation") | C binding
-1086 | [hipblasSdgmmStridedBatched](interfacehipfort__hipblas_1_1hipblassdgmmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1087 | [hipblasDdgmmStridedBatched](interfacehipfort__hipblas_1_1hipblasddgmmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1088 | [hipblasCdgmmStridedBatched](interfacehipfort__hipblas_1_1hipblascdgmmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1089 | [hipblasZdgmmStridedBatched](interfacehipfort__hipblas_1_1hipblaszdgmmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1090 | [hipblasSdgmmStridedBatched_64](interfacehipfort__hipblas_1_1hipblassdgmmstridedbatched__64.html "Interface documentation") | C binding
-1091 | [hipblasDdgmmStridedBatched_64](interfacehipfort__hipblas_1_1hipblasddgmmstridedbatched__64.html "Interface documentation") | C binding
-1092 | [hipblasCdgmmStridedBatched_64](interfacehipfort__hipblas_1_1hipblascdgmmstridedbatched__64.html "Interface documentation") | C binding
-1093 | [hipblasZdgmmStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszdgmmstridedbatched__64.html "Interface documentation") | C binding
-1094 | [hipblasSgetrf](interfacehipfort__hipblas_1_1hipblassgetrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1095 | [hipblasDgetrf](interfacehipfort__hipblas_1_1hipblasdgetrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1096 | [hipblasCgetrf](interfacehipfort__hipblas_1_1hipblascgetrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1097 | [hipblasZgetrf](interfacehipfort__hipblas_1_1hipblaszgetrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1098 | [hipblasSgetrfBatched](interfacehipfort__hipblas_1_1hipblassgetrfbatched.html "Interface documentation") | C binding
-1099 | [hipblasDgetrfBatched](interfacehipfort__hipblas_1_1hipblasdgetrfbatched.html "Interface documentation") | C binding
-1100 | [hipblasCgetrfBatched](interfacehipfort__hipblas_1_1hipblascgetrfbatched.html "Interface documentation") | C binding
-1101 | [hipblasZgetrfBatched](interfacehipfort__hipblas_1_1hipblaszgetrfbatched.html "Interface documentation") | C binding
-1102 | [hipblasSgetrfStridedBatched](interfacehipfort__hipblas_1_1hipblassgetrfstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1103 | [hipblasDgetrfStridedBatched](interfacehipfort__hipblas_1_1hipblasdgetrfstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1104 | [hipblasCgetrfStridedBatched](interfacehipfort__hipblas_1_1hipblascgetrfstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1105 | [hipblasZgetrfStridedBatched](interfacehipfort__hipblas_1_1hipblaszgetrfstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1106 | [hipblasSgetrs](interfacehipfort__hipblas_1_1hipblassgetrs.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1107 | [hipblasDgetrs](interfacehipfort__hipblas_1_1hipblasdgetrs.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1108 | [hipblasCgetrs](interfacehipfort__hipblas_1_1hipblascgetrs.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1109 | [hipblasZgetrs](interfacehipfort__hipblas_1_1hipblaszgetrs.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1110 | [hipblasSgetrsBatched](interfacehipfort__hipblas_1_1hipblassgetrsbatched.html "Interface documentation") | C binding
-1111 | [hipblasDgetrsBatched](interfacehipfort__hipblas_1_1hipblasdgetrsbatched.html "Interface documentation") | C binding
-1112 | [hipblasCgetrsBatched](interfacehipfort__hipblas_1_1hipblascgetrsbatched.html "Interface documentation") | C binding
-1113 | [hipblasZgetrsBatched](interfacehipfort__hipblas_1_1hipblaszgetrsbatched.html "Interface documentation") | C binding
-1114 | [hipblasSgetrsStridedBatched](interfacehipfort__hipblas_1_1hipblassgetrsstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1115 | [hipblasDgetrsStridedBatched](interfacehipfort__hipblas_1_1hipblasdgetrsstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1116 | [hipblasCgetrsStridedBatched](interfacehipfort__hipblas_1_1hipblascgetrsstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1117 | [hipblasZgetrsStridedBatched](interfacehipfort__hipblas_1_1hipblaszgetrsstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1118 | [hipblasSgetriBatched](interfacehipfort__hipblas_1_1hipblassgetribatched.html "Interface documentation") | C binding
-1119 | [hipblasDgetriBatched](interfacehipfort__hipblas_1_1hipblasdgetribatched.html "Interface documentation") | C binding
-1120 | [hipblasCgetriBatched](interfacehipfort__hipblas_1_1hipblascgetribatched.html "Interface documentation") | C binding
-1121 | [hipblasZgetriBatched](interfacehipfort__hipblas_1_1hipblaszgetribatched.html "Interface documentation") | C binding
-1122 | [hipblasSgels](interfacehipfort__hipblas_1_1hipblassgels.html "Interface documentation") | C binding
-1123 | [hipblasDgels](interfacehipfort__hipblas_1_1hipblasdgels.html "Interface documentation") | C binding
-1124 | [hipblasCgels](interfacehipfort__hipblas_1_1hipblascgels.html "Interface documentation") | C binding
-1125 | [hipblasZgels](interfacehipfort__hipblas_1_1hipblaszgels.html "Interface documentation") | C binding
-1126 | [hipblasSgelsBatched](interfacehipfort__hipblas_1_1hipblassgelsbatched.html "Interface documentation") | C binding
-1127 | [hipblasDgelsBatched](interfacehipfort__hipblas_1_1hipblasdgelsbatched.html "Interface documentation") | C binding
-1128 | [hipblasCgelsBatched](interfacehipfort__hipblas_1_1hipblascgelsbatched.html "Interface documentation") | C binding
-1129 | [hipblasZgelsBatched](interfacehipfort__hipblas_1_1hipblaszgelsbatched.html "Interface documentation") | C binding
-1130 | [hipblasSgelsStridedBatched](interfacehipfort__hipblas_1_1hipblassgelsstridedbatched.html "Interface documentation") | C binding
-1131 | [hipblasDgelsStridedBatched](interfacehipfort__hipblas_1_1hipblasdgelsstridedbatched.html "Interface documentation") | C binding
-1132 | [hipblasCgelsStridedBatched](interfacehipfort__hipblas_1_1hipblascgelsstridedbatched.html "Interface documentation") | C binding
-1133 | [hipblasZgelsStridedBatched](interfacehipfort__hipblas_1_1hipblaszgelsstridedbatched.html "Interface documentation") | C binding
-1134 | [hipblasSgeqrf](interfacehipfort__hipblas_1_1hipblassgeqrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1135 | [hipblasDgeqrf](interfacehipfort__hipblas_1_1hipblasdgeqrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1136 | [hipblasCgeqrf](interfacehipfort__hipblas_1_1hipblascgeqrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1137 | [hipblasZgeqrf](interfacehipfort__hipblas_1_1hipblaszgeqrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1138 | [hipblasSgeqrfBatched](interfacehipfort__hipblas_1_1hipblassgeqrfbatched.html "Interface documentation") | C binding
-1139 | [hipblasDgeqrfBatched](interfacehipfort__hipblas_1_1hipblasdgeqrfbatched.html "Interface documentation") | C binding
-1140 | [hipblasCgeqrfBatched](interfacehipfort__hipblas_1_1hipblascgeqrfbatched.html "Interface documentation") | C binding
-1141 | [hipblasZgeqrfBatched](interfacehipfort__hipblas_1_1hipblaszgeqrfbatched.html "Interface documentation") | C binding
-1142 | [hipblasSgeqrfStridedBatched](interfacehipfort__hipblas_1_1hipblassgeqrfstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1143 | [hipblasDgeqrfStridedBatched](interfacehipfort__hipblas_1_1hipblasdgeqrfstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1144 | [hipblasCgeqrfStridedBatched](interfacehipfort__hipblas_1_1hipblascgeqrfstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1145 | [hipblasZgeqrfStridedBatched](interfacehipfort__hipblas_1_1hipblaszgeqrfstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1146 | [hipblasGemmEx](interfacehipfort__hipblas_1_1hipblasgemmex.html "Interface documentation") | C binding
-1147 | [hipblasGemmExWithFlags](interfacehipfort__hipblas_1_1hipblasgemmexwithflags.html "Interface documentation") | C binding
-1148 | [hipblasGemmEx_64](interfacehipfort__hipblas_1_1hipblasgemmex__64.html "Interface documentation") | C binding
-1149 | [hipblasGemmExWithFlags_64](interfacehipfort__hipblas_1_1hipblasgemmexwithflags__64.html "Interface documentation") | C binding
-1150 | [hipblasGemmBatchedEx](interfacehipfort__hipblas_1_1hipblasgemmbatchedex.html "Interface documentation") | C binding
-1151 | [hipblasGemmBatchedExWithFlags](interfacehipfort__hipblas_1_1hipblasgemmbatchedexwithflags.html "Interface documentation") | C binding
-1152 | [hipblasGemmBatchedEx_64](interfacehipfort__hipblas_1_1hipblasgemmbatchedex__64.html "Interface documentation") | C binding
-1153 | [hipblasGemmBatchedExWithFlags_64](interfacehipfort__hipblas_1_1hipblasgemmbatchedexwithflags__64.html "Interface documentation") | C binding
-1154 | [hipblasGemmStridedBatchedEx](interfacehipfort__hipblas_1_1hipblasgemmstridedbatchedex.html "Interface documentation") | C binding
-1155 | [hipblasGemmStridedBatchedExWithFlags](interfacehipfort__hipblas_1_1hipblasgemmstridedbatchedexwithflags.html "Interface documentation") | C binding
-1156 | [hipblasGemmStridedBatchedEx_64](interfacehipfort__hipblas_1_1hipblasgemmstridedbatchedex__64.html "Interface documentation") | C binding
-1157 | [hipblasGemmStridedBatchedExWithFlags_64](interfacehipfort__hipblas_1_1hipblasgemmstridedbatchedexwithflags__64.html "Interface documentation") | C binding
-1158 | [hipblasSyrkEx](interfacehipfort__hipblas_1_1hipblassyrkex.html "Interface documentation") | C binding
-1159 | [hipblasTrsmEx](interfacehipfort__hipblas_1_1hipblastrsmex.html "Interface documentation") | C binding
-1160 | [hipblasHerkEx](interfacehipfort__hipblas_1_1hipblasherkex.html "Interface documentation") | C binding
-1161 | [hipblasTrsmBatchedEx](interfacehipfort__hipblas_1_1hipblastrsmbatchedex.html "Interface documentation") | C binding
-1162 | [hipblasTrsmStridedBatchedEx](interfacehipfort__hipblas_1_1hipblastrsmstridedbatchedex.html "Interface documentation") | C binding
-1163 | [hipblasAxpyEx](interfacehipfort__hipblas_1_1hipblasaxpyex.html "Interface documentation") | C binding
-1164 | [hipblasAxpyEx_64](interfacehipfort__hipblas_1_1hipblasaxpyex__64.html "Interface documentation") | C binding
-1165 | [hipblasAxpyBatchedEx](interfacehipfort__hipblas_1_1hipblasaxpybatchedex.html "Interface documentation") | C binding
-1166 | [hipblasAxpyBatchedEx_64](interfacehipfort__hipblas_1_1hipblasaxpybatchedex__64.html "Interface documentation") | C binding
-1167 | [hipblasAxpyStridedBatchedEx](interfacehipfort__hipblas_1_1hipblasaxpystridedbatchedex.html "Interface documentation") | C binding
-1168 | [hipblasAxpyStridedBatchedEx_64](interfacehipfort__hipblas_1_1hipblasaxpystridedbatchedex__64.html "Interface documentation") | C binding
-1169 | [hipblasDotEx](interfacehipfort__hipblas_1_1hipblasdotex.html "Interface documentation") | C binding
-1170 | [hipblasDotcEx](interfacehipfort__hipblas_1_1hipblasdotcex.html "Interface documentation") | C binding
-1171 | [hipblasDotEx_64](interfacehipfort__hipblas_1_1hipblasdotex__64.html "Interface documentation") | C binding
-1172 | [hipblasDotcEx_64](interfacehipfort__hipblas_1_1hipblasdotcex__64.html "Interface documentation") | C binding
-1173 | [hipblasDotBatchedEx](interfacehipfort__hipblas_1_1hipblasdotbatchedex.html "Interface documentation") | C binding
-1174 | [hipblasDotcBatchedEx](interfacehipfort__hipblas_1_1hipblasdotcbatchedex.html "Interface documentation") | C binding
-1175 | [hipblasDotBatchedEx_64](interfacehipfort__hipblas_1_1hipblasdotbatchedex__64.html "Interface documentation") | C binding
-1176 | [hipblasDotcBatchedEx_64](interfacehipfort__hipblas_1_1hipblasdotcbatchedex__64.html "Interface documentation") | C binding
-1177 | [hipblasDotStridedBatchedEx](interfacehipfort__hipblas_1_1hipblasdotstridedbatchedex.html "Interface documentation") | C binding
-1178 | [hipblasDotcStridedBatchedEx](interfacehipfort__hipblas_1_1hipblasdotcstridedbatchedex.html "Interface documentation") | C binding
-1179 | [hipblasDotStridedBatchedEx_64](interfacehipfort__hipblas_1_1hipblasdotstridedbatchedex__64.html "Interface documentation") | C binding
-1180 | [hipblasDotcStridedBatchedEx_64](interfacehipfort__hipblas_1_1hipblasdotcstridedbatchedex__64.html "Interface documentation") | C binding
-1181 | [hipblasNrm2Ex](interfacehipfort__hipblas_1_1hipblasnrm2ex.html "Interface documentation") | C binding
-1182 | [hipblasNrm2Ex_64](interfacehipfort__hipblas_1_1hipblasnrm2ex__64.html "Interface documentation") | C binding
-1183 | [hipblasNrm2BatchedEx](interfacehipfort__hipblas_1_1hipblasnrm2batchedex.html "Interface documentation") | C binding
-1184 | [hipblasNrm2BatchedEx_64](interfacehipfort__hipblas_1_1hipblasnrm2batchedex__64.html "Interface documentation") | C binding
-1185 | [hipblasNrm2StridedBatchedEx](interfacehipfort__hipblas_1_1hipblasnrm2stridedbatchedex.html "Interface documentation") | C binding
-1186 | [hipblasNrm2StridedBatchedEx_64](interfacehipfort__hipblas_1_1hipblasnrm2stridedbatchedex__64.html "Interface documentation") | C binding
-1187 | [hipblasRotEx](interfacehipfort__hipblas_1_1hipblasrotex.html "Interface documentation") | C binding
-1188 | [hipblasRotEx_64](interfacehipfort__hipblas_1_1hipblasrotex__64.html "Interface documentation") | C binding
-1189 | [hipblasRotBatchedEx](interfacehipfort__hipblas_1_1hipblasrotbatchedex.html "Interface documentation") | C binding
-1190 | [hipblasRotBatchedEx_64](interfacehipfort__hipblas_1_1hipblasrotbatchedex__64.html "Interface documentation") | C binding
-1191 | [hipblasRotStridedBatchedEx](interfacehipfort__hipblas_1_1hipblasrotstridedbatchedex.html "Interface documentation") | C binding
-1192 | [hipblasRotStridedBatchedEx_64](interfacehipfort__hipblas_1_1hipblasrotstridedbatchedex__64.html "Interface documentation") | C binding
-1193 | [hipblasScalEx](interfacehipfort__hipblas_1_1hipblasscalex.html "Interface documentation") | C binding
-1194 | [hipblasScalEx_64](interfacehipfort__hipblas_1_1hipblasscalex__64.html "Interface documentation") | C binding
-1195 | [hipblasScalBatchedEx](interfacehipfort__hipblas_1_1hipblasscalbatchedex.html "Interface documentation") | C binding
-1196 | [hipblasScalBatchedEx_64](interfacehipfort__hipblas_1_1hipblasscalbatchedex__64.html "Interface documentation") | C binding
-1197 | [hipblasScalStridedBatchedEx](interfacehipfort__hipblas_1_1hipblasscalstridedbatchedex.html "Interface documentation") | C binding
-1198 | [hipblasScalStridedBatchedEx_64](interfacehipfort__hipblas_1_1hipblasscalstridedbatchedex__64.html "Interface documentation") | C binding
-1199 | [hipblasStatusToString](interfacehipfort__hipblas_1_1hipblasstatustostring.html "Interface documentation") | C binding
+12 | [hipblasSetAtomicsMode](interfacehipfort__hipblas_1_1hipblassetatomicsmode.html "Interface documentation") | C binding
+13 | [hipblasGetAtomicsMode](interfacehipfort__hipblas_1_1hipblasgetatomicsmode.html "Interface documentation") | C binding, rank_0, rank_1
+14 | [hipblasSetBatchAlphaStride](interfacehipfort__hipblas_1_1hipblassetbatchalphastride.html "Interface documentation") | C binding
+15 | [hipblasGetBatchAlphaStride](interfacehipfort__hipblas_1_1hipblasgetbatchalphastride.html "Interface documentation") | C binding, rank_0, rank_1
+16 | [hipblasSetBatchBetaStride](interfacehipfort__hipblas_1_1hipblassetbatchbetastride.html "Interface documentation") | C binding
+17 | [hipblasGetBatchBetaStride](interfacehipfort__hipblas_1_1hipblasgetbatchbetastride.html "Interface documentation") | C binding, rank_0, rank_1
+18 | [hipblasIsamax](interfacehipfort__hipblas_1_1hipblasisamax.html "Interface documentation") | C binding, rank_0, rank_1
+19 | [hipblasIdamax](interfacehipfort__hipblas_1_1hipblasidamax.html "Interface documentation") | C binding, rank_0, rank_1
+20 | [hipblasIcamax](interfacehipfort__hipblas_1_1hipblasicamax.html "Interface documentation") | C binding, rank_0, rank_1
+21 | [hipblasIzamax](interfacehipfort__hipblas_1_1hipblasizamax.html "Interface documentation") | C binding, rank_0, rank_1
+22 | [hipblasIsamax_64](interfacehipfort__hipblas_1_1hipblasisamax__64.html "Interface documentation") | C binding, rank_0, rank_1
+23 | [hipblasIdamax_64](interfacehipfort__hipblas_1_1hipblasidamax__64.html "Interface documentation") | C binding, rank_0, rank_1
+24 | [hipblasIcamax_64](interfacehipfort__hipblas_1_1hipblasicamax__64.html "Interface documentation") | C binding, rank_0, rank_1
+25 | [hipblasIzamax_64](interfacehipfort__hipblas_1_1hipblasizamax__64.html "Interface documentation") | C binding, rank_0, rank_1
+26 | [hipblasIsamaxBatched](interfacehipfort__hipblas_1_1hipblasisamaxbatched.html "Interface documentation") | C binding
+27 | [hipblasIdamaxBatched](interfacehipfort__hipblas_1_1hipblasidamaxbatched.html "Interface documentation") | C binding
+28 | [hipblasIcamaxBatched](interfacehipfort__hipblas_1_1hipblasicamaxbatched.html "Interface documentation") | C binding
+29 | [hipblasIzamaxBatched](interfacehipfort__hipblas_1_1hipblasizamaxbatched.html "Interface documentation") | C binding
+30 | [hipblasIsamaxBatched_64](interfacehipfort__hipblas_1_1hipblasisamaxbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+31 | [hipblasIdamaxBatched_64](interfacehipfort__hipblas_1_1hipblasidamaxbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+32 | [hipblasIcamaxBatched_64](interfacehipfort__hipblas_1_1hipblasicamaxbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+33 | [hipblasIzamaxBatched_64](interfacehipfort__hipblas_1_1hipblasizamaxbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+34 | [hipblasIsamaxStridedBatched](interfacehipfort__hipblas_1_1hipblasisamaxstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+35 | [hipblasIdamaxStridedBatched](interfacehipfort__hipblas_1_1hipblasidamaxstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+36 | [hipblasIcamaxStridedBatched](interfacehipfort__hipblas_1_1hipblasicamaxstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+37 | [hipblasIzamaxStridedBatched](interfacehipfort__hipblas_1_1hipblasizamaxstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+38 | [hipblasIsamaxStridedBatched_64](interfacehipfort__hipblas_1_1hipblasisamaxstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+39 | [hipblasIdamaxStridedBatched_64](interfacehipfort__hipblas_1_1hipblasidamaxstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+40 | [hipblasIcamaxStridedBatched_64](interfacehipfort__hipblas_1_1hipblasicamaxstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+41 | [hipblasIzamaxStridedBatched_64](interfacehipfort__hipblas_1_1hipblasizamaxstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+42 | [hipblasIsamin](interfacehipfort__hipblas_1_1hipblasisamin.html "Interface documentation") | C binding, rank_0, rank_1
+43 | [hipblasIdamin](interfacehipfort__hipblas_1_1hipblasidamin.html "Interface documentation") | C binding, rank_0, rank_1
+44 | [hipblasIcamin](interfacehipfort__hipblas_1_1hipblasicamin.html "Interface documentation") | C binding, rank_0, rank_1
+45 | [hipblasIzamin](interfacehipfort__hipblas_1_1hipblasizamin.html "Interface documentation") | C binding, rank_0, rank_1
+46 | [hipblasIsamin_64](interfacehipfort__hipblas_1_1hipblasisamin__64.html "Interface documentation") | C binding, rank_0, rank_1
+47 | [hipblasIdamin_64](interfacehipfort__hipblas_1_1hipblasidamin__64.html "Interface documentation") | C binding, rank_0, rank_1
+48 | [hipblasIcamin_64](interfacehipfort__hipblas_1_1hipblasicamin__64.html "Interface documentation") | C binding, rank_0, rank_1
+49 | [hipblasIzamin_64](interfacehipfort__hipblas_1_1hipblasizamin__64.html "Interface documentation") | C binding, rank_0, rank_1
+50 | [hipblasIsaminBatched](interfacehipfort__hipblas_1_1hipblasisaminbatched.html "Interface documentation") | C binding
+51 | [hipblasIdaminBatched](interfacehipfort__hipblas_1_1hipblasidaminbatched.html "Interface documentation") | C binding
+52 | [hipblasIcaminBatched](interfacehipfort__hipblas_1_1hipblasicaminbatched.html "Interface documentation") | C binding
+53 | [hipblasIzaminBatched](interfacehipfort__hipblas_1_1hipblasizaminbatched.html "Interface documentation") | C binding
+54 | [hipblasIsaminBatched_64](interfacehipfort__hipblas_1_1hipblasisaminbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+55 | [hipblasIdaminBatched_64](interfacehipfort__hipblas_1_1hipblasidaminbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+56 | [hipblasIcaminBatched_64](interfacehipfort__hipblas_1_1hipblasicaminbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+57 | [hipblasIzaminBatched_64](interfacehipfort__hipblas_1_1hipblasizaminbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+58 | [hipblasIsaminStridedBatched](interfacehipfort__hipblas_1_1hipblasisaminstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+59 | [hipblasIdaminStridedBatched](interfacehipfort__hipblas_1_1hipblasidaminstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+60 | [hipblasIcaminStridedBatched](interfacehipfort__hipblas_1_1hipblasicaminstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+61 | [hipblasIzaminStridedBatched](interfacehipfort__hipblas_1_1hipblasizaminstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+62 | [hipblasIsaminStridedBatched_64](interfacehipfort__hipblas_1_1hipblasisaminstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+63 | [hipblasIdaminStridedBatched_64](interfacehipfort__hipblas_1_1hipblasidaminstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+64 | [hipblasIcaminStridedBatched_64](interfacehipfort__hipblas_1_1hipblasicaminstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+65 | [hipblasIzaminStridedBatched_64](interfacehipfort__hipblas_1_1hipblasizaminstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+66 | [hipblasSasum](interfacehipfort__hipblas_1_1hipblassasum.html "Interface documentation") | C binding, rank_0, rank_1
+67 | [hipblasDasum](interfacehipfort__hipblas_1_1hipblasdasum.html "Interface documentation") | C binding, rank_0, rank_1
+68 | [hipblasScasum](interfacehipfort__hipblas_1_1hipblasscasum.html "Interface documentation") | C binding, rank_0, rank_1
+69 | [hipblasDzasum](interfacehipfort__hipblas_1_1hipblasdzasum.html "Interface documentation") | C binding, rank_0, rank_1
+70 | [hipblasSasum_64](interfacehipfort__hipblas_1_1hipblassasum__64.html "Interface documentation") | C binding, rank_0, rank_1
+71 | [hipblasDasum_64](interfacehipfort__hipblas_1_1hipblasdasum__64.html "Interface documentation") | C binding, rank_0, rank_1
+72 | [hipblasScasum_64](interfacehipfort__hipblas_1_1hipblasscasum__64.html "Interface documentation") | C binding, rank_0, rank_1
+73 | [hipblasDzasum_64](interfacehipfort__hipblas_1_1hipblasdzasum__64.html "Interface documentation") | C binding, rank_0, rank_1
+74 | [hipblasSasumBatched](interfacehipfort__hipblas_1_1hipblassasumbatched.html "Interface documentation") | C binding
+75 | [hipblasDasumBatched](interfacehipfort__hipblas_1_1hipblasdasumbatched.html "Interface documentation") | C binding
+76 | [hipblasScasumBatched](interfacehipfort__hipblas_1_1hipblasscasumbatched.html "Interface documentation") | C binding
+77 | [hipblasDzasumBatched](interfacehipfort__hipblas_1_1hipblasdzasumbatched.html "Interface documentation") | C binding
+78 | [hipblasSasumBatched_64](interfacehipfort__hipblas_1_1hipblassasumbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+79 | [hipblasDasumBatched_64](interfacehipfort__hipblas_1_1hipblasdasumbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+80 | [hipblasScasumBatched_64](interfacehipfort__hipblas_1_1hipblasscasumbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+81 | [hipblasDzasumBatched_64](interfacehipfort__hipblas_1_1hipblasdzasumbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+82 | [hipblasSasumStridedBatched](interfacehipfort__hipblas_1_1hipblassasumstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+83 | [hipblasDasumStridedBatched](interfacehipfort__hipblas_1_1hipblasdasumstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+84 | [hipblasScasumStridedBatched](interfacehipfort__hipblas_1_1hipblasscasumstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+85 | [hipblasDzasumStridedBatched](interfacehipfort__hipblas_1_1hipblasdzasumstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+86 | [hipblasSasumStridedBatched_64](interfacehipfort__hipblas_1_1hipblassasumstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+87 | [hipblasDasumStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdasumstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+88 | [hipblasScasumStridedBatched_64](interfacehipfort__hipblas_1_1hipblasscasumstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+89 | [hipblasDzasumStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdzasumstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+90 | [hipblasHaxpy](interfacehipfort__hipblas_1_1hipblashaxpy.html "Interface documentation") | C binding
+91 | [hipblasSaxpy](interfacehipfort__hipblas_1_1hipblassaxpy.html "Interface documentation") | C binding, rank_0, rank_1
+92 | [hipblasDaxpy](interfacehipfort__hipblas_1_1hipblasdaxpy.html "Interface documentation") | C binding, rank_0, rank_1
+93 | [hipblasCaxpy](interfacehipfort__hipblas_1_1hipblascaxpy.html "Interface documentation") | C binding, rank_0, rank_1
+94 | [hipblasZaxpy](interfacehipfort__hipblas_1_1hipblaszaxpy.html "Interface documentation") | C binding, rank_0, rank_1
+95 | [hipblasHaxpy_64](interfacehipfort__hipblas_1_1hipblashaxpy__64.html "Interface documentation") | C binding
+96 | [hipblasSaxpy_64](interfacehipfort__hipblas_1_1hipblassaxpy__64.html "Interface documentation") | C binding, rank_0, rank_1
+97 | [hipblasDaxpy_64](interfacehipfort__hipblas_1_1hipblasdaxpy__64.html "Interface documentation") | C binding, rank_0, rank_1
+98 | [hipblasCaxpy_64](interfacehipfort__hipblas_1_1hipblascaxpy__64.html "Interface documentation") | C binding, rank_0, rank_1
+99 | [hipblasZaxpy_64](interfacehipfort__hipblas_1_1hipblaszaxpy__64.html "Interface documentation") | C binding, rank_0, rank_1
+100 | [hipblasHaxpyBatched](interfacehipfort__hipblas_1_1hipblashaxpybatched.html "Interface documentation") | C binding
+101 | [hipblasSaxpyBatched](interfacehipfort__hipblas_1_1hipblassaxpybatched.html "Interface documentation") | C binding
+102 | [hipblasDaxpyBatched](interfacehipfort__hipblas_1_1hipblasdaxpybatched.html "Interface documentation") | C binding
+103 | [hipblasCaxpyBatched](interfacehipfort__hipblas_1_1hipblascaxpybatched.html "Interface documentation") | C binding
+104 | [hipblasZaxpyBatched](interfacehipfort__hipblas_1_1hipblaszaxpybatched.html "Interface documentation") | C binding
+105 | [hipblasHaxpyBatched_64](interfacehipfort__hipblas_1_1hipblashaxpybatched__64.html "Interface documentation") | C binding
+106 | [hipblasSaxpyBatched_64](interfacehipfort__hipblas_1_1hipblassaxpybatched__64.html "Interface documentation") | C binding
+107 | [hipblasDaxpyBatched_64](interfacehipfort__hipblas_1_1hipblasdaxpybatched__64.html "Interface documentation") | C binding
+108 | [hipblasCaxpyBatched_64](interfacehipfort__hipblas_1_1hipblascaxpybatched__64.html "Interface documentation") | C binding
+109 | [hipblasZaxpyBatched_64](interfacehipfort__hipblas_1_1hipblaszaxpybatched__64.html "Interface documentation") | C binding
+110 | [hipblasHaxpyStridedBatched](interfacehipfort__hipblas_1_1hipblashaxpystridedbatched.html "Interface documentation") | C binding
+111 | [hipblasSaxpyStridedBatched](interfacehipfort__hipblas_1_1hipblassaxpystridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+112 | [hipblasDaxpyStridedBatched](interfacehipfort__hipblas_1_1hipblasdaxpystridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+113 | [hipblasCaxpyStridedBatched](interfacehipfort__hipblas_1_1hipblascaxpystridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+114 | [hipblasZaxpyStridedBatched](interfacehipfort__hipblas_1_1hipblaszaxpystridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+115 | [hipblasHaxpyStridedBatched_64](interfacehipfort__hipblas_1_1hipblashaxpystridedbatched__64.html "Interface documentation") | C binding
+116 | [hipblasSaxpyStridedBatched_64](interfacehipfort__hipblas_1_1hipblassaxpystridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+117 | [hipblasDaxpyStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdaxpystridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+118 | [hipblasCaxpyStridedBatched_64](interfacehipfort__hipblas_1_1hipblascaxpystridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+119 | [hipblasZaxpyStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszaxpystridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+120 | [hipblasScopy](interfacehipfort__hipblas_1_1hipblasscopy.html "Interface documentation") | C binding, rank_0, rank_1
+121 | [hipblasDcopy](interfacehipfort__hipblas_1_1hipblasdcopy.html "Interface documentation") | C binding, rank_0, rank_1
+122 | [hipblasCcopy](interfacehipfort__hipblas_1_1hipblasccopy.html "Interface documentation") | C binding, rank_0, rank_1
+123 | [hipblasZcopy](interfacehipfort__hipblas_1_1hipblaszcopy.html "Interface documentation") | C binding, rank_0, rank_1
+124 | [hipblasScopy_64](interfacehipfort__hipblas_1_1hipblasscopy__64.html "Interface documentation") | C binding, rank_0, rank_1
+125 | [hipblasDcopy_64](interfacehipfort__hipblas_1_1hipblasdcopy__64.html "Interface documentation") | C binding, rank_0, rank_1
+126 | [hipblasCcopy_64](interfacehipfort__hipblas_1_1hipblasccopy__64.html "Interface documentation") | C binding, rank_0, rank_1
+127 | [hipblasZcopy_64](interfacehipfort__hipblas_1_1hipblaszcopy__64.html "Interface documentation") | C binding, rank_0, rank_1
+128 | [hipblasScopyBatched](interfacehipfort__hipblas_1_1hipblasscopybatched.html "Interface documentation") | C binding
+129 | [hipblasDcopyBatched](interfacehipfort__hipblas_1_1hipblasdcopybatched.html "Interface documentation") | C binding
+130 | [hipblasCcopyBatched](interfacehipfort__hipblas_1_1hipblasccopybatched.html "Interface documentation") | C binding
+131 | [hipblasZcopyBatched](interfacehipfort__hipblas_1_1hipblaszcopybatched.html "Interface documentation") | C binding
+132 | [hipblasScopyBatched_64](interfacehipfort__hipblas_1_1hipblasscopybatched__64.html "Interface documentation") | C binding
+133 | [hipblasDcopyBatched_64](interfacehipfort__hipblas_1_1hipblasdcopybatched__64.html "Interface documentation") | C binding
+134 | [hipblasCcopyBatched_64](interfacehipfort__hipblas_1_1hipblasccopybatched__64.html "Interface documentation") | C binding
+135 | [hipblasZcopyBatched_64](interfacehipfort__hipblas_1_1hipblaszcopybatched__64.html "Interface documentation") | C binding
+136 | [hipblasScopyStridedBatched](interfacehipfort__hipblas_1_1hipblasscopystridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+137 | [hipblasDcopyStridedBatched](interfacehipfort__hipblas_1_1hipblasdcopystridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+138 | [hipblasCcopyStridedBatched](interfacehipfort__hipblas_1_1hipblasccopystridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+139 | [hipblasZcopyStridedBatched](interfacehipfort__hipblas_1_1hipblaszcopystridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+140 | [hipblasScopyStridedBatched_64](interfacehipfort__hipblas_1_1hipblasscopystridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+141 | [hipblasDcopyStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdcopystridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+142 | [hipblasCcopyStridedBatched_64](interfacehipfort__hipblas_1_1hipblasccopystridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+143 | [hipblasZcopyStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszcopystridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+144 | [hipblasHdot](interfacehipfort__hipblas_1_1hipblashdot.html "Interface documentation") | C binding
+145 | [hipblasBfdot](interfacehipfort__hipblas_1_1hipblasbfdot.html "Interface documentation") | C binding, rank_0, rank_1
+146 | [hipblasSdot](interfacehipfort__hipblas_1_1hipblassdot.html "Interface documentation") | C binding, rank_0, rank_1
+147 | [hipblasDdot](interfacehipfort__hipblas_1_1hipblasddot.html "Interface documentation") | C binding, rank_0, rank_1
+148 | [hipblasCdotc](interfacehipfort__hipblas_1_1hipblascdotc.html "Interface documentation") | C binding, rank_0, rank_1
+149 | [hipblasCdotu](interfacehipfort__hipblas_1_1hipblascdotu.html "Interface documentation") | C binding, rank_0, rank_1
+150 | [hipblasZdotc](interfacehipfort__hipblas_1_1hipblaszdotc.html "Interface documentation") | C binding, rank_0, rank_1
+151 | [hipblasZdotu](interfacehipfort__hipblas_1_1hipblaszdotu.html "Interface documentation") | C binding, rank_0, rank_1
+152 | [hipblasHdot_64](interfacehipfort__hipblas_1_1hipblashdot__64.html "Interface documentation") | C binding
+153 | [hipblasBfdot_64](interfacehipfort__hipblas_1_1hipblasbfdot__64.html "Interface documentation") | C binding, rank_0, rank_1
+154 | [hipblasSdot_64](interfacehipfort__hipblas_1_1hipblassdot__64.html "Interface documentation") | C binding, rank_0, rank_1
+155 | [hipblasDdot_64](interfacehipfort__hipblas_1_1hipblasddot__64.html "Interface documentation") | C binding, rank_0, rank_1
+156 | [hipblasCdotc_64](interfacehipfort__hipblas_1_1hipblascdotc__64.html "Interface documentation") | C binding, rank_0, rank_1
+157 | [hipblasCdotu_64](interfacehipfort__hipblas_1_1hipblascdotu__64.html "Interface documentation") | C binding, rank_0, rank_1
+158 | [hipblasZdotc_64](interfacehipfort__hipblas_1_1hipblaszdotc__64.html "Interface documentation") | C binding, rank_0, rank_1
+159 | [hipblasZdotu_64](interfacehipfort__hipblas_1_1hipblaszdotu__64.html "Interface documentation") | C binding, rank_0, rank_1
+160 | [hipblasHdotBatched](interfacehipfort__hipblas_1_1hipblashdotbatched.html "Interface documentation") | C binding
+161 | [hipblasBfdotBatched](interfacehipfort__hipblas_1_1hipblasbfdotbatched.html "Interface documentation") | C binding, rank_0, rank_1
+162 | [hipblasSdotBatched](interfacehipfort__hipblas_1_1hipblassdotbatched.html "Interface documentation") | C binding
+163 | [hipblasDdotBatched](interfacehipfort__hipblas_1_1hipblasddotbatched.html "Interface documentation") | C binding
+164 | [hipblasCdotcBatched](interfacehipfort__hipblas_1_1hipblascdotcbatched.html "Interface documentation") | C binding
+165 | [hipblasCdotuBatched](interfacehipfort__hipblas_1_1hipblascdotubatched.html "Interface documentation") | C binding
+166 | [hipblasZdotcBatched](interfacehipfort__hipblas_1_1hipblaszdotcbatched.html "Interface documentation") | C binding
+167 | [hipblasZdotuBatched](interfacehipfort__hipblas_1_1hipblaszdotubatched.html "Interface documentation") | C binding
+168 | [hipblasHdotBatched_64](interfacehipfort__hipblas_1_1hipblashdotbatched__64.html "Interface documentation") | C binding
+169 | [hipblasBfdotBatched_64](interfacehipfort__hipblas_1_1hipblasbfdotbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+170 | [hipblasSdotBatched_64](interfacehipfort__hipblas_1_1hipblassdotbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+171 | [hipblasDdotBatched_64](interfacehipfort__hipblas_1_1hipblasddotbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+172 | [hipblasCdotcBatched_64](interfacehipfort__hipblas_1_1hipblascdotcbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+173 | [hipblasCdotuBatched_64](interfacehipfort__hipblas_1_1hipblascdotubatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+174 | [hipblasZdotcBatched_64](interfacehipfort__hipblas_1_1hipblaszdotcbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+175 | [hipblasZdotuBatched_64](interfacehipfort__hipblas_1_1hipblaszdotubatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+176 | [hipblasHdotStridedBatched](interfacehipfort__hipblas_1_1hipblashdotstridedbatched.html "Interface documentation") | C binding
+177 | [hipblasBfdotStridedBatched](interfacehipfort__hipblas_1_1hipblasbfdotstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+178 | [hipblasSdotStridedBatched](interfacehipfort__hipblas_1_1hipblassdotstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+179 | [hipblasDdotStridedBatched](interfacehipfort__hipblas_1_1hipblasddotstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+180 | [hipblasCdotcStridedBatched](interfacehipfort__hipblas_1_1hipblascdotcstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+181 | [hipblasCdotuStridedBatched](interfacehipfort__hipblas_1_1hipblascdotustridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+182 | [hipblasZdotcStridedBatched](interfacehipfort__hipblas_1_1hipblaszdotcstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+183 | [hipblasZdotuStridedBatched](interfacehipfort__hipblas_1_1hipblaszdotustridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+184 | [hipblasHdotStridedBatched_64](interfacehipfort__hipblas_1_1hipblashdotstridedbatched__64.html "Interface documentation") | C binding
+185 | [hipblasBfdotStridedBatched_64](interfacehipfort__hipblas_1_1hipblasbfdotstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+186 | [hipblasSdotStridedBatched_64](interfacehipfort__hipblas_1_1hipblassdotstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+187 | [hipblasDdotStridedBatched_64](interfacehipfort__hipblas_1_1hipblasddotstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+188 | [hipblasCdotcStridedBatched_64](interfacehipfort__hipblas_1_1hipblascdotcstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+189 | [hipblasCdotuStridedBatched_64](interfacehipfort__hipblas_1_1hipblascdotustridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+190 | [hipblasZdotcStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszdotcstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+191 | [hipblasZdotuStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszdotustridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+192 | [hipblasSnrm2](interfacehipfort__hipblas_1_1hipblassnrm2.html "Interface documentation") | C binding, rank_0, rank_1
+193 | [hipblasDnrm2](interfacehipfort__hipblas_1_1hipblasdnrm2.html "Interface documentation") | C binding, rank_0, rank_1
+194 | [hipblasScnrm2](interfacehipfort__hipblas_1_1hipblasscnrm2.html "Interface documentation") | C binding, rank_0, rank_1
+195 | [hipblasDznrm2](interfacehipfort__hipblas_1_1hipblasdznrm2.html "Interface documentation") | C binding, rank_0, rank_1
+196 | [hipblasSnrm2_64](interfacehipfort__hipblas_1_1hipblassnrm2__64.html "Interface documentation") | C binding, rank_0, rank_1
+197 | [hipblasDnrm2_64](interfacehipfort__hipblas_1_1hipblasdnrm2__64.html "Interface documentation") | C binding, rank_0, rank_1
+198 | [hipblasScnrm2_64](interfacehipfort__hipblas_1_1hipblasscnrm2__64.html "Interface documentation") | C binding, rank_0, rank_1
+199 | [hipblasDznrm2_64](interfacehipfort__hipblas_1_1hipblasdznrm2__64.html "Interface documentation") | C binding, rank_0, rank_1
+200 | [hipblasSnrm2Batched](interfacehipfort__hipblas_1_1hipblassnrm2batched.html "Interface documentation") | C binding
+201 | [hipblasDnrm2Batched](interfacehipfort__hipblas_1_1hipblasdnrm2batched.html "Interface documentation") | C binding
+202 | [hipblasScnrm2Batched](interfacehipfort__hipblas_1_1hipblasscnrm2batched.html "Interface documentation") | C binding
+203 | [hipblasDznrm2Batched](interfacehipfort__hipblas_1_1hipblasdznrm2batched.html "Interface documentation") | C binding
+204 | [hipblasSnrm2Batched_64](interfacehipfort__hipblas_1_1hipblassnrm2batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+205 | [hipblasDnrm2Batched_64](interfacehipfort__hipblas_1_1hipblasdnrm2batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+206 | [hipblasScnrm2Batched_64](interfacehipfort__hipblas_1_1hipblasscnrm2batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+207 | [hipblasDznrm2Batched_64](interfacehipfort__hipblas_1_1hipblasdznrm2batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+208 | [hipblasSnrm2StridedBatched](interfacehipfort__hipblas_1_1hipblassnrm2stridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+209 | [hipblasDnrm2StridedBatched](interfacehipfort__hipblas_1_1hipblasdnrm2stridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+210 | [hipblasScnrm2StridedBatched](interfacehipfort__hipblas_1_1hipblasscnrm2stridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+211 | [hipblasDznrm2StridedBatched](interfacehipfort__hipblas_1_1hipblasdznrm2stridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+212 | [hipblasSnrm2StridedBatched_64](interfacehipfort__hipblas_1_1hipblassnrm2stridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+213 | [hipblasDnrm2StridedBatched_64](interfacehipfort__hipblas_1_1hipblasdnrm2stridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+214 | [hipblasScnrm2StridedBatched_64](interfacehipfort__hipblas_1_1hipblasscnrm2stridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+215 | [hipblasDznrm2StridedBatched_64](interfacehipfort__hipblas_1_1hipblasdznrm2stridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+216 | [hipblasSrot](interfacehipfort__hipblas_1_1hipblassrot.html "Interface documentation") | C binding, rank_0, rank_1
+217 | [hipblasDrot](interfacehipfort__hipblas_1_1hipblasdrot.html "Interface documentation") | C binding, rank_0, rank_1
+218 | [hipblasCrot](interfacehipfort__hipblas_1_1hipblascrot.html "Interface documentation") | C binding, rank_0, rank_1
+219 | [hipblasCsrot](interfacehipfort__hipblas_1_1hipblascsrot.html "Interface documentation") | C binding, rank_0, rank_1
+220 | [hipblasZrot](interfacehipfort__hipblas_1_1hipblaszrot.html "Interface documentation") | C binding, rank_0, rank_1
+221 | [hipblasZdrot](interfacehipfort__hipblas_1_1hipblaszdrot.html "Interface documentation") | C binding, rank_0, rank_1
+222 | [hipblasSrot_64](interfacehipfort__hipblas_1_1hipblassrot__64.html "Interface documentation") | C binding, rank_0, rank_1
+223 | [hipblasDrot_64](interfacehipfort__hipblas_1_1hipblasdrot__64.html "Interface documentation") | C binding, rank_0, rank_1
+224 | [hipblasCrot_64](interfacehipfort__hipblas_1_1hipblascrot__64.html "Interface documentation") | C binding, rank_0, rank_1
+225 | [hipblasCsrot_64](interfacehipfort__hipblas_1_1hipblascsrot__64.html "Interface documentation") | C binding, rank_0, rank_1
+226 | [hipblasZrot_64](interfacehipfort__hipblas_1_1hipblaszrot__64.html "Interface documentation") | C binding, rank_0, rank_1
+227 | [hipblasZdrot_64](interfacehipfort__hipblas_1_1hipblaszdrot__64.html "Interface documentation") | C binding, rank_0, rank_1
+228 | [hipblasSrotBatched](interfacehipfort__hipblas_1_1hipblassrotbatched.html "Interface documentation") | C binding
+229 | [hipblasDrotBatched](interfacehipfort__hipblas_1_1hipblasdrotbatched.html "Interface documentation") | C binding
+230 | [hipblasCrotBatched](interfacehipfort__hipblas_1_1hipblascrotbatched.html "Interface documentation") | C binding
+231 | [hipblasCsrotBatched](interfacehipfort__hipblas_1_1hipblascsrotbatched.html "Interface documentation") | C binding
+232 | [hipblasZrotBatched](interfacehipfort__hipblas_1_1hipblaszrotbatched.html "Interface documentation") | C binding
+233 | [hipblasZdrotBatched](interfacehipfort__hipblas_1_1hipblaszdrotbatched.html "Interface documentation") | C binding
+234 | [hipblasSrotBatched_64](interfacehipfort__hipblas_1_1hipblassrotbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+235 | [hipblasDrotBatched_64](interfacehipfort__hipblas_1_1hipblasdrotbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+236 | [hipblasCrotBatched_64](interfacehipfort__hipblas_1_1hipblascrotbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+237 | [hipblasCsrotBatched_64](interfacehipfort__hipblas_1_1hipblascsrotbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+238 | [hipblasZrotBatched_64](interfacehipfort__hipblas_1_1hipblaszrotbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+239 | [hipblasZdrotBatched_64](interfacehipfort__hipblas_1_1hipblaszdrotbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+240 | [hipblasSrotStridedBatched](interfacehipfort__hipblas_1_1hipblassrotstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+241 | [hipblasDrotStridedBatched](interfacehipfort__hipblas_1_1hipblasdrotstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+242 | [hipblasCrotStridedBatched](interfacehipfort__hipblas_1_1hipblascrotstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+243 | [hipblasCsrotStridedBatched](interfacehipfort__hipblas_1_1hipblascsrotstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+244 | [hipblasZrotStridedBatched](interfacehipfort__hipblas_1_1hipblaszrotstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+245 | [hipblasZdrotStridedBatched](interfacehipfort__hipblas_1_1hipblaszdrotstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+246 | [hipblasSrotStridedBatched_64](interfacehipfort__hipblas_1_1hipblassrotstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+247 | [hipblasDrotStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdrotstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+248 | [hipblasCrotStridedBatched_64](interfacehipfort__hipblas_1_1hipblascrotstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+249 | [hipblasCsrotStridedBatched_64](interfacehipfort__hipblas_1_1hipblascsrotstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+250 | [hipblasZrotStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszrotstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+251 | [hipblasZdrotStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszdrotstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+252 | [hipblasSrotg](interfacehipfort__hipblas_1_1hipblassrotg.html "Interface documentation") | C binding, rank_0, rank_1
+253 | [hipblasDrotg](interfacehipfort__hipblas_1_1hipblasdrotg.html "Interface documentation") | C binding, rank_0, rank_1
+254 | [hipblasCrotg](interfacehipfort__hipblas_1_1hipblascrotg.html "Interface documentation") | C binding, rank_0, rank_1
+255 | [hipblasZrotg](interfacehipfort__hipblas_1_1hipblaszrotg.html "Interface documentation") | C binding, rank_0, rank_1
+256 | [hipblasSrotg_64](interfacehipfort__hipblas_1_1hipblassrotg__64.html "Interface documentation") | C binding, rank_0, rank_1
+257 | [hipblasDrotg_64](interfacehipfort__hipblas_1_1hipblasdrotg__64.html "Interface documentation") | C binding, rank_0, rank_1
+258 | [hipblasCrotg_64](interfacehipfort__hipblas_1_1hipblascrotg__64.html "Interface documentation") | C binding, rank_0, rank_1
+259 | [hipblasZrotg_64](interfacehipfort__hipblas_1_1hipblaszrotg__64.html "Interface documentation") | C binding, rank_0, rank_1
+260 | [hipblasSrotgBatched](interfacehipfort__hipblas_1_1hipblassrotgbatched.html "Interface documentation") | C binding
+261 | [hipblasDrotgBatched](interfacehipfort__hipblas_1_1hipblasdrotgbatched.html "Interface documentation") | C binding
+262 | [hipblasCrotgBatched](interfacehipfort__hipblas_1_1hipblascrotgbatched.html "Interface documentation") | C binding
+263 | [hipblasZrotgBatched](interfacehipfort__hipblas_1_1hipblaszrotgbatched.html "Interface documentation") | C binding
+264 | [hipblasSrotgBatched_64](interfacehipfort__hipblas_1_1hipblassrotgbatched__64.html "Interface documentation") | C binding
+265 | [hipblasDrotgBatched_64](interfacehipfort__hipblas_1_1hipblasdrotgbatched__64.html "Interface documentation") | C binding
+266 | [hipblasCrotgBatched_64](interfacehipfort__hipblas_1_1hipblascrotgbatched__64.html "Interface documentation") | C binding
+267 | [hipblasZrotgBatched_64](interfacehipfort__hipblas_1_1hipblaszrotgbatched__64.html "Interface documentation") | C binding
+268 | [hipblasSrotgStridedBatched](interfacehipfort__hipblas_1_1hipblassrotgstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+269 | [hipblasDrotgStridedBatched](interfacehipfort__hipblas_1_1hipblasdrotgstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+270 | [hipblasCrotgStridedBatched](interfacehipfort__hipblas_1_1hipblascrotgstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+271 | [hipblasZrotgStridedBatched](interfacehipfort__hipblas_1_1hipblaszrotgstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+272 | [hipblasSrotgStridedBatched_64](interfacehipfort__hipblas_1_1hipblassrotgstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+273 | [hipblasDrotgStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdrotgstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+274 | [hipblasCrotgStridedBatched_64](interfacehipfort__hipblas_1_1hipblascrotgstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+275 | [hipblasZrotgStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszrotgstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+276 | [hipblasSrotm](interfacehipfort__hipblas_1_1hipblassrotm.html "Interface documentation") | C binding, rank_0, rank_1
+277 | [hipblasDrotm](interfacehipfort__hipblas_1_1hipblasdrotm.html "Interface documentation") | C binding, rank_0, rank_1
+278 | [hipblasSrotm_64](interfacehipfort__hipblas_1_1hipblassrotm__64.html "Interface documentation") | C binding, rank_0, rank_1
+279 | [hipblasDrotm_64](interfacehipfort__hipblas_1_1hipblasdrotm__64.html "Interface documentation") | C binding, rank_0, rank_1
+280 | [hipblasSrotmBatched](interfacehipfort__hipblas_1_1hipblassrotmbatched.html "Interface documentation") | C binding
+281 | [hipblasDrotmBatched](interfacehipfort__hipblas_1_1hipblasdrotmbatched.html "Interface documentation") | C binding
+282 | [hipblasSrotmBatched_64](interfacehipfort__hipblas_1_1hipblassrotmbatched__64.html "Interface documentation") | C binding
+283 | [hipblasDrotmBatched_64](interfacehipfort__hipblas_1_1hipblasdrotmbatched__64.html "Interface documentation") | C binding
+284 | [hipblasSrotmStridedBatched](interfacehipfort__hipblas_1_1hipblassrotmstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+285 | [hipblasDrotmStridedBatched](interfacehipfort__hipblas_1_1hipblasdrotmstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+286 | [hipblasSrotmStridedBatched_64](interfacehipfort__hipblas_1_1hipblassrotmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+287 | [hipblasDrotmStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdrotmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+288 | [hipblasSrotmg](interfacehipfort__hipblas_1_1hipblassrotmg.html "Interface documentation") | C binding, rank_0, rank_1
+289 | [hipblasDrotmg](interfacehipfort__hipblas_1_1hipblasdrotmg.html "Interface documentation") | C binding, rank_0, rank_1
+290 | [hipblasSrotmg_64](interfacehipfort__hipblas_1_1hipblassrotmg__64.html "Interface documentation") | C binding, rank_0, rank_1
+291 | [hipblasDrotmg_64](interfacehipfort__hipblas_1_1hipblasdrotmg__64.html "Interface documentation") | C binding, rank_0, rank_1
+292 | [hipblasSrotmgBatched](interfacehipfort__hipblas_1_1hipblassrotmgbatched.html "Interface documentation") | C binding
+293 | [hipblasDrotmgBatched](interfacehipfort__hipblas_1_1hipblasdrotmgbatched.html "Interface documentation") | C binding
+294 | [hipblasSrotmgBatched_64](interfacehipfort__hipblas_1_1hipblassrotmgbatched__64.html "Interface documentation") | C binding
+295 | [hipblasDrotmgBatched_64](interfacehipfort__hipblas_1_1hipblasdrotmgbatched__64.html "Interface documentation") | C binding
+296 | [hipblasSrotmgStridedBatched](interfacehipfort__hipblas_1_1hipblassrotmgstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+297 | [hipblasDrotmgStridedBatched](interfacehipfort__hipblas_1_1hipblasdrotmgstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+298 | [hipblasSrotmgStridedBatched_64](interfacehipfort__hipblas_1_1hipblassrotmgstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+299 | [hipblasDrotmgStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdrotmgstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+300 | [hipblasSscal](interfacehipfort__hipblas_1_1hipblassscal.html "Interface documentation") | C binding, rank_0, rank_1
+301 | [hipblasDscal](interfacehipfort__hipblas_1_1hipblasdscal.html "Interface documentation") | C binding, rank_0, rank_1
+302 | [hipblasCscal](interfacehipfort__hipblas_1_1hipblascscal.html "Interface documentation") | C binding, rank_0, rank_1
+303 | [hipblasCsscal](interfacehipfort__hipblas_1_1hipblascsscal.html "Interface documentation") | C binding, rank_0, rank_1
+304 | [hipblasZscal](interfacehipfort__hipblas_1_1hipblaszscal.html "Interface documentation") | C binding, rank_0, rank_1
+305 | [hipblasZdscal](interfacehipfort__hipblas_1_1hipblaszdscal.html "Interface documentation") | C binding, rank_0, rank_1
+306 | [hipblasSscal_64](interfacehipfort__hipblas_1_1hipblassscal__64.html "Interface documentation") | C binding, rank_0, rank_1
+307 | [hipblasDscal_64](interfacehipfort__hipblas_1_1hipblasdscal__64.html "Interface documentation") | C binding, rank_0, rank_1
+308 | [hipblasCscal_64](interfacehipfort__hipblas_1_1hipblascscal__64.html "Interface documentation") | C binding, rank_0, rank_1
+309 | [hipblasCsscal_64](interfacehipfort__hipblas_1_1hipblascsscal__64.html "Interface documentation") | C binding, rank_0, rank_1
+310 | [hipblasZscal_64](interfacehipfort__hipblas_1_1hipblaszscal__64.html "Interface documentation") | C binding, rank_0, rank_1
+311 | [hipblasZdscal_64](interfacehipfort__hipblas_1_1hipblaszdscal__64.html "Interface documentation") | C binding, rank_0, rank_1
+312 | [hipblasSscalBatched](interfacehipfort__hipblas_1_1hipblassscalbatched.html "Interface documentation") | C binding
+313 | [hipblasDscalBatched](interfacehipfort__hipblas_1_1hipblasdscalbatched.html "Interface documentation") | C binding
+314 | [hipblasCscalBatched](interfacehipfort__hipblas_1_1hipblascscalbatched.html "Interface documentation") | C binding
+315 | [hipblasZscalBatched](interfacehipfort__hipblas_1_1hipblaszscalbatched.html "Interface documentation") | C binding
+316 | [hipblasCsscalBatched](interfacehipfort__hipblas_1_1hipblascsscalbatched.html "Interface documentation") | C binding
+317 | [hipblasZdscalBatched](interfacehipfort__hipblas_1_1hipblaszdscalbatched.html "Interface documentation") | C binding
+318 | [hipblasSscalBatched_64](interfacehipfort__hipblas_1_1hipblassscalbatched__64.html "Interface documentation") | C binding
+319 | [hipblasDscalBatched_64](interfacehipfort__hipblas_1_1hipblasdscalbatched__64.html "Interface documentation") | C binding
+320 | [hipblasCscalBatched_64](interfacehipfort__hipblas_1_1hipblascscalbatched__64.html "Interface documentation") | C binding
+321 | [hipblasZscalBatched_64](interfacehipfort__hipblas_1_1hipblaszscalbatched__64.html "Interface documentation") | C binding
+322 | [hipblasCsscalBatched_64](interfacehipfort__hipblas_1_1hipblascsscalbatched__64.html "Interface documentation") | C binding
+323 | [hipblasZdscalBatched_64](interfacehipfort__hipblas_1_1hipblaszdscalbatched__64.html "Interface documentation") | C binding
+324 | [hipblasSscalStridedBatched](interfacehipfort__hipblas_1_1hipblassscalstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+325 | [hipblasDscalStridedBatched](interfacehipfort__hipblas_1_1hipblasdscalstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+326 | [hipblasCscalStridedBatched](interfacehipfort__hipblas_1_1hipblascscalstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+327 | [hipblasZscalStridedBatched](interfacehipfort__hipblas_1_1hipblaszscalstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+328 | [hipblasCsscalStridedBatched](interfacehipfort__hipblas_1_1hipblascsscalstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+329 | [hipblasZdscalStridedBatched](interfacehipfort__hipblas_1_1hipblaszdscalstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+330 | [hipblasSscalStridedBatched_64](interfacehipfort__hipblas_1_1hipblassscalstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+331 | [hipblasDscalStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdscalstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+332 | [hipblasCscalStridedBatched_64](interfacehipfort__hipblas_1_1hipblascscalstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+333 | [hipblasZscalStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszscalstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+334 | [hipblasCsscalStridedBatched_64](interfacehipfort__hipblas_1_1hipblascsscalstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+335 | [hipblasZdscalStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszdscalstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+336 | [hipblasSswap](interfacehipfort__hipblas_1_1hipblassswap.html "Interface documentation") | C binding, rank_0, rank_1
+337 | [hipblasDswap](interfacehipfort__hipblas_1_1hipblasdswap.html "Interface documentation") | C binding, rank_0, rank_1
+338 | [hipblasCswap](interfacehipfort__hipblas_1_1hipblascswap.html "Interface documentation") | C binding, rank_0, rank_1
+339 | [hipblasZswap](interfacehipfort__hipblas_1_1hipblaszswap.html "Interface documentation") | C binding, rank_0, rank_1
+340 | [hipblasSswap_64](interfacehipfort__hipblas_1_1hipblassswap__64.html "Interface documentation") | C binding, rank_0, rank_1
+341 | [hipblasDswap_64](interfacehipfort__hipblas_1_1hipblasdswap__64.html "Interface documentation") | C binding, rank_0, rank_1
+342 | [hipblasCswap_64](interfacehipfort__hipblas_1_1hipblascswap__64.html "Interface documentation") | C binding, rank_0, rank_1
+343 | [hipblasZswap_64](interfacehipfort__hipblas_1_1hipblaszswap__64.html "Interface documentation") | C binding, rank_0, rank_1
+344 | [hipblasSswapBatched](interfacehipfort__hipblas_1_1hipblassswapbatched.html "Interface documentation") | C binding
+345 | [hipblasDswapBatched](interfacehipfort__hipblas_1_1hipblasdswapbatched.html "Interface documentation") | C binding
+346 | [hipblasCswapBatched](interfacehipfort__hipblas_1_1hipblascswapbatched.html "Interface documentation") | C binding
+347 | [hipblasZswapBatched](interfacehipfort__hipblas_1_1hipblaszswapbatched.html "Interface documentation") | C binding
+348 | [hipblasSswapBatched_64](interfacehipfort__hipblas_1_1hipblassswapbatched__64.html "Interface documentation") | C binding
+349 | [hipblasDswapBatched_64](interfacehipfort__hipblas_1_1hipblasdswapbatched__64.html "Interface documentation") | C binding
+350 | [hipblasCswapBatched_64](interfacehipfort__hipblas_1_1hipblascswapbatched__64.html "Interface documentation") | C binding
+351 | [hipblasZswapBatched_64](interfacehipfort__hipblas_1_1hipblaszswapbatched__64.html "Interface documentation") | C binding
+352 | [hipblasSswapStridedBatched](interfacehipfort__hipblas_1_1hipblassswapstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+353 | [hipblasDswapStridedBatched](interfacehipfort__hipblas_1_1hipblasdswapstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+354 | [hipblasCswapStridedBatched](interfacehipfort__hipblas_1_1hipblascswapstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+355 | [hipblasZswapStridedBatched](interfacehipfort__hipblas_1_1hipblaszswapstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+356 | [hipblasSswapStridedBatched_64](interfacehipfort__hipblas_1_1hipblassswapstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+357 | [hipblasDswapStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdswapstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+358 | [hipblasCswapStridedBatched_64](interfacehipfort__hipblas_1_1hipblascswapstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+359 | [hipblasZswapStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszswapstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+360 | [hipblasSgbmv](interfacehipfort__hipblas_1_1hipblassgbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+361 | [hipblasDgbmv](interfacehipfort__hipblas_1_1hipblasdgbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+362 | [hipblasCgbmv](interfacehipfort__hipblas_1_1hipblascgbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+363 | [hipblasZgbmv](interfacehipfort__hipblas_1_1hipblaszgbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+364 | [hipblasSgbmv_64](interfacehipfort__hipblas_1_1hipblassgbmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+365 | [hipblasDgbmv_64](interfacehipfort__hipblas_1_1hipblasdgbmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+366 | [hipblasCgbmv_64](interfacehipfort__hipblas_1_1hipblascgbmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+367 | [hipblasZgbmv_64](interfacehipfort__hipblas_1_1hipblaszgbmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+368 | [hipblasSgbmvBatched](interfacehipfort__hipblas_1_1hipblassgbmvbatched.html "Interface documentation") | C binding
+369 | [hipblasDgbmvBatched](interfacehipfort__hipblas_1_1hipblasdgbmvbatched.html "Interface documentation") | C binding
+370 | [hipblasCgbmvBatched](interfacehipfort__hipblas_1_1hipblascgbmvbatched.html "Interface documentation") | C binding
+371 | [hipblasZgbmvBatched](interfacehipfort__hipblas_1_1hipblaszgbmvbatched.html "Interface documentation") | C binding
+372 | [hipblasSgbmvBatched_64](interfacehipfort__hipblas_1_1hipblassgbmvbatched__64.html "Interface documentation") | C binding
+373 | [hipblasDgbmvBatched_64](interfacehipfort__hipblas_1_1hipblasdgbmvbatched__64.html "Interface documentation") | C binding
+374 | [hipblasCgbmvBatched_64](interfacehipfort__hipblas_1_1hipblascgbmvbatched__64.html "Interface documentation") | C binding
+375 | [hipblasZgbmvBatched_64](interfacehipfort__hipblas_1_1hipblaszgbmvbatched__64.html "Interface documentation") | C binding
+376 | [hipblasSgbmvStridedBatched](interfacehipfort__hipblas_1_1hipblassgbmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+377 | [hipblasDgbmvStridedBatched](interfacehipfort__hipblas_1_1hipblasdgbmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+378 | [hipblasCgbmvStridedBatched](interfacehipfort__hipblas_1_1hipblascgbmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+379 | [hipblasZgbmvStridedBatched](interfacehipfort__hipblas_1_1hipblaszgbmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+380 | [hipblasSgbmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblassgbmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+381 | [hipblasDgbmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdgbmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+382 | [hipblasCgbmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblascgbmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+383 | [hipblasZgbmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszgbmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+384 | [hipblasSgemv](interfacehipfort__hipblas_1_1hipblassgemv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+385 | [hipblasDgemv](interfacehipfort__hipblas_1_1hipblasdgemv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+386 | [hipblasCgemv](interfacehipfort__hipblas_1_1hipblascgemv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+387 | [hipblasZgemv](interfacehipfort__hipblas_1_1hipblaszgemv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+388 | [hipblasSgemv_64](interfacehipfort__hipblas_1_1hipblassgemv__64.html "Interface documentation") | C binding, rank_0, rank_1
+389 | [hipblasDgemv_64](interfacehipfort__hipblas_1_1hipblasdgemv__64.html "Interface documentation") | C binding, rank_0, rank_1
+390 | [hipblasCgemv_64](interfacehipfort__hipblas_1_1hipblascgemv__64.html "Interface documentation") | C binding, rank_0, rank_1
+391 | [hipblasZgemv_64](interfacehipfort__hipblas_1_1hipblaszgemv__64.html "Interface documentation") | C binding, rank_0, rank_1
+392 | [hipblasSgemvBatched](interfacehipfort__hipblas_1_1hipblassgemvbatched.html "Interface documentation") | C binding
+393 | [hipblasDgemvBatched](interfacehipfort__hipblas_1_1hipblasdgemvbatched.html "Interface documentation") | C binding
+394 | [hipblasCgemvBatched](interfacehipfort__hipblas_1_1hipblascgemvbatched.html "Interface documentation") | C binding
+395 | [hipblasZgemvBatched](interfacehipfort__hipblas_1_1hipblaszgemvbatched.html "Interface documentation") | C binding
+396 | [hipblasSgemvBatched_64](interfacehipfort__hipblas_1_1hipblassgemvbatched__64.html "Interface documentation") | C binding
+397 | [hipblasDgemvBatched_64](interfacehipfort__hipblas_1_1hipblasdgemvbatched__64.html "Interface documentation") | C binding
+398 | [hipblasCgemvBatched_64](interfacehipfort__hipblas_1_1hipblascgemvbatched__64.html "Interface documentation") | C binding
+399 | [hipblasZgemvBatched_64](interfacehipfort__hipblas_1_1hipblaszgemvbatched__64.html "Interface documentation") | C binding
+400 | [hipblasSgemvStridedBatched](interfacehipfort__hipblas_1_1hipblassgemvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+401 | [hipblasDgemvStridedBatched](interfacehipfort__hipblas_1_1hipblasdgemvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+402 | [hipblasCgemvStridedBatched](interfacehipfort__hipblas_1_1hipblascgemvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+403 | [hipblasZgemvStridedBatched](interfacehipfort__hipblas_1_1hipblaszgemvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+404 | [hipblasSgemvStridedBatched_64](interfacehipfort__hipblas_1_1hipblassgemvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+405 | [hipblasDgemvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdgemvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+406 | [hipblasCgemvStridedBatched_64](interfacehipfort__hipblas_1_1hipblascgemvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+407 | [hipblasZgemvStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszgemvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+408 | [hipblasSger](interfacehipfort__hipblas_1_1hipblassger.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+409 | [hipblasDger](interfacehipfort__hipblas_1_1hipblasdger.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+410 | [hipblasCgeru](interfacehipfort__hipblas_1_1hipblascgeru.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+411 | [hipblasCgerc](interfacehipfort__hipblas_1_1hipblascgerc.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+412 | [hipblasZgeru](interfacehipfort__hipblas_1_1hipblaszgeru.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+413 | [hipblasZgerc](interfacehipfort__hipblas_1_1hipblaszgerc.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+414 | [hipblasSger_64](interfacehipfort__hipblas_1_1hipblassger__64.html "Interface documentation") | C binding, rank_0, rank_1
+415 | [hipblasDger_64](interfacehipfort__hipblas_1_1hipblasdger__64.html "Interface documentation") | C binding, rank_0, rank_1
+416 | [hipblasCgeru_64](interfacehipfort__hipblas_1_1hipblascgeru__64.html "Interface documentation") | C binding, rank_0, rank_1
+417 | [hipblasCgerc_64](interfacehipfort__hipblas_1_1hipblascgerc__64.html "Interface documentation") | C binding, rank_0, rank_1
+418 | [hipblasZgeru_64](interfacehipfort__hipblas_1_1hipblaszgeru__64.html "Interface documentation") | C binding, rank_0, rank_1
+419 | [hipblasZgerc_64](interfacehipfort__hipblas_1_1hipblaszgerc__64.html "Interface documentation") | C binding, rank_0, rank_1
+420 | [hipblasSgerBatched](interfacehipfort__hipblas_1_1hipblassgerbatched.html "Interface documentation") | C binding
+421 | [hipblasDgerBatched](interfacehipfort__hipblas_1_1hipblasdgerbatched.html "Interface documentation") | C binding
+422 | [hipblasCgeruBatched](interfacehipfort__hipblas_1_1hipblascgerubatched.html "Interface documentation") | C binding
+423 | [hipblasCgercBatched](interfacehipfort__hipblas_1_1hipblascgercbatched.html "Interface documentation") | C binding
+424 | [hipblasZgeruBatched](interfacehipfort__hipblas_1_1hipblaszgerubatched.html "Interface documentation") | C binding
+425 | [hipblasZgercBatched](interfacehipfort__hipblas_1_1hipblaszgercbatched.html "Interface documentation") | C binding
+426 | [hipblasSgerBatched_64](interfacehipfort__hipblas_1_1hipblassgerbatched__64.html "Interface documentation") | C binding
+427 | [hipblasDgerBatched_64](interfacehipfort__hipblas_1_1hipblasdgerbatched__64.html "Interface documentation") | C binding
+428 | [hipblasCgeruBatched_64](interfacehipfort__hipblas_1_1hipblascgerubatched__64.html "Interface documentation") | C binding
+429 | [hipblasCgercBatched_64](interfacehipfort__hipblas_1_1hipblascgercbatched__64.html "Interface documentation") | C binding
+430 | [hipblasZgeruBatched_64](interfacehipfort__hipblas_1_1hipblaszgerubatched__64.html "Interface documentation") | C binding
+431 | [hipblasZgercBatched_64](interfacehipfort__hipblas_1_1hipblaszgercbatched__64.html "Interface documentation") | C binding
+432 | [hipblasSgerStridedBatched](interfacehipfort__hipblas_1_1hipblassgerstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+433 | [hipblasDgerStridedBatched](interfacehipfort__hipblas_1_1hipblasdgerstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+434 | [hipblasCgeruStridedBatched](interfacehipfort__hipblas_1_1hipblascgerustridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+435 | [hipblasCgercStridedBatched](interfacehipfort__hipblas_1_1hipblascgercstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+436 | [hipblasZgeruStridedBatched](interfacehipfort__hipblas_1_1hipblaszgerustridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+437 | [hipblasZgercStridedBatched](interfacehipfort__hipblas_1_1hipblaszgercstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+438 | [hipblasSgerStridedBatched_64](interfacehipfort__hipblas_1_1hipblassgerstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+439 | [hipblasDgerStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdgerstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+440 | [hipblasCgeruStridedBatched_64](interfacehipfort__hipblas_1_1hipblascgerustridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+441 | [hipblasCgercStridedBatched_64](interfacehipfort__hipblas_1_1hipblascgercstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+442 | [hipblasZgeruStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszgerustridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+443 | [hipblasZgercStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszgercstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+444 | [hipblasChbmv](interfacehipfort__hipblas_1_1hipblaschbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+445 | [hipblasZhbmv](interfacehipfort__hipblas_1_1hipblaszhbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+446 | [hipblasChbmv_64](interfacehipfort__hipblas_1_1hipblaschbmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+447 | [hipblasZhbmv_64](interfacehipfort__hipblas_1_1hipblaszhbmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+448 | [hipblasChbmvBatched](interfacehipfort__hipblas_1_1hipblaschbmvbatched.html "Interface documentation") | C binding
+449 | [hipblasZhbmvBatched](interfacehipfort__hipblas_1_1hipblaszhbmvbatched.html "Interface documentation") | C binding
+450 | [hipblasChbmvBatched_64](interfacehipfort__hipblas_1_1hipblaschbmvbatched__64.html "Interface documentation") | C binding
+451 | [hipblasZhbmvBatched_64](interfacehipfort__hipblas_1_1hipblaszhbmvbatched__64.html "Interface documentation") | C binding
+452 | [hipblasChbmvStridedBatched](interfacehipfort__hipblas_1_1hipblaschbmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+453 | [hipblasZhbmvStridedBatched](interfacehipfort__hipblas_1_1hipblaszhbmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+454 | [hipblasChbmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblaschbmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+455 | [hipblasZhbmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszhbmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+456 | [hipblasChemv](interfacehipfort__hipblas_1_1hipblaschemv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+457 | [hipblasZhemv](interfacehipfort__hipblas_1_1hipblaszhemv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+458 | [hipblasChemv_64](interfacehipfort__hipblas_1_1hipblaschemv__64.html "Interface documentation") | C binding, rank_0, rank_1
+459 | [hipblasZhemv_64](interfacehipfort__hipblas_1_1hipblaszhemv__64.html "Interface documentation") | C binding, rank_0, rank_1
+460 | [hipblasChemvBatched](interfacehipfort__hipblas_1_1hipblaschemvbatched.html "Interface documentation") | C binding
+461 | [hipblasZhemvBatched](interfacehipfort__hipblas_1_1hipblaszhemvbatched.html "Interface documentation") | C binding
+462 | [hipblasChemvBatched_64](interfacehipfort__hipblas_1_1hipblaschemvbatched__64.html "Interface documentation") | C binding
+463 | [hipblasZhemvBatched_64](interfacehipfort__hipblas_1_1hipblaszhemvbatched__64.html "Interface documentation") | C binding
+464 | [hipblasChemvStridedBatched](interfacehipfort__hipblas_1_1hipblaschemvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+465 | [hipblasZhemvStridedBatched](interfacehipfort__hipblas_1_1hipblaszhemvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+466 | [hipblasChemvStridedBatched_64](interfacehipfort__hipblas_1_1hipblaschemvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+467 | [hipblasZhemvStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszhemvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+468 | [hipblasCher](interfacehipfort__hipblas_1_1hipblascher.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+469 | [hipblasZher](interfacehipfort__hipblas_1_1hipblaszher.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+470 | [hipblasCher_64](interfacehipfort__hipblas_1_1hipblascher__64.html "Interface documentation") | C binding, rank_0, rank_1
+471 | [hipblasZher_64](interfacehipfort__hipblas_1_1hipblaszher__64.html "Interface documentation") | C binding, rank_0, rank_1
+472 | [hipblasCherBatched](interfacehipfort__hipblas_1_1hipblascherbatched.html "Interface documentation") | C binding
+473 | [hipblasZherBatched](interfacehipfort__hipblas_1_1hipblaszherbatched.html "Interface documentation") | C binding
+474 | [hipblasCherBatched_64](interfacehipfort__hipblas_1_1hipblascherbatched__64.html "Interface documentation") | C binding
+475 | [hipblasZherBatched_64](interfacehipfort__hipblas_1_1hipblaszherbatched__64.html "Interface documentation") | C binding
+476 | [hipblasCherStridedBatched](interfacehipfort__hipblas_1_1hipblascherstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+477 | [hipblasZherStridedBatched](interfacehipfort__hipblas_1_1hipblaszherstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+478 | [hipblasCherStridedBatched_64](interfacehipfort__hipblas_1_1hipblascherstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+479 | [hipblasZherStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszherstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+480 | [hipblasCher2](interfacehipfort__hipblas_1_1hipblascher2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+481 | [hipblasZher2](interfacehipfort__hipblas_1_1hipblaszher2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+482 | [hipblasCher2_64](interfacehipfort__hipblas_1_1hipblascher2__64.html "Interface documentation") | C binding, rank_0, rank_1
+483 | [hipblasZher2_64](interfacehipfort__hipblas_1_1hipblaszher2__64.html "Interface documentation") | C binding, rank_0, rank_1
+484 | [hipblasCher2Batched](interfacehipfort__hipblas_1_1hipblascher2batched.html "Interface documentation") | C binding
+485 | [hipblasZher2Batched](interfacehipfort__hipblas_1_1hipblaszher2batched.html "Interface documentation") | C binding
+486 | [hipblasCher2Batched_64](interfacehipfort__hipblas_1_1hipblascher2batched__64.html "Interface documentation") | C binding
+487 | [hipblasZher2Batched_64](interfacehipfort__hipblas_1_1hipblaszher2batched__64.html "Interface documentation") | C binding
+488 | [hipblasCher2StridedBatched](interfacehipfort__hipblas_1_1hipblascher2stridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+489 | [hipblasZher2StridedBatched](interfacehipfort__hipblas_1_1hipblaszher2stridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+490 | [hipblasCher2StridedBatched_64](interfacehipfort__hipblas_1_1hipblascher2stridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+491 | [hipblasZher2StridedBatched_64](interfacehipfort__hipblas_1_1hipblaszher2stridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+492 | [hipblasChpmv](interfacehipfort__hipblas_1_1hipblaschpmv.html "Interface documentation") | C binding, rank_0, rank_1
+493 | [hipblasZhpmv](interfacehipfort__hipblas_1_1hipblaszhpmv.html "Interface documentation") | C binding, rank_0, rank_1
+494 | [hipblasChpmv_64](interfacehipfort__hipblas_1_1hipblaschpmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+495 | [hipblasZhpmv_64](interfacehipfort__hipblas_1_1hipblaszhpmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+496 | [hipblasChpmvBatched](interfacehipfort__hipblas_1_1hipblaschpmvbatched.html "Interface documentation") | C binding
+497 | [hipblasZhpmvBatched](interfacehipfort__hipblas_1_1hipblaszhpmvbatched.html "Interface documentation") | C binding
+498 | [hipblasChpmvBatched_64](interfacehipfort__hipblas_1_1hipblaschpmvbatched__64.html "Interface documentation") | C binding
+499 | [hipblasZhpmvBatched_64](interfacehipfort__hipblas_1_1hipblaszhpmvbatched__64.html "Interface documentation") | C binding
+500 | [hipblasChpmvStridedBatched](interfacehipfort__hipblas_1_1hipblaschpmvstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+501 | [hipblasZhpmvStridedBatched](interfacehipfort__hipblas_1_1hipblaszhpmvstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+502 | [hipblasChpmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblaschpmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+503 | [hipblasZhpmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszhpmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+504 | [hipblasChpr](interfacehipfort__hipblas_1_1hipblaschpr.html "Interface documentation") | C binding, rank_0, rank_1
+505 | [hipblasZhpr](interfacehipfort__hipblas_1_1hipblaszhpr.html "Interface documentation") | C binding, rank_0, rank_1
+506 | [hipblasChpr_64](interfacehipfort__hipblas_1_1hipblaschpr__64.html "Interface documentation") | C binding, rank_0, rank_1
+507 | [hipblasZhpr_64](interfacehipfort__hipblas_1_1hipblaszhpr__64.html "Interface documentation") | C binding, rank_0, rank_1
+508 | [hipblasChprBatched](interfacehipfort__hipblas_1_1hipblaschprbatched.html "Interface documentation") | C binding
+509 | [hipblasZhprBatched](interfacehipfort__hipblas_1_1hipblaszhprbatched.html "Interface documentation") | C binding
+510 | [hipblasChprBatched_64](interfacehipfort__hipblas_1_1hipblaschprbatched__64.html "Interface documentation") | C binding
+511 | [hipblasZhprBatched_64](interfacehipfort__hipblas_1_1hipblaszhprbatched__64.html "Interface documentation") | C binding
+512 | [hipblasChprStridedBatched](interfacehipfort__hipblas_1_1hipblaschprstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+513 | [hipblasZhprStridedBatched](interfacehipfort__hipblas_1_1hipblaszhprstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+514 | [hipblasChprStridedBatched_64](interfacehipfort__hipblas_1_1hipblaschprstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+515 | [hipblasZhprStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszhprstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+516 | [hipblasChpr2](interfacehipfort__hipblas_1_1hipblaschpr2.html "Interface documentation") | C binding, rank_0, rank_1
+517 | [hipblasZhpr2](interfacehipfort__hipblas_1_1hipblaszhpr2.html "Interface documentation") | C binding, rank_0, rank_1
+518 | [hipblasChpr2_64](interfacehipfort__hipblas_1_1hipblaschpr2__64.html "Interface documentation") | C binding, rank_0, rank_1
+519 | [hipblasZhpr2_64](interfacehipfort__hipblas_1_1hipblaszhpr2__64.html "Interface documentation") | C binding, rank_0, rank_1
+520 | [hipblasChpr2Batched](interfacehipfort__hipblas_1_1hipblaschpr2batched.html "Interface documentation") | C binding
+521 | [hipblasZhpr2Batched](interfacehipfort__hipblas_1_1hipblaszhpr2batched.html "Interface documentation") | C binding
+522 | [hipblasChpr2Batched_64](interfacehipfort__hipblas_1_1hipblaschpr2batched__64.html "Interface documentation") | C binding
+523 | [hipblasZhpr2Batched_64](interfacehipfort__hipblas_1_1hipblaszhpr2batched__64.html "Interface documentation") | C binding
+524 | [hipblasChpr2StridedBatched](interfacehipfort__hipblas_1_1hipblaschpr2stridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+525 | [hipblasZhpr2StridedBatched](interfacehipfort__hipblas_1_1hipblaszhpr2stridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+526 | [hipblasChpr2StridedBatched_64](interfacehipfort__hipblas_1_1hipblaschpr2stridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+527 | [hipblasZhpr2StridedBatched_64](interfacehipfort__hipblas_1_1hipblaszhpr2stridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+528 | [hipblasSsbmv](interfacehipfort__hipblas_1_1hipblasssbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+529 | [hipblasDsbmv](interfacehipfort__hipblas_1_1hipblasdsbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+530 | [hipblasSsbmv_64](interfacehipfort__hipblas_1_1hipblasssbmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+531 | [hipblasDsbmv_64](interfacehipfort__hipblas_1_1hipblasdsbmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+532 | [hipblasSsbmvBatched](interfacehipfort__hipblas_1_1hipblasssbmvbatched.html "Interface documentation") | C binding
+533 | [hipblasDsbmvBatched](interfacehipfort__hipblas_1_1hipblasdsbmvbatched.html "Interface documentation") | C binding
+534 | [hipblasSsbmvBatched_64](interfacehipfort__hipblas_1_1hipblasssbmvbatched__64.html "Interface documentation") | C binding
+535 | [hipblasDsbmvBatched_64](interfacehipfort__hipblas_1_1hipblasdsbmvbatched__64.html "Interface documentation") | C binding
+536 | [hipblasSsbmvStridedBatched](interfacehipfort__hipblas_1_1hipblasssbmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+537 | [hipblasDsbmvStridedBatched](interfacehipfort__hipblas_1_1hipblasdsbmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+538 | [hipblasSsbmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasssbmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+539 | [hipblasDsbmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdsbmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+540 | [hipblasSspmv](interfacehipfort__hipblas_1_1hipblassspmv.html "Interface documentation") | C binding, rank_0, rank_1
+541 | [hipblasDspmv](interfacehipfort__hipblas_1_1hipblasdspmv.html "Interface documentation") | C binding, rank_0, rank_1
+542 | [hipblasSspmv_64](interfacehipfort__hipblas_1_1hipblassspmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+543 | [hipblasDspmv_64](interfacehipfort__hipblas_1_1hipblasdspmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+544 | [hipblasSspmvBatched](interfacehipfort__hipblas_1_1hipblassspmvbatched.html "Interface documentation") | C binding
+545 | [hipblasDspmvBatched](interfacehipfort__hipblas_1_1hipblasdspmvbatched.html "Interface documentation") | C binding
+546 | [hipblasSspmvBatched_64](interfacehipfort__hipblas_1_1hipblassspmvbatched__64.html "Interface documentation") | C binding
+547 | [hipblasDspmvBatched_64](interfacehipfort__hipblas_1_1hipblasdspmvbatched__64.html "Interface documentation") | C binding
+548 | [hipblasSspmvStridedBatched](interfacehipfort__hipblas_1_1hipblassspmvstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+549 | [hipblasDspmvStridedBatched](interfacehipfort__hipblas_1_1hipblasdspmvstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+550 | [hipblasSspmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblassspmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+551 | [hipblasDspmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdspmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+552 | [hipblasSspr](interfacehipfort__hipblas_1_1hipblassspr.html "Interface documentation") | C binding, rank_0, rank_1
+553 | [hipblasDspr](interfacehipfort__hipblas_1_1hipblasdspr.html "Interface documentation") | C binding, rank_0, rank_1
+554 | [hipblasCspr](interfacehipfort__hipblas_1_1hipblascspr.html "Interface documentation") | C binding, rank_0, rank_1
+555 | [hipblasZspr](interfacehipfort__hipblas_1_1hipblaszspr.html "Interface documentation") | C binding, rank_0, rank_1
+556 | [hipblasSspr_64](interfacehipfort__hipblas_1_1hipblassspr__64.html "Interface documentation") | C binding, rank_0, rank_1
+557 | [hipblasDspr_64](interfacehipfort__hipblas_1_1hipblasdspr__64.html "Interface documentation") | C binding, rank_0, rank_1
+558 | [hipblasCspr_64](interfacehipfort__hipblas_1_1hipblascspr__64.html "Interface documentation") | C binding, rank_0, rank_1
+559 | [hipblasZspr_64](interfacehipfort__hipblas_1_1hipblaszspr__64.html "Interface documentation") | C binding, rank_0, rank_1
+560 | [hipblasSsprBatched](interfacehipfort__hipblas_1_1hipblasssprbatched.html "Interface documentation") | C binding
+561 | [hipblasDsprBatched](interfacehipfort__hipblas_1_1hipblasdsprbatched.html "Interface documentation") | C binding
+562 | [hipblasCsprBatched](interfacehipfort__hipblas_1_1hipblascsprbatched.html "Interface documentation") | C binding
+563 | [hipblasZsprBatched](interfacehipfort__hipblas_1_1hipblaszsprbatched.html "Interface documentation") | C binding
+564 | [hipblasSsprBatched_64](interfacehipfort__hipblas_1_1hipblasssprbatched__64.html "Interface documentation") | C binding
+565 | [hipblasDsprBatched_64](interfacehipfort__hipblas_1_1hipblasdsprbatched__64.html "Interface documentation") | C binding
+566 | [hipblasCsprBatched_64](interfacehipfort__hipblas_1_1hipblascsprbatched__64.html "Interface documentation") | C binding
+567 | [hipblasZsprBatched_64](interfacehipfort__hipblas_1_1hipblaszsprbatched__64.html "Interface documentation") | C binding
+568 | [hipblasSsprStridedBatched](interfacehipfort__hipblas_1_1hipblasssprstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+569 | [hipblasDsprStridedBatched](interfacehipfort__hipblas_1_1hipblasdsprstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+570 | [hipblasCsprStridedBatched](interfacehipfort__hipblas_1_1hipblascsprstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+571 | [hipblasZsprStridedBatched](interfacehipfort__hipblas_1_1hipblaszsprstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+572 | [hipblasSsprStridedBatched_64](interfacehipfort__hipblas_1_1hipblasssprstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+573 | [hipblasDsprStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdsprstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+574 | [hipblasCsprStridedBatched_64](interfacehipfort__hipblas_1_1hipblascsprstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+575 | [hipblasZsprStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszsprstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+576 | [hipblasSspr2](interfacehipfort__hipblas_1_1hipblassspr2.html "Interface documentation") | C binding, rank_0, rank_1
+577 | [hipblasDspr2](interfacehipfort__hipblas_1_1hipblasdspr2.html "Interface documentation") | C binding, rank_0, rank_1
+578 | [hipblasSspr2_64](interfacehipfort__hipblas_1_1hipblassspr2__64.html "Interface documentation") | C binding, rank_0, rank_1
+579 | [hipblasDspr2_64](interfacehipfort__hipblas_1_1hipblasdspr2__64.html "Interface documentation") | C binding, rank_0, rank_1
+580 | [hipblasSspr2Batched](interfacehipfort__hipblas_1_1hipblassspr2batched.html "Interface documentation") | C binding
+581 | [hipblasDspr2Batched](interfacehipfort__hipblas_1_1hipblasdspr2batched.html "Interface documentation") | C binding
+582 | [hipblasSspr2Batched_64](interfacehipfort__hipblas_1_1hipblassspr2batched__64.html "Interface documentation") | C binding
+583 | [hipblasDspr2Batched_64](interfacehipfort__hipblas_1_1hipblasdspr2batched__64.html "Interface documentation") | C binding
+584 | [hipblasSspr2StridedBatched](interfacehipfort__hipblas_1_1hipblassspr2stridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+585 | [hipblasDspr2StridedBatched](interfacehipfort__hipblas_1_1hipblasdspr2stridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+586 | [hipblasSspr2StridedBatched_64](interfacehipfort__hipblas_1_1hipblassspr2stridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+587 | [hipblasDspr2StridedBatched_64](interfacehipfort__hipblas_1_1hipblasdspr2stridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+588 | [hipblasSsymv](interfacehipfort__hipblas_1_1hipblasssymv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+589 | [hipblasDsymv](interfacehipfort__hipblas_1_1hipblasdsymv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+590 | [hipblasCsymv](interfacehipfort__hipblas_1_1hipblascsymv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+591 | [hipblasZsymv](interfacehipfort__hipblas_1_1hipblaszsymv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+592 | [hipblasSsymv_64](interfacehipfort__hipblas_1_1hipblasssymv__64.html "Interface documentation") | C binding, rank_0, rank_1
+593 | [hipblasDsymv_64](interfacehipfort__hipblas_1_1hipblasdsymv__64.html "Interface documentation") | C binding, rank_0, rank_1
+594 | [hipblasCsymv_64](interfacehipfort__hipblas_1_1hipblascsymv__64.html "Interface documentation") | C binding, rank_0, rank_1
+595 | [hipblasZsymv_64](interfacehipfort__hipblas_1_1hipblaszsymv__64.html "Interface documentation") | C binding, rank_0, rank_1
+596 | [hipblasSsymvBatched](interfacehipfort__hipblas_1_1hipblasssymvbatched.html "Interface documentation") | C binding
+597 | [hipblasDsymvBatched](interfacehipfort__hipblas_1_1hipblasdsymvbatched.html "Interface documentation") | C binding
+598 | [hipblasCsymvBatched](interfacehipfort__hipblas_1_1hipblascsymvbatched.html "Interface documentation") | C binding
+599 | [hipblasZsymvBatched](interfacehipfort__hipblas_1_1hipblaszsymvbatched.html "Interface documentation") | C binding
+600 | [hipblasSsymvBatched_64](interfacehipfort__hipblas_1_1hipblasssymvbatched__64.html "Interface documentation") | C binding
+601 | [hipblasDsymvBatched_64](interfacehipfort__hipblas_1_1hipblasdsymvbatched__64.html "Interface documentation") | C binding
+602 | [hipblasCsymvBatched_64](interfacehipfort__hipblas_1_1hipblascsymvbatched__64.html "Interface documentation") | C binding
+603 | [hipblasZsymvBatched_64](interfacehipfort__hipblas_1_1hipblaszsymvbatched__64.html "Interface documentation") | C binding
+604 | [hipblasSsymvStridedBatched](interfacehipfort__hipblas_1_1hipblasssymvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+605 | [hipblasDsymvStridedBatched](interfacehipfort__hipblas_1_1hipblasdsymvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+606 | [hipblasCsymvStridedBatched](interfacehipfort__hipblas_1_1hipblascsymvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+607 | [hipblasZsymvStridedBatched](interfacehipfort__hipblas_1_1hipblaszsymvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+608 | [hipblasSsymvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasssymvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+609 | [hipblasDsymvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdsymvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+610 | [hipblasCsymvStridedBatched_64](interfacehipfort__hipblas_1_1hipblascsymvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+611 | [hipblasZsymvStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszsymvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+612 | [hipblasSsyr](interfacehipfort__hipblas_1_1hipblasssyr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+613 | [hipblasDsyr](interfacehipfort__hipblas_1_1hipblasdsyr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+614 | [hipblasCsyr](interfacehipfort__hipblas_1_1hipblascsyr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+615 | [hipblasZsyr](interfacehipfort__hipblas_1_1hipblaszsyr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+616 | [hipblasSsyr_64](interfacehipfort__hipblas_1_1hipblasssyr__64.html "Interface documentation") | C binding, rank_0, rank_1
+617 | [hipblasDsyr_64](interfacehipfort__hipblas_1_1hipblasdsyr__64.html "Interface documentation") | C binding, rank_0, rank_1
+618 | [hipblasCsyr_64](interfacehipfort__hipblas_1_1hipblascsyr__64.html "Interface documentation") | C binding, rank_0, rank_1
+619 | [hipblasZsyr_64](interfacehipfort__hipblas_1_1hipblaszsyr__64.html "Interface documentation") | C binding, rank_0, rank_1
+620 | [hipblasSsyrBatched](interfacehipfort__hipblas_1_1hipblasssyrbatched.html "Interface documentation") | C binding
+621 | [hipblasDsyrBatched](interfacehipfort__hipblas_1_1hipblasdsyrbatched.html "Interface documentation") | C binding
+622 | [hipblasCsyrBatched](interfacehipfort__hipblas_1_1hipblascsyrbatched.html "Interface documentation") | C binding
+623 | [hipblasZsyrBatched](interfacehipfort__hipblas_1_1hipblaszsyrbatched.html "Interface documentation") | C binding
+624 | [hipblasSsyrBatched_64](interfacehipfort__hipblas_1_1hipblasssyrbatched__64.html "Interface documentation") | C binding
+625 | [hipblasDsyrBatched_64](interfacehipfort__hipblas_1_1hipblasdsyrbatched__64.html "Interface documentation") | C binding
+626 | [hipblasCsyrBatched_64](interfacehipfort__hipblas_1_1hipblascsyrbatched__64.html "Interface documentation") | C binding
+627 | [hipblasZsyrBatched_64](interfacehipfort__hipblas_1_1hipblaszsyrbatched__64.html "Interface documentation") | C binding
+628 | [hipblasSsyrStridedBatched](interfacehipfort__hipblas_1_1hipblasssyrstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+629 | [hipblasDsyrStridedBatched](interfacehipfort__hipblas_1_1hipblasdsyrstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+630 | [hipblasCsyrStridedBatched](interfacehipfort__hipblas_1_1hipblascsyrstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+631 | [hipblasZsyrStridedBatched](interfacehipfort__hipblas_1_1hipblaszsyrstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+632 | [hipblasSsyrStridedBatched_64](interfacehipfort__hipblas_1_1hipblasssyrstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+633 | [hipblasDsyrStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdsyrstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+634 | [hipblasCsyrStridedBatched_64](interfacehipfort__hipblas_1_1hipblascsyrstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+635 | [hipblasZsyrStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszsyrstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+636 | [hipblasSsyr2](interfacehipfort__hipblas_1_1hipblasssyr2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+637 | [hipblasDsyr2](interfacehipfort__hipblas_1_1hipblasdsyr2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+638 | [hipblasCsyr2](interfacehipfort__hipblas_1_1hipblascsyr2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+639 | [hipblasZsyr2](interfacehipfort__hipblas_1_1hipblaszsyr2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+640 | [hipblasSsyr2_64](interfacehipfort__hipblas_1_1hipblasssyr2__64.html "Interface documentation") | C binding, rank_0, rank_1
+641 | [hipblasDsyr2_64](interfacehipfort__hipblas_1_1hipblasdsyr2__64.html "Interface documentation") | C binding, rank_0, rank_1
+642 | [hipblasCsyr2_64](interfacehipfort__hipblas_1_1hipblascsyr2__64.html "Interface documentation") | C binding, rank_0, rank_1
+643 | [hipblasZsyr2_64](interfacehipfort__hipblas_1_1hipblaszsyr2__64.html "Interface documentation") | C binding, rank_0, rank_1
+644 | [hipblasSsyr2Batched](interfacehipfort__hipblas_1_1hipblasssyr2batched.html "Interface documentation") | C binding
+645 | [hipblasDsyr2Batched](interfacehipfort__hipblas_1_1hipblasdsyr2batched.html "Interface documentation") | C binding
+646 | [hipblasCsyr2Batched](interfacehipfort__hipblas_1_1hipblascsyr2batched.html "Interface documentation") | C binding
+647 | [hipblasZsyr2Batched](interfacehipfort__hipblas_1_1hipblaszsyr2batched.html "Interface documentation") | C binding
+648 | [hipblasSsyr2Batched_64](interfacehipfort__hipblas_1_1hipblasssyr2batched__64.html "Interface documentation") | C binding
+649 | [hipblasDsyr2Batched_64](interfacehipfort__hipblas_1_1hipblasdsyr2batched__64.html "Interface documentation") | C binding
+650 | [hipblasCsyr2Batched_64](interfacehipfort__hipblas_1_1hipblascsyr2batched__64.html "Interface documentation") | C binding
+651 | [hipblasZsyr2Batched_64](interfacehipfort__hipblas_1_1hipblaszsyr2batched__64.html "Interface documentation") | C binding
+652 | [hipblasSsyr2StridedBatched](interfacehipfort__hipblas_1_1hipblasssyr2stridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+653 | [hipblasDsyr2StridedBatched](interfacehipfort__hipblas_1_1hipblasdsyr2stridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+654 | [hipblasCsyr2StridedBatched](interfacehipfort__hipblas_1_1hipblascsyr2stridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+655 | [hipblasZsyr2StridedBatched](interfacehipfort__hipblas_1_1hipblaszsyr2stridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+656 | [hipblasSsyr2StridedBatched_64](interfacehipfort__hipblas_1_1hipblasssyr2stridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+657 | [hipblasDsyr2StridedBatched_64](interfacehipfort__hipblas_1_1hipblasdsyr2stridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+658 | [hipblasCsyr2StridedBatched_64](interfacehipfort__hipblas_1_1hipblascsyr2stridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+659 | [hipblasZsyr2StridedBatched_64](interfacehipfort__hipblas_1_1hipblaszsyr2stridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+660 | [hipblasStbmv](interfacehipfort__hipblas_1_1hipblasstbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+661 | [hipblasDtbmv](interfacehipfort__hipblas_1_1hipblasdtbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+662 | [hipblasCtbmv](interfacehipfort__hipblas_1_1hipblasctbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+663 | [hipblasZtbmv](interfacehipfort__hipblas_1_1hipblasztbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+664 | [hipblasStbmv_64](interfacehipfort__hipblas_1_1hipblasstbmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+665 | [hipblasDtbmv_64](interfacehipfort__hipblas_1_1hipblasdtbmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+666 | [hipblasCtbmv_64](interfacehipfort__hipblas_1_1hipblasctbmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+667 | [hipblasZtbmv_64](interfacehipfort__hipblas_1_1hipblasztbmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+668 | [hipblasStbmvBatched](interfacehipfort__hipblas_1_1hipblasstbmvbatched.html "Interface documentation") | C binding
+669 | [hipblasDtbmvBatched](interfacehipfort__hipblas_1_1hipblasdtbmvbatched.html "Interface documentation") | C binding
+670 | [hipblasCtbmvBatched](interfacehipfort__hipblas_1_1hipblasctbmvbatched.html "Interface documentation") | C binding
+671 | [hipblasZtbmvBatched](interfacehipfort__hipblas_1_1hipblasztbmvbatched.html "Interface documentation") | C binding
+672 | [hipblasStbmvBatched_64](interfacehipfort__hipblas_1_1hipblasstbmvbatched__64.html "Interface documentation") | C binding
+673 | [hipblasDtbmvBatched_64](interfacehipfort__hipblas_1_1hipblasdtbmvbatched__64.html "Interface documentation") | C binding
+674 | [hipblasCtbmvBatched_64](interfacehipfort__hipblas_1_1hipblasctbmvbatched__64.html "Interface documentation") | C binding
+675 | [hipblasZtbmvBatched_64](interfacehipfort__hipblas_1_1hipblasztbmvbatched__64.html "Interface documentation") | C binding
+676 | [hipblasStbmvStridedBatched](interfacehipfort__hipblas_1_1hipblasstbmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+677 | [hipblasDtbmvStridedBatched](interfacehipfort__hipblas_1_1hipblasdtbmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+678 | [hipblasCtbmvStridedBatched](interfacehipfort__hipblas_1_1hipblasctbmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+679 | [hipblasZtbmvStridedBatched](interfacehipfort__hipblas_1_1hipblasztbmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+680 | [hipblasStbmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasstbmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+681 | [hipblasDtbmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdtbmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+682 | [hipblasCtbmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasctbmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+683 | [hipblasZtbmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasztbmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+684 | [hipblasStbsv](interfacehipfort__hipblas_1_1hipblasstbsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+685 | [hipblasDtbsv](interfacehipfort__hipblas_1_1hipblasdtbsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+686 | [hipblasCtbsv](interfacehipfort__hipblas_1_1hipblasctbsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+687 | [hipblasZtbsv](interfacehipfort__hipblas_1_1hipblasztbsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+688 | [hipblasStbsv_64](interfacehipfort__hipblas_1_1hipblasstbsv__64.html "Interface documentation") | C binding, rank_0, rank_1
+689 | [hipblasDtbsv_64](interfacehipfort__hipblas_1_1hipblasdtbsv__64.html "Interface documentation") | C binding, rank_0, rank_1
+690 | [hipblasCtbsv_64](interfacehipfort__hipblas_1_1hipblasctbsv__64.html "Interface documentation") | C binding, rank_0, rank_1
+691 | [hipblasZtbsv_64](interfacehipfort__hipblas_1_1hipblasztbsv__64.html "Interface documentation") | C binding, rank_0, rank_1
+692 | [hipblasStbsvBatched](interfacehipfort__hipblas_1_1hipblasstbsvbatched.html "Interface documentation") | C binding
+693 | [hipblasDtbsvBatched](interfacehipfort__hipblas_1_1hipblasdtbsvbatched.html "Interface documentation") | C binding
+694 | [hipblasCtbsvBatched](interfacehipfort__hipblas_1_1hipblasctbsvbatched.html "Interface documentation") | C binding
+695 | [hipblasZtbsvBatched](interfacehipfort__hipblas_1_1hipblasztbsvbatched.html "Interface documentation") | C binding
+696 | [hipblasStbsvBatched_64](interfacehipfort__hipblas_1_1hipblasstbsvbatched__64.html "Interface documentation") | C binding
+697 | [hipblasDtbsvBatched_64](interfacehipfort__hipblas_1_1hipblasdtbsvbatched__64.html "Interface documentation") | C binding
+698 | [hipblasCtbsvBatched_64](interfacehipfort__hipblas_1_1hipblasctbsvbatched__64.html "Interface documentation") | C binding
+699 | [hipblasZtbsvBatched_64](interfacehipfort__hipblas_1_1hipblasztbsvbatched__64.html "Interface documentation") | C binding
+700 | [hipblasStbsvStridedBatched](interfacehipfort__hipblas_1_1hipblasstbsvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+701 | [hipblasDtbsvStridedBatched](interfacehipfort__hipblas_1_1hipblasdtbsvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+702 | [hipblasCtbsvStridedBatched](interfacehipfort__hipblas_1_1hipblasctbsvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+703 | [hipblasZtbsvStridedBatched](interfacehipfort__hipblas_1_1hipblasztbsvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+704 | [hipblasStbsvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasstbsvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+705 | [hipblasDtbsvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdtbsvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+706 | [hipblasCtbsvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasctbsvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+707 | [hipblasZtbsvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasztbsvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+708 | [hipblasStpmv](interfacehipfort__hipblas_1_1hipblasstpmv.html "Interface documentation") | C binding, rank_0, rank_1
+709 | [hipblasDtpmv](interfacehipfort__hipblas_1_1hipblasdtpmv.html "Interface documentation") | C binding, rank_0, rank_1
+710 | [hipblasCtpmv](interfacehipfort__hipblas_1_1hipblasctpmv.html "Interface documentation") | C binding, rank_0, rank_1
+711 | [hipblasZtpmv](interfacehipfort__hipblas_1_1hipblasztpmv.html "Interface documentation") | C binding, rank_0, rank_1
+712 | [hipblasStpmv_64](interfacehipfort__hipblas_1_1hipblasstpmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+713 | [hipblasDtpmv_64](interfacehipfort__hipblas_1_1hipblasdtpmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+714 | [hipblasCtpmv_64](interfacehipfort__hipblas_1_1hipblasctpmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+715 | [hipblasZtpmv_64](interfacehipfort__hipblas_1_1hipblasztpmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+716 | [hipblasStpmvBatched](interfacehipfort__hipblas_1_1hipblasstpmvbatched.html "Interface documentation") | C binding
+717 | [hipblasDtpmvBatched](interfacehipfort__hipblas_1_1hipblasdtpmvbatched.html "Interface documentation") | C binding
+718 | [hipblasCtpmvBatched](interfacehipfort__hipblas_1_1hipblasctpmvbatched.html "Interface documentation") | C binding
+719 | [hipblasZtpmvBatched](interfacehipfort__hipblas_1_1hipblasztpmvbatched.html "Interface documentation") | C binding
+720 | [hipblasStpmvBatched_64](interfacehipfort__hipblas_1_1hipblasstpmvbatched__64.html "Interface documentation") | C binding
+721 | [hipblasDtpmvBatched_64](interfacehipfort__hipblas_1_1hipblasdtpmvbatched__64.html "Interface documentation") | C binding
+722 | [hipblasCtpmvBatched_64](interfacehipfort__hipblas_1_1hipblasctpmvbatched__64.html "Interface documentation") | C binding
+723 | [hipblasZtpmvBatched_64](interfacehipfort__hipblas_1_1hipblasztpmvbatched__64.html "Interface documentation") | C binding
+724 | [hipblasStpmvStridedBatched](interfacehipfort__hipblas_1_1hipblasstpmvstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+725 | [hipblasDtpmvStridedBatched](interfacehipfort__hipblas_1_1hipblasdtpmvstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+726 | [hipblasCtpmvStridedBatched](interfacehipfort__hipblas_1_1hipblasctpmvstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+727 | [hipblasZtpmvStridedBatched](interfacehipfort__hipblas_1_1hipblasztpmvstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+728 | [hipblasStpmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasstpmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+729 | [hipblasDtpmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdtpmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+730 | [hipblasCtpmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasctpmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+731 | [hipblasZtpmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasztpmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+732 | [hipblasStpsv](interfacehipfort__hipblas_1_1hipblasstpsv.html "Interface documentation") | C binding, rank_0, rank_1
+733 | [hipblasDtpsv](interfacehipfort__hipblas_1_1hipblasdtpsv.html "Interface documentation") | C binding, rank_0, rank_1
+734 | [hipblasCtpsv](interfacehipfort__hipblas_1_1hipblasctpsv.html "Interface documentation") | C binding, rank_0, rank_1
+735 | [hipblasZtpsv](interfacehipfort__hipblas_1_1hipblasztpsv.html "Interface documentation") | C binding, rank_0, rank_1
+736 | [hipblasStpsv_64](interfacehipfort__hipblas_1_1hipblasstpsv__64.html "Interface documentation") | C binding, rank_0, rank_1
+737 | [hipblasDtpsv_64](interfacehipfort__hipblas_1_1hipblasdtpsv__64.html "Interface documentation") | C binding, rank_0, rank_1
+738 | [hipblasCtpsv_64](interfacehipfort__hipblas_1_1hipblasctpsv__64.html "Interface documentation") | C binding, rank_0, rank_1
+739 | [hipblasZtpsv_64](interfacehipfort__hipblas_1_1hipblasztpsv__64.html "Interface documentation") | C binding, rank_0, rank_1
+740 | [hipblasStpsvBatched](interfacehipfort__hipblas_1_1hipblasstpsvbatched.html "Interface documentation") | C binding
+741 | [hipblasDtpsvBatched](interfacehipfort__hipblas_1_1hipblasdtpsvbatched.html "Interface documentation") | C binding
+742 | [hipblasCtpsvBatched](interfacehipfort__hipblas_1_1hipblasctpsvbatched.html "Interface documentation") | C binding
+743 | [hipblasZtpsvBatched](interfacehipfort__hipblas_1_1hipblasztpsvbatched.html "Interface documentation") | C binding
+744 | [hipblasStpsvBatched_64](interfacehipfort__hipblas_1_1hipblasstpsvbatched__64.html "Interface documentation") | C binding
+745 | [hipblasDtpsvBatched_64](interfacehipfort__hipblas_1_1hipblasdtpsvbatched__64.html "Interface documentation") | C binding
+746 | [hipblasCtpsvBatched_64](interfacehipfort__hipblas_1_1hipblasctpsvbatched__64.html "Interface documentation") | C binding
+747 | [hipblasZtpsvBatched_64](interfacehipfort__hipblas_1_1hipblasztpsvbatched__64.html "Interface documentation") | C binding
+748 | [hipblasStpsvStridedBatched](interfacehipfort__hipblas_1_1hipblasstpsvstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+749 | [hipblasDtpsvStridedBatched](interfacehipfort__hipblas_1_1hipblasdtpsvstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+750 | [hipblasCtpsvStridedBatched](interfacehipfort__hipblas_1_1hipblasctpsvstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+751 | [hipblasZtpsvStridedBatched](interfacehipfort__hipblas_1_1hipblasztpsvstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+752 | [hipblasStpsvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasstpsvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+753 | [hipblasDtpsvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdtpsvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+754 | [hipblasCtpsvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasctpsvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+755 | [hipblasZtpsvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasztpsvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+756 | [hipblasStrmv](interfacehipfort__hipblas_1_1hipblasstrmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+757 | [hipblasDtrmv](interfacehipfort__hipblas_1_1hipblasdtrmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+758 | [hipblasCtrmv](interfacehipfort__hipblas_1_1hipblasctrmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+759 | [hipblasZtrmv](interfacehipfort__hipblas_1_1hipblasztrmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+760 | [hipblasStrmv_64](interfacehipfort__hipblas_1_1hipblasstrmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+761 | [hipblasDtrmv_64](interfacehipfort__hipblas_1_1hipblasdtrmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+762 | [hipblasCtrmv_64](interfacehipfort__hipblas_1_1hipblasctrmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+763 | [hipblasZtrmv_64](interfacehipfort__hipblas_1_1hipblasztrmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+764 | [hipblasStrmvBatched](interfacehipfort__hipblas_1_1hipblasstrmvbatched.html "Interface documentation") | C binding
+765 | [hipblasDtrmvBatched](interfacehipfort__hipblas_1_1hipblasdtrmvbatched.html "Interface documentation") | C binding
+766 | [hipblasCtrmvBatched](interfacehipfort__hipblas_1_1hipblasctrmvbatched.html "Interface documentation") | C binding
+767 | [hipblasZtrmvBatched](interfacehipfort__hipblas_1_1hipblasztrmvbatched.html "Interface documentation") | C binding
+768 | [hipblasStrmvBatched_64](interfacehipfort__hipblas_1_1hipblasstrmvbatched__64.html "Interface documentation") | C binding
+769 | [hipblasDtrmvBatched_64](interfacehipfort__hipblas_1_1hipblasdtrmvbatched__64.html "Interface documentation") | C binding
+770 | [hipblasCtrmvBatched_64](interfacehipfort__hipblas_1_1hipblasctrmvbatched__64.html "Interface documentation") | C binding
+771 | [hipblasZtrmvBatched_64](interfacehipfort__hipblas_1_1hipblasztrmvbatched__64.html "Interface documentation") | C binding
+772 | [hipblasStrmvStridedBatched](interfacehipfort__hipblas_1_1hipblasstrmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+773 | [hipblasDtrmvStridedBatched](interfacehipfort__hipblas_1_1hipblasdtrmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+774 | [hipblasCtrmvStridedBatched](interfacehipfort__hipblas_1_1hipblasctrmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+775 | [hipblasZtrmvStridedBatched](interfacehipfort__hipblas_1_1hipblasztrmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+776 | [hipblasStrmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasstrmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+777 | [hipblasDtrmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdtrmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+778 | [hipblasCtrmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasctrmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+779 | [hipblasZtrmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasztrmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+780 | [hipblasStrsv](interfacehipfort__hipblas_1_1hipblasstrsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+781 | [hipblasDtrsv](interfacehipfort__hipblas_1_1hipblasdtrsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+782 | [hipblasCtrsv](interfacehipfort__hipblas_1_1hipblasctrsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+783 | [hipblasZtrsv](interfacehipfort__hipblas_1_1hipblasztrsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+784 | [hipblasStrsv_64](interfacehipfort__hipblas_1_1hipblasstrsv__64.html "Interface documentation") | C binding, rank_0, rank_1
+785 | [hipblasDtrsv_64](interfacehipfort__hipblas_1_1hipblasdtrsv__64.html "Interface documentation") | C binding, rank_0, rank_1
+786 | [hipblasCtrsv_64](interfacehipfort__hipblas_1_1hipblasctrsv__64.html "Interface documentation") | C binding, rank_0, rank_1
+787 | [hipblasZtrsv_64](interfacehipfort__hipblas_1_1hipblasztrsv__64.html "Interface documentation") | C binding, rank_0, rank_1
+788 | [hipblasStrsvBatched](interfacehipfort__hipblas_1_1hipblasstrsvbatched.html "Interface documentation") | C binding
+789 | [hipblasDtrsvBatched](interfacehipfort__hipblas_1_1hipblasdtrsvbatched.html "Interface documentation") | C binding
+790 | [hipblasCtrsvBatched](interfacehipfort__hipblas_1_1hipblasctrsvbatched.html "Interface documentation") | C binding
+791 | [hipblasZtrsvBatched](interfacehipfort__hipblas_1_1hipblasztrsvbatched.html "Interface documentation") | C binding
+792 | [hipblasStrsvBatched_64](interfacehipfort__hipblas_1_1hipblasstrsvbatched__64.html "Interface documentation") | C binding
+793 | [hipblasDtrsvBatched_64](interfacehipfort__hipblas_1_1hipblasdtrsvbatched__64.html "Interface documentation") | C binding
+794 | [hipblasCtrsvBatched_64](interfacehipfort__hipblas_1_1hipblasctrsvbatched__64.html "Interface documentation") | C binding
+795 | [hipblasZtrsvBatched_64](interfacehipfort__hipblas_1_1hipblasztrsvbatched__64.html "Interface documentation") | C binding
+796 | [hipblasStrsvStridedBatched](interfacehipfort__hipblas_1_1hipblasstrsvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+797 | [hipblasDtrsvStridedBatched](interfacehipfort__hipblas_1_1hipblasdtrsvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+798 | [hipblasCtrsvStridedBatched](interfacehipfort__hipblas_1_1hipblasctrsvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+799 | [hipblasZtrsvStridedBatched](interfacehipfort__hipblas_1_1hipblasztrsvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+800 | [hipblasStrsvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasstrsvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+801 | [hipblasDtrsvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdtrsvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+802 | [hipblasCtrsvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasctrsvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+803 | [hipblasZtrsvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasztrsvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+804 | [hipblasHgemm](interfacehipfort__hipblas_1_1hipblashgemm.html "Interface documentation") | C binding
+805 | [hipblasSgemm](interfacehipfort__hipblas_1_1hipblassgemm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+806 | [hipblasDgemm](interfacehipfort__hipblas_1_1hipblasdgemm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+807 | [hipblasCgemm](interfacehipfort__hipblas_1_1hipblascgemm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+808 | [hipblasZgemm](interfacehipfort__hipblas_1_1hipblaszgemm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+809 | [hipblasHgemm_64](interfacehipfort__hipblas_1_1hipblashgemm__64.html "Interface documentation") | C binding
+810 | [hipblasSgemm_64](interfacehipfort__hipblas_1_1hipblassgemm__64.html "Interface documentation") | C binding, rank_0, rank_1
+811 | [hipblasDgemm_64](interfacehipfort__hipblas_1_1hipblasdgemm__64.html "Interface documentation") | C binding, rank_0, rank_1
+812 | [hipblasCgemm_64](interfacehipfort__hipblas_1_1hipblascgemm__64.html "Interface documentation") | C binding, rank_0, rank_1
+813 | [hipblasZgemm_64](interfacehipfort__hipblas_1_1hipblaszgemm__64.html "Interface documentation") | C binding, rank_0, rank_1
+814 | [hipblasHgemmBatched](interfacehipfort__hipblas_1_1hipblashgemmbatched.html "Interface documentation") | C binding
+815 | [hipblasSgemmBatched](interfacehipfort__hipblas_1_1hipblassgemmbatched.html "Interface documentation") | C binding
+816 | [hipblasDgemmBatched](interfacehipfort__hipblas_1_1hipblasdgemmbatched.html "Interface documentation") | C binding
+817 | [hipblasCgemmBatched](interfacehipfort__hipblas_1_1hipblascgemmbatched.html "Interface documentation") | C binding
+818 | [hipblasZgemmBatched](interfacehipfort__hipblas_1_1hipblaszgemmbatched.html "Interface documentation") | C binding
+819 | [hipblasHgemmBatched_64](interfacehipfort__hipblas_1_1hipblashgemmbatched__64.html "Interface documentation") | C binding
+820 | [hipblasSgemmBatched_64](interfacehipfort__hipblas_1_1hipblassgemmbatched__64.html "Interface documentation") | C binding
+821 | [hipblasDgemmBatched_64](interfacehipfort__hipblas_1_1hipblasdgemmbatched__64.html "Interface documentation") | C binding
+822 | [hipblasCgemmBatched_64](interfacehipfort__hipblas_1_1hipblascgemmbatched__64.html "Interface documentation") | C binding
+823 | [hipblasZgemmBatched_64](interfacehipfort__hipblas_1_1hipblaszgemmbatched__64.html "Interface documentation") | C binding
+824 | [hipblasHgemmStridedBatched](interfacehipfort__hipblas_1_1hipblashgemmstridedbatched.html "Interface documentation") | C binding
+825 | [hipblasSgemmStridedBatched](interfacehipfort__hipblas_1_1hipblassgemmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+826 | [hipblasDgemmStridedBatched](interfacehipfort__hipblas_1_1hipblasdgemmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+827 | [hipblasCgemmStridedBatched](interfacehipfort__hipblas_1_1hipblascgemmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+828 | [hipblasZgemmStridedBatched](interfacehipfort__hipblas_1_1hipblaszgemmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+829 | [hipblasHgemmStridedBatched_64](interfacehipfort__hipblas_1_1hipblashgemmstridedbatched__64.html "Interface documentation") | C binding
+830 | [hipblasSgemmStridedBatched_64](interfacehipfort__hipblas_1_1hipblassgemmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+831 | [hipblasDgemmStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdgemmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+832 | [hipblasCgemmStridedBatched_64](interfacehipfort__hipblas_1_1hipblascgemmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+833 | [hipblasZgemmStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszgemmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+834 | [hipblasCherk](interfacehipfort__hipblas_1_1hipblascherk.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+835 | [hipblasZherk](interfacehipfort__hipblas_1_1hipblaszherk.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+836 | [hipblasCherk_64](interfacehipfort__hipblas_1_1hipblascherk__64.html "Interface documentation") | C binding, rank_0, rank_1
+837 | [hipblasZherk_64](interfacehipfort__hipblas_1_1hipblaszherk__64.html "Interface documentation") | C binding, rank_0, rank_1
+838 | [hipblasCherkBatched](interfacehipfort__hipblas_1_1hipblascherkbatched.html "Interface documentation") | C binding
+839 | [hipblasZherkBatched](interfacehipfort__hipblas_1_1hipblaszherkbatched.html "Interface documentation") | C binding
+840 | [hipblasCherkBatched_64](interfacehipfort__hipblas_1_1hipblascherkbatched__64.html "Interface documentation") | C binding
+841 | [hipblasZherkBatched_64](interfacehipfort__hipblas_1_1hipblaszherkbatched__64.html "Interface documentation") | C binding
+842 | [hipblasCherkStridedBatched](interfacehipfort__hipblas_1_1hipblascherkstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+843 | [hipblasZherkStridedBatched](interfacehipfort__hipblas_1_1hipblaszherkstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+844 | [hipblasCherkStridedBatched_64](interfacehipfort__hipblas_1_1hipblascherkstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+845 | [hipblasZherkStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszherkstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+846 | [hipblasCherkx](interfacehipfort__hipblas_1_1hipblascherkx.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+847 | [hipblasZherkx](interfacehipfort__hipblas_1_1hipblaszherkx.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+848 | [hipblasCherkx_64](interfacehipfort__hipblas_1_1hipblascherkx__64.html "Interface documentation") | C binding, rank_0, rank_1
+849 | [hipblasZherkx_64](interfacehipfort__hipblas_1_1hipblaszherkx__64.html "Interface documentation") | C binding, rank_0, rank_1
+850 | [hipblasCherkxBatched](interfacehipfort__hipblas_1_1hipblascherkxbatched.html "Interface documentation") | C binding
+851 | [hipblasZherkxBatched](interfacehipfort__hipblas_1_1hipblaszherkxbatched.html "Interface documentation") | C binding
+852 | [hipblasCherkxBatched_64](interfacehipfort__hipblas_1_1hipblascherkxbatched__64.html "Interface documentation") | C binding
+853 | [hipblasZherkxBatched_64](interfacehipfort__hipblas_1_1hipblaszherkxbatched__64.html "Interface documentation") | C binding
+854 | [hipblasCherkxStridedBatched](interfacehipfort__hipblas_1_1hipblascherkxstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+855 | [hipblasZherkxStridedBatched](interfacehipfort__hipblas_1_1hipblaszherkxstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+856 | [hipblasCherkxStridedBatched_64](interfacehipfort__hipblas_1_1hipblascherkxstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+857 | [hipblasZherkxStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszherkxstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+858 | [hipblasCher2k](interfacehipfort__hipblas_1_1hipblascher2k.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+859 | [hipblasZher2k](interfacehipfort__hipblas_1_1hipblaszher2k.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+860 | [hipblasCher2k_64](interfacehipfort__hipblas_1_1hipblascher2k__64.html "Interface documentation") | C binding, rank_0, rank_1
+861 | [hipblasZher2k_64](interfacehipfort__hipblas_1_1hipblaszher2k__64.html "Interface documentation") | C binding, rank_0, rank_1
+862 | [hipblasCher2kBatched](interfacehipfort__hipblas_1_1hipblascher2kbatched.html "Interface documentation") | C binding
+863 | [hipblasZher2kBatched](interfacehipfort__hipblas_1_1hipblaszher2kbatched.html "Interface documentation") | C binding
+864 | [hipblasCher2kBatched_64](interfacehipfort__hipblas_1_1hipblascher2kbatched__64.html "Interface documentation") | C binding
+865 | [hipblasZher2kBatched_64](interfacehipfort__hipblas_1_1hipblaszher2kbatched__64.html "Interface documentation") | C binding
+866 | [hipblasCher2kStridedBatched](interfacehipfort__hipblas_1_1hipblascher2kstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+867 | [hipblasZher2kStridedBatched](interfacehipfort__hipblas_1_1hipblaszher2kstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+868 | [hipblasCher2kStridedBatched_64](interfacehipfort__hipblas_1_1hipblascher2kstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+869 | [hipblasZher2kStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszher2kstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+870 | [hipblasSsymm](interfacehipfort__hipblas_1_1hipblasssymm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+871 | [hipblasDsymm](interfacehipfort__hipblas_1_1hipblasdsymm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+872 | [hipblasCsymm](interfacehipfort__hipblas_1_1hipblascsymm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+873 | [hipblasZsymm](interfacehipfort__hipblas_1_1hipblaszsymm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+874 | [hipblasSsymm_64](interfacehipfort__hipblas_1_1hipblasssymm__64.html "Interface documentation") | C binding, rank_0, rank_1
+875 | [hipblasDsymm_64](interfacehipfort__hipblas_1_1hipblasdsymm__64.html "Interface documentation") | C binding, rank_0, rank_1
+876 | [hipblasCsymm_64](interfacehipfort__hipblas_1_1hipblascsymm__64.html "Interface documentation") | C binding, rank_0, rank_1
+877 | [hipblasZsymm_64](interfacehipfort__hipblas_1_1hipblaszsymm__64.html "Interface documentation") | C binding, rank_0, rank_1
+878 | [hipblasSsymmBatched](interfacehipfort__hipblas_1_1hipblasssymmbatched.html "Interface documentation") | C binding
+879 | [hipblasDsymmBatched](interfacehipfort__hipblas_1_1hipblasdsymmbatched.html "Interface documentation") | C binding
+880 | [hipblasCsymmBatched](interfacehipfort__hipblas_1_1hipblascsymmbatched.html "Interface documentation") | C binding
+881 | [hipblasZsymmBatched](interfacehipfort__hipblas_1_1hipblaszsymmbatched.html "Interface documentation") | C binding
+882 | [hipblasSsymmBatched_64](interfacehipfort__hipblas_1_1hipblasssymmbatched__64.html "Interface documentation") | C binding
+883 | [hipblasDsymmBatched_64](interfacehipfort__hipblas_1_1hipblasdsymmbatched__64.html "Interface documentation") | C binding
+884 | [hipblasCsymmBatched_64](interfacehipfort__hipblas_1_1hipblascsymmbatched__64.html "Interface documentation") | C binding
+885 | [hipblasZsymmBatched_64](interfacehipfort__hipblas_1_1hipblaszsymmbatched__64.html "Interface documentation") | C binding
+886 | [hipblasSsymmStridedBatched](interfacehipfort__hipblas_1_1hipblasssymmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+887 | [hipblasDsymmStridedBatched](interfacehipfort__hipblas_1_1hipblasdsymmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+888 | [hipblasCsymmStridedBatched](interfacehipfort__hipblas_1_1hipblascsymmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+889 | [hipblasZsymmStridedBatched](interfacehipfort__hipblas_1_1hipblaszsymmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+890 | [hipblasSsymmStridedBatched_64](interfacehipfort__hipblas_1_1hipblasssymmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+891 | [hipblasDsymmStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdsymmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+892 | [hipblasCsymmStridedBatched_64](interfacehipfort__hipblas_1_1hipblascsymmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+893 | [hipblasZsymmStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszsymmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+894 | [hipblasSsyrk](interfacehipfort__hipblas_1_1hipblasssyrk.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+895 | [hipblasDsyrk](interfacehipfort__hipblas_1_1hipblasdsyrk.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+896 | [hipblasCsyrk](interfacehipfort__hipblas_1_1hipblascsyrk.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+897 | [hipblasZsyrk](interfacehipfort__hipblas_1_1hipblaszsyrk.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+898 | [hipblasSsyrk_64](interfacehipfort__hipblas_1_1hipblasssyrk__64.html "Interface documentation") | C binding, rank_0, rank_1
+899 | [hipblasDsyrk_64](interfacehipfort__hipblas_1_1hipblasdsyrk__64.html "Interface documentation") | C binding, rank_0, rank_1
+900 | [hipblasCsyrk_64](interfacehipfort__hipblas_1_1hipblascsyrk__64.html "Interface documentation") | C binding, rank_0, rank_1
+901 | [hipblasZsyrk_64](interfacehipfort__hipblas_1_1hipblaszsyrk__64.html "Interface documentation") | C binding, rank_0, rank_1
+902 | [hipblasSsyrkBatched](interfacehipfort__hipblas_1_1hipblasssyrkbatched.html "Interface documentation") | C binding
+903 | [hipblasDsyrkBatched](interfacehipfort__hipblas_1_1hipblasdsyrkbatched.html "Interface documentation") | C binding
+904 | [hipblasCsyrkBatched](interfacehipfort__hipblas_1_1hipblascsyrkbatched.html "Interface documentation") | C binding
+905 | [hipblasZsyrkBatched](interfacehipfort__hipblas_1_1hipblaszsyrkbatched.html "Interface documentation") | C binding
+906 | [hipblasSsyrkBatched_64](interfacehipfort__hipblas_1_1hipblasssyrkbatched__64.html "Interface documentation") | C binding
+907 | [hipblasDsyrkBatched_64](interfacehipfort__hipblas_1_1hipblasdsyrkbatched__64.html "Interface documentation") | C binding
+908 | [hipblasCsyrkBatched_64](interfacehipfort__hipblas_1_1hipblascsyrkbatched__64.html "Interface documentation") | C binding
+909 | [hipblasZsyrkBatched_64](interfacehipfort__hipblas_1_1hipblaszsyrkbatched__64.html "Interface documentation") | C binding
+910 | [hipblasSsyrkStridedBatched](interfacehipfort__hipblas_1_1hipblasssyrkstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+911 | [hipblasDsyrkStridedBatched](interfacehipfort__hipblas_1_1hipblasdsyrkstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+912 | [hipblasCsyrkStridedBatched](interfacehipfort__hipblas_1_1hipblascsyrkstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+913 | [hipblasZsyrkStridedBatched](interfacehipfort__hipblas_1_1hipblaszsyrkstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+914 | [hipblasSsyrkStridedBatched_64](interfacehipfort__hipblas_1_1hipblasssyrkstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+915 | [hipblasDsyrkStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdsyrkstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+916 | [hipblasCsyrkStridedBatched_64](interfacehipfort__hipblas_1_1hipblascsyrkstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+917 | [hipblasZsyrkStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszsyrkstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+918 | [hipblasSsyr2k](interfacehipfort__hipblas_1_1hipblasssyr2k.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+919 | [hipblasDsyr2k](interfacehipfort__hipblas_1_1hipblasdsyr2k.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+920 | [hipblasCsyr2k](interfacehipfort__hipblas_1_1hipblascsyr2k.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+921 | [hipblasZsyr2k](interfacehipfort__hipblas_1_1hipblaszsyr2k.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+922 | [hipblasSsyr2k_64](interfacehipfort__hipblas_1_1hipblasssyr2k__64.html "Interface documentation") | C binding, rank_0, rank_1
+923 | [hipblasDsyr2k_64](interfacehipfort__hipblas_1_1hipblasdsyr2k__64.html "Interface documentation") | C binding, rank_0, rank_1
+924 | [hipblasCsyr2k_64](interfacehipfort__hipblas_1_1hipblascsyr2k__64.html "Interface documentation") | C binding, rank_0, rank_1
+925 | [hipblasZsyr2k_64](interfacehipfort__hipblas_1_1hipblaszsyr2k__64.html "Interface documentation") | C binding, rank_0, rank_1
+926 | [hipblasSsyr2kBatched](interfacehipfort__hipblas_1_1hipblasssyr2kbatched.html "Interface documentation") | C binding
+927 | [hipblasDsyr2kBatched](interfacehipfort__hipblas_1_1hipblasdsyr2kbatched.html "Interface documentation") | C binding
+928 | [hipblasCsyr2kBatched](interfacehipfort__hipblas_1_1hipblascsyr2kbatched.html "Interface documentation") | C binding
+929 | [hipblasZsyr2kBatched](interfacehipfort__hipblas_1_1hipblaszsyr2kbatched.html "Interface documentation") | C binding
+930 | [hipblasSsyr2kBatched_64](interfacehipfort__hipblas_1_1hipblasssyr2kbatched__64.html "Interface documentation") | C binding
+931 | [hipblasDsyr2kBatched_64](interfacehipfort__hipblas_1_1hipblasdsyr2kbatched__64.html "Interface documentation") | C binding
+932 | [hipblasCsyr2kBatched_64](interfacehipfort__hipblas_1_1hipblascsyr2kbatched__64.html "Interface documentation") | C binding
+933 | [hipblasZsyr2kBatched_64](interfacehipfort__hipblas_1_1hipblaszsyr2kbatched__64.html "Interface documentation") | C binding
+934 | [hipblasSsyr2kStridedBatched](interfacehipfort__hipblas_1_1hipblasssyr2kstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+935 | [hipblasDsyr2kStridedBatched](interfacehipfort__hipblas_1_1hipblasdsyr2kstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+936 | [hipblasCsyr2kStridedBatched](interfacehipfort__hipblas_1_1hipblascsyr2kstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+937 | [hipblasZsyr2kStridedBatched](interfacehipfort__hipblas_1_1hipblaszsyr2kstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+938 | [hipblasSsyr2kStridedBatched_64](interfacehipfort__hipblas_1_1hipblasssyr2kstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+939 | [hipblasDsyr2kStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdsyr2kstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+940 | [hipblasCsyr2kStridedBatched_64](interfacehipfort__hipblas_1_1hipblascsyr2kstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+941 | [hipblasZsyr2kStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszsyr2kstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+942 | [hipblasSsyrkx](interfacehipfort__hipblas_1_1hipblasssyrkx.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+943 | [hipblasDsyrkx](interfacehipfort__hipblas_1_1hipblasdsyrkx.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+944 | [hipblasCsyrkx](interfacehipfort__hipblas_1_1hipblascsyrkx.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+945 | [hipblasZsyrkx](interfacehipfort__hipblas_1_1hipblaszsyrkx.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+946 | [hipblasSsyrkx_64](interfacehipfort__hipblas_1_1hipblasssyrkx__64.html "Interface documentation") | C binding, rank_0, rank_1
+947 | [hipblasDsyrkx_64](interfacehipfort__hipblas_1_1hipblasdsyrkx__64.html "Interface documentation") | C binding, rank_0, rank_1
+948 | [hipblasCsyrkx_64](interfacehipfort__hipblas_1_1hipblascsyrkx__64.html "Interface documentation") | C binding, rank_0, rank_1
+949 | [hipblasZsyrkx_64](interfacehipfort__hipblas_1_1hipblaszsyrkx__64.html "Interface documentation") | C binding, rank_0, rank_1
+950 | [hipblasSsyrkxBatched](interfacehipfort__hipblas_1_1hipblasssyrkxbatched.html "Interface documentation") | C binding
+951 | [hipblasDsyrkxBatched](interfacehipfort__hipblas_1_1hipblasdsyrkxbatched.html "Interface documentation") | C binding
+952 | [hipblasCsyrkxBatched](interfacehipfort__hipblas_1_1hipblascsyrkxbatched.html "Interface documentation") | C binding
+953 | [hipblasZsyrkxBatched](interfacehipfort__hipblas_1_1hipblaszsyrkxbatched.html "Interface documentation") | C binding
+954 | [hipblasSsyrkxBatched_64](interfacehipfort__hipblas_1_1hipblasssyrkxbatched__64.html "Interface documentation") | C binding
+955 | [hipblasDsyrkxBatched_64](interfacehipfort__hipblas_1_1hipblasdsyrkxbatched__64.html "Interface documentation") | C binding
+956 | [hipblasCsyrkxBatched_64](interfacehipfort__hipblas_1_1hipblascsyrkxbatched__64.html "Interface documentation") | C binding
+957 | [hipblasZsyrkxBatched_64](interfacehipfort__hipblas_1_1hipblaszsyrkxbatched__64.html "Interface documentation") | C binding
+958 | [hipblasSsyrkxStridedBatched](interfacehipfort__hipblas_1_1hipblasssyrkxstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+959 | [hipblasDsyrkxStridedBatched](interfacehipfort__hipblas_1_1hipblasdsyrkxstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+960 | [hipblasCsyrkxStridedBatched](interfacehipfort__hipblas_1_1hipblascsyrkxstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+961 | [hipblasZsyrkxStridedBatched](interfacehipfort__hipblas_1_1hipblaszsyrkxstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+962 | [hipblasSsyrkxStridedBatched_64](interfacehipfort__hipblas_1_1hipblasssyrkxstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+963 | [hipblasDsyrkxStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdsyrkxstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+964 | [hipblasCsyrkxStridedBatched_64](interfacehipfort__hipblas_1_1hipblascsyrkxstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+965 | [hipblasZsyrkxStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszsyrkxstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+966 | [hipblasSgeam](interfacehipfort__hipblas_1_1hipblassgeam.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+967 | [hipblasDgeam](interfacehipfort__hipblas_1_1hipblasdgeam.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+968 | [hipblasCgeam](interfacehipfort__hipblas_1_1hipblascgeam.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+969 | [hipblasZgeam](interfacehipfort__hipblas_1_1hipblaszgeam.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+970 | [hipblasSgeam_64](interfacehipfort__hipblas_1_1hipblassgeam__64.html "Interface documentation") | C binding, rank_0, rank_1
+971 | [hipblasDgeam_64](interfacehipfort__hipblas_1_1hipblasdgeam__64.html "Interface documentation") | C binding, rank_0, rank_1
+972 | [hipblasCgeam_64](interfacehipfort__hipblas_1_1hipblascgeam__64.html "Interface documentation") | C binding, rank_0, rank_1
+973 | [hipblasZgeam_64](interfacehipfort__hipblas_1_1hipblaszgeam__64.html "Interface documentation") | C binding, rank_0, rank_1
+974 | [hipblasSgeamBatched](interfacehipfort__hipblas_1_1hipblassgeambatched.html "Interface documentation") | C binding
+975 | [hipblasDgeamBatched](interfacehipfort__hipblas_1_1hipblasdgeambatched.html "Interface documentation") | C binding
+976 | [hipblasCgeamBatched](interfacehipfort__hipblas_1_1hipblascgeambatched.html "Interface documentation") | C binding
+977 | [hipblasZgeamBatched](interfacehipfort__hipblas_1_1hipblaszgeambatched.html "Interface documentation") | C binding
+978 | [hipblasSgeamBatched_64](interfacehipfort__hipblas_1_1hipblassgeambatched__64.html "Interface documentation") | C binding
+979 | [hipblasDgeamBatched_64](interfacehipfort__hipblas_1_1hipblasdgeambatched__64.html "Interface documentation") | C binding
+980 | [hipblasCgeamBatched_64](interfacehipfort__hipblas_1_1hipblascgeambatched__64.html "Interface documentation") | C binding
+981 | [hipblasZgeamBatched_64](interfacehipfort__hipblas_1_1hipblaszgeambatched__64.html "Interface documentation") | C binding
+982 | [hipblasSgeamStridedBatched](interfacehipfort__hipblas_1_1hipblassgeamstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+983 | [hipblasDgeamStridedBatched](interfacehipfort__hipblas_1_1hipblasdgeamstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+984 | [hipblasCgeamStridedBatched](interfacehipfort__hipblas_1_1hipblascgeamstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+985 | [hipblasZgeamStridedBatched](interfacehipfort__hipblas_1_1hipblaszgeamstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+986 | [hipblasSgeamStridedBatched_64](interfacehipfort__hipblas_1_1hipblassgeamstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+987 | [hipblasDgeamStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdgeamstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+988 | [hipblasCgeamStridedBatched_64](interfacehipfort__hipblas_1_1hipblascgeamstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+989 | [hipblasZgeamStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszgeamstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+990 | [hipblasChemm](interfacehipfort__hipblas_1_1hipblaschemm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+991 | [hipblasZhemm](interfacehipfort__hipblas_1_1hipblaszhemm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+992 | [hipblasChemm_64](interfacehipfort__hipblas_1_1hipblaschemm__64.html "Interface documentation") | C binding, rank_0, rank_1
+993 | [hipblasZhemm_64](interfacehipfort__hipblas_1_1hipblaszhemm__64.html "Interface documentation") | C binding, rank_0, rank_1
+994 | [hipblasChemmBatched](interfacehipfort__hipblas_1_1hipblaschemmbatched.html "Interface documentation") | C binding
+995 | [hipblasZhemmBatched](interfacehipfort__hipblas_1_1hipblaszhemmbatched.html "Interface documentation") | C binding
+996 | [hipblasChemmBatched_64](interfacehipfort__hipblas_1_1hipblaschemmbatched__64.html "Interface documentation") | C binding
+997 | [hipblasZhemmBatched_64](interfacehipfort__hipblas_1_1hipblaszhemmbatched__64.html "Interface documentation") | C binding
+998 | [hipblasChemmStridedBatched](interfacehipfort__hipblas_1_1hipblaschemmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+999 | [hipblasZhemmStridedBatched](interfacehipfort__hipblas_1_1hipblaszhemmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1000 | [hipblasChemmStridedBatched_64](interfacehipfort__hipblas_1_1hipblaschemmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+1001 | [hipblasZhemmStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszhemmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+1002 | [hipblasStrmm](interfacehipfort__hipblas_1_1hipblasstrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1003 | [hipblasDtrmm](interfacehipfort__hipblas_1_1hipblasdtrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1004 | [hipblasCtrmm](interfacehipfort__hipblas_1_1hipblasctrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1005 | [hipblasZtrmm](interfacehipfort__hipblas_1_1hipblasztrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1006 | [hipblasStrmm_64](interfacehipfort__hipblas_1_1hipblasstrmm__64.html "Interface documentation") | C binding, rank_0, rank_1
+1007 | [hipblasDtrmm_64](interfacehipfort__hipblas_1_1hipblasdtrmm__64.html "Interface documentation") | C binding, rank_0, rank_1
+1008 | [hipblasCtrmm_64](interfacehipfort__hipblas_1_1hipblasctrmm__64.html "Interface documentation") | C binding, rank_0, rank_1
+1009 | [hipblasZtrmm_64](interfacehipfort__hipblas_1_1hipblasztrmm__64.html "Interface documentation") | C binding, rank_0, rank_1
+1010 | [hipblasStrmmBatched](interfacehipfort__hipblas_1_1hipblasstrmmbatched.html "Interface documentation") | C binding
+1011 | [hipblasDtrmmBatched](interfacehipfort__hipblas_1_1hipblasdtrmmbatched.html "Interface documentation") | C binding
+1012 | [hipblasCtrmmBatched](interfacehipfort__hipblas_1_1hipblasctrmmbatched.html "Interface documentation") | C binding
+1013 | [hipblasZtrmmBatched](interfacehipfort__hipblas_1_1hipblasztrmmbatched.html "Interface documentation") | C binding
+1014 | [hipblasStrmmBatched_64](interfacehipfort__hipblas_1_1hipblasstrmmbatched__64.html "Interface documentation") | C binding
+1015 | [hipblasDtrmmBatched_64](interfacehipfort__hipblas_1_1hipblasdtrmmbatched__64.html "Interface documentation") | C binding
+1016 | [hipblasCtrmmBatched_64](interfacehipfort__hipblas_1_1hipblasctrmmbatched__64.html "Interface documentation") | C binding
+1017 | [hipblasZtrmmBatched_64](interfacehipfort__hipblas_1_1hipblasztrmmbatched__64.html "Interface documentation") | C binding
+1018 | [hipblasStrmmStridedBatched](interfacehipfort__hipblas_1_1hipblasstrmmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1019 | [hipblasDtrmmStridedBatched](interfacehipfort__hipblas_1_1hipblasdtrmmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1020 | [hipblasCtrmmStridedBatched](interfacehipfort__hipblas_1_1hipblasctrmmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1021 | [hipblasZtrmmStridedBatched](interfacehipfort__hipblas_1_1hipblasztrmmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1022 | [hipblasStrmmStridedBatched_64](interfacehipfort__hipblas_1_1hipblasstrmmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+1023 | [hipblasDtrmmStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdtrmmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+1024 | [hipblasCtrmmStridedBatched_64](interfacehipfort__hipblas_1_1hipblasctrmmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+1025 | [hipblasZtrmmStridedBatched_64](interfacehipfort__hipblas_1_1hipblasztrmmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+1026 | [hipblasStrsm](interfacehipfort__hipblas_1_1hipblasstrsm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1027 | [hipblasDtrsm](interfacehipfort__hipblas_1_1hipblasdtrsm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1028 | [hipblasCtrsm](interfacehipfort__hipblas_1_1hipblasctrsm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1029 | [hipblasZtrsm](interfacehipfort__hipblas_1_1hipblasztrsm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1030 | [hipblasStrsm_64](interfacehipfort__hipblas_1_1hipblasstrsm__64.html "Interface documentation") | C binding, rank_0, rank_1
+1031 | [hipblasDtrsm_64](interfacehipfort__hipblas_1_1hipblasdtrsm__64.html "Interface documentation") | C binding, rank_0, rank_1
+1032 | [hipblasCtrsm_64](interfacehipfort__hipblas_1_1hipblasctrsm__64.html "Interface documentation") | C binding, rank_0, rank_1
+1033 | [hipblasZtrsm_64](interfacehipfort__hipblas_1_1hipblasztrsm__64.html "Interface documentation") | C binding, rank_0, rank_1
+1034 | [hipblasStrsmBatched](interfacehipfort__hipblas_1_1hipblasstrsmbatched.html "Interface documentation") | C binding
+1035 | [hipblasDtrsmBatched](interfacehipfort__hipblas_1_1hipblasdtrsmbatched.html "Interface documentation") | C binding
+1036 | [hipblasCtrsmBatched](interfacehipfort__hipblas_1_1hipblasctrsmbatched.html "Interface documentation") | C binding
+1037 | [hipblasZtrsmBatched](interfacehipfort__hipblas_1_1hipblasztrsmbatched.html "Interface documentation") | C binding
+1038 | [hipblasStrsmBatched_64](interfacehipfort__hipblas_1_1hipblasstrsmbatched__64.html "Interface documentation") | C binding
+1039 | [hipblasDtrsmBatched_64](interfacehipfort__hipblas_1_1hipblasdtrsmbatched__64.html "Interface documentation") | C binding
+1040 | [hipblasCtrsmBatched_64](interfacehipfort__hipblas_1_1hipblasctrsmbatched__64.html "Interface documentation") | C binding
+1041 | [hipblasZtrsmBatched_64](interfacehipfort__hipblas_1_1hipblasztrsmbatched__64.html "Interface documentation") | C binding
+1042 | [hipblasStrsmStridedBatched](interfacehipfort__hipblas_1_1hipblasstrsmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1043 | [hipblasDtrsmStridedBatched](interfacehipfort__hipblas_1_1hipblasdtrsmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1044 | [hipblasCtrsmStridedBatched](interfacehipfort__hipblas_1_1hipblasctrsmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1045 | [hipblasZtrsmStridedBatched](interfacehipfort__hipblas_1_1hipblasztrsmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1046 | [hipblasStrsmStridedBatched_64](interfacehipfort__hipblas_1_1hipblasstrsmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+1047 | [hipblasDtrsmStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdtrsmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+1048 | [hipblasCtrsmStridedBatched_64](interfacehipfort__hipblas_1_1hipblasctrsmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+1049 | [hipblasZtrsmStridedBatched_64](interfacehipfort__hipblas_1_1hipblasztrsmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+1050 | [hipblasStrtri](interfacehipfort__hipblas_1_1hipblasstrtri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1051 | [hipblasDtrtri](interfacehipfort__hipblas_1_1hipblasdtrtri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1052 | [hipblasCtrtri](interfacehipfort__hipblas_1_1hipblasctrtri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1053 | [hipblasZtrtri](interfacehipfort__hipblas_1_1hipblasztrtri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1054 | [hipblasStrtriBatched](interfacehipfort__hipblas_1_1hipblasstrtribatched.html "Interface documentation") | C binding
+1055 | [hipblasDtrtriBatched](interfacehipfort__hipblas_1_1hipblasdtrtribatched.html "Interface documentation") | C binding
+1056 | [hipblasCtrtriBatched](interfacehipfort__hipblas_1_1hipblasctrtribatched.html "Interface documentation") | C binding
+1057 | [hipblasZtrtriBatched](interfacehipfort__hipblas_1_1hipblasztrtribatched.html "Interface documentation") | C binding
+1058 | [hipblasStrtriStridedBatched](interfacehipfort__hipblas_1_1hipblasstrtristridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1059 | [hipblasDtrtriStridedBatched](interfacehipfort__hipblas_1_1hipblasdtrtristridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1060 | [hipblasCtrtriStridedBatched](interfacehipfort__hipblas_1_1hipblasctrtristridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1061 | [hipblasZtrtriStridedBatched](interfacehipfort__hipblas_1_1hipblasztrtristridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1062 | [hipblasSdgmm](interfacehipfort__hipblas_1_1hipblassdgmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1063 | [hipblasDdgmm](interfacehipfort__hipblas_1_1hipblasddgmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1064 | [hipblasCdgmm](interfacehipfort__hipblas_1_1hipblascdgmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1065 | [hipblasZdgmm](interfacehipfort__hipblas_1_1hipblaszdgmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1066 | [hipblasSdgmm_64](interfacehipfort__hipblas_1_1hipblassdgmm__64.html "Interface documentation") | C binding, rank_0, rank_1
+1067 | [hipblasDdgmm_64](interfacehipfort__hipblas_1_1hipblasddgmm__64.html "Interface documentation") | C binding, rank_0, rank_1
+1068 | [hipblasCdgmm_64](interfacehipfort__hipblas_1_1hipblascdgmm__64.html "Interface documentation") | C binding, rank_0, rank_1
+1069 | [hipblasZdgmm_64](interfacehipfort__hipblas_1_1hipblaszdgmm__64.html "Interface documentation") | C binding, rank_0, rank_1
+1070 | [hipblasSdgmmBatched](interfacehipfort__hipblas_1_1hipblassdgmmbatched.html "Interface documentation") | C binding
+1071 | [hipblasDdgmmBatched](interfacehipfort__hipblas_1_1hipblasddgmmbatched.html "Interface documentation") | C binding
+1072 | [hipblasCdgmmBatched](interfacehipfort__hipblas_1_1hipblascdgmmbatched.html "Interface documentation") | C binding
+1073 | [hipblasZdgmmBatched](interfacehipfort__hipblas_1_1hipblaszdgmmbatched.html "Interface documentation") | C binding
+1074 | [hipblasSdgmmBatched_64](interfacehipfort__hipblas_1_1hipblassdgmmbatched__64.html "Interface documentation") | C binding
+1075 | [hipblasDdgmmBatched_64](interfacehipfort__hipblas_1_1hipblasddgmmbatched__64.html "Interface documentation") | C binding
+1076 | [hipblasCdgmmBatched_64](interfacehipfort__hipblas_1_1hipblascdgmmbatched__64.html "Interface documentation") | C binding
+1077 | [hipblasZdgmmBatched_64](interfacehipfort__hipblas_1_1hipblaszdgmmbatched__64.html "Interface documentation") | C binding
+1078 | [hipblasSdgmmStridedBatched](interfacehipfort__hipblas_1_1hipblassdgmmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1079 | [hipblasDdgmmStridedBatched](interfacehipfort__hipblas_1_1hipblasddgmmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1080 | [hipblasCdgmmStridedBatched](interfacehipfort__hipblas_1_1hipblascdgmmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1081 | [hipblasZdgmmStridedBatched](interfacehipfort__hipblas_1_1hipblaszdgmmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1082 | [hipblasSdgmmStridedBatched_64](interfacehipfort__hipblas_1_1hipblassdgmmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+1083 | [hipblasDdgmmStridedBatched_64](interfacehipfort__hipblas_1_1hipblasddgmmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+1084 | [hipblasCdgmmStridedBatched_64](interfacehipfort__hipblas_1_1hipblascdgmmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+1085 | [hipblasZdgmmStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszdgmmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+1086 | [hipblasSgetrf](interfacehipfort__hipblas_1_1hipblassgetrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1087 | [hipblasDgetrf](interfacehipfort__hipblas_1_1hipblasdgetrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1088 | [hipblasCgetrf](interfacehipfort__hipblas_1_1hipblascgetrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1089 | [hipblasZgetrf](interfacehipfort__hipblas_1_1hipblaszgetrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1090 | [hipblasSgetrfBatched](interfacehipfort__hipblas_1_1hipblassgetrfbatched.html "Interface documentation") | C binding
+1091 | [hipblasDgetrfBatched](interfacehipfort__hipblas_1_1hipblasdgetrfbatched.html "Interface documentation") | C binding
+1092 | [hipblasCgetrfBatched](interfacehipfort__hipblas_1_1hipblascgetrfbatched.html "Interface documentation") | C binding
+1093 | [hipblasZgetrfBatched](interfacehipfort__hipblas_1_1hipblaszgetrfbatched.html "Interface documentation") | C binding
+1094 | [hipblasSgetrfStridedBatched](interfacehipfort__hipblas_1_1hipblassgetrfstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1095 | [hipblasDgetrfStridedBatched](interfacehipfort__hipblas_1_1hipblasdgetrfstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1096 | [hipblasCgetrfStridedBatched](interfacehipfort__hipblas_1_1hipblascgetrfstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1097 | [hipblasZgetrfStridedBatched](interfacehipfort__hipblas_1_1hipblaszgetrfstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1098 | [hipblasSgetrs](interfacehipfort__hipblas_1_1hipblassgetrs.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1099 | [hipblasDgetrs](interfacehipfort__hipblas_1_1hipblasdgetrs.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1100 | [hipblasCgetrs](interfacehipfort__hipblas_1_1hipblascgetrs.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1101 | [hipblasZgetrs](interfacehipfort__hipblas_1_1hipblaszgetrs.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1102 | [hipblasSgetrsBatched](interfacehipfort__hipblas_1_1hipblassgetrsbatched.html "Interface documentation") | C binding
+1103 | [hipblasDgetrsBatched](interfacehipfort__hipblas_1_1hipblasdgetrsbatched.html "Interface documentation") | C binding
+1104 | [hipblasCgetrsBatched](interfacehipfort__hipblas_1_1hipblascgetrsbatched.html "Interface documentation") | C binding
+1105 | [hipblasZgetrsBatched](interfacehipfort__hipblas_1_1hipblaszgetrsbatched.html "Interface documentation") | C binding
+1106 | [hipblasSgetrsStridedBatched](interfacehipfort__hipblas_1_1hipblassgetrsstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1107 | [hipblasDgetrsStridedBatched](interfacehipfort__hipblas_1_1hipblasdgetrsstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1108 | [hipblasCgetrsStridedBatched](interfacehipfort__hipblas_1_1hipblascgetrsstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1109 | [hipblasZgetrsStridedBatched](interfacehipfort__hipblas_1_1hipblaszgetrsstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1110 | [hipblasSgetriBatched](interfacehipfort__hipblas_1_1hipblassgetribatched.html "Interface documentation") | C binding
+1111 | [hipblasDgetriBatched](interfacehipfort__hipblas_1_1hipblasdgetribatched.html "Interface documentation") | C binding
+1112 | [hipblasCgetriBatched](interfacehipfort__hipblas_1_1hipblascgetribatched.html "Interface documentation") | C binding
+1113 | [hipblasZgetriBatched](interfacehipfort__hipblas_1_1hipblaszgetribatched.html "Interface documentation") | C binding
+1114 | [hipblasSgels](interfacehipfort__hipblas_1_1hipblassgels.html "Interface documentation") | C binding, rank_0, rank_1
+1115 | [hipblasDgels](interfacehipfort__hipblas_1_1hipblasdgels.html "Interface documentation") | C binding, rank_0, rank_1
+1116 | [hipblasCgels](interfacehipfort__hipblas_1_1hipblascgels.html "Interface documentation") | C binding, rank_0, rank_1
+1117 | [hipblasZgels](interfacehipfort__hipblas_1_1hipblaszgels.html "Interface documentation") | C binding, rank_0, rank_1
+1118 | [hipblasSgelsBatched](interfacehipfort__hipblas_1_1hipblassgelsbatched.html "Interface documentation") | C binding, rank_0, rank_1
+1119 | [hipblasDgelsBatched](interfacehipfort__hipblas_1_1hipblasdgelsbatched.html "Interface documentation") | C binding, rank_0, rank_1
+1120 | [hipblasCgelsBatched](interfacehipfort__hipblas_1_1hipblascgelsbatched.html "Interface documentation") | C binding, rank_0, rank_1
+1121 | [hipblasZgelsBatched](interfacehipfort__hipblas_1_1hipblaszgelsbatched.html "Interface documentation") | C binding, rank_0, rank_1
+1122 | [hipblasSgelsStridedBatched](interfacehipfort__hipblas_1_1hipblassgelsstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+1123 | [hipblasDgelsStridedBatched](interfacehipfort__hipblas_1_1hipblasdgelsstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+1124 | [hipblasCgelsStridedBatched](interfacehipfort__hipblas_1_1hipblascgelsstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+1125 | [hipblasZgelsStridedBatched](interfacehipfort__hipblas_1_1hipblaszgelsstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+1126 | [hipblasSgeqrf](interfacehipfort__hipblas_1_1hipblassgeqrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1127 | [hipblasDgeqrf](interfacehipfort__hipblas_1_1hipblasdgeqrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1128 | [hipblasCgeqrf](interfacehipfort__hipblas_1_1hipblascgeqrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1129 | [hipblasZgeqrf](interfacehipfort__hipblas_1_1hipblaszgeqrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1130 | [hipblasSgeqrfBatched](interfacehipfort__hipblas_1_1hipblassgeqrfbatched.html "Interface documentation") | C binding
+1131 | [hipblasDgeqrfBatched](interfacehipfort__hipblas_1_1hipblasdgeqrfbatched.html "Interface documentation") | C binding
+1132 | [hipblasCgeqrfBatched](interfacehipfort__hipblas_1_1hipblascgeqrfbatched.html "Interface documentation") | C binding
+1133 | [hipblasZgeqrfBatched](interfacehipfort__hipblas_1_1hipblaszgeqrfbatched.html "Interface documentation") | C binding
+1134 | [hipblasSgeqrfStridedBatched](interfacehipfort__hipblas_1_1hipblassgeqrfstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1135 | [hipblasDgeqrfStridedBatched](interfacehipfort__hipblas_1_1hipblasdgeqrfstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1136 | [hipblasCgeqrfStridedBatched](interfacehipfort__hipblas_1_1hipblascgeqrfstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1137 | [hipblasZgeqrfStridedBatched](interfacehipfort__hipblas_1_1hipblaszgeqrfstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1138 | [hipblasGemmEx](interfacehipfort__hipblas_1_1hipblasgemmex.html "Interface documentation") | C binding
+1139 | [hipblasGemmExWithFlags](interfacehipfort__hipblas_1_1hipblasgemmexwithflags.html "Interface documentation") | C binding
+1140 | [hipblasGemmEx_64](interfacehipfort__hipblas_1_1hipblasgemmex__64.html "Interface documentation") | C binding
+1141 | [hipblasGemmExWithFlags_64](interfacehipfort__hipblas_1_1hipblasgemmexwithflags__64.html "Interface documentation") | C binding
+1142 | [hipblasGemmBatchedEx](interfacehipfort__hipblas_1_1hipblasgemmbatchedex.html "Interface documentation") | C binding
+1143 | [hipblasGemmBatchedExWithFlags](interfacehipfort__hipblas_1_1hipblasgemmbatchedexwithflags.html "Interface documentation") | C binding
+1144 | [hipblasGemmBatchedEx_64](interfacehipfort__hipblas_1_1hipblasgemmbatchedex__64.html "Interface documentation") | C binding
+1145 | [hipblasGemmBatchedExWithFlags_64](interfacehipfort__hipblas_1_1hipblasgemmbatchedexwithflags__64.html "Interface documentation") | C binding
+1146 | [hipblasGemmStridedBatchedEx](interfacehipfort__hipblas_1_1hipblasgemmstridedbatchedex.html "Interface documentation") | C binding
+1147 | [hipblasGemmStridedBatchedExWithFlags](interfacehipfort__hipblas_1_1hipblasgemmstridedbatchedexwithflags.html "Interface documentation") | C binding
+1148 | [hipblasGemmStridedBatchedEx_64](interfacehipfort__hipblas_1_1hipblasgemmstridedbatchedex__64.html "Interface documentation") | C binding
+1149 | [hipblasGemmStridedBatchedExWithFlags_64](interfacehipfort__hipblas_1_1hipblasgemmstridedbatchedexwithflags__64.html "Interface documentation") | C binding
+1150 | [hipblasSyrkEx](interfacehipfort__hipblas_1_1hipblassyrkex.html "Interface documentation") | C binding
+1151 | [hipblasTrsmEx](interfacehipfort__hipblas_1_1hipblastrsmex.html "Interface documentation") | C binding
+1152 | [hipblasHerkEx](interfacehipfort__hipblas_1_1hipblasherkex.html "Interface documentation") | C binding
+1153 | [hipblasTrsmBatchedEx](interfacehipfort__hipblas_1_1hipblastrsmbatchedex.html "Interface documentation") | C binding
+1154 | [hipblasTrsmStridedBatchedEx](interfacehipfort__hipblas_1_1hipblastrsmstridedbatchedex.html "Interface documentation") | C binding
+1155 | [hipblasAxpyEx](interfacehipfort__hipblas_1_1hipblasaxpyex.html "Interface documentation") | C binding
+1156 | [hipblasAxpyEx_64](interfacehipfort__hipblas_1_1hipblasaxpyex__64.html "Interface documentation") | C binding
+1157 | [hipblasAxpyBatchedEx](interfacehipfort__hipblas_1_1hipblasaxpybatchedex.html "Interface documentation") | C binding
+1158 | [hipblasAxpyBatchedEx_64](interfacehipfort__hipblas_1_1hipblasaxpybatchedex__64.html "Interface documentation") | C binding
+1159 | [hipblasAxpyStridedBatchedEx](interfacehipfort__hipblas_1_1hipblasaxpystridedbatchedex.html "Interface documentation") | C binding
+1160 | [hipblasAxpyStridedBatchedEx_64](interfacehipfort__hipblas_1_1hipblasaxpystridedbatchedex__64.html "Interface documentation") | C binding
+1161 | [hipblasDotEx](interfacehipfort__hipblas_1_1hipblasdotex.html "Interface documentation") | C binding
+1162 | [hipblasDotcEx](interfacehipfort__hipblas_1_1hipblasdotcex.html "Interface documentation") | C binding
+1163 | [hipblasDotEx_64](interfacehipfort__hipblas_1_1hipblasdotex__64.html "Interface documentation") | C binding
+1164 | [hipblasDotcEx_64](interfacehipfort__hipblas_1_1hipblasdotcex__64.html "Interface documentation") | C binding
+1165 | [hipblasDotBatchedEx](interfacehipfort__hipblas_1_1hipblasdotbatchedex.html "Interface documentation") | C binding
+1166 | [hipblasDotcBatchedEx](interfacehipfort__hipblas_1_1hipblasdotcbatchedex.html "Interface documentation") | C binding
+1167 | [hipblasDotBatchedEx_64](interfacehipfort__hipblas_1_1hipblasdotbatchedex__64.html "Interface documentation") | C binding
+1168 | [hipblasDotcBatchedEx_64](interfacehipfort__hipblas_1_1hipblasdotcbatchedex__64.html "Interface documentation") | C binding
+1169 | [hipblasDotStridedBatchedEx](interfacehipfort__hipblas_1_1hipblasdotstridedbatchedex.html "Interface documentation") | C binding
+1170 | [hipblasDotcStridedBatchedEx](interfacehipfort__hipblas_1_1hipblasdotcstridedbatchedex.html "Interface documentation") | C binding
+1171 | [hipblasDotStridedBatchedEx_64](interfacehipfort__hipblas_1_1hipblasdotstridedbatchedex__64.html "Interface documentation") | C binding
+1172 | [hipblasDotcStridedBatchedEx_64](interfacehipfort__hipblas_1_1hipblasdotcstridedbatchedex__64.html "Interface documentation") | C binding
+1173 | [hipblasNrm2Ex](interfacehipfort__hipblas_1_1hipblasnrm2ex.html "Interface documentation") | C binding
+1174 | [hipblasNrm2Ex_64](interfacehipfort__hipblas_1_1hipblasnrm2ex__64.html "Interface documentation") | C binding
+1175 | [hipblasNrm2BatchedEx](interfacehipfort__hipblas_1_1hipblasnrm2batchedex.html "Interface documentation") | C binding
+1176 | [hipblasNrm2BatchedEx_64](interfacehipfort__hipblas_1_1hipblasnrm2batchedex__64.html "Interface documentation") | C binding
+1177 | [hipblasNrm2StridedBatchedEx](interfacehipfort__hipblas_1_1hipblasnrm2stridedbatchedex.html "Interface documentation") | C binding
+1178 | [hipblasNrm2StridedBatchedEx_64](interfacehipfort__hipblas_1_1hipblasnrm2stridedbatchedex__64.html "Interface documentation") | C binding
+1179 | [hipblasRotEx](interfacehipfort__hipblas_1_1hipblasrotex.html "Interface documentation") | C binding
+1180 | [hipblasRotEx_64](interfacehipfort__hipblas_1_1hipblasrotex__64.html "Interface documentation") | C binding
+1181 | [hipblasRotBatchedEx](interfacehipfort__hipblas_1_1hipblasrotbatchedex.html "Interface documentation") | C binding
+1182 | [hipblasRotBatchedEx_64](interfacehipfort__hipblas_1_1hipblasrotbatchedex__64.html "Interface documentation") | C binding
+1183 | [hipblasRotStridedBatchedEx](interfacehipfort__hipblas_1_1hipblasrotstridedbatchedex.html "Interface documentation") | C binding
+1184 | [hipblasRotStridedBatchedEx_64](interfacehipfort__hipblas_1_1hipblasrotstridedbatchedex__64.html "Interface documentation") | C binding
+1185 | [hipblasScalEx](interfacehipfort__hipblas_1_1hipblasscalex.html "Interface documentation") | C binding
+1186 | [hipblasScalEx_64](interfacehipfort__hipblas_1_1hipblasscalex__64.html "Interface documentation") | C binding
+1187 | [hipblasScalBatchedEx](interfacehipfort__hipblas_1_1hipblasscalbatchedex.html "Interface documentation") | C binding
+1188 | [hipblasScalBatchedEx_64](interfacehipfort__hipblas_1_1hipblasscalbatchedex__64.html "Interface documentation") | C binding
+1189 | [hipblasScalStridedBatchedEx](interfacehipfort__hipblas_1_1hipblasscalstridedbatchedex.html "Interface documentation") | C binding
+1190 | [hipblasScalStridedBatchedEx_64](interfacehipfort__hipblas_1_1hipblasscalstridedbatchedex__64.html "Interface documentation") | C binding
+1191 | [hipblasStatusToString](interfacehipfort__hipblas_1_1hipblasstatustostring.html "Interface documentation") | C binding
+1192 | [hipblasSetVector](interfacehipfort__hipblas_1_1hipblassetvector.html "Interface documentation") | C binding, full_rank, rank_0
+1193 | [hipblasGetVector](interfacehipfort__hipblas_1_1hipblasgetvector.html "Interface documentation") | C binding, full_rank, rank_0
+1194 | [hipblasSetMatrix](interfacehipfort__hipblas_1_1hipblassetmatrix.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1195 | [hipblasGetMatrix](interfacehipfort__hipblas_1_1hipblasgetmatrix.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1196 | [hipblasSetVectorAsync](interfacehipfort__hipblas_1_1hipblassetvectorasync.html "Interface documentation") | C binding, full_rank, rank_0
+1197 | [hipblasGetVectorAsync](interfacehipfort__hipblas_1_1hipblasgetvectorasync.html "Interface documentation") | C binding, full_rank, rank_0
+1198 | [hipblasSetMatrixAsync](interfacehipfort__hipblas_1_1hipblassetmatrixasync.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1199 | [hipblasGetMatrixAsync](interfacehipfort__hipblas_1_1hipblasgetmatrixasync.html "Interface documentation") | C binding, full_rank, rank_0, rank_1

--- a/docs/doxygen/input/supported_api_rocblas.md
+++ b/docs/doxygen/input/supported_api_rocblas.md
@@ -7,1211 +7,1211 @@
 3 | [rocblas_set_stream](interfacehipfort__rocblas_1_1rocblas__set__stream.html "Interface documentation") | C binding
 4 | [rocblas_get_stream](interfacehipfort__rocblas_1_1rocblas__get__stream.html "Interface documentation") | C binding
 5 | [rocblas_set_pointer_mode](interfacehipfort__rocblas_1_1rocblas__set__pointer__mode.html "Interface documentation") | C binding
-6 | [rocblas_get_pointer_mode](interfacehipfort__rocblas_1_1rocblas__get__pointer__mode.html "Interface documentation") | C binding
+6 | [rocblas_get_pointer_mode](interfacehipfort__rocblas_1_1rocblas__get__pointer__mode.html "Interface documentation") | C binding, rank_0, rank_1
 7 | [rocblas_set_atomics_mode](interfacehipfort__rocblas_1_1rocblas__set__atomics__mode.html "Interface documentation") | C binding
-8 | [rocblas_get_atomics_mode](interfacehipfort__rocblas_1_1rocblas__get__atomics__mode.html "Interface documentation") | C binding
+8 | [rocblas_get_atomics_mode](interfacehipfort__rocblas_1_1rocblas__get__atomics__mode.html "Interface documentation") | C binding, rank_0, rank_1
 9 | [rocblas_set_batch_alpha_stride](interfacehipfort__rocblas_1_1rocblas__set__batch__alpha__stride.html "Interface documentation") | C binding
-10 | [rocblas_get_batch_alpha_stride](interfacehipfort__rocblas_1_1rocblas__get__batch__alpha__stride.html "Interface documentation") | C binding
+10 | [rocblas_get_batch_alpha_stride](interfacehipfort__rocblas_1_1rocblas__get__batch__alpha__stride.html "Interface documentation") | C binding, rank_0, rank_1
 11 | [rocblas_set_batch_beta_stride](interfacehipfort__rocblas_1_1rocblas__set__batch__beta__stride.html "Interface documentation") | C binding
-12 | [rocblas_get_batch_beta_stride](interfacehipfort__rocblas_1_1rocblas__get__batch__beta__stride.html "Interface documentation") | C binding
+12 | [rocblas_get_batch_beta_stride](interfacehipfort__rocblas_1_1rocblas__get__batch__beta__stride.html "Interface documentation") | C binding, rank_0, rank_1
 13 | [rocblas_set_math_mode](interfacehipfort__rocblas_1_1rocblas__set__math__mode.html "Interface documentation") | C binding
-14 | [rocblas_get_math_mode](interfacehipfort__rocblas_1_1rocblas__get__math__mode.html "Interface documentation") | C binding
+14 | [rocblas_get_math_mode](interfacehipfort__rocblas_1_1rocblas__get__math__mode.html "Interface documentation") | C binding, rank_0, rank_1
 15 | [rocblas_pointer_to_mode](interfacehipfort__rocblas_1_1rocblas__pointer__to__mode.html "Interface documentation") | C binding
-16 | [rocblas_set_vector](interfacehipfort__rocblas_1_1rocblas__set__vector.html "Interface documentation") | C binding, full_rank, rank_0
-17 | [rocblas_set_vector_64](interfacehipfort__rocblas_1_1rocblas__set__vector__64.html "Interface documentation") | C binding
-18 | [rocblas_get_vector](interfacehipfort__rocblas_1_1rocblas__get__vector.html "Interface documentation") | C binding, full_rank, rank_0
-19 | [rocblas_get_vector_64](interfacehipfort__rocblas_1_1rocblas__get__vector__64.html "Interface documentation") | C binding
-20 | [rocblas_set_matrix](interfacehipfort__rocblas_1_1rocblas__set__matrix.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-21 | [rocblas_set_matrix_64](interfacehipfort__rocblas_1_1rocblas__set__matrix__64.html "Interface documentation") | C binding
-22 | [rocblas_get_matrix](interfacehipfort__rocblas_1_1rocblas__get__matrix.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-23 | [rocblas_get_matrix_64](interfacehipfort__rocblas_1_1rocblas__get__matrix__64.html "Interface documentation") | C binding
-24 | [rocblas_set_vector_async](interfacehipfort__rocblas_1_1rocblas__set__vector__async.html "Interface documentation") | C binding, full_rank, rank_0
-25 | [rocblas_set_vector_async_64](interfacehipfort__rocblas_1_1rocblas__set__vector__async__64.html "Interface documentation") | C binding
-26 | [rocblas_get_vector_async](interfacehipfort__rocblas_1_1rocblas__get__vector__async.html "Interface documentation") | C binding, full_rank, rank_0
-27 | [rocblas_get_vector_async_64](interfacehipfort__rocblas_1_1rocblas__get__vector__async__64.html "Interface documentation") | C binding
-28 | [rocblas_set_matrix_async](interfacehipfort__rocblas_1_1rocblas__set__matrix__async.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-29 | [rocblas_set_matrix_async_64](interfacehipfort__rocblas_1_1rocblas__set__matrix__async__64.html "Interface documentation") | C binding
-30 | [rocblas_get_matrix_async](interfacehipfort__rocblas_1_1rocblas__get__matrix__async.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-31 | [rocblas_get_matrix_async_64](interfacehipfort__rocblas_1_1rocblas__get__matrix__async__64.html "Interface documentation") | C binding
-32 | [rocblas_set_start_stop_events](interfacehipfort__rocblas_1_1rocblas__set__start__stop__events.html "Interface documentation") | C binding
-33 | [rocblas_set_solution_fitness_query](interfacehipfort__rocblas_1_1rocblas__set__solution__fitness__query.html "Interface documentation") | C binding
-34 | [rocblas_set_performance_metric](interfacehipfort__rocblas_1_1rocblas__set__performance__metric.html "Interface documentation") | C binding
-35 | [rocblas_get_performance_metric](interfacehipfort__rocblas_1_1rocblas__get__performance__metric.html "Interface documentation") | C binding
-36 | [rocblas_sscal](interfacehipfort__rocblas_1_1rocblas__sscal.html "Interface documentation") | C binding
-37 | [rocblas_dscal](interfacehipfort__rocblas_1_1rocblas__dscal.html "Interface documentation") | C binding
-38 | [rocblas_cscal](interfacehipfort__rocblas_1_1rocblas__cscal.html "Interface documentation") | C binding, rank_0, rank_1
-39 | [rocblas_zscal](interfacehipfort__rocblas_1_1rocblas__zscal.html "Interface documentation") | C binding, rank_0, rank_1
-40 | [rocblas_csscal](interfacehipfort__rocblas_1_1rocblas__csscal.html "Interface documentation") | C binding, rank_0, rank_1
-41 | [rocblas_zdscal](interfacehipfort__rocblas_1_1rocblas__zdscal.html "Interface documentation") | C binding, rank_0, rank_1
-42 | [rocblas_sscal_64](interfacehipfort__rocblas_1_1rocblas__sscal__64.html "Interface documentation") | C binding
-43 | [rocblas_dscal_64](interfacehipfort__rocblas_1_1rocblas__dscal__64.html "Interface documentation") | C binding
-44 | [rocblas_cscal_64](interfacehipfort__rocblas_1_1rocblas__cscal__64.html "Interface documentation") | C binding
-45 | [rocblas_zscal_64](interfacehipfort__rocblas_1_1rocblas__zscal__64.html "Interface documentation") | C binding
-46 | [rocblas_csscal_64](interfacehipfort__rocblas_1_1rocblas__csscal__64.html "Interface documentation") | C binding
-47 | [rocblas_zdscal_64](interfacehipfort__rocblas_1_1rocblas__zdscal__64.html "Interface documentation") | C binding
-48 | [rocblas_sscal_batched](interfacehipfort__rocblas_1_1rocblas__sscal__batched.html "Interface documentation") | C binding
-49 | [rocblas_dscal_batched](interfacehipfort__rocblas_1_1rocblas__dscal__batched.html "Interface documentation") | C binding
-50 | [rocblas_cscal_batched](interfacehipfort__rocblas_1_1rocblas__cscal__batched.html "Interface documentation") | C binding
-51 | [rocblas_zscal_batched](interfacehipfort__rocblas_1_1rocblas__zscal__batched.html "Interface documentation") | C binding
-52 | [rocblas_csscal_batched](interfacehipfort__rocblas_1_1rocblas__csscal__batched.html "Interface documentation") | C binding
-53 | [rocblas_zdscal_batched](interfacehipfort__rocblas_1_1rocblas__zdscal__batched.html "Interface documentation") | C binding
-54 | [rocblas_sscal_batched_64](interfacehipfort__rocblas_1_1rocblas__sscal__batched__64.html "Interface documentation") | C binding
-55 | [rocblas_dscal_batched_64](interfacehipfort__rocblas_1_1rocblas__dscal__batched__64.html "Interface documentation") | C binding
-56 | [rocblas_cscal_batched_64](interfacehipfort__rocblas_1_1rocblas__cscal__batched__64.html "Interface documentation") | C binding
-57 | [rocblas_zscal_batched_64](interfacehipfort__rocblas_1_1rocblas__zscal__batched__64.html "Interface documentation") | C binding
-58 | [rocblas_csscal_batched_64](interfacehipfort__rocblas_1_1rocblas__csscal__batched__64.html "Interface documentation") | C binding
-59 | [rocblas_zdscal_batched_64](interfacehipfort__rocblas_1_1rocblas__zdscal__batched__64.html "Interface documentation") | C binding
-60 | [rocblas_sscal_strided_batched](interfacehipfort__rocblas_1_1rocblas__sscal__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-61 | [rocblas_dscal_strided_batched](interfacehipfort__rocblas_1_1rocblas__dscal__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-62 | [rocblas_cscal_strided_batched](interfacehipfort__rocblas_1_1rocblas__cscal__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-63 | [rocblas_zscal_strided_batched](interfacehipfort__rocblas_1_1rocblas__zscal__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-64 | [rocblas_csscal_strided_batched](interfacehipfort__rocblas_1_1rocblas__csscal__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-65 | [rocblas_zdscal_strided_batched](interfacehipfort__rocblas_1_1rocblas__zdscal__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-66 | [rocblas_sscal_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sscal__strided__batched__64.html "Interface documentation") | C binding
-67 | [rocblas_dscal_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dscal__strided__batched__64.html "Interface documentation") | C binding
-68 | [rocblas_cscal_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cscal__strided__batched__64.html "Interface documentation") | C binding
-69 | [rocblas_zscal_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zscal__strided__batched__64.html "Interface documentation") | C binding
-70 | [rocblas_csscal_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__csscal__strided__batched__64.html "Interface documentation") | C binding
-71 | [rocblas_zdscal_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zdscal__strided__batched__64.html "Interface documentation") | C binding
-72 | [rocblas_scopy](interfacehipfort__rocblas_1_1rocblas__scopy.html "Interface documentation") | C binding, rank_0, rank_1
-73 | [rocblas_dcopy](interfacehipfort__rocblas_1_1rocblas__dcopy.html "Interface documentation") | C binding, rank_0, rank_1
-74 | [rocblas_ccopy](interfacehipfort__rocblas_1_1rocblas__ccopy.html "Interface documentation") | C binding, rank_0, rank_1
-75 | [rocblas_zcopy](interfacehipfort__rocblas_1_1rocblas__zcopy.html "Interface documentation") | C binding, rank_0, rank_1
-76 | [rocblas_scopy_64](interfacehipfort__rocblas_1_1rocblas__scopy__64.html "Interface documentation") | C binding
-77 | [rocblas_dcopy_64](interfacehipfort__rocblas_1_1rocblas__dcopy__64.html "Interface documentation") | C binding
-78 | [rocblas_ccopy_64](interfacehipfort__rocblas_1_1rocblas__ccopy__64.html "Interface documentation") | C binding
-79 | [rocblas_zcopy_64](interfacehipfort__rocblas_1_1rocblas__zcopy__64.html "Interface documentation") | C binding
-80 | [rocblas_scopy_batched](interfacehipfort__rocblas_1_1rocblas__scopy__batched.html "Interface documentation") | C binding
-81 | [rocblas_dcopy_batched](interfacehipfort__rocblas_1_1rocblas__dcopy__batched.html "Interface documentation") | C binding
-82 | [rocblas_ccopy_batched](interfacehipfort__rocblas_1_1rocblas__ccopy__batched.html "Interface documentation") | C binding
-83 | [rocblas_zcopy_batched](interfacehipfort__rocblas_1_1rocblas__zcopy__batched.html "Interface documentation") | C binding
-84 | [rocblas_scopy_batched_64](interfacehipfort__rocblas_1_1rocblas__scopy__batched__64.html "Interface documentation") | C binding
-85 | [rocblas_dcopy_batched_64](interfacehipfort__rocblas_1_1rocblas__dcopy__batched__64.html "Interface documentation") | C binding
-86 | [rocblas_ccopy_batched_64](interfacehipfort__rocblas_1_1rocblas__ccopy__batched__64.html "Interface documentation") | C binding
-87 | [rocblas_zcopy_batched_64](interfacehipfort__rocblas_1_1rocblas__zcopy__batched__64.html "Interface documentation") | C binding
-88 | [rocblas_scopy_strided_batched](interfacehipfort__rocblas_1_1rocblas__scopy__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-89 | [rocblas_dcopy_strided_batched](interfacehipfort__rocblas_1_1rocblas__dcopy__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-90 | [rocblas_ccopy_strided_batched](interfacehipfort__rocblas_1_1rocblas__ccopy__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-91 | [rocblas_zcopy_strided_batched](interfacehipfort__rocblas_1_1rocblas__zcopy__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-92 | [rocblas_scopy_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__scopy__strided__batched__64.html "Interface documentation") | C binding
-93 | [rocblas_dcopy_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dcopy__strided__batched__64.html "Interface documentation") | C binding
-94 | [rocblas_ccopy_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ccopy__strided__batched__64.html "Interface documentation") | C binding
-95 | [rocblas_zcopy_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zcopy__strided__batched__64.html "Interface documentation") | C binding
-96 | [rocblas_sdot](interfacehipfort__rocblas_1_1rocblas__sdot.html "Interface documentation") | C binding, rank_0, rank_1
-97 | [rocblas_ddot](interfacehipfort__rocblas_1_1rocblas__ddot.html "Interface documentation") | C binding, rank_0, rank_1
-98 | [rocblas_hdot](interfacehipfort__rocblas_1_1rocblas__hdot.html "Interface documentation") | C binding
-99 | [rocblas_bfdot](interfacehipfort__rocblas_1_1rocblas__bfdot.html "Interface documentation") | C binding
-100 | [rocblas_cdotu](interfacehipfort__rocblas_1_1rocblas__cdotu.html "Interface documentation") | C binding, rank_0, rank_1
-101 | [rocblas_zdotu](interfacehipfort__rocblas_1_1rocblas__zdotu.html "Interface documentation") | C binding, rank_0, rank_1
-102 | [rocblas_cdotc](interfacehipfort__rocblas_1_1rocblas__cdotc.html "Interface documentation") | C binding, rank_0, rank_1
-103 | [rocblas_zdotc](interfacehipfort__rocblas_1_1rocblas__zdotc.html "Interface documentation") | C binding, rank_0, rank_1
-104 | [rocblas_sdot_64](interfacehipfort__rocblas_1_1rocblas__sdot__64.html "Interface documentation") | C binding
-105 | [rocblas_ddot_64](interfacehipfort__rocblas_1_1rocblas__ddot__64.html "Interface documentation") | C binding
-106 | [rocblas_hdot_64](interfacehipfort__rocblas_1_1rocblas__hdot__64.html "Interface documentation") | C binding
-107 | [rocblas_bfdot_64](interfacehipfort__rocblas_1_1rocblas__bfdot__64.html "Interface documentation") | C binding
-108 | [rocblas_cdotu_64](interfacehipfort__rocblas_1_1rocblas__cdotu__64.html "Interface documentation") | C binding
-109 | [rocblas_zdotu_64](interfacehipfort__rocblas_1_1rocblas__zdotu__64.html "Interface documentation") | C binding
-110 | [rocblas_cdotc_64](interfacehipfort__rocblas_1_1rocblas__cdotc__64.html "Interface documentation") | C binding
-111 | [rocblas_zdotc_64](interfacehipfort__rocblas_1_1rocblas__zdotc__64.html "Interface documentation") | C binding
-112 | [rocblas_sdot_batched](interfacehipfort__rocblas_1_1rocblas__sdot__batched.html "Interface documentation") | C binding
-113 | [rocblas_ddot_batched](interfacehipfort__rocblas_1_1rocblas__ddot__batched.html "Interface documentation") | C binding
-114 | [rocblas_hdot_batched](interfacehipfort__rocblas_1_1rocblas__hdot__batched.html "Interface documentation") | C binding
-115 | [rocblas_bfdot_batched](interfacehipfort__rocblas_1_1rocblas__bfdot__batched.html "Interface documentation") | C binding
-116 | [rocblas_cdotu_batched](interfacehipfort__rocblas_1_1rocblas__cdotu__batched.html "Interface documentation") | C binding
-117 | [rocblas_zdotu_batched](interfacehipfort__rocblas_1_1rocblas__zdotu__batched.html "Interface documentation") | C binding
-118 | [rocblas_cdotc_batched](interfacehipfort__rocblas_1_1rocblas__cdotc__batched.html "Interface documentation") | C binding
-119 | [rocblas_zdotc_batched](interfacehipfort__rocblas_1_1rocblas__zdotc__batched.html "Interface documentation") | C binding
-120 | [rocblas_sdot_batched_64](interfacehipfort__rocblas_1_1rocblas__sdot__batched__64.html "Interface documentation") | C binding
-121 | [rocblas_ddot_batched_64](interfacehipfort__rocblas_1_1rocblas__ddot__batched__64.html "Interface documentation") | C binding
-122 | [rocblas_hdot_batched_64](interfacehipfort__rocblas_1_1rocblas__hdot__batched__64.html "Interface documentation") | C binding
-123 | [rocblas_bfdot_batched_64](interfacehipfort__rocblas_1_1rocblas__bfdot__batched__64.html "Interface documentation") | C binding
-124 | [rocblas_cdotu_batched_64](interfacehipfort__rocblas_1_1rocblas__cdotu__batched__64.html "Interface documentation") | C binding
-125 | [rocblas_zdotu_batched_64](interfacehipfort__rocblas_1_1rocblas__zdotu__batched__64.html "Interface documentation") | C binding
-126 | [rocblas_cdotc_batched_64](interfacehipfort__rocblas_1_1rocblas__cdotc__batched__64.html "Interface documentation") | C binding
-127 | [rocblas_zdotc_batched_64](interfacehipfort__rocblas_1_1rocblas__zdotc__batched__64.html "Interface documentation") | C binding
-128 | [rocblas_sdot_strided_batched](interfacehipfort__rocblas_1_1rocblas__sdot__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-129 | [rocblas_ddot_strided_batched](interfacehipfort__rocblas_1_1rocblas__ddot__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-130 | [rocblas_hdot_strided_batched](interfacehipfort__rocblas_1_1rocblas__hdot__strided__batched.html "Interface documentation") | C binding
-131 | [rocblas_bfdot_strided_batched](interfacehipfort__rocblas_1_1rocblas__bfdot__strided__batched.html "Interface documentation") | C binding
-132 | [rocblas_cdotu_strided_batched](interfacehipfort__rocblas_1_1rocblas__cdotu__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-133 | [rocblas_zdotu_strided_batched](interfacehipfort__rocblas_1_1rocblas__zdotu__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-134 | [rocblas_cdotc_strided_batched](interfacehipfort__rocblas_1_1rocblas__cdotc__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-135 | [rocblas_zdotc_strided_batched](interfacehipfort__rocblas_1_1rocblas__zdotc__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-136 | [rocblas_sdot_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sdot__strided__batched__64.html "Interface documentation") | C binding
-137 | [rocblas_ddot_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ddot__strided__batched__64.html "Interface documentation") | C binding
-138 | [rocblas_hdot_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__hdot__strided__batched__64.html "Interface documentation") | C binding
-139 | [rocblas_bfdot_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__bfdot__strided__batched__64.html "Interface documentation") | C binding
-140 | [rocblas_cdotu_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cdotu__strided__batched__64.html "Interface documentation") | C binding
-141 | [rocblas_zdotu_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zdotu__strided__batched__64.html "Interface documentation") | C binding
-142 | [rocblas_cdotc_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cdotc__strided__batched__64.html "Interface documentation") | C binding
-143 | [rocblas_zdotc_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zdotc__strided__batched__64.html "Interface documentation") | C binding
-144 | [rocblas_sswap](interfacehipfort__rocblas_1_1rocblas__sswap.html "Interface documentation") | C binding
-145 | [rocblas_dswap](interfacehipfort__rocblas_1_1rocblas__dswap.html "Interface documentation") | C binding
-146 | [rocblas_cswap](interfacehipfort__rocblas_1_1rocblas__cswap.html "Interface documentation") | C binding, rank_0, rank_1
-147 | [rocblas_zswap](interfacehipfort__rocblas_1_1rocblas__zswap.html "Interface documentation") | C binding, rank_0, rank_1
-148 | [rocblas_sswap_64](interfacehipfort__rocblas_1_1rocblas__sswap__64.html "Interface documentation") | C binding
-149 | [rocblas_dswap_64](interfacehipfort__rocblas_1_1rocblas__dswap__64.html "Interface documentation") | C binding
-150 | [rocblas_cswap_64](interfacehipfort__rocblas_1_1rocblas__cswap__64.html "Interface documentation") | C binding
-151 | [rocblas_zswap_64](interfacehipfort__rocblas_1_1rocblas__zswap__64.html "Interface documentation") | C binding
-152 | [rocblas_sswap_batched](interfacehipfort__rocblas_1_1rocblas__sswap__batched.html "Interface documentation") | C binding
-153 | [rocblas_dswap_batched](interfacehipfort__rocblas_1_1rocblas__dswap__batched.html "Interface documentation") | C binding
-154 | [rocblas_cswap_batched](interfacehipfort__rocblas_1_1rocblas__cswap__batched.html "Interface documentation") | C binding
-155 | [rocblas_zswap_batched](interfacehipfort__rocblas_1_1rocblas__zswap__batched.html "Interface documentation") | C binding
-156 | [rocblas_sswap_batched_64](interfacehipfort__rocblas_1_1rocblas__sswap__batched__64.html "Interface documentation") | C binding
-157 | [rocblas_dswap_batched_64](interfacehipfort__rocblas_1_1rocblas__dswap__batched__64.html "Interface documentation") | C binding
-158 | [rocblas_cswap_batched_64](interfacehipfort__rocblas_1_1rocblas__cswap__batched__64.html "Interface documentation") | C binding
-159 | [rocblas_zswap_batched_64](interfacehipfort__rocblas_1_1rocblas__zswap__batched__64.html "Interface documentation") | C binding
-160 | [rocblas_sswap_strided_batched](interfacehipfort__rocblas_1_1rocblas__sswap__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-161 | [rocblas_dswap_strided_batched](interfacehipfort__rocblas_1_1rocblas__dswap__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-162 | [rocblas_cswap_strided_batched](interfacehipfort__rocblas_1_1rocblas__cswap__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-163 | [rocblas_zswap_strided_batched](interfacehipfort__rocblas_1_1rocblas__zswap__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-164 | [rocblas_sswap_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sswap__strided__batched__64.html "Interface documentation") | C binding
-165 | [rocblas_dswap_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dswap__strided__batched__64.html "Interface documentation") | C binding
-166 | [rocblas_cswap_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cswap__strided__batched__64.html "Interface documentation") | C binding
-167 | [rocblas_zswap_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zswap__strided__batched__64.html "Interface documentation") | C binding
-168 | [rocblas_haxpy](interfacehipfort__rocblas_1_1rocblas__haxpy.html "Interface documentation") | C binding
-169 | [rocblas_saxpy](interfacehipfort__rocblas_1_1rocblas__saxpy.html "Interface documentation") | C binding, rank_0, rank_1
-170 | [rocblas_daxpy](interfacehipfort__rocblas_1_1rocblas__daxpy.html "Interface documentation") | C binding, rank_0, rank_1
-171 | [rocblas_caxpy](interfacehipfort__rocblas_1_1rocblas__caxpy.html "Interface documentation") | C binding, rank_0, rank_1
-172 | [rocblas_zaxpy](interfacehipfort__rocblas_1_1rocblas__zaxpy.html "Interface documentation") | C binding, rank_0, rank_1
-173 | [rocblas_haxpy_64](interfacehipfort__rocblas_1_1rocblas__haxpy__64.html "Interface documentation") | C binding
-174 | [rocblas_saxpy_64](interfacehipfort__rocblas_1_1rocblas__saxpy__64.html "Interface documentation") | C binding
-175 | [rocblas_daxpy_64](interfacehipfort__rocblas_1_1rocblas__daxpy__64.html "Interface documentation") | C binding
-176 | [rocblas_caxpy_64](interfacehipfort__rocblas_1_1rocblas__caxpy__64.html "Interface documentation") | C binding
-177 | [rocblas_zaxpy_64](interfacehipfort__rocblas_1_1rocblas__zaxpy__64.html "Interface documentation") | C binding
-178 | [rocblas_haxpy_batched](interfacehipfort__rocblas_1_1rocblas__haxpy__batched.html "Interface documentation") | C binding
-179 | [rocblas_saxpy_batched](interfacehipfort__rocblas_1_1rocblas__saxpy__batched.html "Interface documentation") | C binding
-180 | [rocblas_daxpy_batched](interfacehipfort__rocblas_1_1rocblas__daxpy__batched.html "Interface documentation") | C binding
-181 | [rocblas_caxpy_batched](interfacehipfort__rocblas_1_1rocblas__caxpy__batched.html "Interface documentation") | C binding
-182 | [rocblas_zaxpy_batched](interfacehipfort__rocblas_1_1rocblas__zaxpy__batched.html "Interface documentation") | C binding
-183 | [rocblas_haxpy_batched_64](interfacehipfort__rocblas_1_1rocblas__haxpy__batched__64.html "Interface documentation") | C binding
-184 | [rocblas_saxpy_batched_64](interfacehipfort__rocblas_1_1rocblas__saxpy__batched__64.html "Interface documentation") | C binding
-185 | [rocblas_daxpy_batched_64](interfacehipfort__rocblas_1_1rocblas__daxpy__batched__64.html "Interface documentation") | C binding
-186 | [rocblas_caxpy_batched_64](interfacehipfort__rocblas_1_1rocblas__caxpy__batched__64.html "Interface documentation") | C binding
-187 | [rocblas_zaxpy_batched_64](interfacehipfort__rocblas_1_1rocblas__zaxpy__batched__64.html "Interface documentation") | C binding
-188 | [rocblas_haxpy_strided_batched](interfacehipfort__rocblas_1_1rocblas__haxpy__strided__batched.html "Interface documentation") | C binding
-189 | [rocblas_saxpy_strided_batched](interfacehipfort__rocblas_1_1rocblas__saxpy__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-190 | [rocblas_daxpy_strided_batched](interfacehipfort__rocblas_1_1rocblas__daxpy__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-191 | [rocblas_caxpy_strided_batched](interfacehipfort__rocblas_1_1rocblas__caxpy__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-192 | [rocblas_zaxpy_strided_batched](interfacehipfort__rocblas_1_1rocblas__zaxpy__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-193 | [rocblas_haxpy_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__haxpy__strided__batched__64.html "Interface documentation") | C binding
-194 | [rocblas_saxpy_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__saxpy__strided__batched__64.html "Interface documentation") | C binding
-195 | [rocblas_daxpy_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__daxpy__strided__batched__64.html "Interface documentation") | C binding
-196 | [rocblas_caxpy_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__caxpy__strided__batched__64.html "Interface documentation") | C binding
-197 | [rocblas_zaxpy_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zaxpy__strided__batched__64.html "Interface documentation") | C binding
-198 | [rocblas_sasum](interfacehipfort__rocblas_1_1rocblas__sasum.html "Interface documentation") | C binding
-199 | [rocblas_dasum](interfacehipfort__rocblas_1_1rocblas__dasum.html "Interface documentation") | C binding
-200 | [rocblas_scasum](interfacehipfort__rocblas_1_1rocblas__scasum.html "Interface documentation") | C binding, rank_0, rank_1
-201 | [rocblas_dzasum](interfacehipfort__rocblas_1_1rocblas__dzasum.html "Interface documentation") | C binding, rank_0, rank_1
-202 | [rocblas_sasum_64](interfacehipfort__rocblas_1_1rocblas__sasum__64.html "Interface documentation") | C binding
-203 | [rocblas_dasum_64](interfacehipfort__rocblas_1_1rocblas__dasum__64.html "Interface documentation") | C binding
-204 | [rocblas_scasum_64](interfacehipfort__rocblas_1_1rocblas__scasum__64.html "Interface documentation") | C binding
-205 | [rocblas_dzasum_64](interfacehipfort__rocblas_1_1rocblas__dzasum__64.html "Interface documentation") | C binding
-206 | [rocblas_sasum_batched](interfacehipfort__rocblas_1_1rocblas__sasum__batched.html "Interface documentation") | C binding
-207 | [rocblas_dasum_batched](interfacehipfort__rocblas_1_1rocblas__dasum__batched.html "Interface documentation") | C binding
-208 | [rocblas_scasum_batched](interfacehipfort__rocblas_1_1rocblas__scasum__batched.html "Interface documentation") | C binding
-209 | [rocblas_dzasum_batched](interfacehipfort__rocblas_1_1rocblas__dzasum__batched.html "Interface documentation") | C binding
-210 | [rocblas_sasum_batched_64](interfacehipfort__rocblas_1_1rocblas__sasum__batched__64.html "Interface documentation") | C binding
-211 | [rocblas_dasum_batched_64](interfacehipfort__rocblas_1_1rocblas__dasum__batched__64.html "Interface documentation") | C binding
-212 | [rocblas_scasum_batched_64](interfacehipfort__rocblas_1_1rocblas__scasum__batched__64.html "Interface documentation") | C binding
-213 | [rocblas_dzasum_batched_64](interfacehipfort__rocblas_1_1rocblas__dzasum__batched__64.html "Interface documentation") | C binding
-214 | [rocblas_sasum_strided_batched](interfacehipfort__rocblas_1_1rocblas__sasum__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-215 | [rocblas_dasum_strided_batched](interfacehipfort__rocblas_1_1rocblas__dasum__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-216 | [rocblas_scasum_strided_batched](interfacehipfort__rocblas_1_1rocblas__scasum__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-217 | [rocblas_dzasum_strided_batched](interfacehipfort__rocblas_1_1rocblas__dzasum__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-218 | [rocblas_sasum_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sasum__strided__batched__64.html "Interface documentation") | C binding
-219 | [rocblas_dasum_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dasum__strided__batched__64.html "Interface documentation") | C binding
-220 | [rocblas_scasum_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__scasum__strided__batched__64.html "Interface documentation") | C binding
-221 | [rocblas_dzasum_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dzasum__strided__batched__64.html "Interface documentation") | C binding
-222 | [rocblas_snrm2](interfacehipfort__rocblas_1_1rocblas__snrm2.html "Interface documentation") | C binding
-223 | [rocblas_dnrm2](interfacehipfort__rocblas_1_1rocblas__dnrm2.html "Interface documentation") | C binding
-224 | [rocblas_scnrm2](interfacehipfort__rocblas_1_1rocblas__scnrm2.html "Interface documentation") | C binding, rank_0, rank_1
-225 | [rocblas_dznrm2](interfacehipfort__rocblas_1_1rocblas__dznrm2.html "Interface documentation") | C binding, rank_0, rank_1
-226 | [rocblas_snrm2_64](interfacehipfort__rocblas_1_1rocblas__snrm2__64.html "Interface documentation") | C binding
-227 | [rocblas_dnrm2_64](interfacehipfort__rocblas_1_1rocblas__dnrm2__64.html "Interface documentation") | C binding
-228 | [rocblas_scnrm2_64](interfacehipfort__rocblas_1_1rocblas__scnrm2__64.html "Interface documentation") | C binding
-229 | [rocblas_dznrm2_64](interfacehipfort__rocblas_1_1rocblas__dznrm2__64.html "Interface documentation") | C binding
-230 | [rocblas_snrm2_batched](interfacehipfort__rocblas_1_1rocblas__snrm2__batched.html "Interface documentation") | C binding
-231 | [rocblas_dnrm2_batched](interfacehipfort__rocblas_1_1rocblas__dnrm2__batched.html "Interface documentation") | C binding
-232 | [rocblas_scnrm2_batched](interfacehipfort__rocblas_1_1rocblas__scnrm2__batched.html "Interface documentation") | C binding
-233 | [rocblas_dznrm2_batched](interfacehipfort__rocblas_1_1rocblas__dznrm2__batched.html "Interface documentation") | C binding
-234 | [rocblas_snrm2_batched_64](interfacehipfort__rocblas_1_1rocblas__snrm2__batched__64.html "Interface documentation") | C binding
-235 | [rocblas_dnrm2_batched_64](interfacehipfort__rocblas_1_1rocblas__dnrm2__batched__64.html "Interface documentation") | C binding
-236 | [rocblas_scnrm2_batched_64](interfacehipfort__rocblas_1_1rocblas__scnrm2__batched__64.html "Interface documentation") | C binding
-237 | [rocblas_dznrm2_batched_64](interfacehipfort__rocblas_1_1rocblas__dznrm2__batched__64.html "Interface documentation") | C binding
-238 | [rocblas_snrm2_strided_batched](interfacehipfort__rocblas_1_1rocblas__snrm2__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-239 | [rocblas_dnrm2_strided_batched](interfacehipfort__rocblas_1_1rocblas__dnrm2__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-240 | [rocblas_scnrm2_strided_batched](interfacehipfort__rocblas_1_1rocblas__scnrm2__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-241 | [rocblas_dznrm2_strided_batched](interfacehipfort__rocblas_1_1rocblas__dznrm2__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-242 | [rocblas_snrm2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__snrm2__strided__batched__64.html "Interface documentation") | C binding
-243 | [rocblas_dnrm2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dnrm2__strided__batched__64.html "Interface documentation") | C binding
-244 | [rocblas_scnrm2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__scnrm2__strided__batched__64.html "Interface documentation") | C binding
-245 | [rocblas_dznrm2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dznrm2__strided__batched__64.html "Interface documentation") | C binding
-246 | [rocblas_isamax](interfacehipfort__rocblas_1_1rocblas__isamax.html "Interface documentation") | C binding
-247 | [rocblas_idamax](interfacehipfort__rocblas_1_1rocblas__idamax.html "Interface documentation") | C binding
-248 | [rocblas_icamax](interfacehipfort__rocblas_1_1rocblas__icamax.html "Interface documentation") | C binding, rank_0, rank_1
-249 | [rocblas_izamax](interfacehipfort__rocblas_1_1rocblas__izamax.html "Interface documentation") | C binding, rank_0, rank_1
-250 | [rocblas_isamax_64](interfacehipfort__rocblas_1_1rocblas__isamax__64.html "Interface documentation") | C binding
-251 | [rocblas_idamax_64](interfacehipfort__rocblas_1_1rocblas__idamax__64.html "Interface documentation") | C binding
-252 | [rocblas_icamax_64](interfacehipfort__rocblas_1_1rocblas__icamax__64.html "Interface documentation") | C binding
-253 | [rocblas_izamax_64](interfacehipfort__rocblas_1_1rocblas__izamax__64.html "Interface documentation") | C binding
-254 | [rocblas_isamax_batched](interfacehipfort__rocblas_1_1rocblas__isamax__batched.html "Interface documentation") | C binding
-255 | [rocblas_idamax_batched](interfacehipfort__rocblas_1_1rocblas__idamax__batched.html "Interface documentation") | C binding
-256 | [rocblas_icamax_batched](interfacehipfort__rocblas_1_1rocblas__icamax__batched.html "Interface documentation") | C binding
-257 | [rocblas_izamax_batched](interfacehipfort__rocblas_1_1rocblas__izamax__batched.html "Interface documentation") | C binding
-258 | [rocblas_isamax_batched_64](interfacehipfort__rocblas_1_1rocblas__isamax__batched__64.html "Interface documentation") | C binding
-259 | [rocblas_idamax_batched_64](interfacehipfort__rocblas_1_1rocblas__idamax__batched__64.html "Interface documentation") | C binding
-260 | [rocblas_icamax_batched_64](interfacehipfort__rocblas_1_1rocblas__icamax__batched__64.html "Interface documentation") | C binding
-261 | [rocblas_izamax_batched_64](interfacehipfort__rocblas_1_1rocblas__izamax__batched__64.html "Interface documentation") | C binding
-262 | [rocblas_isamax_strided_batched](interfacehipfort__rocblas_1_1rocblas__isamax__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-263 | [rocblas_idamax_strided_batched](interfacehipfort__rocblas_1_1rocblas__idamax__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-264 | [rocblas_icamax_strided_batched](interfacehipfort__rocblas_1_1rocblas__icamax__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-265 | [rocblas_izamax_strided_batched](interfacehipfort__rocblas_1_1rocblas__izamax__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-266 | [rocblas_isamax_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__isamax__strided__batched__64.html "Interface documentation") | C binding
-267 | [rocblas_idamax_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__idamax__strided__batched__64.html "Interface documentation") | C binding
-268 | [rocblas_icamax_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__icamax__strided__batched__64.html "Interface documentation") | C binding
-269 | [rocblas_izamax_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__izamax__strided__batched__64.html "Interface documentation") | C binding
-270 | [rocblas_isamin](interfacehipfort__rocblas_1_1rocblas__isamin.html "Interface documentation") | C binding
-271 | [rocblas_idamin](interfacehipfort__rocblas_1_1rocblas__idamin.html "Interface documentation") | C binding
-272 | [rocblas_icamin](interfacehipfort__rocblas_1_1rocblas__icamin.html "Interface documentation") | C binding, rank_0, rank_1
-273 | [rocblas_izamin](interfacehipfort__rocblas_1_1rocblas__izamin.html "Interface documentation") | C binding, rank_0, rank_1
-274 | [rocblas_isamin_64](interfacehipfort__rocblas_1_1rocblas__isamin__64.html "Interface documentation") | C binding
-275 | [rocblas_idamin_64](interfacehipfort__rocblas_1_1rocblas__idamin__64.html "Interface documentation") | C binding
-276 | [rocblas_icamin_64](interfacehipfort__rocblas_1_1rocblas__icamin__64.html "Interface documentation") | C binding
-277 | [rocblas_izamin_64](interfacehipfort__rocblas_1_1rocblas__izamin__64.html "Interface documentation") | C binding
-278 | [rocblas_isamin_batched](interfacehipfort__rocblas_1_1rocblas__isamin__batched.html "Interface documentation") | C binding
-279 | [rocblas_idamin_batched](interfacehipfort__rocblas_1_1rocblas__idamin__batched.html "Interface documentation") | C binding
-280 | [rocblas_icamin_batched](interfacehipfort__rocblas_1_1rocblas__icamin__batched.html "Interface documentation") | C binding
-281 | [rocblas_izamin_batched](interfacehipfort__rocblas_1_1rocblas__izamin__batched.html "Interface documentation") | C binding
-282 | [rocblas_isamin_batched_64](interfacehipfort__rocblas_1_1rocblas__isamin__batched__64.html "Interface documentation") | C binding
-283 | [rocblas_idamin_batched_64](interfacehipfort__rocblas_1_1rocblas__idamin__batched__64.html "Interface documentation") | C binding
-284 | [rocblas_icamin_batched_64](interfacehipfort__rocblas_1_1rocblas__icamin__batched__64.html "Interface documentation") | C binding
-285 | [rocblas_izamin_batched_64](interfacehipfort__rocblas_1_1rocblas__izamin__batched__64.html "Interface documentation") | C binding
-286 | [rocblas_isamin_strided_batched](interfacehipfort__rocblas_1_1rocblas__isamin__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-287 | [rocblas_idamin_strided_batched](interfacehipfort__rocblas_1_1rocblas__idamin__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-288 | [rocblas_icamin_strided_batched](interfacehipfort__rocblas_1_1rocblas__icamin__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-289 | [rocblas_izamin_strided_batched](interfacehipfort__rocblas_1_1rocblas__izamin__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-290 | [rocblas_isamin_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__isamin__strided__batched__64.html "Interface documentation") | C binding
-291 | [rocblas_idamin_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__idamin__strided__batched__64.html "Interface documentation") | C binding
-292 | [rocblas_icamin_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__icamin__strided__batched__64.html "Interface documentation") | C binding
-293 | [rocblas_izamin_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__izamin__strided__batched__64.html "Interface documentation") | C binding
-294 | [rocblas_srot](interfacehipfort__rocblas_1_1rocblas__srot.html "Interface documentation") | C binding, rank_0, rank_1
-295 | [rocblas_drot](interfacehipfort__rocblas_1_1rocblas__drot.html "Interface documentation") | C binding, rank_0, rank_1
-296 | [rocblas_crot](interfacehipfort__rocblas_1_1rocblas__crot.html "Interface documentation") | C binding, rank_0, rank_1
-297 | [rocblas_csrot](interfacehipfort__rocblas_1_1rocblas__csrot.html "Interface documentation") | C binding, rank_0, rank_1
-298 | [rocblas_zrot](interfacehipfort__rocblas_1_1rocblas__zrot.html "Interface documentation") | C binding, rank_0, rank_1
-299 | [rocblas_zdrot](interfacehipfort__rocblas_1_1rocblas__zdrot.html "Interface documentation") | C binding, rank_0, rank_1
-300 | [rocblas_srot_64](interfacehipfort__rocblas_1_1rocblas__srot__64.html "Interface documentation") | C binding
-301 | [rocblas_drot_64](interfacehipfort__rocblas_1_1rocblas__drot__64.html "Interface documentation") | C binding
-302 | [rocblas_crot_64](interfacehipfort__rocblas_1_1rocblas__crot__64.html "Interface documentation") | C binding
-303 | [rocblas_csrot_64](interfacehipfort__rocblas_1_1rocblas__csrot__64.html "Interface documentation") | C binding
-304 | [rocblas_zrot_64](interfacehipfort__rocblas_1_1rocblas__zrot__64.html "Interface documentation") | C binding
-305 | [rocblas_zdrot_64](interfacehipfort__rocblas_1_1rocblas__zdrot__64.html "Interface documentation") | C binding
-306 | [rocblas_srot_batched](interfacehipfort__rocblas_1_1rocblas__srot__batched.html "Interface documentation") | C binding
-307 | [rocblas_drot_batched](interfacehipfort__rocblas_1_1rocblas__drot__batched.html "Interface documentation") | C binding
-308 | [rocblas_crot_batched](interfacehipfort__rocblas_1_1rocblas__crot__batched.html "Interface documentation") | C binding
-309 | [rocblas_csrot_batched](interfacehipfort__rocblas_1_1rocblas__csrot__batched.html "Interface documentation") | C binding
-310 | [rocblas_zrot_batched](interfacehipfort__rocblas_1_1rocblas__zrot__batched.html "Interface documentation") | C binding
-311 | [rocblas_zdrot_batched](interfacehipfort__rocblas_1_1rocblas__zdrot__batched.html "Interface documentation") | C binding
-312 | [rocblas_srot_batched_64](interfacehipfort__rocblas_1_1rocblas__srot__batched__64.html "Interface documentation") | C binding
-313 | [rocblas_drot_batched_64](interfacehipfort__rocblas_1_1rocblas__drot__batched__64.html "Interface documentation") | C binding
-314 | [rocblas_crot_batched_64](interfacehipfort__rocblas_1_1rocblas__crot__batched__64.html "Interface documentation") | C binding
-315 | [rocblas_csrot_batched_64](interfacehipfort__rocblas_1_1rocblas__csrot__batched__64.html "Interface documentation") | C binding
-316 | [rocblas_zrot_batched_64](interfacehipfort__rocblas_1_1rocblas__zrot__batched__64.html "Interface documentation") | C binding
-317 | [rocblas_zdrot_batched_64](interfacehipfort__rocblas_1_1rocblas__zdrot__batched__64.html "Interface documentation") | C binding
-318 | [rocblas_srot_strided_batched](interfacehipfort__rocblas_1_1rocblas__srot__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-319 | [rocblas_drot_strided_batched](interfacehipfort__rocblas_1_1rocblas__drot__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-320 | [rocblas_crot_strided_batched](interfacehipfort__rocblas_1_1rocblas__crot__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-321 | [rocblas_csrot_strided_batched](interfacehipfort__rocblas_1_1rocblas__csrot__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-322 | [rocblas_zrot_strided_batched](interfacehipfort__rocblas_1_1rocblas__zrot__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-323 | [rocblas_zdrot_strided_batched](interfacehipfort__rocblas_1_1rocblas__zdrot__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-324 | [rocblas_srot_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__srot__strided__batched__64.html "Interface documentation") | C binding
-325 | [rocblas_drot_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__drot__strided__batched__64.html "Interface documentation") | C binding
-326 | [rocblas_crot_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__crot__strided__batched__64.html "Interface documentation") | C binding
-327 | [rocblas_csrot_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__csrot__strided__batched__64.html "Interface documentation") | C binding
-328 | [rocblas_zrot_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zrot__strided__batched__64.html "Interface documentation") | C binding
-329 | [rocblas_zdrot_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zdrot__strided__batched__64.html "Interface documentation") | C binding
-330 | [rocblas_srotg](interfacehipfort__rocblas_1_1rocblas__srotg.html "Interface documentation") | C binding
-331 | [rocblas_drotg](interfacehipfort__rocblas_1_1rocblas__drotg.html "Interface documentation") | C binding
-332 | [rocblas_crotg](interfacehipfort__rocblas_1_1rocblas__crotg.html "Interface documentation") | C binding
-333 | [rocblas_zrotg](interfacehipfort__rocblas_1_1rocblas__zrotg.html "Interface documentation") | C binding
-334 | [rocblas_srotg_64](interfacehipfort__rocblas_1_1rocblas__srotg__64.html "Interface documentation") | C binding
-335 | [rocblas_drotg_64](interfacehipfort__rocblas_1_1rocblas__drotg__64.html "Interface documentation") | C binding
-336 | [rocblas_crotg_64](interfacehipfort__rocblas_1_1rocblas__crotg__64.html "Interface documentation") | C binding
-337 | [rocblas_zrotg_64](interfacehipfort__rocblas_1_1rocblas__zrotg__64.html "Interface documentation") | C binding
-338 | [rocblas_srotg_batched](interfacehipfort__rocblas_1_1rocblas__srotg__batched.html "Interface documentation") | C binding
-339 | [rocblas_drotg_batched](interfacehipfort__rocblas_1_1rocblas__drotg__batched.html "Interface documentation") | C binding
-340 | [rocblas_crotg_batched](interfacehipfort__rocblas_1_1rocblas__crotg__batched.html "Interface documentation") | C binding
-341 | [rocblas_zrotg_batched](interfacehipfort__rocblas_1_1rocblas__zrotg__batched.html "Interface documentation") | C binding
-342 | [rocblas_srotg_batched_64](interfacehipfort__rocblas_1_1rocblas__srotg__batched__64.html "Interface documentation") | C binding
-343 | [rocblas_drotg_batched_64](interfacehipfort__rocblas_1_1rocblas__drotg__batched__64.html "Interface documentation") | C binding
-344 | [rocblas_crotg_batched_64](interfacehipfort__rocblas_1_1rocblas__crotg__batched__64.html "Interface documentation") | C binding
-345 | [rocblas_zrotg_batched_64](interfacehipfort__rocblas_1_1rocblas__zrotg__batched__64.html "Interface documentation") | C binding
-346 | [rocblas_srotg_strided_batched](interfacehipfort__rocblas_1_1rocblas__srotg__strided__batched.html "Interface documentation") | C binding
-347 | [rocblas_drotg_strided_batched](interfacehipfort__rocblas_1_1rocblas__drotg__strided__batched.html "Interface documentation") | C binding
-348 | [rocblas_crotg_strided_batched](interfacehipfort__rocblas_1_1rocblas__crotg__strided__batched.html "Interface documentation") | C binding
-349 | [rocblas_zrotg_strided_batched](interfacehipfort__rocblas_1_1rocblas__zrotg__strided__batched.html "Interface documentation") | C binding
-350 | [rocblas_srotg_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__srotg__strided__batched__64.html "Interface documentation") | C binding
-351 | [rocblas_drotg_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__drotg__strided__batched__64.html "Interface documentation") | C binding
-352 | [rocblas_crotg_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__crotg__strided__batched__64.html "Interface documentation") | C binding
-353 | [rocblas_zrotg_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zrotg__strided__batched__64.html "Interface documentation") | C binding
-354 | [rocblas_srotm](interfacehipfort__rocblas_1_1rocblas__srotm.html "Interface documentation") | C binding, rank_0, rank_1
-355 | [rocblas_drotm](interfacehipfort__rocblas_1_1rocblas__drotm.html "Interface documentation") | C binding, rank_0, rank_1
-356 | [rocblas_srotm_64](interfacehipfort__rocblas_1_1rocblas__srotm__64.html "Interface documentation") | C binding
-357 | [rocblas_drotm_64](interfacehipfort__rocblas_1_1rocblas__drotm__64.html "Interface documentation") | C binding
-358 | [rocblas_srotm_batched](interfacehipfort__rocblas_1_1rocblas__srotm__batched.html "Interface documentation") | C binding
-359 | [rocblas_drotm_batched](interfacehipfort__rocblas_1_1rocblas__drotm__batched.html "Interface documentation") | C binding
-360 | [rocblas_srotm_batched_64](interfacehipfort__rocblas_1_1rocblas__srotm__batched__64.html "Interface documentation") | C binding
-361 | [rocblas_drotm_batched_64](interfacehipfort__rocblas_1_1rocblas__drotm__batched__64.html "Interface documentation") | C binding
-362 | [rocblas_srotm_strided_batched](interfacehipfort__rocblas_1_1rocblas__srotm__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-363 | [rocblas_drotm_strided_batched](interfacehipfort__rocblas_1_1rocblas__drotm__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-364 | [rocblas_srotm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__srotm__strided__batched__64.html "Interface documentation") | C binding
-365 | [rocblas_drotm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__drotm__strided__batched__64.html "Interface documentation") | C binding
-366 | [rocblas_srotmg](interfacehipfort__rocblas_1_1rocblas__srotmg.html "Interface documentation") | C binding
-367 | [rocblas_drotmg](interfacehipfort__rocblas_1_1rocblas__drotmg.html "Interface documentation") | C binding
-368 | [rocblas_srotmg_64](interfacehipfort__rocblas_1_1rocblas__srotmg__64.html "Interface documentation") | C binding
-369 | [rocblas_drotmg_64](interfacehipfort__rocblas_1_1rocblas__drotmg__64.html "Interface documentation") | C binding
-370 | [rocblas_srotmg_batched](interfacehipfort__rocblas_1_1rocblas__srotmg__batched.html "Interface documentation") | C binding
-371 | [rocblas_drotmg_batched](interfacehipfort__rocblas_1_1rocblas__drotmg__batched.html "Interface documentation") | C binding
-372 | [rocblas_srotmg_batched_64](interfacehipfort__rocblas_1_1rocblas__srotmg__batched__64.html "Interface documentation") | C binding
-373 | [rocblas_drotmg_batched_64](interfacehipfort__rocblas_1_1rocblas__drotmg__batched__64.html "Interface documentation") | C binding
-374 | [rocblas_srotmg_strided_batched](interfacehipfort__rocblas_1_1rocblas__srotmg__strided__batched.html "Interface documentation") | C binding
-375 | [rocblas_drotmg_strided_batched](interfacehipfort__rocblas_1_1rocblas__drotmg__strided__batched.html "Interface documentation") | C binding
-376 | [rocblas_srotmg_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__srotmg__strided__batched__64.html "Interface documentation") | C binding
-377 | [rocblas_drotmg_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__drotmg__strided__batched__64.html "Interface documentation") | C binding
-378 | [rocblas_sgbmv](interfacehipfort__rocblas_1_1rocblas__sgbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-379 | [rocblas_dgbmv](interfacehipfort__rocblas_1_1rocblas__dgbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-380 | [rocblas_cgbmv](interfacehipfort__rocblas_1_1rocblas__cgbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-381 | [rocblas_zgbmv](interfacehipfort__rocblas_1_1rocblas__zgbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-382 | [rocblas_sgbmv_64](interfacehipfort__rocblas_1_1rocblas__sgbmv__64.html "Interface documentation") | C binding
-383 | [rocblas_dgbmv_64](interfacehipfort__rocblas_1_1rocblas__dgbmv__64.html "Interface documentation") | C binding
-384 | [rocblas_cgbmv_64](interfacehipfort__rocblas_1_1rocblas__cgbmv__64.html "Interface documentation") | C binding
-385 | [rocblas_zgbmv_64](interfacehipfort__rocblas_1_1rocblas__zgbmv__64.html "Interface documentation") | C binding
-386 | [rocblas_sgbmv_batched](interfacehipfort__rocblas_1_1rocblas__sgbmv__batched.html "Interface documentation") | C binding
-387 | [rocblas_dgbmv_batched](interfacehipfort__rocblas_1_1rocblas__dgbmv__batched.html "Interface documentation") | C binding
-388 | [rocblas_cgbmv_batched](interfacehipfort__rocblas_1_1rocblas__cgbmv__batched.html "Interface documentation") | C binding
-389 | [rocblas_zgbmv_batched](interfacehipfort__rocblas_1_1rocblas__zgbmv__batched.html "Interface documentation") | C binding
-390 | [rocblas_sgbmv_batched_64](interfacehipfort__rocblas_1_1rocblas__sgbmv__batched__64.html "Interface documentation") | C binding
-391 | [rocblas_dgbmv_batched_64](interfacehipfort__rocblas_1_1rocblas__dgbmv__batched__64.html "Interface documentation") | C binding
-392 | [rocblas_cgbmv_batched_64](interfacehipfort__rocblas_1_1rocblas__cgbmv__batched__64.html "Interface documentation") | C binding
-393 | [rocblas_zgbmv_batched_64](interfacehipfort__rocblas_1_1rocblas__zgbmv__batched__64.html "Interface documentation") | C binding
-394 | [rocblas_sgbmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__sgbmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-395 | [rocblas_dgbmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__dgbmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-396 | [rocblas_cgbmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__cgbmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-397 | [rocblas_zgbmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__zgbmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-398 | [rocblas_sgbmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sgbmv__strided__batched__64.html "Interface documentation") | C binding
-399 | [rocblas_dgbmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dgbmv__strided__batched__64.html "Interface documentation") | C binding
-400 | [rocblas_cgbmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cgbmv__strided__batched__64.html "Interface documentation") | C binding
-401 | [rocblas_zgbmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zgbmv__strided__batched__64.html "Interface documentation") | C binding
-402 | [rocblas_sgemv](interfacehipfort__rocblas_1_1rocblas__sgemv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-403 | [rocblas_dgemv](interfacehipfort__rocblas_1_1rocblas__dgemv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-404 | [rocblas_cgemv](interfacehipfort__rocblas_1_1rocblas__cgemv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-405 | [rocblas_zgemv](interfacehipfort__rocblas_1_1rocblas__zgemv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-406 | [rocblas_sgemv_64](interfacehipfort__rocblas_1_1rocblas__sgemv__64.html "Interface documentation") | C binding
-407 | [rocblas_dgemv_64](interfacehipfort__rocblas_1_1rocblas__dgemv__64.html "Interface documentation") | C binding
-408 | [rocblas_cgemv_64](interfacehipfort__rocblas_1_1rocblas__cgemv__64.html "Interface documentation") | C binding
-409 | [rocblas_zgemv_64](interfacehipfort__rocblas_1_1rocblas__zgemv__64.html "Interface documentation") | C binding
-410 | [rocblas_sgemv_batched](interfacehipfort__rocblas_1_1rocblas__sgemv__batched.html "Interface documentation") | C binding
-411 | [rocblas_dgemv_batched](interfacehipfort__rocblas_1_1rocblas__dgemv__batched.html "Interface documentation") | C binding
-412 | [rocblas_cgemv_batched](interfacehipfort__rocblas_1_1rocblas__cgemv__batched.html "Interface documentation") | C binding
-413 | [rocblas_zgemv_batched](interfacehipfort__rocblas_1_1rocblas__zgemv__batched.html "Interface documentation") | C binding
-414 | [rocblas_hshgemv_batched](interfacehipfort__rocblas_1_1rocblas__hshgemv__batched.html "Interface documentation") | C binding
-415 | [rocblas_hssgemv_batched](interfacehipfort__rocblas_1_1rocblas__hssgemv__batched.html "Interface documentation") | C binding
-416 | [rocblas_tstgemv_batched](interfacehipfort__rocblas_1_1rocblas__tstgemv__batched.html "Interface documentation") | C binding
-417 | [rocblas_tssgemv_batched](interfacehipfort__rocblas_1_1rocblas__tssgemv__batched.html "Interface documentation") | C binding
-418 | [rocblas_sgemv_batched_64](interfacehipfort__rocblas_1_1rocblas__sgemv__batched__64.html "Interface documentation") | C binding
-419 | [rocblas_dgemv_batched_64](interfacehipfort__rocblas_1_1rocblas__dgemv__batched__64.html "Interface documentation") | C binding
-420 | [rocblas_cgemv_batched_64](interfacehipfort__rocblas_1_1rocblas__cgemv__batched__64.html "Interface documentation") | C binding
-421 | [rocblas_zgemv_batched_64](interfacehipfort__rocblas_1_1rocblas__zgemv__batched__64.html "Interface documentation") | C binding
-422 | [rocblas_hshgemv_batched_64](interfacehipfort__rocblas_1_1rocblas__hshgemv__batched__64.html "Interface documentation") | C binding
-423 | [rocblas_hssgemv_batched_64](interfacehipfort__rocblas_1_1rocblas__hssgemv__batched__64.html "Interface documentation") | C binding
-424 | [rocblas_tstgemv_batched_64](interfacehipfort__rocblas_1_1rocblas__tstgemv__batched__64.html "Interface documentation") | C binding
-425 | [rocblas_tssgemv_batched_64](interfacehipfort__rocblas_1_1rocblas__tssgemv__batched__64.html "Interface documentation") | C binding
-426 | [rocblas_sgemv_strided_batched](interfacehipfort__rocblas_1_1rocblas__sgemv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-427 | [rocblas_dgemv_strided_batched](interfacehipfort__rocblas_1_1rocblas__dgemv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-428 | [rocblas_cgemv_strided_batched](interfacehipfort__rocblas_1_1rocblas__cgemv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-429 | [rocblas_zgemv_strided_batched](interfacehipfort__rocblas_1_1rocblas__zgemv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-430 | [rocblas_hshgemv_strided_batched](interfacehipfort__rocblas_1_1rocblas__hshgemv__strided__batched.html "Interface documentation") | C binding
-431 | [rocblas_hssgemv_strided_batched](interfacehipfort__rocblas_1_1rocblas__hssgemv__strided__batched.html "Interface documentation") | C binding
-432 | [rocblas_tstgemv_strided_batched](interfacehipfort__rocblas_1_1rocblas__tstgemv__strided__batched.html "Interface documentation") | C binding
-433 | [rocblas_tssgemv_strided_batched](interfacehipfort__rocblas_1_1rocblas__tssgemv__strided__batched.html "Interface documentation") | C binding
-434 | [rocblas_sgemv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sgemv__strided__batched__64.html "Interface documentation") | C binding
-435 | [rocblas_dgemv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dgemv__strided__batched__64.html "Interface documentation") | C binding
-436 | [rocblas_cgemv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cgemv__strided__batched__64.html "Interface documentation") | C binding
-437 | [rocblas_zgemv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zgemv__strided__batched__64.html "Interface documentation") | C binding
-438 | [rocblas_hshgemv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__hshgemv__strided__batched__64.html "Interface documentation") | C binding
-439 | [rocblas_hssgemv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__hssgemv__strided__batched__64.html "Interface documentation") | C binding
-440 | [rocblas_tstgemv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__tstgemv__strided__batched__64.html "Interface documentation") | C binding
-441 | [rocblas_tssgemv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__tssgemv__strided__batched__64.html "Interface documentation") | C binding
-442 | [rocblas_chbmv](interfacehipfort__rocblas_1_1rocblas__chbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-443 | [rocblas_zhbmv](interfacehipfort__rocblas_1_1rocblas__zhbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-444 | [rocblas_chbmv_64](interfacehipfort__rocblas_1_1rocblas__chbmv__64.html "Interface documentation") | C binding
-445 | [rocblas_zhbmv_64](interfacehipfort__rocblas_1_1rocblas__zhbmv__64.html "Interface documentation") | C binding
-446 | [rocblas_chbmv_batched](interfacehipfort__rocblas_1_1rocblas__chbmv__batched.html "Interface documentation") | C binding
-447 | [rocblas_zhbmv_batched](interfacehipfort__rocblas_1_1rocblas__zhbmv__batched.html "Interface documentation") | C binding
-448 | [rocblas_chbmv_batched_64](interfacehipfort__rocblas_1_1rocblas__chbmv__batched__64.html "Interface documentation") | C binding
-449 | [rocblas_zhbmv_batched_64](interfacehipfort__rocblas_1_1rocblas__zhbmv__batched__64.html "Interface documentation") | C binding
-450 | [rocblas_chbmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__chbmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-451 | [rocblas_zhbmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__zhbmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-452 | [rocblas_chbmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__chbmv__strided__batched__64.html "Interface documentation") | C binding
-453 | [rocblas_zhbmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zhbmv__strided__batched__64.html "Interface documentation") | C binding
-454 | [rocblas_chemv](interfacehipfort__rocblas_1_1rocblas__chemv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-455 | [rocblas_zhemv](interfacehipfort__rocblas_1_1rocblas__zhemv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-456 | [rocblas_chemv_64](interfacehipfort__rocblas_1_1rocblas__chemv__64.html "Interface documentation") | C binding
-457 | [rocblas_zhemv_64](interfacehipfort__rocblas_1_1rocblas__zhemv__64.html "Interface documentation") | C binding
-458 | [rocblas_chemv_batched](interfacehipfort__rocblas_1_1rocblas__chemv__batched.html "Interface documentation") | C binding
-459 | [rocblas_zhemv_batched](interfacehipfort__rocblas_1_1rocblas__zhemv__batched.html "Interface documentation") | C binding
-460 | [rocblas_chemv_batched_64](interfacehipfort__rocblas_1_1rocblas__chemv__batched__64.html "Interface documentation") | C binding
-461 | [rocblas_zhemv_batched_64](interfacehipfort__rocblas_1_1rocblas__zhemv__batched__64.html "Interface documentation") | C binding
-462 | [rocblas_chemv_strided_batched](interfacehipfort__rocblas_1_1rocblas__chemv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-463 | [rocblas_zhemv_strided_batched](interfacehipfort__rocblas_1_1rocblas__zhemv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-464 | [rocblas_chemv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__chemv__strided__batched__64.html "Interface documentation") | C binding
-465 | [rocblas_zhemv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zhemv__strided__batched__64.html "Interface documentation") | C binding
-466 | [rocblas_cher](interfacehipfort__rocblas_1_1rocblas__cher.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-467 | [rocblas_zher](interfacehipfort__rocblas_1_1rocblas__zher.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-468 | [rocblas_cher_64](interfacehipfort__rocblas_1_1rocblas__cher__64.html "Interface documentation") | C binding
-469 | [rocblas_zher_64](interfacehipfort__rocblas_1_1rocblas__zher__64.html "Interface documentation") | C binding
-470 | [rocblas_cher_batched](interfacehipfort__rocblas_1_1rocblas__cher__batched.html "Interface documentation") | C binding
-471 | [rocblas_zher_batched](interfacehipfort__rocblas_1_1rocblas__zher__batched.html "Interface documentation") | C binding
-472 | [rocblas_cher_batched_64](interfacehipfort__rocblas_1_1rocblas__cher__batched__64.html "Interface documentation") | C binding
-473 | [rocblas_zher_batched_64](interfacehipfort__rocblas_1_1rocblas__zher__batched__64.html "Interface documentation") | C binding
-474 | [rocblas_cher_strided_batched](interfacehipfort__rocblas_1_1rocblas__cher__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-475 | [rocblas_zher_strided_batched](interfacehipfort__rocblas_1_1rocblas__zher__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-476 | [rocblas_cher_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cher__strided__batched__64.html "Interface documentation") | C binding
-477 | [rocblas_zher_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zher__strided__batched__64.html "Interface documentation") | C binding
-478 | [rocblas_cher2](interfacehipfort__rocblas_1_1rocblas__cher2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-479 | [rocblas_zher2](interfacehipfort__rocblas_1_1rocblas__zher2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-480 | [rocblas_cher2_64](interfacehipfort__rocblas_1_1rocblas__cher2__64.html "Interface documentation") | C binding
-481 | [rocblas_zher2_64](interfacehipfort__rocblas_1_1rocblas__zher2__64.html "Interface documentation") | C binding
-482 | [rocblas_cher2_batched](interfacehipfort__rocblas_1_1rocblas__cher2__batched.html "Interface documentation") | C binding
-483 | [rocblas_zher2_batched](interfacehipfort__rocblas_1_1rocblas__zher2__batched.html "Interface documentation") | C binding
-484 | [rocblas_cher2_batched_64](interfacehipfort__rocblas_1_1rocblas__cher2__batched__64.html "Interface documentation") | C binding
-485 | [rocblas_zher2_batched_64](interfacehipfort__rocblas_1_1rocblas__zher2__batched__64.html "Interface documentation") | C binding
-486 | [rocblas_cher2_strided_batched](interfacehipfort__rocblas_1_1rocblas__cher2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-487 | [rocblas_zher2_strided_batched](interfacehipfort__rocblas_1_1rocblas__zher2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-488 | [rocblas_cher2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cher2__strided__batched__64.html "Interface documentation") | C binding
-489 | [rocblas_zher2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zher2__strided__batched__64.html "Interface documentation") | C binding
-490 | [rocblas_chpmv](interfacehipfort__rocblas_1_1rocblas__chpmv.html "Interface documentation") | C binding, rank_0, rank_1
-491 | [rocblas_zhpmv](interfacehipfort__rocblas_1_1rocblas__zhpmv.html "Interface documentation") | C binding, rank_0, rank_1
-492 | [rocblas_chpmv_64](interfacehipfort__rocblas_1_1rocblas__chpmv__64.html "Interface documentation") | C binding
-493 | [rocblas_zhpmv_64](interfacehipfort__rocblas_1_1rocblas__zhpmv__64.html "Interface documentation") | C binding
-494 | [rocblas_chpmv_batched](interfacehipfort__rocblas_1_1rocblas__chpmv__batched.html "Interface documentation") | C binding
-495 | [rocblas_zhpmv_batched](interfacehipfort__rocblas_1_1rocblas__zhpmv__batched.html "Interface documentation") | C binding
-496 | [rocblas_chpmv_batched_64](interfacehipfort__rocblas_1_1rocblas__chpmv__batched__64.html "Interface documentation") | C binding
-497 | [rocblas_zhpmv_batched_64](interfacehipfort__rocblas_1_1rocblas__zhpmv__batched__64.html "Interface documentation") | C binding
-498 | [rocblas_chpmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__chpmv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-499 | [rocblas_zhpmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__zhpmv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-500 | [rocblas_chpmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__chpmv__strided__batched__64.html "Interface documentation") | C binding
-501 | [rocblas_zhpmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zhpmv__strided__batched__64.html "Interface documentation") | C binding
-502 | [rocblas_chpr](interfacehipfort__rocblas_1_1rocblas__chpr.html "Interface documentation") | C binding, rank_0, rank_1
-503 | [rocblas_zhpr](interfacehipfort__rocblas_1_1rocblas__zhpr.html "Interface documentation") | C binding, rank_0, rank_1
-504 | [rocblas_chpr_64](interfacehipfort__rocblas_1_1rocblas__chpr__64.html "Interface documentation") | C binding
-505 | [rocblas_zhpr_64](interfacehipfort__rocblas_1_1rocblas__zhpr__64.html "Interface documentation") | C binding
-506 | [rocblas_chpr_batched](interfacehipfort__rocblas_1_1rocblas__chpr__batched.html "Interface documentation") | C binding
-507 | [rocblas_zhpr_batched](interfacehipfort__rocblas_1_1rocblas__zhpr__batched.html "Interface documentation") | C binding
-508 | [rocblas_chpr_batched_64](interfacehipfort__rocblas_1_1rocblas__chpr__batched__64.html "Interface documentation") | C binding
-509 | [rocblas_zhpr_batched_64](interfacehipfort__rocblas_1_1rocblas__zhpr__batched__64.html "Interface documentation") | C binding
-510 | [rocblas_chpr_strided_batched](interfacehipfort__rocblas_1_1rocblas__chpr__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-511 | [rocblas_zhpr_strided_batched](interfacehipfort__rocblas_1_1rocblas__zhpr__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-512 | [rocblas_chpr_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__chpr__strided__batched__64.html "Interface documentation") | C binding
-513 | [rocblas_zhpr_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zhpr__strided__batched__64.html "Interface documentation") | C binding
-514 | [rocblas_chpr2](interfacehipfort__rocblas_1_1rocblas__chpr2.html "Interface documentation") | C binding, rank_0, rank_1
-515 | [rocblas_zhpr2](interfacehipfort__rocblas_1_1rocblas__zhpr2.html "Interface documentation") | C binding, rank_0, rank_1
-516 | [rocblas_chpr2_64](interfacehipfort__rocblas_1_1rocblas__chpr2__64.html "Interface documentation") | C binding
-517 | [rocblas_zhpr2_64](interfacehipfort__rocblas_1_1rocblas__zhpr2__64.html "Interface documentation") | C binding
-518 | [rocblas_chpr2_batched](interfacehipfort__rocblas_1_1rocblas__chpr2__batched.html "Interface documentation") | C binding
-519 | [rocblas_zhpr2_batched](interfacehipfort__rocblas_1_1rocblas__zhpr2__batched.html "Interface documentation") | C binding
-520 | [rocblas_chpr2_batched_64](interfacehipfort__rocblas_1_1rocblas__chpr2__batched__64.html "Interface documentation") | C binding
-521 | [rocblas_zhpr2_batched_64](interfacehipfort__rocblas_1_1rocblas__zhpr2__batched__64.html "Interface documentation") | C binding
-522 | [rocblas_chpr2_strided_batched](interfacehipfort__rocblas_1_1rocblas__chpr2__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-523 | [rocblas_zhpr2_strided_batched](interfacehipfort__rocblas_1_1rocblas__zhpr2__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-524 | [rocblas_chpr2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__chpr2__strided__batched__64.html "Interface documentation") | C binding
-525 | [rocblas_zhpr2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zhpr2__strided__batched__64.html "Interface documentation") | C binding
-526 | [rocblas_strmv](interfacehipfort__rocblas_1_1rocblas__strmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-527 | [rocblas_dtrmv](interfacehipfort__rocblas_1_1rocblas__dtrmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-528 | [rocblas_ctrmv](interfacehipfort__rocblas_1_1rocblas__ctrmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-529 | [rocblas_ztrmv](interfacehipfort__rocblas_1_1rocblas__ztrmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-530 | [rocblas_strmv_64](interfacehipfort__rocblas_1_1rocblas__strmv__64.html "Interface documentation") | C binding
-531 | [rocblas_dtrmv_64](interfacehipfort__rocblas_1_1rocblas__dtrmv__64.html "Interface documentation") | C binding
-532 | [rocblas_ctrmv_64](interfacehipfort__rocblas_1_1rocblas__ctrmv__64.html "Interface documentation") | C binding
-533 | [rocblas_ztrmv_64](interfacehipfort__rocblas_1_1rocblas__ztrmv__64.html "Interface documentation") | C binding
-534 | [rocblas_strmv_batched](interfacehipfort__rocblas_1_1rocblas__strmv__batched.html "Interface documentation") | C binding
-535 | [rocblas_dtrmv_batched](interfacehipfort__rocblas_1_1rocblas__dtrmv__batched.html "Interface documentation") | C binding
-536 | [rocblas_ctrmv_batched](interfacehipfort__rocblas_1_1rocblas__ctrmv__batched.html "Interface documentation") | C binding
-537 | [rocblas_ztrmv_batched](interfacehipfort__rocblas_1_1rocblas__ztrmv__batched.html "Interface documentation") | C binding
-538 | [rocblas_strmv_batched_64](interfacehipfort__rocblas_1_1rocblas__strmv__batched__64.html "Interface documentation") | C binding
-539 | [rocblas_dtrmv_batched_64](interfacehipfort__rocblas_1_1rocblas__dtrmv__batched__64.html "Interface documentation") | C binding
-540 | [rocblas_ctrmv_batched_64](interfacehipfort__rocblas_1_1rocblas__ctrmv__batched__64.html "Interface documentation") | C binding
-541 | [rocblas_ztrmv_batched_64](interfacehipfort__rocblas_1_1rocblas__ztrmv__batched__64.html "Interface documentation") | C binding
-542 | [rocblas_strmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__strmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-543 | [rocblas_dtrmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__dtrmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-544 | [rocblas_ctrmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ctrmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-545 | [rocblas_ztrmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ztrmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-546 | [rocblas_strmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__strmv__strided__batched__64.html "Interface documentation") | C binding
-547 | [rocblas_dtrmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dtrmv__strided__batched__64.html "Interface documentation") | C binding
-548 | [rocblas_ctrmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ctrmv__strided__batched__64.html "Interface documentation") | C binding
-549 | [rocblas_ztrmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ztrmv__strided__batched__64.html "Interface documentation") | C binding
-550 | [rocblas_stpmv](interfacehipfort__rocblas_1_1rocblas__stpmv.html "Interface documentation") | C binding, rank_0, rank_1
-551 | [rocblas_dtpmv](interfacehipfort__rocblas_1_1rocblas__dtpmv.html "Interface documentation") | C binding, rank_0, rank_1
-552 | [rocblas_ctpmv](interfacehipfort__rocblas_1_1rocblas__ctpmv.html "Interface documentation") | C binding, rank_0, rank_1
-553 | [rocblas_ztpmv](interfacehipfort__rocblas_1_1rocblas__ztpmv.html "Interface documentation") | C binding, rank_0, rank_1
-554 | [rocblas_stpmv_64](interfacehipfort__rocblas_1_1rocblas__stpmv__64.html "Interface documentation") | C binding
-555 | [rocblas_dtpmv_64](interfacehipfort__rocblas_1_1rocblas__dtpmv__64.html "Interface documentation") | C binding
-556 | [rocblas_ctpmv_64](interfacehipfort__rocblas_1_1rocblas__ctpmv__64.html "Interface documentation") | C binding
-557 | [rocblas_ztpmv_64](interfacehipfort__rocblas_1_1rocblas__ztpmv__64.html "Interface documentation") | C binding
-558 | [rocblas_stpmv_batched](interfacehipfort__rocblas_1_1rocblas__stpmv__batched.html "Interface documentation") | C binding
-559 | [rocblas_dtpmv_batched](interfacehipfort__rocblas_1_1rocblas__dtpmv__batched.html "Interface documentation") | C binding
-560 | [rocblas_ctpmv_batched](interfacehipfort__rocblas_1_1rocblas__ctpmv__batched.html "Interface documentation") | C binding
-561 | [rocblas_ztpmv_batched](interfacehipfort__rocblas_1_1rocblas__ztpmv__batched.html "Interface documentation") | C binding
-562 | [rocblas_stpmv_batched_64](interfacehipfort__rocblas_1_1rocblas__stpmv__batched__64.html "Interface documentation") | C binding
-563 | [rocblas_dtpmv_batched_64](interfacehipfort__rocblas_1_1rocblas__dtpmv__batched__64.html "Interface documentation") | C binding
-564 | [rocblas_ctpmv_batched_64](interfacehipfort__rocblas_1_1rocblas__ctpmv__batched__64.html "Interface documentation") | C binding
-565 | [rocblas_ztpmv_batched_64](interfacehipfort__rocblas_1_1rocblas__ztpmv__batched__64.html "Interface documentation") | C binding
-566 | [rocblas_stpmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__stpmv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-567 | [rocblas_dtpmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__dtpmv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-568 | [rocblas_ctpmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ctpmv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-569 | [rocblas_ztpmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ztpmv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-570 | [rocblas_stpmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__stpmv__strided__batched__64.html "Interface documentation") | C binding
-571 | [rocblas_dtpmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dtpmv__strided__batched__64.html "Interface documentation") | C binding
-572 | [rocblas_ctpmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ctpmv__strided__batched__64.html "Interface documentation") | C binding
-573 | [rocblas_ztpmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ztpmv__strided__batched__64.html "Interface documentation") | C binding
-574 | [rocblas_stbmv](interfacehipfort__rocblas_1_1rocblas__stbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-575 | [rocblas_dtbmv](interfacehipfort__rocblas_1_1rocblas__dtbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-576 | [rocblas_ctbmv](interfacehipfort__rocblas_1_1rocblas__ctbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-577 | [rocblas_ztbmv](interfacehipfort__rocblas_1_1rocblas__ztbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-578 | [rocblas_stbmv_64](interfacehipfort__rocblas_1_1rocblas__stbmv__64.html "Interface documentation") | C binding
-579 | [rocblas_dtbmv_64](interfacehipfort__rocblas_1_1rocblas__dtbmv__64.html "Interface documentation") | C binding
-580 | [rocblas_ctbmv_64](interfacehipfort__rocblas_1_1rocblas__ctbmv__64.html "Interface documentation") | C binding
-581 | [rocblas_ztbmv_64](interfacehipfort__rocblas_1_1rocblas__ztbmv__64.html "Interface documentation") | C binding
-582 | [rocblas_stbmv_batched](interfacehipfort__rocblas_1_1rocblas__stbmv__batched.html "Interface documentation") | C binding
-583 | [rocblas_dtbmv_batched](interfacehipfort__rocblas_1_1rocblas__dtbmv__batched.html "Interface documentation") | C binding
-584 | [rocblas_ctbmv_batched](interfacehipfort__rocblas_1_1rocblas__ctbmv__batched.html "Interface documentation") | C binding
-585 | [rocblas_ztbmv_batched](interfacehipfort__rocblas_1_1rocblas__ztbmv__batched.html "Interface documentation") | C binding
-586 | [rocblas_stbmv_batched_64](interfacehipfort__rocblas_1_1rocblas__stbmv__batched__64.html "Interface documentation") | C binding
-587 | [rocblas_dtbmv_batched_64](interfacehipfort__rocblas_1_1rocblas__dtbmv__batched__64.html "Interface documentation") | C binding
-588 | [rocblas_ctbmv_batched_64](interfacehipfort__rocblas_1_1rocblas__ctbmv__batched__64.html "Interface documentation") | C binding
-589 | [rocblas_ztbmv_batched_64](interfacehipfort__rocblas_1_1rocblas__ztbmv__batched__64.html "Interface documentation") | C binding
-590 | [rocblas_stbmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__stbmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-591 | [rocblas_dtbmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__dtbmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-592 | [rocblas_ctbmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ctbmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-593 | [rocblas_ztbmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ztbmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-594 | [rocblas_stbmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__stbmv__strided__batched__64.html "Interface documentation") | C binding
-595 | [rocblas_dtbmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dtbmv__strided__batched__64.html "Interface documentation") | C binding
-596 | [rocblas_ctbmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ctbmv__strided__batched__64.html "Interface documentation") | C binding
-597 | [rocblas_ztbmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ztbmv__strided__batched__64.html "Interface documentation") | C binding
-598 | [rocblas_stbsv](interfacehipfort__rocblas_1_1rocblas__stbsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-599 | [rocblas_dtbsv](interfacehipfort__rocblas_1_1rocblas__dtbsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-600 | [rocblas_ctbsv](interfacehipfort__rocblas_1_1rocblas__ctbsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-601 | [rocblas_ztbsv](interfacehipfort__rocblas_1_1rocblas__ztbsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-602 | [rocblas_stbsv_64](interfacehipfort__rocblas_1_1rocblas__stbsv__64.html "Interface documentation") | C binding
-603 | [rocblas_dtbsv_64](interfacehipfort__rocblas_1_1rocblas__dtbsv__64.html "Interface documentation") | C binding
-604 | [rocblas_ctbsv_64](interfacehipfort__rocblas_1_1rocblas__ctbsv__64.html "Interface documentation") | C binding
-605 | [rocblas_ztbsv_64](interfacehipfort__rocblas_1_1rocblas__ztbsv__64.html "Interface documentation") | C binding
-606 | [rocblas_stbsv_batched](interfacehipfort__rocblas_1_1rocblas__stbsv__batched.html "Interface documentation") | C binding
-607 | [rocblas_dtbsv_batched](interfacehipfort__rocblas_1_1rocblas__dtbsv__batched.html "Interface documentation") | C binding
-608 | [rocblas_ctbsv_batched](interfacehipfort__rocblas_1_1rocblas__ctbsv__batched.html "Interface documentation") | C binding
-609 | [rocblas_ztbsv_batched](interfacehipfort__rocblas_1_1rocblas__ztbsv__batched.html "Interface documentation") | C binding
-610 | [rocblas_stbsv_batched_64](interfacehipfort__rocblas_1_1rocblas__stbsv__batched__64.html "Interface documentation") | C binding
-611 | [rocblas_dtbsv_batched_64](interfacehipfort__rocblas_1_1rocblas__dtbsv__batched__64.html "Interface documentation") | C binding
-612 | [rocblas_ctbsv_batched_64](interfacehipfort__rocblas_1_1rocblas__ctbsv__batched__64.html "Interface documentation") | C binding
-613 | [rocblas_ztbsv_batched_64](interfacehipfort__rocblas_1_1rocblas__ztbsv__batched__64.html "Interface documentation") | C binding
-614 | [rocblas_stbsv_strided_batched](interfacehipfort__rocblas_1_1rocblas__stbsv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-615 | [rocblas_dtbsv_strided_batched](interfacehipfort__rocblas_1_1rocblas__dtbsv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-616 | [rocblas_ctbsv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ctbsv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-617 | [rocblas_ztbsv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ztbsv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-618 | [rocblas_stbsv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__stbsv__strided__batched__64.html "Interface documentation") | C binding
-619 | [rocblas_dtbsv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dtbsv__strided__batched__64.html "Interface documentation") | C binding
-620 | [rocblas_ctbsv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ctbsv__strided__batched__64.html "Interface documentation") | C binding
-621 | [rocblas_ztbsv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ztbsv__strided__batched__64.html "Interface documentation") | C binding
-622 | [rocblas_strsv](interfacehipfort__rocblas_1_1rocblas__strsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-623 | [rocblas_dtrsv](interfacehipfort__rocblas_1_1rocblas__dtrsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-624 | [rocblas_ctrsv](interfacehipfort__rocblas_1_1rocblas__ctrsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-625 | [rocblas_ztrsv](interfacehipfort__rocblas_1_1rocblas__ztrsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-626 | [rocblas_strsv_64](interfacehipfort__rocblas_1_1rocblas__strsv__64.html "Interface documentation") | C binding
-627 | [rocblas_dtrsv_64](interfacehipfort__rocblas_1_1rocblas__dtrsv__64.html "Interface documentation") | C binding
-628 | [rocblas_ctrsv_64](interfacehipfort__rocblas_1_1rocblas__ctrsv__64.html "Interface documentation") | C binding
-629 | [rocblas_ztrsv_64](interfacehipfort__rocblas_1_1rocblas__ztrsv__64.html "Interface documentation") | C binding
-630 | [rocblas_strsv_batched](interfacehipfort__rocblas_1_1rocblas__strsv__batched.html "Interface documentation") | C binding
-631 | [rocblas_dtrsv_batched](interfacehipfort__rocblas_1_1rocblas__dtrsv__batched.html "Interface documentation") | C binding
-632 | [rocblas_ctrsv_batched](interfacehipfort__rocblas_1_1rocblas__ctrsv__batched.html "Interface documentation") | C binding
-633 | [rocblas_ztrsv_batched](interfacehipfort__rocblas_1_1rocblas__ztrsv__batched.html "Interface documentation") | C binding
-634 | [rocblas_strsv_batched_64](interfacehipfort__rocblas_1_1rocblas__strsv__batched__64.html "Interface documentation") | C binding
-635 | [rocblas_dtrsv_batched_64](interfacehipfort__rocblas_1_1rocblas__dtrsv__batched__64.html "Interface documentation") | C binding
-636 | [rocblas_ctrsv_batched_64](interfacehipfort__rocblas_1_1rocblas__ctrsv__batched__64.html "Interface documentation") | C binding
-637 | [rocblas_ztrsv_batched_64](interfacehipfort__rocblas_1_1rocblas__ztrsv__batched__64.html "Interface documentation") | C binding
-638 | [rocblas_strsv_strided_batched](interfacehipfort__rocblas_1_1rocblas__strsv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-639 | [rocblas_dtrsv_strided_batched](interfacehipfort__rocblas_1_1rocblas__dtrsv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-640 | [rocblas_ctrsv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ctrsv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-641 | [rocblas_ztrsv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ztrsv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-642 | [rocblas_strsv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__strsv__strided__batched__64.html "Interface documentation") | C binding
-643 | [rocblas_dtrsv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dtrsv__strided__batched__64.html "Interface documentation") | C binding
-644 | [rocblas_ctrsv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ctrsv__strided__batched__64.html "Interface documentation") | C binding
-645 | [rocblas_ztrsv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ztrsv__strided__batched__64.html "Interface documentation") | C binding
-646 | [rocblas_stpsv](interfacehipfort__rocblas_1_1rocblas__stpsv.html "Interface documentation") | C binding, rank_0, rank_1
-647 | [rocblas_dtpsv](interfacehipfort__rocblas_1_1rocblas__dtpsv.html "Interface documentation") | C binding, rank_0, rank_1
-648 | [rocblas_ctpsv](interfacehipfort__rocblas_1_1rocblas__ctpsv.html "Interface documentation") | C binding, rank_0, rank_1
-649 | [rocblas_ztpsv](interfacehipfort__rocblas_1_1rocblas__ztpsv.html "Interface documentation") | C binding, rank_0, rank_1
-650 | [rocblas_stpsv_64](interfacehipfort__rocblas_1_1rocblas__stpsv__64.html "Interface documentation") | C binding
-651 | [rocblas_dtpsv_64](interfacehipfort__rocblas_1_1rocblas__dtpsv__64.html "Interface documentation") | C binding
-652 | [rocblas_ctpsv_64](interfacehipfort__rocblas_1_1rocblas__ctpsv__64.html "Interface documentation") | C binding
-653 | [rocblas_ztpsv_64](interfacehipfort__rocblas_1_1rocblas__ztpsv__64.html "Interface documentation") | C binding
-654 | [rocblas_stpsv_batched](interfacehipfort__rocblas_1_1rocblas__stpsv__batched.html "Interface documentation") | C binding
-655 | [rocblas_dtpsv_batched](interfacehipfort__rocblas_1_1rocblas__dtpsv__batched.html "Interface documentation") | C binding
-656 | [rocblas_ctpsv_batched](interfacehipfort__rocblas_1_1rocblas__ctpsv__batched.html "Interface documentation") | C binding
-657 | [rocblas_ztpsv_batched](interfacehipfort__rocblas_1_1rocblas__ztpsv__batched.html "Interface documentation") | C binding
-658 | [rocblas_stpsv_batched_64](interfacehipfort__rocblas_1_1rocblas__stpsv__batched__64.html "Interface documentation") | C binding
-659 | [rocblas_dtpsv_batched_64](interfacehipfort__rocblas_1_1rocblas__dtpsv__batched__64.html "Interface documentation") | C binding
-660 | [rocblas_ctpsv_batched_64](interfacehipfort__rocblas_1_1rocblas__ctpsv__batched__64.html "Interface documentation") | C binding
-661 | [rocblas_ztpsv_batched_64](interfacehipfort__rocblas_1_1rocblas__ztpsv__batched__64.html "Interface documentation") | C binding
-662 | [rocblas_stpsv_strided_batched](interfacehipfort__rocblas_1_1rocblas__stpsv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-663 | [rocblas_dtpsv_strided_batched](interfacehipfort__rocblas_1_1rocblas__dtpsv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-664 | [rocblas_ctpsv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ctpsv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-665 | [rocblas_ztpsv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ztpsv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-666 | [rocblas_stpsv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__stpsv__strided__batched__64.html "Interface documentation") | C binding
-667 | [rocblas_dtpsv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dtpsv__strided__batched__64.html "Interface documentation") | C binding
-668 | [rocblas_ctpsv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ctpsv__strided__batched__64.html "Interface documentation") | C binding
-669 | [rocblas_ztpsv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ztpsv__strided__batched__64.html "Interface documentation") | C binding
-670 | [rocblas_ssymv](interfacehipfort__rocblas_1_1rocblas__ssymv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-671 | [rocblas_dsymv](interfacehipfort__rocblas_1_1rocblas__dsymv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-672 | [rocblas_csymv](interfacehipfort__rocblas_1_1rocblas__csymv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-673 | [rocblas_zsymv](interfacehipfort__rocblas_1_1rocblas__zsymv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-674 | [rocblas_ssymv_64](interfacehipfort__rocblas_1_1rocblas__ssymv__64.html "Interface documentation") | C binding
-675 | [rocblas_dsymv_64](interfacehipfort__rocblas_1_1rocblas__dsymv__64.html "Interface documentation") | C binding
-676 | [rocblas_csymv_64](interfacehipfort__rocblas_1_1rocblas__csymv__64.html "Interface documentation") | C binding
-677 | [rocblas_zsymv_64](interfacehipfort__rocblas_1_1rocblas__zsymv__64.html "Interface documentation") | C binding
-678 | [rocblas_ssymv_batched](interfacehipfort__rocblas_1_1rocblas__ssymv__batched.html "Interface documentation") | C binding
-679 | [rocblas_dsymv_batched](interfacehipfort__rocblas_1_1rocblas__dsymv__batched.html "Interface documentation") | C binding
-680 | [rocblas_csymv_batched](interfacehipfort__rocblas_1_1rocblas__csymv__batched.html "Interface documentation") | C binding
-681 | [rocblas_zsymv_batched](interfacehipfort__rocblas_1_1rocblas__zsymv__batched.html "Interface documentation") | C binding
-682 | [rocblas_ssymv_batched_64](interfacehipfort__rocblas_1_1rocblas__ssymv__batched__64.html "Interface documentation") | C binding
-683 | [rocblas_dsymv_batched_64](interfacehipfort__rocblas_1_1rocblas__dsymv__batched__64.html "Interface documentation") | C binding
-684 | [rocblas_csymv_batched_64](interfacehipfort__rocblas_1_1rocblas__csymv__batched__64.html "Interface documentation") | C binding
-685 | [rocblas_zsymv_batched_64](interfacehipfort__rocblas_1_1rocblas__zsymv__batched__64.html "Interface documentation") | C binding
-686 | [rocblas_ssymv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ssymv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-687 | [rocblas_dsymv_strided_batched](interfacehipfort__rocblas_1_1rocblas__dsymv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-688 | [rocblas_csymv_strided_batched](interfacehipfort__rocblas_1_1rocblas__csymv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-689 | [rocblas_zsymv_strided_batched](interfacehipfort__rocblas_1_1rocblas__zsymv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-690 | [rocblas_ssymv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ssymv__strided__batched__64.html "Interface documentation") | C binding
-691 | [rocblas_dsymv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dsymv__strided__batched__64.html "Interface documentation") | C binding
-692 | [rocblas_csymv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__csymv__strided__batched__64.html "Interface documentation") | C binding
-693 | [rocblas_zsymv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zsymv__strided__batched__64.html "Interface documentation") | C binding
-694 | [rocblas_sspmv](interfacehipfort__rocblas_1_1rocblas__sspmv.html "Interface documentation") | C binding, rank_0, rank_1
-695 | [rocblas_dspmv](interfacehipfort__rocblas_1_1rocblas__dspmv.html "Interface documentation") | C binding, rank_0, rank_1
-696 | [rocblas_sspmv_64](interfacehipfort__rocblas_1_1rocblas__sspmv__64.html "Interface documentation") | C binding
-697 | [rocblas_dspmv_64](interfacehipfort__rocblas_1_1rocblas__dspmv__64.html "Interface documentation") | C binding
-698 | [rocblas_sspmv_batched](interfacehipfort__rocblas_1_1rocblas__sspmv__batched.html "Interface documentation") | C binding
-699 | [rocblas_dspmv_batched](interfacehipfort__rocblas_1_1rocblas__dspmv__batched.html "Interface documentation") | C binding
-700 | [rocblas_sspmv_batched_64](interfacehipfort__rocblas_1_1rocblas__sspmv__batched__64.html "Interface documentation") | C binding
-701 | [rocblas_dspmv_batched_64](interfacehipfort__rocblas_1_1rocblas__dspmv__batched__64.html "Interface documentation") | C binding
-702 | [rocblas_sspmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__sspmv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-703 | [rocblas_dspmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__dspmv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-704 | [rocblas_sspmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sspmv__strided__batched__64.html "Interface documentation") | C binding
-705 | [rocblas_dspmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dspmv__strided__batched__64.html "Interface documentation") | C binding
-706 | [rocblas_ssbmv](interfacehipfort__rocblas_1_1rocblas__ssbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-707 | [rocblas_dsbmv](interfacehipfort__rocblas_1_1rocblas__dsbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-708 | [rocblas_ssbmv_64](interfacehipfort__rocblas_1_1rocblas__ssbmv__64.html "Interface documentation") | C binding
-709 | [rocblas_dsbmv_64](interfacehipfort__rocblas_1_1rocblas__dsbmv__64.html "Interface documentation") | C binding
-710 | [rocblas_ssbmv_batched](interfacehipfort__rocblas_1_1rocblas__ssbmv__batched.html "Interface documentation") | C binding
-711 | [rocblas_dsbmv_batched](interfacehipfort__rocblas_1_1rocblas__dsbmv__batched.html "Interface documentation") | C binding
-712 | [rocblas_ssbmv_batched_64](interfacehipfort__rocblas_1_1rocblas__ssbmv__batched__64.html "Interface documentation") | C binding
-713 | [rocblas_dsbmv_batched_64](interfacehipfort__rocblas_1_1rocblas__dsbmv__batched__64.html "Interface documentation") | C binding
-714 | [rocblas_ssbmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ssbmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-715 | [rocblas_dsbmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__dsbmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-716 | [rocblas_ssbmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ssbmv__strided__batched__64.html "Interface documentation") | C binding
-717 | [rocblas_dsbmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dsbmv__strided__batched__64.html "Interface documentation") | C binding
-718 | [rocblas_sger](interfacehipfort__rocblas_1_1rocblas__sger.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-719 | [rocblas_dger](interfacehipfort__rocblas_1_1rocblas__dger.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-720 | [rocblas_cgeru](interfacehipfort__rocblas_1_1rocblas__cgeru.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-721 | [rocblas_zgeru](interfacehipfort__rocblas_1_1rocblas__zgeru.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-722 | [rocblas_cgerc](interfacehipfort__rocblas_1_1rocblas__cgerc.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-723 | [rocblas_zgerc](interfacehipfort__rocblas_1_1rocblas__zgerc.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-724 | [rocblas_sger_64](interfacehipfort__rocblas_1_1rocblas__sger__64.html "Interface documentation") | C binding
-725 | [rocblas_dger_64](interfacehipfort__rocblas_1_1rocblas__dger__64.html "Interface documentation") | C binding
-726 | [rocblas_cgeru_64](interfacehipfort__rocblas_1_1rocblas__cgeru__64.html "Interface documentation") | C binding
-727 | [rocblas_zgeru_64](interfacehipfort__rocblas_1_1rocblas__zgeru__64.html "Interface documentation") | C binding
-728 | [rocblas_cgerc_64](interfacehipfort__rocblas_1_1rocblas__cgerc__64.html "Interface documentation") | C binding
-729 | [rocblas_zgerc_64](interfacehipfort__rocblas_1_1rocblas__zgerc__64.html "Interface documentation") | C binding
-730 | [rocblas_sger_batched](interfacehipfort__rocblas_1_1rocblas__sger__batched.html "Interface documentation") | C binding
-731 | [rocblas_dger_batched](interfacehipfort__rocblas_1_1rocblas__dger__batched.html "Interface documentation") | C binding
-732 | [rocblas_cgeru_batched](interfacehipfort__rocblas_1_1rocblas__cgeru__batched.html "Interface documentation") | C binding
-733 | [rocblas_zgeru_batched](interfacehipfort__rocblas_1_1rocblas__zgeru__batched.html "Interface documentation") | C binding
-734 | [rocblas_cgerc_batched](interfacehipfort__rocblas_1_1rocblas__cgerc__batched.html "Interface documentation") | C binding
-735 | [rocblas_zgerc_batched](interfacehipfort__rocblas_1_1rocblas__zgerc__batched.html "Interface documentation") | C binding
-736 | [rocblas_sger_batched_64](interfacehipfort__rocblas_1_1rocblas__sger__batched__64.html "Interface documentation") | C binding
-737 | [rocblas_dger_batched_64](interfacehipfort__rocblas_1_1rocblas__dger__batched__64.html "Interface documentation") | C binding
-738 | [rocblas_cgeru_batched_64](interfacehipfort__rocblas_1_1rocblas__cgeru__batched__64.html "Interface documentation") | C binding
-739 | [rocblas_zgeru_batched_64](interfacehipfort__rocblas_1_1rocblas__zgeru__batched__64.html "Interface documentation") | C binding
-740 | [rocblas_cgerc_batched_64](interfacehipfort__rocblas_1_1rocblas__cgerc__batched__64.html "Interface documentation") | C binding
-741 | [rocblas_zgerc_batched_64](interfacehipfort__rocblas_1_1rocblas__zgerc__batched__64.html "Interface documentation") | C binding
-742 | [rocblas_sger_strided_batched](interfacehipfort__rocblas_1_1rocblas__sger__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-743 | [rocblas_dger_strided_batched](interfacehipfort__rocblas_1_1rocblas__dger__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-744 | [rocblas_cgeru_strided_batched](interfacehipfort__rocblas_1_1rocblas__cgeru__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-745 | [rocblas_zgeru_strided_batched](interfacehipfort__rocblas_1_1rocblas__zgeru__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-746 | [rocblas_cgerc_strided_batched](interfacehipfort__rocblas_1_1rocblas__cgerc__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-747 | [rocblas_zgerc_strided_batched](interfacehipfort__rocblas_1_1rocblas__zgerc__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-748 | [rocblas_sger_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sger__strided__batched__64.html "Interface documentation") | C binding
-749 | [rocblas_dger_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dger__strided__batched__64.html "Interface documentation") | C binding
-750 | [rocblas_cgeru_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cgeru__strided__batched__64.html "Interface documentation") | C binding
-751 | [rocblas_zgeru_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zgeru__strided__batched__64.html "Interface documentation") | C binding
-752 | [rocblas_cgerc_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cgerc__strided__batched__64.html "Interface documentation") | C binding
-753 | [rocblas_zgerc_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zgerc__strided__batched__64.html "Interface documentation") | C binding
-754 | [rocblas_sspr](interfacehipfort__rocblas_1_1rocblas__sspr.html "Interface documentation") | C binding, rank_0, rank_1
-755 | [rocblas_dspr](interfacehipfort__rocblas_1_1rocblas__dspr.html "Interface documentation") | C binding, rank_0, rank_1
-756 | [rocblas_cspr](interfacehipfort__rocblas_1_1rocblas__cspr.html "Interface documentation") | C binding, rank_0, rank_1
-757 | [rocblas_zspr](interfacehipfort__rocblas_1_1rocblas__zspr.html "Interface documentation") | C binding, rank_0, rank_1
-758 | [rocblas_sspr_64](interfacehipfort__rocblas_1_1rocblas__sspr__64.html "Interface documentation") | C binding
-759 | [rocblas_dspr_64](interfacehipfort__rocblas_1_1rocblas__dspr__64.html "Interface documentation") | C binding
-760 | [rocblas_cspr_64](interfacehipfort__rocblas_1_1rocblas__cspr__64.html "Interface documentation") | C binding
-761 | [rocblas_zspr_64](interfacehipfort__rocblas_1_1rocblas__zspr__64.html "Interface documentation") | C binding
-762 | [rocblas_sspr_batched](interfacehipfort__rocblas_1_1rocblas__sspr__batched.html "Interface documentation") | C binding
-763 | [rocblas_dspr_batched](interfacehipfort__rocblas_1_1rocblas__dspr__batched.html "Interface documentation") | C binding
-764 | [rocblas_cspr_batched](interfacehipfort__rocblas_1_1rocblas__cspr__batched.html "Interface documentation") | C binding
-765 | [rocblas_zspr_batched](interfacehipfort__rocblas_1_1rocblas__zspr__batched.html "Interface documentation") | C binding
-766 | [rocblas_sspr_batched_64](interfacehipfort__rocblas_1_1rocblas__sspr__batched__64.html "Interface documentation") | C binding
-767 | [rocblas_dspr_batched_64](interfacehipfort__rocblas_1_1rocblas__dspr__batched__64.html "Interface documentation") | C binding
-768 | [rocblas_cspr_batched_64](interfacehipfort__rocblas_1_1rocblas__cspr__batched__64.html "Interface documentation") | C binding
-769 | [rocblas_zspr_batched_64](interfacehipfort__rocblas_1_1rocblas__zspr__batched__64.html "Interface documentation") | C binding
-770 | [rocblas_sspr_strided_batched](interfacehipfort__rocblas_1_1rocblas__sspr__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-771 | [rocblas_dspr_strided_batched](interfacehipfort__rocblas_1_1rocblas__dspr__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-772 | [rocblas_cspr_strided_batched](interfacehipfort__rocblas_1_1rocblas__cspr__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-773 | [rocblas_zspr_strided_batched](interfacehipfort__rocblas_1_1rocblas__zspr__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-774 | [rocblas_sspr_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sspr__strided__batched__64.html "Interface documentation") | C binding
-775 | [rocblas_dspr_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dspr__strided__batched__64.html "Interface documentation") | C binding
-776 | [rocblas_cspr_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cspr__strided__batched__64.html "Interface documentation") | C binding
-777 | [rocblas_zspr_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zspr__strided__batched__64.html "Interface documentation") | C binding
-778 | [rocblas_sspr2](interfacehipfort__rocblas_1_1rocblas__sspr2.html "Interface documentation") | C binding, rank_0, rank_1
-779 | [rocblas_dspr2](interfacehipfort__rocblas_1_1rocblas__dspr2.html "Interface documentation") | C binding, rank_0, rank_1
-780 | [rocblas_sspr2_64](interfacehipfort__rocblas_1_1rocblas__sspr2__64.html "Interface documentation") | C binding
-781 | [rocblas_dspr2_64](interfacehipfort__rocblas_1_1rocblas__dspr2__64.html "Interface documentation") | C binding
-782 | [rocblas_sspr2_batched](interfacehipfort__rocblas_1_1rocblas__sspr2__batched.html "Interface documentation") | C binding
-783 | [rocblas_dspr2_batched](interfacehipfort__rocblas_1_1rocblas__dspr2__batched.html "Interface documentation") | C binding
-784 | [rocblas_sspr2_batched_64](interfacehipfort__rocblas_1_1rocblas__sspr2__batched__64.html "Interface documentation") | C binding
-785 | [rocblas_dspr2_batched_64](interfacehipfort__rocblas_1_1rocblas__dspr2__batched__64.html "Interface documentation") | C binding
-786 | [rocblas_sspr2_strided_batched](interfacehipfort__rocblas_1_1rocblas__sspr2__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-787 | [rocblas_dspr2_strided_batched](interfacehipfort__rocblas_1_1rocblas__dspr2__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-788 | [rocblas_sspr2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sspr2__strided__batched__64.html "Interface documentation") | C binding
-789 | [rocblas_dspr2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dspr2__strided__batched__64.html "Interface documentation") | C binding
-790 | [rocblas_ssyr](interfacehipfort__rocblas_1_1rocblas__ssyr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-791 | [rocblas_dsyr](interfacehipfort__rocblas_1_1rocblas__dsyr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-792 | [rocblas_csyr](interfacehipfort__rocblas_1_1rocblas__csyr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-793 | [rocblas_zsyr](interfacehipfort__rocblas_1_1rocblas__zsyr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-794 | [rocblas_ssyr_64](interfacehipfort__rocblas_1_1rocblas__ssyr__64.html "Interface documentation") | C binding
-795 | [rocblas_dsyr_64](interfacehipfort__rocblas_1_1rocblas__dsyr__64.html "Interface documentation") | C binding
-796 | [rocblas_csyr_64](interfacehipfort__rocblas_1_1rocblas__csyr__64.html "Interface documentation") | C binding
-797 | [rocblas_zsyr_64](interfacehipfort__rocblas_1_1rocblas__zsyr__64.html "Interface documentation") | C binding
-798 | [rocblas_ssyr_batched](interfacehipfort__rocblas_1_1rocblas__ssyr__batched.html "Interface documentation") | C binding
-799 | [rocblas_dsyr_batched](interfacehipfort__rocblas_1_1rocblas__dsyr__batched.html "Interface documentation") | C binding
-800 | [rocblas_csyr_batched](interfacehipfort__rocblas_1_1rocblas__csyr__batched.html "Interface documentation") | C binding
-801 | [rocblas_zsyr_batched](interfacehipfort__rocblas_1_1rocblas__zsyr__batched.html "Interface documentation") | C binding
-802 | [rocblas_ssyr_batched_64](interfacehipfort__rocblas_1_1rocblas__ssyr__batched__64.html "Interface documentation") | C binding
-803 | [rocblas_dsyr_batched_64](interfacehipfort__rocblas_1_1rocblas__dsyr__batched__64.html "Interface documentation") | C binding
-804 | [rocblas_csyr_batched_64](interfacehipfort__rocblas_1_1rocblas__csyr__batched__64.html "Interface documentation") | C binding
-805 | [rocblas_zsyr_batched_64](interfacehipfort__rocblas_1_1rocblas__zsyr__batched__64.html "Interface documentation") | C binding
-806 | [rocblas_ssyr_strided_batched](interfacehipfort__rocblas_1_1rocblas__ssyr__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-807 | [rocblas_dsyr_strided_batched](interfacehipfort__rocblas_1_1rocblas__dsyr__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-808 | [rocblas_csyr_strided_batched](interfacehipfort__rocblas_1_1rocblas__csyr__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-809 | [rocblas_zsyr_strided_batched](interfacehipfort__rocblas_1_1rocblas__zsyr__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-810 | [rocblas_ssyr_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ssyr__strided__batched__64.html "Interface documentation") | C binding
-811 | [rocblas_dsyr_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dsyr__strided__batched__64.html "Interface documentation") | C binding
-812 | [rocblas_csyr_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__csyr__strided__batched__64.html "Interface documentation") | C binding
-813 | [rocblas_zsyr_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zsyr__strided__batched__64.html "Interface documentation") | C binding
-814 | [rocblas_ssyr2](interfacehipfort__rocblas_1_1rocblas__ssyr2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-815 | [rocblas_dsyr2](interfacehipfort__rocblas_1_1rocblas__dsyr2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-816 | [rocblas_csyr2](interfacehipfort__rocblas_1_1rocblas__csyr2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-817 | [rocblas_zsyr2](interfacehipfort__rocblas_1_1rocblas__zsyr2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-818 | [rocblas_ssyr2_64](interfacehipfort__rocblas_1_1rocblas__ssyr2__64.html "Interface documentation") | C binding
-819 | [rocblas_dsyr2_64](interfacehipfort__rocblas_1_1rocblas__dsyr2__64.html "Interface documentation") | C binding
-820 | [rocblas_csyr2_64](interfacehipfort__rocblas_1_1rocblas__csyr2__64.html "Interface documentation") | C binding
-821 | [rocblas_zsyr2_64](interfacehipfort__rocblas_1_1rocblas__zsyr2__64.html "Interface documentation") | C binding
-822 | [rocblas_ssyr2_batched](interfacehipfort__rocblas_1_1rocblas__ssyr2__batched.html "Interface documentation") | C binding
-823 | [rocblas_dsyr2_batched](interfacehipfort__rocblas_1_1rocblas__dsyr2__batched.html "Interface documentation") | C binding
-824 | [rocblas_csyr2_batched](interfacehipfort__rocblas_1_1rocblas__csyr2__batched.html "Interface documentation") | C binding
-825 | [rocblas_zsyr2_batched](interfacehipfort__rocblas_1_1rocblas__zsyr2__batched.html "Interface documentation") | C binding
-826 | [rocblas_ssyr2_batched_64](interfacehipfort__rocblas_1_1rocblas__ssyr2__batched__64.html "Interface documentation") | C binding
-827 | [rocblas_dsyr2_batched_64](interfacehipfort__rocblas_1_1rocblas__dsyr2__batched__64.html "Interface documentation") | C binding
-828 | [rocblas_csyr2_batched_64](interfacehipfort__rocblas_1_1rocblas__csyr2__batched__64.html "Interface documentation") | C binding
-829 | [rocblas_zsyr2_batched_64](interfacehipfort__rocblas_1_1rocblas__zsyr2__batched__64.html "Interface documentation") | C binding
-830 | [rocblas_ssyr2_strided_batched](interfacehipfort__rocblas_1_1rocblas__ssyr2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-831 | [rocblas_dsyr2_strided_batched](interfacehipfort__rocblas_1_1rocblas__dsyr2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-832 | [rocblas_csyr2_strided_batched](interfacehipfort__rocblas_1_1rocblas__csyr2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-833 | [rocblas_zsyr2_strided_batched](interfacehipfort__rocblas_1_1rocblas__zsyr2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-834 | [rocblas_ssyr2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ssyr2__strided__batched__64.html "Interface documentation") | C binding
-835 | [rocblas_dsyr2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dsyr2__strided__batched__64.html "Interface documentation") | C binding
-836 | [rocblas_csyr2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__csyr2__strided__batched__64.html "Interface documentation") | C binding
-837 | [rocblas_zsyr2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zsyr2__strided__batched__64.html "Interface documentation") | C binding
-838 | [rocblas_chemm](interfacehipfort__rocblas_1_1rocblas__chemm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-839 | [rocblas_zhemm](interfacehipfort__rocblas_1_1rocblas__zhemm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-840 | [rocblas_chemm_64](interfacehipfort__rocblas_1_1rocblas__chemm__64.html "Interface documentation") | C binding
-841 | [rocblas_zhemm_64](interfacehipfort__rocblas_1_1rocblas__zhemm__64.html "Interface documentation") | C binding
-842 | [rocblas_chemm_batched](interfacehipfort__rocblas_1_1rocblas__chemm__batched.html "Interface documentation") | C binding
-843 | [rocblas_zhemm_batched](interfacehipfort__rocblas_1_1rocblas__zhemm__batched.html "Interface documentation") | C binding
-844 | [rocblas_chemm_batched_64](interfacehipfort__rocblas_1_1rocblas__chemm__batched__64.html "Interface documentation") | C binding
-845 | [rocblas_zhemm_batched_64](interfacehipfort__rocblas_1_1rocblas__zhemm__batched__64.html "Interface documentation") | C binding
-846 | [rocblas_chemm_strided_batched](interfacehipfort__rocblas_1_1rocblas__chemm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-847 | [rocblas_zhemm_strided_batched](interfacehipfort__rocblas_1_1rocblas__zhemm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-848 | [rocblas_chemm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__chemm__strided__batched__64.html "Interface documentation") | C binding
-849 | [rocblas_zhemm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zhemm__strided__batched__64.html "Interface documentation") | C binding
-850 | [rocblas_cherk](interfacehipfort__rocblas_1_1rocblas__cherk.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-851 | [rocblas_zherk](interfacehipfort__rocblas_1_1rocblas__zherk.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-852 | [rocblas_cherk_64](interfacehipfort__rocblas_1_1rocblas__cherk__64.html "Interface documentation") | C binding
-853 | [rocblas_zherk_64](interfacehipfort__rocblas_1_1rocblas__zherk__64.html "Interface documentation") | C binding
-854 | [rocblas_cherk_batched](interfacehipfort__rocblas_1_1rocblas__cherk__batched.html "Interface documentation") | C binding
-855 | [rocblas_zherk_batched](interfacehipfort__rocblas_1_1rocblas__zherk__batched.html "Interface documentation") | C binding
-856 | [rocblas_cherk_batched_64](interfacehipfort__rocblas_1_1rocblas__cherk__batched__64.html "Interface documentation") | C binding
-857 | [rocblas_zherk_batched_64](interfacehipfort__rocblas_1_1rocblas__zherk__batched__64.html "Interface documentation") | C binding
-858 | [rocblas_cherk_strided_batched](interfacehipfort__rocblas_1_1rocblas__cherk__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-859 | [rocblas_zherk_strided_batched](interfacehipfort__rocblas_1_1rocblas__zherk__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-860 | [rocblas_cherk_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cherk__strided__batched__64.html "Interface documentation") | C binding
-861 | [rocblas_zherk_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zherk__strided__batched__64.html "Interface documentation") | C binding
-862 | [rocblas_cher2k](interfacehipfort__rocblas_1_1rocblas__cher2k.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-863 | [rocblas_zher2k](interfacehipfort__rocblas_1_1rocblas__zher2k.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-864 | [rocblas_cher2k_64](interfacehipfort__rocblas_1_1rocblas__cher2k__64.html "Interface documentation") | C binding
-865 | [rocblas_zher2k_64](interfacehipfort__rocblas_1_1rocblas__zher2k__64.html "Interface documentation") | C binding
-866 | [rocblas_cher2k_batched](interfacehipfort__rocblas_1_1rocblas__cher2k__batched.html "Interface documentation") | C binding
-867 | [rocblas_zher2k_batched](interfacehipfort__rocblas_1_1rocblas__zher2k__batched.html "Interface documentation") | C binding
-868 | [rocblas_cher2k_batched_64](interfacehipfort__rocblas_1_1rocblas__cher2k__batched__64.html "Interface documentation") | C binding
-869 | [rocblas_zher2k_batched_64](interfacehipfort__rocblas_1_1rocblas__zher2k__batched__64.html "Interface documentation") | C binding
-870 | [rocblas_cher2k_strided_batched](interfacehipfort__rocblas_1_1rocblas__cher2k__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-871 | [rocblas_zher2k_strided_batched](interfacehipfort__rocblas_1_1rocblas__zher2k__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-872 | [rocblas_cher2k_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cher2k__strided__batched__64.html "Interface documentation") | C binding
-873 | [rocblas_zher2k_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zher2k__strided__batched__64.html "Interface documentation") | C binding
-874 | [rocblas_cherkx](interfacehipfort__rocblas_1_1rocblas__cherkx.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-875 | [rocblas_zherkx](interfacehipfort__rocblas_1_1rocblas__zherkx.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-876 | [rocblas_cherkx_64](interfacehipfort__rocblas_1_1rocblas__cherkx__64.html "Interface documentation") | C binding
-877 | [rocblas_zherkx_64](interfacehipfort__rocblas_1_1rocblas__zherkx__64.html "Interface documentation") | C binding
-878 | [rocblas_cherkx_batched](interfacehipfort__rocblas_1_1rocblas__cherkx__batched.html "Interface documentation") | C binding
-879 | [rocblas_zherkx_batched](interfacehipfort__rocblas_1_1rocblas__zherkx__batched.html "Interface documentation") | C binding
-880 | [rocblas_cherkx_batched_64](interfacehipfort__rocblas_1_1rocblas__cherkx__batched__64.html "Interface documentation") | C binding
-881 | [rocblas_zherkx_batched_64](interfacehipfort__rocblas_1_1rocblas__zherkx__batched__64.html "Interface documentation") | C binding
-882 | [rocblas_cherkx_strided_batched](interfacehipfort__rocblas_1_1rocblas__cherkx__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-883 | [rocblas_zherkx_strided_batched](interfacehipfort__rocblas_1_1rocblas__zherkx__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-884 | [rocblas_cherkx_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cherkx__strided__batched__64.html "Interface documentation") | C binding
-885 | [rocblas_zherkx_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zherkx__strided__batched__64.html "Interface documentation") | C binding
-886 | [rocblas_ssymm](interfacehipfort__rocblas_1_1rocblas__ssymm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-887 | [rocblas_dsymm](interfacehipfort__rocblas_1_1rocblas__dsymm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-888 | [rocblas_csymm](interfacehipfort__rocblas_1_1rocblas__csymm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-889 | [rocblas_zsymm](interfacehipfort__rocblas_1_1rocblas__zsymm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-890 | [rocblas_ssymm_64](interfacehipfort__rocblas_1_1rocblas__ssymm__64.html "Interface documentation") | C binding
-891 | [rocblas_dsymm_64](interfacehipfort__rocblas_1_1rocblas__dsymm__64.html "Interface documentation") | C binding
-892 | [rocblas_csymm_64](interfacehipfort__rocblas_1_1rocblas__csymm__64.html "Interface documentation") | C binding
-893 | [rocblas_zsymm_64](interfacehipfort__rocblas_1_1rocblas__zsymm__64.html "Interface documentation") | C binding
-894 | [rocblas_ssymm_batched](interfacehipfort__rocblas_1_1rocblas__ssymm__batched.html "Interface documentation") | C binding
-895 | [rocblas_dsymm_batched](interfacehipfort__rocblas_1_1rocblas__dsymm__batched.html "Interface documentation") | C binding
-896 | [rocblas_csymm_batched](interfacehipfort__rocblas_1_1rocblas__csymm__batched.html "Interface documentation") | C binding
-897 | [rocblas_zsymm_batched](interfacehipfort__rocblas_1_1rocblas__zsymm__batched.html "Interface documentation") | C binding
-898 | [rocblas_ssymm_batched_64](interfacehipfort__rocblas_1_1rocblas__ssymm__batched__64.html "Interface documentation") | C binding
-899 | [rocblas_dsymm_batched_64](interfacehipfort__rocblas_1_1rocblas__dsymm__batched__64.html "Interface documentation") | C binding
-900 | [rocblas_csymm_batched_64](interfacehipfort__rocblas_1_1rocblas__csymm__batched__64.html "Interface documentation") | C binding
-901 | [rocblas_zsymm_batched_64](interfacehipfort__rocblas_1_1rocblas__zsymm__batched__64.html "Interface documentation") | C binding
-902 | [rocblas_ssymm_strided_batched](interfacehipfort__rocblas_1_1rocblas__ssymm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-903 | [rocblas_dsymm_strided_batched](interfacehipfort__rocblas_1_1rocblas__dsymm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-904 | [rocblas_csymm_strided_batched](interfacehipfort__rocblas_1_1rocblas__csymm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-905 | [rocblas_zsymm_strided_batched](interfacehipfort__rocblas_1_1rocblas__zsymm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-906 | [rocblas_ssymm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ssymm__strided__batched__64.html "Interface documentation") | C binding
-907 | [rocblas_dsymm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dsymm__strided__batched__64.html "Interface documentation") | C binding
-908 | [rocblas_csymm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__csymm__strided__batched__64.html "Interface documentation") | C binding
-909 | [rocblas_zsymm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zsymm__strided__batched__64.html "Interface documentation") | C binding
-910 | [rocblas_ssyrk](interfacehipfort__rocblas_1_1rocblas__ssyrk.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-911 | [rocblas_dsyrk](interfacehipfort__rocblas_1_1rocblas__dsyrk.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-912 | [rocblas_csyrk](interfacehipfort__rocblas_1_1rocblas__csyrk.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-913 | [rocblas_zsyrk](interfacehipfort__rocblas_1_1rocblas__zsyrk.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-914 | [rocblas_ssyrk_64](interfacehipfort__rocblas_1_1rocblas__ssyrk__64.html "Interface documentation") | C binding
-915 | [rocblas_dsyrk_64](interfacehipfort__rocblas_1_1rocblas__dsyrk__64.html "Interface documentation") | C binding
-916 | [rocblas_csyrk_64](interfacehipfort__rocblas_1_1rocblas__csyrk__64.html "Interface documentation") | C binding
-917 | [rocblas_zsyrk_64](interfacehipfort__rocblas_1_1rocblas__zsyrk__64.html "Interface documentation") | C binding
-918 | [rocblas_ssyrk_batched](interfacehipfort__rocblas_1_1rocblas__ssyrk__batched.html "Interface documentation") | C binding
-919 | [rocblas_dsyrk_batched](interfacehipfort__rocblas_1_1rocblas__dsyrk__batched.html "Interface documentation") | C binding
-920 | [rocblas_csyrk_batched](interfacehipfort__rocblas_1_1rocblas__csyrk__batched.html "Interface documentation") | C binding
-921 | [rocblas_zsyrk_batched](interfacehipfort__rocblas_1_1rocblas__zsyrk__batched.html "Interface documentation") | C binding
-922 | [rocblas_ssyrk_batched_64](interfacehipfort__rocblas_1_1rocblas__ssyrk__batched__64.html "Interface documentation") | C binding
-923 | [rocblas_dsyrk_batched_64](interfacehipfort__rocblas_1_1rocblas__dsyrk__batched__64.html "Interface documentation") | C binding
-924 | [rocblas_csyrk_batched_64](interfacehipfort__rocblas_1_1rocblas__csyrk__batched__64.html "Interface documentation") | C binding
-925 | [rocblas_zsyrk_batched_64](interfacehipfort__rocblas_1_1rocblas__zsyrk__batched__64.html "Interface documentation") | C binding
-926 | [rocblas_ssyrk_strided_batched](interfacehipfort__rocblas_1_1rocblas__ssyrk__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-927 | [rocblas_dsyrk_strided_batched](interfacehipfort__rocblas_1_1rocblas__dsyrk__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-928 | [rocblas_csyrk_strided_batched](interfacehipfort__rocblas_1_1rocblas__csyrk__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-929 | [rocblas_zsyrk_strided_batched](interfacehipfort__rocblas_1_1rocblas__zsyrk__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-930 | [rocblas_ssyrk_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ssyrk__strided__batched__64.html "Interface documentation") | C binding
-931 | [rocblas_dsyrk_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dsyrk__strided__batched__64.html "Interface documentation") | C binding
-932 | [rocblas_csyrk_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__csyrk__strided__batched__64.html "Interface documentation") | C binding
-933 | [rocblas_zsyrk_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zsyrk__strided__batched__64.html "Interface documentation") | C binding
-934 | [rocblas_ssyr2k](interfacehipfort__rocblas_1_1rocblas__ssyr2k.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-935 | [rocblas_dsyr2k](interfacehipfort__rocblas_1_1rocblas__dsyr2k.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-936 | [rocblas_csyr2k](interfacehipfort__rocblas_1_1rocblas__csyr2k.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-937 | [rocblas_zsyr2k](interfacehipfort__rocblas_1_1rocblas__zsyr2k.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-938 | [rocblas_ssyr2k_64](interfacehipfort__rocblas_1_1rocblas__ssyr2k__64.html "Interface documentation") | C binding
-939 | [rocblas_dsyr2k_64](interfacehipfort__rocblas_1_1rocblas__dsyr2k__64.html "Interface documentation") | C binding
-940 | [rocblas_csyr2k_64](interfacehipfort__rocblas_1_1rocblas__csyr2k__64.html "Interface documentation") | C binding
-941 | [rocblas_zsyr2k_64](interfacehipfort__rocblas_1_1rocblas__zsyr2k__64.html "Interface documentation") | C binding
-942 | [rocblas_ssyr2k_batched](interfacehipfort__rocblas_1_1rocblas__ssyr2k__batched.html "Interface documentation") | C binding
-943 | [rocblas_dsyr2k_batched](interfacehipfort__rocblas_1_1rocblas__dsyr2k__batched.html "Interface documentation") | C binding
-944 | [rocblas_csyr2k_batched](interfacehipfort__rocblas_1_1rocblas__csyr2k__batched.html "Interface documentation") | C binding
-945 | [rocblas_zsyr2k_batched](interfacehipfort__rocblas_1_1rocblas__zsyr2k__batched.html "Interface documentation") | C binding
-946 | [rocblas_ssyr2k_batched_64](interfacehipfort__rocblas_1_1rocblas__ssyr2k__batched__64.html "Interface documentation") | C binding
-947 | [rocblas_dsyr2k_batched_64](interfacehipfort__rocblas_1_1rocblas__dsyr2k__batched__64.html "Interface documentation") | C binding
-948 | [rocblas_csyr2k_batched_64](interfacehipfort__rocblas_1_1rocblas__csyr2k__batched__64.html "Interface documentation") | C binding
-949 | [rocblas_zsyr2k_batched_64](interfacehipfort__rocblas_1_1rocblas__zsyr2k__batched__64.html "Interface documentation") | C binding
-950 | [rocblas_ssyr2k_strided_batched](interfacehipfort__rocblas_1_1rocblas__ssyr2k__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-951 | [rocblas_dsyr2k_strided_batched](interfacehipfort__rocblas_1_1rocblas__dsyr2k__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-952 | [rocblas_csyr2k_strided_batched](interfacehipfort__rocblas_1_1rocblas__csyr2k__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-953 | [rocblas_zsyr2k_strided_batched](interfacehipfort__rocblas_1_1rocblas__zsyr2k__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-954 | [rocblas_ssyr2k_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ssyr2k__strided__batched__64.html "Interface documentation") | C binding
-955 | [rocblas_dsyr2k_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dsyr2k__strided__batched__64.html "Interface documentation") | C binding
-956 | [rocblas_csyr2k_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__csyr2k__strided__batched__64.html "Interface documentation") | C binding
-957 | [rocblas_zsyr2k_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zsyr2k__strided__batched__64.html "Interface documentation") | C binding
-958 | [rocblas_ssyrkx](interfacehipfort__rocblas_1_1rocblas__ssyrkx.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-959 | [rocblas_dsyrkx](interfacehipfort__rocblas_1_1rocblas__dsyrkx.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-960 | [rocblas_csyrkx](interfacehipfort__rocblas_1_1rocblas__csyrkx.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-961 | [rocblas_zsyrkx](interfacehipfort__rocblas_1_1rocblas__zsyrkx.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-962 | [rocblas_ssyrkx_64](interfacehipfort__rocblas_1_1rocblas__ssyrkx__64.html "Interface documentation") | C binding
-963 | [rocblas_dsyrkx_64](interfacehipfort__rocblas_1_1rocblas__dsyrkx__64.html "Interface documentation") | C binding
-964 | [rocblas_csyrkx_64](interfacehipfort__rocblas_1_1rocblas__csyrkx__64.html "Interface documentation") | C binding
-965 | [rocblas_zsyrkx_64](interfacehipfort__rocblas_1_1rocblas__zsyrkx__64.html "Interface documentation") | C binding
-966 | [rocblas_ssyrkx_batched](interfacehipfort__rocblas_1_1rocblas__ssyrkx__batched.html "Interface documentation") | C binding
-967 | [rocblas_dsyrkx_batched](interfacehipfort__rocblas_1_1rocblas__dsyrkx__batched.html "Interface documentation") | C binding
-968 | [rocblas_csyrkx_batched](interfacehipfort__rocblas_1_1rocblas__csyrkx__batched.html "Interface documentation") | C binding
-969 | [rocblas_zsyrkx_batched](interfacehipfort__rocblas_1_1rocblas__zsyrkx__batched.html "Interface documentation") | C binding
-970 | [rocblas_ssyrkx_batched_64](interfacehipfort__rocblas_1_1rocblas__ssyrkx__batched__64.html "Interface documentation") | C binding
-971 | [rocblas_dsyrkx_batched_64](interfacehipfort__rocblas_1_1rocblas__dsyrkx__batched__64.html "Interface documentation") | C binding
-972 | [rocblas_csyrkx_batched_64](interfacehipfort__rocblas_1_1rocblas__csyrkx__batched__64.html "Interface documentation") | C binding
-973 | [rocblas_zsyrkx_batched_64](interfacehipfort__rocblas_1_1rocblas__zsyrkx__batched__64.html "Interface documentation") | C binding
-974 | [rocblas_ssyrkx_strided_batched](interfacehipfort__rocblas_1_1rocblas__ssyrkx__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-975 | [rocblas_dsyrkx_strided_batched](interfacehipfort__rocblas_1_1rocblas__dsyrkx__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-976 | [rocblas_csyrkx_strided_batched](interfacehipfort__rocblas_1_1rocblas__csyrkx__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-977 | [rocblas_zsyrkx_strided_batched](interfacehipfort__rocblas_1_1rocblas__zsyrkx__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-978 | [rocblas_ssyrkx_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ssyrkx__strided__batched__64.html "Interface documentation") | C binding
-979 | [rocblas_dsyrkx_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dsyrkx__strided__batched__64.html "Interface documentation") | C binding
-980 | [rocblas_csyrkx_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__csyrkx__strided__batched__64.html "Interface documentation") | C binding
-981 | [rocblas_zsyrkx_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zsyrkx__strided__batched__64.html "Interface documentation") | C binding
-982 | [rocblas_strmm](interfacehipfort__rocblas_1_1rocblas__strmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-983 | [rocblas_dtrmm](interfacehipfort__rocblas_1_1rocblas__dtrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-984 | [rocblas_ctrmm](interfacehipfort__rocblas_1_1rocblas__ctrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-985 | [rocblas_ztrmm](interfacehipfort__rocblas_1_1rocblas__ztrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-986 | [rocblas_strmm_64](interfacehipfort__rocblas_1_1rocblas__strmm__64.html "Interface documentation") | C binding
-987 | [rocblas_dtrmm_64](interfacehipfort__rocblas_1_1rocblas__dtrmm__64.html "Interface documentation") | C binding
-988 | [rocblas_ctrmm_64](interfacehipfort__rocblas_1_1rocblas__ctrmm__64.html "Interface documentation") | C binding
-989 | [rocblas_ztrmm_64](interfacehipfort__rocblas_1_1rocblas__ztrmm__64.html "Interface documentation") | C binding
-990 | [rocblas_strmm_batched](interfacehipfort__rocblas_1_1rocblas__strmm__batched.html "Interface documentation") | C binding
-991 | [rocblas_dtrmm_batched](interfacehipfort__rocblas_1_1rocblas__dtrmm__batched.html "Interface documentation") | C binding
-992 | [rocblas_ctrmm_batched](interfacehipfort__rocblas_1_1rocblas__ctrmm__batched.html "Interface documentation") | C binding
-993 | [rocblas_ztrmm_batched](interfacehipfort__rocblas_1_1rocblas__ztrmm__batched.html "Interface documentation") | C binding
-994 | [rocblas_strmm_batched_64](interfacehipfort__rocblas_1_1rocblas__strmm__batched__64.html "Interface documentation") | C binding
-995 | [rocblas_dtrmm_batched_64](interfacehipfort__rocblas_1_1rocblas__dtrmm__batched__64.html "Interface documentation") | C binding
-996 | [rocblas_ctrmm_batched_64](interfacehipfort__rocblas_1_1rocblas__ctrmm__batched__64.html "Interface documentation") | C binding
-997 | [rocblas_ztrmm_batched_64](interfacehipfort__rocblas_1_1rocblas__ztrmm__batched__64.html "Interface documentation") | C binding
-998 | [rocblas_strmm_strided_batched](interfacehipfort__rocblas_1_1rocblas__strmm__strided__batched.html "Interface documentation") | C binding
-999 | [rocblas_dtrmm_strided_batched](interfacehipfort__rocblas_1_1rocblas__dtrmm__strided__batched.html "Interface documentation") | C binding
-1000 | [rocblas_ctrmm_strided_batched](interfacehipfort__rocblas_1_1rocblas__ctrmm__strided__batched.html "Interface documentation") | C binding
-1001 | [rocblas_ztrmm_strided_batched](interfacehipfort__rocblas_1_1rocblas__ztrmm__strided__batched.html "Interface documentation") | C binding
-1002 | [rocblas_strmm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__strmm__strided__batched__64.html "Interface documentation") | C binding
-1003 | [rocblas_dtrmm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dtrmm__strided__batched__64.html "Interface documentation") | C binding
-1004 | [rocblas_ctrmm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ctrmm__strided__batched__64.html "Interface documentation") | C binding
-1005 | [rocblas_ztrmm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ztrmm__strided__batched__64.html "Interface documentation") | C binding
-1006 | [rocblas_strtri](interfacehipfort__rocblas_1_1rocblas__strtri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1007 | [rocblas_dtrtri](interfacehipfort__rocblas_1_1rocblas__dtrtri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1008 | [rocblas_ctrtri](interfacehipfort__rocblas_1_1rocblas__ctrtri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1009 | [rocblas_ztrtri](interfacehipfort__rocblas_1_1rocblas__ztrtri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1010 | [rocblas_strtri_batched](interfacehipfort__rocblas_1_1rocblas__strtri__batched.html "Interface documentation") | C binding
-1011 | [rocblas_dtrtri_batched](interfacehipfort__rocblas_1_1rocblas__dtrtri__batched.html "Interface documentation") | C binding
-1012 | [rocblas_ctrtri_batched](interfacehipfort__rocblas_1_1rocblas__ctrtri__batched.html "Interface documentation") | C binding
-1013 | [rocblas_ztrtri_batched](interfacehipfort__rocblas_1_1rocblas__ztrtri__batched.html "Interface documentation") | C binding
-1014 | [rocblas_strtri_strided_batched](interfacehipfort__rocblas_1_1rocblas__strtri__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1015 | [rocblas_dtrtri_strided_batched](interfacehipfort__rocblas_1_1rocblas__dtrtri__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1016 | [rocblas_ctrtri_strided_batched](interfacehipfort__rocblas_1_1rocblas__ctrtri__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1017 | [rocblas_ztrtri_strided_batched](interfacehipfort__rocblas_1_1rocblas__ztrtri__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1018 | [rocblas_strsm](interfacehipfort__rocblas_1_1rocblas__strsm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1019 | [rocblas_dtrsm](interfacehipfort__rocblas_1_1rocblas__dtrsm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1020 | [rocblas_ctrsm](interfacehipfort__rocblas_1_1rocblas__ctrsm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1021 | [rocblas_ztrsm](interfacehipfort__rocblas_1_1rocblas__ztrsm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1022 | [rocblas_strsm_64](interfacehipfort__rocblas_1_1rocblas__strsm__64.html "Interface documentation") | C binding
-1023 | [rocblas_dtrsm_64](interfacehipfort__rocblas_1_1rocblas__dtrsm__64.html "Interface documentation") | C binding
-1024 | [rocblas_ctrsm_64](interfacehipfort__rocblas_1_1rocblas__ctrsm__64.html "Interface documentation") | C binding
-1025 | [rocblas_ztrsm_64](interfacehipfort__rocblas_1_1rocblas__ztrsm__64.html "Interface documentation") | C binding
-1026 | [rocblas_strsm_batched](interfacehipfort__rocblas_1_1rocblas__strsm__batched.html "Interface documentation") | C binding
-1027 | [rocblas_dtrsm_batched](interfacehipfort__rocblas_1_1rocblas__dtrsm__batched.html "Interface documentation") | C binding
-1028 | [rocblas_ctrsm_batched](interfacehipfort__rocblas_1_1rocblas__ctrsm__batched.html "Interface documentation") | C binding
-1029 | [rocblas_ztrsm_batched](interfacehipfort__rocblas_1_1rocblas__ztrsm__batched.html "Interface documentation") | C binding
-1030 | [rocblas_strsm_batched_64](interfacehipfort__rocblas_1_1rocblas__strsm__batched__64.html "Interface documentation") | C binding
-1031 | [rocblas_dtrsm_batched_64](interfacehipfort__rocblas_1_1rocblas__dtrsm__batched__64.html "Interface documentation") | C binding
-1032 | [rocblas_ctrsm_batched_64](interfacehipfort__rocblas_1_1rocblas__ctrsm__batched__64.html "Interface documentation") | C binding
-1033 | [rocblas_ztrsm_batched_64](interfacehipfort__rocblas_1_1rocblas__ztrsm__batched__64.html "Interface documentation") | C binding
-1034 | [rocblas_strsm_strided_batched](interfacehipfort__rocblas_1_1rocblas__strsm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1035 | [rocblas_dtrsm_strided_batched](interfacehipfort__rocblas_1_1rocblas__dtrsm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1036 | [rocblas_ctrsm_strided_batched](interfacehipfort__rocblas_1_1rocblas__ctrsm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1037 | [rocblas_ztrsm_strided_batched](interfacehipfort__rocblas_1_1rocblas__ztrsm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1038 | [rocblas_strsm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__strsm__strided__batched__64.html "Interface documentation") | C binding
-1039 | [rocblas_dtrsm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dtrsm__strided__batched__64.html "Interface documentation") | C binding
-1040 | [rocblas_ctrsm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ctrsm__strided__batched__64.html "Interface documentation") | C binding
-1041 | [rocblas_ztrsm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ztrsm__strided__batched__64.html "Interface documentation") | C binding
-1042 | [rocblas_sgemm](interfacehipfort__rocblas_1_1rocblas__sgemm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1043 | [rocblas_dgemm](interfacehipfort__rocblas_1_1rocblas__dgemm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1044 | [rocblas_hgemm](interfacehipfort__rocblas_1_1rocblas__hgemm.html "Interface documentation") | C binding
-1045 | [rocblas_cgemm](interfacehipfort__rocblas_1_1rocblas__cgemm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1046 | [rocblas_zgemm](interfacehipfort__rocblas_1_1rocblas__zgemm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1047 | [rocblas_sgemm_64](interfacehipfort__rocblas_1_1rocblas__sgemm__64.html "Interface documentation") | C binding
-1048 | [rocblas_dgemm_64](interfacehipfort__rocblas_1_1rocblas__dgemm__64.html "Interface documentation") | C binding
-1049 | [rocblas_hgemm_64](interfacehipfort__rocblas_1_1rocblas__hgemm__64.html "Interface documentation") | C binding
-1050 | [rocblas_cgemm_64](interfacehipfort__rocblas_1_1rocblas__cgemm__64.html "Interface documentation") | C binding
-1051 | [rocblas_zgemm_64](interfacehipfort__rocblas_1_1rocblas__zgemm__64.html "Interface documentation") | C binding
-1052 | [rocblas_sgemm_batched](interfacehipfort__rocblas_1_1rocblas__sgemm__batched.html "Interface documentation") | C binding
-1053 | [rocblas_dgemm_batched](interfacehipfort__rocblas_1_1rocblas__dgemm__batched.html "Interface documentation") | C binding
-1054 | [rocblas_hgemm_batched](interfacehipfort__rocblas_1_1rocblas__hgemm__batched.html "Interface documentation") | C binding
-1055 | [rocblas_cgemm_batched](interfacehipfort__rocblas_1_1rocblas__cgemm__batched.html "Interface documentation") | C binding
-1056 | [rocblas_zgemm_batched](interfacehipfort__rocblas_1_1rocblas__zgemm__batched.html "Interface documentation") | C binding
-1057 | [rocblas_sgemm_batched_64](interfacehipfort__rocblas_1_1rocblas__sgemm__batched__64.html "Interface documentation") | C binding
-1058 | [rocblas_dgemm_batched_64](interfacehipfort__rocblas_1_1rocblas__dgemm__batched__64.html "Interface documentation") | C binding
-1059 | [rocblas_hgemm_batched_64](interfacehipfort__rocblas_1_1rocblas__hgemm__batched__64.html "Interface documentation") | C binding
-1060 | [rocblas_cgemm_batched_64](interfacehipfort__rocblas_1_1rocblas__cgemm__batched__64.html "Interface documentation") | C binding
-1061 | [rocblas_zgemm_batched_64](interfacehipfort__rocblas_1_1rocblas__zgemm__batched__64.html "Interface documentation") | C binding
-1062 | [rocblas_sgemm_strided_batched](interfacehipfort__rocblas_1_1rocblas__sgemm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1063 | [rocblas_dgemm_strided_batched](interfacehipfort__rocblas_1_1rocblas__dgemm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1064 | [rocblas_hgemm_strided_batched](interfacehipfort__rocblas_1_1rocblas__hgemm__strided__batched.html "Interface documentation") | C binding
-1065 | [rocblas_cgemm_strided_batched](interfacehipfort__rocblas_1_1rocblas__cgemm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1066 | [rocblas_zgemm_strided_batched](interfacehipfort__rocblas_1_1rocblas__zgemm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1067 | [rocblas_sgemm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sgemm__strided__batched__64.html "Interface documentation") | C binding
-1068 | [rocblas_dgemm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dgemm__strided__batched__64.html "Interface documentation") | C binding
-1069 | [rocblas_hgemm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__hgemm__strided__batched__64.html "Interface documentation") | C binding
-1070 | [rocblas_cgemm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cgemm__strided__batched__64.html "Interface documentation") | C binding
-1071 | [rocblas_zgemm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zgemm__strided__batched__64.html "Interface documentation") | C binding
-1072 | [rocblas_sdgmm](interfacehipfort__rocblas_1_1rocblas__sdgmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1073 | [rocblas_ddgmm](interfacehipfort__rocblas_1_1rocblas__ddgmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1074 | [rocblas_cdgmm](interfacehipfort__rocblas_1_1rocblas__cdgmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1075 | [rocblas_zdgmm](interfacehipfort__rocblas_1_1rocblas__zdgmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1076 | [rocblas_sdgmm_64](interfacehipfort__rocblas_1_1rocblas__sdgmm__64.html "Interface documentation") | C binding
-1077 | [rocblas_ddgmm_64](interfacehipfort__rocblas_1_1rocblas__ddgmm__64.html "Interface documentation") | C binding
-1078 | [rocblas_cdgmm_64](interfacehipfort__rocblas_1_1rocblas__cdgmm__64.html "Interface documentation") | C binding
-1079 | [rocblas_zdgmm_64](interfacehipfort__rocblas_1_1rocblas__zdgmm__64.html "Interface documentation") | C binding
-1080 | [rocblas_sdgmm_batched](interfacehipfort__rocblas_1_1rocblas__sdgmm__batched.html "Interface documentation") | C binding
-1081 | [rocblas_ddgmm_batched](interfacehipfort__rocblas_1_1rocblas__ddgmm__batched.html "Interface documentation") | C binding
-1082 | [rocblas_cdgmm_batched](interfacehipfort__rocblas_1_1rocblas__cdgmm__batched.html "Interface documentation") | C binding
-1083 | [rocblas_zdgmm_batched](interfacehipfort__rocblas_1_1rocblas__zdgmm__batched.html "Interface documentation") | C binding
-1084 | [rocblas_sdgmm_batched_64](interfacehipfort__rocblas_1_1rocblas__sdgmm__batched__64.html "Interface documentation") | C binding
-1085 | [rocblas_ddgmm_batched_64](interfacehipfort__rocblas_1_1rocblas__ddgmm__batched__64.html "Interface documentation") | C binding
-1086 | [rocblas_cdgmm_batched_64](interfacehipfort__rocblas_1_1rocblas__cdgmm__batched__64.html "Interface documentation") | C binding
-1087 | [rocblas_zdgmm_batched_64](interfacehipfort__rocblas_1_1rocblas__zdgmm__batched__64.html "Interface documentation") | C binding
-1088 | [rocblas_sdgmm_strided_batched](interfacehipfort__rocblas_1_1rocblas__sdgmm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1089 | [rocblas_ddgmm_strided_batched](interfacehipfort__rocblas_1_1rocblas__ddgmm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1090 | [rocblas_cdgmm_strided_batched](interfacehipfort__rocblas_1_1rocblas__cdgmm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1091 | [rocblas_zdgmm_strided_batched](interfacehipfort__rocblas_1_1rocblas__zdgmm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1092 | [rocblas_sdgmm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sdgmm__strided__batched__64.html "Interface documentation") | C binding
-1093 | [rocblas_ddgmm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ddgmm__strided__batched__64.html "Interface documentation") | C binding
-1094 | [rocblas_cdgmm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cdgmm__strided__batched__64.html "Interface documentation") | C binding
-1095 | [rocblas_zdgmm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zdgmm__strided__batched__64.html "Interface documentation") | C binding
-1096 | [rocblas_sgeam](interfacehipfort__rocblas_1_1rocblas__sgeam.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1097 | [rocblas_dgeam](interfacehipfort__rocblas_1_1rocblas__dgeam.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1098 | [rocblas_cgeam](interfacehipfort__rocblas_1_1rocblas__cgeam.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1099 | [rocblas_zgeam](interfacehipfort__rocblas_1_1rocblas__zgeam.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1100 | [rocblas_sgeam_64](interfacehipfort__rocblas_1_1rocblas__sgeam__64.html "Interface documentation") | C binding
-1101 | [rocblas_dgeam_64](interfacehipfort__rocblas_1_1rocblas__dgeam__64.html "Interface documentation") | C binding
-1102 | [rocblas_cgeam_64](interfacehipfort__rocblas_1_1rocblas__cgeam__64.html "Interface documentation") | C binding
-1103 | [rocblas_zgeam_64](interfacehipfort__rocblas_1_1rocblas__zgeam__64.html "Interface documentation") | C binding
-1104 | [rocblas_sgeam_batched](interfacehipfort__rocblas_1_1rocblas__sgeam__batched.html "Interface documentation") | C binding
-1105 | [rocblas_dgeam_batched](interfacehipfort__rocblas_1_1rocblas__dgeam__batched.html "Interface documentation") | C binding
-1106 | [rocblas_cgeam_batched](interfacehipfort__rocblas_1_1rocblas__cgeam__batched.html "Interface documentation") | C binding
-1107 | [rocblas_zgeam_batched](interfacehipfort__rocblas_1_1rocblas__zgeam__batched.html "Interface documentation") | C binding
-1108 | [rocblas_sgeam_batched_64](interfacehipfort__rocblas_1_1rocblas__sgeam__batched__64.html "Interface documentation") | C binding
-1109 | [rocblas_dgeam_batched_64](interfacehipfort__rocblas_1_1rocblas__dgeam__batched__64.html "Interface documentation") | C binding
-1110 | [rocblas_cgeam_batched_64](interfacehipfort__rocblas_1_1rocblas__cgeam__batched__64.html "Interface documentation") | C binding
-1111 | [rocblas_zgeam_batched_64](interfacehipfort__rocblas_1_1rocblas__zgeam__batched__64.html "Interface documentation") | C binding
-1112 | [rocblas_sgeam_strided_batched](interfacehipfort__rocblas_1_1rocblas__sgeam__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1113 | [rocblas_dgeam_strided_batched](interfacehipfort__rocblas_1_1rocblas__dgeam__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1114 | [rocblas_cgeam_strided_batched](interfacehipfort__rocblas_1_1rocblas__cgeam__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1115 | [rocblas_zgeam_strided_batched](interfacehipfort__rocblas_1_1rocblas__zgeam__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1116 | [rocblas_sgeam_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sgeam__strided__batched__64.html "Interface documentation") | C binding
-1117 | [rocblas_dgeam_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dgeam__strided__batched__64.html "Interface documentation") | C binding
-1118 | [rocblas_cgeam_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cgeam__strided__batched__64.html "Interface documentation") | C binding
-1119 | [rocblas_zgeam_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zgeam__strided__batched__64.html "Interface documentation") | C binding
-1120 | [rocblas_gemm_ex](interfacehipfort__rocblas_1_1rocblas__gemm__ex.html "Interface documentation") | C binding
-1121 | [rocblas_gemm_ex_64](interfacehipfort__rocblas_1_1rocblas__gemm__ex__64.html "Interface documentation") | C binding
-1122 | [rocblas_gemm_batched_ex](interfacehipfort__rocblas_1_1rocblas__gemm__batched__ex.html "Interface documentation") | C binding
-1123 | [rocblas_gemm_batched_ex_64](interfacehipfort__rocblas_1_1rocblas__gemm__batched__ex__64.html "Interface documentation") | C binding
-1124 | [rocblas_gemm_strided_batched_ex](interfacehipfort__rocblas_1_1rocblas__gemm__strided__batched__ex.html "Interface documentation") | C binding
-1125 | [rocblas_gemm_strided_batched_ex_64](interfacehipfort__rocblas_1_1rocblas__gemm__strided__batched__ex__64.html "Interface documentation") | C binding
-1126 | [rocblas_sgemmt](interfacehipfort__rocblas_1_1rocblas__sgemmt.html "Interface documentation") | C binding
-1127 | [rocblas_dgemmt](interfacehipfort__rocblas_1_1rocblas__dgemmt.html "Interface documentation") | C binding
-1128 | [rocblas_cgemmt](interfacehipfort__rocblas_1_1rocblas__cgemmt.html "Interface documentation") | C binding
-1129 | [rocblas_zgemmt](interfacehipfort__rocblas_1_1rocblas__zgemmt.html "Interface documentation") | C binding
-1130 | [rocblas_sgemmt_64](interfacehipfort__rocblas_1_1rocblas__sgemmt__64.html "Interface documentation") | C binding
-1131 | [rocblas_dgemmt_64](interfacehipfort__rocblas_1_1rocblas__dgemmt__64.html "Interface documentation") | C binding
-1132 | [rocblas_cgemmt_64](interfacehipfort__rocblas_1_1rocblas__cgemmt__64.html "Interface documentation") | C binding
-1133 | [rocblas_zgemmt_64](interfacehipfort__rocblas_1_1rocblas__zgemmt__64.html "Interface documentation") | C binding
-1134 | [rocblas_sgemmt_batched](interfacehipfort__rocblas_1_1rocblas__sgemmt__batched.html "Interface documentation") | C binding
-1135 | [rocblas_dgemmt_batched](interfacehipfort__rocblas_1_1rocblas__dgemmt__batched.html "Interface documentation") | C binding
-1136 | [rocblas_cgemmt_batched](interfacehipfort__rocblas_1_1rocblas__cgemmt__batched.html "Interface documentation") | C binding
-1137 | [rocblas_zgemmt_batched](interfacehipfort__rocblas_1_1rocblas__zgemmt__batched.html "Interface documentation") | C binding
-1138 | [rocblas_sgemmt_batched_64](interfacehipfort__rocblas_1_1rocblas__sgemmt__batched__64.html "Interface documentation") | C binding
-1139 | [rocblas_dgemmt_batched_64](interfacehipfort__rocblas_1_1rocblas__dgemmt__batched__64.html "Interface documentation") | C binding
-1140 | [rocblas_cgemmt_batched_64](interfacehipfort__rocblas_1_1rocblas__cgemmt__batched__64.html "Interface documentation") | C binding
-1141 | [rocblas_zgemmt_batched_64](interfacehipfort__rocblas_1_1rocblas__zgemmt__batched__64.html "Interface documentation") | C binding
-1142 | [rocblas_sgemmt_strided_batched](interfacehipfort__rocblas_1_1rocblas__sgemmt__strided__batched.html "Interface documentation") | C binding
-1143 | [rocblas_dgemmt_strided_batched](interfacehipfort__rocblas_1_1rocblas__dgemmt__strided__batched.html "Interface documentation") | C binding
-1144 | [rocblas_cgemmt_strided_batched](interfacehipfort__rocblas_1_1rocblas__cgemmt__strided__batched.html "Interface documentation") | C binding
-1145 | [rocblas_zgemmt_strided_batched](interfacehipfort__rocblas_1_1rocblas__zgemmt__strided__batched.html "Interface documentation") | C binding
-1146 | [rocblas_sgemmt_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sgemmt__strided__batched__64.html "Interface documentation") | C binding
-1147 | [rocblas_dgemmt_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dgemmt__strided__batched__64.html "Interface documentation") | C binding
-1148 | [rocblas_cgemmt_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cgemmt__strided__batched__64.html "Interface documentation") | C binding
-1149 | [rocblas_zgemmt_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zgemmt__strided__batched__64.html "Interface documentation") | C binding
-1150 | [rocblas_geam_ex](interfacehipfort__rocblas_1_1rocblas__geam__ex.html "Interface documentation") | C binding
-1151 | [rocblas_trsm_ex](interfacehipfort__rocblas_1_1rocblas__trsm__ex.html "Interface documentation") | C binding
-1152 | [rocblas_trsm_batched_ex](interfacehipfort__rocblas_1_1rocblas__trsm__batched__ex.html "Interface documentation") | C binding
-1153 | [rocblas_trsm_strided_batched_ex](interfacehipfort__rocblas_1_1rocblas__trsm__strided__batched__ex.html "Interface documentation") | C binding
-1154 | [rocblas_syrk_ex](interfacehipfort__rocblas_1_1rocblas__syrk__ex.html "Interface documentation") | C binding
-1155 | [rocblas_herk_ex](interfacehipfort__rocblas_1_1rocblas__herk__ex.html "Interface documentation") | C binding
-1156 | [rocblas_axpy_ex](interfacehipfort__rocblas_1_1rocblas__axpy__ex.html "Interface documentation") | C binding
-1157 | [rocblas_axpy_ex_64](interfacehipfort__rocblas_1_1rocblas__axpy__ex__64.html "Interface documentation") | C binding
-1158 | [rocblas_axpy_batched_ex](interfacehipfort__rocblas_1_1rocblas__axpy__batched__ex.html "Interface documentation") | C binding
-1159 | [rocblas_axpy_batched_ex_64](interfacehipfort__rocblas_1_1rocblas__axpy__batched__ex__64.html "Interface documentation") | C binding
-1160 | [rocblas_axpy_strided_batched_ex](interfacehipfort__rocblas_1_1rocblas__axpy__strided__batched__ex.html "Interface documentation") | C binding
-1161 | [rocblas_axpy_strided_batched_ex_64](interfacehipfort__rocblas_1_1rocblas__axpy__strided__batched__ex__64.html "Interface documentation") | C binding
-1162 | [rocblas_dot_ex](interfacehipfort__rocblas_1_1rocblas__dot__ex.html "Interface documentation") | C binding
-1163 | [rocblas_dotc_ex](interfacehipfort__rocblas_1_1rocblas__dotc__ex.html "Interface documentation") | C binding
-1164 | [rocblas_dot_ex_64](interfacehipfort__rocblas_1_1rocblas__dot__ex__64.html "Interface documentation") | C binding
-1165 | [rocblas_dotc_ex_64](interfacehipfort__rocblas_1_1rocblas__dotc__ex__64.html "Interface documentation") | C binding
-1166 | [rocblas_dot_batched_ex](interfacehipfort__rocblas_1_1rocblas__dot__batched__ex.html "Interface documentation") | C binding
-1167 | [rocblas_dotc_batched_ex](interfacehipfort__rocblas_1_1rocblas__dotc__batched__ex.html "Interface documentation") | C binding
-1168 | [rocblas_dot_batched_ex_64](interfacehipfort__rocblas_1_1rocblas__dot__batched__ex__64.html "Interface documentation") | C binding
-1169 | [rocblas_dotc_batched_ex_64](interfacehipfort__rocblas_1_1rocblas__dotc__batched__ex__64.html "Interface documentation") | C binding
-1170 | [rocblas_dot_strided_batched_ex](interfacehipfort__rocblas_1_1rocblas__dot__strided__batched__ex.html "Interface documentation") | C binding
-1171 | [rocblas_dot_strided_batched_ex_64](interfacehipfort__rocblas_1_1rocblas__dot__strided__batched__ex__64.html "Interface documentation") | C binding
-1172 | [rocblas_dotc_strided_batched_ex](interfacehipfort__rocblas_1_1rocblas__dotc__strided__batched__ex.html "Interface documentation") | C binding
-1173 | [rocblas_dotc_strided_batched_ex_64](interfacehipfort__rocblas_1_1rocblas__dotc__strided__batched__ex__64.html "Interface documentation") | C binding
-1174 | [rocblas_nrm2_ex](interfacehipfort__rocblas_1_1rocblas__nrm2__ex.html "Interface documentation") | C binding
-1175 | [rocblas_nrm2_ex_64](interfacehipfort__rocblas_1_1rocblas__nrm2__ex__64.html "Interface documentation") | C binding
-1176 | [rocblas_nrm2_batched_ex](interfacehipfort__rocblas_1_1rocblas__nrm2__batched__ex.html "Interface documentation") | C binding
-1177 | [rocblas_nrm2_batched_ex_64](interfacehipfort__rocblas_1_1rocblas__nrm2__batched__ex__64.html "Interface documentation") | C binding
-1178 | [rocblas_nrm2_strided_batched_ex](interfacehipfort__rocblas_1_1rocblas__nrm2__strided__batched__ex.html "Interface documentation") | C binding
-1179 | [rocblas_nrm2_strided_batched_ex_64](interfacehipfort__rocblas_1_1rocblas__nrm2__strided__batched__ex__64.html "Interface documentation") | C binding
-1180 | [rocblas_rot_ex](interfacehipfort__rocblas_1_1rocblas__rot__ex.html "Interface documentation") | C binding
-1181 | [rocblas_rot_ex_64](interfacehipfort__rocblas_1_1rocblas__rot__ex__64.html "Interface documentation") | C binding
-1182 | [rocblas_rot_batched_ex](interfacehipfort__rocblas_1_1rocblas__rot__batched__ex.html "Interface documentation") | C binding
-1183 | [rocblas_rot_batched_ex_64](interfacehipfort__rocblas_1_1rocblas__rot__batched__ex__64.html "Interface documentation") | C binding
-1184 | [rocblas_rot_strided_batched_ex](interfacehipfort__rocblas_1_1rocblas__rot__strided__batched__ex.html "Interface documentation") | C binding
-1185 | [rocblas_rot_strided_batched_ex_64](interfacehipfort__rocblas_1_1rocblas__rot__strided__batched__ex__64.html "Interface documentation") | C binding
-1186 | [rocblas_scal_ex](interfacehipfort__rocblas_1_1rocblas__scal__ex.html "Interface documentation") | C binding
-1187 | [rocblas_scal_ex_64](interfacehipfort__rocblas_1_1rocblas__scal__ex__64.html "Interface documentation") | C binding
-1188 | [rocblas_scal_batched_ex](interfacehipfort__rocblas_1_1rocblas__scal__batched__ex.html "Interface documentation") | C binding
-1189 | [rocblas_scal_batched_ex_64](interfacehipfort__rocblas_1_1rocblas__scal__batched__ex__64.html "Interface documentation") | C binding
-1190 | [rocblas_scal_strided_batched_ex](interfacehipfort__rocblas_1_1rocblas__scal__strided__batched__ex.html "Interface documentation") | C binding
-1191 | [rocblas_scal_strided_batched_ex_64](interfacehipfort__rocblas_1_1rocblas__scal__strided__batched__ex__64.html "Interface documentation") | C binding
-1192 | [rocblas_status_to_string](interfacehipfort__rocblas_1_1rocblas__status__to__string.html "Interface documentation") | C binding
-1193 | [rocblas_initialize](interfacehipfort__rocblas_1_1rocblas__initialize.html "Interface documentation") | C binding
-1194 | [rocblas_get_version_string](interfacehipfort__rocblas_1_1rocblas__get__version__string.html "Interface documentation") | C binding
-1195 | [rocblas_get_version_string_size](interfacehipfort__rocblas_1_1rocblas__get__version__string__size.html "Interface documentation") | C binding
-1196 | [rocblas_get_commit_hash_string](interfacehipfort__rocblas_1_1rocblas__get__commit__hash__string.html "Interface documentation") | C binding
-1197 | [rocblas_get_commit_hash_string_size](interfacehipfort__rocblas_1_1rocblas__get__commit__hash__string__size.html "Interface documentation") | C binding
-1198 | [rocblas_start_device_memory_size_query](interfacehipfort__rocblas_1_1rocblas__start__device__memory__size__query.html "Interface documentation") | C binding
-1199 | [rocblas_stop_device_memory_size_query](interfacehipfort__rocblas_1_1rocblas__stop__device__memory__size__query.html "Interface documentation") | C binding
-1200 | [rocblas_is_device_memory_size_query](interfacehipfort__rocblas_1_1rocblas__is__device__memory__size__query.html "Interface documentation") | C binding
-1201 | [rocblas_set_optimal_device_memory_size_impl](interfacehipfort__rocblas_1_1rocblas__set__optimal__device__memory__size__impl.html "Interface documentation") | C binding
-1202 | [rocblas_device_malloc_alloc](interfacehipfort__rocblas_1_1rocblas__device__malloc__alloc.html "Interface documentation") | C binding
-1203 | [rocblas_device_malloc_success](interfacehipfort__rocblas_1_1rocblas__device__malloc__success.html "Interface documentation") | C binding
-1204 | [rocblas_device_malloc_ptr](interfacehipfort__rocblas_1_1rocblas__device__malloc__ptr.html "Interface documentation") | C binding
-1205 | [rocblas_device_malloc_get](interfacehipfort__rocblas_1_1rocblas__device__malloc__get.html "Interface documentation") | C binding
-1206 | [rocblas_device_malloc_free](interfacehipfort__rocblas_1_1rocblas__device__malloc__free.html "Interface documentation") | C binding
-1207 | [rocblas_device_malloc_set_default_memory_size](interfacehipfort__rocblas_1_1rocblas__device__malloc__set__default__memory__size.html "Interface documentation") | C binding
-1208 | [rocblas_get_device_memory_size](interfacehipfort__rocblas_1_1rocblas__get__device__memory__size.html "Interface documentation") | C binding
-1209 | [rocblas_set_device_memory_size](interfacehipfort__rocblas_1_1rocblas__set__device__memory__size.html "Interface documentation") | C binding
-1210 | [rocblas_set_workspace](interfacehipfort__rocblas_1_1rocblas__set__workspace.html "Interface documentation") | C binding
-1211 | [rocblas_is_managing_device_memory](interfacehipfort__rocblas_1_1rocblas__is__managing__device__memory.html "Interface documentation") | C binding
-1212 | [rocblas_is_user_managing_device_memory](interfacehipfort__rocblas_1_1rocblas__is__user__managing__device__memory.html "Interface documentation") | C binding
-1213 | [rocblas_abort](interfacehipfort__rocblas_1_1rocblas__abort.html "Interface documentation") | C binding
+16 | [rocblas_set_vector_64](interfacehipfort__rocblas_1_1rocblas__set__vector__64.html "Interface documentation") | C binding
+17 | [rocblas_get_vector_64](interfacehipfort__rocblas_1_1rocblas__get__vector__64.html "Interface documentation") | C binding
+18 | [rocblas_set_matrix_64](interfacehipfort__rocblas_1_1rocblas__set__matrix__64.html "Interface documentation") | C binding
+19 | [rocblas_get_matrix_64](interfacehipfort__rocblas_1_1rocblas__get__matrix__64.html "Interface documentation") | C binding
+20 | [rocblas_set_vector_async_64](interfacehipfort__rocblas_1_1rocblas__set__vector__async__64.html "Interface documentation") | C binding
+21 | [rocblas_get_vector_async_64](interfacehipfort__rocblas_1_1rocblas__get__vector__async__64.html "Interface documentation") | C binding
+22 | [rocblas_set_matrix_async_64](interfacehipfort__rocblas_1_1rocblas__set__matrix__async__64.html "Interface documentation") | C binding
+23 | [rocblas_get_matrix_async_64](interfacehipfort__rocblas_1_1rocblas__get__matrix__async__64.html "Interface documentation") | C binding
+24 | [rocblas_set_start_stop_events](interfacehipfort__rocblas_1_1rocblas__set__start__stop__events.html "Interface documentation") | C binding
+25 | [rocblas_set_solution_fitness_query](interfacehipfort__rocblas_1_1rocblas__set__solution__fitness__query.html "Interface documentation") | C binding
+26 | [rocblas_set_performance_metric](interfacehipfort__rocblas_1_1rocblas__set__performance__metric.html "Interface documentation") | C binding
+27 | [rocblas_get_performance_metric](interfacehipfort__rocblas_1_1rocblas__get__performance__metric.html "Interface documentation") | C binding, rank_0, rank_1
+28 | [rocblas_sscal](interfacehipfort__rocblas_1_1rocblas__sscal.html "Interface documentation") | C binding, rank_0, rank_1
+29 | [rocblas_dscal](interfacehipfort__rocblas_1_1rocblas__dscal.html "Interface documentation") | C binding, rank_0, rank_1
+30 | [rocblas_cscal](interfacehipfort__rocblas_1_1rocblas__cscal.html "Interface documentation") | C binding, rank_0, rank_1
+31 | [rocblas_zscal](interfacehipfort__rocblas_1_1rocblas__zscal.html "Interface documentation") | C binding, rank_0, rank_1
+32 | [rocblas_csscal](interfacehipfort__rocblas_1_1rocblas__csscal.html "Interface documentation") | C binding, rank_0, rank_1
+33 | [rocblas_zdscal](interfacehipfort__rocblas_1_1rocblas__zdscal.html "Interface documentation") | C binding, rank_0, rank_1
+34 | [rocblas_sscal_64](interfacehipfort__rocblas_1_1rocblas__sscal__64.html "Interface documentation") | C binding, rank_0, rank_1
+35 | [rocblas_dscal_64](interfacehipfort__rocblas_1_1rocblas__dscal__64.html "Interface documentation") | C binding, rank_0, rank_1
+36 | [rocblas_cscal_64](interfacehipfort__rocblas_1_1rocblas__cscal__64.html "Interface documentation") | C binding, rank_0, rank_1
+37 | [rocblas_zscal_64](interfacehipfort__rocblas_1_1rocblas__zscal__64.html "Interface documentation") | C binding, rank_0, rank_1
+38 | [rocblas_csscal_64](interfacehipfort__rocblas_1_1rocblas__csscal__64.html "Interface documentation") | C binding, rank_0, rank_1
+39 | [rocblas_zdscal_64](interfacehipfort__rocblas_1_1rocblas__zdscal__64.html "Interface documentation") | C binding, rank_0, rank_1
+40 | [rocblas_sscal_batched](interfacehipfort__rocblas_1_1rocblas__sscal__batched.html "Interface documentation") | C binding
+41 | [rocblas_dscal_batched](interfacehipfort__rocblas_1_1rocblas__dscal__batched.html "Interface documentation") | C binding
+42 | [rocblas_cscal_batched](interfacehipfort__rocblas_1_1rocblas__cscal__batched.html "Interface documentation") | C binding
+43 | [rocblas_zscal_batched](interfacehipfort__rocblas_1_1rocblas__zscal__batched.html "Interface documentation") | C binding
+44 | [rocblas_csscal_batched](interfacehipfort__rocblas_1_1rocblas__csscal__batched.html "Interface documentation") | C binding
+45 | [rocblas_zdscal_batched](interfacehipfort__rocblas_1_1rocblas__zdscal__batched.html "Interface documentation") | C binding
+46 | [rocblas_sscal_batched_64](interfacehipfort__rocblas_1_1rocblas__sscal__batched__64.html "Interface documentation") | C binding
+47 | [rocblas_dscal_batched_64](interfacehipfort__rocblas_1_1rocblas__dscal__batched__64.html "Interface documentation") | C binding
+48 | [rocblas_cscal_batched_64](interfacehipfort__rocblas_1_1rocblas__cscal__batched__64.html "Interface documentation") | C binding
+49 | [rocblas_zscal_batched_64](interfacehipfort__rocblas_1_1rocblas__zscal__batched__64.html "Interface documentation") | C binding
+50 | [rocblas_csscal_batched_64](interfacehipfort__rocblas_1_1rocblas__csscal__batched__64.html "Interface documentation") | C binding
+51 | [rocblas_zdscal_batched_64](interfacehipfort__rocblas_1_1rocblas__zdscal__batched__64.html "Interface documentation") | C binding
+52 | [rocblas_sscal_strided_batched](interfacehipfort__rocblas_1_1rocblas__sscal__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+53 | [rocblas_dscal_strided_batched](interfacehipfort__rocblas_1_1rocblas__dscal__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+54 | [rocblas_cscal_strided_batched](interfacehipfort__rocblas_1_1rocblas__cscal__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+55 | [rocblas_zscal_strided_batched](interfacehipfort__rocblas_1_1rocblas__zscal__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+56 | [rocblas_csscal_strided_batched](interfacehipfort__rocblas_1_1rocblas__csscal__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+57 | [rocblas_zdscal_strided_batched](interfacehipfort__rocblas_1_1rocblas__zdscal__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+58 | [rocblas_sscal_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sscal__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+59 | [rocblas_dscal_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dscal__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+60 | [rocblas_cscal_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cscal__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+61 | [rocblas_zscal_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zscal__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+62 | [rocblas_csscal_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__csscal__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+63 | [rocblas_zdscal_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zdscal__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+64 | [rocblas_scopy](interfacehipfort__rocblas_1_1rocblas__scopy.html "Interface documentation") | C binding, rank_0, rank_1
+65 | [rocblas_dcopy](interfacehipfort__rocblas_1_1rocblas__dcopy.html "Interface documentation") | C binding, rank_0, rank_1
+66 | [rocblas_ccopy](interfacehipfort__rocblas_1_1rocblas__ccopy.html "Interface documentation") | C binding, rank_0, rank_1
+67 | [rocblas_zcopy](interfacehipfort__rocblas_1_1rocblas__zcopy.html "Interface documentation") | C binding, rank_0, rank_1
+68 | [rocblas_scopy_64](interfacehipfort__rocblas_1_1rocblas__scopy__64.html "Interface documentation") | C binding, rank_0, rank_1
+69 | [rocblas_dcopy_64](interfacehipfort__rocblas_1_1rocblas__dcopy__64.html "Interface documentation") | C binding, rank_0, rank_1
+70 | [rocblas_ccopy_64](interfacehipfort__rocblas_1_1rocblas__ccopy__64.html "Interface documentation") | C binding, rank_0, rank_1
+71 | [rocblas_zcopy_64](interfacehipfort__rocblas_1_1rocblas__zcopy__64.html "Interface documentation") | C binding, rank_0, rank_1
+72 | [rocblas_scopy_batched](interfacehipfort__rocblas_1_1rocblas__scopy__batched.html "Interface documentation") | C binding
+73 | [rocblas_dcopy_batched](interfacehipfort__rocblas_1_1rocblas__dcopy__batched.html "Interface documentation") | C binding
+74 | [rocblas_ccopy_batched](interfacehipfort__rocblas_1_1rocblas__ccopy__batched.html "Interface documentation") | C binding
+75 | [rocblas_zcopy_batched](interfacehipfort__rocblas_1_1rocblas__zcopy__batched.html "Interface documentation") | C binding
+76 | [rocblas_scopy_batched_64](interfacehipfort__rocblas_1_1rocblas__scopy__batched__64.html "Interface documentation") | C binding
+77 | [rocblas_dcopy_batched_64](interfacehipfort__rocblas_1_1rocblas__dcopy__batched__64.html "Interface documentation") | C binding
+78 | [rocblas_ccopy_batched_64](interfacehipfort__rocblas_1_1rocblas__ccopy__batched__64.html "Interface documentation") | C binding
+79 | [rocblas_zcopy_batched_64](interfacehipfort__rocblas_1_1rocblas__zcopy__batched__64.html "Interface documentation") | C binding
+80 | [rocblas_scopy_strided_batched](interfacehipfort__rocblas_1_1rocblas__scopy__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+81 | [rocblas_dcopy_strided_batched](interfacehipfort__rocblas_1_1rocblas__dcopy__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+82 | [rocblas_ccopy_strided_batched](interfacehipfort__rocblas_1_1rocblas__ccopy__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+83 | [rocblas_zcopy_strided_batched](interfacehipfort__rocblas_1_1rocblas__zcopy__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+84 | [rocblas_scopy_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__scopy__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+85 | [rocblas_dcopy_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dcopy__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+86 | [rocblas_ccopy_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ccopy__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+87 | [rocblas_zcopy_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zcopy__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+88 | [rocblas_sdot](interfacehipfort__rocblas_1_1rocblas__sdot.html "Interface documentation") | C binding, rank_0, rank_1
+89 | [rocblas_ddot](interfacehipfort__rocblas_1_1rocblas__ddot.html "Interface documentation") | C binding, rank_0, rank_1
+90 | [rocblas_hdot](interfacehipfort__rocblas_1_1rocblas__hdot.html "Interface documentation") | C binding, rank_0, rank_1
+91 | [rocblas_bfdot](interfacehipfort__rocblas_1_1rocblas__bfdot.html "Interface documentation") | C binding, rank_0, rank_1
+92 | [rocblas_cdotu](interfacehipfort__rocblas_1_1rocblas__cdotu.html "Interface documentation") | C binding, rank_0, rank_1
+93 | [rocblas_zdotu](interfacehipfort__rocblas_1_1rocblas__zdotu.html "Interface documentation") | C binding, rank_0, rank_1
+94 | [rocblas_cdotc](interfacehipfort__rocblas_1_1rocblas__cdotc.html "Interface documentation") | C binding, rank_0, rank_1
+95 | [rocblas_zdotc](interfacehipfort__rocblas_1_1rocblas__zdotc.html "Interface documentation") | C binding, rank_0, rank_1
+96 | [rocblas_sdot_64](interfacehipfort__rocblas_1_1rocblas__sdot__64.html "Interface documentation") | C binding, rank_0, rank_1
+97 | [rocblas_ddot_64](interfacehipfort__rocblas_1_1rocblas__ddot__64.html "Interface documentation") | C binding, rank_0, rank_1
+98 | [rocblas_hdot_64](interfacehipfort__rocblas_1_1rocblas__hdot__64.html "Interface documentation") | C binding, rank_0, rank_1
+99 | [rocblas_bfdot_64](interfacehipfort__rocblas_1_1rocblas__bfdot__64.html "Interface documentation") | C binding, rank_0, rank_1
+100 | [rocblas_cdotu_64](interfacehipfort__rocblas_1_1rocblas__cdotu__64.html "Interface documentation") | C binding, rank_0, rank_1
+101 | [rocblas_zdotu_64](interfacehipfort__rocblas_1_1rocblas__zdotu__64.html "Interface documentation") | C binding, rank_0, rank_1
+102 | [rocblas_cdotc_64](interfacehipfort__rocblas_1_1rocblas__cdotc__64.html "Interface documentation") | C binding, rank_0, rank_1
+103 | [rocblas_zdotc_64](interfacehipfort__rocblas_1_1rocblas__zdotc__64.html "Interface documentation") | C binding, rank_0, rank_1
+104 | [rocblas_sdot_batched](interfacehipfort__rocblas_1_1rocblas__sdot__batched.html "Interface documentation") | C binding
+105 | [rocblas_ddot_batched](interfacehipfort__rocblas_1_1rocblas__ddot__batched.html "Interface documentation") | C binding
+106 | [rocblas_hdot_batched](interfacehipfort__rocblas_1_1rocblas__hdot__batched.html "Interface documentation") | C binding, rank_0, rank_1
+107 | [rocblas_bfdot_batched](interfacehipfort__rocblas_1_1rocblas__bfdot__batched.html "Interface documentation") | C binding, rank_0, rank_1
+108 | [rocblas_cdotu_batched](interfacehipfort__rocblas_1_1rocblas__cdotu__batched.html "Interface documentation") | C binding
+109 | [rocblas_zdotu_batched](interfacehipfort__rocblas_1_1rocblas__zdotu__batched.html "Interface documentation") | C binding
+110 | [rocblas_cdotc_batched](interfacehipfort__rocblas_1_1rocblas__cdotc__batched.html "Interface documentation") | C binding
+111 | [rocblas_zdotc_batched](interfacehipfort__rocblas_1_1rocblas__zdotc__batched.html "Interface documentation") | C binding
+112 | [rocblas_sdot_batched_64](interfacehipfort__rocblas_1_1rocblas__sdot__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+113 | [rocblas_ddot_batched_64](interfacehipfort__rocblas_1_1rocblas__ddot__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+114 | [rocblas_hdot_batched_64](interfacehipfort__rocblas_1_1rocblas__hdot__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+115 | [rocblas_bfdot_batched_64](interfacehipfort__rocblas_1_1rocblas__bfdot__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+116 | [rocblas_cdotu_batched_64](interfacehipfort__rocblas_1_1rocblas__cdotu__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+117 | [rocblas_zdotu_batched_64](interfacehipfort__rocblas_1_1rocblas__zdotu__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+118 | [rocblas_cdotc_batched_64](interfacehipfort__rocblas_1_1rocblas__cdotc__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+119 | [rocblas_zdotc_batched_64](interfacehipfort__rocblas_1_1rocblas__zdotc__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+120 | [rocblas_sdot_strided_batched](interfacehipfort__rocblas_1_1rocblas__sdot__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+121 | [rocblas_ddot_strided_batched](interfacehipfort__rocblas_1_1rocblas__ddot__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+122 | [rocblas_hdot_strided_batched](interfacehipfort__rocblas_1_1rocblas__hdot__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+123 | [rocblas_bfdot_strided_batched](interfacehipfort__rocblas_1_1rocblas__bfdot__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+124 | [rocblas_cdotu_strided_batched](interfacehipfort__rocblas_1_1rocblas__cdotu__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+125 | [rocblas_zdotu_strided_batched](interfacehipfort__rocblas_1_1rocblas__zdotu__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+126 | [rocblas_cdotc_strided_batched](interfacehipfort__rocblas_1_1rocblas__cdotc__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+127 | [rocblas_zdotc_strided_batched](interfacehipfort__rocblas_1_1rocblas__zdotc__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+128 | [rocblas_sdot_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sdot__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+129 | [rocblas_ddot_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ddot__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+130 | [rocblas_hdot_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__hdot__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+131 | [rocblas_bfdot_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__bfdot__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+132 | [rocblas_cdotu_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cdotu__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+133 | [rocblas_zdotu_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zdotu__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+134 | [rocblas_cdotc_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cdotc__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+135 | [rocblas_zdotc_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zdotc__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+136 | [rocblas_sswap](interfacehipfort__rocblas_1_1rocblas__sswap.html "Interface documentation") | C binding, rank_0, rank_1
+137 | [rocblas_dswap](interfacehipfort__rocblas_1_1rocblas__dswap.html "Interface documentation") | C binding, rank_0, rank_1
+138 | [rocblas_cswap](interfacehipfort__rocblas_1_1rocblas__cswap.html "Interface documentation") | C binding, rank_0, rank_1
+139 | [rocblas_zswap](interfacehipfort__rocblas_1_1rocblas__zswap.html "Interface documentation") | C binding, rank_0, rank_1
+140 | [rocblas_sswap_64](interfacehipfort__rocblas_1_1rocblas__sswap__64.html "Interface documentation") | C binding, rank_0, rank_1
+141 | [rocblas_dswap_64](interfacehipfort__rocblas_1_1rocblas__dswap__64.html "Interface documentation") | C binding, rank_0, rank_1
+142 | [rocblas_cswap_64](interfacehipfort__rocblas_1_1rocblas__cswap__64.html "Interface documentation") | C binding, rank_0, rank_1
+143 | [rocblas_zswap_64](interfacehipfort__rocblas_1_1rocblas__zswap__64.html "Interface documentation") | C binding, rank_0, rank_1
+144 | [rocblas_sswap_batched](interfacehipfort__rocblas_1_1rocblas__sswap__batched.html "Interface documentation") | C binding
+145 | [rocblas_dswap_batched](interfacehipfort__rocblas_1_1rocblas__dswap__batched.html "Interface documentation") | C binding
+146 | [rocblas_cswap_batched](interfacehipfort__rocblas_1_1rocblas__cswap__batched.html "Interface documentation") | C binding
+147 | [rocblas_zswap_batched](interfacehipfort__rocblas_1_1rocblas__zswap__batched.html "Interface documentation") | C binding
+148 | [rocblas_sswap_batched_64](interfacehipfort__rocblas_1_1rocblas__sswap__batched__64.html "Interface documentation") | C binding
+149 | [rocblas_dswap_batched_64](interfacehipfort__rocblas_1_1rocblas__dswap__batched__64.html "Interface documentation") | C binding
+150 | [rocblas_cswap_batched_64](interfacehipfort__rocblas_1_1rocblas__cswap__batched__64.html "Interface documentation") | C binding
+151 | [rocblas_zswap_batched_64](interfacehipfort__rocblas_1_1rocblas__zswap__batched__64.html "Interface documentation") | C binding
+152 | [rocblas_sswap_strided_batched](interfacehipfort__rocblas_1_1rocblas__sswap__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+153 | [rocblas_dswap_strided_batched](interfacehipfort__rocblas_1_1rocblas__dswap__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+154 | [rocblas_cswap_strided_batched](interfacehipfort__rocblas_1_1rocblas__cswap__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+155 | [rocblas_zswap_strided_batched](interfacehipfort__rocblas_1_1rocblas__zswap__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+156 | [rocblas_sswap_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sswap__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+157 | [rocblas_dswap_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dswap__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+158 | [rocblas_cswap_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cswap__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+159 | [rocblas_zswap_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zswap__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+160 | [rocblas_haxpy](interfacehipfort__rocblas_1_1rocblas__haxpy.html "Interface documentation") | C binding, rank_0, rank_1
+161 | [rocblas_saxpy](interfacehipfort__rocblas_1_1rocblas__saxpy.html "Interface documentation") | C binding, rank_0, rank_1
+162 | [rocblas_daxpy](interfacehipfort__rocblas_1_1rocblas__daxpy.html "Interface documentation") | C binding, rank_0, rank_1
+163 | [rocblas_caxpy](interfacehipfort__rocblas_1_1rocblas__caxpy.html "Interface documentation") | C binding, rank_0, rank_1
+164 | [rocblas_zaxpy](interfacehipfort__rocblas_1_1rocblas__zaxpy.html "Interface documentation") | C binding, rank_0, rank_1
+165 | [rocblas_haxpy_64](interfacehipfort__rocblas_1_1rocblas__haxpy__64.html "Interface documentation") | C binding, rank_0, rank_1
+166 | [rocblas_saxpy_64](interfacehipfort__rocblas_1_1rocblas__saxpy__64.html "Interface documentation") | C binding, rank_0, rank_1
+167 | [rocblas_daxpy_64](interfacehipfort__rocblas_1_1rocblas__daxpy__64.html "Interface documentation") | C binding, rank_0, rank_1
+168 | [rocblas_caxpy_64](interfacehipfort__rocblas_1_1rocblas__caxpy__64.html "Interface documentation") | C binding, rank_0, rank_1
+169 | [rocblas_zaxpy_64](interfacehipfort__rocblas_1_1rocblas__zaxpy__64.html "Interface documentation") | C binding, rank_0, rank_1
+170 | [rocblas_haxpy_batched](interfacehipfort__rocblas_1_1rocblas__haxpy__batched.html "Interface documentation") | C binding
+171 | [rocblas_saxpy_batched](interfacehipfort__rocblas_1_1rocblas__saxpy__batched.html "Interface documentation") | C binding
+172 | [rocblas_daxpy_batched](interfacehipfort__rocblas_1_1rocblas__daxpy__batched.html "Interface documentation") | C binding
+173 | [rocblas_caxpy_batched](interfacehipfort__rocblas_1_1rocblas__caxpy__batched.html "Interface documentation") | C binding
+174 | [rocblas_zaxpy_batched](interfacehipfort__rocblas_1_1rocblas__zaxpy__batched.html "Interface documentation") | C binding
+175 | [rocblas_haxpy_batched_64](interfacehipfort__rocblas_1_1rocblas__haxpy__batched__64.html "Interface documentation") | C binding
+176 | [rocblas_saxpy_batched_64](interfacehipfort__rocblas_1_1rocblas__saxpy__batched__64.html "Interface documentation") | C binding
+177 | [rocblas_daxpy_batched_64](interfacehipfort__rocblas_1_1rocblas__daxpy__batched__64.html "Interface documentation") | C binding
+178 | [rocblas_caxpy_batched_64](interfacehipfort__rocblas_1_1rocblas__caxpy__batched__64.html "Interface documentation") | C binding
+179 | [rocblas_zaxpy_batched_64](interfacehipfort__rocblas_1_1rocblas__zaxpy__batched__64.html "Interface documentation") | C binding
+180 | [rocblas_haxpy_strided_batched](interfacehipfort__rocblas_1_1rocblas__haxpy__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+181 | [rocblas_saxpy_strided_batched](interfacehipfort__rocblas_1_1rocblas__saxpy__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+182 | [rocblas_daxpy_strided_batched](interfacehipfort__rocblas_1_1rocblas__daxpy__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+183 | [rocblas_caxpy_strided_batched](interfacehipfort__rocblas_1_1rocblas__caxpy__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+184 | [rocblas_zaxpy_strided_batched](interfacehipfort__rocblas_1_1rocblas__zaxpy__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+185 | [rocblas_haxpy_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__haxpy__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+186 | [rocblas_saxpy_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__saxpy__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+187 | [rocblas_daxpy_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__daxpy__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+188 | [rocblas_caxpy_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__caxpy__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+189 | [rocblas_zaxpy_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zaxpy__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+190 | [rocblas_sasum](interfacehipfort__rocblas_1_1rocblas__sasum.html "Interface documentation") | C binding, rank_0, rank_1
+191 | [rocblas_dasum](interfacehipfort__rocblas_1_1rocblas__dasum.html "Interface documentation") | C binding, rank_0, rank_1
+192 | [rocblas_scasum](interfacehipfort__rocblas_1_1rocblas__scasum.html "Interface documentation") | C binding, rank_0, rank_1
+193 | [rocblas_dzasum](interfacehipfort__rocblas_1_1rocblas__dzasum.html "Interface documentation") | C binding, rank_0, rank_1
+194 | [rocblas_sasum_64](interfacehipfort__rocblas_1_1rocblas__sasum__64.html "Interface documentation") | C binding, rank_0, rank_1
+195 | [rocblas_dasum_64](interfacehipfort__rocblas_1_1rocblas__dasum__64.html "Interface documentation") | C binding, rank_0, rank_1
+196 | [rocblas_scasum_64](interfacehipfort__rocblas_1_1rocblas__scasum__64.html "Interface documentation") | C binding, rank_0, rank_1
+197 | [rocblas_dzasum_64](interfacehipfort__rocblas_1_1rocblas__dzasum__64.html "Interface documentation") | C binding, rank_0, rank_1
+198 | [rocblas_sasum_batched](interfacehipfort__rocblas_1_1rocblas__sasum__batched.html "Interface documentation") | C binding
+199 | [rocblas_dasum_batched](interfacehipfort__rocblas_1_1rocblas__dasum__batched.html "Interface documentation") | C binding
+200 | [rocblas_scasum_batched](interfacehipfort__rocblas_1_1rocblas__scasum__batched.html "Interface documentation") | C binding
+201 | [rocblas_dzasum_batched](interfacehipfort__rocblas_1_1rocblas__dzasum__batched.html "Interface documentation") | C binding
+202 | [rocblas_sasum_batched_64](interfacehipfort__rocblas_1_1rocblas__sasum__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+203 | [rocblas_dasum_batched_64](interfacehipfort__rocblas_1_1rocblas__dasum__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+204 | [rocblas_scasum_batched_64](interfacehipfort__rocblas_1_1rocblas__scasum__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+205 | [rocblas_dzasum_batched_64](interfacehipfort__rocblas_1_1rocblas__dzasum__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+206 | [rocblas_sasum_strided_batched](interfacehipfort__rocblas_1_1rocblas__sasum__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+207 | [rocblas_dasum_strided_batched](interfacehipfort__rocblas_1_1rocblas__dasum__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+208 | [rocblas_scasum_strided_batched](interfacehipfort__rocblas_1_1rocblas__scasum__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+209 | [rocblas_dzasum_strided_batched](interfacehipfort__rocblas_1_1rocblas__dzasum__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+210 | [rocblas_sasum_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sasum__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+211 | [rocblas_dasum_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dasum__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+212 | [rocblas_scasum_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__scasum__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+213 | [rocblas_dzasum_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dzasum__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+214 | [rocblas_snrm2](interfacehipfort__rocblas_1_1rocblas__snrm2.html "Interface documentation") | C binding, rank_0, rank_1
+215 | [rocblas_dnrm2](interfacehipfort__rocblas_1_1rocblas__dnrm2.html "Interface documentation") | C binding, rank_0, rank_1
+216 | [rocblas_scnrm2](interfacehipfort__rocblas_1_1rocblas__scnrm2.html "Interface documentation") | C binding, rank_0, rank_1
+217 | [rocblas_dznrm2](interfacehipfort__rocblas_1_1rocblas__dznrm2.html "Interface documentation") | C binding, rank_0, rank_1
+218 | [rocblas_snrm2_64](interfacehipfort__rocblas_1_1rocblas__snrm2__64.html "Interface documentation") | C binding, rank_0, rank_1
+219 | [rocblas_dnrm2_64](interfacehipfort__rocblas_1_1rocblas__dnrm2__64.html "Interface documentation") | C binding, rank_0, rank_1
+220 | [rocblas_scnrm2_64](interfacehipfort__rocblas_1_1rocblas__scnrm2__64.html "Interface documentation") | C binding, rank_0, rank_1
+221 | [rocblas_dznrm2_64](interfacehipfort__rocblas_1_1rocblas__dznrm2__64.html "Interface documentation") | C binding, rank_0, rank_1
+222 | [rocblas_snrm2_batched](interfacehipfort__rocblas_1_1rocblas__snrm2__batched.html "Interface documentation") | C binding
+223 | [rocblas_dnrm2_batched](interfacehipfort__rocblas_1_1rocblas__dnrm2__batched.html "Interface documentation") | C binding
+224 | [rocblas_scnrm2_batched](interfacehipfort__rocblas_1_1rocblas__scnrm2__batched.html "Interface documentation") | C binding
+225 | [rocblas_dznrm2_batched](interfacehipfort__rocblas_1_1rocblas__dznrm2__batched.html "Interface documentation") | C binding
+226 | [rocblas_snrm2_batched_64](interfacehipfort__rocblas_1_1rocblas__snrm2__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+227 | [rocblas_dnrm2_batched_64](interfacehipfort__rocblas_1_1rocblas__dnrm2__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+228 | [rocblas_scnrm2_batched_64](interfacehipfort__rocblas_1_1rocblas__scnrm2__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+229 | [rocblas_dznrm2_batched_64](interfacehipfort__rocblas_1_1rocblas__dznrm2__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+230 | [rocblas_snrm2_strided_batched](interfacehipfort__rocblas_1_1rocblas__snrm2__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+231 | [rocblas_dnrm2_strided_batched](interfacehipfort__rocblas_1_1rocblas__dnrm2__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+232 | [rocblas_scnrm2_strided_batched](interfacehipfort__rocblas_1_1rocblas__scnrm2__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+233 | [rocblas_dznrm2_strided_batched](interfacehipfort__rocblas_1_1rocblas__dznrm2__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+234 | [rocblas_snrm2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__snrm2__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+235 | [rocblas_dnrm2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dnrm2__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+236 | [rocblas_scnrm2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__scnrm2__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+237 | [rocblas_dznrm2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dznrm2__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+238 | [rocblas_isamax](interfacehipfort__rocblas_1_1rocblas__isamax.html "Interface documentation") | C binding, rank_0, rank_1
+239 | [rocblas_idamax](interfacehipfort__rocblas_1_1rocblas__idamax.html "Interface documentation") | C binding, rank_0, rank_1
+240 | [rocblas_icamax](interfacehipfort__rocblas_1_1rocblas__icamax.html "Interface documentation") | C binding, rank_0, rank_1
+241 | [rocblas_izamax](interfacehipfort__rocblas_1_1rocblas__izamax.html "Interface documentation") | C binding, rank_0, rank_1
+242 | [rocblas_isamax_64](interfacehipfort__rocblas_1_1rocblas__isamax__64.html "Interface documentation") | C binding, rank_0, rank_1
+243 | [rocblas_idamax_64](interfacehipfort__rocblas_1_1rocblas__idamax__64.html "Interface documentation") | C binding, rank_0, rank_1
+244 | [rocblas_icamax_64](interfacehipfort__rocblas_1_1rocblas__icamax__64.html "Interface documentation") | C binding, rank_0, rank_1
+245 | [rocblas_izamax_64](interfacehipfort__rocblas_1_1rocblas__izamax__64.html "Interface documentation") | C binding, rank_0, rank_1
+246 | [rocblas_isamax_batched](interfacehipfort__rocblas_1_1rocblas__isamax__batched.html "Interface documentation") | C binding
+247 | [rocblas_idamax_batched](interfacehipfort__rocblas_1_1rocblas__idamax__batched.html "Interface documentation") | C binding
+248 | [rocblas_icamax_batched](interfacehipfort__rocblas_1_1rocblas__icamax__batched.html "Interface documentation") | C binding
+249 | [rocblas_izamax_batched](interfacehipfort__rocblas_1_1rocblas__izamax__batched.html "Interface documentation") | C binding
+250 | [rocblas_isamax_batched_64](interfacehipfort__rocblas_1_1rocblas__isamax__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+251 | [rocblas_idamax_batched_64](interfacehipfort__rocblas_1_1rocblas__idamax__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+252 | [rocblas_icamax_batched_64](interfacehipfort__rocblas_1_1rocblas__icamax__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+253 | [rocblas_izamax_batched_64](interfacehipfort__rocblas_1_1rocblas__izamax__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+254 | [rocblas_isamax_strided_batched](interfacehipfort__rocblas_1_1rocblas__isamax__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+255 | [rocblas_idamax_strided_batched](interfacehipfort__rocblas_1_1rocblas__idamax__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+256 | [rocblas_icamax_strided_batched](interfacehipfort__rocblas_1_1rocblas__icamax__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+257 | [rocblas_izamax_strided_batched](interfacehipfort__rocblas_1_1rocblas__izamax__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+258 | [rocblas_isamax_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__isamax__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+259 | [rocblas_idamax_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__idamax__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+260 | [rocblas_icamax_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__icamax__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+261 | [rocblas_izamax_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__izamax__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+262 | [rocblas_isamin](interfacehipfort__rocblas_1_1rocblas__isamin.html "Interface documentation") | C binding, rank_0, rank_1
+263 | [rocblas_idamin](interfacehipfort__rocblas_1_1rocblas__idamin.html "Interface documentation") | C binding, rank_0, rank_1
+264 | [rocblas_icamin](interfacehipfort__rocblas_1_1rocblas__icamin.html "Interface documentation") | C binding, rank_0, rank_1
+265 | [rocblas_izamin](interfacehipfort__rocblas_1_1rocblas__izamin.html "Interface documentation") | C binding, rank_0, rank_1
+266 | [rocblas_isamin_64](interfacehipfort__rocblas_1_1rocblas__isamin__64.html "Interface documentation") | C binding, rank_0, rank_1
+267 | [rocblas_idamin_64](interfacehipfort__rocblas_1_1rocblas__idamin__64.html "Interface documentation") | C binding, rank_0, rank_1
+268 | [rocblas_icamin_64](interfacehipfort__rocblas_1_1rocblas__icamin__64.html "Interface documentation") | C binding, rank_0, rank_1
+269 | [rocblas_izamin_64](interfacehipfort__rocblas_1_1rocblas__izamin__64.html "Interface documentation") | C binding, rank_0, rank_1
+270 | [rocblas_isamin_batched](interfacehipfort__rocblas_1_1rocblas__isamin__batched.html "Interface documentation") | C binding
+271 | [rocblas_idamin_batched](interfacehipfort__rocblas_1_1rocblas__idamin__batched.html "Interface documentation") | C binding
+272 | [rocblas_icamin_batched](interfacehipfort__rocblas_1_1rocblas__icamin__batched.html "Interface documentation") | C binding
+273 | [rocblas_izamin_batched](interfacehipfort__rocblas_1_1rocblas__izamin__batched.html "Interface documentation") | C binding
+274 | [rocblas_isamin_batched_64](interfacehipfort__rocblas_1_1rocblas__isamin__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+275 | [rocblas_idamin_batched_64](interfacehipfort__rocblas_1_1rocblas__idamin__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+276 | [rocblas_icamin_batched_64](interfacehipfort__rocblas_1_1rocblas__icamin__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+277 | [rocblas_izamin_batched_64](interfacehipfort__rocblas_1_1rocblas__izamin__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+278 | [rocblas_isamin_strided_batched](interfacehipfort__rocblas_1_1rocblas__isamin__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+279 | [rocblas_idamin_strided_batched](interfacehipfort__rocblas_1_1rocblas__idamin__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+280 | [rocblas_icamin_strided_batched](interfacehipfort__rocblas_1_1rocblas__icamin__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+281 | [rocblas_izamin_strided_batched](interfacehipfort__rocblas_1_1rocblas__izamin__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+282 | [rocblas_isamin_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__isamin__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+283 | [rocblas_idamin_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__idamin__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+284 | [rocblas_icamin_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__icamin__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+285 | [rocblas_izamin_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__izamin__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+286 | [rocblas_srot](interfacehipfort__rocblas_1_1rocblas__srot.html "Interface documentation") | C binding, rank_0, rank_1
+287 | [rocblas_drot](interfacehipfort__rocblas_1_1rocblas__drot.html "Interface documentation") | C binding, rank_0, rank_1
+288 | [rocblas_crot](interfacehipfort__rocblas_1_1rocblas__crot.html "Interface documentation") | C binding, rank_0, rank_1
+289 | [rocblas_csrot](interfacehipfort__rocblas_1_1rocblas__csrot.html "Interface documentation") | C binding, rank_0, rank_1
+290 | [rocblas_zrot](interfacehipfort__rocblas_1_1rocblas__zrot.html "Interface documentation") | C binding, rank_0, rank_1
+291 | [rocblas_zdrot](interfacehipfort__rocblas_1_1rocblas__zdrot.html "Interface documentation") | C binding, rank_0, rank_1
+292 | [rocblas_srot_64](interfacehipfort__rocblas_1_1rocblas__srot__64.html "Interface documentation") | C binding, rank_0, rank_1
+293 | [rocblas_drot_64](interfacehipfort__rocblas_1_1rocblas__drot__64.html "Interface documentation") | C binding, rank_0, rank_1
+294 | [rocblas_crot_64](interfacehipfort__rocblas_1_1rocblas__crot__64.html "Interface documentation") | C binding, rank_0, rank_1
+295 | [rocblas_csrot_64](interfacehipfort__rocblas_1_1rocblas__csrot__64.html "Interface documentation") | C binding, rank_0, rank_1
+296 | [rocblas_zrot_64](interfacehipfort__rocblas_1_1rocblas__zrot__64.html "Interface documentation") | C binding, rank_0, rank_1
+297 | [rocblas_zdrot_64](interfacehipfort__rocblas_1_1rocblas__zdrot__64.html "Interface documentation") | C binding, rank_0, rank_1
+298 | [rocblas_srot_batched](interfacehipfort__rocblas_1_1rocblas__srot__batched.html "Interface documentation") | C binding
+299 | [rocblas_drot_batched](interfacehipfort__rocblas_1_1rocblas__drot__batched.html "Interface documentation") | C binding
+300 | [rocblas_crot_batched](interfacehipfort__rocblas_1_1rocblas__crot__batched.html "Interface documentation") | C binding
+301 | [rocblas_csrot_batched](interfacehipfort__rocblas_1_1rocblas__csrot__batched.html "Interface documentation") | C binding
+302 | [rocblas_zrot_batched](interfacehipfort__rocblas_1_1rocblas__zrot__batched.html "Interface documentation") | C binding
+303 | [rocblas_zdrot_batched](interfacehipfort__rocblas_1_1rocblas__zdrot__batched.html "Interface documentation") | C binding
+304 | [rocblas_srot_batched_64](interfacehipfort__rocblas_1_1rocblas__srot__batched__64.html "Interface documentation") | C binding
+305 | [rocblas_drot_batched_64](interfacehipfort__rocblas_1_1rocblas__drot__batched__64.html "Interface documentation") | C binding
+306 | [rocblas_crot_batched_64](interfacehipfort__rocblas_1_1rocblas__crot__batched__64.html "Interface documentation") | C binding
+307 | [rocblas_csrot_batched_64](interfacehipfort__rocblas_1_1rocblas__csrot__batched__64.html "Interface documentation") | C binding
+308 | [rocblas_zrot_batched_64](interfacehipfort__rocblas_1_1rocblas__zrot__batched__64.html "Interface documentation") | C binding
+309 | [rocblas_zdrot_batched_64](interfacehipfort__rocblas_1_1rocblas__zdrot__batched__64.html "Interface documentation") | C binding
+310 | [rocblas_srot_strided_batched](interfacehipfort__rocblas_1_1rocblas__srot__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+311 | [rocblas_drot_strided_batched](interfacehipfort__rocblas_1_1rocblas__drot__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+312 | [rocblas_crot_strided_batched](interfacehipfort__rocblas_1_1rocblas__crot__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+313 | [rocblas_csrot_strided_batched](interfacehipfort__rocblas_1_1rocblas__csrot__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+314 | [rocblas_zrot_strided_batched](interfacehipfort__rocblas_1_1rocblas__zrot__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+315 | [rocblas_zdrot_strided_batched](interfacehipfort__rocblas_1_1rocblas__zdrot__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+316 | [rocblas_srot_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__srot__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+317 | [rocblas_drot_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__drot__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+318 | [rocblas_crot_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__crot__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+319 | [rocblas_csrot_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__csrot__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+320 | [rocblas_zrot_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zrot__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+321 | [rocblas_zdrot_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zdrot__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+322 | [rocblas_srotg](interfacehipfort__rocblas_1_1rocblas__srotg.html "Interface documentation") | C binding, rank_0, rank_1
+323 | [rocblas_drotg](interfacehipfort__rocblas_1_1rocblas__drotg.html "Interface documentation") | C binding, rank_0, rank_1
+324 | [rocblas_crotg](interfacehipfort__rocblas_1_1rocblas__crotg.html "Interface documentation") | C binding, rank_0, rank_1
+325 | [rocblas_zrotg](interfacehipfort__rocblas_1_1rocblas__zrotg.html "Interface documentation") | C binding, rank_0, rank_1
+326 | [rocblas_srotg_64](interfacehipfort__rocblas_1_1rocblas__srotg__64.html "Interface documentation") | C binding, rank_0, rank_1
+327 | [rocblas_drotg_64](interfacehipfort__rocblas_1_1rocblas__drotg__64.html "Interface documentation") | C binding, rank_0, rank_1
+328 | [rocblas_crotg_64](interfacehipfort__rocblas_1_1rocblas__crotg__64.html "Interface documentation") | C binding, rank_0, rank_1
+329 | [rocblas_zrotg_64](interfacehipfort__rocblas_1_1rocblas__zrotg__64.html "Interface documentation") | C binding, rank_0, rank_1
+330 | [rocblas_srotg_batched](interfacehipfort__rocblas_1_1rocblas__srotg__batched.html "Interface documentation") | C binding
+331 | [rocblas_drotg_batched](interfacehipfort__rocblas_1_1rocblas__drotg__batched.html "Interface documentation") | C binding
+332 | [rocblas_crotg_batched](interfacehipfort__rocblas_1_1rocblas__crotg__batched.html "Interface documentation") | C binding
+333 | [rocblas_zrotg_batched](interfacehipfort__rocblas_1_1rocblas__zrotg__batched.html "Interface documentation") | C binding
+334 | [rocblas_srotg_batched_64](interfacehipfort__rocblas_1_1rocblas__srotg__batched__64.html "Interface documentation") | C binding
+335 | [rocblas_drotg_batched_64](interfacehipfort__rocblas_1_1rocblas__drotg__batched__64.html "Interface documentation") | C binding
+336 | [rocblas_crotg_batched_64](interfacehipfort__rocblas_1_1rocblas__crotg__batched__64.html "Interface documentation") | C binding
+337 | [rocblas_zrotg_batched_64](interfacehipfort__rocblas_1_1rocblas__zrotg__batched__64.html "Interface documentation") | C binding
+338 | [rocblas_srotg_strided_batched](interfacehipfort__rocblas_1_1rocblas__srotg__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+339 | [rocblas_drotg_strided_batched](interfacehipfort__rocblas_1_1rocblas__drotg__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+340 | [rocblas_crotg_strided_batched](interfacehipfort__rocblas_1_1rocblas__crotg__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+341 | [rocblas_zrotg_strided_batched](interfacehipfort__rocblas_1_1rocblas__zrotg__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+342 | [rocblas_srotg_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__srotg__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+343 | [rocblas_drotg_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__drotg__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+344 | [rocblas_crotg_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__crotg__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+345 | [rocblas_zrotg_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zrotg__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+346 | [rocblas_srotm](interfacehipfort__rocblas_1_1rocblas__srotm.html "Interface documentation") | C binding, rank_0, rank_1
+347 | [rocblas_drotm](interfacehipfort__rocblas_1_1rocblas__drotm.html "Interface documentation") | C binding, rank_0, rank_1
+348 | [rocblas_srotm_64](interfacehipfort__rocblas_1_1rocblas__srotm__64.html "Interface documentation") | C binding, rank_0, rank_1
+349 | [rocblas_drotm_64](interfacehipfort__rocblas_1_1rocblas__drotm__64.html "Interface documentation") | C binding, rank_0, rank_1
+350 | [rocblas_srotm_batched](interfacehipfort__rocblas_1_1rocblas__srotm__batched.html "Interface documentation") | C binding
+351 | [rocblas_drotm_batched](interfacehipfort__rocblas_1_1rocblas__drotm__batched.html "Interface documentation") | C binding
+352 | [rocblas_srotm_batched_64](interfacehipfort__rocblas_1_1rocblas__srotm__batched__64.html "Interface documentation") | C binding
+353 | [rocblas_drotm_batched_64](interfacehipfort__rocblas_1_1rocblas__drotm__batched__64.html "Interface documentation") | C binding
+354 | [rocblas_srotm_strided_batched](interfacehipfort__rocblas_1_1rocblas__srotm__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+355 | [rocblas_drotm_strided_batched](interfacehipfort__rocblas_1_1rocblas__drotm__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+356 | [rocblas_srotm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__srotm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+357 | [rocblas_drotm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__drotm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+358 | [rocblas_srotmg](interfacehipfort__rocblas_1_1rocblas__srotmg.html "Interface documentation") | C binding, rank_0, rank_1
+359 | [rocblas_drotmg](interfacehipfort__rocblas_1_1rocblas__drotmg.html "Interface documentation") | C binding, rank_0, rank_1
+360 | [rocblas_srotmg_64](interfacehipfort__rocblas_1_1rocblas__srotmg__64.html "Interface documentation") | C binding, rank_0, rank_1
+361 | [rocblas_drotmg_64](interfacehipfort__rocblas_1_1rocblas__drotmg__64.html "Interface documentation") | C binding, rank_0, rank_1
+362 | [rocblas_srotmg_batched](interfacehipfort__rocblas_1_1rocblas__srotmg__batched.html "Interface documentation") | C binding
+363 | [rocblas_drotmg_batched](interfacehipfort__rocblas_1_1rocblas__drotmg__batched.html "Interface documentation") | C binding
+364 | [rocblas_srotmg_batched_64](interfacehipfort__rocblas_1_1rocblas__srotmg__batched__64.html "Interface documentation") | C binding
+365 | [rocblas_drotmg_batched_64](interfacehipfort__rocblas_1_1rocblas__drotmg__batched__64.html "Interface documentation") | C binding
+366 | [rocblas_srotmg_strided_batched](interfacehipfort__rocblas_1_1rocblas__srotmg__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+367 | [rocblas_drotmg_strided_batched](interfacehipfort__rocblas_1_1rocblas__drotmg__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+368 | [rocblas_srotmg_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__srotmg__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+369 | [rocblas_drotmg_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__drotmg__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+370 | [rocblas_sgbmv](interfacehipfort__rocblas_1_1rocblas__sgbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+371 | [rocblas_dgbmv](interfacehipfort__rocblas_1_1rocblas__dgbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+372 | [rocblas_cgbmv](interfacehipfort__rocblas_1_1rocblas__cgbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+373 | [rocblas_zgbmv](interfacehipfort__rocblas_1_1rocblas__zgbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+374 | [rocblas_sgbmv_64](interfacehipfort__rocblas_1_1rocblas__sgbmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+375 | [rocblas_dgbmv_64](interfacehipfort__rocblas_1_1rocblas__dgbmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+376 | [rocblas_cgbmv_64](interfacehipfort__rocblas_1_1rocblas__cgbmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+377 | [rocblas_zgbmv_64](interfacehipfort__rocblas_1_1rocblas__zgbmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+378 | [rocblas_sgbmv_batched](interfacehipfort__rocblas_1_1rocblas__sgbmv__batched.html "Interface documentation") | C binding
+379 | [rocblas_dgbmv_batched](interfacehipfort__rocblas_1_1rocblas__dgbmv__batched.html "Interface documentation") | C binding
+380 | [rocblas_cgbmv_batched](interfacehipfort__rocblas_1_1rocblas__cgbmv__batched.html "Interface documentation") | C binding
+381 | [rocblas_zgbmv_batched](interfacehipfort__rocblas_1_1rocblas__zgbmv__batched.html "Interface documentation") | C binding
+382 | [rocblas_sgbmv_batched_64](interfacehipfort__rocblas_1_1rocblas__sgbmv__batched__64.html "Interface documentation") | C binding
+383 | [rocblas_dgbmv_batched_64](interfacehipfort__rocblas_1_1rocblas__dgbmv__batched__64.html "Interface documentation") | C binding
+384 | [rocblas_cgbmv_batched_64](interfacehipfort__rocblas_1_1rocblas__cgbmv__batched__64.html "Interface documentation") | C binding
+385 | [rocblas_zgbmv_batched_64](interfacehipfort__rocblas_1_1rocblas__zgbmv__batched__64.html "Interface documentation") | C binding
+386 | [rocblas_sgbmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__sgbmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+387 | [rocblas_dgbmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__dgbmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+388 | [rocblas_cgbmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__cgbmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+389 | [rocblas_zgbmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__zgbmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+390 | [rocblas_sgbmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sgbmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+391 | [rocblas_dgbmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dgbmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+392 | [rocblas_cgbmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cgbmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+393 | [rocblas_zgbmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zgbmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+394 | [rocblas_sgemv](interfacehipfort__rocblas_1_1rocblas__sgemv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+395 | [rocblas_dgemv](interfacehipfort__rocblas_1_1rocblas__dgemv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+396 | [rocblas_cgemv](interfacehipfort__rocblas_1_1rocblas__cgemv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+397 | [rocblas_zgemv](interfacehipfort__rocblas_1_1rocblas__zgemv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+398 | [rocblas_sgemv_64](interfacehipfort__rocblas_1_1rocblas__sgemv__64.html "Interface documentation") | C binding, rank_0, rank_1
+399 | [rocblas_dgemv_64](interfacehipfort__rocblas_1_1rocblas__dgemv__64.html "Interface documentation") | C binding, rank_0, rank_1
+400 | [rocblas_cgemv_64](interfacehipfort__rocblas_1_1rocblas__cgemv__64.html "Interface documentation") | C binding, rank_0, rank_1
+401 | [rocblas_zgemv_64](interfacehipfort__rocblas_1_1rocblas__zgemv__64.html "Interface documentation") | C binding, rank_0, rank_1
+402 | [rocblas_sgemv_batched](interfacehipfort__rocblas_1_1rocblas__sgemv__batched.html "Interface documentation") | C binding
+403 | [rocblas_dgemv_batched](interfacehipfort__rocblas_1_1rocblas__dgemv__batched.html "Interface documentation") | C binding
+404 | [rocblas_cgemv_batched](interfacehipfort__rocblas_1_1rocblas__cgemv__batched.html "Interface documentation") | C binding
+405 | [rocblas_zgemv_batched](interfacehipfort__rocblas_1_1rocblas__zgemv__batched.html "Interface documentation") | C binding
+406 | [rocblas_hshgemv_batched](interfacehipfort__rocblas_1_1rocblas__hshgemv__batched.html "Interface documentation") | C binding
+407 | [rocblas_hssgemv_batched](interfacehipfort__rocblas_1_1rocblas__hssgemv__batched.html "Interface documentation") | C binding
+408 | [rocblas_tstgemv_batched](interfacehipfort__rocblas_1_1rocblas__tstgemv__batched.html "Interface documentation") | C binding
+409 | [rocblas_tssgemv_batched](interfacehipfort__rocblas_1_1rocblas__tssgemv__batched.html "Interface documentation") | C binding
+410 | [rocblas_sgemv_batched_64](interfacehipfort__rocblas_1_1rocblas__sgemv__batched__64.html "Interface documentation") | C binding
+411 | [rocblas_dgemv_batched_64](interfacehipfort__rocblas_1_1rocblas__dgemv__batched__64.html "Interface documentation") | C binding
+412 | [rocblas_cgemv_batched_64](interfacehipfort__rocblas_1_1rocblas__cgemv__batched__64.html "Interface documentation") | C binding
+413 | [rocblas_zgemv_batched_64](interfacehipfort__rocblas_1_1rocblas__zgemv__batched__64.html "Interface documentation") | C binding
+414 | [rocblas_hshgemv_batched_64](interfacehipfort__rocblas_1_1rocblas__hshgemv__batched__64.html "Interface documentation") | C binding
+415 | [rocblas_hssgemv_batched_64](interfacehipfort__rocblas_1_1rocblas__hssgemv__batched__64.html "Interface documentation") | C binding
+416 | [rocblas_tstgemv_batched_64](interfacehipfort__rocblas_1_1rocblas__tstgemv__batched__64.html "Interface documentation") | C binding
+417 | [rocblas_tssgemv_batched_64](interfacehipfort__rocblas_1_1rocblas__tssgemv__batched__64.html "Interface documentation") | C binding
+418 | [rocblas_sgemv_strided_batched](interfacehipfort__rocblas_1_1rocblas__sgemv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+419 | [rocblas_dgemv_strided_batched](interfacehipfort__rocblas_1_1rocblas__dgemv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+420 | [rocblas_cgemv_strided_batched](interfacehipfort__rocblas_1_1rocblas__cgemv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+421 | [rocblas_zgemv_strided_batched](interfacehipfort__rocblas_1_1rocblas__zgemv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+422 | [rocblas_hshgemv_strided_batched](interfacehipfort__rocblas_1_1rocblas__hshgemv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+423 | [rocblas_hssgemv_strided_batched](interfacehipfort__rocblas_1_1rocblas__hssgemv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+424 | [rocblas_tstgemv_strided_batched](interfacehipfort__rocblas_1_1rocblas__tstgemv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+425 | [rocblas_tssgemv_strided_batched](interfacehipfort__rocblas_1_1rocblas__tssgemv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+426 | [rocblas_sgemv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sgemv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+427 | [rocblas_dgemv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dgemv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+428 | [rocblas_cgemv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cgemv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+429 | [rocblas_zgemv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zgemv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+430 | [rocblas_hshgemv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__hshgemv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+431 | [rocblas_hssgemv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__hssgemv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+432 | [rocblas_tstgemv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__tstgemv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+433 | [rocblas_tssgemv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__tssgemv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+434 | [rocblas_chbmv](interfacehipfort__rocblas_1_1rocblas__chbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+435 | [rocblas_zhbmv](interfacehipfort__rocblas_1_1rocblas__zhbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+436 | [rocblas_chbmv_64](interfacehipfort__rocblas_1_1rocblas__chbmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+437 | [rocblas_zhbmv_64](interfacehipfort__rocblas_1_1rocblas__zhbmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+438 | [rocblas_chbmv_batched](interfacehipfort__rocblas_1_1rocblas__chbmv__batched.html "Interface documentation") | C binding
+439 | [rocblas_zhbmv_batched](interfacehipfort__rocblas_1_1rocblas__zhbmv__batched.html "Interface documentation") | C binding
+440 | [rocblas_chbmv_batched_64](interfacehipfort__rocblas_1_1rocblas__chbmv__batched__64.html "Interface documentation") | C binding
+441 | [rocblas_zhbmv_batched_64](interfacehipfort__rocblas_1_1rocblas__zhbmv__batched__64.html "Interface documentation") | C binding
+442 | [rocblas_chbmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__chbmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+443 | [rocblas_zhbmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__zhbmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+444 | [rocblas_chbmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__chbmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+445 | [rocblas_zhbmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zhbmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+446 | [rocblas_chemv](interfacehipfort__rocblas_1_1rocblas__chemv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+447 | [rocblas_zhemv](interfacehipfort__rocblas_1_1rocblas__zhemv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+448 | [rocblas_chemv_64](interfacehipfort__rocblas_1_1rocblas__chemv__64.html "Interface documentation") | C binding, rank_0, rank_1
+449 | [rocblas_zhemv_64](interfacehipfort__rocblas_1_1rocblas__zhemv__64.html "Interface documentation") | C binding, rank_0, rank_1
+450 | [rocblas_chemv_batched](interfacehipfort__rocblas_1_1rocblas__chemv__batched.html "Interface documentation") | C binding
+451 | [rocblas_zhemv_batched](interfacehipfort__rocblas_1_1rocblas__zhemv__batched.html "Interface documentation") | C binding
+452 | [rocblas_chemv_batched_64](interfacehipfort__rocblas_1_1rocblas__chemv__batched__64.html "Interface documentation") | C binding
+453 | [rocblas_zhemv_batched_64](interfacehipfort__rocblas_1_1rocblas__zhemv__batched__64.html "Interface documentation") | C binding
+454 | [rocblas_chemv_strided_batched](interfacehipfort__rocblas_1_1rocblas__chemv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+455 | [rocblas_zhemv_strided_batched](interfacehipfort__rocblas_1_1rocblas__zhemv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+456 | [rocblas_chemv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__chemv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+457 | [rocblas_zhemv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zhemv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+458 | [rocblas_cher](interfacehipfort__rocblas_1_1rocblas__cher.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+459 | [rocblas_zher](interfacehipfort__rocblas_1_1rocblas__zher.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+460 | [rocblas_cher_64](interfacehipfort__rocblas_1_1rocblas__cher__64.html "Interface documentation") | C binding, rank_0, rank_1
+461 | [rocblas_zher_64](interfacehipfort__rocblas_1_1rocblas__zher__64.html "Interface documentation") | C binding, rank_0, rank_1
+462 | [rocblas_cher_batched](interfacehipfort__rocblas_1_1rocblas__cher__batched.html "Interface documentation") | C binding
+463 | [rocblas_zher_batched](interfacehipfort__rocblas_1_1rocblas__zher__batched.html "Interface documentation") | C binding
+464 | [rocblas_cher_batched_64](interfacehipfort__rocblas_1_1rocblas__cher__batched__64.html "Interface documentation") | C binding
+465 | [rocblas_zher_batched_64](interfacehipfort__rocblas_1_1rocblas__zher__batched__64.html "Interface documentation") | C binding
+466 | [rocblas_cher_strided_batched](interfacehipfort__rocblas_1_1rocblas__cher__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+467 | [rocblas_zher_strided_batched](interfacehipfort__rocblas_1_1rocblas__zher__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+468 | [rocblas_cher_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cher__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+469 | [rocblas_zher_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zher__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+470 | [rocblas_cher2](interfacehipfort__rocblas_1_1rocblas__cher2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+471 | [rocblas_zher2](interfacehipfort__rocblas_1_1rocblas__zher2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+472 | [rocblas_cher2_64](interfacehipfort__rocblas_1_1rocblas__cher2__64.html "Interface documentation") | C binding, rank_0, rank_1
+473 | [rocblas_zher2_64](interfacehipfort__rocblas_1_1rocblas__zher2__64.html "Interface documentation") | C binding, rank_0, rank_1
+474 | [rocblas_cher2_batched](interfacehipfort__rocblas_1_1rocblas__cher2__batched.html "Interface documentation") | C binding
+475 | [rocblas_zher2_batched](interfacehipfort__rocblas_1_1rocblas__zher2__batched.html "Interface documentation") | C binding
+476 | [rocblas_cher2_batched_64](interfacehipfort__rocblas_1_1rocblas__cher2__batched__64.html "Interface documentation") | C binding
+477 | [rocblas_zher2_batched_64](interfacehipfort__rocblas_1_1rocblas__zher2__batched__64.html "Interface documentation") | C binding
+478 | [rocblas_cher2_strided_batched](interfacehipfort__rocblas_1_1rocblas__cher2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+479 | [rocblas_zher2_strided_batched](interfacehipfort__rocblas_1_1rocblas__zher2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+480 | [rocblas_cher2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cher2__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+481 | [rocblas_zher2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zher2__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+482 | [rocblas_chpmv](interfacehipfort__rocblas_1_1rocblas__chpmv.html "Interface documentation") | C binding, rank_0, rank_1
+483 | [rocblas_zhpmv](interfacehipfort__rocblas_1_1rocblas__zhpmv.html "Interface documentation") | C binding, rank_0, rank_1
+484 | [rocblas_chpmv_64](interfacehipfort__rocblas_1_1rocblas__chpmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+485 | [rocblas_zhpmv_64](interfacehipfort__rocblas_1_1rocblas__zhpmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+486 | [rocblas_chpmv_batched](interfacehipfort__rocblas_1_1rocblas__chpmv__batched.html "Interface documentation") | C binding
+487 | [rocblas_zhpmv_batched](interfacehipfort__rocblas_1_1rocblas__zhpmv__batched.html "Interface documentation") | C binding
+488 | [rocblas_chpmv_batched_64](interfacehipfort__rocblas_1_1rocblas__chpmv__batched__64.html "Interface documentation") | C binding
+489 | [rocblas_zhpmv_batched_64](interfacehipfort__rocblas_1_1rocblas__zhpmv__batched__64.html "Interface documentation") | C binding
+490 | [rocblas_chpmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__chpmv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+491 | [rocblas_zhpmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__zhpmv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+492 | [rocblas_chpmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__chpmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+493 | [rocblas_zhpmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zhpmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+494 | [rocblas_chpr](interfacehipfort__rocblas_1_1rocblas__chpr.html "Interface documentation") | C binding, rank_0, rank_1
+495 | [rocblas_zhpr](interfacehipfort__rocblas_1_1rocblas__zhpr.html "Interface documentation") | C binding, rank_0, rank_1
+496 | [rocblas_chpr_64](interfacehipfort__rocblas_1_1rocblas__chpr__64.html "Interface documentation") | C binding, rank_0, rank_1
+497 | [rocblas_zhpr_64](interfacehipfort__rocblas_1_1rocblas__zhpr__64.html "Interface documentation") | C binding, rank_0, rank_1
+498 | [rocblas_chpr_batched](interfacehipfort__rocblas_1_1rocblas__chpr__batched.html "Interface documentation") | C binding
+499 | [rocblas_zhpr_batched](interfacehipfort__rocblas_1_1rocblas__zhpr__batched.html "Interface documentation") | C binding
+500 | [rocblas_chpr_batched_64](interfacehipfort__rocblas_1_1rocblas__chpr__batched__64.html "Interface documentation") | C binding
+501 | [rocblas_zhpr_batched_64](interfacehipfort__rocblas_1_1rocblas__zhpr__batched__64.html "Interface documentation") | C binding
+502 | [rocblas_chpr_strided_batched](interfacehipfort__rocblas_1_1rocblas__chpr__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+503 | [rocblas_zhpr_strided_batched](interfacehipfort__rocblas_1_1rocblas__zhpr__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+504 | [rocblas_chpr_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__chpr__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+505 | [rocblas_zhpr_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zhpr__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+506 | [rocblas_chpr2](interfacehipfort__rocblas_1_1rocblas__chpr2.html "Interface documentation") | C binding, rank_0, rank_1
+507 | [rocblas_zhpr2](interfacehipfort__rocblas_1_1rocblas__zhpr2.html "Interface documentation") | C binding, rank_0, rank_1
+508 | [rocblas_chpr2_64](interfacehipfort__rocblas_1_1rocblas__chpr2__64.html "Interface documentation") | C binding, rank_0, rank_1
+509 | [rocblas_zhpr2_64](interfacehipfort__rocblas_1_1rocblas__zhpr2__64.html "Interface documentation") | C binding, rank_0, rank_1
+510 | [rocblas_chpr2_batched](interfacehipfort__rocblas_1_1rocblas__chpr2__batched.html "Interface documentation") | C binding
+511 | [rocblas_zhpr2_batched](interfacehipfort__rocblas_1_1rocblas__zhpr2__batched.html "Interface documentation") | C binding
+512 | [rocblas_chpr2_batched_64](interfacehipfort__rocblas_1_1rocblas__chpr2__batched__64.html "Interface documentation") | C binding
+513 | [rocblas_zhpr2_batched_64](interfacehipfort__rocblas_1_1rocblas__zhpr2__batched__64.html "Interface documentation") | C binding
+514 | [rocblas_chpr2_strided_batched](interfacehipfort__rocblas_1_1rocblas__chpr2__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+515 | [rocblas_zhpr2_strided_batched](interfacehipfort__rocblas_1_1rocblas__zhpr2__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+516 | [rocblas_chpr2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__chpr2__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+517 | [rocblas_zhpr2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zhpr2__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+518 | [rocblas_strmv](interfacehipfort__rocblas_1_1rocblas__strmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+519 | [rocblas_dtrmv](interfacehipfort__rocblas_1_1rocblas__dtrmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+520 | [rocblas_ctrmv](interfacehipfort__rocblas_1_1rocblas__ctrmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+521 | [rocblas_ztrmv](interfacehipfort__rocblas_1_1rocblas__ztrmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+522 | [rocblas_strmv_64](interfacehipfort__rocblas_1_1rocblas__strmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+523 | [rocblas_dtrmv_64](interfacehipfort__rocblas_1_1rocblas__dtrmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+524 | [rocblas_ctrmv_64](interfacehipfort__rocblas_1_1rocblas__ctrmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+525 | [rocblas_ztrmv_64](interfacehipfort__rocblas_1_1rocblas__ztrmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+526 | [rocblas_strmv_batched](interfacehipfort__rocblas_1_1rocblas__strmv__batched.html "Interface documentation") | C binding
+527 | [rocblas_dtrmv_batched](interfacehipfort__rocblas_1_1rocblas__dtrmv__batched.html "Interface documentation") | C binding
+528 | [rocblas_ctrmv_batched](interfacehipfort__rocblas_1_1rocblas__ctrmv__batched.html "Interface documentation") | C binding
+529 | [rocblas_ztrmv_batched](interfacehipfort__rocblas_1_1rocblas__ztrmv__batched.html "Interface documentation") | C binding
+530 | [rocblas_strmv_batched_64](interfacehipfort__rocblas_1_1rocblas__strmv__batched__64.html "Interface documentation") | C binding
+531 | [rocblas_dtrmv_batched_64](interfacehipfort__rocblas_1_1rocblas__dtrmv__batched__64.html "Interface documentation") | C binding
+532 | [rocblas_ctrmv_batched_64](interfacehipfort__rocblas_1_1rocblas__ctrmv__batched__64.html "Interface documentation") | C binding
+533 | [rocblas_ztrmv_batched_64](interfacehipfort__rocblas_1_1rocblas__ztrmv__batched__64.html "Interface documentation") | C binding
+534 | [rocblas_strmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__strmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+535 | [rocblas_dtrmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__dtrmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+536 | [rocblas_ctrmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ctrmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+537 | [rocblas_ztrmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ztrmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+538 | [rocblas_strmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__strmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+539 | [rocblas_dtrmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dtrmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+540 | [rocblas_ctrmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ctrmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+541 | [rocblas_ztrmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ztrmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+542 | [rocblas_stpmv](interfacehipfort__rocblas_1_1rocblas__stpmv.html "Interface documentation") | C binding, rank_0, rank_1
+543 | [rocblas_dtpmv](interfacehipfort__rocblas_1_1rocblas__dtpmv.html "Interface documentation") | C binding, rank_0, rank_1
+544 | [rocblas_ctpmv](interfacehipfort__rocblas_1_1rocblas__ctpmv.html "Interface documentation") | C binding, rank_0, rank_1
+545 | [rocblas_ztpmv](interfacehipfort__rocblas_1_1rocblas__ztpmv.html "Interface documentation") | C binding, rank_0, rank_1
+546 | [rocblas_stpmv_64](interfacehipfort__rocblas_1_1rocblas__stpmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+547 | [rocblas_dtpmv_64](interfacehipfort__rocblas_1_1rocblas__dtpmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+548 | [rocblas_ctpmv_64](interfacehipfort__rocblas_1_1rocblas__ctpmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+549 | [rocblas_ztpmv_64](interfacehipfort__rocblas_1_1rocblas__ztpmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+550 | [rocblas_stpmv_batched](interfacehipfort__rocblas_1_1rocblas__stpmv__batched.html "Interface documentation") | C binding
+551 | [rocblas_dtpmv_batched](interfacehipfort__rocblas_1_1rocblas__dtpmv__batched.html "Interface documentation") | C binding
+552 | [rocblas_ctpmv_batched](interfacehipfort__rocblas_1_1rocblas__ctpmv__batched.html "Interface documentation") | C binding
+553 | [rocblas_ztpmv_batched](interfacehipfort__rocblas_1_1rocblas__ztpmv__batched.html "Interface documentation") | C binding
+554 | [rocblas_stpmv_batched_64](interfacehipfort__rocblas_1_1rocblas__stpmv__batched__64.html "Interface documentation") | C binding
+555 | [rocblas_dtpmv_batched_64](interfacehipfort__rocblas_1_1rocblas__dtpmv__batched__64.html "Interface documentation") | C binding
+556 | [rocblas_ctpmv_batched_64](interfacehipfort__rocblas_1_1rocblas__ctpmv__batched__64.html "Interface documentation") | C binding
+557 | [rocblas_ztpmv_batched_64](interfacehipfort__rocblas_1_1rocblas__ztpmv__batched__64.html "Interface documentation") | C binding
+558 | [rocblas_stpmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__stpmv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+559 | [rocblas_dtpmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__dtpmv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+560 | [rocblas_ctpmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ctpmv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+561 | [rocblas_ztpmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ztpmv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+562 | [rocblas_stpmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__stpmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+563 | [rocblas_dtpmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dtpmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+564 | [rocblas_ctpmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ctpmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+565 | [rocblas_ztpmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ztpmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+566 | [rocblas_stbmv](interfacehipfort__rocblas_1_1rocblas__stbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+567 | [rocblas_dtbmv](interfacehipfort__rocblas_1_1rocblas__dtbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+568 | [rocblas_ctbmv](interfacehipfort__rocblas_1_1rocblas__ctbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+569 | [rocblas_ztbmv](interfacehipfort__rocblas_1_1rocblas__ztbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+570 | [rocblas_stbmv_64](interfacehipfort__rocblas_1_1rocblas__stbmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+571 | [rocblas_dtbmv_64](interfacehipfort__rocblas_1_1rocblas__dtbmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+572 | [rocblas_ctbmv_64](interfacehipfort__rocblas_1_1rocblas__ctbmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+573 | [rocblas_ztbmv_64](interfacehipfort__rocblas_1_1rocblas__ztbmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+574 | [rocblas_stbmv_batched](interfacehipfort__rocblas_1_1rocblas__stbmv__batched.html "Interface documentation") | C binding
+575 | [rocblas_dtbmv_batched](interfacehipfort__rocblas_1_1rocblas__dtbmv__batched.html "Interface documentation") | C binding
+576 | [rocblas_ctbmv_batched](interfacehipfort__rocblas_1_1rocblas__ctbmv__batched.html "Interface documentation") | C binding
+577 | [rocblas_ztbmv_batched](interfacehipfort__rocblas_1_1rocblas__ztbmv__batched.html "Interface documentation") | C binding
+578 | [rocblas_stbmv_batched_64](interfacehipfort__rocblas_1_1rocblas__stbmv__batched__64.html "Interface documentation") | C binding
+579 | [rocblas_dtbmv_batched_64](interfacehipfort__rocblas_1_1rocblas__dtbmv__batched__64.html "Interface documentation") | C binding
+580 | [rocblas_ctbmv_batched_64](interfacehipfort__rocblas_1_1rocblas__ctbmv__batched__64.html "Interface documentation") | C binding
+581 | [rocblas_ztbmv_batched_64](interfacehipfort__rocblas_1_1rocblas__ztbmv__batched__64.html "Interface documentation") | C binding
+582 | [rocblas_stbmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__stbmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+583 | [rocblas_dtbmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__dtbmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+584 | [rocblas_ctbmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ctbmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+585 | [rocblas_ztbmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ztbmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+586 | [rocblas_stbmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__stbmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+587 | [rocblas_dtbmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dtbmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+588 | [rocblas_ctbmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ctbmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+589 | [rocblas_ztbmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ztbmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+590 | [rocblas_stbsv](interfacehipfort__rocblas_1_1rocblas__stbsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+591 | [rocblas_dtbsv](interfacehipfort__rocblas_1_1rocblas__dtbsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+592 | [rocblas_ctbsv](interfacehipfort__rocblas_1_1rocblas__ctbsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+593 | [rocblas_ztbsv](interfacehipfort__rocblas_1_1rocblas__ztbsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+594 | [rocblas_stbsv_64](interfacehipfort__rocblas_1_1rocblas__stbsv__64.html "Interface documentation") | C binding, rank_0, rank_1
+595 | [rocblas_dtbsv_64](interfacehipfort__rocblas_1_1rocblas__dtbsv__64.html "Interface documentation") | C binding, rank_0, rank_1
+596 | [rocblas_ctbsv_64](interfacehipfort__rocblas_1_1rocblas__ctbsv__64.html "Interface documentation") | C binding, rank_0, rank_1
+597 | [rocblas_ztbsv_64](interfacehipfort__rocblas_1_1rocblas__ztbsv__64.html "Interface documentation") | C binding, rank_0, rank_1
+598 | [rocblas_stbsv_batched](interfacehipfort__rocblas_1_1rocblas__stbsv__batched.html "Interface documentation") | C binding
+599 | [rocblas_dtbsv_batched](interfacehipfort__rocblas_1_1rocblas__dtbsv__batched.html "Interface documentation") | C binding
+600 | [rocblas_ctbsv_batched](interfacehipfort__rocblas_1_1rocblas__ctbsv__batched.html "Interface documentation") | C binding
+601 | [rocblas_ztbsv_batched](interfacehipfort__rocblas_1_1rocblas__ztbsv__batched.html "Interface documentation") | C binding
+602 | [rocblas_stbsv_batched_64](interfacehipfort__rocblas_1_1rocblas__stbsv__batched__64.html "Interface documentation") | C binding
+603 | [rocblas_dtbsv_batched_64](interfacehipfort__rocblas_1_1rocblas__dtbsv__batched__64.html "Interface documentation") | C binding
+604 | [rocblas_ctbsv_batched_64](interfacehipfort__rocblas_1_1rocblas__ctbsv__batched__64.html "Interface documentation") | C binding
+605 | [rocblas_ztbsv_batched_64](interfacehipfort__rocblas_1_1rocblas__ztbsv__batched__64.html "Interface documentation") | C binding
+606 | [rocblas_stbsv_strided_batched](interfacehipfort__rocblas_1_1rocblas__stbsv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+607 | [rocblas_dtbsv_strided_batched](interfacehipfort__rocblas_1_1rocblas__dtbsv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+608 | [rocblas_ctbsv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ctbsv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+609 | [rocblas_ztbsv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ztbsv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+610 | [rocblas_stbsv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__stbsv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+611 | [rocblas_dtbsv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dtbsv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+612 | [rocblas_ctbsv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ctbsv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+613 | [rocblas_ztbsv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ztbsv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+614 | [rocblas_strsv](interfacehipfort__rocblas_1_1rocblas__strsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+615 | [rocblas_dtrsv](interfacehipfort__rocblas_1_1rocblas__dtrsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+616 | [rocblas_ctrsv](interfacehipfort__rocblas_1_1rocblas__ctrsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+617 | [rocblas_ztrsv](interfacehipfort__rocblas_1_1rocblas__ztrsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+618 | [rocblas_strsv_64](interfacehipfort__rocblas_1_1rocblas__strsv__64.html "Interface documentation") | C binding, rank_0, rank_1
+619 | [rocblas_dtrsv_64](interfacehipfort__rocblas_1_1rocblas__dtrsv__64.html "Interface documentation") | C binding, rank_0, rank_1
+620 | [rocblas_ctrsv_64](interfacehipfort__rocblas_1_1rocblas__ctrsv__64.html "Interface documentation") | C binding, rank_0, rank_1
+621 | [rocblas_ztrsv_64](interfacehipfort__rocblas_1_1rocblas__ztrsv__64.html "Interface documentation") | C binding, rank_0, rank_1
+622 | [rocblas_strsv_batched](interfacehipfort__rocblas_1_1rocblas__strsv__batched.html "Interface documentation") | C binding
+623 | [rocblas_dtrsv_batched](interfacehipfort__rocblas_1_1rocblas__dtrsv__batched.html "Interface documentation") | C binding
+624 | [rocblas_ctrsv_batched](interfacehipfort__rocblas_1_1rocblas__ctrsv__batched.html "Interface documentation") | C binding
+625 | [rocblas_ztrsv_batched](interfacehipfort__rocblas_1_1rocblas__ztrsv__batched.html "Interface documentation") | C binding
+626 | [rocblas_strsv_batched_64](interfacehipfort__rocblas_1_1rocblas__strsv__batched__64.html "Interface documentation") | C binding
+627 | [rocblas_dtrsv_batched_64](interfacehipfort__rocblas_1_1rocblas__dtrsv__batched__64.html "Interface documentation") | C binding
+628 | [rocblas_ctrsv_batched_64](interfacehipfort__rocblas_1_1rocblas__ctrsv__batched__64.html "Interface documentation") | C binding
+629 | [rocblas_ztrsv_batched_64](interfacehipfort__rocblas_1_1rocblas__ztrsv__batched__64.html "Interface documentation") | C binding
+630 | [rocblas_strsv_strided_batched](interfacehipfort__rocblas_1_1rocblas__strsv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+631 | [rocblas_dtrsv_strided_batched](interfacehipfort__rocblas_1_1rocblas__dtrsv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+632 | [rocblas_ctrsv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ctrsv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+633 | [rocblas_ztrsv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ztrsv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+634 | [rocblas_strsv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__strsv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+635 | [rocblas_dtrsv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dtrsv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+636 | [rocblas_ctrsv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ctrsv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+637 | [rocblas_ztrsv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ztrsv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+638 | [rocblas_stpsv](interfacehipfort__rocblas_1_1rocblas__stpsv.html "Interface documentation") | C binding, rank_0, rank_1
+639 | [rocblas_dtpsv](interfacehipfort__rocblas_1_1rocblas__dtpsv.html "Interface documentation") | C binding, rank_0, rank_1
+640 | [rocblas_ctpsv](interfacehipfort__rocblas_1_1rocblas__ctpsv.html "Interface documentation") | C binding, rank_0, rank_1
+641 | [rocblas_ztpsv](interfacehipfort__rocblas_1_1rocblas__ztpsv.html "Interface documentation") | C binding, rank_0, rank_1
+642 | [rocblas_stpsv_64](interfacehipfort__rocblas_1_1rocblas__stpsv__64.html "Interface documentation") | C binding, rank_0, rank_1
+643 | [rocblas_dtpsv_64](interfacehipfort__rocblas_1_1rocblas__dtpsv__64.html "Interface documentation") | C binding, rank_0, rank_1
+644 | [rocblas_ctpsv_64](interfacehipfort__rocblas_1_1rocblas__ctpsv__64.html "Interface documentation") | C binding, rank_0, rank_1
+645 | [rocblas_ztpsv_64](interfacehipfort__rocblas_1_1rocblas__ztpsv__64.html "Interface documentation") | C binding, rank_0, rank_1
+646 | [rocblas_stpsv_batched](interfacehipfort__rocblas_1_1rocblas__stpsv__batched.html "Interface documentation") | C binding
+647 | [rocblas_dtpsv_batched](interfacehipfort__rocblas_1_1rocblas__dtpsv__batched.html "Interface documentation") | C binding
+648 | [rocblas_ctpsv_batched](interfacehipfort__rocblas_1_1rocblas__ctpsv__batched.html "Interface documentation") | C binding
+649 | [rocblas_ztpsv_batched](interfacehipfort__rocblas_1_1rocblas__ztpsv__batched.html "Interface documentation") | C binding
+650 | [rocblas_stpsv_batched_64](interfacehipfort__rocblas_1_1rocblas__stpsv__batched__64.html "Interface documentation") | C binding
+651 | [rocblas_dtpsv_batched_64](interfacehipfort__rocblas_1_1rocblas__dtpsv__batched__64.html "Interface documentation") | C binding
+652 | [rocblas_ctpsv_batched_64](interfacehipfort__rocblas_1_1rocblas__ctpsv__batched__64.html "Interface documentation") | C binding
+653 | [rocblas_ztpsv_batched_64](interfacehipfort__rocblas_1_1rocblas__ztpsv__batched__64.html "Interface documentation") | C binding
+654 | [rocblas_stpsv_strided_batched](interfacehipfort__rocblas_1_1rocblas__stpsv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+655 | [rocblas_dtpsv_strided_batched](interfacehipfort__rocblas_1_1rocblas__dtpsv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+656 | [rocblas_ctpsv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ctpsv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+657 | [rocblas_ztpsv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ztpsv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+658 | [rocblas_stpsv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__stpsv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+659 | [rocblas_dtpsv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dtpsv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+660 | [rocblas_ctpsv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ctpsv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+661 | [rocblas_ztpsv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ztpsv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+662 | [rocblas_ssymv](interfacehipfort__rocblas_1_1rocblas__ssymv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+663 | [rocblas_dsymv](interfacehipfort__rocblas_1_1rocblas__dsymv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+664 | [rocblas_csymv](interfacehipfort__rocblas_1_1rocblas__csymv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+665 | [rocblas_zsymv](interfacehipfort__rocblas_1_1rocblas__zsymv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+666 | [rocblas_ssymv_64](interfacehipfort__rocblas_1_1rocblas__ssymv__64.html "Interface documentation") | C binding, rank_0, rank_1
+667 | [rocblas_dsymv_64](interfacehipfort__rocblas_1_1rocblas__dsymv__64.html "Interface documentation") | C binding, rank_0, rank_1
+668 | [rocblas_csymv_64](interfacehipfort__rocblas_1_1rocblas__csymv__64.html "Interface documentation") | C binding, rank_0, rank_1
+669 | [rocblas_zsymv_64](interfacehipfort__rocblas_1_1rocblas__zsymv__64.html "Interface documentation") | C binding, rank_0, rank_1
+670 | [rocblas_ssymv_batched](interfacehipfort__rocblas_1_1rocblas__ssymv__batched.html "Interface documentation") | C binding
+671 | [rocblas_dsymv_batched](interfacehipfort__rocblas_1_1rocblas__dsymv__batched.html "Interface documentation") | C binding
+672 | [rocblas_csymv_batched](interfacehipfort__rocblas_1_1rocblas__csymv__batched.html "Interface documentation") | C binding
+673 | [rocblas_zsymv_batched](interfacehipfort__rocblas_1_1rocblas__zsymv__batched.html "Interface documentation") | C binding
+674 | [rocblas_ssymv_batched_64](interfacehipfort__rocblas_1_1rocblas__ssymv__batched__64.html "Interface documentation") | C binding
+675 | [rocblas_dsymv_batched_64](interfacehipfort__rocblas_1_1rocblas__dsymv__batched__64.html "Interface documentation") | C binding
+676 | [rocblas_csymv_batched_64](interfacehipfort__rocblas_1_1rocblas__csymv__batched__64.html "Interface documentation") | C binding
+677 | [rocblas_zsymv_batched_64](interfacehipfort__rocblas_1_1rocblas__zsymv__batched__64.html "Interface documentation") | C binding
+678 | [rocblas_ssymv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ssymv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+679 | [rocblas_dsymv_strided_batched](interfacehipfort__rocblas_1_1rocblas__dsymv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+680 | [rocblas_csymv_strided_batched](interfacehipfort__rocblas_1_1rocblas__csymv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+681 | [rocblas_zsymv_strided_batched](interfacehipfort__rocblas_1_1rocblas__zsymv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+682 | [rocblas_ssymv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ssymv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+683 | [rocblas_dsymv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dsymv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+684 | [rocblas_csymv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__csymv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+685 | [rocblas_zsymv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zsymv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+686 | [rocblas_sspmv](interfacehipfort__rocblas_1_1rocblas__sspmv.html "Interface documentation") | C binding, rank_0, rank_1
+687 | [rocblas_dspmv](interfacehipfort__rocblas_1_1rocblas__dspmv.html "Interface documentation") | C binding, rank_0, rank_1
+688 | [rocblas_sspmv_64](interfacehipfort__rocblas_1_1rocblas__sspmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+689 | [rocblas_dspmv_64](interfacehipfort__rocblas_1_1rocblas__dspmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+690 | [rocblas_sspmv_batched](interfacehipfort__rocblas_1_1rocblas__sspmv__batched.html "Interface documentation") | C binding
+691 | [rocblas_dspmv_batched](interfacehipfort__rocblas_1_1rocblas__dspmv__batched.html "Interface documentation") | C binding
+692 | [rocblas_sspmv_batched_64](interfacehipfort__rocblas_1_1rocblas__sspmv__batched__64.html "Interface documentation") | C binding
+693 | [rocblas_dspmv_batched_64](interfacehipfort__rocblas_1_1rocblas__dspmv__batched__64.html "Interface documentation") | C binding
+694 | [rocblas_sspmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__sspmv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+695 | [rocblas_dspmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__dspmv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+696 | [rocblas_sspmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sspmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+697 | [rocblas_dspmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dspmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+698 | [rocblas_ssbmv](interfacehipfort__rocblas_1_1rocblas__ssbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+699 | [rocblas_dsbmv](interfacehipfort__rocblas_1_1rocblas__dsbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+700 | [rocblas_ssbmv_64](interfacehipfort__rocblas_1_1rocblas__ssbmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+701 | [rocblas_dsbmv_64](interfacehipfort__rocblas_1_1rocblas__dsbmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+702 | [rocblas_ssbmv_batched](interfacehipfort__rocblas_1_1rocblas__ssbmv__batched.html "Interface documentation") | C binding
+703 | [rocblas_dsbmv_batched](interfacehipfort__rocblas_1_1rocblas__dsbmv__batched.html "Interface documentation") | C binding
+704 | [rocblas_ssbmv_batched_64](interfacehipfort__rocblas_1_1rocblas__ssbmv__batched__64.html "Interface documentation") | C binding
+705 | [rocblas_dsbmv_batched_64](interfacehipfort__rocblas_1_1rocblas__dsbmv__batched__64.html "Interface documentation") | C binding
+706 | [rocblas_ssbmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ssbmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+707 | [rocblas_dsbmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__dsbmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+708 | [rocblas_ssbmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ssbmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+709 | [rocblas_dsbmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dsbmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+710 | [rocblas_sger](interfacehipfort__rocblas_1_1rocblas__sger.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+711 | [rocblas_dger](interfacehipfort__rocblas_1_1rocblas__dger.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+712 | [rocblas_cgeru](interfacehipfort__rocblas_1_1rocblas__cgeru.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+713 | [rocblas_zgeru](interfacehipfort__rocblas_1_1rocblas__zgeru.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+714 | [rocblas_cgerc](interfacehipfort__rocblas_1_1rocblas__cgerc.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+715 | [rocblas_zgerc](interfacehipfort__rocblas_1_1rocblas__zgerc.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+716 | [rocblas_sger_64](interfacehipfort__rocblas_1_1rocblas__sger__64.html "Interface documentation") | C binding, rank_0, rank_1
+717 | [rocblas_dger_64](interfacehipfort__rocblas_1_1rocblas__dger__64.html "Interface documentation") | C binding, rank_0, rank_1
+718 | [rocblas_cgeru_64](interfacehipfort__rocblas_1_1rocblas__cgeru__64.html "Interface documentation") | C binding, rank_0, rank_1
+719 | [rocblas_zgeru_64](interfacehipfort__rocblas_1_1rocblas__zgeru__64.html "Interface documentation") | C binding, rank_0, rank_1
+720 | [rocblas_cgerc_64](interfacehipfort__rocblas_1_1rocblas__cgerc__64.html "Interface documentation") | C binding, rank_0, rank_1
+721 | [rocblas_zgerc_64](interfacehipfort__rocblas_1_1rocblas__zgerc__64.html "Interface documentation") | C binding, rank_0, rank_1
+722 | [rocblas_sger_batched](interfacehipfort__rocblas_1_1rocblas__sger__batched.html "Interface documentation") | C binding
+723 | [rocblas_dger_batched](interfacehipfort__rocblas_1_1rocblas__dger__batched.html "Interface documentation") | C binding
+724 | [rocblas_cgeru_batched](interfacehipfort__rocblas_1_1rocblas__cgeru__batched.html "Interface documentation") | C binding
+725 | [rocblas_zgeru_batched](interfacehipfort__rocblas_1_1rocblas__zgeru__batched.html "Interface documentation") | C binding
+726 | [rocblas_cgerc_batched](interfacehipfort__rocblas_1_1rocblas__cgerc__batched.html "Interface documentation") | C binding
+727 | [rocblas_zgerc_batched](interfacehipfort__rocblas_1_1rocblas__zgerc__batched.html "Interface documentation") | C binding
+728 | [rocblas_sger_batched_64](interfacehipfort__rocblas_1_1rocblas__sger__batched__64.html "Interface documentation") | C binding
+729 | [rocblas_dger_batched_64](interfacehipfort__rocblas_1_1rocblas__dger__batched__64.html "Interface documentation") | C binding
+730 | [rocblas_cgeru_batched_64](interfacehipfort__rocblas_1_1rocblas__cgeru__batched__64.html "Interface documentation") | C binding
+731 | [rocblas_zgeru_batched_64](interfacehipfort__rocblas_1_1rocblas__zgeru__batched__64.html "Interface documentation") | C binding
+732 | [rocblas_cgerc_batched_64](interfacehipfort__rocblas_1_1rocblas__cgerc__batched__64.html "Interface documentation") | C binding
+733 | [rocblas_zgerc_batched_64](interfacehipfort__rocblas_1_1rocblas__zgerc__batched__64.html "Interface documentation") | C binding
+734 | [rocblas_sger_strided_batched](interfacehipfort__rocblas_1_1rocblas__sger__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+735 | [rocblas_dger_strided_batched](interfacehipfort__rocblas_1_1rocblas__dger__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+736 | [rocblas_cgeru_strided_batched](interfacehipfort__rocblas_1_1rocblas__cgeru__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+737 | [rocblas_zgeru_strided_batched](interfacehipfort__rocblas_1_1rocblas__zgeru__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+738 | [rocblas_cgerc_strided_batched](interfacehipfort__rocblas_1_1rocblas__cgerc__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+739 | [rocblas_zgerc_strided_batched](interfacehipfort__rocblas_1_1rocblas__zgerc__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+740 | [rocblas_sger_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sger__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+741 | [rocblas_dger_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dger__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+742 | [rocblas_cgeru_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cgeru__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+743 | [rocblas_zgeru_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zgeru__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+744 | [rocblas_cgerc_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cgerc__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+745 | [rocblas_zgerc_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zgerc__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+746 | [rocblas_sspr](interfacehipfort__rocblas_1_1rocblas__sspr.html "Interface documentation") | C binding, rank_0, rank_1
+747 | [rocblas_dspr](interfacehipfort__rocblas_1_1rocblas__dspr.html "Interface documentation") | C binding, rank_0, rank_1
+748 | [rocblas_cspr](interfacehipfort__rocblas_1_1rocblas__cspr.html "Interface documentation") | C binding, rank_0, rank_1
+749 | [rocblas_zspr](interfacehipfort__rocblas_1_1rocblas__zspr.html "Interface documentation") | C binding, rank_0, rank_1
+750 | [rocblas_sspr_64](interfacehipfort__rocblas_1_1rocblas__sspr__64.html "Interface documentation") | C binding, rank_0, rank_1
+751 | [rocblas_dspr_64](interfacehipfort__rocblas_1_1rocblas__dspr__64.html "Interface documentation") | C binding, rank_0, rank_1
+752 | [rocblas_cspr_64](interfacehipfort__rocblas_1_1rocblas__cspr__64.html "Interface documentation") | C binding, rank_0, rank_1
+753 | [rocblas_zspr_64](interfacehipfort__rocblas_1_1rocblas__zspr__64.html "Interface documentation") | C binding, rank_0, rank_1
+754 | [rocblas_sspr_batched](interfacehipfort__rocblas_1_1rocblas__sspr__batched.html "Interface documentation") | C binding
+755 | [rocblas_dspr_batched](interfacehipfort__rocblas_1_1rocblas__dspr__batched.html "Interface documentation") | C binding
+756 | [rocblas_cspr_batched](interfacehipfort__rocblas_1_1rocblas__cspr__batched.html "Interface documentation") | C binding
+757 | [rocblas_zspr_batched](interfacehipfort__rocblas_1_1rocblas__zspr__batched.html "Interface documentation") | C binding
+758 | [rocblas_sspr_batched_64](interfacehipfort__rocblas_1_1rocblas__sspr__batched__64.html "Interface documentation") | C binding
+759 | [rocblas_dspr_batched_64](interfacehipfort__rocblas_1_1rocblas__dspr__batched__64.html "Interface documentation") | C binding
+760 | [rocblas_cspr_batched_64](interfacehipfort__rocblas_1_1rocblas__cspr__batched__64.html "Interface documentation") | C binding
+761 | [rocblas_zspr_batched_64](interfacehipfort__rocblas_1_1rocblas__zspr__batched__64.html "Interface documentation") | C binding
+762 | [rocblas_sspr_strided_batched](interfacehipfort__rocblas_1_1rocblas__sspr__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+763 | [rocblas_dspr_strided_batched](interfacehipfort__rocblas_1_1rocblas__dspr__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+764 | [rocblas_cspr_strided_batched](interfacehipfort__rocblas_1_1rocblas__cspr__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+765 | [rocblas_zspr_strided_batched](interfacehipfort__rocblas_1_1rocblas__zspr__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+766 | [rocblas_sspr_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sspr__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+767 | [rocblas_dspr_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dspr__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+768 | [rocblas_cspr_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cspr__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+769 | [rocblas_zspr_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zspr__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+770 | [rocblas_sspr2](interfacehipfort__rocblas_1_1rocblas__sspr2.html "Interface documentation") | C binding, rank_0, rank_1
+771 | [rocblas_dspr2](interfacehipfort__rocblas_1_1rocblas__dspr2.html "Interface documentation") | C binding, rank_0, rank_1
+772 | [rocblas_sspr2_64](interfacehipfort__rocblas_1_1rocblas__sspr2__64.html "Interface documentation") | C binding, rank_0, rank_1
+773 | [rocblas_dspr2_64](interfacehipfort__rocblas_1_1rocblas__dspr2__64.html "Interface documentation") | C binding, rank_0, rank_1
+774 | [rocblas_sspr2_batched](interfacehipfort__rocblas_1_1rocblas__sspr2__batched.html "Interface documentation") | C binding
+775 | [rocblas_dspr2_batched](interfacehipfort__rocblas_1_1rocblas__dspr2__batched.html "Interface documentation") | C binding
+776 | [rocblas_sspr2_batched_64](interfacehipfort__rocblas_1_1rocblas__sspr2__batched__64.html "Interface documentation") | C binding
+777 | [rocblas_dspr2_batched_64](interfacehipfort__rocblas_1_1rocblas__dspr2__batched__64.html "Interface documentation") | C binding
+778 | [rocblas_sspr2_strided_batched](interfacehipfort__rocblas_1_1rocblas__sspr2__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+779 | [rocblas_dspr2_strided_batched](interfacehipfort__rocblas_1_1rocblas__dspr2__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+780 | [rocblas_sspr2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sspr2__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+781 | [rocblas_dspr2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dspr2__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+782 | [rocblas_ssyr](interfacehipfort__rocblas_1_1rocblas__ssyr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+783 | [rocblas_dsyr](interfacehipfort__rocblas_1_1rocblas__dsyr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+784 | [rocblas_csyr](interfacehipfort__rocblas_1_1rocblas__csyr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+785 | [rocblas_zsyr](interfacehipfort__rocblas_1_1rocblas__zsyr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+786 | [rocblas_ssyr_64](interfacehipfort__rocblas_1_1rocblas__ssyr__64.html "Interface documentation") | C binding, rank_0, rank_1
+787 | [rocblas_dsyr_64](interfacehipfort__rocblas_1_1rocblas__dsyr__64.html "Interface documentation") | C binding, rank_0, rank_1
+788 | [rocblas_csyr_64](interfacehipfort__rocblas_1_1rocblas__csyr__64.html "Interface documentation") | C binding, rank_0, rank_1
+789 | [rocblas_zsyr_64](interfacehipfort__rocblas_1_1rocblas__zsyr__64.html "Interface documentation") | C binding, rank_0, rank_1
+790 | [rocblas_ssyr_batched](interfacehipfort__rocblas_1_1rocblas__ssyr__batched.html "Interface documentation") | C binding
+791 | [rocblas_dsyr_batched](interfacehipfort__rocblas_1_1rocblas__dsyr__batched.html "Interface documentation") | C binding
+792 | [rocblas_csyr_batched](interfacehipfort__rocblas_1_1rocblas__csyr__batched.html "Interface documentation") | C binding
+793 | [rocblas_zsyr_batched](interfacehipfort__rocblas_1_1rocblas__zsyr__batched.html "Interface documentation") | C binding
+794 | [rocblas_ssyr_batched_64](interfacehipfort__rocblas_1_1rocblas__ssyr__batched__64.html "Interface documentation") | C binding
+795 | [rocblas_dsyr_batched_64](interfacehipfort__rocblas_1_1rocblas__dsyr__batched__64.html "Interface documentation") | C binding
+796 | [rocblas_csyr_batched_64](interfacehipfort__rocblas_1_1rocblas__csyr__batched__64.html "Interface documentation") | C binding
+797 | [rocblas_zsyr_batched_64](interfacehipfort__rocblas_1_1rocblas__zsyr__batched__64.html "Interface documentation") | C binding
+798 | [rocblas_ssyr_strided_batched](interfacehipfort__rocblas_1_1rocblas__ssyr__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+799 | [rocblas_dsyr_strided_batched](interfacehipfort__rocblas_1_1rocblas__dsyr__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+800 | [rocblas_csyr_strided_batched](interfacehipfort__rocblas_1_1rocblas__csyr__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+801 | [rocblas_zsyr_strided_batched](interfacehipfort__rocblas_1_1rocblas__zsyr__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+802 | [rocblas_ssyr_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ssyr__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+803 | [rocblas_dsyr_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dsyr__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+804 | [rocblas_csyr_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__csyr__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+805 | [rocblas_zsyr_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zsyr__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+806 | [rocblas_ssyr2](interfacehipfort__rocblas_1_1rocblas__ssyr2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+807 | [rocblas_dsyr2](interfacehipfort__rocblas_1_1rocblas__dsyr2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+808 | [rocblas_csyr2](interfacehipfort__rocblas_1_1rocblas__csyr2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+809 | [rocblas_zsyr2](interfacehipfort__rocblas_1_1rocblas__zsyr2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+810 | [rocblas_ssyr2_64](interfacehipfort__rocblas_1_1rocblas__ssyr2__64.html "Interface documentation") | C binding, rank_0, rank_1
+811 | [rocblas_dsyr2_64](interfacehipfort__rocblas_1_1rocblas__dsyr2__64.html "Interface documentation") | C binding, rank_0, rank_1
+812 | [rocblas_csyr2_64](interfacehipfort__rocblas_1_1rocblas__csyr2__64.html "Interface documentation") | C binding, rank_0, rank_1
+813 | [rocblas_zsyr2_64](interfacehipfort__rocblas_1_1rocblas__zsyr2__64.html "Interface documentation") | C binding, rank_0, rank_1
+814 | [rocblas_ssyr2_batched](interfacehipfort__rocblas_1_1rocblas__ssyr2__batched.html "Interface documentation") | C binding
+815 | [rocblas_dsyr2_batched](interfacehipfort__rocblas_1_1rocblas__dsyr2__batched.html "Interface documentation") | C binding
+816 | [rocblas_csyr2_batched](interfacehipfort__rocblas_1_1rocblas__csyr2__batched.html "Interface documentation") | C binding
+817 | [rocblas_zsyr2_batched](interfacehipfort__rocblas_1_1rocblas__zsyr2__batched.html "Interface documentation") | C binding
+818 | [rocblas_ssyr2_batched_64](interfacehipfort__rocblas_1_1rocblas__ssyr2__batched__64.html "Interface documentation") | C binding
+819 | [rocblas_dsyr2_batched_64](interfacehipfort__rocblas_1_1rocblas__dsyr2__batched__64.html "Interface documentation") | C binding
+820 | [rocblas_csyr2_batched_64](interfacehipfort__rocblas_1_1rocblas__csyr2__batched__64.html "Interface documentation") | C binding
+821 | [rocblas_zsyr2_batched_64](interfacehipfort__rocblas_1_1rocblas__zsyr2__batched__64.html "Interface documentation") | C binding
+822 | [rocblas_ssyr2_strided_batched](interfacehipfort__rocblas_1_1rocblas__ssyr2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+823 | [rocblas_dsyr2_strided_batched](interfacehipfort__rocblas_1_1rocblas__dsyr2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+824 | [rocblas_csyr2_strided_batched](interfacehipfort__rocblas_1_1rocblas__csyr2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+825 | [rocblas_zsyr2_strided_batched](interfacehipfort__rocblas_1_1rocblas__zsyr2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+826 | [rocblas_ssyr2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ssyr2__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+827 | [rocblas_dsyr2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dsyr2__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+828 | [rocblas_csyr2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__csyr2__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+829 | [rocblas_zsyr2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zsyr2__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+830 | [rocblas_chemm](interfacehipfort__rocblas_1_1rocblas__chemm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+831 | [rocblas_zhemm](interfacehipfort__rocblas_1_1rocblas__zhemm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+832 | [rocblas_chemm_64](interfacehipfort__rocblas_1_1rocblas__chemm__64.html "Interface documentation") | C binding, rank_0, rank_1
+833 | [rocblas_zhemm_64](interfacehipfort__rocblas_1_1rocblas__zhemm__64.html "Interface documentation") | C binding, rank_0, rank_1
+834 | [rocblas_chemm_batched](interfacehipfort__rocblas_1_1rocblas__chemm__batched.html "Interface documentation") | C binding
+835 | [rocblas_zhemm_batched](interfacehipfort__rocblas_1_1rocblas__zhemm__batched.html "Interface documentation") | C binding
+836 | [rocblas_chemm_batched_64](interfacehipfort__rocblas_1_1rocblas__chemm__batched__64.html "Interface documentation") | C binding
+837 | [rocblas_zhemm_batched_64](interfacehipfort__rocblas_1_1rocblas__zhemm__batched__64.html "Interface documentation") | C binding
+838 | [rocblas_chemm_strided_batched](interfacehipfort__rocblas_1_1rocblas__chemm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+839 | [rocblas_zhemm_strided_batched](interfacehipfort__rocblas_1_1rocblas__zhemm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+840 | [rocblas_chemm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__chemm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+841 | [rocblas_zhemm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zhemm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+842 | [rocblas_cherk](interfacehipfort__rocblas_1_1rocblas__cherk.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+843 | [rocblas_zherk](interfacehipfort__rocblas_1_1rocblas__zherk.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+844 | [rocblas_cherk_64](interfacehipfort__rocblas_1_1rocblas__cherk__64.html "Interface documentation") | C binding, rank_0, rank_1
+845 | [rocblas_zherk_64](interfacehipfort__rocblas_1_1rocblas__zherk__64.html "Interface documentation") | C binding, rank_0, rank_1
+846 | [rocblas_cherk_batched](interfacehipfort__rocblas_1_1rocblas__cherk__batched.html "Interface documentation") | C binding
+847 | [rocblas_zherk_batched](interfacehipfort__rocblas_1_1rocblas__zherk__batched.html "Interface documentation") | C binding
+848 | [rocblas_cherk_batched_64](interfacehipfort__rocblas_1_1rocblas__cherk__batched__64.html "Interface documentation") | C binding
+849 | [rocblas_zherk_batched_64](interfacehipfort__rocblas_1_1rocblas__zherk__batched__64.html "Interface documentation") | C binding
+850 | [rocblas_cherk_strided_batched](interfacehipfort__rocblas_1_1rocblas__cherk__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+851 | [rocblas_zherk_strided_batched](interfacehipfort__rocblas_1_1rocblas__zherk__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+852 | [rocblas_cherk_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cherk__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+853 | [rocblas_zherk_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zherk__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+854 | [rocblas_cher2k](interfacehipfort__rocblas_1_1rocblas__cher2k.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+855 | [rocblas_zher2k](interfacehipfort__rocblas_1_1rocblas__zher2k.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+856 | [rocblas_cher2k_64](interfacehipfort__rocblas_1_1rocblas__cher2k__64.html "Interface documentation") | C binding, rank_0, rank_1
+857 | [rocblas_zher2k_64](interfacehipfort__rocblas_1_1rocblas__zher2k__64.html "Interface documentation") | C binding, rank_0, rank_1
+858 | [rocblas_cher2k_batched](interfacehipfort__rocblas_1_1rocblas__cher2k__batched.html "Interface documentation") | C binding
+859 | [rocblas_zher2k_batched](interfacehipfort__rocblas_1_1rocblas__zher2k__batched.html "Interface documentation") | C binding
+860 | [rocblas_cher2k_batched_64](interfacehipfort__rocblas_1_1rocblas__cher2k__batched__64.html "Interface documentation") | C binding
+861 | [rocblas_zher2k_batched_64](interfacehipfort__rocblas_1_1rocblas__zher2k__batched__64.html "Interface documentation") | C binding
+862 | [rocblas_cher2k_strided_batched](interfacehipfort__rocblas_1_1rocblas__cher2k__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+863 | [rocblas_zher2k_strided_batched](interfacehipfort__rocblas_1_1rocblas__zher2k__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+864 | [rocblas_cher2k_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cher2k__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+865 | [rocblas_zher2k_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zher2k__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+866 | [rocblas_cherkx](interfacehipfort__rocblas_1_1rocblas__cherkx.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+867 | [rocblas_zherkx](interfacehipfort__rocblas_1_1rocblas__zherkx.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+868 | [rocblas_cherkx_64](interfacehipfort__rocblas_1_1rocblas__cherkx__64.html "Interface documentation") | C binding, rank_0, rank_1
+869 | [rocblas_zherkx_64](interfacehipfort__rocblas_1_1rocblas__zherkx__64.html "Interface documentation") | C binding, rank_0, rank_1
+870 | [rocblas_cherkx_batched](interfacehipfort__rocblas_1_1rocblas__cherkx__batched.html "Interface documentation") | C binding
+871 | [rocblas_zherkx_batched](interfacehipfort__rocblas_1_1rocblas__zherkx__batched.html "Interface documentation") | C binding
+872 | [rocblas_cherkx_batched_64](interfacehipfort__rocblas_1_1rocblas__cherkx__batched__64.html "Interface documentation") | C binding
+873 | [rocblas_zherkx_batched_64](interfacehipfort__rocblas_1_1rocblas__zherkx__batched__64.html "Interface documentation") | C binding
+874 | [rocblas_cherkx_strided_batched](interfacehipfort__rocblas_1_1rocblas__cherkx__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+875 | [rocblas_zherkx_strided_batched](interfacehipfort__rocblas_1_1rocblas__zherkx__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+876 | [rocblas_cherkx_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cherkx__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+877 | [rocblas_zherkx_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zherkx__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+878 | [rocblas_ssymm](interfacehipfort__rocblas_1_1rocblas__ssymm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+879 | [rocblas_dsymm](interfacehipfort__rocblas_1_1rocblas__dsymm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+880 | [rocblas_csymm](interfacehipfort__rocblas_1_1rocblas__csymm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+881 | [rocblas_zsymm](interfacehipfort__rocblas_1_1rocblas__zsymm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+882 | [rocblas_ssymm_64](interfacehipfort__rocblas_1_1rocblas__ssymm__64.html "Interface documentation") | C binding, rank_0, rank_1
+883 | [rocblas_dsymm_64](interfacehipfort__rocblas_1_1rocblas__dsymm__64.html "Interface documentation") | C binding, rank_0, rank_1
+884 | [rocblas_csymm_64](interfacehipfort__rocblas_1_1rocblas__csymm__64.html "Interface documentation") | C binding, rank_0, rank_1
+885 | [rocblas_zsymm_64](interfacehipfort__rocblas_1_1rocblas__zsymm__64.html "Interface documentation") | C binding, rank_0, rank_1
+886 | [rocblas_ssymm_batched](interfacehipfort__rocblas_1_1rocblas__ssymm__batched.html "Interface documentation") | C binding
+887 | [rocblas_dsymm_batched](interfacehipfort__rocblas_1_1rocblas__dsymm__batched.html "Interface documentation") | C binding
+888 | [rocblas_csymm_batched](interfacehipfort__rocblas_1_1rocblas__csymm__batched.html "Interface documentation") | C binding
+889 | [rocblas_zsymm_batched](interfacehipfort__rocblas_1_1rocblas__zsymm__batched.html "Interface documentation") | C binding
+890 | [rocblas_ssymm_batched_64](interfacehipfort__rocblas_1_1rocblas__ssymm__batched__64.html "Interface documentation") | C binding
+891 | [rocblas_dsymm_batched_64](interfacehipfort__rocblas_1_1rocblas__dsymm__batched__64.html "Interface documentation") | C binding
+892 | [rocblas_csymm_batched_64](interfacehipfort__rocblas_1_1rocblas__csymm__batched__64.html "Interface documentation") | C binding
+893 | [rocblas_zsymm_batched_64](interfacehipfort__rocblas_1_1rocblas__zsymm__batched__64.html "Interface documentation") | C binding
+894 | [rocblas_ssymm_strided_batched](interfacehipfort__rocblas_1_1rocblas__ssymm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+895 | [rocblas_dsymm_strided_batched](interfacehipfort__rocblas_1_1rocblas__dsymm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+896 | [rocblas_csymm_strided_batched](interfacehipfort__rocblas_1_1rocblas__csymm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+897 | [rocblas_zsymm_strided_batched](interfacehipfort__rocblas_1_1rocblas__zsymm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+898 | [rocblas_ssymm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ssymm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+899 | [rocblas_dsymm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dsymm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+900 | [rocblas_csymm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__csymm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+901 | [rocblas_zsymm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zsymm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+902 | [rocblas_ssyrk](interfacehipfort__rocblas_1_1rocblas__ssyrk.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+903 | [rocblas_dsyrk](interfacehipfort__rocblas_1_1rocblas__dsyrk.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+904 | [rocblas_csyrk](interfacehipfort__rocblas_1_1rocblas__csyrk.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+905 | [rocblas_zsyrk](interfacehipfort__rocblas_1_1rocblas__zsyrk.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+906 | [rocblas_ssyrk_64](interfacehipfort__rocblas_1_1rocblas__ssyrk__64.html "Interface documentation") | C binding, rank_0, rank_1
+907 | [rocblas_dsyrk_64](interfacehipfort__rocblas_1_1rocblas__dsyrk__64.html "Interface documentation") | C binding, rank_0, rank_1
+908 | [rocblas_csyrk_64](interfacehipfort__rocblas_1_1rocblas__csyrk__64.html "Interface documentation") | C binding, rank_0, rank_1
+909 | [rocblas_zsyrk_64](interfacehipfort__rocblas_1_1rocblas__zsyrk__64.html "Interface documentation") | C binding, rank_0, rank_1
+910 | [rocblas_ssyrk_batched](interfacehipfort__rocblas_1_1rocblas__ssyrk__batched.html "Interface documentation") | C binding
+911 | [rocblas_dsyrk_batched](interfacehipfort__rocblas_1_1rocblas__dsyrk__batched.html "Interface documentation") | C binding
+912 | [rocblas_csyrk_batched](interfacehipfort__rocblas_1_1rocblas__csyrk__batched.html "Interface documentation") | C binding
+913 | [rocblas_zsyrk_batched](interfacehipfort__rocblas_1_1rocblas__zsyrk__batched.html "Interface documentation") | C binding
+914 | [rocblas_ssyrk_batched_64](interfacehipfort__rocblas_1_1rocblas__ssyrk__batched__64.html "Interface documentation") | C binding
+915 | [rocblas_dsyrk_batched_64](interfacehipfort__rocblas_1_1rocblas__dsyrk__batched__64.html "Interface documentation") | C binding
+916 | [rocblas_csyrk_batched_64](interfacehipfort__rocblas_1_1rocblas__csyrk__batched__64.html "Interface documentation") | C binding
+917 | [rocblas_zsyrk_batched_64](interfacehipfort__rocblas_1_1rocblas__zsyrk__batched__64.html "Interface documentation") | C binding
+918 | [rocblas_ssyrk_strided_batched](interfacehipfort__rocblas_1_1rocblas__ssyrk__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+919 | [rocblas_dsyrk_strided_batched](interfacehipfort__rocblas_1_1rocblas__dsyrk__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+920 | [rocblas_csyrk_strided_batched](interfacehipfort__rocblas_1_1rocblas__csyrk__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+921 | [rocblas_zsyrk_strided_batched](interfacehipfort__rocblas_1_1rocblas__zsyrk__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+922 | [rocblas_ssyrk_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ssyrk__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+923 | [rocblas_dsyrk_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dsyrk__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+924 | [rocblas_csyrk_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__csyrk__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+925 | [rocblas_zsyrk_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zsyrk__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+926 | [rocblas_ssyr2k](interfacehipfort__rocblas_1_1rocblas__ssyr2k.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+927 | [rocblas_dsyr2k](interfacehipfort__rocblas_1_1rocblas__dsyr2k.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+928 | [rocblas_csyr2k](interfacehipfort__rocblas_1_1rocblas__csyr2k.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+929 | [rocblas_zsyr2k](interfacehipfort__rocblas_1_1rocblas__zsyr2k.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+930 | [rocblas_ssyr2k_64](interfacehipfort__rocblas_1_1rocblas__ssyr2k__64.html "Interface documentation") | C binding, rank_0, rank_1
+931 | [rocblas_dsyr2k_64](interfacehipfort__rocblas_1_1rocblas__dsyr2k__64.html "Interface documentation") | C binding, rank_0, rank_1
+932 | [rocblas_csyr2k_64](interfacehipfort__rocblas_1_1rocblas__csyr2k__64.html "Interface documentation") | C binding, rank_0, rank_1
+933 | [rocblas_zsyr2k_64](interfacehipfort__rocblas_1_1rocblas__zsyr2k__64.html "Interface documentation") | C binding, rank_0, rank_1
+934 | [rocblas_ssyr2k_batched](interfacehipfort__rocblas_1_1rocblas__ssyr2k__batched.html "Interface documentation") | C binding
+935 | [rocblas_dsyr2k_batched](interfacehipfort__rocblas_1_1rocblas__dsyr2k__batched.html "Interface documentation") | C binding
+936 | [rocblas_csyr2k_batched](interfacehipfort__rocblas_1_1rocblas__csyr2k__batched.html "Interface documentation") | C binding
+937 | [rocblas_zsyr2k_batched](interfacehipfort__rocblas_1_1rocblas__zsyr2k__batched.html "Interface documentation") | C binding
+938 | [rocblas_ssyr2k_batched_64](interfacehipfort__rocblas_1_1rocblas__ssyr2k__batched__64.html "Interface documentation") | C binding
+939 | [rocblas_dsyr2k_batched_64](interfacehipfort__rocblas_1_1rocblas__dsyr2k__batched__64.html "Interface documentation") | C binding
+940 | [rocblas_csyr2k_batched_64](interfacehipfort__rocblas_1_1rocblas__csyr2k__batched__64.html "Interface documentation") | C binding
+941 | [rocblas_zsyr2k_batched_64](interfacehipfort__rocblas_1_1rocblas__zsyr2k__batched__64.html "Interface documentation") | C binding
+942 | [rocblas_ssyr2k_strided_batched](interfacehipfort__rocblas_1_1rocblas__ssyr2k__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+943 | [rocblas_dsyr2k_strided_batched](interfacehipfort__rocblas_1_1rocblas__dsyr2k__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+944 | [rocblas_csyr2k_strided_batched](interfacehipfort__rocblas_1_1rocblas__csyr2k__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+945 | [rocblas_zsyr2k_strided_batched](interfacehipfort__rocblas_1_1rocblas__zsyr2k__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+946 | [rocblas_ssyr2k_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ssyr2k__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+947 | [rocblas_dsyr2k_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dsyr2k__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+948 | [rocblas_csyr2k_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__csyr2k__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+949 | [rocblas_zsyr2k_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zsyr2k__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+950 | [rocblas_ssyrkx](interfacehipfort__rocblas_1_1rocblas__ssyrkx.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+951 | [rocblas_dsyrkx](interfacehipfort__rocblas_1_1rocblas__dsyrkx.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+952 | [rocblas_csyrkx](interfacehipfort__rocblas_1_1rocblas__csyrkx.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+953 | [rocblas_zsyrkx](interfacehipfort__rocblas_1_1rocblas__zsyrkx.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+954 | [rocblas_ssyrkx_64](interfacehipfort__rocblas_1_1rocblas__ssyrkx__64.html "Interface documentation") | C binding, rank_0, rank_1
+955 | [rocblas_dsyrkx_64](interfacehipfort__rocblas_1_1rocblas__dsyrkx__64.html "Interface documentation") | C binding, rank_0, rank_1
+956 | [rocblas_csyrkx_64](interfacehipfort__rocblas_1_1rocblas__csyrkx__64.html "Interface documentation") | C binding, rank_0, rank_1
+957 | [rocblas_zsyrkx_64](interfacehipfort__rocblas_1_1rocblas__zsyrkx__64.html "Interface documentation") | C binding, rank_0, rank_1
+958 | [rocblas_ssyrkx_batched](interfacehipfort__rocblas_1_1rocblas__ssyrkx__batched.html "Interface documentation") | C binding
+959 | [rocblas_dsyrkx_batched](interfacehipfort__rocblas_1_1rocblas__dsyrkx__batched.html "Interface documentation") | C binding
+960 | [rocblas_csyrkx_batched](interfacehipfort__rocblas_1_1rocblas__csyrkx__batched.html "Interface documentation") | C binding
+961 | [rocblas_zsyrkx_batched](interfacehipfort__rocblas_1_1rocblas__zsyrkx__batched.html "Interface documentation") | C binding
+962 | [rocblas_ssyrkx_batched_64](interfacehipfort__rocblas_1_1rocblas__ssyrkx__batched__64.html "Interface documentation") | C binding
+963 | [rocblas_dsyrkx_batched_64](interfacehipfort__rocblas_1_1rocblas__dsyrkx__batched__64.html "Interface documentation") | C binding
+964 | [rocblas_csyrkx_batched_64](interfacehipfort__rocblas_1_1rocblas__csyrkx__batched__64.html "Interface documentation") | C binding
+965 | [rocblas_zsyrkx_batched_64](interfacehipfort__rocblas_1_1rocblas__zsyrkx__batched__64.html "Interface documentation") | C binding
+966 | [rocblas_ssyrkx_strided_batched](interfacehipfort__rocblas_1_1rocblas__ssyrkx__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+967 | [rocblas_dsyrkx_strided_batched](interfacehipfort__rocblas_1_1rocblas__dsyrkx__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+968 | [rocblas_csyrkx_strided_batched](interfacehipfort__rocblas_1_1rocblas__csyrkx__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+969 | [rocblas_zsyrkx_strided_batched](interfacehipfort__rocblas_1_1rocblas__zsyrkx__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+970 | [rocblas_ssyrkx_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ssyrkx__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+971 | [rocblas_dsyrkx_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dsyrkx__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+972 | [rocblas_csyrkx_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__csyrkx__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+973 | [rocblas_zsyrkx_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zsyrkx__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+974 | [rocblas_strmm](interfacehipfort__rocblas_1_1rocblas__strmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+975 | [rocblas_dtrmm](interfacehipfort__rocblas_1_1rocblas__dtrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+976 | [rocblas_ctrmm](interfacehipfort__rocblas_1_1rocblas__ctrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+977 | [rocblas_ztrmm](interfacehipfort__rocblas_1_1rocblas__ztrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+978 | [rocblas_strmm_64](interfacehipfort__rocblas_1_1rocblas__strmm__64.html "Interface documentation") | C binding, rank_0, rank_1
+979 | [rocblas_dtrmm_64](interfacehipfort__rocblas_1_1rocblas__dtrmm__64.html "Interface documentation") | C binding, rank_0, rank_1
+980 | [rocblas_ctrmm_64](interfacehipfort__rocblas_1_1rocblas__ctrmm__64.html "Interface documentation") | C binding, rank_0, rank_1
+981 | [rocblas_ztrmm_64](interfacehipfort__rocblas_1_1rocblas__ztrmm__64.html "Interface documentation") | C binding, rank_0, rank_1
+982 | [rocblas_strmm_batched](interfacehipfort__rocblas_1_1rocblas__strmm__batched.html "Interface documentation") | C binding
+983 | [rocblas_dtrmm_batched](interfacehipfort__rocblas_1_1rocblas__dtrmm__batched.html "Interface documentation") | C binding
+984 | [rocblas_ctrmm_batched](interfacehipfort__rocblas_1_1rocblas__ctrmm__batched.html "Interface documentation") | C binding
+985 | [rocblas_ztrmm_batched](interfacehipfort__rocblas_1_1rocblas__ztrmm__batched.html "Interface documentation") | C binding
+986 | [rocblas_strmm_batched_64](interfacehipfort__rocblas_1_1rocblas__strmm__batched__64.html "Interface documentation") | C binding
+987 | [rocblas_dtrmm_batched_64](interfacehipfort__rocblas_1_1rocblas__dtrmm__batched__64.html "Interface documentation") | C binding
+988 | [rocblas_ctrmm_batched_64](interfacehipfort__rocblas_1_1rocblas__ctrmm__batched__64.html "Interface documentation") | C binding
+989 | [rocblas_ztrmm_batched_64](interfacehipfort__rocblas_1_1rocblas__ztrmm__batched__64.html "Interface documentation") | C binding
+990 | [rocblas_strmm_strided_batched](interfacehipfort__rocblas_1_1rocblas__strmm__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+991 | [rocblas_dtrmm_strided_batched](interfacehipfort__rocblas_1_1rocblas__dtrmm__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+992 | [rocblas_ctrmm_strided_batched](interfacehipfort__rocblas_1_1rocblas__ctrmm__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+993 | [rocblas_ztrmm_strided_batched](interfacehipfort__rocblas_1_1rocblas__ztrmm__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+994 | [rocblas_strmm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__strmm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+995 | [rocblas_dtrmm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dtrmm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+996 | [rocblas_ctrmm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ctrmm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+997 | [rocblas_ztrmm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ztrmm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+998 | [rocblas_strtri](interfacehipfort__rocblas_1_1rocblas__strtri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+999 | [rocblas_dtrtri](interfacehipfort__rocblas_1_1rocblas__dtrtri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1000 | [rocblas_ctrtri](interfacehipfort__rocblas_1_1rocblas__ctrtri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1001 | [rocblas_ztrtri](interfacehipfort__rocblas_1_1rocblas__ztrtri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1002 | [rocblas_strtri_batched](interfacehipfort__rocblas_1_1rocblas__strtri__batched.html "Interface documentation") | C binding
+1003 | [rocblas_dtrtri_batched](interfacehipfort__rocblas_1_1rocblas__dtrtri__batched.html "Interface documentation") | C binding
+1004 | [rocblas_ctrtri_batched](interfacehipfort__rocblas_1_1rocblas__ctrtri__batched.html "Interface documentation") | C binding
+1005 | [rocblas_ztrtri_batched](interfacehipfort__rocblas_1_1rocblas__ztrtri__batched.html "Interface documentation") | C binding
+1006 | [rocblas_strtri_strided_batched](interfacehipfort__rocblas_1_1rocblas__strtri__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1007 | [rocblas_dtrtri_strided_batched](interfacehipfort__rocblas_1_1rocblas__dtrtri__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1008 | [rocblas_ctrtri_strided_batched](interfacehipfort__rocblas_1_1rocblas__ctrtri__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1009 | [rocblas_ztrtri_strided_batched](interfacehipfort__rocblas_1_1rocblas__ztrtri__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1010 | [rocblas_strsm](interfacehipfort__rocblas_1_1rocblas__strsm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1011 | [rocblas_dtrsm](interfacehipfort__rocblas_1_1rocblas__dtrsm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1012 | [rocblas_ctrsm](interfacehipfort__rocblas_1_1rocblas__ctrsm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1013 | [rocblas_ztrsm](interfacehipfort__rocblas_1_1rocblas__ztrsm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1014 | [rocblas_strsm_64](interfacehipfort__rocblas_1_1rocblas__strsm__64.html "Interface documentation") | C binding, rank_0, rank_1
+1015 | [rocblas_dtrsm_64](interfacehipfort__rocblas_1_1rocblas__dtrsm__64.html "Interface documentation") | C binding, rank_0, rank_1
+1016 | [rocblas_ctrsm_64](interfacehipfort__rocblas_1_1rocblas__ctrsm__64.html "Interface documentation") | C binding, rank_0, rank_1
+1017 | [rocblas_ztrsm_64](interfacehipfort__rocblas_1_1rocblas__ztrsm__64.html "Interface documentation") | C binding, rank_0, rank_1
+1018 | [rocblas_strsm_batched](interfacehipfort__rocblas_1_1rocblas__strsm__batched.html "Interface documentation") | C binding
+1019 | [rocblas_dtrsm_batched](interfacehipfort__rocblas_1_1rocblas__dtrsm__batched.html "Interface documentation") | C binding
+1020 | [rocblas_ctrsm_batched](interfacehipfort__rocblas_1_1rocblas__ctrsm__batched.html "Interface documentation") | C binding
+1021 | [rocblas_ztrsm_batched](interfacehipfort__rocblas_1_1rocblas__ztrsm__batched.html "Interface documentation") | C binding
+1022 | [rocblas_strsm_batched_64](interfacehipfort__rocblas_1_1rocblas__strsm__batched__64.html "Interface documentation") | C binding
+1023 | [rocblas_dtrsm_batched_64](interfacehipfort__rocblas_1_1rocblas__dtrsm__batched__64.html "Interface documentation") | C binding
+1024 | [rocblas_ctrsm_batched_64](interfacehipfort__rocblas_1_1rocblas__ctrsm__batched__64.html "Interface documentation") | C binding
+1025 | [rocblas_ztrsm_batched_64](interfacehipfort__rocblas_1_1rocblas__ztrsm__batched__64.html "Interface documentation") | C binding
+1026 | [rocblas_strsm_strided_batched](interfacehipfort__rocblas_1_1rocblas__strsm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1027 | [rocblas_dtrsm_strided_batched](interfacehipfort__rocblas_1_1rocblas__dtrsm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1028 | [rocblas_ctrsm_strided_batched](interfacehipfort__rocblas_1_1rocblas__ctrsm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1029 | [rocblas_ztrsm_strided_batched](interfacehipfort__rocblas_1_1rocblas__ztrsm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1030 | [rocblas_strsm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__strsm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+1031 | [rocblas_dtrsm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dtrsm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+1032 | [rocblas_ctrsm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ctrsm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+1033 | [rocblas_ztrsm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ztrsm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+1034 | [rocblas_sgemm](interfacehipfort__rocblas_1_1rocblas__sgemm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1035 | [rocblas_dgemm](interfacehipfort__rocblas_1_1rocblas__dgemm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1036 | [rocblas_hgemm](interfacehipfort__rocblas_1_1rocblas__hgemm.html "Interface documentation") | C binding, rank_0, rank_1
+1037 | [rocblas_cgemm](interfacehipfort__rocblas_1_1rocblas__cgemm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1038 | [rocblas_zgemm](interfacehipfort__rocblas_1_1rocblas__zgemm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1039 | [rocblas_sgemm_64](interfacehipfort__rocblas_1_1rocblas__sgemm__64.html "Interface documentation") | C binding, rank_0, rank_1
+1040 | [rocblas_dgemm_64](interfacehipfort__rocblas_1_1rocblas__dgemm__64.html "Interface documentation") | C binding, rank_0, rank_1
+1041 | [rocblas_hgemm_64](interfacehipfort__rocblas_1_1rocblas__hgemm__64.html "Interface documentation") | C binding, rank_0, rank_1
+1042 | [rocblas_cgemm_64](interfacehipfort__rocblas_1_1rocblas__cgemm__64.html "Interface documentation") | C binding, rank_0, rank_1
+1043 | [rocblas_zgemm_64](interfacehipfort__rocblas_1_1rocblas__zgemm__64.html "Interface documentation") | C binding, rank_0, rank_1
+1044 | [rocblas_sgemm_batched](interfacehipfort__rocblas_1_1rocblas__sgemm__batched.html "Interface documentation") | C binding
+1045 | [rocblas_dgemm_batched](interfacehipfort__rocblas_1_1rocblas__dgemm__batched.html "Interface documentation") | C binding
+1046 | [rocblas_hgemm_batched](interfacehipfort__rocblas_1_1rocblas__hgemm__batched.html "Interface documentation") | C binding
+1047 | [rocblas_cgemm_batched](interfacehipfort__rocblas_1_1rocblas__cgemm__batched.html "Interface documentation") | C binding
+1048 | [rocblas_zgemm_batched](interfacehipfort__rocblas_1_1rocblas__zgemm__batched.html "Interface documentation") | C binding
+1049 | [rocblas_sgemm_batched_64](interfacehipfort__rocblas_1_1rocblas__sgemm__batched__64.html "Interface documentation") | C binding
+1050 | [rocblas_dgemm_batched_64](interfacehipfort__rocblas_1_1rocblas__dgemm__batched__64.html "Interface documentation") | C binding
+1051 | [rocblas_hgemm_batched_64](interfacehipfort__rocblas_1_1rocblas__hgemm__batched__64.html "Interface documentation") | C binding
+1052 | [rocblas_cgemm_batched_64](interfacehipfort__rocblas_1_1rocblas__cgemm__batched__64.html "Interface documentation") | C binding
+1053 | [rocblas_zgemm_batched_64](interfacehipfort__rocblas_1_1rocblas__zgemm__batched__64.html "Interface documentation") | C binding
+1054 | [rocblas_sgemm_strided_batched](interfacehipfort__rocblas_1_1rocblas__sgemm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1055 | [rocblas_dgemm_strided_batched](interfacehipfort__rocblas_1_1rocblas__dgemm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1056 | [rocblas_hgemm_strided_batched](interfacehipfort__rocblas_1_1rocblas__hgemm__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+1057 | [rocblas_cgemm_strided_batched](interfacehipfort__rocblas_1_1rocblas__cgemm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1058 | [rocblas_zgemm_strided_batched](interfacehipfort__rocblas_1_1rocblas__zgemm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1059 | [rocblas_sgemm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sgemm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+1060 | [rocblas_dgemm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dgemm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+1061 | [rocblas_hgemm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__hgemm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+1062 | [rocblas_cgemm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cgemm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+1063 | [rocblas_zgemm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zgemm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+1064 | [rocblas_sdgmm](interfacehipfort__rocblas_1_1rocblas__sdgmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1065 | [rocblas_ddgmm](interfacehipfort__rocblas_1_1rocblas__ddgmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1066 | [rocblas_cdgmm](interfacehipfort__rocblas_1_1rocblas__cdgmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1067 | [rocblas_zdgmm](interfacehipfort__rocblas_1_1rocblas__zdgmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1068 | [rocblas_sdgmm_64](interfacehipfort__rocblas_1_1rocblas__sdgmm__64.html "Interface documentation") | C binding, rank_0, rank_1
+1069 | [rocblas_ddgmm_64](interfacehipfort__rocblas_1_1rocblas__ddgmm__64.html "Interface documentation") | C binding, rank_0, rank_1
+1070 | [rocblas_cdgmm_64](interfacehipfort__rocblas_1_1rocblas__cdgmm__64.html "Interface documentation") | C binding, rank_0, rank_1
+1071 | [rocblas_zdgmm_64](interfacehipfort__rocblas_1_1rocblas__zdgmm__64.html "Interface documentation") | C binding, rank_0, rank_1
+1072 | [rocblas_sdgmm_batched](interfacehipfort__rocblas_1_1rocblas__sdgmm__batched.html "Interface documentation") | C binding
+1073 | [rocblas_ddgmm_batched](interfacehipfort__rocblas_1_1rocblas__ddgmm__batched.html "Interface documentation") | C binding
+1074 | [rocblas_cdgmm_batched](interfacehipfort__rocblas_1_1rocblas__cdgmm__batched.html "Interface documentation") | C binding
+1075 | [rocblas_zdgmm_batched](interfacehipfort__rocblas_1_1rocblas__zdgmm__batched.html "Interface documentation") | C binding
+1076 | [rocblas_sdgmm_batched_64](interfacehipfort__rocblas_1_1rocblas__sdgmm__batched__64.html "Interface documentation") | C binding
+1077 | [rocblas_ddgmm_batched_64](interfacehipfort__rocblas_1_1rocblas__ddgmm__batched__64.html "Interface documentation") | C binding
+1078 | [rocblas_cdgmm_batched_64](interfacehipfort__rocblas_1_1rocblas__cdgmm__batched__64.html "Interface documentation") | C binding
+1079 | [rocblas_zdgmm_batched_64](interfacehipfort__rocblas_1_1rocblas__zdgmm__batched__64.html "Interface documentation") | C binding
+1080 | [rocblas_sdgmm_strided_batched](interfacehipfort__rocblas_1_1rocblas__sdgmm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1081 | [rocblas_ddgmm_strided_batched](interfacehipfort__rocblas_1_1rocblas__ddgmm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1082 | [rocblas_cdgmm_strided_batched](interfacehipfort__rocblas_1_1rocblas__cdgmm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1083 | [rocblas_zdgmm_strided_batched](interfacehipfort__rocblas_1_1rocblas__zdgmm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1084 | [rocblas_sdgmm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sdgmm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+1085 | [rocblas_ddgmm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ddgmm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+1086 | [rocblas_cdgmm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cdgmm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+1087 | [rocblas_zdgmm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zdgmm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+1088 | [rocblas_sgeam](interfacehipfort__rocblas_1_1rocblas__sgeam.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1089 | [rocblas_dgeam](interfacehipfort__rocblas_1_1rocblas__dgeam.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1090 | [rocblas_cgeam](interfacehipfort__rocblas_1_1rocblas__cgeam.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1091 | [rocblas_zgeam](interfacehipfort__rocblas_1_1rocblas__zgeam.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1092 | [rocblas_sgeam_64](interfacehipfort__rocblas_1_1rocblas__sgeam__64.html "Interface documentation") | C binding, rank_0, rank_1
+1093 | [rocblas_dgeam_64](interfacehipfort__rocblas_1_1rocblas__dgeam__64.html "Interface documentation") | C binding, rank_0, rank_1
+1094 | [rocblas_cgeam_64](interfacehipfort__rocblas_1_1rocblas__cgeam__64.html "Interface documentation") | C binding, rank_0, rank_1
+1095 | [rocblas_zgeam_64](interfacehipfort__rocblas_1_1rocblas__zgeam__64.html "Interface documentation") | C binding, rank_0, rank_1
+1096 | [rocblas_sgeam_batched](interfacehipfort__rocblas_1_1rocblas__sgeam__batched.html "Interface documentation") | C binding
+1097 | [rocblas_dgeam_batched](interfacehipfort__rocblas_1_1rocblas__dgeam__batched.html "Interface documentation") | C binding
+1098 | [rocblas_cgeam_batched](interfacehipfort__rocblas_1_1rocblas__cgeam__batched.html "Interface documentation") | C binding
+1099 | [rocblas_zgeam_batched](interfacehipfort__rocblas_1_1rocblas__zgeam__batched.html "Interface documentation") | C binding
+1100 | [rocblas_sgeam_batched_64](interfacehipfort__rocblas_1_1rocblas__sgeam__batched__64.html "Interface documentation") | C binding
+1101 | [rocblas_dgeam_batched_64](interfacehipfort__rocblas_1_1rocblas__dgeam__batched__64.html "Interface documentation") | C binding
+1102 | [rocblas_cgeam_batched_64](interfacehipfort__rocblas_1_1rocblas__cgeam__batched__64.html "Interface documentation") | C binding
+1103 | [rocblas_zgeam_batched_64](interfacehipfort__rocblas_1_1rocblas__zgeam__batched__64.html "Interface documentation") | C binding
+1104 | [rocblas_sgeam_strided_batched](interfacehipfort__rocblas_1_1rocblas__sgeam__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1105 | [rocblas_dgeam_strided_batched](interfacehipfort__rocblas_1_1rocblas__dgeam__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1106 | [rocblas_cgeam_strided_batched](interfacehipfort__rocblas_1_1rocblas__cgeam__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1107 | [rocblas_zgeam_strided_batched](interfacehipfort__rocblas_1_1rocblas__zgeam__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1108 | [rocblas_sgeam_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sgeam__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+1109 | [rocblas_dgeam_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dgeam__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+1110 | [rocblas_cgeam_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cgeam__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+1111 | [rocblas_zgeam_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zgeam__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+1112 | [rocblas_gemm_ex](interfacehipfort__rocblas_1_1rocblas__gemm__ex.html "Interface documentation") | C binding
+1113 | [rocblas_gemm_ex_64](interfacehipfort__rocblas_1_1rocblas__gemm__ex__64.html "Interface documentation") | C binding
+1114 | [rocblas_gemm_batched_ex](interfacehipfort__rocblas_1_1rocblas__gemm__batched__ex.html "Interface documentation") | C binding
+1115 | [rocblas_gemm_batched_ex_64](interfacehipfort__rocblas_1_1rocblas__gemm__batched__ex__64.html "Interface documentation") | C binding
+1116 | [rocblas_gemm_strided_batched_ex](interfacehipfort__rocblas_1_1rocblas__gemm__strided__batched__ex.html "Interface documentation") | C binding
+1117 | [rocblas_gemm_strided_batched_ex_64](interfacehipfort__rocblas_1_1rocblas__gemm__strided__batched__ex__64.html "Interface documentation") | C binding
+1118 | [rocblas_sgemmt](interfacehipfort__rocblas_1_1rocblas__sgemmt.html "Interface documentation") | C binding, rank_0, rank_1
+1119 | [rocblas_dgemmt](interfacehipfort__rocblas_1_1rocblas__dgemmt.html "Interface documentation") | C binding, rank_0, rank_1
+1120 | [rocblas_cgemmt](interfacehipfort__rocblas_1_1rocblas__cgemmt.html "Interface documentation") | C binding, rank_0, rank_1
+1121 | [rocblas_zgemmt](interfacehipfort__rocblas_1_1rocblas__zgemmt.html "Interface documentation") | C binding, rank_0, rank_1
+1122 | [rocblas_sgemmt_64](interfacehipfort__rocblas_1_1rocblas__sgemmt__64.html "Interface documentation") | C binding, rank_0, rank_1
+1123 | [rocblas_dgemmt_64](interfacehipfort__rocblas_1_1rocblas__dgemmt__64.html "Interface documentation") | C binding, rank_0, rank_1
+1124 | [rocblas_cgemmt_64](interfacehipfort__rocblas_1_1rocblas__cgemmt__64.html "Interface documentation") | C binding, rank_0, rank_1
+1125 | [rocblas_zgemmt_64](interfacehipfort__rocblas_1_1rocblas__zgemmt__64.html "Interface documentation") | C binding, rank_0, rank_1
+1126 | [rocblas_sgemmt_batched](interfacehipfort__rocblas_1_1rocblas__sgemmt__batched.html "Interface documentation") | C binding
+1127 | [rocblas_dgemmt_batched](interfacehipfort__rocblas_1_1rocblas__dgemmt__batched.html "Interface documentation") | C binding
+1128 | [rocblas_cgemmt_batched](interfacehipfort__rocblas_1_1rocblas__cgemmt__batched.html "Interface documentation") | C binding
+1129 | [rocblas_zgemmt_batched](interfacehipfort__rocblas_1_1rocblas__zgemmt__batched.html "Interface documentation") | C binding
+1130 | [rocblas_sgemmt_batched_64](interfacehipfort__rocblas_1_1rocblas__sgemmt__batched__64.html "Interface documentation") | C binding
+1131 | [rocblas_dgemmt_batched_64](interfacehipfort__rocblas_1_1rocblas__dgemmt__batched__64.html "Interface documentation") | C binding
+1132 | [rocblas_cgemmt_batched_64](interfacehipfort__rocblas_1_1rocblas__cgemmt__batched__64.html "Interface documentation") | C binding
+1133 | [rocblas_zgemmt_batched_64](interfacehipfort__rocblas_1_1rocblas__zgemmt__batched__64.html "Interface documentation") | C binding
+1134 | [rocblas_sgemmt_strided_batched](interfacehipfort__rocblas_1_1rocblas__sgemmt__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+1135 | [rocblas_dgemmt_strided_batched](interfacehipfort__rocblas_1_1rocblas__dgemmt__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+1136 | [rocblas_cgemmt_strided_batched](interfacehipfort__rocblas_1_1rocblas__cgemmt__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+1137 | [rocblas_zgemmt_strided_batched](interfacehipfort__rocblas_1_1rocblas__zgemmt__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
+1138 | [rocblas_sgemmt_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sgemmt__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+1139 | [rocblas_dgemmt_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dgemmt__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+1140 | [rocblas_cgemmt_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cgemmt__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+1141 | [rocblas_zgemmt_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zgemmt__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+1142 | [rocblas_geam_ex](interfacehipfort__rocblas_1_1rocblas__geam__ex.html "Interface documentation") | C binding
+1143 | [rocblas_trsm_ex](interfacehipfort__rocblas_1_1rocblas__trsm__ex.html "Interface documentation") | C binding
+1144 | [rocblas_trsm_batched_ex](interfacehipfort__rocblas_1_1rocblas__trsm__batched__ex.html "Interface documentation") | C binding
+1145 | [rocblas_trsm_strided_batched_ex](interfacehipfort__rocblas_1_1rocblas__trsm__strided__batched__ex.html "Interface documentation") | C binding
+1146 | [rocblas_syrk_ex](interfacehipfort__rocblas_1_1rocblas__syrk__ex.html "Interface documentation") | C binding
+1147 | [rocblas_herk_ex](interfacehipfort__rocblas_1_1rocblas__herk__ex.html "Interface documentation") | C binding
+1148 | [rocblas_axpy_ex](interfacehipfort__rocblas_1_1rocblas__axpy__ex.html "Interface documentation") | C binding
+1149 | [rocblas_axpy_ex_64](interfacehipfort__rocblas_1_1rocblas__axpy__ex__64.html "Interface documentation") | C binding
+1150 | [rocblas_axpy_batched_ex](interfacehipfort__rocblas_1_1rocblas__axpy__batched__ex.html "Interface documentation") | C binding
+1151 | [rocblas_axpy_batched_ex_64](interfacehipfort__rocblas_1_1rocblas__axpy__batched__ex__64.html "Interface documentation") | C binding
+1152 | [rocblas_axpy_strided_batched_ex](interfacehipfort__rocblas_1_1rocblas__axpy__strided__batched__ex.html "Interface documentation") | C binding
+1153 | [rocblas_axpy_strided_batched_ex_64](interfacehipfort__rocblas_1_1rocblas__axpy__strided__batched__ex__64.html "Interface documentation") | C binding
+1154 | [rocblas_dot_ex](interfacehipfort__rocblas_1_1rocblas__dot__ex.html "Interface documentation") | C binding
+1155 | [rocblas_dotc_ex](interfacehipfort__rocblas_1_1rocblas__dotc__ex.html "Interface documentation") | C binding
+1156 | [rocblas_dot_ex_64](interfacehipfort__rocblas_1_1rocblas__dot__ex__64.html "Interface documentation") | C binding
+1157 | [rocblas_dotc_ex_64](interfacehipfort__rocblas_1_1rocblas__dotc__ex__64.html "Interface documentation") | C binding
+1158 | [rocblas_dot_batched_ex](interfacehipfort__rocblas_1_1rocblas__dot__batched__ex.html "Interface documentation") | C binding
+1159 | [rocblas_dotc_batched_ex](interfacehipfort__rocblas_1_1rocblas__dotc__batched__ex.html "Interface documentation") | C binding
+1160 | [rocblas_dot_batched_ex_64](interfacehipfort__rocblas_1_1rocblas__dot__batched__ex__64.html "Interface documentation") | C binding
+1161 | [rocblas_dotc_batched_ex_64](interfacehipfort__rocblas_1_1rocblas__dotc__batched__ex__64.html "Interface documentation") | C binding
+1162 | [rocblas_dot_strided_batched_ex](interfacehipfort__rocblas_1_1rocblas__dot__strided__batched__ex.html "Interface documentation") | C binding
+1163 | [rocblas_dot_strided_batched_ex_64](interfacehipfort__rocblas_1_1rocblas__dot__strided__batched__ex__64.html "Interface documentation") | C binding
+1164 | [rocblas_dotc_strided_batched_ex](interfacehipfort__rocblas_1_1rocblas__dotc__strided__batched__ex.html "Interface documentation") | C binding
+1165 | [rocblas_dotc_strided_batched_ex_64](interfacehipfort__rocblas_1_1rocblas__dotc__strided__batched__ex__64.html "Interface documentation") | C binding
+1166 | [rocblas_nrm2_ex](interfacehipfort__rocblas_1_1rocblas__nrm2__ex.html "Interface documentation") | C binding
+1167 | [rocblas_nrm2_ex_64](interfacehipfort__rocblas_1_1rocblas__nrm2__ex__64.html "Interface documentation") | C binding
+1168 | [rocblas_nrm2_batched_ex](interfacehipfort__rocblas_1_1rocblas__nrm2__batched__ex.html "Interface documentation") | C binding
+1169 | [rocblas_nrm2_batched_ex_64](interfacehipfort__rocblas_1_1rocblas__nrm2__batched__ex__64.html "Interface documentation") | C binding
+1170 | [rocblas_nrm2_strided_batched_ex](interfacehipfort__rocblas_1_1rocblas__nrm2__strided__batched__ex.html "Interface documentation") | C binding
+1171 | [rocblas_nrm2_strided_batched_ex_64](interfacehipfort__rocblas_1_1rocblas__nrm2__strided__batched__ex__64.html "Interface documentation") | C binding
+1172 | [rocblas_rot_ex](interfacehipfort__rocblas_1_1rocblas__rot__ex.html "Interface documentation") | C binding
+1173 | [rocblas_rot_ex_64](interfacehipfort__rocblas_1_1rocblas__rot__ex__64.html "Interface documentation") | C binding
+1174 | [rocblas_rot_batched_ex](interfacehipfort__rocblas_1_1rocblas__rot__batched__ex.html "Interface documentation") | C binding
+1175 | [rocblas_rot_batched_ex_64](interfacehipfort__rocblas_1_1rocblas__rot__batched__ex__64.html "Interface documentation") | C binding
+1176 | [rocblas_rot_strided_batched_ex](interfacehipfort__rocblas_1_1rocblas__rot__strided__batched__ex.html "Interface documentation") | C binding
+1177 | [rocblas_rot_strided_batched_ex_64](interfacehipfort__rocblas_1_1rocblas__rot__strided__batched__ex__64.html "Interface documentation") | C binding
+1178 | [rocblas_scal_ex](interfacehipfort__rocblas_1_1rocblas__scal__ex.html "Interface documentation") | C binding
+1179 | [rocblas_scal_ex_64](interfacehipfort__rocblas_1_1rocblas__scal__ex__64.html "Interface documentation") | C binding
+1180 | [rocblas_scal_batched_ex](interfacehipfort__rocblas_1_1rocblas__scal__batched__ex.html "Interface documentation") | C binding
+1181 | [rocblas_scal_batched_ex_64](interfacehipfort__rocblas_1_1rocblas__scal__batched__ex__64.html "Interface documentation") | C binding
+1182 | [rocblas_scal_strided_batched_ex](interfacehipfort__rocblas_1_1rocblas__scal__strided__batched__ex.html "Interface documentation") | C binding
+1183 | [rocblas_scal_strided_batched_ex_64](interfacehipfort__rocblas_1_1rocblas__scal__strided__batched__ex__64.html "Interface documentation") | C binding
+1184 | [rocblas_status_to_string](interfacehipfort__rocblas_1_1rocblas__status__to__string.html "Interface documentation") | C binding
+1185 | [rocblas_initialize](interfacehipfort__rocblas_1_1rocblas__initialize.html "Interface documentation") | C binding
+1186 | [rocblas_get_version_string](interfacehipfort__rocblas_1_1rocblas__get__version__string.html "Interface documentation") | C binding
+1187 | [rocblas_get_version_string_size](interfacehipfort__rocblas_1_1rocblas__get__version__string__size.html "Interface documentation") | C binding
+1188 | [rocblas_get_commit_hash_string](interfacehipfort__rocblas_1_1rocblas__get__commit__hash__string.html "Interface documentation") | C binding
+1189 | [rocblas_get_commit_hash_string_size](interfacehipfort__rocblas_1_1rocblas__get__commit__hash__string__size.html "Interface documentation") | C binding
+1190 | [rocblas_start_device_memory_size_query](interfacehipfort__rocblas_1_1rocblas__start__device__memory__size__query.html "Interface documentation") | C binding
+1191 | [rocblas_stop_device_memory_size_query](interfacehipfort__rocblas_1_1rocblas__stop__device__memory__size__query.html "Interface documentation") | C binding
+1192 | [rocblas_is_device_memory_size_query](interfacehipfort__rocblas_1_1rocblas__is__device__memory__size__query.html "Interface documentation") | C binding
+1193 | [rocblas_set_optimal_device_memory_size_impl](interfacehipfort__rocblas_1_1rocblas__set__optimal__device__memory__size__impl.html "Interface documentation") | C binding
+1194 | [rocblas_device_malloc_alloc](interfacehipfort__rocblas_1_1rocblas__device__malloc__alloc.html "Interface documentation") | C binding
+1195 | [rocblas_device_malloc_success](interfacehipfort__rocblas_1_1rocblas__device__malloc__success.html "Interface documentation") | C binding
+1196 | [rocblas_device_malloc_ptr](interfacehipfort__rocblas_1_1rocblas__device__malloc__ptr.html "Interface documentation") | C binding
+1197 | [rocblas_device_malloc_get](interfacehipfort__rocblas_1_1rocblas__device__malloc__get.html "Interface documentation") | C binding
+1198 | [rocblas_device_malloc_free](interfacehipfort__rocblas_1_1rocblas__device__malloc__free.html "Interface documentation") | C binding
+1199 | [rocblas_device_malloc_set_default_memory_size](interfacehipfort__rocblas_1_1rocblas__device__malloc__set__default__memory__size.html "Interface documentation") | C binding
+1200 | [rocblas_get_device_memory_size](interfacehipfort__rocblas_1_1rocblas__get__device__memory__size.html "Interface documentation") | C binding
+1201 | [rocblas_set_device_memory_size](interfacehipfort__rocblas_1_1rocblas__set__device__memory__size.html "Interface documentation") | C binding
+1202 | [rocblas_set_workspace](interfacehipfort__rocblas_1_1rocblas__set__workspace.html "Interface documentation") | C binding
+1203 | [rocblas_is_managing_device_memory](interfacehipfort__rocblas_1_1rocblas__is__managing__device__memory.html "Interface documentation") | C binding
+1204 | [rocblas_is_user_managing_device_memory](interfacehipfort__rocblas_1_1rocblas__is__user__managing__device__memory.html "Interface documentation") | C binding
+1205 | [rocblas_abort](interfacehipfort__rocblas_1_1rocblas__abort.html "Interface documentation") | C binding
+1206 | [rocblas_set_vector](interfacehipfort__rocblas_1_1rocblas__set__vector.html "Interface documentation") | C binding, full_rank, rank_0
+1207 | [rocblas_get_vector](interfacehipfort__rocblas_1_1rocblas__get__vector.html "Interface documentation") | C binding, full_rank, rank_0
+1208 | [rocblas_set_matrix](interfacehipfort__rocblas_1_1rocblas__set__matrix.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1209 | [rocblas_get_matrix](interfacehipfort__rocblas_1_1rocblas__get__matrix.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1210 | [rocblas_set_vector_async](interfacehipfort__rocblas_1_1rocblas__set__vector__async.html "Interface documentation") | C binding, full_rank, rank_0
+1211 | [rocblas_get_vector_async](interfacehipfort__rocblas_1_1rocblas__get__vector__async.html "Interface documentation") | C binding, full_rank, rank_0
+1212 | [rocblas_set_matrix_async](interfacehipfort__rocblas_1_1rocblas__set__matrix__async.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1213 | [rocblas_get_matrix_async](interfacehipfort__rocblas_1_1rocblas__get__matrix__async.html "Interface documentation") | C binding, full_rank, rank_0, rank_1


### PR DESCRIPTION
## Summary

Regenerates `docs/doxygen/input/supported_api_hipblas.md` and `supported_api_rocblas.md` so the ILP64 (`_64`) routines list their native **array overloads** added in the ILP64 PR.

For example `hipblasSgemm_64` now shows `C binding, rank_0, rank_1` instead of `C binding` only. The previously committed tables were generated before the `_64` array-overload change landed and were therefore stale.

Scoped to hipBLAS/rocBLAS.