### PR TITLE
Show the assumed_rank variant in the hipBLAS/rocBLAS supported_api tables

### DIFF
--- a/docs/doxygen/input/supported_api_hipblas.md
+++ b/docs/doxygen/input/supported_api_hipblas.md
@@ -5,102 +5,102 @@
 1 | [hipblasCreate](interfacehipfort__hipblas_1_1hipblascreate.html "Interface documentation") | C binding
 2 | [hipblasDestroy](interfacehipfort__hipblas_1_1hipblasdestroy.html "Interface documentation") | C binding
 3 | [hipblasGetVersion](interfacehipfort__hipblas_1_1hipblasgetversion.html "Interface documentation") | C binding
-4 | [hipblasGetProperty](interfacehipfort__hipblas_1_1hipblasgetproperty.html "Interface documentation") | C binding, rank_0, rank_1
+4 | [hipblasGetProperty](interfacehipfort__hipblas_1_1hipblasgetproperty.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 5 | [hipblasSetStream](interfacehipfort__hipblas_1_1hipblassetstream.html "Interface documentation") | C binding
 6 | [hipblasGetStream](interfacehipfort__hipblas_1_1hipblasgetstream.html "Interface documentation") | C binding
 7 | [hipblasSetPointerMode](interfacehipfort__hipblas_1_1hipblassetpointermode.html "Interface documentation") | C binding
-8 | [hipblasGetPointerMode](interfacehipfort__hipblas_1_1hipblasgetpointermode.html "Interface documentation") | C binding, rank_0, rank_1
+8 | [hipblasGetPointerMode](interfacehipfort__hipblas_1_1hipblasgetpointermode.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 9 | [hipblasSetMathMode](interfacehipfort__hipblas_1_1hipblassetmathmode.html "Interface documentation") | C binding
-10 | [hipblasGetMathMode](interfacehipfort__hipblas_1_1hipblasgetmathmode.html "Interface documentation") | C binding, rank_0, rank_1
+10 | [hipblasGetMathMode](interfacehipfort__hipblas_1_1hipblasgetmathmode.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 11 | [hipblasSetWorkspace](interfacehipfort__hipblas_1_1hipblassetworkspace.html "Interface documentation") | C binding
 12 | [hipblasSetAtomicsMode](interfacehipfort__hipblas_1_1hipblassetatomicsmode.html "Interface documentation") | C binding
-13 | [hipblasGetAtomicsMode](interfacehipfort__hipblas_1_1hipblasgetatomicsmode.html "Interface documentation") | C binding, rank_0, rank_1
+13 | [hipblasGetAtomicsMode](interfacehipfort__hipblas_1_1hipblasgetatomicsmode.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 14 | [hipblasSetBatchAlphaStride](interfacehipfort__hipblas_1_1hipblassetbatchalphastride.html "Interface documentation") | C binding
-15 | [hipblasGetBatchAlphaStride](interfacehipfort__hipblas_1_1hipblasgetbatchalphastride.html "Interface documentation") | C binding, rank_0, rank_1
+15 | [hipblasGetBatchAlphaStride](interfacehipfort__hipblas_1_1hipblasgetbatchalphastride.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 16 | [hipblasSetBatchBetaStride](interfacehipfort__hipblas_1_1hipblassetbatchbetastride.html "Interface documentation") | C binding
-17 | [hipblasGetBatchBetaStride](interfacehipfort__hipblas_1_1hipblasgetbatchbetastride.html "Interface documentation") | C binding, rank_0, rank_1
-18 | [hipblasIsamax](interfacehipfort__hipblas_1_1hipblasisamax.html "Interface documentation") | C binding, rank_0, rank_1
-19 | [hipblasIdamax](interfacehipfort__hipblas_1_1hipblasidamax.html "Interface documentation") | C binding, rank_0, rank_1
-20 | [hipblasIcamax](interfacehipfort__hipblas_1_1hipblasicamax.html "Interface documentation") | C binding, rank_0, rank_1
-21 | [hipblasIzamax](interfacehipfort__hipblas_1_1hipblasizamax.html "Interface documentation") | C binding, rank_0, rank_1
-22 | [hipblasIsamax_64](interfacehipfort__hipblas_1_1hipblasisamax__64.html "Interface documentation") | C binding, rank_0, rank_1
-23 | [hipblasIdamax_64](interfacehipfort__hipblas_1_1hipblasidamax__64.html "Interface documentation") | C binding, rank_0, rank_1
-24 | [hipblasIcamax_64](interfacehipfort__hipblas_1_1hipblasicamax__64.html "Interface documentation") | C binding, rank_0, rank_1
-25 | [hipblasIzamax_64](interfacehipfort__hipblas_1_1hipblasizamax__64.html "Interface documentation") | C binding, rank_0, rank_1
+17 | [hipblasGetBatchBetaStride](interfacehipfort__hipblas_1_1hipblasgetbatchbetastride.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+18 | [hipblasIsamax](interfacehipfort__hipblas_1_1hipblasisamax.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+19 | [hipblasIdamax](interfacehipfort__hipblas_1_1hipblasidamax.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+20 | [hipblasIcamax](interfacehipfort__hipblas_1_1hipblasicamax.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+21 | [hipblasIzamax](interfacehipfort__hipblas_1_1hipblasizamax.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+22 | [hipblasIsamax_64](interfacehipfort__hipblas_1_1hipblasisamax__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+23 | [hipblasIdamax_64](interfacehipfort__hipblas_1_1hipblasidamax__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+24 | [hipblasIcamax_64](interfacehipfort__hipblas_1_1hipblasicamax__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+25 | [hipblasIzamax_64](interfacehipfort__hipblas_1_1hipblasizamax__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 26 | [hipblasIsamaxBatched](interfacehipfort__hipblas_1_1hipblasisamaxbatched.html "Interface documentation") | C binding
 27 | [hipblasIdamaxBatched](interfacehipfort__hipblas_1_1hipblasidamaxbatched.html "Interface documentation") | C binding
 28 | [hipblasIcamaxBatched](interfacehipfort__hipblas_1_1hipblasicamaxbatched.html "Interface documentation") | C binding
 29 | [hipblasIzamaxBatched](interfacehipfort__hipblas_1_1hipblasizamaxbatched.html "Interface documentation") | C binding
-30 | [hipblasIsamaxBatched_64](interfacehipfort__hipblas_1_1hipblasisamaxbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-31 | [hipblasIdamaxBatched_64](interfacehipfort__hipblas_1_1hipblasidamaxbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-32 | [hipblasIcamaxBatched_64](interfacehipfort__hipblas_1_1hipblasicamaxbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-33 | [hipblasIzamaxBatched_64](interfacehipfort__hipblas_1_1hipblasizamaxbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-34 | [hipblasIsamaxStridedBatched](interfacehipfort__hipblas_1_1hipblasisamaxstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-35 | [hipblasIdamaxStridedBatched](interfacehipfort__hipblas_1_1hipblasidamaxstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-36 | [hipblasIcamaxStridedBatched](interfacehipfort__hipblas_1_1hipblasicamaxstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-37 | [hipblasIzamaxStridedBatched](interfacehipfort__hipblas_1_1hipblasizamaxstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-38 | [hipblasIsamaxStridedBatched_64](interfacehipfort__hipblas_1_1hipblasisamaxstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-39 | [hipblasIdamaxStridedBatched_64](interfacehipfort__hipblas_1_1hipblasidamaxstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-40 | [hipblasIcamaxStridedBatched_64](interfacehipfort__hipblas_1_1hipblasicamaxstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-41 | [hipblasIzamaxStridedBatched_64](interfacehipfort__hipblas_1_1hipblasizamaxstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-42 | [hipblasIsamin](interfacehipfort__hipblas_1_1hipblasisamin.html "Interface documentation") | C binding, rank_0, rank_1
-43 | [hipblasIdamin](interfacehipfort__hipblas_1_1hipblasidamin.html "Interface documentation") | C binding, rank_0, rank_1
-44 | [hipblasIcamin](interfacehipfort__hipblas_1_1hipblasicamin.html "Interface documentation") | C binding, rank_0, rank_1
-45 | [hipblasIzamin](interfacehipfort__hipblas_1_1hipblasizamin.html "Interface documentation") | C binding, rank_0, rank_1
-46 | [hipblasIsamin_64](interfacehipfort__hipblas_1_1hipblasisamin__64.html "Interface documentation") | C binding, rank_0, rank_1
-47 | [hipblasIdamin_64](interfacehipfort__hipblas_1_1hipblasidamin__64.html "Interface documentation") | C binding, rank_0, rank_1
-48 | [hipblasIcamin_64](interfacehipfort__hipblas_1_1hipblasicamin__64.html "Interface documentation") | C binding, rank_0, rank_1
-49 | [hipblasIzamin_64](interfacehipfort__hipblas_1_1hipblasizamin__64.html "Interface documentation") | C binding, rank_0, rank_1
+30 | [hipblasIsamaxBatched_64](interfacehipfort__hipblas_1_1hipblasisamaxbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+31 | [hipblasIdamaxBatched_64](interfacehipfort__hipblas_1_1hipblasidamaxbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+32 | [hipblasIcamaxBatched_64](interfacehipfort__hipblas_1_1hipblasicamaxbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+33 | [hipblasIzamaxBatched_64](interfacehipfort__hipblas_1_1hipblasizamaxbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+34 | [hipblasIsamaxStridedBatched](interfacehipfort__hipblas_1_1hipblasisamaxstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+35 | [hipblasIdamaxStridedBatched](interfacehipfort__hipblas_1_1hipblasidamaxstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+36 | [hipblasIcamaxStridedBatched](interfacehipfort__hipblas_1_1hipblasicamaxstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+37 | [hipblasIzamaxStridedBatched](interfacehipfort__hipblas_1_1hipblasizamaxstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+38 | [hipblasIsamaxStridedBatched_64](interfacehipfort__hipblas_1_1hipblasisamaxstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+39 | [hipblasIdamaxStridedBatched_64](interfacehipfort__hipblas_1_1hipblasidamaxstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+40 | [hipblasIcamaxStridedBatched_64](interfacehipfort__hipblas_1_1hipblasicamaxstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+41 | [hipblasIzamaxStridedBatched_64](interfacehipfort__hipblas_1_1hipblasizamaxstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+42 | [hipblasIsamin](interfacehipfort__hipblas_1_1hipblasisamin.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+43 | [hipblasIdamin](interfacehipfort__hipblas_1_1hipblasidamin.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+44 | [hipblasIcamin](interfacehipfort__hipblas_1_1hipblasicamin.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+45 | [hipblasIzamin](interfacehipfort__hipblas_1_1hipblasizamin.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+46 | [hipblasIsamin_64](interfacehipfort__hipblas_1_1hipblasisamin__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+47 | [hipblasIdamin_64](interfacehipfort__hipblas_1_1hipblasidamin__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+48 | [hipblasIcamin_64](interfacehipfort__hipblas_1_1hipblasicamin__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+49 | [hipblasIzamin_64](interfacehipfort__hipblas_1_1hipblasizamin__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 50 | [hipblasIsaminBatched](interfacehipfort__hipblas_1_1hipblasisaminbatched.html "Interface documentation") | C binding
 51 | [hipblasIdaminBatched](interfacehipfort__hipblas_1_1hipblasidaminbatched.html "Interface documentation") | C binding
 52 | [hipblasIcaminBatched](interfacehipfort__hipblas_1_1hipblasicaminbatched.html "Interface documentation") | C binding
 53 | [hipblasIzaminBatched](interfacehipfort__hipblas_1_1hipblasizaminbatched.html "Interface documentation") | C binding
-54 | [hipblasIsaminBatched_64](interfacehipfort__hipblas_1_1hipblasisaminbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-55 | [hipblasIdaminBatched_64](interfacehipfort__hipblas_1_1hipblasidaminbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-56 | [hipblasIcaminBatched_64](interfacehipfort__hipblas_1_1hipblasicaminbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-57 | [hipblasIzaminBatched_64](interfacehipfort__hipblas_1_1hipblasizaminbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-58 | [hipblasIsaminStridedBatched](interfacehipfort__hipblas_1_1hipblasisaminstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-59 | [hipblasIdaminStridedBatched](interfacehipfort__hipblas_1_1hipblasidaminstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-60 | [hipblasIcaminStridedBatched](interfacehipfort__hipblas_1_1hipblasicaminstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-61 | [hipblasIzaminStridedBatched](interfacehipfort__hipblas_1_1hipblasizaminstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-62 | [hipblasIsaminStridedBatched_64](interfacehipfort__hipblas_1_1hipblasisaminstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-63 | [hipblasIdaminStridedBatched_64](interfacehipfort__hipblas_1_1hipblasidaminstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-64 | [hipblasIcaminStridedBatched_64](interfacehipfort__hipblas_1_1hipblasicaminstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-65 | [hipblasIzaminStridedBatched_64](interfacehipfort__hipblas_1_1hipblasizaminstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-66 | [hipblasSasum](interfacehipfort__hipblas_1_1hipblassasum.html "Interface documentation") | C binding, rank_0, rank_1
-67 | [hipblasDasum](interfacehipfort__hipblas_1_1hipblasdasum.html "Interface documentation") | C binding, rank_0, rank_1
-68 | [hipblasScasum](interfacehipfort__hipblas_1_1hipblasscasum.html "Interface documentation") | C binding, rank_0, rank_1
-69 | [hipblasDzasum](interfacehipfort__hipblas_1_1hipblasdzasum.html "Interface documentation") | C binding, rank_0, rank_1
-70 | [hipblasSasum_64](interfacehipfort__hipblas_1_1hipblassasum__64.html "Interface documentation") | C binding, rank_0, rank_1
-71 | [hipblasDasum_64](interfacehipfort__hipblas_1_1hipblasdasum__64.html "Interface documentation") | C binding, rank_0, rank_1
-72 | [hipblasScasum_64](interfacehipfort__hipblas_1_1hipblasscasum__64.html "Interface documentation") | C binding, rank_0, rank_1
-73 | [hipblasDzasum_64](interfacehipfort__hipblas_1_1hipblasdzasum__64.html "Interface documentation") | C binding, rank_0, rank_1
+54 | [hipblasIsaminBatched_64](interfacehipfort__hipblas_1_1hipblasisaminbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+55 | [hipblasIdaminBatched_64](interfacehipfort__hipblas_1_1hipblasidaminbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+56 | [hipblasIcaminBatched_64](interfacehipfort__hipblas_1_1hipblasicaminbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+57 | [hipblasIzaminBatched_64](interfacehipfort__hipblas_1_1hipblasizaminbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+58 | [hipblasIsaminStridedBatched](interfacehipfort__hipblas_1_1hipblasisaminstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+59 | [hipblasIdaminStridedBatched](interfacehipfort__hipblas_1_1hipblasidaminstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+60 | [hipblasIcaminStridedBatched](interfacehipfort__hipblas_1_1hipblasicaminstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+61 | [hipblasIzaminStridedBatched](interfacehipfort__hipblas_1_1hipblasizaminstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+62 | [hipblasIsaminStridedBatched_64](interfacehipfort__hipblas_1_1hipblasisaminstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+63 | [hipblasIdaminStridedBatched_64](interfacehipfort__hipblas_1_1hipblasidaminstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+64 | [hipblasIcaminStridedBatched_64](interfacehipfort__hipblas_1_1hipblasicaminstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+65 | [hipblasIzaminStridedBatched_64](interfacehipfort__hipblas_1_1hipblasizaminstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+66 | [hipblasSasum](interfacehipfort__hipblas_1_1hipblassasum.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+67 | [hipblasDasum](interfacehipfort__hipblas_1_1hipblasdasum.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+68 | [hipblasScasum](interfacehipfort__hipblas_1_1hipblasscasum.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+69 | [hipblasDzasum](interfacehipfort__hipblas_1_1hipblasdzasum.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+70 | [hipblasSasum_64](interfacehipfort__hipblas_1_1hipblassasum__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+71 | [hipblasDasum_64](interfacehipfort__hipblas_1_1hipblasdasum__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+72 | [hipblasScasum_64](interfacehipfort__hipblas_1_1hipblasscasum__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+73 | [hipblasDzasum_64](interfacehipfort__hipblas_1_1hipblasdzasum__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 74 | [hipblasSasumBatched](interfacehipfort__hipblas_1_1hipblassasumbatched.html "Interface documentation") | C binding
 75 | [hipblasDasumBatched](interfacehipfort__hipblas_1_1hipblasdasumbatched.html "Interface documentation") | C binding
 76 | [hipblasScasumBatched](interfacehipfort__hipblas_1_1hipblasscasumbatched.html "Interface documentation") | C binding
 77 | [hipblasDzasumBatched](interfacehipfort__hipblas_1_1hipblasdzasumbatched.html "Interface documentation") | C binding
-78 | [hipblasSasumBatched_64](interfacehipfort__hipblas_1_1hipblassasumbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-79 | [hipblasDasumBatched_64](interfacehipfort__hipblas_1_1hipblasdasumbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-80 | [hipblasScasumBatched_64](interfacehipfort__hipblas_1_1hipblasscasumbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-81 | [hipblasDzasumBatched_64](interfacehipfort__hipblas_1_1hipblasdzasumbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-82 | [hipblasSasumStridedBatched](interfacehipfort__hipblas_1_1hipblassasumstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-83 | [hipblasDasumStridedBatched](interfacehipfort__hipblas_1_1hipblasdasumstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-84 | [hipblasScasumStridedBatched](interfacehipfort__hipblas_1_1hipblasscasumstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-85 | [hipblasDzasumStridedBatched](interfacehipfort__hipblas_1_1hipblasdzasumstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-86 | [hipblasSasumStridedBatched_64](interfacehipfort__hipblas_1_1hipblassasumstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-87 | [hipblasDasumStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdasumstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-88 | [hipblasScasumStridedBatched_64](interfacehipfort__hipblas_1_1hipblasscasumstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-89 | [hipblasDzasumStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdzasumstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+78 | [hipblasSasumBatched_64](interfacehipfort__hipblas_1_1hipblassasumbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+79 | [hipblasDasumBatched_64](interfacehipfort__hipblas_1_1hipblasdasumbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+80 | [hipblasScasumBatched_64](interfacehipfort__hipblas_1_1hipblasscasumbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+81 | [hipblasDzasumBatched_64](interfacehipfort__hipblas_1_1hipblasdzasumbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+82 | [hipblasSasumStridedBatched](interfacehipfort__hipblas_1_1hipblassasumstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+83 | [hipblasDasumStridedBatched](interfacehipfort__hipblas_1_1hipblasdasumstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+84 | [hipblasScasumStridedBatched](interfacehipfort__hipblas_1_1hipblasscasumstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+85 | [hipblasDzasumStridedBatched](interfacehipfort__hipblas_1_1hipblasdzasumstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+86 | [hipblasSasumStridedBatched_64](interfacehipfort__hipblas_1_1hipblassasumstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+87 | [hipblasDasumStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdasumstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+88 | [hipblasScasumStridedBatched_64](interfacehipfort__hipblas_1_1hipblasscasumstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+89 | [hipblasDzasumStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdzasumstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 90 | [hipblasHaxpy](interfacehipfort__hipblas_1_1hipblashaxpy.html "Interface documentation") | C binding
-91 | [hipblasSaxpy](interfacehipfort__hipblas_1_1hipblassaxpy.html "Interface documentation") | C binding, rank_0, rank_1
-92 | [hipblasDaxpy](interfacehipfort__hipblas_1_1hipblasdaxpy.html "Interface documentation") | C binding, rank_0, rank_1
-93 | [hipblasCaxpy](interfacehipfort__hipblas_1_1hipblascaxpy.html "Interface documentation") | C binding, rank_0, rank_1
-94 | [hipblasZaxpy](interfacehipfort__hipblas_1_1hipblaszaxpy.html "Interface documentation") | C binding, rank_0, rank_1
+91 | [hipblasSaxpy](interfacehipfort__hipblas_1_1hipblassaxpy.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+92 | [hipblasDaxpy](interfacehipfort__hipblas_1_1hipblasdaxpy.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+93 | [hipblasCaxpy](interfacehipfort__hipblas_1_1hipblascaxpy.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+94 | [hipblasZaxpy](interfacehipfort__hipblas_1_1hipblaszaxpy.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 95 | [hipblasHaxpy_64](interfacehipfort__hipblas_1_1hipblashaxpy__64.html "Interface documentation") | C binding
-96 | [hipblasSaxpy_64](interfacehipfort__hipblas_1_1hipblassaxpy__64.html "Interface documentation") | C binding, rank_0, rank_1
-97 | [hipblasDaxpy_64](interfacehipfort__hipblas_1_1hipblasdaxpy__64.html "Interface documentation") | C binding, rank_0, rank_1
-98 | [hipblasCaxpy_64](interfacehipfort__hipblas_1_1hipblascaxpy__64.html "Interface documentation") | C binding, rank_0, rank_1
-99 | [hipblasZaxpy_64](interfacehipfort__hipblas_1_1hipblaszaxpy__64.html "Interface documentation") | C binding, rank_0, rank_1
+96 | [hipblasSaxpy_64](interfacehipfort__hipblas_1_1hipblassaxpy__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+97 | [hipblasDaxpy_64](interfacehipfort__hipblas_1_1hipblasdaxpy__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+98 | [hipblasCaxpy_64](interfacehipfort__hipblas_1_1hipblascaxpy__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+99 | [hipblasZaxpy_64](interfacehipfort__hipblas_1_1hipblaszaxpy__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 100 | [hipblasHaxpyBatched](interfacehipfort__hipblas_1_1hipblashaxpybatched.html "Interface documentation") | C binding
 101 | [hipblasSaxpyBatched](interfacehipfort__hipblas_1_1hipblassaxpybatched.html "Interface documentation") | C binding
 102 | [hipblasDaxpyBatched](interfacehipfort__hipblas_1_1hipblasdaxpybatched.html "Interface documentation") | C binding
@@ -112,23 +112,23 @@
 108 | [hipblasCaxpyBatched_64](interfacehipfort__hipblas_1_1hipblascaxpybatched__64.html "Interface documentation") | C binding
 109 | [hipblasZaxpyBatched_64](interfacehipfort__hipblas_1_1hipblaszaxpybatched__64.html "Interface documentation") | C binding
 110 | [hipblasHaxpyStridedBatched](interfacehipfort__hipblas_1_1hipblashaxpystridedbatched.html "Interface documentation") | C binding
-111 | [hipblasSaxpyStridedBatched](interfacehipfort__hipblas_1_1hipblassaxpystridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-112 | [hipblasDaxpyStridedBatched](interfacehipfort__hipblas_1_1hipblasdaxpystridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-113 | [hipblasCaxpyStridedBatched](interfacehipfort__hipblas_1_1hipblascaxpystridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-114 | [hipblasZaxpyStridedBatched](interfacehipfort__hipblas_1_1hipblaszaxpystridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+111 | [hipblasSaxpyStridedBatched](interfacehipfort__hipblas_1_1hipblassaxpystridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+112 | [hipblasDaxpyStridedBatched](interfacehipfort__hipblas_1_1hipblasdaxpystridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+113 | [hipblasCaxpyStridedBatched](interfacehipfort__hipblas_1_1hipblascaxpystridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+114 | [hipblasZaxpyStridedBatched](interfacehipfort__hipblas_1_1hipblaszaxpystridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 115 | [hipblasHaxpyStridedBatched_64](interfacehipfort__hipblas_1_1hipblashaxpystridedbatched__64.html "Interface documentation") | C binding
-116 | [hipblasSaxpyStridedBatched_64](interfacehipfort__hipblas_1_1hipblassaxpystridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-117 | [hipblasDaxpyStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdaxpystridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-118 | [hipblasCaxpyStridedBatched_64](interfacehipfort__hipblas_1_1hipblascaxpystridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-119 | [hipblasZaxpyStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszaxpystridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-120 | [hipblasScopy](interfacehipfort__hipblas_1_1hipblasscopy.html "Interface documentation") | C binding, rank_0, rank_1
-121 | [hipblasDcopy](interfacehipfort__hipblas_1_1hipblasdcopy.html "Interface documentation") | C binding, rank_0, rank_1
-122 | [hipblasCcopy](interfacehipfort__hipblas_1_1hipblasccopy.html "Interface documentation") | C binding, rank_0, rank_1
-123 | [hipblasZcopy](interfacehipfort__hipblas_1_1hipblaszcopy.html "Interface documentation") | C binding, rank_0, rank_1
-124 | [hipblasScopy_64](interfacehipfort__hipblas_1_1hipblasscopy__64.html "Interface documentation") | C binding, rank_0, rank_1
-125 | [hipblasDcopy_64](interfacehipfort__hipblas_1_1hipblasdcopy__64.html "Interface documentation") | C binding, rank_0, rank_1
-126 | [hipblasCcopy_64](interfacehipfort__hipblas_1_1hipblasccopy__64.html "Interface documentation") | C binding, rank_0, rank_1
-127 | [hipblasZcopy_64](interfacehipfort__hipblas_1_1hipblaszcopy__64.html "Interface documentation") | C binding, rank_0, rank_1
+116 | [hipblasSaxpyStridedBatched_64](interfacehipfort__hipblas_1_1hipblassaxpystridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+117 | [hipblasDaxpyStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdaxpystridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+118 | [hipblasCaxpyStridedBatched_64](interfacehipfort__hipblas_1_1hipblascaxpystridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+119 | [hipblasZaxpyStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszaxpystridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+120 | [hipblasScopy](interfacehipfort__hipblas_1_1hipblasscopy.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+121 | [hipblasDcopy](interfacehipfort__hipblas_1_1hipblasdcopy.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+122 | [hipblasCcopy](interfacehipfort__hipblas_1_1hipblasccopy.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+123 | [hipblasZcopy](interfacehipfort__hipblas_1_1hipblaszcopy.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+124 | [hipblasScopy_64](interfacehipfort__hipblas_1_1hipblasscopy__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+125 | [hipblasDcopy_64](interfacehipfort__hipblas_1_1hipblasdcopy__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+126 | [hipblasCcopy_64](interfacehipfort__hipblas_1_1hipblasccopy__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+127 | [hipblasZcopy_64](interfacehipfort__hipblas_1_1hipblaszcopy__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 128 | [hipblasScopyBatched](interfacehipfort__hipblas_1_1hipblasscopybatched.html "Interface documentation") | C binding
 129 | [hipblasDcopyBatched](interfacehipfort__hipblas_1_1hipblasdcopybatched.html "Interface documentation") | C binding
 130 | [hipblasCcopyBatched](interfacehipfort__hipblas_1_1hipblasccopybatched.html "Interface documentation") | C binding
@@ -137,32 +137,32 @@
 133 | [hipblasDcopyBatched_64](interfacehipfort__hipblas_1_1hipblasdcopybatched__64.html "Interface documentation") | C binding
 134 | [hipblasCcopyBatched_64](interfacehipfort__hipblas_1_1hipblasccopybatched__64.html "Interface documentation") | C binding
 135 | [hipblasZcopyBatched_64](interfacehipfort__hipblas_1_1hipblaszcopybatched__64.html "Interface documentation") | C binding
-136 | [hipblasScopyStridedBatched](interfacehipfort__hipblas_1_1hipblasscopystridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-137 | [hipblasDcopyStridedBatched](interfacehipfort__hipblas_1_1hipblasdcopystridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-138 | [hipblasCcopyStridedBatched](interfacehipfort__hipblas_1_1hipblasccopystridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-139 | [hipblasZcopyStridedBatched](interfacehipfort__hipblas_1_1hipblaszcopystridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-140 | [hipblasScopyStridedBatched_64](interfacehipfort__hipblas_1_1hipblasscopystridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-141 | [hipblasDcopyStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdcopystridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-142 | [hipblasCcopyStridedBatched_64](interfacehipfort__hipblas_1_1hipblasccopystridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-143 | [hipblasZcopyStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszcopystridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+136 | [hipblasScopyStridedBatched](interfacehipfort__hipblas_1_1hipblasscopystridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+137 | [hipblasDcopyStridedBatched](interfacehipfort__hipblas_1_1hipblasdcopystridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+138 | [hipblasCcopyStridedBatched](interfacehipfort__hipblas_1_1hipblasccopystridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+139 | [hipblasZcopyStridedBatched](interfacehipfort__hipblas_1_1hipblaszcopystridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+140 | [hipblasScopyStridedBatched_64](interfacehipfort__hipblas_1_1hipblasscopystridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+141 | [hipblasDcopyStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdcopystridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+142 | [hipblasCcopyStridedBatched_64](interfacehipfort__hipblas_1_1hipblasccopystridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+143 | [hipblasZcopyStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszcopystridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 144 | [hipblasHdot](interfacehipfort__hipblas_1_1hipblashdot.html "Interface documentation") | C binding
-145 | [hipblasBfdot](interfacehipfort__hipblas_1_1hipblasbfdot.html "Interface documentation") | C binding, rank_0, rank_1
-146 | [hipblasSdot](interfacehipfort__hipblas_1_1hipblassdot.html "Interface documentation") | C binding, rank_0, rank_1
-147 | [hipblasDdot](interfacehipfort__hipblas_1_1hipblasddot.html "Interface documentation") | C binding, rank_0, rank_1
-148 | [hipblasCdotc](interfacehipfort__hipblas_1_1hipblascdotc.html "Interface documentation") | C binding, rank_0, rank_1
-149 | [hipblasCdotu](interfacehipfort__hipblas_1_1hipblascdotu.html "Interface documentation") | C binding, rank_0, rank_1
-150 | [hipblasZdotc](interfacehipfort__hipblas_1_1hipblaszdotc.html "Interface documentation") | C binding, rank_0, rank_1
-151 | [hipblasZdotu](interfacehipfort__hipblas_1_1hipblaszdotu.html "Interface documentation") | C binding, rank_0, rank_1
+145 | [hipblasBfdot](interfacehipfort__hipblas_1_1hipblasbfdot.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+146 | [hipblasSdot](interfacehipfort__hipblas_1_1hipblassdot.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+147 | [hipblasDdot](interfacehipfort__hipblas_1_1hipblasddot.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+148 | [hipblasCdotc](interfacehipfort__hipblas_1_1hipblascdotc.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+149 | [hipblasCdotu](interfacehipfort__hipblas_1_1hipblascdotu.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+150 | [hipblasZdotc](interfacehipfort__hipblas_1_1hipblaszdotc.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+151 | [hipblasZdotu](interfacehipfort__hipblas_1_1hipblaszdotu.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 152 | [hipblasHdot_64](interfacehipfort__hipblas_1_1hipblashdot__64.html "Interface documentation") | C binding
-153 | [hipblasBfdot_64](interfacehipfort__hipblas_1_1hipblasbfdot__64.html "Interface documentation") | C binding, rank_0, rank_1
-154 | [hipblasSdot_64](interfacehipfort__hipblas_1_1hipblassdot__64.html "Interface documentation") | C binding, rank_0, rank_1
-155 | [hipblasDdot_64](interfacehipfort__hipblas_1_1hipblasddot__64.html "Interface documentation") | C binding, rank_0, rank_1
-156 | [hipblasCdotc_64](interfacehipfort__hipblas_1_1hipblascdotc__64.html "Interface documentation") | C binding, rank_0, rank_1
-157 | [hipblasCdotu_64](interfacehipfort__hipblas_1_1hipblascdotu__64.html "Interface documentation") | C binding, rank_0, rank_1
-158 | [hipblasZdotc_64](interfacehipfort__hipblas_1_1hipblaszdotc__64.html "Interface documentation") | C binding, rank_0, rank_1
-159 | [hipblasZdotu_64](interfacehipfort__hipblas_1_1hipblaszdotu__64.html "Interface documentation") | C binding, rank_0, rank_1
+153 | [hipblasBfdot_64](interfacehipfort__hipblas_1_1hipblasbfdot__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+154 | [hipblasSdot_64](interfacehipfort__hipblas_1_1hipblassdot__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+155 | [hipblasDdot_64](interfacehipfort__hipblas_1_1hipblasddot__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+156 | [hipblasCdotc_64](interfacehipfort__hipblas_1_1hipblascdotc__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+157 | [hipblasCdotu_64](interfacehipfort__hipblas_1_1hipblascdotu__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+158 | [hipblasZdotc_64](interfacehipfort__hipblas_1_1hipblaszdotc__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+159 | [hipblasZdotu_64](interfacehipfort__hipblas_1_1hipblaszdotu__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 160 | [hipblasHdotBatched](interfacehipfort__hipblas_1_1hipblashdotbatched.html "Interface documentation") | C binding
-161 | [hipblasBfdotBatched](interfacehipfort__hipblas_1_1hipblasbfdotbatched.html "Interface documentation") | C binding, rank_0, rank_1
+161 | [hipblasBfdotBatched](interfacehipfort__hipblas_1_1hipblasbfdotbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 162 | [hipblasSdotBatched](interfacehipfort__hipblas_1_1hipblassdotbatched.html "Interface documentation") | C binding
 163 | [hipblasDdotBatched](interfacehipfort__hipblas_1_1hipblasddotbatched.html "Interface documentation") | C binding
 164 | [hipblasCdotcBatched](interfacehipfort__hipblas_1_1hipblascdotcbatched.html "Interface documentation") | C binding
@@ -170,97 +170,97 @@
 166 | [hipblasZdotcBatched](interfacehipfort__hipblas_1_1hipblaszdotcbatched.html "Interface documentation") | C binding
 167 | [hipblasZdotuBatched](interfacehipfort__hipblas_1_1hipblaszdotubatched.html "Interface documentation") | C binding
 168 | [hipblasHdotBatched_64](interfacehipfort__hipblas_1_1hipblashdotbatched__64.html "Interface documentation") | C binding
-169 | [hipblasBfdotBatched_64](interfacehipfort__hipblas_1_1hipblasbfdotbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-170 | [hipblasSdotBatched_64](interfacehipfort__hipblas_1_1hipblassdotbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-171 | [hipblasDdotBatched_64](interfacehipfort__hipblas_1_1hipblasddotbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-172 | [hipblasCdotcBatched_64](interfacehipfort__hipblas_1_1hipblascdotcbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-173 | [hipblasCdotuBatched_64](interfacehipfort__hipblas_1_1hipblascdotubatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-174 | [hipblasZdotcBatched_64](interfacehipfort__hipblas_1_1hipblaszdotcbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-175 | [hipblasZdotuBatched_64](interfacehipfort__hipblas_1_1hipblaszdotubatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+169 | [hipblasBfdotBatched_64](interfacehipfort__hipblas_1_1hipblasbfdotbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+170 | [hipblasSdotBatched_64](interfacehipfort__hipblas_1_1hipblassdotbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+171 | [hipblasDdotBatched_64](interfacehipfort__hipblas_1_1hipblasddotbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+172 | [hipblasCdotcBatched_64](interfacehipfort__hipblas_1_1hipblascdotcbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+173 | [hipblasCdotuBatched_64](interfacehipfort__hipblas_1_1hipblascdotubatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+174 | [hipblasZdotcBatched_64](interfacehipfort__hipblas_1_1hipblaszdotcbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+175 | [hipblasZdotuBatched_64](interfacehipfort__hipblas_1_1hipblaszdotubatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 176 | [hipblasHdotStridedBatched](interfacehipfort__hipblas_1_1hipblashdotstridedbatched.html "Interface documentation") | C binding
-177 | [hipblasBfdotStridedBatched](interfacehipfort__hipblas_1_1hipblasbfdotstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-178 | [hipblasSdotStridedBatched](interfacehipfort__hipblas_1_1hipblassdotstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-179 | [hipblasDdotStridedBatched](interfacehipfort__hipblas_1_1hipblasddotstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-180 | [hipblasCdotcStridedBatched](interfacehipfort__hipblas_1_1hipblascdotcstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-181 | [hipblasCdotuStridedBatched](interfacehipfort__hipblas_1_1hipblascdotustridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-182 | [hipblasZdotcStridedBatched](interfacehipfort__hipblas_1_1hipblaszdotcstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-183 | [hipblasZdotuStridedBatched](interfacehipfort__hipblas_1_1hipblaszdotustridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
+177 | [hipblasBfdotStridedBatched](interfacehipfort__hipblas_1_1hipblasbfdotstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+178 | [hipblasSdotStridedBatched](interfacehipfort__hipblas_1_1hipblassdotstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+179 | [hipblasDdotStridedBatched](interfacehipfort__hipblas_1_1hipblasddotstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+180 | [hipblasCdotcStridedBatched](interfacehipfort__hipblas_1_1hipblascdotcstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+181 | [hipblasCdotuStridedBatched](interfacehipfort__hipblas_1_1hipblascdotustridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+182 | [hipblasZdotcStridedBatched](interfacehipfort__hipblas_1_1hipblaszdotcstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+183 | [hipblasZdotuStridedBatched](interfacehipfort__hipblas_1_1hipblaszdotustridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 184 | [hipblasHdotStridedBatched_64](interfacehipfort__hipblas_1_1hipblashdotstridedbatched__64.html "Interface documentation") | C binding
-185 | [hipblasBfdotStridedBatched_64](interfacehipfort__hipblas_1_1hipblasbfdotstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-186 | [hipblasSdotStridedBatched_64](interfacehipfort__hipblas_1_1hipblassdotstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-187 | [hipblasDdotStridedBatched_64](interfacehipfort__hipblas_1_1hipblasddotstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-188 | [hipblasCdotcStridedBatched_64](interfacehipfort__hipblas_1_1hipblascdotcstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-189 | [hipblasCdotuStridedBatched_64](interfacehipfort__hipblas_1_1hipblascdotustridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-190 | [hipblasZdotcStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszdotcstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-191 | [hipblasZdotuStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszdotustridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-192 | [hipblasSnrm2](interfacehipfort__hipblas_1_1hipblassnrm2.html "Interface documentation") | C binding, rank_0, rank_1
-193 | [hipblasDnrm2](interfacehipfort__hipblas_1_1hipblasdnrm2.html "Interface documentation") | C binding, rank_0, rank_1
-194 | [hipblasScnrm2](interfacehipfort__hipblas_1_1hipblasscnrm2.html "Interface documentation") | C binding, rank_0, rank_1
-195 | [hipblasDznrm2](interfacehipfort__hipblas_1_1hipblasdznrm2.html "Interface documentation") | C binding, rank_0, rank_1
-196 | [hipblasSnrm2_64](interfacehipfort__hipblas_1_1hipblassnrm2__64.html "Interface documentation") | C binding, rank_0, rank_1
-197 | [hipblasDnrm2_64](interfacehipfort__hipblas_1_1hipblasdnrm2__64.html "Interface documentation") | C binding, rank_0, rank_1
-198 | [hipblasScnrm2_64](interfacehipfort__hipblas_1_1hipblasscnrm2__64.html "Interface documentation") | C binding, rank_0, rank_1
-199 | [hipblasDznrm2_64](interfacehipfort__hipblas_1_1hipblasdznrm2__64.html "Interface documentation") | C binding, rank_0, rank_1
+185 | [hipblasBfdotStridedBatched_64](interfacehipfort__hipblas_1_1hipblasbfdotstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+186 | [hipblasSdotStridedBatched_64](interfacehipfort__hipblas_1_1hipblassdotstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+187 | [hipblasDdotStridedBatched_64](interfacehipfort__hipblas_1_1hipblasddotstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+188 | [hipblasCdotcStridedBatched_64](interfacehipfort__hipblas_1_1hipblascdotcstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+189 | [hipblasCdotuStridedBatched_64](interfacehipfort__hipblas_1_1hipblascdotustridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+190 | [hipblasZdotcStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszdotcstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+191 | [hipblasZdotuStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszdotustridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+192 | [hipblasSnrm2](interfacehipfort__hipblas_1_1hipblassnrm2.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+193 | [hipblasDnrm2](interfacehipfort__hipblas_1_1hipblasdnrm2.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+194 | [hipblasScnrm2](interfacehipfort__hipblas_1_1hipblasscnrm2.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+195 | [hipblasDznrm2](interfacehipfort__hipblas_1_1hipblasdznrm2.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+196 | [hipblasSnrm2_64](interfacehipfort__hipblas_1_1hipblassnrm2__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+197 | [hipblasDnrm2_64](interfacehipfort__hipblas_1_1hipblasdnrm2__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+198 | [hipblasScnrm2_64](interfacehipfort__hipblas_1_1hipblasscnrm2__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+199 | [hipblasDznrm2_64](interfacehipfort__hipblas_1_1hipblasdznrm2__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 200 | [hipblasSnrm2Batched](interfacehipfort__hipblas_1_1hipblassnrm2batched.html "Interface documentation") | C binding
 201 | [hipblasDnrm2Batched](interfacehipfort__hipblas_1_1hipblasdnrm2batched.html "Interface documentation") | C binding
 202 | [hipblasScnrm2Batched](interfacehipfort__hipblas_1_1hipblasscnrm2batched.html "Interface documentation") | C binding
 203 | [hipblasDznrm2Batched](interfacehipfort__hipblas_1_1hipblasdznrm2batched.html "Interface documentation") | C binding
-204 | [hipblasSnrm2Batched_64](interfacehipfort__hipblas_1_1hipblassnrm2batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-205 | [hipblasDnrm2Batched_64](interfacehipfort__hipblas_1_1hipblasdnrm2batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-206 | [hipblasScnrm2Batched_64](interfacehipfort__hipblas_1_1hipblasscnrm2batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-207 | [hipblasDznrm2Batched_64](interfacehipfort__hipblas_1_1hipblasdznrm2batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-208 | [hipblasSnrm2StridedBatched](interfacehipfort__hipblas_1_1hipblassnrm2stridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-209 | [hipblasDnrm2StridedBatched](interfacehipfort__hipblas_1_1hipblasdnrm2stridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-210 | [hipblasScnrm2StridedBatched](interfacehipfort__hipblas_1_1hipblasscnrm2stridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-211 | [hipblasDznrm2StridedBatched](interfacehipfort__hipblas_1_1hipblasdznrm2stridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-212 | [hipblasSnrm2StridedBatched_64](interfacehipfort__hipblas_1_1hipblassnrm2stridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-213 | [hipblasDnrm2StridedBatched_64](interfacehipfort__hipblas_1_1hipblasdnrm2stridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-214 | [hipblasScnrm2StridedBatched_64](interfacehipfort__hipblas_1_1hipblasscnrm2stridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-215 | [hipblasDznrm2StridedBatched_64](interfacehipfort__hipblas_1_1hipblasdznrm2stridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-216 | [hipblasSrot](interfacehipfort__hipblas_1_1hipblassrot.html "Interface documentation") | C binding, rank_0, rank_1
-217 | [hipblasDrot](interfacehipfort__hipblas_1_1hipblasdrot.html "Interface documentation") | C binding, rank_0, rank_1
-218 | [hipblasCrot](interfacehipfort__hipblas_1_1hipblascrot.html "Interface documentation") | C binding, rank_0, rank_1
-219 | [hipblasCsrot](interfacehipfort__hipblas_1_1hipblascsrot.html "Interface documentation") | C binding, rank_0, rank_1
-220 | [hipblasZrot](interfacehipfort__hipblas_1_1hipblaszrot.html "Interface documentation") | C binding, rank_0, rank_1
-221 | [hipblasZdrot](interfacehipfort__hipblas_1_1hipblaszdrot.html "Interface documentation") | C binding, rank_0, rank_1
-222 | [hipblasSrot_64](interfacehipfort__hipblas_1_1hipblassrot__64.html "Interface documentation") | C binding, rank_0, rank_1
-223 | [hipblasDrot_64](interfacehipfort__hipblas_1_1hipblasdrot__64.html "Interface documentation") | C binding, rank_0, rank_1
-224 | [hipblasCrot_64](interfacehipfort__hipblas_1_1hipblascrot__64.html "Interface documentation") | C binding, rank_0, rank_1
-225 | [hipblasCsrot_64](interfacehipfort__hipblas_1_1hipblascsrot__64.html "Interface documentation") | C binding, rank_0, rank_1
-226 | [hipblasZrot_64](interfacehipfort__hipblas_1_1hipblaszrot__64.html "Interface documentation") | C binding, rank_0, rank_1
-227 | [hipblasZdrot_64](interfacehipfort__hipblas_1_1hipblaszdrot__64.html "Interface documentation") | C binding, rank_0, rank_1
+204 | [hipblasSnrm2Batched_64](interfacehipfort__hipblas_1_1hipblassnrm2batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+205 | [hipblasDnrm2Batched_64](interfacehipfort__hipblas_1_1hipblasdnrm2batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+206 | [hipblasScnrm2Batched_64](interfacehipfort__hipblas_1_1hipblasscnrm2batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+207 | [hipblasDznrm2Batched_64](interfacehipfort__hipblas_1_1hipblasdznrm2batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+208 | [hipblasSnrm2StridedBatched](interfacehipfort__hipblas_1_1hipblassnrm2stridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+209 | [hipblasDnrm2StridedBatched](interfacehipfort__hipblas_1_1hipblasdnrm2stridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+210 | [hipblasScnrm2StridedBatched](interfacehipfort__hipblas_1_1hipblasscnrm2stridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+211 | [hipblasDznrm2StridedBatched](interfacehipfort__hipblas_1_1hipblasdznrm2stridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+212 | [hipblasSnrm2StridedBatched_64](interfacehipfort__hipblas_1_1hipblassnrm2stridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+213 | [hipblasDnrm2StridedBatched_64](interfacehipfort__hipblas_1_1hipblasdnrm2stridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+214 | [hipblasScnrm2StridedBatched_64](interfacehipfort__hipblas_1_1hipblasscnrm2stridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+215 | [hipblasDznrm2StridedBatched_64](interfacehipfort__hipblas_1_1hipblasdznrm2stridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+216 | [hipblasSrot](interfacehipfort__hipblas_1_1hipblassrot.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+217 | [hipblasDrot](interfacehipfort__hipblas_1_1hipblasdrot.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+218 | [hipblasCrot](interfacehipfort__hipblas_1_1hipblascrot.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+219 | [hipblasCsrot](interfacehipfort__hipblas_1_1hipblascsrot.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+220 | [hipblasZrot](interfacehipfort__hipblas_1_1hipblaszrot.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+221 | [hipblasZdrot](interfacehipfort__hipblas_1_1hipblaszdrot.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+222 | [hipblasSrot_64](interfacehipfort__hipblas_1_1hipblassrot__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+223 | [hipblasDrot_64](interfacehipfort__hipblas_1_1hipblasdrot__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+224 | [hipblasCrot_64](interfacehipfort__hipblas_1_1hipblascrot__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+225 | [hipblasCsrot_64](interfacehipfort__hipblas_1_1hipblascsrot__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+226 | [hipblasZrot_64](interfacehipfort__hipblas_1_1hipblaszrot__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+227 | [hipblasZdrot_64](interfacehipfort__hipblas_1_1hipblaszdrot__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 228 | [hipblasSrotBatched](interfacehipfort__hipblas_1_1hipblassrotbatched.html "Interface documentation") | C binding
 229 | [hipblasDrotBatched](interfacehipfort__hipblas_1_1hipblasdrotbatched.html "Interface documentation") | C binding
 230 | [hipblasCrotBatched](interfacehipfort__hipblas_1_1hipblascrotbatched.html "Interface documentation") | C binding
 231 | [hipblasCsrotBatched](interfacehipfort__hipblas_1_1hipblascsrotbatched.html "Interface documentation") | C binding
 232 | [hipblasZrotBatched](interfacehipfort__hipblas_1_1hipblaszrotbatched.html "Interface documentation") | C binding
 233 | [hipblasZdrotBatched](interfacehipfort__hipblas_1_1hipblaszdrotbatched.html "Interface documentation") | C binding
-234 | [hipblasSrotBatched_64](interfacehipfort__hipblas_1_1hipblassrotbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-235 | [hipblasDrotBatched_64](interfacehipfort__hipblas_1_1hipblasdrotbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-236 | [hipblasCrotBatched_64](interfacehipfort__hipblas_1_1hipblascrotbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-237 | [hipblasCsrotBatched_64](interfacehipfort__hipblas_1_1hipblascsrotbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-238 | [hipblasZrotBatched_64](interfacehipfort__hipblas_1_1hipblaszrotbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-239 | [hipblasZdrotBatched_64](interfacehipfort__hipblas_1_1hipblaszdrotbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-240 | [hipblasSrotStridedBatched](interfacehipfort__hipblas_1_1hipblassrotstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-241 | [hipblasDrotStridedBatched](interfacehipfort__hipblas_1_1hipblasdrotstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-242 | [hipblasCrotStridedBatched](interfacehipfort__hipblas_1_1hipblascrotstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-243 | [hipblasCsrotStridedBatched](interfacehipfort__hipblas_1_1hipblascsrotstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-244 | [hipblasZrotStridedBatched](interfacehipfort__hipblas_1_1hipblaszrotstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-245 | [hipblasZdrotStridedBatched](interfacehipfort__hipblas_1_1hipblaszdrotstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-246 | [hipblasSrotStridedBatched_64](interfacehipfort__hipblas_1_1hipblassrotstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-247 | [hipblasDrotStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdrotstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-248 | [hipblasCrotStridedBatched_64](interfacehipfort__hipblas_1_1hipblascrotstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-249 | [hipblasCsrotStridedBatched_64](interfacehipfort__hipblas_1_1hipblascsrotstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-250 | [hipblasZrotStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszrotstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-251 | [hipblasZdrotStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszdrotstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-252 | [hipblasSrotg](interfacehipfort__hipblas_1_1hipblassrotg.html "Interface documentation") | C binding, rank_0, rank_1
-253 | [hipblasDrotg](interfacehipfort__hipblas_1_1hipblasdrotg.html "Interface documentation") | C binding, rank_0, rank_1
-254 | [hipblasCrotg](interfacehipfort__hipblas_1_1hipblascrotg.html "Interface documentation") | C binding, rank_0, rank_1
-255 | [hipblasZrotg](interfacehipfort__hipblas_1_1hipblaszrotg.html "Interface documentation") | C binding, rank_0, rank_1
-256 | [hipblasSrotg_64](interfacehipfort__hipblas_1_1hipblassrotg__64.html "Interface documentation") | C binding, rank_0, rank_1
-257 | [hipblasDrotg_64](interfacehipfort__hipblas_1_1hipblasdrotg__64.html "Interface documentation") | C binding, rank_0, rank_1
-258 | [hipblasCrotg_64](interfacehipfort__hipblas_1_1hipblascrotg__64.html "Interface documentation") | C binding, rank_0, rank_1
-259 | [hipblasZrotg_64](interfacehipfort__hipblas_1_1hipblaszrotg__64.html "Interface documentation") | C binding, rank_0, rank_1
+234 | [hipblasSrotBatched_64](interfacehipfort__hipblas_1_1hipblassrotbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+235 | [hipblasDrotBatched_64](interfacehipfort__hipblas_1_1hipblasdrotbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+236 | [hipblasCrotBatched_64](interfacehipfort__hipblas_1_1hipblascrotbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+237 | [hipblasCsrotBatched_64](interfacehipfort__hipblas_1_1hipblascsrotbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+238 | [hipblasZrotBatched_64](interfacehipfort__hipblas_1_1hipblaszrotbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+239 | [hipblasZdrotBatched_64](interfacehipfort__hipblas_1_1hipblaszdrotbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+240 | [hipblasSrotStridedBatched](interfacehipfort__hipblas_1_1hipblassrotstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+241 | [hipblasDrotStridedBatched](interfacehipfort__hipblas_1_1hipblasdrotstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+242 | [hipblasCrotStridedBatched](interfacehipfort__hipblas_1_1hipblascrotstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+243 | [hipblasCsrotStridedBatched](interfacehipfort__hipblas_1_1hipblascsrotstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+244 | [hipblasZrotStridedBatched](interfacehipfort__hipblas_1_1hipblaszrotstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+245 | [hipblasZdrotStridedBatched](interfacehipfort__hipblas_1_1hipblaszdrotstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+246 | [hipblasSrotStridedBatched_64](interfacehipfort__hipblas_1_1hipblassrotstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+247 | [hipblasDrotStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdrotstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+248 | [hipblasCrotStridedBatched_64](interfacehipfort__hipblas_1_1hipblascrotstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+249 | [hipblasCsrotStridedBatched_64](interfacehipfort__hipblas_1_1hipblascsrotstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+250 | [hipblasZrotStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszrotstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+251 | [hipblasZdrotStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszdrotstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+252 | [hipblasSrotg](interfacehipfort__hipblas_1_1hipblassrotg.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+253 | [hipblasDrotg](interfacehipfort__hipblas_1_1hipblasdrotg.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+254 | [hipblasCrotg](interfacehipfort__hipblas_1_1hipblascrotg.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+255 | [hipblasZrotg](interfacehipfort__hipblas_1_1hipblaszrotg.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+256 | [hipblasSrotg_64](interfacehipfort__hipblas_1_1hipblassrotg__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+257 | [hipblasDrotg_64](interfacehipfort__hipblas_1_1hipblasdrotg__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+258 | [hipblasCrotg_64](interfacehipfort__hipblas_1_1hipblascrotg__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+259 | [hipblasZrotg_64](interfacehipfort__hipblas_1_1hipblaszrotg__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 260 | [hipblasSrotgBatched](interfacehipfort__hipblas_1_1hipblassrotgbatched.html "Interface documentation") | C binding
 261 | [hipblasDrotgBatched](interfacehipfort__hipblas_1_1hipblasdrotgbatched.html "Interface documentation") | C binding
 262 | [hipblasCrotgBatched](interfacehipfort__hipblas_1_1hipblascrotgbatched.html "Interface documentation") | C binding
@@ -269,50 +269,50 @@
 265 | [hipblasDrotgBatched_64](interfacehipfort__hipblas_1_1hipblasdrotgbatched__64.html "Interface documentation") | C binding
 266 | [hipblasCrotgBatched_64](interfacehipfort__hipblas_1_1hipblascrotgbatched__64.html "Interface documentation") | C binding
 267 | [hipblasZrotgBatched_64](interfacehipfort__hipblas_1_1hipblaszrotgbatched__64.html "Interface documentation") | C binding
-268 | [hipblasSrotgStridedBatched](interfacehipfort__hipblas_1_1hipblassrotgstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-269 | [hipblasDrotgStridedBatched](interfacehipfort__hipblas_1_1hipblasdrotgstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-270 | [hipblasCrotgStridedBatched](interfacehipfort__hipblas_1_1hipblascrotgstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-271 | [hipblasZrotgStridedBatched](interfacehipfort__hipblas_1_1hipblaszrotgstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-272 | [hipblasSrotgStridedBatched_64](interfacehipfort__hipblas_1_1hipblassrotgstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-273 | [hipblasDrotgStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdrotgstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-274 | [hipblasCrotgStridedBatched_64](interfacehipfort__hipblas_1_1hipblascrotgstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-275 | [hipblasZrotgStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszrotgstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-276 | [hipblasSrotm](interfacehipfort__hipblas_1_1hipblassrotm.html "Interface documentation") | C binding, rank_0, rank_1
-277 | [hipblasDrotm](interfacehipfort__hipblas_1_1hipblasdrotm.html "Interface documentation") | C binding, rank_0, rank_1
-278 | [hipblasSrotm_64](interfacehipfort__hipblas_1_1hipblassrotm__64.html "Interface documentation") | C binding, rank_0, rank_1
-279 | [hipblasDrotm_64](interfacehipfort__hipblas_1_1hipblasdrotm__64.html "Interface documentation") | C binding, rank_0, rank_1
+268 | [hipblasSrotgStridedBatched](interfacehipfort__hipblas_1_1hipblassrotgstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+269 | [hipblasDrotgStridedBatched](interfacehipfort__hipblas_1_1hipblasdrotgstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+270 | [hipblasCrotgStridedBatched](interfacehipfort__hipblas_1_1hipblascrotgstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+271 | [hipblasZrotgStridedBatched](interfacehipfort__hipblas_1_1hipblaszrotgstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+272 | [hipblasSrotgStridedBatched_64](interfacehipfort__hipblas_1_1hipblassrotgstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+273 | [hipblasDrotgStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdrotgstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+274 | [hipblasCrotgStridedBatched_64](interfacehipfort__hipblas_1_1hipblascrotgstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+275 | [hipblasZrotgStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszrotgstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+276 | [hipblasSrotm](interfacehipfort__hipblas_1_1hipblassrotm.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+277 | [hipblasDrotm](interfacehipfort__hipblas_1_1hipblasdrotm.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+278 | [hipblasSrotm_64](interfacehipfort__hipblas_1_1hipblassrotm__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+279 | [hipblasDrotm_64](interfacehipfort__hipblas_1_1hipblasdrotm__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 280 | [hipblasSrotmBatched](interfacehipfort__hipblas_1_1hipblassrotmbatched.html "Interface documentation") | C binding
 281 | [hipblasDrotmBatched](interfacehipfort__hipblas_1_1hipblasdrotmbatched.html "Interface documentation") | C binding
 282 | [hipblasSrotmBatched_64](interfacehipfort__hipblas_1_1hipblassrotmbatched__64.html "Interface documentation") | C binding
 283 | [hipblasDrotmBatched_64](interfacehipfort__hipblas_1_1hipblasdrotmbatched__64.html "Interface documentation") | C binding
-284 | [hipblasSrotmStridedBatched](interfacehipfort__hipblas_1_1hipblassrotmstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-285 | [hipblasDrotmStridedBatched](interfacehipfort__hipblas_1_1hipblasdrotmstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-286 | [hipblasSrotmStridedBatched_64](interfacehipfort__hipblas_1_1hipblassrotmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-287 | [hipblasDrotmStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdrotmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-288 | [hipblasSrotmg](interfacehipfort__hipblas_1_1hipblassrotmg.html "Interface documentation") | C binding, rank_0, rank_1
-289 | [hipblasDrotmg](interfacehipfort__hipblas_1_1hipblasdrotmg.html "Interface documentation") | C binding, rank_0, rank_1
-290 | [hipblasSrotmg_64](interfacehipfort__hipblas_1_1hipblassrotmg__64.html "Interface documentation") | C binding, rank_0, rank_1
-291 | [hipblasDrotmg_64](interfacehipfort__hipblas_1_1hipblasdrotmg__64.html "Interface documentation") | C binding, rank_0, rank_1
+284 | [hipblasSrotmStridedBatched](interfacehipfort__hipblas_1_1hipblassrotmstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+285 | [hipblasDrotmStridedBatched](interfacehipfort__hipblas_1_1hipblasdrotmstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+286 | [hipblasSrotmStridedBatched_64](interfacehipfort__hipblas_1_1hipblassrotmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+287 | [hipblasDrotmStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdrotmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+288 | [hipblasSrotmg](interfacehipfort__hipblas_1_1hipblassrotmg.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+289 | [hipblasDrotmg](interfacehipfort__hipblas_1_1hipblasdrotmg.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+290 | [hipblasSrotmg_64](interfacehipfort__hipblas_1_1hipblassrotmg__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+291 | [hipblasDrotmg_64](interfacehipfort__hipblas_1_1hipblasdrotmg__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 292 | [hipblasSrotmgBatched](interfacehipfort__hipblas_1_1hipblassrotmgbatched.html "Interface documentation") | C binding
 293 | [hipblasDrotmgBatched](interfacehipfort__hipblas_1_1hipblasdrotmgbatched.html "Interface documentation") | C binding
 294 | [hipblasSrotmgBatched_64](interfacehipfort__hipblas_1_1hipblassrotmgbatched__64.html "Interface documentation") | C binding
 295 | [hipblasDrotmgBatched_64](interfacehipfort__hipblas_1_1hipblasdrotmgbatched__64.html "Interface documentation") | C binding
-296 | [hipblasSrotmgStridedBatched](interfacehipfort__hipblas_1_1hipblassrotmgstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-297 | [hipblasDrotmgStridedBatched](interfacehipfort__hipblas_1_1hipblasdrotmgstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-298 | [hipblasSrotmgStridedBatched_64](interfacehipfort__hipblas_1_1hipblassrotmgstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-299 | [hipblasDrotmgStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdrotmgstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-300 | [hipblasSscal](interfacehipfort__hipblas_1_1hipblassscal.html "Interface documentation") | C binding, rank_0, rank_1
-301 | [hipblasDscal](interfacehipfort__hipblas_1_1hipblasdscal.html "Interface documentation") | C binding, rank_0, rank_1
-302 | [hipblasCscal](interfacehipfort__hipblas_1_1hipblascscal.html "Interface documentation") | C binding, rank_0, rank_1
-303 | [hipblasCsscal](interfacehipfort__hipblas_1_1hipblascsscal.html "Interface documentation") | C binding, rank_0, rank_1
-304 | [hipblasZscal](interfacehipfort__hipblas_1_1hipblaszscal.html "Interface documentation") | C binding, rank_0, rank_1
-305 | [hipblasZdscal](interfacehipfort__hipblas_1_1hipblaszdscal.html "Interface documentation") | C binding, rank_0, rank_1
-306 | [hipblasSscal_64](interfacehipfort__hipblas_1_1hipblassscal__64.html "Interface documentation") | C binding, rank_0, rank_1
-307 | [hipblasDscal_64](interfacehipfort__hipblas_1_1hipblasdscal__64.html "Interface documentation") | C binding, rank_0, rank_1
-308 | [hipblasCscal_64](interfacehipfort__hipblas_1_1hipblascscal__64.html "Interface documentation") | C binding, rank_0, rank_1
-309 | [hipblasCsscal_64](interfacehipfort__hipblas_1_1hipblascsscal__64.html "Interface documentation") | C binding, rank_0, rank_1
-310 | [hipblasZscal_64](interfacehipfort__hipblas_1_1hipblaszscal__64.html "Interface documentation") | C binding, rank_0, rank_1
-311 | [hipblasZdscal_64](interfacehipfort__hipblas_1_1hipblaszdscal__64.html "Interface documentation") | C binding, rank_0, rank_1
+296 | [hipblasSrotmgStridedBatched](interfacehipfort__hipblas_1_1hipblassrotmgstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+297 | [hipblasDrotmgStridedBatched](interfacehipfort__hipblas_1_1hipblasdrotmgstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+298 | [hipblasSrotmgStridedBatched_64](interfacehipfort__hipblas_1_1hipblassrotmgstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+299 | [hipblasDrotmgStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdrotmgstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+300 | [hipblasSscal](interfacehipfort__hipblas_1_1hipblassscal.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+301 | [hipblasDscal](interfacehipfort__hipblas_1_1hipblasdscal.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+302 | [hipblasCscal](interfacehipfort__hipblas_1_1hipblascscal.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+303 | [hipblasCsscal](interfacehipfort__hipblas_1_1hipblascsscal.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+304 | [hipblasZscal](interfacehipfort__hipblas_1_1hipblaszscal.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+305 | [hipblasZdscal](interfacehipfort__hipblas_1_1hipblaszdscal.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+306 | [hipblasSscal_64](interfacehipfort__hipblas_1_1hipblassscal__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+307 | [hipblasDscal_64](interfacehipfort__hipblas_1_1hipblasdscal__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+308 | [hipblasCscal_64](interfacehipfort__hipblas_1_1hipblascscal__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+309 | [hipblasCsscal_64](interfacehipfort__hipblas_1_1hipblascsscal__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+310 | [hipblasZscal_64](interfacehipfort__hipblas_1_1hipblaszscal__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+311 | [hipblasZdscal_64](interfacehipfort__hipblas_1_1hipblaszdscal__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 312 | [hipblasSscalBatched](interfacehipfort__hipblas_1_1hipblassscalbatched.html "Interface documentation") | C binding
 313 | [hipblasDscalBatched](interfacehipfort__hipblas_1_1hipblasdscalbatched.html "Interface documentation") | C binding
 314 | [hipblasCscalBatched](interfacehipfort__hipblas_1_1hipblascscalbatched.html "Interface documentation") | C binding
@@ -325,26 +325,26 @@
 321 | [hipblasZscalBatched_64](interfacehipfort__hipblas_1_1hipblaszscalbatched__64.html "Interface documentation") | C binding
 322 | [hipblasCsscalBatched_64](interfacehipfort__hipblas_1_1hipblascsscalbatched__64.html "Interface documentation") | C binding
 323 | [hipblasZdscalBatched_64](interfacehipfort__hipblas_1_1hipblaszdscalbatched__64.html "Interface documentation") | C binding
-324 | [hipblasSscalStridedBatched](interfacehipfort__hipblas_1_1hipblassscalstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-325 | [hipblasDscalStridedBatched](interfacehipfort__hipblas_1_1hipblasdscalstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-326 | [hipblasCscalStridedBatched](interfacehipfort__hipblas_1_1hipblascscalstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-327 | [hipblasZscalStridedBatched](interfacehipfort__hipblas_1_1hipblaszscalstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-328 | [hipblasCsscalStridedBatched](interfacehipfort__hipblas_1_1hipblascsscalstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-329 | [hipblasZdscalStridedBatched](interfacehipfort__hipblas_1_1hipblaszdscalstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-330 | [hipblasSscalStridedBatched_64](interfacehipfort__hipblas_1_1hipblassscalstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-331 | [hipblasDscalStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdscalstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-332 | [hipblasCscalStridedBatched_64](interfacehipfort__hipblas_1_1hipblascscalstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-333 | [hipblasZscalStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszscalstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-334 | [hipblasCsscalStridedBatched_64](interfacehipfort__hipblas_1_1hipblascsscalstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-335 | [hipblasZdscalStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszdscalstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-336 | [hipblasSswap](interfacehipfort__hipblas_1_1hipblassswap.html "Interface documentation") | C binding, rank_0, rank_1
-337 | [hipblasDswap](interfacehipfort__hipblas_1_1hipblasdswap.html "Interface documentation") | C binding, rank_0, rank_1
-338 | [hipblasCswap](interfacehipfort__hipblas_1_1hipblascswap.html "Interface documentation") | C binding, rank_0, rank_1
-339 | [hipblasZswap](interfacehipfort__hipblas_1_1hipblaszswap.html "Interface documentation") | C binding, rank_0, rank_1
-340 | [hipblasSswap_64](interfacehipfort__hipblas_1_1hipblassswap__64.html "Interface documentation") | C binding, rank_0, rank_1
-341 | [hipblasDswap_64](interfacehipfort__hipblas_1_1hipblasdswap__64.html "Interface documentation") | C binding, rank_0, rank_1
-342 | [hipblasCswap_64](interfacehipfort__hipblas_1_1hipblascswap__64.html "Interface documentation") | C binding, rank_0, rank_1
-343 | [hipblasZswap_64](interfacehipfort__hipblas_1_1hipblaszswap__64.html "Interface documentation") | C binding, rank_0, rank_1
+324 | [hipblasSscalStridedBatched](interfacehipfort__hipblas_1_1hipblassscalstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+325 | [hipblasDscalStridedBatched](interfacehipfort__hipblas_1_1hipblasdscalstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+326 | [hipblasCscalStridedBatched](interfacehipfort__hipblas_1_1hipblascscalstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+327 | [hipblasZscalStridedBatched](interfacehipfort__hipblas_1_1hipblaszscalstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+328 | [hipblasCsscalStridedBatched](interfacehipfort__hipblas_1_1hipblascsscalstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+329 | [hipblasZdscalStridedBatched](interfacehipfort__hipblas_1_1hipblaszdscalstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+330 | [hipblasSscalStridedBatched_64](interfacehipfort__hipblas_1_1hipblassscalstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+331 | [hipblasDscalStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdscalstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+332 | [hipblasCscalStridedBatched_64](interfacehipfort__hipblas_1_1hipblascscalstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+333 | [hipblasZscalStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszscalstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+334 | [hipblasCsscalStridedBatched_64](interfacehipfort__hipblas_1_1hipblascsscalstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+335 | [hipblasZdscalStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszdscalstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+336 | [hipblasSswap](interfacehipfort__hipblas_1_1hipblassswap.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+337 | [hipblasDswap](interfacehipfort__hipblas_1_1hipblasdswap.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+338 | [hipblasCswap](interfacehipfort__hipblas_1_1hipblascswap.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+339 | [hipblasZswap](interfacehipfort__hipblas_1_1hipblaszswap.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+340 | [hipblasSswap_64](interfacehipfort__hipblas_1_1hipblassswap__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+341 | [hipblasDswap_64](interfacehipfort__hipblas_1_1hipblasdswap__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+342 | [hipblasCswap_64](interfacehipfort__hipblas_1_1hipblascswap__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+343 | [hipblasZswap_64](interfacehipfort__hipblas_1_1hipblaszswap__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 344 | [hipblasSswapBatched](interfacehipfort__hipblas_1_1hipblassswapbatched.html "Interface documentation") | C binding
 345 | [hipblasDswapBatched](interfacehipfort__hipblas_1_1hipblasdswapbatched.html "Interface documentation") | C binding
 346 | [hipblasCswapBatched](interfacehipfort__hipblas_1_1hipblascswapbatched.html "Interface documentation") | C binding
@@ -353,22 +353,22 @@
 349 | [hipblasDswapBatched_64](interfacehipfort__hipblas_1_1hipblasdswapbatched__64.html "Interface documentation") | C binding
 350 | [hipblasCswapBatched_64](interfacehipfort__hipblas_1_1hipblascswapbatched__64.html "Interface documentation") | C binding
 351 | [hipblasZswapBatched_64](interfacehipfort__hipblas_1_1hipblaszswapbatched__64.html "Interface documentation") | C binding
-352 | [hipblasSswapStridedBatched](interfacehipfort__hipblas_1_1hipblassswapstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-353 | [hipblasDswapStridedBatched](interfacehipfort__hipblas_1_1hipblasdswapstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-354 | [hipblasCswapStridedBatched](interfacehipfort__hipblas_1_1hipblascswapstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-355 | [hipblasZswapStridedBatched](interfacehipfort__hipblas_1_1hipblaszswapstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-356 | [hipblasSswapStridedBatched_64](interfacehipfort__hipblas_1_1hipblassswapstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-357 | [hipblasDswapStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdswapstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-358 | [hipblasCswapStridedBatched_64](interfacehipfort__hipblas_1_1hipblascswapstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-359 | [hipblasZswapStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszswapstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-360 | [hipblasSgbmv](interfacehipfort__hipblas_1_1hipblassgbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-361 | [hipblasDgbmv](interfacehipfort__hipblas_1_1hipblasdgbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-362 | [hipblasCgbmv](interfacehipfort__hipblas_1_1hipblascgbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-363 | [hipblasZgbmv](interfacehipfort__hipblas_1_1hipblaszgbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-364 | [hipblasSgbmv_64](interfacehipfort__hipblas_1_1hipblassgbmv__64.html "Interface documentation") | C binding, rank_0, rank_1
-365 | [hipblasDgbmv_64](interfacehipfort__hipblas_1_1hipblasdgbmv__64.html "Interface documentation") | C binding, rank_0, rank_1
-366 | [hipblasCgbmv_64](interfacehipfort__hipblas_1_1hipblascgbmv__64.html "Interface documentation") | C binding, rank_0, rank_1
-367 | [hipblasZgbmv_64](interfacehipfort__hipblas_1_1hipblaszgbmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+352 | [hipblasSswapStridedBatched](interfacehipfort__hipblas_1_1hipblassswapstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+353 | [hipblasDswapStridedBatched](interfacehipfort__hipblas_1_1hipblasdswapstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+354 | [hipblasCswapStridedBatched](interfacehipfort__hipblas_1_1hipblascswapstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+355 | [hipblasZswapStridedBatched](interfacehipfort__hipblas_1_1hipblaszswapstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+356 | [hipblasSswapStridedBatched_64](interfacehipfort__hipblas_1_1hipblassswapstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+357 | [hipblasDswapStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdswapstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+358 | [hipblasCswapStridedBatched_64](interfacehipfort__hipblas_1_1hipblascswapstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+359 | [hipblasZswapStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszswapstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+360 | [hipblasSgbmv](interfacehipfort__hipblas_1_1hipblassgbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+361 | [hipblasDgbmv](interfacehipfort__hipblas_1_1hipblasdgbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+362 | [hipblasCgbmv](interfacehipfort__hipblas_1_1hipblascgbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+363 | [hipblasZgbmv](interfacehipfort__hipblas_1_1hipblaszgbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+364 | [hipblasSgbmv_64](interfacehipfort__hipblas_1_1hipblassgbmv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+365 | [hipblasDgbmv_64](interfacehipfort__hipblas_1_1hipblasdgbmv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+366 | [hipblasCgbmv_64](interfacehipfort__hipblas_1_1hipblascgbmv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+367 | [hipblasZgbmv_64](interfacehipfort__hipblas_1_1hipblaszgbmv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 368 | [hipblasSgbmvBatched](interfacehipfort__hipblas_1_1hipblassgbmvbatched.html "Interface documentation") | C binding
 369 | [hipblasDgbmvBatched](interfacehipfort__hipblas_1_1hipblasdgbmvbatched.html "Interface documentation") | C binding
 370 | [hipblasCgbmvBatched](interfacehipfort__hipblas_1_1hipblascgbmvbatched.html "Interface documentation") | C binding
@@ -377,22 +377,22 @@
 373 | [hipblasDgbmvBatched_64](interfacehipfort__hipblas_1_1hipblasdgbmvbatched__64.html "Interface documentation") | C binding
 374 | [hipblasCgbmvBatched_64](interfacehipfort__hipblas_1_1hipblascgbmvbatched__64.html "Interface documentation") | C binding
 375 | [hipblasZgbmvBatched_64](interfacehipfort__hipblas_1_1hipblaszgbmvbatched__64.html "Interface documentation") | C binding
-376 | [hipblasSgbmvStridedBatched](interfacehipfort__hipblas_1_1hipblassgbmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-377 | [hipblasDgbmvStridedBatched](interfacehipfort__hipblas_1_1hipblasdgbmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-378 | [hipblasCgbmvStridedBatched](interfacehipfort__hipblas_1_1hipblascgbmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-379 | [hipblasZgbmvStridedBatched](interfacehipfort__hipblas_1_1hipblaszgbmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-380 | [hipblasSgbmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblassgbmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-381 | [hipblasDgbmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdgbmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-382 | [hipblasCgbmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblascgbmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-383 | [hipblasZgbmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszgbmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-384 | [hipblasSgemv](interfacehipfort__hipblas_1_1hipblassgemv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-385 | [hipblasDgemv](interfacehipfort__hipblas_1_1hipblasdgemv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-386 | [hipblasCgemv](interfacehipfort__hipblas_1_1hipblascgemv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-387 | [hipblasZgemv](interfacehipfort__hipblas_1_1hipblaszgemv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-388 | [hipblasSgemv_64](interfacehipfort__hipblas_1_1hipblassgemv__64.html "Interface documentation") | C binding, rank_0, rank_1
-389 | [hipblasDgemv_64](interfacehipfort__hipblas_1_1hipblasdgemv__64.html "Interface documentation") | C binding, rank_0, rank_1
-390 | [hipblasCgemv_64](interfacehipfort__hipblas_1_1hipblascgemv__64.html "Interface documentation") | C binding, rank_0, rank_1
-391 | [hipblasZgemv_64](interfacehipfort__hipblas_1_1hipblaszgemv__64.html "Interface documentation") | C binding, rank_0, rank_1
+376 | [hipblasSgbmvStridedBatched](interfacehipfort__hipblas_1_1hipblassgbmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+377 | [hipblasDgbmvStridedBatched](interfacehipfort__hipblas_1_1hipblasdgbmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+378 | [hipblasCgbmvStridedBatched](interfacehipfort__hipblas_1_1hipblascgbmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+379 | [hipblasZgbmvStridedBatched](interfacehipfort__hipblas_1_1hipblaszgbmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+380 | [hipblasSgbmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblassgbmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+381 | [hipblasDgbmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdgbmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+382 | [hipblasCgbmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblascgbmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+383 | [hipblasZgbmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszgbmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+384 | [hipblasSgemv](interfacehipfort__hipblas_1_1hipblassgemv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+385 | [hipblasDgemv](interfacehipfort__hipblas_1_1hipblasdgemv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+386 | [hipblasCgemv](interfacehipfort__hipblas_1_1hipblascgemv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+387 | [hipblasZgemv](interfacehipfort__hipblas_1_1hipblaszgemv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+388 | [hipblasSgemv_64](interfacehipfort__hipblas_1_1hipblassgemv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+389 | [hipblasDgemv_64](interfacehipfort__hipblas_1_1hipblasdgemv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+390 | [hipblasCgemv_64](interfacehipfort__hipblas_1_1hipblascgemv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+391 | [hipblasZgemv_64](interfacehipfort__hipblas_1_1hipblaszgemv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 392 | [hipblasSgemvBatched](interfacehipfort__hipblas_1_1hipblassgemvbatched.html "Interface documentation") | C binding
 393 | [hipblasDgemvBatched](interfacehipfort__hipblas_1_1hipblasdgemvbatched.html "Interface documentation") | C binding
 394 | [hipblasCgemvBatched](interfacehipfort__hipblas_1_1hipblascgemvbatched.html "Interface documentation") | C binding
@@ -401,26 +401,26 @@
 397 | [hipblasDgemvBatched_64](interfacehipfort__hipblas_1_1hipblasdgemvbatched__64.html "Interface documentation") | C binding
 398 | [hipblasCgemvBatched_64](interfacehipfort__hipblas_1_1hipblascgemvbatched__64.html "Interface documentation") | C binding
 399 | [hipblasZgemvBatched_64](interfacehipfort__hipblas_1_1hipblaszgemvbatched__64.html "Interface documentation") | C binding
-400 | [hipblasSgemvStridedBatched](interfacehipfort__hipblas_1_1hipblassgemvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-401 | [hipblasDgemvStridedBatched](interfacehipfort__hipblas_1_1hipblasdgemvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-402 | [hipblasCgemvStridedBatched](interfacehipfort__hipblas_1_1hipblascgemvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-403 | [hipblasZgemvStridedBatched](interfacehipfort__hipblas_1_1hipblaszgemvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-404 | [hipblasSgemvStridedBatched_64](interfacehipfort__hipblas_1_1hipblassgemvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-405 | [hipblasDgemvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdgemvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-406 | [hipblasCgemvStridedBatched_64](interfacehipfort__hipblas_1_1hipblascgemvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-407 | [hipblasZgemvStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszgemvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-408 | [hipblasSger](interfacehipfort__hipblas_1_1hipblassger.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-409 | [hipblasDger](interfacehipfort__hipblas_1_1hipblasdger.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-410 | [hipblasCgeru](interfacehipfort__hipblas_1_1hipblascgeru.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-411 | [hipblasCgerc](interfacehipfort__hipblas_1_1hipblascgerc.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-412 | [hipblasZgeru](interfacehipfort__hipblas_1_1hipblaszgeru.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-413 | [hipblasZgerc](interfacehipfort__hipblas_1_1hipblaszgerc.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-414 | [hipblasSger_64](interfacehipfort__hipblas_1_1hipblassger__64.html "Interface documentation") | C binding, rank_0, rank_1
-415 | [hipblasDger_64](interfacehipfort__hipblas_1_1hipblasdger__64.html "Interface documentation") | C binding, rank_0, rank_1
-416 | [hipblasCgeru_64](interfacehipfort__hipblas_1_1hipblascgeru__64.html "Interface documentation") | C binding, rank_0, rank_1
-417 | [hipblasCgerc_64](interfacehipfort__hipblas_1_1hipblascgerc__64.html "Interface documentation") | C binding, rank_0, rank_1
-418 | [hipblasZgeru_64](interfacehipfort__hipblas_1_1hipblaszgeru__64.html "Interface documentation") | C binding, rank_0, rank_1
-419 | [hipblasZgerc_64](interfacehipfort__hipblas_1_1hipblaszgerc__64.html "Interface documentation") | C binding, rank_0, rank_1
+400 | [hipblasSgemvStridedBatched](interfacehipfort__hipblas_1_1hipblassgemvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+401 | [hipblasDgemvStridedBatched](interfacehipfort__hipblas_1_1hipblasdgemvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+402 | [hipblasCgemvStridedBatched](interfacehipfort__hipblas_1_1hipblascgemvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+403 | [hipblasZgemvStridedBatched](interfacehipfort__hipblas_1_1hipblaszgemvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+404 | [hipblasSgemvStridedBatched_64](interfacehipfort__hipblas_1_1hipblassgemvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+405 | [hipblasDgemvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdgemvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+406 | [hipblasCgemvStridedBatched_64](interfacehipfort__hipblas_1_1hipblascgemvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+407 | [hipblasZgemvStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszgemvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+408 | [hipblasSger](interfacehipfort__hipblas_1_1hipblassger.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+409 | [hipblasDger](interfacehipfort__hipblas_1_1hipblasdger.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+410 | [hipblasCgeru](interfacehipfort__hipblas_1_1hipblascgeru.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+411 | [hipblasCgerc](interfacehipfort__hipblas_1_1hipblascgerc.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+412 | [hipblasZgeru](interfacehipfort__hipblas_1_1hipblaszgeru.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+413 | [hipblasZgerc](interfacehipfort__hipblas_1_1hipblaszgerc.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+414 | [hipblasSger_64](interfacehipfort__hipblas_1_1hipblassger__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+415 | [hipblasDger_64](interfacehipfort__hipblas_1_1hipblasdger__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+416 | [hipblasCgeru_64](interfacehipfort__hipblas_1_1hipblascgeru__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+417 | [hipblasCgerc_64](interfacehipfort__hipblas_1_1hipblascgerc__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+418 | [hipblasZgeru_64](interfacehipfort__hipblas_1_1hipblaszgeru__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+419 | [hipblasZgerc_64](interfacehipfort__hipblas_1_1hipblaszgerc__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 420 | [hipblasSgerBatched](interfacehipfort__hipblas_1_1hipblassgerbatched.html "Interface documentation") | C binding
 421 | [hipblasDgerBatched](interfacehipfort__hipblas_1_1hipblasdgerbatched.html "Interface documentation") | C binding
 422 | [hipblasCgeruBatched](interfacehipfort__hipblas_1_1hipblascgerubatched.html "Interface documentation") | C binding
@@ -433,134 +433,134 @@
 429 | [hipblasCgercBatched_64](interfacehipfort__hipblas_1_1hipblascgercbatched__64.html "Interface documentation") | C binding
 430 | [hipblasZgeruBatched_64](interfacehipfort__hipblas_1_1hipblaszgerubatched__64.html "Interface documentation") | C binding
 431 | [hipblasZgercBatched_64](interfacehipfort__hipblas_1_1hipblaszgercbatched__64.html "Interface documentation") | C binding
-432 | [hipblasSgerStridedBatched](interfacehipfort__hipblas_1_1hipblassgerstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-433 | [hipblasDgerStridedBatched](interfacehipfort__hipblas_1_1hipblasdgerstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-434 | [hipblasCgeruStridedBatched](interfacehipfort__hipblas_1_1hipblascgerustridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-435 | [hipblasCgercStridedBatched](interfacehipfort__hipblas_1_1hipblascgercstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-436 | [hipblasZgeruStridedBatched](interfacehipfort__hipblas_1_1hipblaszgerustridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-437 | [hipblasZgercStridedBatched](interfacehipfort__hipblas_1_1hipblaszgercstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-438 | [hipblasSgerStridedBatched_64](interfacehipfort__hipblas_1_1hipblassgerstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-439 | [hipblasDgerStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdgerstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-440 | [hipblasCgeruStridedBatched_64](interfacehipfort__hipblas_1_1hipblascgerustridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-441 | [hipblasCgercStridedBatched_64](interfacehipfort__hipblas_1_1hipblascgercstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-442 | [hipblasZgeruStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszgerustridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-443 | [hipblasZgercStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszgercstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-444 | [hipblasChbmv](interfacehipfort__hipblas_1_1hipblaschbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-445 | [hipblasZhbmv](interfacehipfort__hipblas_1_1hipblaszhbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-446 | [hipblasChbmv_64](interfacehipfort__hipblas_1_1hipblaschbmv__64.html "Interface documentation") | C binding, rank_0, rank_1
-447 | [hipblasZhbmv_64](interfacehipfort__hipblas_1_1hipblaszhbmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+432 | [hipblasSgerStridedBatched](interfacehipfort__hipblas_1_1hipblassgerstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+433 | [hipblasDgerStridedBatched](interfacehipfort__hipblas_1_1hipblasdgerstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+434 | [hipblasCgeruStridedBatched](interfacehipfort__hipblas_1_1hipblascgerustridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+435 | [hipblasCgercStridedBatched](interfacehipfort__hipblas_1_1hipblascgercstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+436 | [hipblasZgeruStridedBatched](interfacehipfort__hipblas_1_1hipblaszgerustridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+437 | [hipblasZgercStridedBatched](interfacehipfort__hipblas_1_1hipblaszgercstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+438 | [hipblasSgerStridedBatched_64](interfacehipfort__hipblas_1_1hipblassgerstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+439 | [hipblasDgerStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdgerstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+440 | [hipblasCgeruStridedBatched_64](interfacehipfort__hipblas_1_1hipblascgerustridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+441 | [hipblasCgercStridedBatched_64](interfacehipfort__hipblas_1_1hipblascgercstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+442 | [hipblasZgeruStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszgerustridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+443 | [hipblasZgercStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszgercstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+444 | [hipblasChbmv](interfacehipfort__hipblas_1_1hipblaschbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+445 | [hipblasZhbmv](interfacehipfort__hipblas_1_1hipblaszhbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+446 | [hipblasChbmv_64](interfacehipfort__hipblas_1_1hipblaschbmv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+447 | [hipblasZhbmv_64](interfacehipfort__hipblas_1_1hipblaszhbmv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 448 | [hipblasChbmvBatched](interfacehipfort__hipblas_1_1hipblaschbmvbatched.html "Interface documentation") | C binding
 449 | [hipblasZhbmvBatched](interfacehipfort__hipblas_1_1hipblaszhbmvbatched.html "Interface documentation") | C binding
 450 | [hipblasChbmvBatched_64](interfacehipfort__hipblas_1_1hipblaschbmvbatched__64.html "Interface documentation") | C binding
 451 | [hipblasZhbmvBatched_64](interfacehipfort__hipblas_1_1hipblaszhbmvbatched__64.html "Interface documentation") | C binding
-452 | [hipblasChbmvStridedBatched](interfacehipfort__hipblas_1_1hipblaschbmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-453 | [hipblasZhbmvStridedBatched](interfacehipfort__hipblas_1_1hipblaszhbmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-454 | [hipblasChbmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblaschbmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-455 | [hipblasZhbmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszhbmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-456 | [hipblasChemv](interfacehipfort__hipblas_1_1hipblaschemv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-457 | [hipblasZhemv](interfacehipfort__hipblas_1_1hipblaszhemv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-458 | [hipblasChemv_64](interfacehipfort__hipblas_1_1hipblaschemv__64.html "Interface documentation") | C binding, rank_0, rank_1
-459 | [hipblasZhemv_64](interfacehipfort__hipblas_1_1hipblaszhemv__64.html "Interface documentation") | C binding, rank_0, rank_1
+452 | [hipblasChbmvStridedBatched](interfacehipfort__hipblas_1_1hipblaschbmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+453 | [hipblasZhbmvStridedBatched](interfacehipfort__hipblas_1_1hipblaszhbmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+454 | [hipblasChbmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblaschbmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+455 | [hipblasZhbmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszhbmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+456 | [hipblasChemv](interfacehipfort__hipblas_1_1hipblaschemv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+457 | [hipblasZhemv](interfacehipfort__hipblas_1_1hipblaszhemv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+458 | [hipblasChemv_64](interfacehipfort__hipblas_1_1hipblaschemv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+459 | [hipblasZhemv_64](interfacehipfort__hipblas_1_1hipblaszhemv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 460 | [hipblasChemvBatched](interfacehipfort__hipblas_1_1hipblaschemvbatched.html "Interface documentation") | C binding
 461 | [hipblasZhemvBatched](interfacehipfort__hipblas_1_1hipblaszhemvbatched.html "Interface documentation") | C binding
 462 | [hipblasChemvBatched_64](interfacehipfort__hipblas_1_1hipblaschemvbatched__64.html "Interface documentation") | C binding
 463 | [hipblasZhemvBatched_64](interfacehipfort__hipblas_1_1hipblaszhemvbatched__64.html "Interface documentation") | C binding
-464 | [hipblasChemvStridedBatched](interfacehipfort__hipblas_1_1hipblaschemvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-465 | [hipblasZhemvStridedBatched](interfacehipfort__hipblas_1_1hipblaszhemvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-466 | [hipblasChemvStridedBatched_64](interfacehipfort__hipblas_1_1hipblaschemvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-467 | [hipblasZhemvStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszhemvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-468 | [hipblasCher](interfacehipfort__hipblas_1_1hipblascher.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-469 | [hipblasZher](interfacehipfort__hipblas_1_1hipblaszher.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-470 | [hipblasCher_64](interfacehipfort__hipblas_1_1hipblascher__64.html "Interface documentation") | C binding, rank_0, rank_1
-471 | [hipblasZher_64](interfacehipfort__hipblas_1_1hipblaszher__64.html "Interface documentation") | C binding, rank_0, rank_1
+464 | [hipblasChemvStridedBatched](interfacehipfort__hipblas_1_1hipblaschemvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+465 | [hipblasZhemvStridedBatched](interfacehipfort__hipblas_1_1hipblaszhemvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+466 | [hipblasChemvStridedBatched_64](interfacehipfort__hipblas_1_1hipblaschemvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+467 | [hipblasZhemvStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszhemvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+468 | [hipblasCher](interfacehipfort__hipblas_1_1hipblascher.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+469 | [hipblasZher](interfacehipfort__hipblas_1_1hipblaszher.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+470 | [hipblasCher_64](interfacehipfort__hipblas_1_1hipblascher__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+471 | [hipblasZher_64](interfacehipfort__hipblas_1_1hipblaszher__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 472 | [hipblasCherBatched](interfacehipfort__hipblas_1_1hipblascherbatched.html "Interface documentation") | C binding
 473 | [hipblasZherBatched](interfacehipfort__hipblas_1_1hipblaszherbatched.html "Interface documentation") | C binding
 474 | [hipblasCherBatched_64](interfacehipfort__hipblas_1_1hipblascherbatched__64.html "Interface documentation") | C binding
 475 | [hipblasZherBatched_64](interfacehipfort__hipblas_1_1hipblaszherbatched__64.html "Interface documentation") | C binding
-476 | [hipblasCherStridedBatched](interfacehipfort__hipblas_1_1hipblascherstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-477 | [hipblasZherStridedBatched](interfacehipfort__hipblas_1_1hipblaszherstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-478 | [hipblasCherStridedBatched_64](interfacehipfort__hipblas_1_1hipblascherstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-479 | [hipblasZherStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszherstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-480 | [hipblasCher2](interfacehipfort__hipblas_1_1hipblascher2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-481 | [hipblasZher2](interfacehipfort__hipblas_1_1hipblaszher2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-482 | [hipblasCher2_64](interfacehipfort__hipblas_1_1hipblascher2__64.html "Interface documentation") | C binding, rank_0, rank_1
-483 | [hipblasZher2_64](interfacehipfort__hipblas_1_1hipblaszher2__64.html "Interface documentation") | C binding, rank_0, rank_1
+476 | [hipblasCherStridedBatched](interfacehipfort__hipblas_1_1hipblascherstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+477 | [hipblasZherStridedBatched](interfacehipfort__hipblas_1_1hipblaszherstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+478 | [hipblasCherStridedBatched_64](interfacehipfort__hipblas_1_1hipblascherstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+479 | [hipblasZherStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszherstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+480 | [hipblasCher2](interfacehipfort__hipblas_1_1hipblascher2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+481 | [hipblasZher2](interfacehipfort__hipblas_1_1hipblaszher2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+482 | [hipblasCher2_64](interfacehipfort__hipblas_1_1hipblascher2__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+483 | [hipblasZher2_64](interfacehipfort__hipblas_1_1hipblaszher2__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 484 | [hipblasCher2Batched](interfacehipfort__hipblas_1_1hipblascher2batched.html "Interface documentation") | C binding
 485 | [hipblasZher2Batched](interfacehipfort__hipblas_1_1hipblaszher2batched.html "Interface documentation") | C binding
 486 | [hipblasCher2Batched_64](interfacehipfort__hipblas_1_1hipblascher2batched__64.html "Interface documentation") | C binding
 487 | [hipblasZher2Batched_64](interfacehipfort__hipblas_1_1hipblaszher2batched__64.html "Interface documentation") | C binding
-488 | [hipblasCher2StridedBatched](interfacehipfort__hipblas_1_1hipblascher2stridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-489 | [hipblasZher2StridedBatched](interfacehipfort__hipblas_1_1hipblaszher2stridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-490 | [hipblasCher2StridedBatched_64](interfacehipfort__hipblas_1_1hipblascher2stridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-491 | [hipblasZher2StridedBatched_64](interfacehipfort__hipblas_1_1hipblaszher2stridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-492 | [hipblasChpmv](interfacehipfort__hipblas_1_1hipblaschpmv.html "Interface documentation") | C binding, rank_0, rank_1
-493 | [hipblasZhpmv](interfacehipfort__hipblas_1_1hipblaszhpmv.html "Interface documentation") | C binding, rank_0, rank_1
-494 | [hipblasChpmv_64](interfacehipfort__hipblas_1_1hipblaschpmv__64.html "Interface documentation") | C binding, rank_0, rank_1
-495 | [hipblasZhpmv_64](interfacehipfort__hipblas_1_1hipblaszhpmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+488 | [hipblasCher2StridedBatched](interfacehipfort__hipblas_1_1hipblascher2stridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+489 | [hipblasZher2StridedBatched](interfacehipfort__hipblas_1_1hipblaszher2stridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+490 | [hipblasCher2StridedBatched_64](interfacehipfort__hipblas_1_1hipblascher2stridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+491 | [hipblasZher2StridedBatched_64](interfacehipfort__hipblas_1_1hipblaszher2stridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+492 | [hipblasChpmv](interfacehipfort__hipblas_1_1hipblaschpmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+493 | [hipblasZhpmv](interfacehipfort__hipblas_1_1hipblaszhpmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+494 | [hipblasChpmv_64](interfacehipfort__hipblas_1_1hipblaschpmv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+495 | [hipblasZhpmv_64](interfacehipfort__hipblas_1_1hipblaszhpmv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 496 | [hipblasChpmvBatched](interfacehipfort__hipblas_1_1hipblaschpmvbatched.html "Interface documentation") | C binding
 497 | [hipblasZhpmvBatched](interfacehipfort__hipblas_1_1hipblaszhpmvbatched.html "Interface documentation") | C binding
 498 | [hipblasChpmvBatched_64](interfacehipfort__hipblas_1_1hipblaschpmvbatched__64.html "Interface documentation") | C binding
 499 | [hipblasZhpmvBatched_64](interfacehipfort__hipblas_1_1hipblaszhpmvbatched__64.html "Interface documentation") | C binding
-500 | [hipblasChpmvStridedBatched](interfacehipfort__hipblas_1_1hipblaschpmvstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-501 | [hipblasZhpmvStridedBatched](interfacehipfort__hipblas_1_1hipblaszhpmvstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-502 | [hipblasChpmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblaschpmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-503 | [hipblasZhpmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszhpmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-504 | [hipblasChpr](interfacehipfort__hipblas_1_1hipblaschpr.html "Interface documentation") | C binding, rank_0, rank_1
-505 | [hipblasZhpr](interfacehipfort__hipblas_1_1hipblaszhpr.html "Interface documentation") | C binding, rank_0, rank_1
-506 | [hipblasChpr_64](interfacehipfort__hipblas_1_1hipblaschpr__64.html "Interface documentation") | C binding, rank_0, rank_1
-507 | [hipblasZhpr_64](interfacehipfort__hipblas_1_1hipblaszhpr__64.html "Interface documentation") | C binding, rank_0, rank_1
+500 | [hipblasChpmvStridedBatched](interfacehipfort__hipblas_1_1hipblaschpmvstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+501 | [hipblasZhpmvStridedBatched](interfacehipfort__hipblas_1_1hipblaszhpmvstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+502 | [hipblasChpmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblaschpmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+503 | [hipblasZhpmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszhpmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+504 | [hipblasChpr](interfacehipfort__hipblas_1_1hipblaschpr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+505 | [hipblasZhpr](interfacehipfort__hipblas_1_1hipblaszhpr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+506 | [hipblasChpr_64](interfacehipfort__hipblas_1_1hipblaschpr__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+507 | [hipblasZhpr_64](interfacehipfort__hipblas_1_1hipblaszhpr__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 508 | [hipblasChprBatched](interfacehipfort__hipblas_1_1hipblaschprbatched.html "Interface documentation") | C binding
 509 | [hipblasZhprBatched](interfacehipfort__hipblas_1_1hipblaszhprbatched.html "Interface documentation") | C binding
 510 | [hipblasChprBatched_64](interfacehipfort__hipblas_1_1hipblaschprbatched__64.html "Interface documentation") | C binding
 511 | [hipblasZhprBatched_64](interfacehipfort__hipblas_1_1hipblaszhprbatched__64.html "Interface documentation") | C binding
-512 | [hipblasChprStridedBatched](interfacehipfort__hipblas_1_1hipblaschprstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-513 | [hipblasZhprStridedBatched](interfacehipfort__hipblas_1_1hipblaszhprstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-514 | [hipblasChprStridedBatched_64](interfacehipfort__hipblas_1_1hipblaschprstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-515 | [hipblasZhprStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszhprstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-516 | [hipblasChpr2](interfacehipfort__hipblas_1_1hipblaschpr2.html "Interface documentation") | C binding, rank_0, rank_1
-517 | [hipblasZhpr2](interfacehipfort__hipblas_1_1hipblaszhpr2.html "Interface documentation") | C binding, rank_0, rank_1
-518 | [hipblasChpr2_64](interfacehipfort__hipblas_1_1hipblaschpr2__64.html "Interface documentation") | C binding, rank_0, rank_1
-519 | [hipblasZhpr2_64](interfacehipfort__hipblas_1_1hipblaszhpr2__64.html "Interface documentation") | C binding, rank_0, rank_1
+512 | [hipblasChprStridedBatched](interfacehipfort__hipblas_1_1hipblaschprstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+513 | [hipblasZhprStridedBatched](interfacehipfort__hipblas_1_1hipblaszhprstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+514 | [hipblasChprStridedBatched_64](interfacehipfort__hipblas_1_1hipblaschprstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+515 | [hipblasZhprStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszhprstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+516 | [hipblasChpr2](interfacehipfort__hipblas_1_1hipblaschpr2.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+517 | [hipblasZhpr2](interfacehipfort__hipblas_1_1hipblaszhpr2.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+518 | [hipblasChpr2_64](interfacehipfort__hipblas_1_1hipblaschpr2__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+519 | [hipblasZhpr2_64](interfacehipfort__hipblas_1_1hipblaszhpr2__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 520 | [hipblasChpr2Batched](interfacehipfort__hipblas_1_1hipblaschpr2batched.html "Interface documentation") | C binding
 521 | [hipblasZhpr2Batched](interfacehipfort__hipblas_1_1hipblaszhpr2batched.html "Interface documentation") | C binding
 522 | [hipblasChpr2Batched_64](interfacehipfort__hipblas_1_1hipblaschpr2batched__64.html "Interface documentation") | C binding
 523 | [hipblasZhpr2Batched_64](interfacehipfort__hipblas_1_1hipblaszhpr2batched__64.html "Interface documentation") | C binding
-524 | [hipblasChpr2StridedBatched](interfacehipfort__hipblas_1_1hipblaschpr2stridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-525 | [hipblasZhpr2StridedBatched](interfacehipfort__hipblas_1_1hipblaszhpr2stridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-526 | [hipblasChpr2StridedBatched_64](interfacehipfort__hipblas_1_1hipblaschpr2stridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-527 | [hipblasZhpr2StridedBatched_64](interfacehipfort__hipblas_1_1hipblaszhpr2stridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-528 | [hipblasSsbmv](interfacehipfort__hipblas_1_1hipblasssbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-529 | [hipblasDsbmv](interfacehipfort__hipblas_1_1hipblasdsbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-530 | [hipblasSsbmv_64](interfacehipfort__hipblas_1_1hipblasssbmv__64.html "Interface documentation") | C binding, rank_0, rank_1
-531 | [hipblasDsbmv_64](interfacehipfort__hipblas_1_1hipblasdsbmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+524 | [hipblasChpr2StridedBatched](interfacehipfort__hipblas_1_1hipblaschpr2stridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+525 | [hipblasZhpr2StridedBatched](interfacehipfort__hipblas_1_1hipblaszhpr2stridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+526 | [hipblasChpr2StridedBatched_64](interfacehipfort__hipblas_1_1hipblaschpr2stridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+527 | [hipblasZhpr2StridedBatched_64](interfacehipfort__hipblas_1_1hipblaszhpr2stridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+528 | [hipblasSsbmv](interfacehipfort__hipblas_1_1hipblasssbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+529 | [hipblasDsbmv](interfacehipfort__hipblas_1_1hipblasdsbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+530 | [hipblasSsbmv_64](interfacehipfort__hipblas_1_1hipblasssbmv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+531 | [hipblasDsbmv_64](interfacehipfort__hipblas_1_1hipblasdsbmv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 532 | [hipblasSsbmvBatched](interfacehipfort__hipblas_1_1hipblasssbmvbatched.html "Interface documentation") | C binding
 533 | [hipblasDsbmvBatched](interfacehipfort__hipblas_1_1hipblasdsbmvbatched.html "Interface documentation") | C binding
 534 | [hipblasSsbmvBatched_64](interfacehipfort__hipblas_1_1hipblasssbmvbatched__64.html "Interface documentation") | C binding
 535 | [hipblasDsbmvBatched_64](interfacehipfort__hipblas_1_1hipblasdsbmvbatched__64.html "Interface documentation") | C binding
-536 | [hipblasSsbmvStridedBatched](interfacehipfort__hipblas_1_1hipblasssbmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-537 | [hipblasDsbmvStridedBatched](interfacehipfort__hipblas_1_1hipblasdsbmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-538 | [hipblasSsbmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasssbmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-539 | [hipblasDsbmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdsbmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-540 | [hipblasSspmv](interfacehipfort__hipblas_1_1hipblassspmv.html "Interface documentation") | C binding, rank_0, rank_1
-541 | [hipblasDspmv](interfacehipfort__hipblas_1_1hipblasdspmv.html "Interface documentation") | C binding, rank_0, rank_1
-542 | [hipblasSspmv_64](interfacehipfort__hipblas_1_1hipblassspmv__64.html "Interface documentation") | C binding, rank_0, rank_1
-543 | [hipblasDspmv_64](interfacehipfort__hipblas_1_1hipblasdspmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+536 | [hipblasSsbmvStridedBatched](interfacehipfort__hipblas_1_1hipblasssbmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+537 | [hipblasDsbmvStridedBatched](interfacehipfort__hipblas_1_1hipblasdsbmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+538 | [hipblasSsbmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasssbmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+539 | [hipblasDsbmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdsbmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+540 | [hipblasSspmv](interfacehipfort__hipblas_1_1hipblassspmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+541 | [hipblasDspmv](interfacehipfort__hipblas_1_1hipblasdspmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+542 | [hipblasSspmv_64](interfacehipfort__hipblas_1_1hipblassspmv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+543 | [hipblasDspmv_64](interfacehipfort__hipblas_1_1hipblasdspmv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 544 | [hipblasSspmvBatched](interfacehipfort__hipblas_1_1hipblassspmvbatched.html "Interface documentation") | C binding
 545 | [hipblasDspmvBatched](interfacehipfort__hipblas_1_1hipblasdspmvbatched.html "Interface documentation") | C binding
 546 | [hipblasSspmvBatched_64](interfacehipfort__hipblas_1_1hipblassspmvbatched__64.html "Interface documentation") | C binding
 547 | [hipblasDspmvBatched_64](interfacehipfort__hipblas_1_1hipblasdspmvbatched__64.html "Interface documentation") | C binding
-548 | [hipblasSspmvStridedBatched](interfacehipfort__hipblas_1_1hipblassspmvstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-549 | [hipblasDspmvStridedBatched](interfacehipfort__hipblas_1_1hipblasdspmvstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-550 | [hipblasSspmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblassspmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-551 | [hipblasDspmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdspmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-552 | [hipblasSspr](interfacehipfort__hipblas_1_1hipblassspr.html "Interface documentation") | C binding, rank_0, rank_1
-553 | [hipblasDspr](interfacehipfort__hipblas_1_1hipblasdspr.html "Interface documentation") | C binding, rank_0, rank_1
-554 | [hipblasCspr](interfacehipfort__hipblas_1_1hipblascspr.html "Interface documentation") | C binding, rank_0, rank_1
-555 | [hipblasZspr](interfacehipfort__hipblas_1_1hipblaszspr.html "Interface documentation") | C binding, rank_0, rank_1
-556 | [hipblasSspr_64](interfacehipfort__hipblas_1_1hipblassspr__64.html "Interface documentation") | C binding, rank_0, rank_1
-557 | [hipblasDspr_64](interfacehipfort__hipblas_1_1hipblasdspr__64.html "Interface documentation") | C binding, rank_0, rank_1
-558 | [hipblasCspr_64](interfacehipfort__hipblas_1_1hipblascspr__64.html "Interface documentation") | C binding, rank_0, rank_1
-559 | [hipblasZspr_64](interfacehipfort__hipblas_1_1hipblaszspr__64.html "Interface documentation") | C binding, rank_0, rank_1
+548 | [hipblasSspmvStridedBatched](interfacehipfort__hipblas_1_1hipblassspmvstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+549 | [hipblasDspmvStridedBatched](interfacehipfort__hipblas_1_1hipblasdspmvstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+550 | [hipblasSspmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblassspmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+551 | [hipblasDspmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdspmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+552 | [hipblasSspr](interfacehipfort__hipblas_1_1hipblassspr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+553 | [hipblasDspr](interfacehipfort__hipblas_1_1hipblasdspr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+554 | [hipblasCspr](interfacehipfort__hipblas_1_1hipblascspr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+555 | [hipblasZspr](interfacehipfort__hipblas_1_1hipblaszspr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+556 | [hipblasSspr_64](interfacehipfort__hipblas_1_1hipblassspr__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+557 | [hipblasDspr_64](interfacehipfort__hipblas_1_1hipblasdspr__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+558 | [hipblasCspr_64](interfacehipfort__hipblas_1_1hipblascspr__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+559 | [hipblasZspr_64](interfacehipfort__hipblas_1_1hipblaszspr__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 560 | [hipblasSsprBatched](interfacehipfort__hipblas_1_1hipblasssprbatched.html "Interface documentation") | C binding
 561 | [hipblasDsprBatched](interfacehipfort__hipblas_1_1hipblasdsprbatched.html "Interface documentation") | C binding
 562 | [hipblasCsprBatched](interfacehipfort__hipblas_1_1hipblascsprbatched.html "Interface documentation") | C binding
@@ -569,34 +569,34 @@
 565 | [hipblasDsprBatched_64](interfacehipfort__hipblas_1_1hipblasdsprbatched__64.html "Interface documentation") | C binding
 566 | [hipblasCsprBatched_64](interfacehipfort__hipblas_1_1hipblascsprbatched__64.html "Interface documentation") | C binding
 567 | [hipblasZsprBatched_64](interfacehipfort__hipblas_1_1hipblaszsprbatched__64.html "Interface documentation") | C binding
-568 | [hipblasSsprStridedBatched](interfacehipfort__hipblas_1_1hipblasssprstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-569 | [hipblasDsprStridedBatched](interfacehipfort__hipblas_1_1hipblasdsprstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-570 | [hipblasCsprStridedBatched](interfacehipfort__hipblas_1_1hipblascsprstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-571 | [hipblasZsprStridedBatched](interfacehipfort__hipblas_1_1hipblaszsprstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-572 | [hipblasSsprStridedBatched_64](interfacehipfort__hipblas_1_1hipblasssprstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-573 | [hipblasDsprStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdsprstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-574 | [hipblasCsprStridedBatched_64](interfacehipfort__hipblas_1_1hipblascsprstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-575 | [hipblasZsprStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszsprstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-576 | [hipblasSspr2](interfacehipfort__hipblas_1_1hipblassspr2.html "Interface documentation") | C binding, rank_0, rank_1
-577 | [hipblasDspr2](interfacehipfort__hipblas_1_1hipblasdspr2.html "Interface documentation") | C binding, rank_0, rank_1
-578 | [hipblasSspr2_64](interfacehipfort__hipblas_1_1hipblassspr2__64.html "Interface documentation") | C binding, rank_0, rank_1
-579 | [hipblasDspr2_64](interfacehipfort__hipblas_1_1hipblasdspr2__64.html "Interface documentation") | C binding, rank_0, rank_1
+568 | [hipblasSsprStridedBatched](interfacehipfort__hipblas_1_1hipblasssprstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+569 | [hipblasDsprStridedBatched](interfacehipfort__hipblas_1_1hipblasdsprstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+570 | [hipblasCsprStridedBatched](interfacehipfort__hipblas_1_1hipblascsprstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+571 | [hipblasZsprStridedBatched](interfacehipfort__hipblas_1_1hipblaszsprstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+572 | [hipblasSsprStridedBatched_64](interfacehipfort__hipblas_1_1hipblasssprstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+573 | [hipblasDsprStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdsprstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+574 | [hipblasCsprStridedBatched_64](interfacehipfort__hipblas_1_1hipblascsprstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+575 | [hipblasZsprStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszsprstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+576 | [hipblasSspr2](interfacehipfort__hipblas_1_1hipblassspr2.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+577 | [hipblasDspr2](interfacehipfort__hipblas_1_1hipblasdspr2.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+578 | [hipblasSspr2_64](interfacehipfort__hipblas_1_1hipblassspr2__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+579 | [hipblasDspr2_64](interfacehipfort__hipblas_1_1hipblasdspr2__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 580 | [hipblasSspr2Batched](interfacehipfort__hipblas_1_1hipblassspr2batched.html "Interface documentation") | C binding
 581 | [hipblasDspr2Batched](interfacehipfort__hipblas_1_1hipblasdspr2batched.html "Interface documentation") | C binding
 582 | [hipblasSspr2Batched_64](interfacehipfort__hipblas_1_1hipblassspr2batched__64.html "Interface documentation") | C binding
 583 | [hipblasDspr2Batched_64](interfacehipfort__hipblas_1_1hipblasdspr2batched__64.html "Interface documentation") | C binding
-584 | [hipblasSspr2StridedBatched](interfacehipfort__hipblas_1_1hipblassspr2stridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-585 | [hipblasDspr2StridedBatched](interfacehipfort__hipblas_1_1hipblasdspr2stridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-586 | [hipblasSspr2StridedBatched_64](interfacehipfort__hipblas_1_1hipblassspr2stridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-587 | [hipblasDspr2StridedBatched_64](interfacehipfort__hipblas_1_1hipblasdspr2stridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-588 | [hipblasSsymv](interfacehipfort__hipblas_1_1hipblasssymv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-589 | [hipblasDsymv](interfacehipfort__hipblas_1_1hipblasdsymv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-590 | [hipblasCsymv](interfacehipfort__hipblas_1_1hipblascsymv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-591 | [hipblasZsymv](interfacehipfort__hipblas_1_1hipblaszsymv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-592 | [hipblasSsymv_64](interfacehipfort__hipblas_1_1hipblasssymv__64.html "Interface documentation") | C binding, rank_0, rank_1
-593 | [hipblasDsymv_64](interfacehipfort__hipblas_1_1hipblasdsymv__64.html "Interface documentation") | C binding, rank_0, rank_1
-594 | [hipblasCsymv_64](interfacehipfort__hipblas_1_1hipblascsymv__64.html "Interface documentation") | C binding, rank_0, rank_1
-595 | [hipblasZsymv_64](interfacehipfort__hipblas_1_1hipblaszsymv__64.html "Interface documentation") | C binding, rank_0, rank_1
+584 | [hipblasSspr2StridedBatched](interfacehipfort__hipblas_1_1hipblassspr2stridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+585 | [hipblasDspr2StridedBatched](interfacehipfort__hipblas_1_1hipblasdspr2stridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+586 | [hipblasSspr2StridedBatched_64](interfacehipfort__hipblas_1_1hipblassspr2stridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+587 | [hipblasDspr2StridedBatched_64](interfacehipfort__hipblas_1_1hipblasdspr2stridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+588 | [hipblasSsymv](interfacehipfort__hipblas_1_1hipblasssymv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+589 | [hipblasDsymv](interfacehipfort__hipblas_1_1hipblasdsymv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+590 | [hipblasCsymv](interfacehipfort__hipblas_1_1hipblascsymv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+591 | [hipblasZsymv](interfacehipfort__hipblas_1_1hipblaszsymv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+592 | [hipblasSsymv_64](interfacehipfort__hipblas_1_1hipblasssymv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+593 | [hipblasDsymv_64](interfacehipfort__hipblas_1_1hipblasdsymv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+594 | [hipblasCsymv_64](interfacehipfort__hipblas_1_1hipblascsymv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+595 | [hipblasZsymv_64](interfacehipfort__hipblas_1_1hipblaszsymv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 596 | [hipblasSsymvBatched](interfacehipfort__hipblas_1_1hipblasssymvbatched.html "Interface documentation") | C binding
 597 | [hipblasDsymvBatched](interfacehipfort__hipblas_1_1hipblasdsymvbatched.html "Interface documentation") | C binding
 598 | [hipblasCsymvBatched](interfacehipfort__hipblas_1_1hipblascsymvbatched.html "Interface documentation") | C binding
@@ -605,22 +605,22 @@
 601 | [hipblasDsymvBatched_64](interfacehipfort__hipblas_1_1hipblasdsymvbatched__64.html "Interface documentation") | C binding
 602 | [hipblasCsymvBatched_64](interfacehipfort__hipblas_1_1hipblascsymvbatched__64.html "Interface documentation") | C binding
 603 | [hipblasZsymvBatched_64](interfacehipfort__hipblas_1_1hipblaszsymvbatched__64.html "Interface documentation") | C binding
-604 | [hipblasSsymvStridedBatched](interfacehipfort__hipblas_1_1hipblasssymvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-605 | [hipblasDsymvStridedBatched](interfacehipfort__hipblas_1_1hipblasdsymvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-606 | [hipblasCsymvStridedBatched](interfacehipfort__hipblas_1_1hipblascsymvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-607 | [hipblasZsymvStridedBatched](interfacehipfort__hipblas_1_1hipblaszsymvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-608 | [hipblasSsymvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasssymvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-609 | [hipblasDsymvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdsymvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-610 | [hipblasCsymvStridedBatched_64](interfacehipfort__hipblas_1_1hipblascsymvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-611 | [hipblasZsymvStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszsymvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-612 | [hipblasSsyr](interfacehipfort__hipblas_1_1hipblasssyr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-613 | [hipblasDsyr](interfacehipfort__hipblas_1_1hipblasdsyr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-614 | [hipblasCsyr](interfacehipfort__hipblas_1_1hipblascsyr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-615 | [hipblasZsyr](interfacehipfort__hipblas_1_1hipblaszsyr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-616 | [hipblasSsyr_64](interfacehipfort__hipblas_1_1hipblasssyr__64.html "Interface documentation") | C binding, rank_0, rank_1
-617 | [hipblasDsyr_64](interfacehipfort__hipblas_1_1hipblasdsyr__64.html "Interface documentation") | C binding, rank_0, rank_1
-618 | [hipblasCsyr_64](interfacehipfort__hipblas_1_1hipblascsyr__64.html "Interface documentation") | C binding, rank_0, rank_1
-619 | [hipblasZsyr_64](interfacehipfort__hipblas_1_1hipblaszsyr__64.html "Interface documentation") | C binding, rank_0, rank_1
+604 | [hipblasSsymvStridedBatched](interfacehipfort__hipblas_1_1hipblasssymvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+605 | [hipblasDsymvStridedBatched](interfacehipfort__hipblas_1_1hipblasdsymvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+606 | [hipblasCsymvStridedBatched](interfacehipfort__hipblas_1_1hipblascsymvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+607 | [hipblasZsymvStridedBatched](interfacehipfort__hipblas_1_1hipblaszsymvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+608 | [hipblasSsymvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasssymvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+609 | [hipblasDsymvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdsymvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+610 | [hipblasCsymvStridedBatched_64](interfacehipfort__hipblas_1_1hipblascsymvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+611 | [hipblasZsymvStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszsymvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+612 | [hipblasSsyr](interfacehipfort__hipblas_1_1hipblasssyr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+613 | [hipblasDsyr](interfacehipfort__hipblas_1_1hipblasdsyr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+614 | [hipblasCsyr](interfacehipfort__hipblas_1_1hipblascsyr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+615 | [hipblasZsyr](interfacehipfort__hipblas_1_1hipblaszsyr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+616 | [hipblasSsyr_64](interfacehipfort__hipblas_1_1hipblasssyr__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+617 | [hipblasDsyr_64](interfacehipfort__hipblas_1_1hipblasdsyr__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+618 | [hipblasCsyr_64](interfacehipfort__hipblas_1_1hipblascsyr__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+619 | [hipblasZsyr_64](interfacehipfort__hipblas_1_1hipblaszsyr__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 620 | [hipblasSsyrBatched](interfacehipfort__hipblas_1_1hipblasssyrbatched.html "Interface documentation") | C binding
 621 | [hipblasDsyrBatched](interfacehipfort__hipblas_1_1hipblasdsyrbatched.html "Interface documentation") | C binding
 622 | [hipblasCsyrBatched](interfacehipfort__hipblas_1_1hipblascsyrbatched.html "Interface documentation") | C binding
@@ -629,22 +629,22 @@
 625 | [hipblasDsyrBatched_64](interfacehipfort__hipblas_1_1hipblasdsyrbatched__64.html "Interface documentation") | C binding
 626 | [hipblasCsyrBatched_64](interfacehipfort__hipblas_1_1hipblascsyrbatched__64.html "Interface documentation") | C binding
 627 | [hipblasZsyrBatched_64](interfacehipfort__hipblas_1_1hipblaszsyrbatched__64.html "Interface documentation") | C binding
-628 | [hipblasSsyrStridedBatched](interfacehipfort__hipblas_1_1hipblasssyrstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-629 | [hipblasDsyrStridedBatched](interfacehipfort__hipblas_1_1hipblasdsyrstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-630 | [hipblasCsyrStridedBatched](interfacehipfort__hipblas_1_1hipblascsyrstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-631 | [hipblasZsyrStridedBatched](interfacehipfort__hipblas_1_1hipblaszsyrstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-632 | [hipblasSsyrStridedBatched_64](interfacehipfort__hipblas_1_1hipblasssyrstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-633 | [hipblasDsyrStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdsyrstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-634 | [hipblasCsyrStridedBatched_64](interfacehipfort__hipblas_1_1hipblascsyrstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-635 | [hipblasZsyrStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszsyrstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-636 | [hipblasSsyr2](interfacehipfort__hipblas_1_1hipblasssyr2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-637 | [hipblasDsyr2](interfacehipfort__hipblas_1_1hipblasdsyr2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-638 | [hipblasCsyr2](interfacehipfort__hipblas_1_1hipblascsyr2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-639 | [hipblasZsyr2](interfacehipfort__hipblas_1_1hipblaszsyr2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-640 | [hipblasSsyr2_64](interfacehipfort__hipblas_1_1hipblasssyr2__64.html "Interface documentation") | C binding, rank_0, rank_1
-641 | [hipblasDsyr2_64](interfacehipfort__hipblas_1_1hipblasdsyr2__64.html "Interface documentation") | C binding, rank_0, rank_1
-642 | [hipblasCsyr2_64](interfacehipfort__hipblas_1_1hipblascsyr2__64.html "Interface documentation") | C binding, rank_0, rank_1
-643 | [hipblasZsyr2_64](interfacehipfort__hipblas_1_1hipblaszsyr2__64.html "Interface documentation") | C binding, rank_0, rank_1
+628 | [hipblasSsyrStridedBatched](interfacehipfort__hipblas_1_1hipblasssyrstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+629 | [hipblasDsyrStridedBatched](interfacehipfort__hipblas_1_1hipblasdsyrstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+630 | [hipblasCsyrStridedBatched](interfacehipfort__hipblas_1_1hipblascsyrstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+631 | [hipblasZsyrStridedBatched](interfacehipfort__hipblas_1_1hipblaszsyrstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+632 | [hipblasSsyrStridedBatched_64](interfacehipfort__hipblas_1_1hipblasssyrstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+633 | [hipblasDsyrStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdsyrstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+634 | [hipblasCsyrStridedBatched_64](interfacehipfort__hipblas_1_1hipblascsyrstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+635 | [hipblasZsyrStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszsyrstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+636 | [hipblasSsyr2](interfacehipfort__hipblas_1_1hipblasssyr2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+637 | [hipblasDsyr2](interfacehipfort__hipblas_1_1hipblasdsyr2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+638 | [hipblasCsyr2](interfacehipfort__hipblas_1_1hipblascsyr2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+639 | [hipblasZsyr2](interfacehipfort__hipblas_1_1hipblaszsyr2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+640 | [hipblasSsyr2_64](interfacehipfort__hipblas_1_1hipblasssyr2__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+641 | [hipblasDsyr2_64](interfacehipfort__hipblas_1_1hipblasdsyr2__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+642 | [hipblasCsyr2_64](interfacehipfort__hipblas_1_1hipblascsyr2__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+643 | [hipblasZsyr2_64](interfacehipfort__hipblas_1_1hipblaszsyr2__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 644 | [hipblasSsyr2Batched](interfacehipfort__hipblas_1_1hipblasssyr2batched.html "Interface documentation") | C binding
 645 | [hipblasDsyr2Batched](interfacehipfort__hipblas_1_1hipblasdsyr2batched.html "Interface documentation") | C binding
 646 | [hipblasCsyr2Batched](interfacehipfort__hipblas_1_1hipblascsyr2batched.html "Interface documentation") | C binding
@@ -653,22 +653,22 @@
 649 | [hipblasDsyr2Batched_64](interfacehipfort__hipblas_1_1hipblasdsyr2batched__64.html "Interface documentation") | C binding
 650 | [hipblasCsyr2Batched_64](interfacehipfort__hipblas_1_1hipblascsyr2batched__64.html "Interface documentation") | C binding
 651 | [hipblasZsyr2Batched_64](interfacehipfort__hipblas_1_1hipblaszsyr2batched__64.html "Interface documentation") | C binding
-652 | [hipblasSsyr2StridedBatched](interfacehipfort__hipblas_1_1hipblasssyr2stridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-653 | [hipblasDsyr2StridedBatched](interfacehipfort__hipblas_1_1hipblasdsyr2stridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-654 | [hipblasCsyr2StridedBatched](interfacehipfort__hipblas_1_1hipblascsyr2stridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-655 | [hipblasZsyr2StridedBatched](interfacehipfort__hipblas_1_1hipblaszsyr2stridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-656 | [hipblasSsyr2StridedBatched_64](interfacehipfort__hipblas_1_1hipblasssyr2stridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-657 | [hipblasDsyr2StridedBatched_64](interfacehipfort__hipblas_1_1hipblasdsyr2stridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-658 | [hipblasCsyr2StridedBatched_64](interfacehipfort__hipblas_1_1hipblascsyr2stridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-659 | [hipblasZsyr2StridedBatched_64](interfacehipfort__hipblas_1_1hipblaszsyr2stridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-660 | [hipblasStbmv](interfacehipfort__hipblas_1_1hipblasstbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-661 | [hipblasDtbmv](interfacehipfort__hipblas_1_1hipblasdtbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-662 | [hipblasCtbmv](interfacehipfort__hipblas_1_1hipblasctbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-663 | [hipblasZtbmv](interfacehipfort__hipblas_1_1hipblasztbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-664 | [hipblasStbmv_64](interfacehipfort__hipblas_1_1hipblasstbmv__64.html "Interface documentation") | C binding, rank_0, rank_1
-665 | [hipblasDtbmv_64](interfacehipfort__hipblas_1_1hipblasdtbmv__64.html "Interface documentation") | C binding, rank_0, rank_1
-666 | [hipblasCtbmv_64](interfacehipfort__hipblas_1_1hipblasctbmv__64.html "Interface documentation") | C binding, rank_0, rank_1
-667 | [hipblasZtbmv_64](interfacehipfort__hipblas_1_1hipblasztbmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+652 | [hipblasSsyr2StridedBatched](interfacehipfort__hipblas_1_1hipblasssyr2stridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+653 | [hipblasDsyr2StridedBatched](interfacehipfort__hipblas_1_1hipblasdsyr2stridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+654 | [hipblasCsyr2StridedBatched](interfacehipfort__hipblas_1_1hipblascsyr2stridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+655 | [hipblasZsyr2StridedBatched](interfacehipfort__hipblas_1_1hipblaszsyr2stridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+656 | [hipblasSsyr2StridedBatched_64](interfacehipfort__hipblas_1_1hipblasssyr2stridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+657 | [hipblasDsyr2StridedBatched_64](interfacehipfort__hipblas_1_1hipblasdsyr2stridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+658 | [hipblasCsyr2StridedBatched_64](interfacehipfort__hipblas_1_1hipblascsyr2stridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+659 | [hipblasZsyr2StridedBatched_64](interfacehipfort__hipblas_1_1hipblaszsyr2stridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+660 | [hipblasStbmv](interfacehipfort__hipblas_1_1hipblasstbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+661 | [hipblasDtbmv](interfacehipfort__hipblas_1_1hipblasdtbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+662 | [hipblasCtbmv](interfacehipfort__hipblas_1_1hipblasctbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+663 | [hipblasZtbmv](interfacehipfort__hipblas_1_1hipblasztbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+664 | [hipblasStbmv_64](interfacehipfort__hipblas_1_1hipblasstbmv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+665 | [hipblasDtbmv_64](interfacehipfort__hipblas_1_1hipblasdtbmv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+666 | [hipblasCtbmv_64](interfacehipfort__hipblas_1_1hipblasctbmv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+667 | [hipblasZtbmv_64](interfacehipfort__hipblas_1_1hipblasztbmv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 668 | [hipblasStbmvBatched](interfacehipfort__hipblas_1_1hipblasstbmvbatched.html "Interface documentation") | C binding
 669 | [hipblasDtbmvBatched](interfacehipfort__hipblas_1_1hipblasdtbmvbatched.html "Interface documentation") | C binding
 670 | [hipblasCtbmvBatched](interfacehipfort__hipblas_1_1hipblasctbmvbatched.html "Interface documentation") | C binding
@@ -677,22 +677,22 @@
 673 | [hipblasDtbmvBatched_64](interfacehipfort__hipblas_1_1hipblasdtbmvbatched__64.html "Interface documentation") | C binding
 674 | [hipblasCtbmvBatched_64](interfacehipfort__hipblas_1_1hipblasctbmvbatched__64.html "Interface documentation") | C binding
 675 | [hipblasZtbmvBatched_64](interfacehipfort__hipblas_1_1hipblasztbmvbatched__64.html "Interface documentation") | C binding
-676 | [hipblasStbmvStridedBatched](interfacehipfort__hipblas_1_1hipblasstbmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-677 | [hipblasDtbmvStridedBatched](interfacehipfort__hipblas_1_1hipblasdtbmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-678 | [hipblasCtbmvStridedBatched](interfacehipfort__hipblas_1_1hipblasctbmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-679 | [hipblasZtbmvStridedBatched](interfacehipfort__hipblas_1_1hipblasztbmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-680 | [hipblasStbmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasstbmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-681 | [hipblasDtbmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdtbmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-682 | [hipblasCtbmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasctbmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-683 | [hipblasZtbmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasztbmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-684 | [hipblasStbsv](interfacehipfort__hipblas_1_1hipblasstbsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-685 | [hipblasDtbsv](interfacehipfort__hipblas_1_1hipblasdtbsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-686 | [hipblasCtbsv](interfacehipfort__hipblas_1_1hipblasctbsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-687 | [hipblasZtbsv](interfacehipfort__hipblas_1_1hipblasztbsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-688 | [hipblasStbsv_64](interfacehipfort__hipblas_1_1hipblasstbsv__64.html "Interface documentation") | C binding, rank_0, rank_1
-689 | [hipblasDtbsv_64](interfacehipfort__hipblas_1_1hipblasdtbsv__64.html "Interface documentation") | C binding, rank_0, rank_1
-690 | [hipblasCtbsv_64](interfacehipfort__hipblas_1_1hipblasctbsv__64.html "Interface documentation") | C binding, rank_0, rank_1
-691 | [hipblasZtbsv_64](interfacehipfort__hipblas_1_1hipblasztbsv__64.html "Interface documentation") | C binding, rank_0, rank_1
+676 | [hipblasStbmvStridedBatched](interfacehipfort__hipblas_1_1hipblasstbmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+677 | [hipblasDtbmvStridedBatched](interfacehipfort__hipblas_1_1hipblasdtbmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+678 | [hipblasCtbmvStridedBatched](interfacehipfort__hipblas_1_1hipblasctbmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+679 | [hipblasZtbmvStridedBatched](interfacehipfort__hipblas_1_1hipblasztbmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+680 | [hipblasStbmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasstbmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+681 | [hipblasDtbmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdtbmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+682 | [hipblasCtbmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasctbmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+683 | [hipblasZtbmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasztbmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+684 | [hipblasStbsv](interfacehipfort__hipblas_1_1hipblasstbsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+685 | [hipblasDtbsv](interfacehipfort__hipblas_1_1hipblasdtbsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+686 | [hipblasCtbsv](interfacehipfort__hipblas_1_1hipblasctbsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+687 | [hipblasZtbsv](interfacehipfort__hipblas_1_1hipblasztbsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+688 | [hipblasStbsv_64](interfacehipfort__hipblas_1_1hipblasstbsv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+689 | [hipblasDtbsv_64](interfacehipfort__hipblas_1_1hipblasdtbsv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+690 | [hipblasCtbsv_64](interfacehipfort__hipblas_1_1hipblasctbsv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+691 | [hipblasZtbsv_64](interfacehipfort__hipblas_1_1hipblasztbsv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 692 | [hipblasStbsvBatched](interfacehipfort__hipblas_1_1hipblasstbsvbatched.html "Interface documentation") | C binding
 693 | [hipblasDtbsvBatched](interfacehipfort__hipblas_1_1hipblasdtbsvbatched.html "Interface documentation") | C binding
 694 | [hipblasCtbsvBatched](interfacehipfort__hipblas_1_1hipblasctbsvbatched.html "Interface documentation") | C binding
@@ -701,22 +701,22 @@
 697 | [hipblasDtbsvBatched_64](interfacehipfort__hipblas_1_1hipblasdtbsvbatched__64.html "Interface documentation") | C binding
 698 | [hipblasCtbsvBatched_64](interfacehipfort__hipblas_1_1hipblasctbsvbatched__64.html "Interface documentation") | C binding
 699 | [hipblasZtbsvBatched_64](interfacehipfort__hipblas_1_1hipblasztbsvbatched__64.html "Interface documentation") | C binding
-700 | [hipblasStbsvStridedBatched](interfacehipfort__hipblas_1_1hipblasstbsvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-701 | [hipblasDtbsvStridedBatched](interfacehipfort__hipblas_1_1hipblasdtbsvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-702 | [hipblasCtbsvStridedBatched](interfacehipfort__hipblas_1_1hipblasctbsvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-703 | [hipblasZtbsvStridedBatched](interfacehipfort__hipblas_1_1hipblasztbsvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-704 | [hipblasStbsvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasstbsvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-705 | [hipblasDtbsvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdtbsvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-706 | [hipblasCtbsvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasctbsvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-707 | [hipblasZtbsvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasztbsvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-708 | [hipblasStpmv](interfacehipfort__hipblas_1_1hipblasstpmv.html "Interface documentation") | C binding, rank_0, rank_1
-709 | [hipblasDtpmv](interfacehipfort__hipblas_1_1hipblasdtpmv.html "Interface documentation") | C binding, rank_0, rank_1
-710 | [hipblasCtpmv](interfacehipfort__hipblas_1_1hipblasctpmv.html "Interface documentation") | C binding, rank_0, rank_1
-711 | [hipblasZtpmv](interfacehipfort__hipblas_1_1hipblasztpmv.html "Interface documentation") | C binding, rank_0, rank_1
-712 | [hipblasStpmv_64](interfacehipfort__hipblas_1_1hipblasstpmv__64.html "Interface documentation") | C binding, rank_0, rank_1
-713 | [hipblasDtpmv_64](interfacehipfort__hipblas_1_1hipblasdtpmv__64.html "Interface documentation") | C binding, rank_0, rank_1
-714 | [hipblasCtpmv_64](interfacehipfort__hipblas_1_1hipblasctpmv__64.html "Interface documentation") | C binding, rank_0, rank_1
-715 | [hipblasZtpmv_64](interfacehipfort__hipblas_1_1hipblasztpmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+700 | [hipblasStbsvStridedBatched](interfacehipfort__hipblas_1_1hipblasstbsvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+701 | [hipblasDtbsvStridedBatched](interfacehipfort__hipblas_1_1hipblasdtbsvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+702 | [hipblasCtbsvStridedBatched](interfacehipfort__hipblas_1_1hipblasctbsvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+703 | [hipblasZtbsvStridedBatched](interfacehipfort__hipblas_1_1hipblasztbsvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+704 | [hipblasStbsvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasstbsvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+705 | [hipblasDtbsvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdtbsvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+706 | [hipblasCtbsvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasctbsvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+707 | [hipblasZtbsvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasztbsvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+708 | [hipblasStpmv](interfacehipfort__hipblas_1_1hipblasstpmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+709 | [hipblasDtpmv](interfacehipfort__hipblas_1_1hipblasdtpmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+710 | [hipblasCtpmv](interfacehipfort__hipblas_1_1hipblasctpmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+711 | [hipblasZtpmv](interfacehipfort__hipblas_1_1hipblasztpmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+712 | [hipblasStpmv_64](interfacehipfort__hipblas_1_1hipblasstpmv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+713 | [hipblasDtpmv_64](interfacehipfort__hipblas_1_1hipblasdtpmv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+714 | [hipblasCtpmv_64](interfacehipfort__hipblas_1_1hipblasctpmv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+715 | [hipblasZtpmv_64](interfacehipfort__hipblas_1_1hipblasztpmv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 716 | [hipblasStpmvBatched](interfacehipfort__hipblas_1_1hipblasstpmvbatched.html "Interface documentation") | C binding
 717 | [hipblasDtpmvBatched](interfacehipfort__hipblas_1_1hipblasdtpmvbatched.html "Interface documentation") | C binding
 718 | [hipblasCtpmvBatched](interfacehipfort__hipblas_1_1hipblasctpmvbatched.html "Interface documentation") | C binding
@@ -725,22 +725,22 @@
 721 | [hipblasDtpmvBatched_64](interfacehipfort__hipblas_1_1hipblasdtpmvbatched__64.html "Interface documentation") | C binding
 722 | [hipblasCtpmvBatched_64](interfacehipfort__hipblas_1_1hipblasctpmvbatched__64.html "Interface documentation") | C binding
 723 | [hipblasZtpmvBatched_64](interfacehipfort__hipblas_1_1hipblasztpmvbatched__64.html "Interface documentation") | C binding
-724 | [hipblasStpmvStridedBatched](interfacehipfort__hipblas_1_1hipblasstpmvstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-725 | [hipblasDtpmvStridedBatched](interfacehipfort__hipblas_1_1hipblasdtpmvstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-726 | [hipblasCtpmvStridedBatched](interfacehipfort__hipblas_1_1hipblasctpmvstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-727 | [hipblasZtpmvStridedBatched](interfacehipfort__hipblas_1_1hipblasztpmvstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-728 | [hipblasStpmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasstpmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-729 | [hipblasDtpmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdtpmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-730 | [hipblasCtpmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasctpmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-731 | [hipblasZtpmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasztpmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-732 | [hipblasStpsv](interfacehipfort__hipblas_1_1hipblasstpsv.html "Interface documentation") | C binding, rank_0, rank_1
-733 | [hipblasDtpsv](interfacehipfort__hipblas_1_1hipblasdtpsv.html "Interface documentation") | C binding, rank_0, rank_1
-734 | [hipblasCtpsv](interfacehipfort__hipblas_1_1hipblasctpsv.html "Interface documentation") | C binding, rank_0, rank_1
-735 | [hipblasZtpsv](interfacehipfort__hipblas_1_1hipblasztpsv.html "Interface documentation") | C binding, rank_0, rank_1
-736 | [hipblasStpsv_64](interfacehipfort__hipblas_1_1hipblasstpsv__64.html "Interface documentation") | C binding, rank_0, rank_1
-737 | [hipblasDtpsv_64](interfacehipfort__hipblas_1_1hipblasdtpsv__64.html "Interface documentation") | C binding, rank_0, rank_1
-738 | [hipblasCtpsv_64](interfacehipfort__hipblas_1_1hipblasctpsv__64.html "Interface documentation") | C binding, rank_0, rank_1
-739 | [hipblasZtpsv_64](interfacehipfort__hipblas_1_1hipblasztpsv__64.html "Interface documentation") | C binding, rank_0, rank_1
+724 | [hipblasStpmvStridedBatched](interfacehipfort__hipblas_1_1hipblasstpmvstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+725 | [hipblasDtpmvStridedBatched](interfacehipfort__hipblas_1_1hipblasdtpmvstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+726 | [hipblasCtpmvStridedBatched](interfacehipfort__hipblas_1_1hipblasctpmvstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+727 | [hipblasZtpmvStridedBatched](interfacehipfort__hipblas_1_1hipblasztpmvstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+728 | [hipblasStpmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasstpmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+729 | [hipblasDtpmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdtpmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+730 | [hipblasCtpmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasctpmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+731 | [hipblasZtpmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasztpmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+732 | [hipblasStpsv](interfacehipfort__hipblas_1_1hipblasstpsv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+733 | [hipblasDtpsv](interfacehipfort__hipblas_1_1hipblasdtpsv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+734 | [hipblasCtpsv](interfacehipfort__hipblas_1_1hipblasctpsv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+735 | [hipblasZtpsv](interfacehipfort__hipblas_1_1hipblasztpsv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+736 | [hipblasStpsv_64](interfacehipfort__hipblas_1_1hipblasstpsv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+737 | [hipblasDtpsv_64](interfacehipfort__hipblas_1_1hipblasdtpsv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+738 | [hipblasCtpsv_64](interfacehipfort__hipblas_1_1hipblasctpsv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+739 | [hipblasZtpsv_64](interfacehipfort__hipblas_1_1hipblasztpsv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 740 | [hipblasStpsvBatched](interfacehipfort__hipblas_1_1hipblasstpsvbatched.html "Interface documentation") | C binding
 741 | [hipblasDtpsvBatched](interfacehipfort__hipblas_1_1hipblasdtpsvbatched.html "Interface documentation") | C binding
 742 | [hipblasCtpsvBatched](interfacehipfort__hipblas_1_1hipblasctpsvbatched.html "Interface documentation") | C binding
@@ -749,22 +749,22 @@
 745 | [hipblasDtpsvBatched_64](interfacehipfort__hipblas_1_1hipblasdtpsvbatched__64.html "Interface documentation") | C binding
 746 | [hipblasCtpsvBatched_64](interfacehipfort__hipblas_1_1hipblasctpsvbatched__64.html "Interface documentation") | C binding
 747 | [hipblasZtpsvBatched_64](interfacehipfort__hipblas_1_1hipblasztpsvbatched__64.html "Interface documentation") | C binding
-748 | [hipblasStpsvStridedBatched](interfacehipfort__hipblas_1_1hipblasstpsvstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-749 | [hipblasDtpsvStridedBatched](interfacehipfort__hipblas_1_1hipblasdtpsvstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-750 | [hipblasCtpsvStridedBatched](interfacehipfort__hipblas_1_1hipblasctpsvstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-751 | [hipblasZtpsvStridedBatched](interfacehipfort__hipblas_1_1hipblasztpsvstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-752 | [hipblasStpsvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasstpsvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-753 | [hipblasDtpsvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdtpsvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-754 | [hipblasCtpsvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasctpsvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-755 | [hipblasZtpsvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasztpsvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-756 | [hipblasStrmv](interfacehipfort__hipblas_1_1hipblasstrmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-757 | [hipblasDtrmv](interfacehipfort__hipblas_1_1hipblasdtrmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-758 | [hipblasCtrmv](interfacehipfort__hipblas_1_1hipblasctrmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-759 | [hipblasZtrmv](interfacehipfort__hipblas_1_1hipblasztrmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-760 | [hipblasStrmv_64](interfacehipfort__hipblas_1_1hipblasstrmv__64.html "Interface documentation") | C binding, rank_0, rank_1
-761 | [hipblasDtrmv_64](interfacehipfort__hipblas_1_1hipblasdtrmv__64.html "Interface documentation") | C binding, rank_0, rank_1
-762 | [hipblasCtrmv_64](interfacehipfort__hipblas_1_1hipblasctrmv__64.html "Interface documentation") | C binding, rank_0, rank_1
-763 | [hipblasZtrmv_64](interfacehipfort__hipblas_1_1hipblasztrmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+748 | [hipblasStpsvStridedBatched](interfacehipfort__hipblas_1_1hipblasstpsvstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+749 | [hipblasDtpsvStridedBatched](interfacehipfort__hipblas_1_1hipblasdtpsvstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+750 | [hipblasCtpsvStridedBatched](interfacehipfort__hipblas_1_1hipblasctpsvstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+751 | [hipblasZtpsvStridedBatched](interfacehipfort__hipblas_1_1hipblasztpsvstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+752 | [hipblasStpsvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasstpsvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+753 | [hipblasDtpsvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdtpsvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+754 | [hipblasCtpsvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasctpsvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+755 | [hipblasZtpsvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasztpsvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+756 | [hipblasStrmv](interfacehipfort__hipblas_1_1hipblasstrmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+757 | [hipblasDtrmv](interfacehipfort__hipblas_1_1hipblasdtrmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+758 | [hipblasCtrmv](interfacehipfort__hipblas_1_1hipblasctrmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+759 | [hipblasZtrmv](interfacehipfort__hipblas_1_1hipblasztrmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+760 | [hipblasStrmv_64](interfacehipfort__hipblas_1_1hipblasstrmv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+761 | [hipblasDtrmv_64](interfacehipfort__hipblas_1_1hipblasdtrmv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+762 | [hipblasCtrmv_64](interfacehipfort__hipblas_1_1hipblasctrmv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+763 | [hipblasZtrmv_64](interfacehipfort__hipblas_1_1hipblasztrmv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 764 | [hipblasStrmvBatched](interfacehipfort__hipblas_1_1hipblasstrmvbatched.html "Interface documentation") | C binding
 765 | [hipblasDtrmvBatched](interfacehipfort__hipblas_1_1hipblasdtrmvbatched.html "Interface documentation") | C binding
 766 | [hipblasCtrmvBatched](interfacehipfort__hipblas_1_1hipblasctrmvbatched.html "Interface documentation") | C binding
@@ -773,22 +773,22 @@
 769 | [hipblasDtrmvBatched_64](interfacehipfort__hipblas_1_1hipblasdtrmvbatched__64.html "Interface documentation") | C binding
 770 | [hipblasCtrmvBatched_64](interfacehipfort__hipblas_1_1hipblasctrmvbatched__64.html "Interface documentation") | C binding
 771 | [hipblasZtrmvBatched_64](interfacehipfort__hipblas_1_1hipblasztrmvbatched__64.html "Interface documentation") | C binding
-772 | [hipblasStrmvStridedBatched](interfacehipfort__hipblas_1_1hipblasstrmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-773 | [hipblasDtrmvStridedBatched](interfacehipfort__hipblas_1_1hipblasdtrmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-774 | [hipblasCtrmvStridedBatched](interfacehipfort__hipblas_1_1hipblasctrmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-775 | [hipblasZtrmvStridedBatched](interfacehipfort__hipblas_1_1hipblasztrmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-776 | [hipblasStrmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasstrmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-777 | [hipblasDtrmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdtrmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-778 | [hipblasCtrmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasctrmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-779 | [hipblasZtrmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasztrmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-780 | [hipblasStrsv](interfacehipfort__hipblas_1_1hipblasstrsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-781 | [hipblasDtrsv](interfacehipfort__hipblas_1_1hipblasdtrsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-782 | [hipblasCtrsv](interfacehipfort__hipblas_1_1hipblasctrsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-783 | [hipblasZtrsv](interfacehipfort__hipblas_1_1hipblasztrsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-784 | [hipblasStrsv_64](interfacehipfort__hipblas_1_1hipblasstrsv__64.html "Interface documentation") | C binding, rank_0, rank_1
-785 | [hipblasDtrsv_64](interfacehipfort__hipblas_1_1hipblasdtrsv__64.html "Interface documentation") | C binding, rank_0, rank_1
-786 | [hipblasCtrsv_64](interfacehipfort__hipblas_1_1hipblasctrsv__64.html "Interface documentation") | C binding, rank_0, rank_1
-787 | [hipblasZtrsv_64](interfacehipfort__hipblas_1_1hipblasztrsv__64.html "Interface documentation") | C binding, rank_0, rank_1
+772 | [hipblasStrmvStridedBatched](interfacehipfort__hipblas_1_1hipblasstrmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+773 | [hipblasDtrmvStridedBatched](interfacehipfort__hipblas_1_1hipblasdtrmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+774 | [hipblasCtrmvStridedBatched](interfacehipfort__hipblas_1_1hipblasctrmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+775 | [hipblasZtrmvStridedBatched](interfacehipfort__hipblas_1_1hipblasztrmvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+776 | [hipblasStrmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasstrmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+777 | [hipblasDtrmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdtrmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+778 | [hipblasCtrmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasctrmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+779 | [hipblasZtrmvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasztrmvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+780 | [hipblasStrsv](interfacehipfort__hipblas_1_1hipblasstrsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+781 | [hipblasDtrsv](interfacehipfort__hipblas_1_1hipblasdtrsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+782 | [hipblasCtrsv](interfacehipfort__hipblas_1_1hipblasctrsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+783 | [hipblasZtrsv](interfacehipfort__hipblas_1_1hipblasztrsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+784 | [hipblasStrsv_64](interfacehipfort__hipblas_1_1hipblasstrsv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+785 | [hipblasDtrsv_64](interfacehipfort__hipblas_1_1hipblasdtrsv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+786 | [hipblasCtrsv_64](interfacehipfort__hipblas_1_1hipblasctrsv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+787 | [hipblasZtrsv_64](interfacehipfort__hipblas_1_1hipblasztrsv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 788 | [hipblasStrsvBatched](interfacehipfort__hipblas_1_1hipblasstrsvbatched.html "Interface documentation") | C binding
 789 | [hipblasDtrsvBatched](interfacehipfort__hipblas_1_1hipblasdtrsvbatched.html "Interface documentation") | C binding
 790 | [hipblasCtrsvBatched](interfacehipfort__hipblas_1_1hipblasctrsvbatched.html "Interface documentation") | C binding
@@ -797,24 +797,24 @@
 793 | [hipblasDtrsvBatched_64](interfacehipfort__hipblas_1_1hipblasdtrsvbatched__64.html "Interface documentation") | C binding
 794 | [hipblasCtrsvBatched_64](interfacehipfort__hipblas_1_1hipblasctrsvbatched__64.html "Interface documentation") | C binding
 795 | [hipblasZtrsvBatched_64](interfacehipfort__hipblas_1_1hipblasztrsvbatched__64.html "Interface documentation") | C binding
-796 | [hipblasStrsvStridedBatched](interfacehipfort__hipblas_1_1hipblasstrsvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-797 | [hipblasDtrsvStridedBatched](interfacehipfort__hipblas_1_1hipblasdtrsvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-798 | [hipblasCtrsvStridedBatched](interfacehipfort__hipblas_1_1hipblasctrsvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-799 | [hipblasZtrsvStridedBatched](interfacehipfort__hipblas_1_1hipblasztrsvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-800 | [hipblasStrsvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasstrsvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-801 | [hipblasDtrsvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdtrsvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-802 | [hipblasCtrsvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasctrsvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-803 | [hipblasZtrsvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasztrsvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
+796 | [hipblasStrsvStridedBatched](interfacehipfort__hipblas_1_1hipblasstrsvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+797 | [hipblasDtrsvStridedBatched](interfacehipfort__hipblas_1_1hipblasdtrsvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+798 | [hipblasCtrsvStridedBatched](interfacehipfort__hipblas_1_1hipblasctrsvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+799 | [hipblasZtrsvStridedBatched](interfacehipfort__hipblas_1_1hipblasztrsvstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+800 | [hipblasStrsvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasstrsvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+801 | [hipblasDtrsvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdtrsvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+802 | [hipblasCtrsvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasctrsvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+803 | [hipblasZtrsvStridedBatched_64](interfacehipfort__hipblas_1_1hipblasztrsvstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 804 | [hipblasHgemm](interfacehipfort__hipblas_1_1hipblashgemm.html "Interface documentation") | C binding
-805 | [hipblasSgemm](interfacehipfort__hipblas_1_1hipblassgemm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-806 | [hipblasDgemm](interfacehipfort__hipblas_1_1hipblasdgemm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-807 | [hipblasCgemm](interfacehipfort__hipblas_1_1hipblascgemm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-808 | [hipblasZgemm](interfacehipfort__hipblas_1_1hipblaszgemm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+805 | [hipblasSgemm](interfacehipfort__hipblas_1_1hipblassgemm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+806 | [hipblasDgemm](interfacehipfort__hipblas_1_1hipblasdgemm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+807 | [hipblasCgemm](interfacehipfort__hipblas_1_1hipblascgemm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+808 | [hipblasZgemm](interfacehipfort__hipblas_1_1hipblaszgemm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 809 | [hipblasHgemm_64](interfacehipfort__hipblas_1_1hipblashgemm__64.html "Interface documentation") | C binding
-810 | [hipblasSgemm_64](interfacehipfort__hipblas_1_1hipblassgemm__64.html "Interface documentation") | C binding, rank_0, rank_1
-811 | [hipblasDgemm_64](interfacehipfort__hipblas_1_1hipblasdgemm__64.html "Interface documentation") | C binding, rank_0, rank_1
-812 | [hipblasCgemm_64](interfacehipfort__hipblas_1_1hipblascgemm__64.html "Interface documentation") | C binding, rank_0, rank_1
-813 | [hipblasZgemm_64](interfacehipfort__hipblas_1_1hipblaszgemm__64.html "Interface documentation") | C binding, rank_0, rank_1
+810 | [hipblasSgemm_64](interfacehipfort__hipblas_1_1hipblassgemm__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+811 | [hipblasDgemm_64](interfacehipfort__hipblas_1_1hipblasdgemm__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+812 | [hipblasCgemm_64](interfacehipfort__hipblas_1_1hipblascgemm__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+813 | [hipblasZgemm_64](interfacehipfort__hipblas_1_1hipblaszgemm__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 814 | [hipblasHgemmBatched](interfacehipfort__hipblas_1_1hipblashgemmbatched.html "Interface documentation") | C binding
 815 | [hipblasSgemmBatched](interfacehipfort__hipblas_1_1hipblassgemmbatched.html "Interface documentation") | C binding
 816 | [hipblasDgemmBatched](interfacehipfort__hipblas_1_1hipblasdgemmbatched.html "Interface documentation") | C binding
@@ -826,59 +826,59 @@
 822 | [hipblasCgemmBatched_64](interfacehipfort__hipblas_1_1hipblascgemmbatched__64.html "Interface documentation") | C binding
 823 | [hipblasZgemmBatched_64](interfacehipfort__hipblas_1_1hipblaszgemmbatched__64.html "Interface documentation") | C binding
 824 | [hipblasHgemmStridedBatched](interfacehipfort__hipblas_1_1hipblashgemmstridedbatched.html "Interface documentation") | C binding
-825 | [hipblasSgemmStridedBatched](interfacehipfort__hipblas_1_1hipblassgemmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-826 | [hipblasDgemmStridedBatched](interfacehipfort__hipblas_1_1hipblasdgemmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-827 | [hipblasCgemmStridedBatched](interfacehipfort__hipblas_1_1hipblascgemmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-828 | [hipblasZgemmStridedBatched](interfacehipfort__hipblas_1_1hipblaszgemmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+825 | [hipblasSgemmStridedBatched](interfacehipfort__hipblas_1_1hipblassgemmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+826 | [hipblasDgemmStridedBatched](interfacehipfort__hipblas_1_1hipblasdgemmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+827 | [hipblasCgemmStridedBatched](interfacehipfort__hipblas_1_1hipblascgemmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+828 | [hipblasZgemmStridedBatched](interfacehipfort__hipblas_1_1hipblaszgemmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 829 | [hipblasHgemmStridedBatched_64](interfacehipfort__hipblas_1_1hipblashgemmstridedbatched__64.html "Interface documentation") | C binding
-830 | [hipblasSgemmStridedBatched_64](interfacehipfort__hipblas_1_1hipblassgemmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-831 | [hipblasDgemmStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdgemmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-832 | [hipblasCgemmStridedBatched_64](interfacehipfort__hipblas_1_1hipblascgemmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-833 | [hipblasZgemmStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszgemmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-834 | [hipblasCherk](interfacehipfort__hipblas_1_1hipblascherk.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-835 | [hipblasZherk](interfacehipfort__hipblas_1_1hipblaszherk.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-836 | [hipblasCherk_64](interfacehipfort__hipblas_1_1hipblascherk__64.html "Interface documentation") | C binding, rank_0, rank_1
-837 | [hipblasZherk_64](interfacehipfort__hipblas_1_1hipblaszherk__64.html "Interface documentation") | C binding, rank_0, rank_1
+830 | [hipblasSgemmStridedBatched_64](interfacehipfort__hipblas_1_1hipblassgemmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+831 | [hipblasDgemmStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdgemmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+832 | [hipblasCgemmStridedBatched_64](interfacehipfort__hipblas_1_1hipblascgemmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+833 | [hipblasZgemmStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszgemmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+834 | [hipblasCherk](interfacehipfort__hipblas_1_1hipblascherk.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+835 | [hipblasZherk](interfacehipfort__hipblas_1_1hipblaszherk.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+836 | [hipblasCherk_64](interfacehipfort__hipblas_1_1hipblascherk__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+837 | [hipblasZherk_64](interfacehipfort__hipblas_1_1hipblaszherk__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 838 | [hipblasCherkBatched](interfacehipfort__hipblas_1_1hipblascherkbatched.html "Interface documentation") | C binding
 839 | [hipblasZherkBatched](interfacehipfort__hipblas_1_1hipblaszherkbatched.html "Interface documentation") | C binding
 840 | [hipblasCherkBatched_64](interfacehipfort__hipblas_1_1hipblascherkbatched__64.html "Interface documentation") | C binding
 841 | [hipblasZherkBatched_64](interfacehipfort__hipblas_1_1hipblaszherkbatched__64.html "Interface documentation") | C binding
-842 | [hipblasCherkStridedBatched](interfacehipfort__hipblas_1_1hipblascherkstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-843 | [hipblasZherkStridedBatched](interfacehipfort__hipblas_1_1hipblaszherkstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-844 | [hipblasCherkStridedBatched_64](interfacehipfort__hipblas_1_1hipblascherkstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-845 | [hipblasZherkStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszherkstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-846 | [hipblasCherkx](interfacehipfort__hipblas_1_1hipblascherkx.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-847 | [hipblasZherkx](interfacehipfort__hipblas_1_1hipblaszherkx.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-848 | [hipblasCherkx_64](interfacehipfort__hipblas_1_1hipblascherkx__64.html "Interface documentation") | C binding, rank_0, rank_1
-849 | [hipblasZherkx_64](interfacehipfort__hipblas_1_1hipblaszherkx__64.html "Interface documentation") | C binding, rank_0, rank_1
+842 | [hipblasCherkStridedBatched](interfacehipfort__hipblas_1_1hipblascherkstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+843 | [hipblasZherkStridedBatched](interfacehipfort__hipblas_1_1hipblaszherkstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+844 | [hipblasCherkStridedBatched_64](interfacehipfort__hipblas_1_1hipblascherkstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+845 | [hipblasZherkStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszherkstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+846 | [hipblasCherkx](interfacehipfort__hipblas_1_1hipblascherkx.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+847 | [hipblasZherkx](interfacehipfort__hipblas_1_1hipblaszherkx.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+848 | [hipblasCherkx_64](interfacehipfort__hipblas_1_1hipblascherkx__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+849 | [hipblasZherkx_64](interfacehipfort__hipblas_1_1hipblaszherkx__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 850 | [hipblasCherkxBatched](interfacehipfort__hipblas_1_1hipblascherkxbatched.html "Interface documentation") | C binding
 851 | [hipblasZherkxBatched](interfacehipfort__hipblas_1_1hipblaszherkxbatched.html "Interface documentation") | C binding
 852 | [hipblasCherkxBatched_64](interfacehipfort__hipblas_1_1hipblascherkxbatched__64.html "Interface documentation") | C binding
 853 | [hipblasZherkxBatched_64](interfacehipfort__hipblas_1_1hipblaszherkxbatched__64.html "Interface documentation") | C binding
-854 | [hipblasCherkxStridedBatched](interfacehipfort__hipblas_1_1hipblascherkxstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-855 | [hipblasZherkxStridedBatched](interfacehipfort__hipblas_1_1hipblaszherkxstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-856 | [hipblasCherkxStridedBatched_64](interfacehipfort__hipblas_1_1hipblascherkxstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-857 | [hipblasZherkxStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszherkxstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-858 | [hipblasCher2k](interfacehipfort__hipblas_1_1hipblascher2k.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-859 | [hipblasZher2k](interfacehipfort__hipblas_1_1hipblaszher2k.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-860 | [hipblasCher2k_64](interfacehipfort__hipblas_1_1hipblascher2k__64.html "Interface documentation") | C binding, rank_0, rank_1
-861 | [hipblasZher2k_64](interfacehipfort__hipblas_1_1hipblaszher2k__64.html "Interface documentation") | C binding, rank_0, rank_1
+854 | [hipblasCherkxStridedBatched](interfacehipfort__hipblas_1_1hipblascherkxstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+855 | [hipblasZherkxStridedBatched](interfacehipfort__hipblas_1_1hipblaszherkxstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+856 | [hipblasCherkxStridedBatched_64](interfacehipfort__hipblas_1_1hipblascherkxstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+857 | [hipblasZherkxStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszherkxstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+858 | [hipblasCher2k](interfacehipfort__hipblas_1_1hipblascher2k.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+859 | [hipblasZher2k](interfacehipfort__hipblas_1_1hipblaszher2k.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+860 | [hipblasCher2k_64](interfacehipfort__hipblas_1_1hipblascher2k__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+861 | [hipblasZher2k_64](interfacehipfort__hipblas_1_1hipblaszher2k__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 862 | [hipblasCher2kBatched](interfacehipfort__hipblas_1_1hipblascher2kbatched.html "Interface documentation") | C binding
 863 | [hipblasZher2kBatched](interfacehipfort__hipblas_1_1hipblaszher2kbatched.html "Interface documentation") | C binding
 864 | [hipblasCher2kBatched_64](interfacehipfort__hipblas_1_1hipblascher2kbatched__64.html "Interface documentation") | C binding
 865 | [hipblasZher2kBatched_64](interfacehipfort__hipblas_1_1hipblaszher2kbatched__64.html "Interface documentation") | C binding
-866 | [hipblasCher2kStridedBatched](interfacehipfort__hipblas_1_1hipblascher2kstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-867 | [hipblasZher2kStridedBatched](interfacehipfort__hipblas_1_1hipblaszher2kstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-868 | [hipblasCher2kStridedBatched_64](interfacehipfort__hipblas_1_1hipblascher2kstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-869 | [hipblasZher2kStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszher2kstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-870 | [hipblasSsymm](interfacehipfort__hipblas_1_1hipblasssymm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-871 | [hipblasDsymm](interfacehipfort__hipblas_1_1hipblasdsymm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-872 | [hipblasCsymm](interfacehipfort__hipblas_1_1hipblascsymm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-873 | [hipblasZsymm](interfacehipfort__hipblas_1_1hipblaszsymm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-874 | [hipblasSsymm_64](interfacehipfort__hipblas_1_1hipblasssymm__64.html "Interface documentation") | C binding, rank_0, rank_1
-875 | [hipblasDsymm_64](interfacehipfort__hipblas_1_1hipblasdsymm__64.html "Interface documentation") | C binding, rank_0, rank_1
-876 | [hipblasCsymm_64](interfacehipfort__hipblas_1_1hipblascsymm__64.html "Interface documentation") | C binding, rank_0, rank_1
-877 | [hipblasZsymm_64](interfacehipfort__hipblas_1_1hipblaszsymm__64.html "Interface documentation") | C binding, rank_0, rank_1
+866 | [hipblasCher2kStridedBatched](interfacehipfort__hipblas_1_1hipblascher2kstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+867 | [hipblasZher2kStridedBatched](interfacehipfort__hipblas_1_1hipblaszher2kstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+868 | [hipblasCher2kStridedBatched_64](interfacehipfort__hipblas_1_1hipblascher2kstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+869 | [hipblasZher2kStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszher2kstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+870 | [hipblasSsymm](interfacehipfort__hipblas_1_1hipblasssymm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+871 | [hipblasDsymm](interfacehipfort__hipblas_1_1hipblasdsymm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+872 | [hipblasCsymm](interfacehipfort__hipblas_1_1hipblascsymm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+873 | [hipblasZsymm](interfacehipfort__hipblas_1_1hipblaszsymm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+874 | [hipblasSsymm_64](interfacehipfort__hipblas_1_1hipblasssymm__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+875 | [hipblasDsymm_64](interfacehipfort__hipblas_1_1hipblasdsymm__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+876 | [hipblasCsymm_64](interfacehipfort__hipblas_1_1hipblascsymm__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+877 | [hipblasZsymm_64](interfacehipfort__hipblas_1_1hipblaszsymm__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 878 | [hipblasSsymmBatched](interfacehipfort__hipblas_1_1hipblasssymmbatched.html "Interface documentation") | C binding
 879 | [hipblasDsymmBatched](interfacehipfort__hipblas_1_1hipblasdsymmbatched.html "Interface documentation") | C binding
 880 | [hipblasCsymmBatched](interfacehipfort__hipblas_1_1hipblascsymmbatched.html "Interface documentation") | C binding
@@ -887,22 +887,22 @@
 883 | [hipblasDsymmBatched_64](interfacehipfort__hipblas_1_1hipblasdsymmbatched__64.html "Interface documentation") | C binding
 884 | [hipblasCsymmBatched_64](interfacehipfort__hipblas_1_1hipblascsymmbatched__64.html "Interface documentation") | C binding
 885 | [hipblasZsymmBatched_64](interfacehipfort__hipblas_1_1hipblaszsymmbatched__64.html "Interface documentation") | C binding
-886 | [hipblasSsymmStridedBatched](interfacehipfort__hipblas_1_1hipblasssymmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-887 | [hipblasDsymmStridedBatched](interfacehipfort__hipblas_1_1hipblasdsymmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-888 | [hipblasCsymmStridedBatched](interfacehipfort__hipblas_1_1hipblascsymmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-889 | [hipblasZsymmStridedBatched](interfacehipfort__hipblas_1_1hipblaszsymmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-890 | [hipblasSsymmStridedBatched_64](interfacehipfort__hipblas_1_1hipblasssymmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-891 | [hipblasDsymmStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdsymmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-892 | [hipblasCsymmStridedBatched_64](interfacehipfort__hipblas_1_1hipblascsymmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-893 | [hipblasZsymmStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszsymmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-894 | [hipblasSsyrk](interfacehipfort__hipblas_1_1hipblasssyrk.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-895 | [hipblasDsyrk](interfacehipfort__hipblas_1_1hipblasdsyrk.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-896 | [hipblasCsyrk](interfacehipfort__hipblas_1_1hipblascsyrk.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-897 | [hipblasZsyrk](interfacehipfort__hipblas_1_1hipblaszsyrk.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-898 | [hipblasSsyrk_64](interfacehipfort__hipblas_1_1hipblasssyrk__64.html "Interface documentation") | C binding, rank_0, rank_1
-899 | [hipblasDsyrk_64](interfacehipfort__hipblas_1_1hipblasdsyrk__64.html "Interface documentation") | C binding, rank_0, rank_1
-900 | [hipblasCsyrk_64](interfacehipfort__hipblas_1_1hipblascsyrk__64.html "Interface documentation") | C binding, rank_0, rank_1
-901 | [hipblasZsyrk_64](interfacehipfort__hipblas_1_1hipblaszsyrk__64.html "Interface documentation") | C binding, rank_0, rank_1
+886 | [hipblasSsymmStridedBatched](interfacehipfort__hipblas_1_1hipblasssymmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+887 | [hipblasDsymmStridedBatched](interfacehipfort__hipblas_1_1hipblasdsymmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+888 | [hipblasCsymmStridedBatched](interfacehipfort__hipblas_1_1hipblascsymmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+889 | [hipblasZsymmStridedBatched](interfacehipfort__hipblas_1_1hipblaszsymmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+890 | [hipblasSsymmStridedBatched_64](interfacehipfort__hipblas_1_1hipblasssymmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+891 | [hipblasDsymmStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdsymmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+892 | [hipblasCsymmStridedBatched_64](interfacehipfort__hipblas_1_1hipblascsymmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+893 | [hipblasZsymmStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszsymmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+894 | [hipblasSsyrk](interfacehipfort__hipblas_1_1hipblasssyrk.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+895 | [hipblasDsyrk](interfacehipfort__hipblas_1_1hipblasdsyrk.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+896 | [hipblasCsyrk](interfacehipfort__hipblas_1_1hipblascsyrk.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+897 | [hipblasZsyrk](interfacehipfort__hipblas_1_1hipblaszsyrk.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+898 | [hipblasSsyrk_64](interfacehipfort__hipblas_1_1hipblasssyrk__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+899 | [hipblasDsyrk_64](interfacehipfort__hipblas_1_1hipblasdsyrk__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+900 | [hipblasCsyrk_64](interfacehipfort__hipblas_1_1hipblascsyrk__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+901 | [hipblasZsyrk_64](interfacehipfort__hipblas_1_1hipblaszsyrk__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 902 | [hipblasSsyrkBatched](interfacehipfort__hipblas_1_1hipblasssyrkbatched.html "Interface documentation") | C binding
 903 | [hipblasDsyrkBatched](interfacehipfort__hipblas_1_1hipblasdsyrkbatched.html "Interface documentation") | C binding
 904 | [hipblasCsyrkBatched](interfacehipfort__hipblas_1_1hipblascsyrkbatched.html "Interface documentation") | C binding
@@ -911,22 +911,22 @@
 907 | [hipblasDsyrkBatched_64](interfacehipfort__hipblas_1_1hipblasdsyrkbatched__64.html "Interface documentation") | C binding
 908 | [hipblasCsyrkBatched_64](interfacehipfort__hipblas_1_1hipblascsyrkbatched__64.html "Interface documentation") | C binding
 909 | [hipblasZsyrkBatched_64](interfacehipfort__hipblas_1_1hipblaszsyrkbatched__64.html "Interface documentation") | C binding
-910 | [hipblasSsyrkStridedBatched](interfacehipfort__hipblas_1_1hipblasssyrkstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-911 | [hipblasDsyrkStridedBatched](interfacehipfort__hipblas_1_1hipblasdsyrkstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-912 | [hipblasCsyrkStridedBatched](interfacehipfort__hipblas_1_1hipblascsyrkstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-913 | [hipblasZsyrkStridedBatched](interfacehipfort__hipblas_1_1hipblaszsyrkstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-914 | [hipblasSsyrkStridedBatched_64](interfacehipfort__hipblas_1_1hipblasssyrkstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-915 | [hipblasDsyrkStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdsyrkstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-916 | [hipblasCsyrkStridedBatched_64](interfacehipfort__hipblas_1_1hipblascsyrkstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-917 | [hipblasZsyrkStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszsyrkstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-918 | [hipblasSsyr2k](interfacehipfort__hipblas_1_1hipblasssyr2k.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-919 | [hipblasDsyr2k](interfacehipfort__hipblas_1_1hipblasdsyr2k.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-920 | [hipblasCsyr2k](interfacehipfort__hipblas_1_1hipblascsyr2k.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-921 | [hipblasZsyr2k](interfacehipfort__hipblas_1_1hipblaszsyr2k.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-922 | [hipblasSsyr2k_64](interfacehipfort__hipblas_1_1hipblasssyr2k__64.html "Interface documentation") | C binding, rank_0, rank_1
-923 | [hipblasDsyr2k_64](interfacehipfort__hipblas_1_1hipblasdsyr2k__64.html "Interface documentation") | C binding, rank_0, rank_1
-924 | [hipblasCsyr2k_64](interfacehipfort__hipblas_1_1hipblascsyr2k__64.html "Interface documentation") | C binding, rank_0, rank_1
-925 | [hipblasZsyr2k_64](interfacehipfort__hipblas_1_1hipblaszsyr2k__64.html "Interface documentation") | C binding, rank_0, rank_1
+910 | [hipblasSsyrkStridedBatched](interfacehipfort__hipblas_1_1hipblasssyrkstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+911 | [hipblasDsyrkStridedBatched](interfacehipfort__hipblas_1_1hipblasdsyrkstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+912 | [hipblasCsyrkStridedBatched](interfacehipfort__hipblas_1_1hipblascsyrkstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+913 | [hipblasZsyrkStridedBatched](interfacehipfort__hipblas_1_1hipblaszsyrkstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+914 | [hipblasSsyrkStridedBatched_64](interfacehipfort__hipblas_1_1hipblasssyrkstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+915 | [hipblasDsyrkStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdsyrkstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+916 | [hipblasCsyrkStridedBatched_64](interfacehipfort__hipblas_1_1hipblascsyrkstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+917 | [hipblasZsyrkStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszsyrkstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+918 | [hipblasSsyr2k](interfacehipfort__hipblas_1_1hipblasssyr2k.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+919 | [hipblasDsyr2k](interfacehipfort__hipblas_1_1hipblasdsyr2k.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+920 | [hipblasCsyr2k](interfacehipfort__hipblas_1_1hipblascsyr2k.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+921 | [hipblasZsyr2k](interfacehipfort__hipblas_1_1hipblaszsyr2k.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+922 | [hipblasSsyr2k_64](interfacehipfort__hipblas_1_1hipblasssyr2k__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+923 | [hipblasDsyr2k_64](interfacehipfort__hipblas_1_1hipblasdsyr2k__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+924 | [hipblasCsyr2k_64](interfacehipfort__hipblas_1_1hipblascsyr2k__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+925 | [hipblasZsyr2k_64](interfacehipfort__hipblas_1_1hipblaszsyr2k__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 926 | [hipblasSsyr2kBatched](interfacehipfort__hipblas_1_1hipblasssyr2kbatched.html "Interface documentation") | C binding
 927 | [hipblasDsyr2kBatched](interfacehipfort__hipblas_1_1hipblasdsyr2kbatched.html "Interface documentation") | C binding
 928 | [hipblasCsyr2kBatched](interfacehipfort__hipblas_1_1hipblascsyr2kbatched.html "Interface documentation") | C binding
@@ -935,22 +935,22 @@
 931 | [hipblasDsyr2kBatched_64](interfacehipfort__hipblas_1_1hipblasdsyr2kbatched__64.html "Interface documentation") | C binding
 932 | [hipblasCsyr2kBatched_64](interfacehipfort__hipblas_1_1hipblascsyr2kbatched__64.html "Interface documentation") | C binding
 933 | [hipblasZsyr2kBatched_64](interfacehipfort__hipblas_1_1hipblaszsyr2kbatched__64.html "Interface documentation") | C binding
-934 | [hipblasSsyr2kStridedBatched](interfacehipfort__hipblas_1_1hipblasssyr2kstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-935 | [hipblasDsyr2kStridedBatched](interfacehipfort__hipblas_1_1hipblasdsyr2kstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-936 | [hipblasCsyr2kStridedBatched](interfacehipfort__hipblas_1_1hipblascsyr2kstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-937 | [hipblasZsyr2kStridedBatched](interfacehipfort__hipblas_1_1hipblaszsyr2kstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-938 | [hipblasSsyr2kStridedBatched_64](interfacehipfort__hipblas_1_1hipblasssyr2kstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-939 | [hipblasDsyr2kStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdsyr2kstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-940 | [hipblasCsyr2kStridedBatched_64](interfacehipfort__hipblas_1_1hipblascsyr2kstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-941 | [hipblasZsyr2kStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszsyr2kstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-942 | [hipblasSsyrkx](interfacehipfort__hipblas_1_1hipblasssyrkx.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-943 | [hipblasDsyrkx](interfacehipfort__hipblas_1_1hipblasdsyrkx.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-944 | [hipblasCsyrkx](interfacehipfort__hipblas_1_1hipblascsyrkx.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-945 | [hipblasZsyrkx](interfacehipfort__hipblas_1_1hipblaszsyrkx.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-946 | [hipblasSsyrkx_64](interfacehipfort__hipblas_1_1hipblasssyrkx__64.html "Interface documentation") | C binding, rank_0, rank_1
-947 | [hipblasDsyrkx_64](interfacehipfort__hipblas_1_1hipblasdsyrkx__64.html "Interface documentation") | C binding, rank_0, rank_1
-948 | [hipblasCsyrkx_64](interfacehipfort__hipblas_1_1hipblascsyrkx__64.html "Interface documentation") | C binding, rank_0, rank_1
-949 | [hipblasZsyrkx_64](interfacehipfort__hipblas_1_1hipblaszsyrkx__64.html "Interface documentation") | C binding, rank_0, rank_1
+934 | [hipblasSsyr2kStridedBatched](interfacehipfort__hipblas_1_1hipblasssyr2kstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+935 | [hipblasDsyr2kStridedBatched](interfacehipfort__hipblas_1_1hipblasdsyr2kstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+936 | [hipblasCsyr2kStridedBatched](interfacehipfort__hipblas_1_1hipblascsyr2kstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+937 | [hipblasZsyr2kStridedBatched](interfacehipfort__hipblas_1_1hipblaszsyr2kstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+938 | [hipblasSsyr2kStridedBatched_64](interfacehipfort__hipblas_1_1hipblasssyr2kstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+939 | [hipblasDsyr2kStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdsyr2kstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+940 | [hipblasCsyr2kStridedBatched_64](interfacehipfort__hipblas_1_1hipblascsyr2kstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+941 | [hipblasZsyr2kStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszsyr2kstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+942 | [hipblasSsyrkx](interfacehipfort__hipblas_1_1hipblasssyrkx.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+943 | [hipblasDsyrkx](interfacehipfort__hipblas_1_1hipblasdsyrkx.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+944 | [hipblasCsyrkx](interfacehipfort__hipblas_1_1hipblascsyrkx.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+945 | [hipblasZsyrkx](interfacehipfort__hipblas_1_1hipblaszsyrkx.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+946 | [hipblasSsyrkx_64](interfacehipfort__hipblas_1_1hipblasssyrkx__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+947 | [hipblasDsyrkx_64](interfacehipfort__hipblas_1_1hipblasdsyrkx__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+948 | [hipblasCsyrkx_64](interfacehipfort__hipblas_1_1hipblascsyrkx__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+949 | [hipblasZsyrkx_64](interfacehipfort__hipblas_1_1hipblaszsyrkx__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 950 | [hipblasSsyrkxBatched](interfacehipfort__hipblas_1_1hipblasssyrkxbatched.html "Interface documentation") | C binding
 951 | [hipblasDsyrkxBatched](interfacehipfort__hipblas_1_1hipblasdsyrkxbatched.html "Interface documentation") | C binding
 952 | [hipblasCsyrkxBatched](interfacehipfort__hipblas_1_1hipblascsyrkxbatched.html "Interface documentation") | C binding
@@ -959,22 +959,22 @@
 955 | [hipblasDsyrkxBatched_64](interfacehipfort__hipblas_1_1hipblasdsyrkxbatched__64.html "Interface documentation") | C binding
 956 | [hipblasCsyrkxBatched_64](interfacehipfort__hipblas_1_1hipblascsyrkxbatched__64.html "Interface documentation") | C binding
 957 | [hipblasZsyrkxBatched_64](interfacehipfort__hipblas_1_1hipblaszsyrkxbatched__64.html "Interface documentation") | C binding
-958 | [hipblasSsyrkxStridedBatched](interfacehipfort__hipblas_1_1hipblasssyrkxstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-959 | [hipblasDsyrkxStridedBatched](interfacehipfort__hipblas_1_1hipblasdsyrkxstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-960 | [hipblasCsyrkxStridedBatched](interfacehipfort__hipblas_1_1hipblascsyrkxstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-961 | [hipblasZsyrkxStridedBatched](interfacehipfort__hipblas_1_1hipblaszsyrkxstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-962 | [hipblasSsyrkxStridedBatched_64](interfacehipfort__hipblas_1_1hipblasssyrkxstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-963 | [hipblasDsyrkxStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdsyrkxstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-964 | [hipblasCsyrkxStridedBatched_64](interfacehipfort__hipblas_1_1hipblascsyrkxstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-965 | [hipblasZsyrkxStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszsyrkxstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-966 | [hipblasSgeam](interfacehipfort__hipblas_1_1hipblassgeam.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-967 | [hipblasDgeam](interfacehipfort__hipblas_1_1hipblasdgeam.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-968 | [hipblasCgeam](interfacehipfort__hipblas_1_1hipblascgeam.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-969 | [hipblasZgeam](interfacehipfort__hipblas_1_1hipblaszgeam.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-970 | [hipblasSgeam_64](interfacehipfort__hipblas_1_1hipblassgeam__64.html "Interface documentation") | C binding, rank_0, rank_1
-971 | [hipblasDgeam_64](interfacehipfort__hipblas_1_1hipblasdgeam__64.html "Interface documentation") | C binding, rank_0, rank_1
-972 | [hipblasCgeam_64](interfacehipfort__hipblas_1_1hipblascgeam__64.html "Interface documentation") | C binding, rank_0, rank_1
-973 | [hipblasZgeam_64](interfacehipfort__hipblas_1_1hipblaszgeam__64.html "Interface documentation") | C binding, rank_0, rank_1
+958 | [hipblasSsyrkxStridedBatched](interfacehipfort__hipblas_1_1hipblasssyrkxstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+959 | [hipblasDsyrkxStridedBatched](interfacehipfort__hipblas_1_1hipblasdsyrkxstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+960 | [hipblasCsyrkxStridedBatched](interfacehipfort__hipblas_1_1hipblascsyrkxstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+961 | [hipblasZsyrkxStridedBatched](interfacehipfort__hipblas_1_1hipblaszsyrkxstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+962 | [hipblasSsyrkxStridedBatched_64](interfacehipfort__hipblas_1_1hipblasssyrkxstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+963 | [hipblasDsyrkxStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdsyrkxstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+964 | [hipblasCsyrkxStridedBatched_64](interfacehipfort__hipblas_1_1hipblascsyrkxstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+965 | [hipblasZsyrkxStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszsyrkxstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+966 | [hipblasSgeam](interfacehipfort__hipblas_1_1hipblassgeam.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+967 | [hipblasDgeam](interfacehipfort__hipblas_1_1hipblasdgeam.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+968 | [hipblasCgeam](interfacehipfort__hipblas_1_1hipblascgeam.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+969 | [hipblasZgeam](interfacehipfort__hipblas_1_1hipblaszgeam.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+970 | [hipblasSgeam_64](interfacehipfort__hipblas_1_1hipblassgeam__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+971 | [hipblasDgeam_64](interfacehipfort__hipblas_1_1hipblasdgeam__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+972 | [hipblasCgeam_64](interfacehipfort__hipblas_1_1hipblascgeam__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+973 | [hipblasZgeam_64](interfacehipfort__hipblas_1_1hipblaszgeam__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 974 | [hipblasSgeamBatched](interfacehipfort__hipblas_1_1hipblassgeambatched.html "Interface documentation") | C binding
 975 | [hipblasDgeamBatched](interfacehipfort__hipblas_1_1hipblasdgeambatched.html "Interface documentation") | C binding
 976 | [hipblasCgeamBatched](interfacehipfort__hipblas_1_1hipblascgeambatched.html "Interface documentation") | C binding
@@ -983,34 +983,34 @@
 979 | [hipblasDgeamBatched_64](interfacehipfort__hipblas_1_1hipblasdgeambatched__64.html "Interface documentation") | C binding
 980 | [hipblasCgeamBatched_64](interfacehipfort__hipblas_1_1hipblascgeambatched__64.html "Interface documentation") | C binding
 981 | [hipblasZgeamBatched_64](interfacehipfort__hipblas_1_1hipblaszgeambatched__64.html "Interface documentation") | C binding
-982 | [hipblasSgeamStridedBatched](interfacehipfort__hipblas_1_1hipblassgeamstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-983 | [hipblasDgeamStridedBatched](interfacehipfort__hipblas_1_1hipblasdgeamstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-984 | [hipblasCgeamStridedBatched](interfacehipfort__hipblas_1_1hipblascgeamstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-985 | [hipblasZgeamStridedBatched](interfacehipfort__hipblas_1_1hipblaszgeamstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-986 | [hipblasSgeamStridedBatched_64](interfacehipfort__hipblas_1_1hipblassgeamstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-987 | [hipblasDgeamStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdgeamstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-988 | [hipblasCgeamStridedBatched_64](interfacehipfort__hipblas_1_1hipblascgeamstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-989 | [hipblasZgeamStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszgeamstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-990 | [hipblasChemm](interfacehipfort__hipblas_1_1hipblaschemm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-991 | [hipblasZhemm](interfacehipfort__hipblas_1_1hipblaszhemm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-992 | [hipblasChemm_64](interfacehipfort__hipblas_1_1hipblaschemm__64.html "Interface documentation") | C binding, rank_0, rank_1
-993 | [hipblasZhemm_64](interfacehipfort__hipblas_1_1hipblaszhemm__64.html "Interface documentation") | C binding, rank_0, rank_1
+982 | [hipblasSgeamStridedBatched](interfacehipfort__hipblas_1_1hipblassgeamstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+983 | [hipblasDgeamStridedBatched](interfacehipfort__hipblas_1_1hipblasdgeamstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+984 | [hipblasCgeamStridedBatched](interfacehipfort__hipblas_1_1hipblascgeamstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+985 | [hipblasZgeamStridedBatched](interfacehipfort__hipblas_1_1hipblaszgeamstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+986 | [hipblasSgeamStridedBatched_64](interfacehipfort__hipblas_1_1hipblassgeamstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+987 | [hipblasDgeamStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdgeamstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+988 | [hipblasCgeamStridedBatched_64](interfacehipfort__hipblas_1_1hipblascgeamstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+989 | [hipblasZgeamStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszgeamstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+990 | [hipblasChemm](interfacehipfort__hipblas_1_1hipblaschemm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+991 | [hipblasZhemm](interfacehipfort__hipblas_1_1hipblaszhemm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+992 | [hipblasChemm_64](interfacehipfort__hipblas_1_1hipblaschemm__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+993 | [hipblasZhemm_64](interfacehipfort__hipblas_1_1hipblaszhemm__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 994 | [hipblasChemmBatched](interfacehipfort__hipblas_1_1hipblaschemmbatched.html "Interface documentation") | C binding
 995 | [hipblasZhemmBatched](interfacehipfort__hipblas_1_1hipblaszhemmbatched.html "Interface documentation") | C binding
 996 | [hipblasChemmBatched_64](interfacehipfort__hipblas_1_1hipblaschemmbatched__64.html "Interface documentation") | C binding
 997 | [hipblasZhemmBatched_64](interfacehipfort__hipblas_1_1hipblaszhemmbatched__64.html "Interface documentation") | C binding
-998 | [hipblasChemmStridedBatched](interfacehipfort__hipblas_1_1hipblaschemmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-999 | [hipblasZhemmStridedBatched](interfacehipfort__hipblas_1_1hipblaszhemmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1000 | [hipblasChemmStridedBatched_64](interfacehipfort__hipblas_1_1hipblaschemmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-1001 | [hipblasZhemmStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszhemmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-1002 | [hipblasStrmm](interfacehipfort__hipblas_1_1hipblasstrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1003 | [hipblasDtrmm](interfacehipfort__hipblas_1_1hipblasdtrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1004 | [hipblasCtrmm](interfacehipfort__hipblas_1_1hipblasctrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1005 | [hipblasZtrmm](interfacehipfort__hipblas_1_1hipblasztrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1006 | [hipblasStrmm_64](interfacehipfort__hipblas_1_1hipblasstrmm__64.html "Interface documentation") | C binding, rank_0, rank_1
-1007 | [hipblasDtrmm_64](interfacehipfort__hipblas_1_1hipblasdtrmm__64.html "Interface documentation") | C binding, rank_0, rank_1
-1008 | [hipblasCtrmm_64](interfacehipfort__hipblas_1_1hipblasctrmm__64.html "Interface documentation") | C binding, rank_0, rank_1
-1009 | [hipblasZtrmm_64](interfacehipfort__hipblas_1_1hipblasztrmm__64.html "Interface documentation") | C binding, rank_0, rank_1
+998 | [hipblasChemmStridedBatched](interfacehipfort__hipblas_1_1hipblaschemmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+999 | [hipblasZhemmStridedBatched](interfacehipfort__hipblas_1_1hipblaszhemmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1000 | [hipblasChemmStridedBatched_64](interfacehipfort__hipblas_1_1hipblaschemmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1001 | [hipblasZhemmStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszhemmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1002 | [hipblasStrmm](interfacehipfort__hipblas_1_1hipblasstrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1003 | [hipblasDtrmm](interfacehipfort__hipblas_1_1hipblasdtrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1004 | [hipblasCtrmm](interfacehipfort__hipblas_1_1hipblasctrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1005 | [hipblasZtrmm](interfacehipfort__hipblas_1_1hipblasztrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1006 | [hipblasStrmm_64](interfacehipfort__hipblas_1_1hipblasstrmm__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1007 | [hipblasDtrmm_64](interfacehipfort__hipblas_1_1hipblasdtrmm__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1008 | [hipblasCtrmm_64](interfacehipfort__hipblas_1_1hipblasctrmm__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1009 | [hipblasZtrmm_64](interfacehipfort__hipblas_1_1hipblasztrmm__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 1010 | [hipblasStrmmBatched](interfacehipfort__hipblas_1_1hipblasstrmmbatched.html "Interface documentation") | C binding
 1011 | [hipblasDtrmmBatched](interfacehipfort__hipblas_1_1hipblasdtrmmbatched.html "Interface documentation") | C binding
 1012 | [hipblasCtrmmBatched](interfacehipfort__hipblas_1_1hipblasctrmmbatched.html "Interface documentation") | C binding
@@ -1019,22 +1019,22 @@
 1015 | [hipblasDtrmmBatched_64](interfacehipfort__hipblas_1_1hipblasdtrmmbatched__64.html "Interface documentation") | C binding
 1016 | [hipblasCtrmmBatched_64](interfacehipfort__hipblas_1_1hipblasctrmmbatched__64.html "Interface documentation") | C binding
 1017 | [hipblasZtrmmBatched_64](interfacehipfort__hipblas_1_1hipblasztrmmbatched__64.html "Interface documentation") | C binding
-1018 | [hipblasStrmmStridedBatched](interfacehipfort__hipblas_1_1hipblasstrmmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1019 | [hipblasDtrmmStridedBatched](interfacehipfort__hipblas_1_1hipblasdtrmmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1020 | [hipblasCtrmmStridedBatched](interfacehipfort__hipblas_1_1hipblasctrmmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1021 | [hipblasZtrmmStridedBatched](interfacehipfort__hipblas_1_1hipblasztrmmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1022 | [hipblasStrmmStridedBatched_64](interfacehipfort__hipblas_1_1hipblasstrmmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-1023 | [hipblasDtrmmStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdtrmmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-1024 | [hipblasCtrmmStridedBatched_64](interfacehipfort__hipblas_1_1hipblasctrmmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-1025 | [hipblasZtrmmStridedBatched_64](interfacehipfort__hipblas_1_1hipblasztrmmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-1026 | [hipblasStrsm](interfacehipfort__hipblas_1_1hipblasstrsm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1027 | [hipblasDtrsm](interfacehipfort__hipblas_1_1hipblasdtrsm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1028 | [hipblasCtrsm](interfacehipfort__hipblas_1_1hipblasctrsm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1029 | [hipblasZtrsm](interfacehipfort__hipblas_1_1hipblasztrsm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1030 | [hipblasStrsm_64](interfacehipfort__hipblas_1_1hipblasstrsm__64.html "Interface documentation") | C binding, rank_0, rank_1
-1031 | [hipblasDtrsm_64](interfacehipfort__hipblas_1_1hipblasdtrsm__64.html "Interface documentation") | C binding, rank_0, rank_1
-1032 | [hipblasCtrsm_64](interfacehipfort__hipblas_1_1hipblasctrsm__64.html "Interface documentation") | C binding, rank_0, rank_1
-1033 | [hipblasZtrsm_64](interfacehipfort__hipblas_1_1hipblasztrsm__64.html "Interface documentation") | C binding, rank_0, rank_1
+1018 | [hipblasStrmmStridedBatched](interfacehipfort__hipblas_1_1hipblasstrmmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1019 | [hipblasDtrmmStridedBatched](interfacehipfort__hipblas_1_1hipblasdtrmmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1020 | [hipblasCtrmmStridedBatched](interfacehipfort__hipblas_1_1hipblasctrmmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1021 | [hipblasZtrmmStridedBatched](interfacehipfort__hipblas_1_1hipblasztrmmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1022 | [hipblasStrmmStridedBatched_64](interfacehipfort__hipblas_1_1hipblasstrmmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1023 | [hipblasDtrmmStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdtrmmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1024 | [hipblasCtrmmStridedBatched_64](interfacehipfort__hipblas_1_1hipblasctrmmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1025 | [hipblasZtrmmStridedBatched_64](interfacehipfort__hipblas_1_1hipblasztrmmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1026 | [hipblasStrsm](interfacehipfort__hipblas_1_1hipblasstrsm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1027 | [hipblasDtrsm](interfacehipfort__hipblas_1_1hipblasdtrsm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1028 | [hipblasCtrsm](interfacehipfort__hipblas_1_1hipblasctrsm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1029 | [hipblasZtrsm](interfacehipfort__hipblas_1_1hipblasztrsm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1030 | [hipblasStrsm_64](interfacehipfort__hipblas_1_1hipblasstrsm__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1031 | [hipblasDtrsm_64](interfacehipfort__hipblas_1_1hipblasdtrsm__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1032 | [hipblasCtrsm_64](interfacehipfort__hipblas_1_1hipblasctrsm__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1033 | [hipblasZtrsm_64](interfacehipfort__hipblas_1_1hipblasztrsm__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 1034 | [hipblasStrsmBatched](interfacehipfort__hipblas_1_1hipblasstrsmbatched.html "Interface documentation") | C binding
 1035 | [hipblasDtrsmBatched](interfacehipfort__hipblas_1_1hipblasdtrsmbatched.html "Interface documentation") | C binding
 1036 | [hipblasCtrsmBatched](interfacehipfort__hipblas_1_1hipblasctrsmbatched.html "Interface documentation") | C binding
@@ -1043,34 +1043,34 @@
 1039 | [hipblasDtrsmBatched_64](interfacehipfort__hipblas_1_1hipblasdtrsmbatched__64.html "Interface documentation") | C binding
 1040 | [hipblasCtrsmBatched_64](interfacehipfort__hipblas_1_1hipblasctrsmbatched__64.html "Interface documentation") | C binding
 1041 | [hipblasZtrsmBatched_64](interfacehipfort__hipblas_1_1hipblasztrsmbatched__64.html "Interface documentation") | C binding
-1042 | [hipblasStrsmStridedBatched](interfacehipfort__hipblas_1_1hipblasstrsmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1043 | [hipblasDtrsmStridedBatched](interfacehipfort__hipblas_1_1hipblasdtrsmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1044 | [hipblasCtrsmStridedBatched](interfacehipfort__hipblas_1_1hipblasctrsmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1045 | [hipblasZtrsmStridedBatched](interfacehipfort__hipblas_1_1hipblasztrsmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1046 | [hipblasStrsmStridedBatched_64](interfacehipfort__hipblas_1_1hipblasstrsmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-1047 | [hipblasDtrsmStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdtrsmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-1048 | [hipblasCtrsmStridedBatched_64](interfacehipfort__hipblas_1_1hipblasctrsmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-1049 | [hipblasZtrsmStridedBatched_64](interfacehipfort__hipblas_1_1hipblasztrsmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-1050 | [hipblasStrtri](interfacehipfort__hipblas_1_1hipblasstrtri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1051 | [hipblasDtrtri](interfacehipfort__hipblas_1_1hipblasdtrtri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1052 | [hipblasCtrtri](interfacehipfort__hipblas_1_1hipblasctrtri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1053 | [hipblasZtrtri](interfacehipfort__hipblas_1_1hipblasztrtri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1042 | [hipblasStrsmStridedBatched](interfacehipfort__hipblas_1_1hipblasstrsmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1043 | [hipblasDtrsmStridedBatched](interfacehipfort__hipblas_1_1hipblasdtrsmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1044 | [hipblasCtrsmStridedBatched](interfacehipfort__hipblas_1_1hipblasctrsmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1045 | [hipblasZtrsmStridedBatched](interfacehipfort__hipblas_1_1hipblasztrsmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1046 | [hipblasStrsmStridedBatched_64](interfacehipfort__hipblas_1_1hipblasstrsmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1047 | [hipblasDtrsmStridedBatched_64](interfacehipfort__hipblas_1_1hipblasdtrsmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1048 | [hipblasCtrsmStridedBatched_64](interfacehipfort__hipblas_1_1hipblasctrsmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1049 | [hipblasZtrsmStridedBatched_64](interfacehipfort__hipblas_1_1hipblasztrsmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1050 | [hipblasStrtri](interfacehipfort__hipblas_1_1hipblasstrtri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1051 | [hipblasDtrtri](interfacehipfort__hipblas_1_1hipblasdtrtri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1052 | [hipblasCtrtri](interfacehipfort__hipblas_1_1hipblasctrtri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1053 | [hipblasZtrtri](interfacehipfort__hipblas_1_1hipblasztrtri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 1054 | [hipblasStrtriBatched](interfacehipfort__hipblas_1_1hipblasstrtribatched.html "Interface documentation") | C binding
 1055 | [hipblasDtrtriBatched](interfacehipfort__hipblas_1_1hipblasdtrtribatched.html "Interface documentation") | C binding
 1056 | [hipblasCtrtriBatched](interfacehipfort__hipblas_1_1hipblasctrtribatched.html "Interface documentation") | C binding
 1057 | [hipblasZtrtriBatched](interfacehipfort__hipblas_1_1hipblasztrtribatched.html "Interface documentation") | C binding
-1058 | [hipblasStrtriStridedBatched](interfacehipfort__hipblas_1_1hipblasstrtristridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1059 | [hipblasDtrtriStridedBatched](interfacehipfort__hipblas_1_1hipblasdtrtristridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1060 | [hipblasCtrtriStridedBatched](interfacehipfort__hipblas_1_1hipblasctrtristridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1061 | [hipblasZtrtriStridedBatched](interfacehipfort__hipblas_1_1hipblasztrtristridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1062 | [hipblasSdgmm](interfacehipfort__hipblas_1_1hipblassdgmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1063 | [hipblasDdgmm](interfacehipfort__hipblas_1_1hipblasddgmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1064 | [hipblasCdgmm](interfacehipfort__hipblas_1_1hipblascdgmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1065 | [hipblasZdgmm](interfacehipfort__hipblas_1_1hipblaszdgmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1066 | [hipblasSdgmm_64](interfacehipfort__hipblas_1_1hipblassdgmm__64.html "Interface documentation") | C binding, rank_0, rank_1
-1067 | [hipblasDdgmm_64](interfacehipfort__hipblas_1_1hipblasddgmm__64.html "Interface documentation") | C binding, rank_0, rank_1
-1068 | [hipblasCdgmm_64](interfacehipfort__hipblas_1_1hipblascdgmm__64.html "Interface documentation") | C binding, rank_0, rank_1
-1069 | [hipblasZdgmm_64](interfacehipfort__hipblas_1_1hipblaszdgmm__64.html "Interface documentation") | C binding, rank_0, rank_1
+1058 | [hipblasStrtriStridedBatched](interfacehipfort__hipblas_1_1hipblasstrtristridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1059 | [hipblasDtrtriStridedBatched](interfacehipfort__hipblas_1_1hipblasdtrtristridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1060 | [hipblasCtrtriStridedBatched](interfacehipfort__hipblas_1_1hipblasctrtristridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1061 | [hipblasZtrtriStridedBatched](interfacehipfort__hipblas_1_1hipblasztrtristridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1062 | [hipblasSdgmm](interfacehipfort__hipblas_1_1hipblassdgmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1063 | [hipblasDdgmm](interfacehipfort__hipblas_1_1hipblasddgmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1064 | [hipblasCdgmm](interfacehipfort__hipblas_1_1hipblascdgmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1065 | [hipblasZdgmm](interfacehipfort__hipblas_1_1hipblaszdgmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1066 | [hipblasSdgmm_64](interfacehipfort__hipblas_1_1hipblassdgmm__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1067 | [hipblasDdgmm_64](interfacehipfort__hipblas_1_1hipblasddgmm__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1068 | [hipblasCdgmm_64](interfacehipfort__hipblas_1_1hipblascdgmm__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1069 | [hipblasZdgmm_64](interfacehipfort__hipblas_1_1hipblaszdgmm__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 1070 | [hipblasSdgmmBatched](interfacehipfort__hipblas_1_1hipblassdgmmbatched.html "Interface documentation") | C binding
 1071 | [hipblasDdgmmBatched](interfacehipfort__hipblas_1_1hipblasddgmmbatched.html "Interface documentation") | C binding
 1072 | [hipblasCdgmmBatched](interfacehipfort__hipblas_1_1hipblascdgmmbatched.html "Interface documentation") | C binding
@@ -1079,66 +1079,66 @@
 1075 | [hipblasDdgmmBatched_64](interfacehipfort__hipblas_1_1hipblasddgmmbatched__64.html "Interface documentation") | C binding
 1076 | [hipblasCdgmmBatched_64](interfacehipfort__hipblas_1_1hipblascdgmmbatched__64.html "Interface documentation") | C binding
 1077 | [hipblasZdgmmBatched_64](interfacehipfort__hipblas_1_1hipblaszdgmmbatched__64.html "Interface documentation") | C binding
-1078 | [hipblasSdgmmStridedBatched](interfacehipfort__hipblas_1_1hipblassdgmmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1079 | [hipblasDdgmmStridedBatched](interfacehipfort__hipblas_1_1hipblasddgmmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1080 | [hipblasCdgmmStridedBatched](interfacehipfort__hipblas_1_1hipblascdgmmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1081 | [hipblasZdgmmStridedBatched](interfacehipfort__hipblas_1_1hipblaszdgmmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1082 | [hipblasSdgmmStridedBatched_64](interfacehipfort__hipblas_1_1hipblassdgmmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-1083 | [hipblasDdgmmStridedBatched_64](interfacehipfort__hipblas_1_1hipblasddgmmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-1084 | [hipblasCdgmmStridedBatched_64](interfacehipfort__hipblas_1_1hipblascdgmmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-1085 | [hipblasZdgmmStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszdgmmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1
-1086 | [hipblasSgetrf](interfacehipfort__hipblas_1_1hipblassgetrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1087 | [hipblasDgetrf](interfacehipfort__hipblas_1_1hipblasdgetrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1088 | [hipblasCgetrf](interfacehipfort__hipblas_1_1hipblascgetrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1089 | [hipblasZgetrf](interfacehipfort__hipblas_1_1hipblaszgetrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1078 | [hipblasSdgmmStridedBatched](interfacehipfort__hipblas_1_1hipblassdgmmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1079 | [hipblasDdgmmStridedBatched](interfacehipfort__hipblas_1_1hipblasddgmmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1080 | [hipblasCdgmmStridedBatched](interfacehipfort__hipblas_1_1hipblascdgmmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1081 | [hipblasZdgmmStridedBatched](interfacehipfort__hipblas_1_1hipblaszdgmmstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1082 | [hipblasSdgmmStridedBatched_64](interfacehipfort__hipblas_1_1hipblassdgmmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1083 | [hipblasDdgmmStridedBatched_64](interfacehipfort__hipblas_1_1hipblasddgmmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1084 | [hipblasCdgmmStridedBatched_64](interfacehipfort__hipblas_1_1hipblascdgmmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1085 | [hipblasZdgmmStridedBatched_64](interfacehipfort__hipblas_1_1hipblaszdgmmstridedbatched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1086 | [hipblasSgetrf](interfacehipfort__hipblas_1_1hipblassgetrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1087 | [hipblasDgetrf](interfacehipfort__hipblas_1_1hipblasdgetrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1088 | [hipblasCgetrf](interfacehipfort__hipblas_1_1hipblascgetrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1089 | [hipblasZgetrf](interfacehipfort__hipblas_1_1hipblaszgetrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 1090 | [hipblasSgetrfBatched](interfacehipfort__hipblas_1_1hipblassgetrfbatched.html "Interface documentation") | C binding
 1091 | [hipblasDgetrfBatched](interfacehipfort__hipblas_1_1hipblasdgetrfbatched.html "Interface documentation") | C binding
 1092 | [hipblasCgetrfBatched](interfacehipfort__hipblas_1_1hipblascgetrfbatched.html "Interface documentation") | C binding
 1093 | [hipblasZgetrfBatched](interfacehipfort__hipblas_1_1hipblaszgetrfbatched.html "Interface documentation") | C binding
-1094 | [hipblasSgetrfStridedBatched](interfacehipfort__hipblas_1_1hipblassgetrfstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1095 | [hipblasDgetrfStridedBatched](interfacehipfort__hipblas_1_1hipblasdgetrfstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1096 | [hipblasCgetrfStridedBatched](interfacehipfort__hipblas_1_1hipblascgetrfstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1097 | [hipblasZgetrfStridedBatched](interfacehipfort__hipblas_1_1hipblaszgetrfstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1098 | [hipblasSgetrs](interfacehipfort__hipblas_1_1hipblassgetrs.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1099 | [hipblasDgetrs](interfacehipfort__hipblas_1_1hipblasdgetrs.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1100 | [hipblasCgetrs](interfacehipfort__hipblas_1_1hipblascgetrs.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1101 | [hipblasZgetrs](interfacehipfort__hipblas_1_1hipblaszgetrs.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1094 | [hipblasSgetrfStridedBatched](interfacehipfort__hipblas_1_1hipblassgetrfstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1095 | [hipblasDgetrfStridedBatched](interfacehipfort__hipblas_1_1hipblasdgetrfstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1096 | [hipblasCgetrfStridedBatched](interfacehipfort__hipblas_1_1hipblascgetrfstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1097 | [hipblasZgetrfStridedBatched](interfacehipfort__hipblas_1_1hipblaszgetrfstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1098 | [hipblasSgetrs](interfacehipfort__hipblas_1_1hipblassgetrs.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1099 | [hipblasDgetrs](interfacehipfort__hipblas_1_1hipblasdgetrs.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1100 | [hipblasCgetrs](interfacehipfort__hipblas_1_1hipblascgetrs.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1101 | [hipblasZgetrs](interfacehipfort__hipblas_1_1hipblaszgetrs.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 1102 | [hipblasSgetrsBatched](interfacehipfort__hipblas_1_1hipblassgetrsbatched.html "Interface documentation") | C binding
 1103 | [hipblasDgetrsBatched](interfacehipfort__hipblas_1_1hipblasdgetrsbatched.html "Interface documentation") | C binding
 1104 | [hipblasCgetrsBatched](interfacehipfort__hipblas_1_1hipblascgetrsbatched.html "Interface documentation") | C binding
 1105 | [hipblasZgetrsBatched](interfacehipfort__hipblas_1_1hipblaszgetrsbatched.html "Interface documentation") | C binding
-1106 | [hipblasSgetrsStridedBatched](interfacehipfort__hipblas_1_1hipblassgetrsstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1107 | [hipblasDgetrsStridedBatched](interfacehipfort__hipblas_1_1hipblasdgetrsstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1108 | [hipblasCgetrsStridedBatched](interfacehipfort__hipblas_1_1hipblascgetrsstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1109 | [hipblasZgetrsStridedBatched](interfacehipfort__hipblas_1_1hipblaszgetrsstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1106 | [hipblasSgetrsStridedBatched](interfacehipfort__hipblas_1_1hipblassgetrsstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1107 | [hipblasDgetrsStridedBatched](interfacehipfort__hipblas_1_1hipblasdgetrsstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1108 | [hipblasCgetrsStridedBatched](interfacehipfort__hipblas_1_1hipblascgetrsstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1109 | [hipblasZgetrsStridedBatched](interfacehipfort__hipblas_1_1hipblaszgetrsstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 1110 | [hipblasSgetriBatched](interfacehipfort__hipblas_1_1hipblassgetribatched.html "Interface documentation") | C binding
 1111 | [hipblasDgetriBatched](interfacehipfort__hipblas_1_1hipblasdgetribatched.html "Interface documentation") | C binding
 1112 | [hipblasCgetriBatched](interfacehipfort__hipblas_1_1hipblascgetribatched.html "Interface documentation") | C binding
 1113 | [hipblasZgetriBatched](interfacehipfort__hipblas_1_1hipblaszgetribatched.html "Interface documentation") | C binding
-1114 | [hipblasSgels](interfacehipfort__hipblas_1_1hipblassgels.html "Interface documentation") | C binding, rank_0, rank_1
-1115 | [hipblasDgels](interfacehipfort__hipblas_1_1hipblasdgels.html "Interface documentation") | C binding, rank_0, rank_1
-1116 | [hipblasCgels](interfacehipfort__hipblas_1_1hipblascgels.html "Interface documentation") | C binding, rank_0, rank_1
-1117 | [hipblasZgels](interfacehipfort__hipblas_1_1hipblaszgels.html "Interface documentation") | C binding, rank_0, rank_1
-1118 | [hipblasSgelsBatched](interfacehipfort__hipblas_1_1hipblassgelsbatched.html "Interface documentation") | C binding, rank_0, rank_1
-1119 | [hipblasDgelsBatched](interfacehipfort__hipblas_1_1hipblasdgelsbatched.html "Interface documentation") | C binding, rank_0, rank_1
-1120 | [hipblasCgelsBatched](interfacehipfort__hipblas_1_1hipblascgelsbatched.html "Interface documentation") | C binding, rank_0, rank_1
-1121 | [hipblasZgelsBatched](interfacehipfort__hipblas_1_1hipblaszgelsbatched.html "Interface documentation") | C binding, rank_0, rank_1
-1122 | [hipblasSgelsStridedBatched](interfacehipfort__hipblas_1_1hipblassgelsstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-1123 | [hipblasDgelsStridedBatched](interfacehipfort__hipblas_1_1hipblasdgelsstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-1124 | [hipblasCgelsStridedBatched](interfacehipfort__hipblas_1_1hipblascgelsstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-1125 | [hipblasZgelsStridedBatched](interfacehipfort__hipblas_1_1hipblaszgelsstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1
-1126 | [hipblasSgeqrf](interfacehipfort__hipblas_1_1hipblassgeqrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1127 | [hipblasDgeqrf](interfacehipfort__hipblas_1_1hipblasdgeqrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1128 | [hipblasCgeqrf](interfacehipfort__hipblas_1_1hipblascgeqrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1129 | [hipblasZgeqrf](interfacehipfort__hipblas_1_1hipblaszgeqrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1114 | [hipblasSgels](interfacehipfort__hipblas_1_1hipblassgels.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1115 | [hipblasDgels](interfacehipfort__hipblas_1_1hipblasdgels.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1116 | [hipblasCgels](interfacehipfort__hipblas_1_1hipblascgels.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1117 | [hipblasZgels](interfacehipfort__hipblas_1_1hipblaszgels.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1118 | [hipblasSgelsBatched](interfacehipfort__hipblas_1_1hipblassgelsbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1119 | [hipblasDgelsBatched](interfacehipfort__hipblas_1_1hipblasdgelsbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1120 | [hipblasCgelsBatched](interfacehipfort__hipblas_1_1hipblascgelsbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1121 | [hipblasZgelsBatched](interfacehipfort__hipblas_1_1hipblaszgelsbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1122 | [hipblasSgelsStridedBatched](interfacehipfort__hipblas_1_1hipblassgelsstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1123 | [hipblasDgelsStridedBatched](interfacehipfort__hipblas_1_1hipblasdgelsstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1124 | [hipblasCgelsStridedBatched](interfacehipfort__hipblas_1_1hipblascgelsstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1125 | [hipblasZgelsStridedBatched](interfacehipfort__hipblas_1_1hipblaszgelsstridedbatched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1126 | [hipblasSgeqrf](interfacehipfort__hipblas_1_1hipblassgeqrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1127 | [hipblasDgeqrf](interfacehipfort__hipblas_1_1hipblasdgeqrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1128 | [hipblasCgeqrf](interfacehipfort__hipblas_1_1hipblascgeqrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1129 | [hipblasZgeqrf](interfacehipfort__hipblas_1_1hipblaszgeqrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 1130 | [hipblasSgeqrfBatched](interfacehipfort__hipblas_1_1hipblassgeqrfbatched.html "Interface documentation") | C binding
 1131 | [hipblasDgeqrfBatched](interfacehipfort__hipblas_1_1hipblasdgeqrfbatched.html "Interface documentation") | C binding
 1132 | [hipblasCgeqrfBatched](interfacehipfort__hipblas_1_1hipblascgeqrfbatched.html "Interface documentation") | C binding
 1133 | [hipblasZgeqrfBatched](interfacehipfort__hipblas_1_1hipblaszgeqrfbatched.html "Interface documentation") | C binding
-1134 | [hipblasSgeqrfStridedBatched](interfacehipfort__hipblas_1_1hipblassgeqrfstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1135 | [hipblasDgeqrfStridedBatched](interfacehipfort__hipblas_1_1hipblasdgeqrfstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1136 | [hipblasCgeqrfStridedBatched](interfacehipfort__hipblas_1_1hipblascgeqrfstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1137 | [hipblasZgeqrfStridedBatched](interfacehipfort__hipblas_1_1hipblaszgeqrfstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1134 | [hipblasSgeqrfStridedBatched](interfacehipfort__hipblas_1_1hipblassgeqrfstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1135 | [hipblasDgeqrfStridedBatched](interfacehipfort__hipblas_1_1hipblasdgeqrfstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1136 | [hipblasCgeqrfStridedBatched](interfacehipfort__hipblas_1_1hipblascgeqrfstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1137 | [hipblasZgeqrfStridedBatched](interfacehipfort__hipblas_1_1hipblaszgeqrfstridedbatched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 1138 | [hipblasGemmEx](interfacehipfort__hipblas_1_1hipblasgemmex.html "Interface documentation") | C binding
 1139 | [hipblasGemmExWithFlags](interfacehipfort__hipblas_1_1hipblasgemmexwithflags.html "Interface documentation") | C binding
 1140 | [hipblasGemmEx_64](interfacehipfort__hipblas_1_1hipblasgemmex__64.html "Interface documentation") | C binding
@@ -1193,11 +1193,11 @@
 1189 | [hipblasScalStridedBatchedEx](interfacehipfort__hipblas_1_1hipblasscalstridedbatchedex.html "Interface documentation") | C binding
 1190 | [hipblasScalStridedBatchedEx_64](interfacehipfort__hipblas_1_1hipblasscalstridedbatchedex__64.html "Interface documentation") | C binding
 1191 | [hipblasStatusToString](interfacehipfort__hipblas_1_1hipblasstatustostring.html "Interface documentation") | C binding
-1192 | [hipblasSetVector](interfacehipfort__hipblas_1_1hipblassetvector.html "Interface documentation") | C binding, full_rank, rank_0
-1193 | [hipblasGetVector](interfacehipfort__hipblas_1_1hipblasgetvector.html "Interface documentation") | C binding, full_rank, rank_0
-1194 | [hipblasSetMatrix](interfacehipfort__hipblas_1_1hipblassetmatrix.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1195 | [hipblasGetMatrix](interfacehipfort__hipblas_1_1hipblasgetmatrix.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1196 | [hipblasSetVectorAsync](interfacehipfort__hipblas_1_1hipblassetvectorasync.html "Interface documentation") | C binding, full_rank, rank_0
-1197 | [hipblasGetVectorAsync](interfacehipfort__hipblas_1_1hipblasgetvectorasync.html "Interface documentation") | C binding, full_rank, rank_0
-1198 | [hipblasSetMatrixAsync](interfacehipfort__hipblas_1_1hipblassetmatrixasync.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1199 | [hipblasGetMatrixAsync](interfacehipfort__hipblas_1_1hipblasgetmatrixasync.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1192 | [hipblasSetVector](interfacehipfort__hipblas_1_1hipblassetvector.html "Interface documentation") | C binding, full_rank, rank_0, assumed_rank
+1193 | [hipblasGetVector](interfacehipfort__hipblas_1_1hipblasgetvector.html "Interface documentation") | C binding, full_rank, rank_0, assumed_rank
+1194 | [hipblasSetMatrix](interfacehipfort__hipblas_1_1hipblassetmatrix.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1195 | [hipblasGetMatrix](interfacehipfort__hipblas_1_1hipblasgetmatrix.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1196 | [hipblasSetVectorAsync](interfacehipfort__hipblas_1_1hipblassetvectorasync.html "Interface documentation") | C binding, full_rank, rank_0, assumed_rank
+1197 | [hipblasGetVectorAsync](interfacehipfort__hipblas_1_1hipblasgetvectorasync.html "Interface documentation") | C binding, full_rank, rank_0, assumed_rank
+1198 | [hipblasSetMatrixAsync](interfacehipfort__hipblas_1_1hipblassetmatrixasync.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1199 | [hipblasGetMatrixAsync](interfacehipfort__hipblas_1_1hipblasgetmatrixasync.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank

--- a/docs/doxygen/input/supported_api_rocblas.md
+++ b/docs/doxygen/input/supported_api_rocblas.md
@@ -7,15 +7,15 @@
 3 | [rocblas_set_stream](interfacehipfort__rocblas_1_1rocblas__set__stream.html "Interface documentation") | C binding
 4 | [rocblas_get_stream](interfacehipfort__rocblas_1_1rocblas__get__stream.html "Interface documentation") | C binding
 5 | [rocblas_set_pointer_mode](interfacehipfort__rocblas_1_1rocblas__set__pointer__mode.html "Interface documentation") | C binding
-6 | [rocblas_get_pointer_mode](interfacehipfort__rocblas_1_1rocblas__get__pointer__mode.html "Interface documentation") | C binding, rank_0, rank_1
+6 | [rocblas_get_pointer_mode](interfacehipfort__rocblas_1_1rocblas__get__pointer__mode.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 7 | [rocblas_set_atomics_mode](interfacehipfort__rocblas_1_1rocblas__set__atomics__mode.html "Interface documentation") | C binding
-8 | [rocblas_get_atomics_mode](interfacehipfort__rocblas_1_1rocblas__get__atomics__mode.html "Interface documentation") | C binding, rank_0, rank_1
+8 | [rocblas_get_atomics_mode](interfacehipfort__rocblas_1_1rocblas__get__atomics__mode.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 9 | [rocblas_set_batch_alpha_stride](interfacehipfort__rocblas_1_1rocblas__set__batch__alpha__stride.html "Interface documentation") | C binding
-10 | [rocblas_get_batch_alpha_stride](interfacehipfort__rocblas_1_1rocblas__get__batch__alpha__stride.html "Interface documentation") | C binding, rank_0, rank_1
+10 | [rocblas_get_batch_alpha_stride](interfacehipfort__rocblas_1_1rocblas__get__batch__alpha__stride.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 11 | [rocblas_set_batch_beta_stride](interfacehipfort__rocblas_1_1rocblas__set__batch__beta__stride.html "Interface documentation") | C binding
-12 | [rocblas_get_batch_beta_stride](interfacehipfort__rocblas_1_1rocblas__get__batch__beta__stride.html "Interface documentation") | C binding, rank_0, rank_1
+12 | [rocblas_get_batch_beta_stride](interfacehipfort__rocblas_1_1rocblas__get__batch__beta__stride.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 13 | [rocblas_set_math_mode](interfacehipfort__rocblas_1_1rocblas__set__math__mode.html "Interface documentation") | C binding
-14 | [rocblas_get_math_mode](interfacehipfort__rocblas_1_1rocblas__get__math__mode.html "Interface documentation") | C binding, rank_0, rank_1
+14 | [rocblas_get_math_mode](interfacehipfort__rocblas_1_1rocblas__get__math__mode.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 15 | [rocblas_pointer_to_mode](interfacehipfort__rocblas_1_1rocblas__pointer__to__mode.html "Interface documentation") | C binding
 16 | [rocblas_set_vector_64](interfacehipfort__rocblas_1_1rocblas__set__vector__64.html "Interface documentation") | C binding
 17 | [rocblas_get_vector_64](interfacehipfort__rocblas_1_1rocblas__get__vector__64.html "Interface documentation") | C binding
@@ -28,19 +28,19 @@
 24 | [rocblas_set_start_stop_events](interfacehipfort__rocblas_1_1rocblas__set__start__stop__events.html "Interface documentation") | C binding
 25 | [rocblas_set_solution_fitness_query](interfacehipfort__rocblas_1_1rocblas__set__solution__fitness__query.html "Interface documentation") | C binding
 26 | [rocblas_set_performance_metric](interfacehipfort__rocblas_1_1rocblas__set__performance__metric.html "Interface documentation") | C binding
-27 | [rocblas_get_performance_metric](interfacehipfort__rocblas_1_1rocblas__get__performance__metric.html "Interface documentation") | C binding, rank_0, rank_1
-28 | [rocblas_sscal](interfacehipfort__rocblas_1_1rocblas__sscal.html "Interface documentation") | C binding, rank_0, rank_1
-29 | [rocblas_dscal](interfacehipfort__rocblas_1_1rocblas__dscal.html "Interface documentation") | C binding, rank_0, rank_1
-30 | [rocblas_cscal](interfacehipfort__rocblas_1_1rocblas__cscal.html "Interface documentation") | C binding, rank_0, rank_1
-31 | [rocblas_zscal](interfacehipfort__rocblas_1_1rocblas__zscal.html "Interface documentation") | C binding, rank_0, rank_1
-32 | [rocblas_csscal](interfacehipfort__rocblas_1_1rocblas__csscal.html "Interface documentation") | C binding, rank_0, rank_1
-33 | [rocblas_zdscal](interfacehipfort__rocblas_1_1rocblas__zdscal.html "Interface documentation") | C binding, rank_0, rank_1
-34 | [rocblas_sscal_64](interfacehipfort__rocblas_1_1rocblas__sscal__64.html "Interface documentation") | C binding, rank_0, rank_1
-35 | [rocblas_dscal_64](interfacehipfort__rocblas_1_1rocblas__dscal__64.html "Interface documentation") | C binding, rank_0, rank_1
-36 | [rocblas_cscal_64](interfacehipfort__rocblas_1_1rocblas__cscal__64.html "Interface documentation") | C binding, rank_0, rank_1
-37 | [rocblas_zscal_64](interfacehipfort__rocblas_1_1rocblas__zscal__64.html "Interface documentation") | C binding, rank_0, rank_1
-38 | [rocblas_csscal_64](interfacehipfort__rocblas_1_1rocblas__csscal__64.html "Interface documentation") | C binding, rank_0, rank_1
-39 | [rocblas_zdscal_64](interfacehipfort__rocblas_1_1rocblas__zdscal__64.html "Interface documentation") | C binding, rank_0, rank_1
+27 | [rocblas_get_performance_metric](interfacehipfort__rocblas_1_1rocblas__get__performance__metric.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+28 | [rocblas_sscal](interfacehipfort__rocblas_1_1rocblas__sscal.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+29 | [rocblas_dscal](interfacehipfort__rocblas_1_1rocblas__dscal.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+30 | [rocblas_cscal](interfacehipfort__rocblas_1_1rocblas__cscal.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+31 | [rocblas_zscal](interfacehipfort__rocblas_1_1rocblas__zscal.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+32 | [rocblas_csscal](interfacehipfort__rocblas_1_1rocblas__csscal.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+33 | [rocblas_zdscal](interfacehipfort__rocblas_1_1rocblas__zdscal.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+34 | [rocblas_sscal_64](interfacehipfort__rocblas_1_1rocblas__sscal__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+35 | [rocblas_dscal_64](interfacehipfort__rocblas_1_1rocblas__dscal__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+36 | [rocblas_cscal_64](interfacehipfort__rocblas_1_1rocblas__cscal__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+37 | [rocblas_zscal_64](interfacehipfort__rocblas_1_1rocblas__zscal__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+38 | [rocblas_csscal_64](interfacehipfort__rocblas_1_1rocblas__csscal__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+39 | [rocblas_zdscal_64](interfacehipfort__rocblas_1_1rocblas__zdscal__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 40 | [rocblas_sscal_batched](interfacehipfort__rocblas_1_1rocblas__sscal__batched.html "Interface documentation") | C binding
 41 | [rocblas_dscal_batched](interfacehipfort__rocblas_1_1rocblas__dscal__batched.html "Interface documentation") | C binding
 42 | [rocblas_cscal_batched](interfacehipfort__rocblas_1_1rocblas__cscal__batched.html "Interface documentation") | C binding
@@ -53,26 +53,26 @@
 49 | [rocblas_zscal_batched_64](interfacehipfort__rocblas_1_1rocblas__zscal__batched__64.html "Interface documentation") | C binding
 50 | [rocblas_csscal_batched_64](interfacehipfort__rocblas_1_1rocblas__csscal__batched__64.html "Interface documentation") | C binding
 51 | [rocblas_zdscal_batched_64](interfacehipfort__rocblas_1_1rocblas__zdscal__batched__64.html "Interface documentation") | C binding
-52 | [rocblas_sscal_strided_batched](interfacehipfort__rocblas_1_1rocblas__sscal__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-53 | [rocblas_dscal_strided_batched](interfacehipfort__rocblas_1_1rocblas__dscal__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-54 | [rocblas_cscal_strided_batched](interfacehipfort__rocblas_1_1rocblas__cscal__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-55 | [rocblas_zscal_strided_batched](interfacehipfort__rocblas_1_1rocblas__zscal__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-56 | [rocblas_csscal_strided_batched](interfacehipfort__rocblas_1_1rocblas__csscal__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-57 | [rocblas_zdscal_strided_batched](interfacehipfort__rocblas_1_1rocblas__zdscal__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-58 | [rocblas_sscal_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sscal__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-59 | [rocblas_dscal_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dscal__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-60 | [rocblas_cscal_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cscal__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-61 | [rocblas_zscal_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zscal__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-62 | [rocblas_csscal_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__csscal__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-63 | [rocblas_zdscal_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zdscal__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-64 | [rocblas_scopy](interfacehipfort__rocblas_1_1rocblas__scopy.html "Interface documentation") | C binding, rank_0, rank_1
-65 | [rocblas_dcopy](interfacehipfort__rocblas_1_1rocblas__dcopy.html "Interface documentation") | C binding, rank_0, rank_1
-66 | [rocblas_ccopy](interfacehipfort__rocblas_1_1rocblas__ccopy.html "Interface documentation") | C binding, rank_0, rank_1
-67 | [rocblas_zcopy](interfacehipfort__rocblas_1_1rocblas__zcopy.html "Interface documentation") | C binding, rank_0, rank_1
-68 | [rocblas_scopy_64](interfacehipfort__rocblas_1_1rocblas__scopy__64.html "Interface documentation") | C binding, rank_0, rank_1
-69 | [rocblas_dcopy_64](interfacehipfort__rocblas_1_1rocblas__dcopy__64.html "Interface documentation") | C binding, rank_0, rank_1
-70 | [rocblas_ccopy_64](interfacehipfort__rocblas_1_1rocblas__ccopy__64.html "Interface documentation") | C binding, rank_0, rank_1
-71 | [rocblas_zcopy_64](interfacehipfort__rocblas_1_1rocblas__zcopy__64.html "Interface documentation") | C binding, rank_0, rank_1
+52 | [rocblas_sscal_strided_batched](interfacehipfort__rocblas_1_1rocblas__sscal__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+53 | [rocblas_dscal_strided_batched](interfacehipfort__rocblas_1_1rocblas__dscal__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+54 | [rocblas_cscal_strided_batched](interfacehipfort__rocblas_1_1rocblas__cscal__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+55 | [rocblas_zscal_strided_batched](interfacehipfort__rocblas_1_1rocblas__zscal__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+56 | [rocblas_csscal_strided_batched](interfacehipfort__rocblas_1_1rocblas__csscal__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+57 | [rocblas_zdscal_strided_batched](interfacehipfort__rocblas_1_1rocblas__zdscal__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+58 | [rocblas_sscal_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sscal__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+59 | [rocblas_dscal_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dscal__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+60 | [rocblas_cscal_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cscal__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+61 | [rocblas_zscal_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zscal__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+62 | [rocblas_csscal_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__csscal__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+63 | [rocblas_zdscal_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zdscal__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+64 | [rocblas_scopy](interfacehipfort__rocblas_1_1rocblas__scopy.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+65 | [rocblas_dcopy](interfacehipfort__rocblas_1_1rocblas__dcopy.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+66 | [rocblas_ccopy](interfacehipfort__rocblas_1_1rocblas__ccopy.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+67 | [rocblas_zcopy](interfacehipfort__rocblas_1_1rocblas__zcopy.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+68 | [rocblas_scopy_64](interfacehipfort__rocblas_1_1rocblas__scopy__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+69 | [rocblas_dcopy_64](interfacehipfort__rocblas_1_1rocblas__dcopy__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+70 | [rocblas_ccopy_64](interfacehipfort__rocblas_1_1rocblas__ccopy__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+71 | [rocblas_zcopy_64](interfacehipfort__rocblas_1_1rocblas__zcopy__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 72 | [rocblas_scopy_batched](interfacehipfort__rocblas_1_1rocblas__scopy__batched.html "Interface documentation") | C binding
 73 | [rocblas_dcopy_batched](interfacehipfort__rocblas_1_1rocblas__dcopy__batched.html "Interface documentation") | C binding
 74 | [rocblas_ccopy_batched](interfacehipfort__rocblas_1_1rocblas__ccopy__batched.html "Interface documentation") | C binding
@@ -81,70 +81,70 @@
 77 | [rocblas_dcopy_batched_64](interfacehipfort__rocblas_1_1rocblas__dcopy__batched__64.html "Interface documentation") | C binding
 78 | [rocblas_ccopy_batched_64](interfacehipfort__rocblas_1_1rocblas__ccopy__batched__64.html "Interface documentation") | C binding
 79 | [rocblas_zcopy_batched_64](interfacehipfort__rocblas_1_1rocblas__zcopy__batched__64.html "Interface documentation") | C binding
-80 | [rocblas_scopy_strided_batched](interfacehipfort__rocblas_1_1rocblas__scopy__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-81 | [rocblas_dcopy_strided_batched](interfacehipfort__rocblas_1_1rocblas__dcopy__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-82 | [rocblas_ccopy_strided_batched](interfacehipfort__rocblas_1_1rocblas__ccopy__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-83 | [rocblas_zcopy_strided_batched](interfacehipfort__rocblas_1_1rocblas__zcopy__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-84 | [rocblas_scopy_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__scopy__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-85 | [rocblas_dcopy_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dcopy__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-86 | [rocblas_ccopy_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ccopy__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-87 | [rocblas_zcopy_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zcopy__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-88 | [rocblas_sdot](interfacehipfort__rocblas_1_1rocblas__sdot.html "Interface documentation") | C binding, rank_0, rank_1
-89 | [rocblas_ddot](interfacehipfort__rocblas_1_1rocblas__ddot.html "Interface documentation") | C binding, rank_0, rank_1
-90 | [rocblas_hdot](interfacehipfort__rocblas_1_1rocblas__hdot.html "Interface documentation") | C binding, rank_0, rank_1
-91 | [rocblas_bfdot](interfacehipfort__rocblas_1_1rocblas__bfdot.html "Interface documentation") | C binding, rank_0, rank_1
-92 | [rocblas_cdotu](interfacehipfort__rocblas_1_1rocblas__cdotu.html "Interface documentation") | C binding, rank_0, rank_1
-93 | [rocblas_zdotu](interfacehipfort__rocblas_1_1rocblas__zdotu.html "Interface documentation") | C binding, rank_0, rank_1
-94 | [rocblas_cdotc](interfacehipfort__rocblas_1_1rocblas__cdotc.html "Interface documentation") | C binding, rank_0, rank_1
-95 | [rocblas_zdotc](interfacehipfort__rocblas_1_1rocblas__zdotc.html "Interface documentation") | C binding, rank_0, rank_1
-96 | [rocblas_sdot_64](interfacehipfort__rocblas_1_1rocblas__sdot__64.html "Interface documentation") | C binding, rank_0, rank_1
-97 | [rocblas_ddot_64](interfacehipfort__rocblas_1_1rocblas__ddot__64.html "Interface documentation") | C binding, rank_0, rank_1
-98 | [rocblas_hdot_64](interfacehipfort__rocblas_1_1rocblas__hdot__64.html "Interface documentation") | C binding, rank_0, rank_1
-99 | [rocblas_bfdot_64](interfacehipfort__rocblas_1_1rocblas__bfdot__64.html "Interface documentation") | C binding, rank_0, rank_1
-100 | [rocblas_cdotu_64](interfacehipfort__rocblas_1_1rocblas__cdotu__64.html "Interface documentation") | C binding, rank_0, rank_1
-101 | [rocblas_zdotu_64](interfacehipfort__rocblas_1_1rocblas__zdotu__64.html "Interface documentation") | C binding, rank_0, rank_1
-102 | [rocblas_cdotc_64](interfacehipfort__rocblas_1_1rocblas__cdotc__64.html "Interface documentation") | C binding, rank_0, rank_1
-103 | [rocblas_zdotc_64](interfacehipfort__rocblas_1_1rocblas__zdotc__64.html "Interface documentation") | C binding, rank_0, rank_1
+80 | [rocblas_scopy_strided_batched](interfacehipfort__rocblas_1_1rocblas__scopy__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+81 | [rocblas_dcopy_strided_batched](interfacehipfort__rocblas_1_1rocblas__dcopy__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+82 | [rocblas_ccopy_strided_batched](interfacehipfort__rocblas_1_1rocblas__ccopy__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+83 | [rocblas_zcopy_strided_batched](interfacehipfort__rocblas_1_1rocblas__zcopy__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+84 | [rocblas_scopy_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__scopy__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+85 | [rocblas_dcopy_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dcopy__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+86 | [rocblas_ccopy_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ccopy__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+87 | [rocblas_zcopy_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zcopy__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+88 | [rocblas_sdot](interfacehipfort__rocblas_1_1rocblas__sdot.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+89 | [rocblas_ddot](interfacehipfort__rocblas_1_1rocblas__ddot.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+90 | [rocblas_hdot](interfacehipfort__rocblas_1_1rocblas__hdot.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+91 | [rocblas_bfdot](interfacehipfort__rocblas_1_1rocblas__bfdot.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+92 | [rocblas_cdotu](interfacehipfort__rocblas_1_1rocblas__cdotu.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+93 | [rocblas_zdotu](interfacehipfort__rocblas_1_1rocblas__zdotu.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+94 | [rocblas_cdotc](interfacehipfort__rocblas_1_1rocblas__cdotc.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+95 | [rocblas_zdotc](interfacehipfort__rocblas_1_1rocblas__zdotc.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+96 | [rocblas_sdot_64](interfacehipfort__rocblas_1_1rocblas__sdot__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+97 | [rocblas_ddot_64](interfacehipfort__rocblas_1_1rocblas__ddot__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+98 | [rocblas_hdot_64](interfacehipfort__rocblas_1_1rocblas__hdot__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+99 | [rocblas_bfdot_64](interfacehipfort__rocblas_1_1rocblas__bfdot__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+100 | [rocblas_cdotu_64](interfacehipfort__rocblas_1_1rocblas__cdotu__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+101 | [rocblas_zdotu_64](interfacehipfort__rocblas_1_1rocblas__zdotu__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+102 | [rocblas_cdotc_64](interfacehipfort__rocblas_1_1rocblas__cdotc__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+103 | [rocblas_zdotc_64](interfacehipfort__rocblas_1_1rocblas__zdotc__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 104 | [rocblas_sdot_batched](interfacehipfort__rocblas_1_1rocblas__sdot__batched.html "Interface documentation") | C binding
 105 | [rocblas_ddot_batched](interfacehipfort__rocblas_1_1rocblas__ddot__batched.html "Interface documentation") | C binding
-106 | [rocblas_hdot_batched](interfacehipfort__rocblas_1_1rocblas__hdot__batched.html "Interface documentation") | C binding, rank_0, rank_1
-107 | [rocblas_bfdot_batched](interfacehipfort__rocblas_1_1rocblas__bfdot__batched.html "Interface documentation") | C binding, rank_0, rank_1
+106 | [rocblas_hdot_batched](interfacehipfort__rocblas_1_1rocblas__hdot__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+107 | [rocblas_bfdot_batched](interfacehipfort__rocblas_1_1rocblas__bfdot__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 108 | [rocblas_cdotu_batched](interfacehipfort__rocblas_1_1rocblas__cdotu__batched.html "Interface documentation") | C binding
 109 | [rocblas_zdotu_batched](interfacehipfort__rocblas_1_1rocblas__zdotu__batched.html "Interface documentation") | C binding
 110 | [rocblas_cdotc_batched](interfacehipfort__rocblas_1_1rocblas__cdotc__batched.html "Interface documentation") | C binding
 111 | [rocblas_zdotc_batched](interfacehipfort__rocblas_1_1rocblas__zdotc__batched.html "Interface documentation") | C binding
-112 | [rocblas_sdot_batched_64](interfacehipfort__rocblas_1_1rocblas__sdot__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-113 | [rocblas_ddot_batched_64](interfacehipfort__rocblas_1_1rocblas__ddot__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-114 | [rocblas_hdot_batched_64](interfacehipfort__rocblas_1_1rocblas__hdot__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-115 | [rocblas_bfdot_batched_64](interfacehipfort__rocblas_1_1rocblas__bfdot__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-116 | [rocblas_cdotu_batched_64](interfacehipfort__rocblas_1_1rocblas__cdotu__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-117 | [rocblas_zdotu_batched_64](interfacehipfort__rocblas_1_1rocblas__zdotu__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-118 | [rocblas_cdotc_batched_64](interfacehipfort__rocblas_1_1rocblas__cdotc__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-119 | [rocblas_zdotc_batched_64](interfacehipfort__rocblas_1_1rocblas__zdotc__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-120 | [rocblas_sdot_strided_batched](interfacehipfort__rocblas_1_1rocblas__sdot__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-121 | [rocblas_ddot_strided_batched](interfacehipfort__rocblas_1_1rocblas__ddot__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-122 | [rocblas_hdot_strided_batched](interfacehipfort__rocblas_1_1rocblas__hdot__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-123 | [rocblas_bfdot_strided_batched](interfacehipfort__rocblas_1_1rocblas__bfdot__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-124 | [rocblas_cdotu_strided_batched](interfacehipfort__rocblas_1_1rocblas__cdotu__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-125 | [rocblas_zdotu_strided_batched](interfacehipfort__rocblas_1_1rocblas__zdotu__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-126 | [rocblas_cdotc_strided_batched](interfacehipfort__rocblas_1_1rocblas__cdotc__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-127 | [rocblas_zdotc_strided_batched](interfacehipfort__rocblas_1_1rocblas__zdotc__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-128 | [rocblas_sdot_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sdot__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-129 | [rocblas_ddot_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ddot__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-130 | [rocblas_hdot_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__hdot__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-131 | [rocblas_bfdot_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__bfdot__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-132 | [rocblas_cdotu_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cdotu__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-133 | [rocblas_zdotu_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zdotu__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-134 | [rocblas_cdotc_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cdotc__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-135 | [rocblas_zdotc_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zdotc__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-136 | [rocblas_sswap](interfacehipfort__rocblas_1_1rocblas__sswap.html "Interface documentation") | C binding, rank_0, rank_1
-137 | [rocblas_dswap](interfacehipfort__rocblas_1_1rocblas__dswap.html "Interface documentation") | C binding, rank_0, rank_1
-138 | [rocblas_cswap](interfacehipfort__rocblas_1_1rocblas__cswap.html "Interface documentation") | C binding, rank_0, rank_1
-139 | [rocblas_zswap](interfacehipfort__rocblas_1_1rocblas__zswap.html "Interface documentation") | C binding, rank_0, rank_1
-140 | [rocblas_sswap_64](interfacehipfort__rocblas_1_1rocblas__sswap__64.html "Interface documentation") | C binding, rank_0, rank_1
-141 | [rocblas_dswap_64](interfacehipfort__rocblas_1_1rocblas__dswap__64.html "Interface documentation") | C binding, rank_0, rank_1
-142 | [rocblas_cswap_64](interfacehipfort__rocblas_1_1rocblas__cswap__64.html "Interface documentation") | C binding, rank_0, rank_1
-143 | [rocblas_zswap_64](interfacehipfort__rocblas_1_1rocblas__zswap__64.html "Interface documentation") | C binding, rank_0, rank_1
+112 | [rocblas_sdot_batched_64](interfacehipfort__rocblas_1_1rocblas__sdot__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+113 | [rocblas_ddot_batched_64](interfacehipfort__rocblas_1_1rocblas__ddot__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+114 | [rocblas_hdot_batched_64](interfacehipfort__rocblas_1_1rocblas__hdot__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+115 | [rocblas_bfdot_batched_64](interfacehipfort__rocblas_1_1rocblas__bfdot__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+116 | [rocblas_cdotu_batched_64](interfacehipfort__rocblas_1_1rocblas__cdotu__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+117 | [rocblas_zdotu_batched_64](interfacehipfort__rocblas_1_1rocblas__zdotu__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+118 | [rocblas_cdotc_batched_64](interfacehipfort__rocblas_1_1rocblas__cdotc__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+119 | [rocblas_zdotc_batched_64](interfacehipfort__rocblas_1_1rocblas__zdotc__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+120 | [rocblas_sdot_strided_batched](interfacehipfort__rocblas_1_1rocblas__sdot__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+121 | [rocblas_ddot_strided_batched](interfacehipfort__rocblas_1_1rocblas__ddot__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+122 | [rocblas_hdot_strided_batched](interfacehipfort__rocblas_1_1rocblas__hdot__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+123 | [rocblas_bfdot_strided_batched](interfacehipfort__rocblas_1_1rocblas__bfdot__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+124 | [rocblas_cdotu_strided_batched](interfacehipfort__rocblas_1_1rocblas__cdotu__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+125 | [rocblas_zdotu_strided_batched](interfacehipfort__rocblas_1_1rocblas__zdotu__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+126 | [rocblas_cdotc_strided_batched](interfacehipfort__rocblas_1_1rocblas__cdotc__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+127 | [rocblas_zdotc_strided_batched](interfacehipfort__rocblas_1_1rocblas__zdotc__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+128 | [rocblas_sdot_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sdot__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+129 | [rocblas_ddot_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ddot__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+130 | [rocblas_hdot_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__hdot__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+131 | [rocblas_bfdot_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__bfdot__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+132 | [rocblas_cdotu_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cdotu__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+133 | [rocblas_zdotu_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zdotu__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+134 | [rocblas_cdotc_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cdotc__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+135 | [rocblas_zdotc_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zdotc__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+136 | [rocblas_sswap](interfacehipfort__rocblas_1_1rocblas__sswap.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+137 | [rocblas_dswap](interfacehipfort__rocblas_1_1rocblas__dswap.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+138 | [rocblas_cswap](interfacehipfort__rocblas_1_1rocblas__cswap.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+139 | [rocblas_zswap](interfacehipfort__rocblas_1_1rocblas__zswap.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+140 | [rocblas_sswap_64](interfacehipfort__rocblas_1_1rocblas__sswap__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+141 | [rocblas_dswap_64](interfacehipfort__rocblas_1_1rocblas__dswap__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+142 | [rocblas_cswap_64](interfacehipfort__rocblas_1_1rocblas__cswap__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+143 | [rocblas_zswap_64](interfacehipfort__rocblas_1_1rocblas__zswap__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 144 | [rocblas_sswap_batched](interfacehipfort__rocblas_1_1rocblas__sswap__batched.html "Interface documentation") | C binding
 145 | [rocblas_dswap_batched](interfacehipfort__rocblas_1_1rocblas__dswap__batched.html "Interface documentation") | C binding
 146 | [rocblas_cswap_batched](interfacehipfort__rocblas_1_1rocblas__cswap__batched.html "Interface documentation") | C binding
@@ -153,24 +153,24 @@
 149 | [rocblas_dswap_batched_64](interfacehipfort__rocblas_1_1rocblas__dswap__batched__64.html "Interface documentation") | C binding
 150 | [rocblas_cswap_batched_64](interfacehipfort__rocblas_1_1rocblas__cswap__batched__64.html "Interface documentation") | C binding
 151 | [rocblas_zswap_batched_64](interfacehipfort__rocblas_1_1rocblas__zswap__batched__64.html "Interface documentation") | C binding
-152 | [rocblas_sswap_strided_batched](interfacehipfort__rocblas_1_1rocblas__sswap__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-153 | [rocblas_dswap_strided_batched](interfacehipfort__rocblas_1_1rocblas__dswap__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-154 | [rocblas_cswap_strided_batched](interfacehipfort__rocblas_1_1rocblas__cswap__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-155 | [rocblas_zswap_strided_batched](interfacehipfort__rocblas_1_1rocblas__zswap__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-156 | [rocblas_sswap_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sswap__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-157 | [rocblas_dswap_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dswap__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-158 | [rocblas_cswap_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cswap__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-159 | [rocblas_zswap_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zswap__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-160 | [rocblas_haxpy](interfacehipfort__rocblas_1_1rocblas__haxpy.html "Interface documentation") | C binding, rank_0, rank_1
-161 | [rocblas_saxpy](interfacehipfort__rocblas_1_1rocblas__saxpy.html "Interface documentation") | C binding, rank_0, rank_1
-162 | [rocblas_daxpy](interfacehipfort__rocblas_1_1rocblas__daxpy.html "Interface documentation") | C binding, rank_0, rank_1
-163 | [rocblas_caxpy](interfacehipfort__rocblas_1_1rocblas__caxpy.html "Interface documentation") | C binding, rank_0, rank_1
-164 | [rocblas_zaxpy](interfacehipfort__rocblas_1_1rocblas__zaxpy.html "Interface documentation") | C binding, rank_0, rank_1
-165 | [rocblas_haxpy_64](interfacehipfort__rocblas_1_1rocblas__haxpy__64.html "Interface documentation") | C binding, rank_0, rank_1
-166 | [rocblas_saxpy_64](interfacehipfort__rocblas_1_1rocblas__saxpy__64.html "Interface documentation") | C binding, rank_0, rank_1
-167 | [rocblas_daxpy_64](interfacehipfort__rocblas_1_1rocblas__daxpy__64.html "Interface documentation") | C binding, rank_0, rank_1
-168 | [rocblas_caxpy_64](interfacehipfort__rocblas_1_1rocblas__caxpy__64.html "Interface documentation") | C binding, rank_0, rank_1
-169 | [rocblas_zaxpy_64](interfacehipfort__rocblas_1_1rocblas__zaxpy__64.html "Interface documentation") | C binding, rank_0, rank_1
+152 | [rocblas_sswap_strided_batched](interfacehipfort__rocblas_1_1rocblas__sswap__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+153 | [rocblas_dswap_strided_batched](interfacehipfort__rocblas_1_1rocblas__dswap__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+154 | [rocblas_cswap_strided_batched](interfacehipfort__rocblas_1_1rocblas__cswap__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+155 | [rocblas_zswap_strided_batched](interfacehipfort__rocblas_1_1rocblas__zswap__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+156 | [rocblas_sswap_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sswap__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+157 | [rocblas_dswap_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dswap__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+158 | [rocblas_cswap_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cswap__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+159 | [rocblas_zswap_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zswap__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+160 | [rocblas_haxpy](interfacehipfort__rocblas_1_1rocblas__haxpy.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+161 | [rocblas_saxpy](interfacehipfort__rocblas_1_1rocblas__saxpy.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+162 | [rocblas_daxpy](interfacehipfort__rocblas_1_1rocblas__daxpy.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+163 | [rocblas_caxpy](interfacehipfort__rocblas_1_1rocblas__caxpy.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+164 | [rocblas_zaxpy](interfacehipfort__rocblas_1_1rocblas__zaxpy.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+165 | [rocblas_haxpy_64](interfacehipfort__rocblas_1_1rocblas__haxpy__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+166 | [rocblas_saxpy_64](interfacehipfort__rocblas_1_1rocblas__saxpy__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+167 | [rocblas_daxpy_64](interfacehipfort__rocblas_1_1rocblas__daxpy__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+168 | [rocblas_caxpy_64](interfacehipfort__rocblas_1_1rocblas__caxpy__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+169 | [rocblas_zaxpy_64](interfacehipfort__rocblas_1_1rocblas__zaxpy__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 170 | [rocblas_haxpy_batched](interfacehipfort__rocblas_1_1rocblas__haxpy__batched.html "Interface documentation") | C binding
 171 | [rocblas_saxpy_batched](interfacehipfort__rocblas_1_1rocblas__saxpy__batched.html "Interface documentation") | C binding
 172 | [rocblas_daxpy_batched](interfacehipfort__rocblas_1_1rocblas__daxpy__batched.html "Interface documentation") | C binding
@@ -181,124 +181,124 @@
 177 | [rocblas_daxpy_batched_64](interfacehipfort__rocblas_1_1rocblas__daxpy__batched__64.html "Interface documentation") | C binding
 178 | [rocblas_caxpy_batched_64](interfacehipfort__rocblas_1_1rocblas__caxpy__batched__64.html "Interface documentation") | C binding
 179 | [rocblas_zaxpy_batched_64](interfacehipfort__rocblas_1_1rocblas__zaxpy__batched__64.html "Interface documentation") | C binding
-180 | [rocblas_haxpy_strided_batched](interfacehipfort__rocblas_1_1rocblas__haxpy__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-181 | [rocblas_saxpy_strided_batched](interfacehipfort__rocblas_1_1rocblas__saxpy__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-182 | [rocblas_daxpy_strided_batched](interfacehipfort__rocblas_1_1rocblas__daxpy__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-183 | [rocblas_caxpy_strided_batched](interfacehipfort__rocblas_1_1rocblas__caxpy__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-184 | [rocblas_zaxpy_strided_batched](interfacehipfort__rocblas_1_1rocblas__zaxpy__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-185 | [rocblas_haxpy_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__haxpy__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-186 | [rocblas_saxpy_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__saxpy__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-187 | [rocblas_daxpy_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__daxpy__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-188 | [rocblas_caxpy_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__caxpy__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-189 | [rocblas_zaxpy_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zaxpy__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-190 | [rocblas_sasum](interfacehipfort__rocblas_1_1rocblas__sasum.html "Interface documentation") | C binding, rank_0, rank_1
-191 | [rocblas_dasum](interfacehipfort__rocblas_1_1rocblas__dasum.html "Interface documentation") | C binding, rank_0, rank_1
-192 | [rocblas_scasum](interfacehipfort__rocblas_1_1rocblas__scasum.html "Interface documentation") | C binding, rank_0, rank_1
-193 | [rocblas_dzasum](interfacehipfort__rocblas_1_1rocblas__dzasum.html "Interface documentation") | C binding, rank_0, rank_1
-194 | [rocblas_sasum_64](interfacehipfort__rocblas_1_1rocblas__sasum__64.html "Interface documentation") | C binding, rank_0, rank_1
-195 | [rocblas_dasum_64](interfacehipfort__rocblas_1_1rocblas__dasum__64.html "Interface documentation") | C binding, rank_0, rank_1
-196 | [rocblas_scasum_64](interfacehipfort__rocblas_1_1rocblas__scasum__64.html "Interface documentation") | C binding, rank_0, rank_1
-197 | [rocblas_dzasum_64](interfacehipfort__rocblas_1_1rocblas__dzasum__64.html "Interface documentation") | C binding, rank_0, rank_1
+180 | [rocblas_haxpy_strided_batched](interfacehipfort__rocblas_1_1rocblas__haxpy__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+181 | [rocblas_saxpy_strided_batched](interfacehipfort__rocblas_1_1rocblas__saxpy__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+182 | [rocblas_daxpy_strided_batched](interfacehipfort__rocblas_1_1rocblas__daxpy__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+183 | [rocblas_caxpy_strided_batched](interfacehipfort__rocblas_1_1rocblas__caxpy__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+184 | [rocblas_zaxpy_strided_batched](interfacehipfort__rocblas_1_1rocblas__zaxpy__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+185 | [rocblas_haxpy_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__haxpy__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+186 | [rocblas_saxpy_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__saxpy__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+187 | [rocblas_daxpy_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__daxpy__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+188 | [rocblas_caxpy_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__caxpy__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+189 | [rocblas_zaxpy_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zaxpy__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+190 | [rocblas_sasum](interfacehipfort__rocblas_1_1rocblas__sasum.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+191 | [rocblas_dasum](interfacehipfort__rocblas_1_1rocblas__dasum.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+192 | [rocblas_scasum](interfacehipfort__rocblas_1_1rocblas__scasum.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+193 | [rocblas_dzasum](interfacehipfort__rocblas_1_1rocblas__dzasum.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+194 | [rocblas_sasum_64](interfacehipfort__rocblas_1_1rocblas__sasum__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+195 | [rocblas_dasum_64](interfacehipfort__rocblas_1_1rocblas__dasum__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+196 | [rocblas_scasum_64](interfacehipfort__rocblas_1_1rocblas__scasum__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+197 | [rocblas_dzasum_64](interfacehipfort__rocblas_1_1rocblas__dzasum__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 198 | [rocblas_sasum_batched](interfacehipfort__rocblas_1_1rocblas__sasum__batched.html "Interface documentation") | C binding
 199 | [rocblas_dasum_batched](interfacehipfort__rocblas_1_1rocblas__dasum__batched.html "Interface documentation") | C binding
 200 | [rocblas_scasum_batched](interfacehipfort__rocblas_1_1rocblas__scasum__batched.html "Interface documentation") | C binding
 201 | [rocblas_dzasum_batched](interfacehipfort__rocblas_1_1rocblas__dzasum__batched.html "Interface documentation") | C binding
-202 | [rocblas_sasum_batched_64](interfacehipfort__rocblas_1_1rocblas__sasum__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-203 | [rocblas_dasum_batched_64](interfacehipfort__rocblas_1_1rocblas__dasum__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-204 | [rocblas_scasum_batched_64](interfacehipfort__rocblas_1_1rocblas__scasum__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-205 | [rocblas_dzasum_batched_64](interfacehipfort__rocblas_1_1rocblas__dzasum__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-206 | [rocblas_sasum_strided_batched](interfacehipfort__rocblas_1_1rocblas__sasum__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-207 | [rocblas_dasum_strided_batched](interfacehipfort__rocblas_1_1rocblas__dasum__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-208 | [rocblas_scasum_strided_batched](interfacehipfort__rocblas_1_1rocblas__scasum__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-209 | [rocblas_dzasum_strided_batched](interfacehipfort__rocblas_1_1rocblas__dzasum__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-210 | [rocblas_sasum_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sasum__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-211 | [rocblas_dasum_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dasum__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-212 | [rocblas_scasum_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__scasum__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-213 | [rocblas_dzasum_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dzasum__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-214 | [rocblas_snrm2](interfacehipfort__rocblas_1_1rocblas__snrm2.html "Interface documentation") | C binding, rank_0, rank_1
-215 | [rocblas_dnrm2](interfacehipfort__rocblas_1_1rocblas__dnrm2.html "Interface documentation") | C binding, rank_0, rank_1
-216 | [rocblas_scnrm2](interfacehipfort__rocblas_1_1rocblas__scnrm2.html "Interface documentation") | C binding, rank_0, rank_1
-217 | [rocblas_dznrm2](interfacehipfort__rocblas_1_1rocblas__dznrm2.html "Interface documentation") | C binding, rank_0, rank_1
-218 | [rocblas_snrm2_64](interfacehipfort__rocblas_1_1rocblas__snrm2__64.html "Interface documentation") | C binding, rank_0, rank_1
-219 | [rocblas_dnrm2_64](interfacehipfort__rocblas_1_1rocblas__dnrm2__64.html "Interface documentation") | C binding, rank_0, rank_1
-220 | [rocblas_scnrm2_64](interfacehipfort__rocblas_1_1rocblas__scnrm2__64.html "Interface documentation") | C binding, rank_0, rank_1
-221 | [rocblas_dznrm2_64](interfacehipfort__rocblas_1_1rocblas__dznrm2__64.html "Interface documentation") | C binding, rank_0, rank_1
+202 | [rocblas_sasum_batched_64](interfacehipfort__rocblas_1_1rocblas__sasum__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+203 | [rocblas_dasum_batched_64](interfacehipfort__rocblas_1_1rocblas__dasum__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+204 | [rocblas_scasum_batched_64](interfacehipfort__rocblas_1_1rocblas__scasum__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+205 | [rocblas_dzasum_batched_64](interfacehipfort__rocblas_1_1rocblas__dzasum__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+206 | [rocblas_sasum_strided_batched](interfacehipfort__rocblas_1_1rocblas__sasum__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+207 | [rocblas_dasum_strided_batched](interfacehipfort__rocblas_1_1rocblas__dasum__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+208 | [rocblas_scasum_strided_batched](interfacehipfort__rocblas_1_1rocblas__scasum__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+209 | [rocblas_dzasum_strided_batched](interfacehipfort__rocblas_1_1rocblas__dzasum__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+210 | [rocblas_sasum_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sasum__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+211 | [rocblas_dasum_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dasum__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+212 | [rocblas_scasum_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__scasum__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+213 | [rocblas_dzasum_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dzasum__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+214 | [rocblas_snrm2](interfacehipfort__rocblas_1_1rocblas__snrm2.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+215 | [rocblas_dnrm2](interfacehipfort__rocblas_1_1rocblas__dnrm2.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+216 | [rocblas_scnrm2](interfacehipfort__rocblas_1_1rocblas__scnrm2.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+217 | [rocblas_dznrm2](interfacehipfort__rocblas_1_1rocblas__dznrm2.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+218 | [rocblas_snrm2_64](interfacehipfort__rocblas_1_1rocblas__snrm2__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+219 | [rocblas_dnrm2_64](interfacehipfort__rocblas_1_1rocblas__dnrm2__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+220 | [rocblas_scnrm2_64](interfacehipfort__rocblas_1_1rocblas__scnrm2__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+221 | [rocblas_dznrm2_64](interfacehipfort__rocblas_1_1rocblas__dznrm2__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 222 | [rocblas_snrm2_batched](interfacehipfort__rocblas_1_1rocblas__snrm2__batched.html "Interface documentation") | C binding
 223 | [rocblas_dnrm2_batched](interfacehipfort__rocblas_1_1rocblas__dnrm2__batched.html "Interface documentation") | C binding
 224 | [rocblas_scnrm2_batched](interfacehipfort__rocblas_1_1rocblas__scnrm2__batched.html "Interface documentation") | C binding
 225 | [rocblas_dznrm2_batched](interfacehipfort__rocblas_1_1rocblas__dznrm2__batched.html "Interface documentation") | C binding
-226 | [rocblas_snrm2_batched_64](interfacehipfort__rocblas_1_1rocblas__snrm2__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-227 | [rocblas_dnrm2_batched_64](interfacehipfort__rocblas_1_1rocblas__dnrm2__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-228 | [rocblas_scnrm2_batched_64](interfacehipfort__rocblas_1_1rocblas__scnrm2__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-229 | [rocblas_dznrm2_batched_64](interfacehipfort__rocblas_1_1rocblas__dznrm2__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-230 | [rocblas_snrm2_strided_batched](interfacehipfort__rocblas_1_1rocblas__snrm2__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-231 | [rocblas_dnrm2_strided_batched](interfacehipfort__rocblas_1_1rocblas__dnrm2__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-232 | [rocblas_scnrm2_strided_batched](interfacehipfort__rocblas_1_1rocblas__scnrm2__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-233 | [rocblas_dznrm2_strided_batched](interfacehipfort__rocblas_1_1rocblas__dznrm2__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-234 | [rocblas_snrm2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__snrm2__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-235 | [rocblas_dnrm2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dnrm2__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-236 | [rocblas_scnrm2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__scnrm2__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-237 | [rocblas_dznrm2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dznrm2__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-238 | [rocblas_isamax](interfacehipfort__rocblas_1_1rocblas__isamax.html "Interface documentation") | C binding, rank_0, rank_1
-239 | [rocblas_idamax](interfacehipfort__rocblas_1_1rocblas__idamax.html "Interface documentation") | C binding, rank_0, rank_1
-240 | [rocblas_icamax](interfacehipfort__rocblas_1_1rocblas__icamax.html "Interface documentation") | C binding, rank_0, rank_1
-241 | [rocblas_izamax](interfacehipfort__rocblas_1_1rocblas__izamax.html "Interface documentation") | C binding, rank_0, rank_1
-242 | [rocblas_isamax_64](interfacehipfort__rocblas_1_1rocblas__isamax__64.html "Interface documentation") | C binding, rank_0, rank_1
-243 | [rocblas_idamax_64](interfacehipfort__rocblas_1_1rocblas__idamax__64.html "Interface documentation") | C binding, rank_0, rank_1
-244 | [rocblas_icamax_64](interfacehipfort__rocblas_1_1rocblas__icamax__64.html "Interface documentation") | C binding, rank_0, rank_1
-245 | [rocblas_izamax_64](interfacehipfort__rocblas_1_1rocblas__izamax__64.html "Interface documentation") | C binding, rank_0, rank_1
+226 | [rocblas_snrm2_batched_64](interfacehipfort__rocblas_1_1rocblas__snrm2__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+227 | [rocblas_dnrm2_batched_64](interfacehipfort__rocblas_1_1rocblas__dnrm2__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+228 | [rocblas_scnrm2_batched_64](interfacehipfort__rocblas_1_1rocblas__scnrm2__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+229 | [rocblas_dznrm2_batched_64](interfacehipfort__rocblas_1_1rocblas__dznrm2__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+230 | [rocblas_snrm2_strided_batched](interfacehipfort__rocblas_1_1rocblas__snrm2__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+231 | [rocblas_dnrm2_strided_batched](interfacehipfort__rocblas_1_1rocblas__dnrm2__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+232 | [rocblas_scnrm2_strided_batched](interfacehipfort__rocblas_1_1rocblas__scnrm2__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+233 | [rocblas_dznrm2_strided_batched](interfacehipfort__rocblas_1_1rocblas__dznrm2__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+234 | [rocblas_snrm2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__snrm2__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+235 | [rocblas_dnrm2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dnrm2__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+236 | [rocblas_scnrm2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__scnrm2__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+237 | [rocblas_dznrm2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dznrm2__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+238 | [rocblas_isamax](interfacehipfort__rocblas_1_1rocblas__isamax.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+239 | [rocblas_idamax](interfacehipfort__rocblas_1_1rocblas__idamax.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+240 | [rocblas_icamax](interfacehipfort__rocblas_1_1rocblas__icamax.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+241 | [rocblas_izamax](interfacehipfort__rocblas_1_1rocblas__izamax.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+242 | [rocblas_isamax_64](interfacehipfort__rocblas_1_1rocblas__isamax__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+243 | [rocblas_idamax_64](interfacehipfort__rocblas_1_1rocblas__idamax__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+244 | [rocblas_icamax_64](interfacehipfort__rocblas_1_1rocblas__icamax__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+245 | [rocblas_izamax_64](interfacehipfort__rocblas_1_1rocblas__izamax__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 246 | [rocblas_isamax_batched](interfacehipfort__rocblas_1_1rocblas__isamax__batched.html "Interface documentation") | C binding
 247 | [rocblas_idamax_batched](interfacehipfort__rocblas_1_1rocblas__idamax__batched.html "Interface documentation") | C binding
 248 | [rocblas_icamax_batched](interfacehipfort__rocblas_1_1rocblas__icamax__batched.html "Interface documentation") | C binding
 249 | [rocblas_izamax_batched](interfacehipfort__rocblas_1_1rocblas__izamax__batched.html "Interface documentation") | C binding
-250 | [rocblas_isamax_batched_64](interfacehipfort__rocblas_1_1rocblas__isamax__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-251 | [rocblas_idamax_batched_64](interfacehipfort__rocblas_1_1rocblas__idamax__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-252 | [rocblas_icamax_batched_64](interfacehipfort__rocblas_1_1rocblas__icamax__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-253 | [rocblas_izamax_batched_64](interfacehipfort__rocblas_1_1rocblas__izamax__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-254 | [rocblas_isamax_strided_batched](interfacehipfort__rocblas_1_1rocblas__isamax__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-255 | [rocblas_idamax_strided_batched](interfacehipfort__rocblas_1_1rocblas__idamax__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-256 | [rocblas_icamax_strided_batched](interfacehipfort__rocblas_1_1rocblas__icamax__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-257 | [rocblas_izamax_strided_batched](interfacehipfort__rocblas_1_1rocblas__izamax__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-258 | [rocblas_isamax_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__isamax__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-259 | [rocblas_idamax_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__idamax__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-260 | [rocblas_icamax_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__icamax__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-261 | [rocblas_izamax_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__izamax__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-262 | [rocblas_isamin](interfacehipfort__rocblas_1_1rocblas__isamin.html "Interface documentation") | C binding, rank_0, rank_1
-263 | [rocblas_idamin](interfacehipfort__rocblas_1_1rocblas__idamin.html "Interface documentation") | C binding, rank_0, rank_1
-264 | [rocblas_icamin](interfacehipfort__rocblas_1_1rocblas__icamin.html "Interface documentation") | C binding, rank_0, rank_1
-265 | [rocblas_izamin](interfacehipfort__rocblas_1_1rocblas__izamin.html "Interface documentation") | C binding, rank_0, rank_1
-266 | [rocblas_isamin_64](interfacehipfort__rocblas_1_1rocblas__isamin__64.html "Interface documentation") | C binding, rank_0, rank_1
-267 | [rocblas_idamin_64](interfacehipfort__rocblas_1_1rocblas__idamin__64.html "Interface documentation") | C binding, rank_0, rank_1
-268 | [rocblas_icamin_64](interfacehipfort__rocblas_1_1rocblas__icamin__64.html "Interface documentation") | C binding, rank_0, rank_1
-269 | [rocblas_izamin_64](interfacehipfort__rocblas_1_1rocblas__izamin__64.html "Interface documentation") | C binding, rank_0, rank_1
+250 | [rocblas_isamax_batched_64](interfacehipfort__rocblas_1_1rocblas__isamax__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+251 | [rocblas_idamax_batched_64](interfacehipfort__rocblas_1_1rocblas__idamax__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+252 | [rocblas_icamax_batched_64](interfacehipfort__rocblas_1_1rocblas__icamax__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+253 | [rocblas_izamax_batched_64](interfacehipfort__rocblas_1_1rocblas__izamax__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+254 | [rocblas_isamax_strided_batched](interfacehipfort__rocblas_1_1rocblas__isamax__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+255 | [rocblas_idamax_strided_batched](interfacehipfort__rocblas_1_1rocblas__idamax__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+256 | [rocblas_icamax_strided_batched](interfacehipfort__rocblas_1_1rocblas__icamax__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+257 | [rocblas_izamax_strided_batched](interfacehipfort__rocblas_1_1rocblas__izamax__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+258 | [rocblas_isamax_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__isamax__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+259 | [rocblas_idamax_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__idamax__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+260 | [rocblas_icamax_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__icamax__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+261 | [rocblas_izamax_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__izamax__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+262 | [rocblas_isamin](interfacehipfort__rocblas_1_1rocblas__isamin.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+263 | [rocblas_idamin](interfacehipfort__rocblas_1_1rocblas__idamin.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+264 | [rocblas_icamin](interfacehipfort__rocblas_1_1rocblas__icamin.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+265 | [rocblas_izamin](interfacehipfort__rocblas_1_1rocblas__izamin.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+266 | [rocblas_isamin_64](interfacehipfort__rocblas_1_1rocblas__isamin__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+267 | [rocblas_idamin_64](interfacehipfort__rocblas_1_1rocblas__idamin__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+268 | [rocblas_icamin_64](interfacehipfort__rocblas_1_1rocblas__icamin__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+269 | [rocblas_izamin_64](interfacehipfort__rocblas_1_1rocblas__izamin__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 270 | [rocblas_isamin_batched](interfacehipfort__rocblas_1_1rocblas__isamin__batched.html "Interface documentation") | C binding
 271 | [rocblas_idamin_batched](interfacehipfort__rocblas_1_1rocblas__idamin__batched.html "Interface documentation") | C binding
 272 | [rocblas_icamin_batched](interfacehipfort__rocblas_1_1rocblas__icamin__batched.html "Interface documentation") | C binding
 273 | [rocblas_izamin_batched](interfacehipfort__rocblas_1_1rocblas__izamin__batched.html "Interface documentation") | C binding
-274 | [rocblas_isamin_batched_64](interfacehipfort__rocblas_1_1rocblas__isamin__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-275 | [rocblas_idamin_batched_64](interfacehipfort__rocblas_1_1rocblas__idamin__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-276 | [rocblas_icamin_batched_64](interfacehipfort__rocblas_1_1rocblas__icamin__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-277 | [rocblas_izamin_batched_64](interfacehipfort__rocblas_1_1rocblas__izamin__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-278 | [rocblas_isamin_strided_batched](interfacehipfort__rocblas_1_1rocblas__isamin__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-279 | [rocblas_idamin_strided_batched](interfacehipfort__rocblas_1_1rocblas__idamin__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-280 | [rocblas_icamin_strided_batched](interfacehipfort__rocblas_1_1rocblas__icamin__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-281 | [rocblas_izamin_strided_batched](interfacehipfort__rocblas_1_1rocblas__izamin__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-282 | [rocblas_isamin_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__isamin__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-283 | [rocblas_idamin_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__idamin__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-284 | [rocblas_icamin_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__icamin__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-285 | [rocblas_izamin_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__izamin__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-286 | [rocblas_srot](interfacehipfort__rocblas_1_1rocblas__srot.html "Interface documentation") | C binding, rank_0, rank_1
-287 | [rocblas_drot](interfacehipfort__rocblas_1_1rocblas__drot.html "Interface documentation") | C binding, rank_0, rank_1
-288 | [rocblas_crot](interfacehipfort__rocblas_1_1rocblas__crot.html "Interface documentation") | C binding, rank_0, rank_1
-289 | [rocblas_csrot](interfacehipfort__rocblas_1_1rocblas__csrot.html "Interface documentation") | C binding, rank_0, rank_1
-290 | [rocblas_zrot](interfacehipfort__rocblas_1_1rocblas__zrot.html "Interface documentation") | C binding, rank_0, rank_1
-291 | [rocblas_zdrot](interfacehipfort__rocblas_1_1rocblas__zdrot.html "Interface documentation") | C binding, rank_0, rank_1
-292 | [rocblas_srot_64](interfacehipfort__rocblas_1_1rocblas__srot__64.html "Interface documentation") | C binding, rank_0, rank_1
-293 | [rocblas_drot_64](interfacehipfort__rocblas_1_1rocblas__drot__64.html "Interface documentation") | C binding, rank_0, rank_1
-294 | [rocblas_crot_64](interfacehipfort__rocblas_1_1rocblas__crot__64.html "Interface documentation") | C binding, rank_0, rank_1
-295 | [rocblas_csrot_64](interfacehipfort__rocblas_1_1rocblas__csrot__64.html "Interface documentation") | C binding, rank_0, rank_1
-296 | [rocblas_zrot_64](interfacehipfort__rocblas_1_1rocblas__zrot__64.html "Interface documentation") | C binding, rank_0, rank_1
-297 | [rocblas_zdrot_64](interfacehipfort__rocblas_1_1rocblas__zdrot__64.html "Interface documentation") | C binding, rank_0, rank_1
+274 | [rocblas_isamin_batched_64](interfacehipfort__rocblas_1_1rocblas__isamin__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+275 | [rocblas_idamin_batched_64](interfacehipfort__rocblas_1_1rocblas__idamin__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+276 | [rocblas_icamin_batched_64](interfacehipfort__rocblas_1_1rocblas__icamin__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+277 | [rocblas_izamin_batched_64](interfacehipfort__rocblas_1_1rocblas__izamin__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+278 | [rocblas_isamin_strided_batched](interfacehipfort__rocblas_1_1rocblas__isamin__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+279 | [rocblas_idamin_strided_batched](interfacehipfort__rocblas_1_1rocblas__idamin__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+280 | [rocblas_icamin_strided_batched](interfacehipfort__rocblas_1_1rocblas__icamin__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+281 | [rocblas_izamin_strided_batched](interfacehipfort__rocblas_1_1rocblas__izamin__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+282 | [rocblas_isamin_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__isamin__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+283 | [rocblas_idamin_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__idamin__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+284 | [rocblas_icamin_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__icamin__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+285 | [rocblas_izamin_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__izamin__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+286 | [rocblas_srot](interfacehipfort__rocblas_1_1rocblas__srot.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+287 | [rocblas_drot](interfacehipfort__rocblas_1_1rocblas__drot.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+288 | [rocblas_crot](interfacehipfort__rocblas_1_1rocblas__crot.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+289 | [rocblas_csrot](interfacehipfort__rocblas_1_1rocblas__csrot.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+290 | [rocblas_zrot](interfacehipfort__rocblas_1_1rocblas__zrot.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+291 | [rocblas_zdrot](interfacehipfort__rocblas_1_1rocblas__zdrot.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+292 | [rocblas_srot_64](interfacehipfort__rocblas_1_1rocblas__srot__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+293 | [rocblas_drot_64](interfacehipfort__rocblas_1_1rocblas__drot__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+294 | [rocblas_crot_64](interfacehipfort__rocblas_1_1rocblas__crot__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+295 | [rocblas_csrot_64](interfacehipfort__rocblas_1_1rocblas__csrot__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+296 | [rocblas_zrot_64](interfacehipfort__rocblas_1_1rocblas__zrot__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+297 | [rocblas_zdrot_64](interfacehipfort__rocblas_1_1rocblas__zdrot__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 298 | [rocblas_srot_batched](interfacehipfort__rocblas_1_1rocblas__srot__batched.html "Interface documentation") | C binding
 299 | [rocblas_drot_batched](interfacehipfort__rocblas_1_1rocblas__drot__batched.html "Interface documentation") | C binding
 300 | [rocblas_crot_batched](interfacehipfort__rocblas_1_1rocblas__crot__batched.html "Interface documentation") | C binding
@@ -311,26 +311,26 @@
 307 | [rocblas_csrot_batched_64](interfacehipfort__rocblas_1_1rocblas__csrot__batched__64.html "Interface documentation") | C binding
 308 | [rocblas_zrot_batched_64](interfacehipfort__rocblas_1_1rocblas__zrot__batched__64.html "Interface documentation") | C binding
 309 | [rocblas_zdrot_batched_64](interfacehipfort__rocblas_1_1rocblas__zdrot__batched__64.html "Interface documentation") | C binding
-310 | [rocblas_srot_strided_batched](interfacehipfort__rocblas_1_1rocblas__srot__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-311 | [rocblas_drot_strided_batched](interfacehipfort__rocblas_1_1rocblas__drot__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-312 | [rocblas_crot_strided_batched](interfacehipfort__rocblas_1_1rocblas__crot__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-313 | [rocblas_csrot_strided_batched](interfacehipfort__rocblas_1_1rocblas__csrot__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-314 | [rocblas_zrot_strided_batched](interfacehipfort__rocblas_1_1rocblas__zrot__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-315 | [rocblas_zdrot_strided_batched](interfacehipfort__rocblas_1_1rocblas__zdrot__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-316 | [rocblas_srot_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__srot__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-317 | [rocblas_drot_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__drot__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-318 | [rocblas_crot_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__crot__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-319 | [rocblas_csrot_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__csrot__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-320 | [rocblas_zrot_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zrot__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-321 | [rocblas_zdrot_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zdrot__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-322 | [rocblas_srotg](interfacehipfort__rocblas_1_1rocblas__srotg.html "Interface documentation") | C binding, rank_0, rank_1
-323 | [rocblas_drotg](interfacehipfort__rocblas_1_1rocblas__drotg.html "Interface documentation") | C binding, rank_0, rank_1
-324 | [rocblas_crotg](interfacehipfort__rocblas_1_1rocblas__crotg.html "Interface documentation") | C binding, rank_0, rank_1
-325 | [rocblas_zrotg](interfacehipfort__rocblas_1_1rocblas__zrotg.html "Interface documentation") | C binding, rank_0, rank_1
-326 | [rocblas_srotg_64](interfacehipfort__rocblas_1_1rocblas__srotg__64.html "Interface documentation") | C binding, rank_0, rank_1
-327 | [rocblas_drotg_64](interfacehipfort__rocblas_1_1rocblas__drotg__64.html "Interface documentation") | C binding, rank_0, rank_1
-328 | [rocblas_crotg_64](interfacehipfort__rocblas_1_1rocblas__crotg__64.html "Interface documentation") | C binding, rank_0, rank_1
-329 | [rocblas_zrotg_64](interfacehipfort__rocblas_1_1rocblas__zrotg__64.html "Interface documentation") | C binding, rank_0, rank_1
+310 | [rocblas_srot_strided_batched](interfacehipfort__rocblas_1_1rocblas__srot__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+311 | [rocblas_drot_strided_batched](interfacehipfort__rocblas_1_1rocblas__drot__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+312 | [rocblas_crot_strided_batched](interfacehipfort__rocblas_1_1rocblas__crot__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+313 | [rocblas_csrot_strided_batched](interfacehipfort__rocblas_1_1rocblas__csrot__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+314 | [rocblas_zrot_strided_batched](interfacehipfort__rocblas_1_1rocblas__zrot__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+315 | [rocblas_zdrot_strided_batched](interfacehipfort__rocblas_1_1rocblas__zdrot__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+316 | [rocblas_srot_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__srot__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+317 | [rocblas_drot_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__drot__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+318 | [rocblas_crot_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__crot__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+319 | [rocblas_csrot_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__csrot__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+320 | [rocblas_zrot_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zrot__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+321 | [rocblas_zdrot_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zdrot__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+322 | [rocblas_srotg](interfacehipfort__rocblas_1_1rocblas__srotg.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+323 | [rocblas_drotg](interfacehipfort__rocblas_1_1rocblas__drotg.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+324 | [rocblas_crotg](interfacehipfort__rocblas_1_1rocblas__crotg.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+325 | [rocblas_zrotg](interfacehipfort__rocblas_1_1rocblas__zrotg.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+326 | [rocblas_srotg_64](interfacehipfort__rocblas_1_1rocblas__srotg__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+327 | [rocblas_drotg_64](interfacehipfort__rocblas_1_1rocblas__drotg__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+328 | [rocblas_crotg_64](interfacehipfort__rocblas_1_1rocblas__crotg__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+329 | [rocblas_zrotg_64](interfacehipfort__rocblas_1_1rocblas__zrotg__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 330 | [rocblas_srotg_batched](interfacehipfort__rocblas_1_1rocblas__srotg__batched.html "Interface documentation") | C binding
 331 | [rocblas_drotg_batched](interfacehipfort__rocblas_1_1rocblas__drotg__batched.html "Interface documentation") | C binding
 332 | [rocblas_crotg_batched](interfacehipfort__rocblas_1_1rocblas__crotg__batched.html "Interface documentation") | C binding
@@ -339,46 +339,46 @@
 335 | [rocblas_drotg_batched_64](interfacehipfort__rocblas_1_1rocblas__drotg__batched__64.html "Interface documentation") | C binding
 336 | [rocblas_crotg_batched_64](interfacehipfort__rocblas_1_1rocblas__crotg__batched__64.html "Interface documentation") | C binding
 337 | [rocblas_zrotg_batched_64](interfacehipfort__rocblas_1_1rocblas__zrotg__batched__64.html "Interface documentation") | C binding
-338 | [rocblas_srotg_strided_batched](interfacehipfort__rocblas_1_1rocblas__srotg__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-339 | [rocblas_drotg_strided_batched](interfacehipfort__rocblas_1_1rocblas__drotg__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-340 | [rocblas_crotg_strided_batched](interfacehipfort__rocblas_1_1rocblas__crotg__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-341 | [rocblas_zrotg_strided_batched](interfacehipfort__rocblas_1_1rocblas__zrotg__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-342 | [rocblas_srotg_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__srotg__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-343 | [rocblas_drotg_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__drotg__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-344 | [rocblas_crotg_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__crotg__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-345 | [rocblas_zrotg_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zrotg__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-346 | [rocblas_srotm](interfacehipfort__rocblas_1_1rocblas__srotm.html "Interface documentation") | C binding, rank_0, rank_1
-347 | [rocblas_drotm](interfacehipfort__rocblas_1_1rocblas__drotm.html "Interface documentation") | C binding, rank_0, rank_1
-348 | [rocblas_srotm_64](interfacehipfort__rocblas_1_1rocblas__srotm__64.html "Interface documentation") | C binding, rank_0, rank_1
-349 | [rocblas_drotm_64](interfacehipfort__rocblas_1_1rocblas__drotm__64.html "Interface documentation") | C binding, rank_0, rank_1
+338 | [rocblas_srotg_strided_batched](interfacehipfort__rocblas_1_1rocblas__srotg__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+339 | [rocblas_drotg_strided_batched](interfacehipfort__rocblas_1_1rocblas__drotg__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+340 | [rocblas_crotg_strided_batched](interfacehipfort__rocblas_1_1rocblas__crotg__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+341 | [rocblas_zrotg_strided_batched](interfacehipfort__rocblas_1_1rocblas__zrotg__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+342 | [rocblas_srotg_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__srotg__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+343 | [rocblas_drotg_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__drotg__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+344 | [rocblas_crotg_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__crotg__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+345 | [rocblas_zrotg_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zrotg__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+346 | [rocblas_srotm](interfacehipfort__rocblas_1_1rocblas__srotm.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+347 | [rocblas_drotm](interfacehipfort__rocblas_1_1rocblas__drotm.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+348 | [rocblas_srotm_64](interfacehipfort__rocblas_1_1rocblas__srotm__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+349 | [rocblas_drotm_64](interfacehipfort__rocblas_1_1rocblas__drotm__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 350 | [rocblas_srotm_batched](interfacehipfort__rocblas_1_1rocblas__srotm__batched.html "Interface documentation") | C binding
 351 | [rocblas_drotm_batched](interfacehipfort__rocblas_1_1rocblas__drotm__batched.html "Interface documentation") | C binding
 352 | [rocblas_srotm_batched_64](interfacehipfort__rocblas_1_1rocblas__srotm__batched__64.html "Interface documentation") | C binding
 353 | [rocblas_drotm_batched_64](interfacehipfort__rocblas_1_1rocblas__drotm__batched__64.html "Interface documentation") | C binding
-354 | [rocblas_srotm_strided_batched](interfacehipfort__rocblas_1_1rocblas__srotm__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-355 | [rocblas_drotm_strided_batched](interfacehipfort__rocblas_1_1rocblas__drotm__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-356 | [rocblas_srotm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__srotm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-357 | [rocblas_drotm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__drotm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-358 | [rocblas_srotmg](interfacehipfort__rocblas_1_1rocblas__srotmg.html "Interface documentation") | C binding, rank_0, rank_1
-359 | [rocblas_drotmg](interfacehipfort__rocblas_1_1rocblas__drotmg.html "Interface documentation") | C binding, rank_0, rank_1
-360 | [rocblas_srotmg_64](interfacehipfort__rocblas_1_1rocblas__srotmg__64.html "Interface documentation") | C binding, rank_0, rank_1
-361 | [rocblas_drotmg_64](interfacehipfort__rocblas_1_1rocblas__drotmg__64.html "Interface documentation") | C binding, rank_0, rank_1
+354 | [rocblas_srotm_strided_batched](interfacehipfort__rocblas_1_1rocblas__srotm__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+355 | [rocblas_drotm_strided_batched](interfacehipfort__rocblas_1_1rocblas__drotm__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+356 | [rocblas_srotm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__srotm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+357 | [rocblas_drotm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__drotm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+358 | [rocblas_srotmg](interfacehipfort__rocblas_1_1rocblas__srotmg.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+359 | [rocblas_drotmg](interfacehipfort__rocblas_1_1rocblas__drotmg.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+360 | [rocblas_srotmg_64](interfacehipfort__rocblas_1_1rocblas__srotmg__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+361 | [rocblas_drotmg_64](interfacehipfort__rocblas_1_1rocblas__drotmg__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 362 | [rocblas_srotmg_batched](interfacehipfort__rocblas_1_1rocblas__srotmg__batched.html "Interface documentation") | C binding
 363 | [rocblas_drotmg_batched](interfacehipfort__rocblas_1_1rocblas__drotmg__batched.html "Interface documentation") | C binding
 364 | [rocblas_srotmg_batched_64](interfacehipfort__rocblas_1_1rocblas__srotmg__batched__64.html "Interface documentation") | C binding
 365 | [rocblas_drotmg_batched_64](interfacehipfort__rocblas_1_1rocblas__drotmg__batched__64.html "Interface documentation") | C binding
-366 | [rocblas_srotmg_strided_batched](interfacehipfort__rocblas_1_1rocblas__srotmg__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-367 | [rocblas_drotmg_strided_batched](interfacehipfort__rocblas_1_1rocblas__drotmg__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-368 | [rocblas_srotmg_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__srotmg__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-369 | [rocblas_drotmg_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__drotmg__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-370 | [rocblas_sgbmv](interfacehipfort__rocblas_1_1rocblas__sgbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-371 | [rocblas_dgbmv](interfacehipfort__rocblas_1_1rocblas__dgbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-372 | [rocblas_cgbmv](interfacehipfort__rocblas_1_1rocblas__cgbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-373 | [rocblas_zgbmv](interfacehipfort__rocblas_1_1rocblas__zgbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-374 | [rocblas_sgbmv_64](interfacehipfort__rocblas_1_1rocblas__sgbmv__64.html "Interface documentation") | C binding, rank_0, rank_1
-375 | [rocblas_dgbmv_64](interfacehipfort__rocblas_1_1rocblas__dgbmv__64.html "Interface documentation") | C binding, rank_0, rank_1
-376 | [rocblas_cgbmv_64](interfacehipfort__rocblas_1_1rocblas__cgbmv__64.html "Interface documentation") | C binding, rank_0, rank_1
-377 | [rocblas_zgbmv_64](interfacehipfort__rocblas_1_1rocblas__zgbmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+366 | [rocblas_srotmg_strided_batched](interfacehipfort__rocblas_1_1rocblas__srotmg__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+367 | [rocblas_drotmg_strided_batched](interfacehipfort__rocblas_1_1rocblas__drotmg__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+368 | [rocblas_srotmg_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__srotmg__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+369 | [rocblas_drotmg_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__drotmg__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+370 | [rocblas_sgbmv](interfacehipfort__rocblas_1_1rocblas__sgbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+371 | [rocblas_dgbmv](interfacehipfort__rocblas_1_1rocblas__dgbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+372 | [rocblas_cgbmv](interfacehipfort__rocblas_1_1rocblas__cgbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+373 | [rocblas_zgbmv](interfacehipfort__rocblas_1_1rocblas__zgbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+374 | [rocblas_sgbmv_64](interfacehipfort__rocblas_1_1rocblas__sgbmv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+375 | [rocblas_dgbmv_64](interfacehipfort__rocblas_1_1rocblas__dgbmv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+376 | [rocblas_cgbmv_64](interfacehipfort__rocblas_1_1rocblas__cgbmv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+377 | [rocblas_zgbmv_64](interfacehipfort__rocblas_1_1rocblas__zgbmv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 378 | [rocblas_sgbmv_batched](interfacehipfort__rocblas_1_1rocblas__sgbmv__batched.html "Interface documentation") | C binding
 379 | [rocblas_dgbmv_batched](interfacehipfort__rocblas_1_1rocblas__dgbmv__batched.html "Interface documentation") | C binding
 380 | [rocblas_cgbmv_batched](interfacehipfort__rocblas_1_1rocblas__cgbmv__batched.html "Interface documentation") | C binding
@@ -387,22 +387,22 @@
 383 | [rocblas_dgbmv_batched_64](interfacehipfort__rocblas_1_1rocblas__dgbmv__batched__64.html "Interface documentation") | C binding
 384 | [rocblas_cgbmv_batched_64](interfacehipfort__rocblas_1_1rocblas__cgbmv__batched__64.html "Interface documentation") | C binding
 385 | [rocblas_zgbmv_batched_64](interfacehipfort__rocblas_1_1rocblas__zgbmv__batched__64.html "Interface documentation") | C binding
-386 | [rocblas_sgbmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__sgbmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-387 | [rocblas_dgbmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__dgbmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-388 | [rocblas_cgbmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__cgbmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-389 | [rocblas_zgbmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__zgbmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-390 | [rocblas_sgbmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sgbmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-391 | [rocblas_dgbmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dgbmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-392 | [rocblas_cgbmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cgbmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-393 | [rocblas_zgbmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zgbmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-394 | [rocblas_sgemv](interfacehipfort__rocblas_1_1rocblas__sgemv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-395 | [rocblas_dgemv](interfacehipfort__rocblas_1_1rocblas__dgemv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-396 | [rocblas_cgemv](interfacehipfort__rocblas_1_1rocblas__cgemv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-397 | [rocblas_zgemv](interfacehipfort__rocblas_1_1rocblas__zgemv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-398 | [rocblas_sgemv_64](interfacehipfort__rocblas_1_1rocblas__sgemv__64.html "Interface documentation") | C binding, rank_0, rank_1
-399 | [rocblas_dgemv_64](interfacehipfort__rocblas_1_1rocblas__dgemv__64.html "Interface documentation") | C binding, rank_0, rank_1
-400 | [rocblas_cgemv_64](interfacehipfort__rocblas_1_1rocblas__cgemv__64.html "Interface documentation") | C binding, rank_0, rank_1
-401 | [rocblas_zgemv_64](interfacehipfort__rocblas_1_1rocblas__zgemv__64.html "Interface documentation") | C binding, rank_0, rank_1
+386 | [rocblas_sgbmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__sgbmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+387 | [rocblas_dgbmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__dgbmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+388 | [rocblas_cgbmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__cgbmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+389 | [rocblas_zgbmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__zgbmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+390 | [rocblas_sgbmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sgbmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+391 | [rocblas_dgbmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dgbmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+392 | [rocblas_cgbmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cgbmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+393 | [rocblas_zgbmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zgbmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+394 | [rocblas_sgemv](interfacehipfort__rocblas_1_1rocblas__sgemv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+395 | [rocblas_dgemv](interfacehipfort__rocblas_1_1rocblas__dgemv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+396 | [rocblas_cgemv](interfacehipfort__rocblas_1_1rocblas__cgemv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+397 | [rocblas_zgemv](interfacehipfort__rocblas_1_1rocblas__zgemv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+398 | [rocblas_sgemv_64](interfacehipfort__rocblas_1_1rocblas__sgemv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+399 | [rocblas_dgemv_64](interfacehipfort__rocblas_1_1rocblas__dgemv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+400 | [rocblas_cgemv_64](interfacehipfort__rocblas_1_1rocblas__cgemv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+401 | [rocblas_zgemv_64](interfacehipfort__rocblas_1_1rocblas__zgemv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 402 | [rocblas_sgemv_batched](interfacehipfort__rocblas_1_1rocblas__sgemv__batched.html "Interface documentation") | C binding
 403 | [rocblas_dgemv_batched](interfacehipfort__rocblas_1_1rocblas__dgemv__batched.html "Interface documentation") | C binding
 404 | [rocblas_cgemv_batched](interfacehipfort__rocblas_1_1rocblas__cgemv__batched.html "Interface documentation") | C binding
@@ -419,114 +419,114 @@
 415 | [rocblas_hssgemv_batched_64](interfacehipfort__rocblas_1_1rocblas__hssgemv__batched__64.html "Interface documentation") | C binding
 416 | [rocblas_tstgemv_batched_64](interfacehipfort__rocblas_1_1rocblas__tstgemv__batched__64.html "Interface documentation") | C binding
 417 | [rocblas_tssgemv_batched_64](interfacehipfort__rocblas_1_1rocblas__tssgemv__batched__64.html "Interface documentation") | C binding
-418 | [rocblas_sgemv_strided_batched](interfacehipfort__rocblas_1_1rocblas__sgemv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-419 | [rocblas_dgemv_strided_batched](interfacehipfort__rocblas_1_1rocblas__dgemv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-420 | [rocblas_cgemv_strided_batched](interfacehipfort__rocblas_1_1rocblas__cgemv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-421 | [rocblas_zgemv_strided_batched](interfacehipfort__rocblas_1_1rocblas__zgemv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-422 | [rocblas_hshgemv_strided_batched](interfacehipfort__rocblas_1_1rocblas__hshgemv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-423 | [rocblas_hssgemv_strided_batched](interfacehipfort__rocblas_1_1rocblas__hssgemv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-424 | [rocblas_tstgemv_strided_batched](interfacehipfort__rocblas_1_1rocblas__tstgemv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-425 | [rocblas_tssgemv_strided_batched](interfacehipfort__rocblas_1_1rocblas__tssgemv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-426 | [rocblas_sgemv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sgemv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-427 | [rocblas_dgemv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dgemv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-428 | [rocblas_cgemv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cgemv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-429 | [rocblas_zgemv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zgemv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-430 | [rocblas_hshgemv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__hshgemv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-431 | [rocblas_hssgemv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__hssgemv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-432 | [rocblas_tstgemv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__tstgemv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-433 | [rocblas_tssgemv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__tssgemv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-434 | [rocblas_chbmv](interfacehipfort__rocblas_1_1rocblas__chbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-435 | [rocblas_zhbmv](interfacehipfort__rocblas_1_1rocblas__zhbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-436 | [rocblas_chbmv_64](interfacehipfort__rocblas_1_1rocblas__chbmv__64.html "Interface documentation") | C binding, rank_0, rank_1
-437 | [rocblas_zhbmv_64](interfacehipfort__rocblas_1_1rocblas__zhbmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+418 | [rocblas_sgemv_strided_batched](interfacehipfort__rocblas_1_1rocblas__sgemv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+419 | [rocblas_dgemv_strided_batched](interfacehipfort__rocblas_1_1rocblas__dgemv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+420 | [rocblas_cgemv_strided_batched](interfacehipfort__rocblas_1_1rocblas__cgemv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+421 | [rocblas_zgemv_strided_batched](interfacehipfort__rocblas_1_1rocblas__zgemv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+422 | [rocblas_hshgemv_strided_batched](interfacehipfort__rocblas_1_1rocblas__hshgemv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+423 | [rocblas_hssgemv_strided_batched](interfacehipfort__rocblas_1_1rocblas__hssgemv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+424 | [rocblas_tstgemv_strided_batched](interfacehipfort__rocblas_1_1rocblas__tstgemv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+425 | [rocblas_tssgemv_strided_batched](interfacehipfort__rocblas_1_1rocblas__tssgemv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+426 | [rocblas_sgemv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sgemv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+427 | [rocblas_dgemv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dgemv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+428 | [rocblas_cgemv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cgemv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+429 | [rocblas_zgemv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zgemv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+430 | [rocblas_hshgemv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__hshgemv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+431 | [rocblas_hssgemv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__hssgemv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+432 | [rocblas_tstgemv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__tstgemv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+433 | [rocblas_tssgemv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__tssgemv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+434 | [rocblas_chbmv](interfacehipfort__rocblas_1_1rocblas__chbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+435 | [rocblas_zhbmv](interfacehipfort__rocblas_1_1rocblas__zhbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+436 | [rocblas_chbmv_64](interfacehipfort__rocblas_1_1rocblas__chbmv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+437 | [rocblas_zhbmv_64](interfacehipfort__rocblas_1_1rocblas__zhbmv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 438 | [rocblas_chbmv_batched](interfacehipfort__rocblas_1_1rocblas__chbmv__batched.html "Interface documentation") | C binding
 439 | [rocblas_zhbmv_batched](interfacehipfort__rocblas_1_1rocblas__zhbmv__batched.html "Interface documentation") | C binding
 440 | [rocblas_chbmv_batched_64](interfacehipfort__rocblas_1_1rocblas__chbmv__batched__64.html "Interface documentation") | C binding
 441 | [rocblas_zhbmv_batched_64](interfacehipfort__rocblas_1_1rocblas__zhbmv__batched__64.html "Interface documentation") | C binding
-442 | [rocblas_chbmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__chbmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-443 | [rocblas_zhbmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__zhbmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-444 | [rocblas_chbmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__chbmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-445 | [rocblas_zhbmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zhbmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-446 | [rocblas_chemv](interfacehipfort__rocblas_1_1rocblas__chemv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-447 | [rocblas_zhemv](interfacehipfort__rocblas_1_1rocblas__zhemv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-448 | [rocblas_chemv_64](interfacehipfort__rocblas_1_1rocblas__chemv__64.html "Interface documentation") | C binding, rank_0, rank_1
-449 | [rocblas_zhemv_64](interfacehipfort__rocblas_1_1rocblas__zhemv__64.html "Interface documentation") | C binding, rank_0, rank_1
+442 | [rocblas_chbmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__chbmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+443 | [rocblas_zhbmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__zhbmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+444 | [rocblas_chbmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__chbmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+445 | [rocblas_zhbmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zhbmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+446 | [rocblas_chemv](interfacehipfort__rocblas_1_1rocblas__chemv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+447 | [rocblas_zhemv](interfacehipfort__rocblas_1_1rocblas__zhemv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+448 | [rocblas_chemv_64](interfacehipfort__rocblas_1_1rocblas__chemv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+449 | [rocblas_zhemv_64](interfacehipfort__rocblas_1_1rocblas__zhemv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 450 | [rocblas_chemv_batched](interfacehipfort__rocblas_1_1rocblas__chemv__batched.html "Interface documentation") | C binding
 451 | [rocblas_zhemv_batched](interfacehipfort__rocblas_1_1rocblas__zhemv__batched.html "Interface documentation") | C binding
 452 | [rocblas_chemv_batched_64](interfacehipfort__rocblas_1_1rocblas__chemv__batched__64.html "Interface documentation") | C binding
 453 | [rocblas_zhemv_batched_64](interfacehipfort__rocblas_1_1rocblas__zhemv__batched__64.html "Interface documentation") | C binding
-454 | [rocblas_chemv_strided_batched](interfacehipfort__rocblas_1_1rocblas__chemv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-455 | [rocblas_zhemv_strided_batched](interfacehipfort__rocblas_1_1rocblas__zhemv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-456 | [rocblas_chemv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__chemv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-457 | [rocblas_zhemv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zhemv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-458 | [rocblas_cher](interfacehipfort__rocblas_1_1rocblas__cher.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-459 | [rocblas_zher](interfacehipfort__rocblas_1_1rocblas__zher.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-460 | [rocblas_cher_64](interfacehipfort__rocblas_1_1rocblas__cher__64.html "Interface documentation") | C binding, rank_0, rank_1
-461 | [rocblas_zher_64](interfacehipfort__rocblas_1_1rocblas__zher__64.html "Interface documentation") | C binding, rank_0, rank_1
+454 | [rocblas_chemv_strided_batched](interfacehipfort__rocblas_1_1rocblas__chemv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+455 | [rocblas_zhemv_strided_batched](interfacehipfort__rocblas_1_1rocblas__zhemv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+456 | [rocblas_chemv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__chemv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+457 | [rocblas_zhemv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zhemv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+458 | [rocblas_cher](interfacehipfort__rocblas_1_1rocblas__cher.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+459 | [rocblas_zher](interfacehipfort__rocblas_1_1rocblas__zher.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+460 | [rocblas_cher_64](interfacehipfort__rocblas_1_1rocblas__cher__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+461 | [rocblas_zher_64](interfacehipfort__rocblas_1_1rocblas__zher__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 462 | [rocblas_cher_batched](interfacehipfort__rocblas_1_1rocblas__cher__batched.html "Interface documentation") | C binding
 463 | [rocblas_zher_batched](interfacehipfort__rocblas_1_1rocblas__zher__batched.html "Interface documentation") | C binding
 464 | [rocblas_cher_batched_64](interfacehipfort__rocblas_1_1rocblas__cher__batched__64.html "Interface documentation") | C binding
 465 | [rocblas_zher_batched_64](interfacehipfort__rocblas_1_1rocblas__zher__batched__64.html "Interface documentation") | C binding
-466 | [rocblas_cher_strided_batched](interfacehipfort__rocblas_1_1rocblas__cher__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-467 | [rocblas_zher_strided_batched](interfacehipfort__rocblas_1_1rocblas__zher__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-468 | [rocblas_cher_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cher__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-469 | [rocblas_zher_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zher__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-470 | [rocblas_cher2](interfacehipfort__rocblas_1_1rocblas__cher2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-471 | [rocblas_zher2](interfacehipfort__rocblas_1_1rocblas__zher2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-472 | [rocblas_cher2_64](interfacehipfort__rocblas_1_1rocblas__cher2__64.html "Interface documentation") | C binding, rank_0, rank_1
-473 | [rocblas_zher2_64](interfacehipfort__rocblas_1_1rocblas__zher2__64.html "Interface documentation") | C binding, rank_0, rank_1
+466 | [rocblas_cher_strided_batched](interfacehipfort__rocblas_1_1rocblas__cher__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+467 | [rocblas_zher_strided_batched](interfacehipfort__rocblas_1_1rocblas__zher__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+468 | [rocblas_cher_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cher__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+469 | [rocblas_zher_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zher__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+470 | [rocblas_cher2](interfacehipfort__rocblas_1_1rocblas__cher2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+471 | [rocblas_zher2](interfacehipfort__rocblas_1_1rocblas__zher2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+472 | [rocblas_cher2_64](interfacehipfort__rocblas_1_1rocblas__cher2__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+473 | [rocblas_zher2_64](interfacehipfort__rocblas_1_1rocblas__zher2__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 474 | [rocblas_cher2_batched](interfacehipfort__rocblas_1_1rocblas__cher2__batched.html "Interface documentation") | C binding
 475 | [rocblas_zher2_batched](interfacehipfort__rocblas_1_1rocblas__zher2__batched.html "Interface documentation") | C binding
 476 | [rocblas_cher2_batched_64](interfacehipfort__rocblas_1_1rocblas__cher2__batched__64.html "Interface documentation") | C binding
 477 | [rocblas_zher2_batched_64](interfacehipfort__rocblas_1_1rocblas__zher2__batched__64.html "Interface documentation") | C binding
-478 | [rocblas_cher2_strided_batched](interfacehipfort__rocblas_1_1rocblas__cher2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-479 | [rocblas_zher2_strided_batched](interfacehipfort__rocblas_1_1rocblas__zher2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-480 | [rocblas_cher2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cher2__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-481 | [rocblas_zher2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zher2__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-482 | [rocblas_chpmv](interfacehipfort__rocblas_1_1rocblas__chpmv.html "Interface documentation") | C binding, rank_0, rank_1
-483 | [rocblas_zhpmv](interfacehipfort__rocblas_1_1rocblas__zhpmv.html "Interface documentation") | C binding, rank_0, rank_1
-484 | [rocblas_chpmv_64](interfacehipfort__rocblas_1_1rocblas__chpmv__64.html "Interface documentation") | C binding, rank_0, rank_1
-485 | [rocblas_zhpmv_64](interfacehipfort__rocblas_1_1rocblas__zhpmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+478 | [rocblas_cher2_strided_batched](interfacehipfort__rocblas_1_1rocblas__cher2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+479 | [rocblas_zher2_strided_batched](interfacehipfort__rocblas_1_1rocblas__zher2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+480 | [rocblas_cher2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cher2__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+481 | [rocblas_zher2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zher2__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+482 | [rocblas_chpmv](interfacehipfort__rocblas_1_1rocblas__chpmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+483 | [rocblas_zhpmv](interfacehipfort__rocblas_1_1rocblas__zhpmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+484 | [rocblas_chpmv_64](interfacehipfort__rocblas_1_1rocblas__chpmv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+485 | [rocblas_zhpmv_64](interfacehipfort__rocblas_1_1rocblas__zhpmv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 486 | [rocblas_chpmv_batched](interfacehipfort__rocblas_1_1rocblas__chpmv__batched.html "Interface documentation") | C binding
 487 | [rocblas_zhpmv_batched](interfacehipfort__rocblas_1_1rocblas__zhpmv__batched.html "Interface documentation") | C binding
 488 | [rocblas_chpmv_batched_64](interfacehipfort__rocblas_1_1rocblas__chpmv__batched__64.html "Interface documentation") | C binding
 489 | [rocblas_zhpmv_batched_64](interfacehipfort__rocblas_1_1rocblas__zhpmv__batched__64.html "Interface documentation") | C binding
-490 | [rocblas_chpmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__chpmv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-491 | [rocblas_zhpmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__zhpmv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-492 | [rocblas_chpmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__chpmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-493 | [rocblas_zhpmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zhpmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-494 | [rocblas_chpr](interfacehipfort__rocblas_1_1rocblas__chpr.html "Interface documentation") | C binding, rank_0, rank_1
-495 | [rocblas_zhpr](interfacehipfort__rocblas_1_1rocblas__zhpr.html "Interface documentation") | C binding, rank_0, rank_1
-496 | [rocblas_chpr_64](interfacehipfort__rocblas_1_1rocblas__chpr__64.html "Interface documentation") | C binding, rank_0, rank_1
-497 | [rocblas_zhpr_64](interfacehipfort__rocblas_1_1rocblas__zhpr__64.html "Interface documentation") | C binding, rank_0, rank_1
+490 | [rocblas_chpmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__chpmv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+491 | [rocblas_zhpmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__zhpmv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+492 | [rocblas_chpmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__chpmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+493 | [rocblas_zhpmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zhpmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+494 | [rocblas_chpr](interfacehipfort__rocblas_1_1rocblas__chpr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+495 | [rocblas_zhpr](interfacehipfort__rocblas_1_1rocblas__zhpr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+496 | [rocblas_chpr_64](interfacehipfort__rocblas_1_1rocblas__chpr__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+497 | [rocblas_zhpr_64](interfacehipfort__rocblas_1_1rocblas__zhpr__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 498 | [rocblas_chpr_batched](interfacehipfort__rocblas_1_1rocblas__chpr__batched.html "Interface documentation") | C binding
 499 | [rocblas_zhpr_batched](interfacehipfort__rocblas_1_1rocblas__zhpr__batched.html "Interface documentation") | C binding
 500 | [rocblas_chpr_batched_64](interfacehipfort__rocblas_1_1rocblas__chpr__batched__64.html "Interface documentation") | C binding
 501 | [rocblas_zhpr_batched_64](interfacehipfort__rocblas_1_1rocblas__zhpr__batched__64.html "Interface documentation") | C binding
-502 | [rocblas_chpr_strided_batched](interfacehipfort__rocblas_1_1rocblas__chpr__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-503 | [rocblas_zhpr_strided_batched](interfacehipfort__rocblas_1_1rocblas__zhpr__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-504 | [rocblas_chpr_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__chpr__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-505 | [rocblas_zhpr_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zhpr__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-506 | [rocblas_chpr2](interfacehipfort__rocblas_1_1rocblas__chpr2.html "Interface documentation") | C binding, rank_0, rank_1
-507 | [rocblas_zhpr2](interfacehipfort__rocblas_1_1rocblas__zhpr2.html "Interface documentation") | C binding, rank_0, rank_1
-508 | [rocblas_chpr2_64](interfacehipfort__rocblas_1_1rocblas__chpr2__64.html "Interface documentation") | C binding, rank_0, rank_1
-509 | [rocblas_zhpr2_64](interfacehipfort__rocblas_1_1rocblas__zhpr2__64.html "Interface documentation") | C binding, rank_0, rank_1
+502 | [rocblas_chpr_strided_batched](interfacehipfort__rocblas_1_1rocblas__chpr__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+503 | [rocblas_zhpr_strided_batched](interfacehipfort__rocblas_1_1rocblas__zhpr__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+504 | [rocblas_chpr_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__chpr__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+505 | [rocblas_zhpr_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zhpr__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+506 | [rocblas_chpr2](interfacehipfort__rocblas_1_1rocblas__chpr2.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+507 | [rocblas_zhpr2](interfacehipfort__rocblas_1_1rocblas__zhpr2.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+508 | [rocblas_chpr2_64](interfacehipfort__rocblas_1_1rocblas__chpr2__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+509 | [rocblas_zhpr2_64](interfacehipfort__rocblas_1_1rocblas__zhpr2__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 510 | [rocblas_chpr2_batched](interfacehipfort__rocblas_1_1rocblas__chpr2__batched.html "Interface documentation") | C binding
 511 | [rocblas_zhpr2_batched](interfacehipfort__rocblas_1_1rocblas__zhpr2__batched.html "Interface documentation") | C binding
 512 | [rocblas_chpr2_batched_64](interfacehipfort__rocblas_1_1rocblas__chpr2__batched__64.html "Interface documentation") | C binding
 513 | [rocblas_zhpr2_batched_64](interfacehipfort__rocblas_1_1rocblas__zhpr2__batched__64.html "Interface documentation") | C binding
-514 | [rocblas_chpr2_strided_batched](interfacehipfort__rocblas_1_1rocblas__chpr2__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-515 | [rocblas_zhpr2_strided_batched](interfacehipfort__rocblas_1_1rocblas__zhpr2__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-516 | [rocblas_chpr2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__chpr2__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-517 | [rocblas_zhpr2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zhpr2__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-518 | [rocblas_strmv](interfacehipfort__rocblas_1_1rocblas__strmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-519 | [rocblas_dtrmv](interfacehipfort__rocblas_1_1rocblas__dtrmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-520 | [rocblas_ctrmv](interfacehipfort__rocblas_1_1rocblas__ctrmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-521 | [rocblas_ztrmv](interfacehipfort__rocblas_1_1rocblas__ztrmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-522 | [rocblas_strmv_64](interfacehipfort__rocblas_1_1rocblas__strmv__64.html "Interface documentation") | C binding, rank_0, rank_1
-523 | [rocblas_dtrmv_64](interfacehipfort__rocblas_1_1rocblas__dtrmv__64.html "Interface documentation") | C binding, rank_0, rank_1
-524 | [rocblas_ctrmv_64](interfacehipfort__rocblas_1_1rocblas__ctrmv__64.html "Interface documentation") | C binding, rank_0, rank_1
-525 | [rocblas_ztrmv_64](interfacehipfort__rocblas_1_1rocblas__ztrmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+514 | [rocblas_chpr2_strided_batched](interfacehipfort__rocblas_1_1rocblas__chpr2__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+515 | [rocblas_zhpr2_strided_batched](interfacehipfort__rocblas_1_1rocblas__zhpr2__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+516 | [rocblas_chpr2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__chpr2__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+517 | [rocblas_zhpr2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zhpr2__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+518 | [rocblas_strmv](interfacehipfort__rocblas_1_1rocblas__strmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+519 | [rocblas_dtrmv](interfacehipfort__rocblas_1_1rocblas__dtrmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+520 | [rocblas_ctrmv](interfacehipfort__rocblas_1_1rocblas__ctrmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+521 | [rocblas_ztrmv](interfacehipfort__rocblas_1_1rocblas__ztrmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+522 | [rocblas_strmv_64](interfacehipfort__rocblas_1_1rocblas__strmv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+523 | [rocblas_dtrmv_64](interfacehipfort__rocblas_1_1rocblas__dtrmv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+524 | [rocblas_ctrmv_64](interfacehipfort__rocblas_1_1rocblas__ctrmv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+525 | [rocblas_ztrmv_64](interfacehipfort__rocblas_1_1rocblas__ztrmv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 526 | [rocblas_strmv_batched](interfacehipfort__rocblas_1_1rocblas__strmv__batched.html "Interface documentation") | C binding
 527 | [rocblas_dtrmv_batched](interfacehipfort__rocblas_1_1rocblas__dtrmv__batched.html "Interface documentation") | C binding
 528 | [rocblas_ctrmv_batched](interfacehipfort__rocblas_1_1rocblas__ctrmv__batched.html "Interface documentation") | C binding
@@ -535,22 +535,22 @@
 531 | [rocblas_dtrmv_batched_64](interfacehipfort__rocblas_1_1rocblas__dtrmv__batched__64.html "Interface documentation") | C binding
 532 | [rocblas_ctrmv_batched_64](interfacehipfort__rocblas_1_1rocblas__ctrmv__batched__64.html "Interface documentation") | C binding
 533 | [rocblas_ztrmv_batched_64](interfacehipfort__rocblas_1_1rocblas__ztrmv__batched__64.html "Interface documentation") | C binding
-534 | [rocblas_strmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__strmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-535 | [rocblas_dtrmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__dtrmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-536 | [rocblas_ctrmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ctrmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-537 | [rocblas_ztrmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ztrmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-538 | [rocblas_strmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__strmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-539 | [rocblas_dtrmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dtrmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-540 | [rocblas_ctrmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ctrmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-541 | [rocblas_ztrmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ztrmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-542 | [rocblas_stpmv](interfacehipfort__rocblas_1_1rocblas__stpmv.html "Interface documentation") | C binding, rank_0, rank_1
-543 | [rocblas_dtpmv](interfacehipfort__rocblas_1_1rocblas__dtpmv.html "Interface documentation") | C binding, rank_0, rank_1
-544 | [rocblas_ctpmv](interfacehipfort__rocblas_1_1rocblas__ctpmv.html "Interface documentation") | C binding, rank_0, rank_1
-545 | [rocblas_ztpmv](interfacehipfort__rocblas_1_1rocblas__ztpmv.html "Interface documentation") | C binding, rank_0, rank_1
-546 | [rocblas_stpmv_64](interfacehipfort__rocblas_1_1rocblas__stpmv__64.html "Interface documentation") | C binding, rank_0, rank_1
-547 | [rocblas_dtpmv_64](interfacehipfort__rocblas_1_1rocblas__dtpmv__64.html "Interface documentation") | C binding, rank_0, rank_1
-548 | [rocblas_ctpmv_64](interfacehipfort__rocblas_1_1rocblas__ctpmv__64.html "Interface documentation") | C binding, rank_0, rank_1
-549 | [rocblas_ztpmv_64](interfacehipfort__rocblas_1_1rocblas__ztpmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+534 | [rocblas_strmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__strmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+535 | [rocblas_dtrmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__dtrmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+536 | [rocblas_ctrmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ctrmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+537 | [rocblas_ztrmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ztrmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+538 | [rocblas_strmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__strmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+539 | [rocblas_dtrmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dtrmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+540 | [rocblas_ctrmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ctrmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+541 | [rocblas_ztrmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ztrmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+542 | [rocblas_stpmv](interfacehipfort__rocblas_1_1rocblas__stpmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+543 | [rocblas_dtpmv](interfacehipfort__rocblas_1_1rocblas__dtpmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+544 | [rocblas_ctpmv](interfacehipfort__rocblas_1_1rocblas__ctpmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+545 | [rocblas_ztpmv](interfacehipfort__rocblas_1_1rocblas__ztpmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+546 | [rocblas_stpmv_64](interfacehipfort__rocblas_1_1rocblas__stpmv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+547 | [rocblas_dtpmv_64](interfacehipfort__rocblas_1_1rocblas__dtpmv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+548 | [rocblas_ctpmv_64](interfacehipfort__rocblas_1_1rocblas__ctpmv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+549 | [rocblas_ztpmv_64](interfacehipfort__rocblas_1_1rocblas__ztpmv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 550 | [rocblas_stpmv_batched](interfacehipfort__rocblas_1_1rocblas__stpmv__batched.html "Interface documentation") | C binding
 551 | [rocblas_dtpmv_batched](interfacehipfort__rocblas_1_1rocblas__dtpmv__batched.html "Interface documentation") | C binding
 552 | [rocblas_ctpmv_batched](interfacehipfort__rocblas_1_1rocblas__ctpmv__batched.html "Interface documentation") | C binding
@@ -559,22 +559,22 @@
 555 | [rocblas_dtpmv_batched_64](interfacehipfort__rocblas_1_1rocblas__dtpmv__batched__64.html "Interface documentation") | C binding
 556 | [rocblas_ctpmv_batched_64](interfacehipfort__rocblas_1_1rocblas__ctpmv__batched__64.html "Interface documentation") | C binding
 557 | [rocblas_ztpmv_batched_64](interfacehipfort__rocblas_1_1rocblas__ztpmv__batched__64.html "Interface documentation") | C binding
-558 | [rocblas_stpmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__stpmv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-559 | [rocblas_dtpmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__dtpmv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-560 | [rocblas_ctpmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ctpmv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-561 | [rocblas_ztpmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ztpmv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-562 | [rocblas_stpmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__stpmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-563 | [rocblas_dtpmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dtpmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-564 | [rocblas_ctpmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ctpmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-565 | [rocblas_ztpmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ztpmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-566 | [rocblas_stbmv](interfacehipfort__rocblas_1_1rocblas__stbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-567 | [rocblas_dtbmv](interfacehipfort__rocblas_1_1rocblas__dtbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-568 | [rocblas_ctbmv](interfacehipfort__rocblas_1_1rocblas__ctbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-569 | [rocblas_ztbmv](interfacehipfort__rocblas_1_1rocblas__ztbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-570 | [rocblas_stbmv_64](interfacehipfort__rocblas_1_1rocblas__stbmv__64.html "Interface documentation") | C binding, rank_0, rank_1
-571 | [rocblas_dtbmv_64](interfacehipfort__rocblas_1_1rocblas__dtbmv__64.html "Interface documentation") | C binding, rank_0, rank_1
-572 | [rocblas_ctbmv_64](interfacehipfort__rocblas_1_1rocblas__ctbmv__64.html "Interface documentation") | C binding, rank_0, rank_1
-573 | [rocblas_ztbmv_64](interfacehipfort__rocblas_1_1rocblas__ztbmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+558 | [rocblas_stpmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__stpmv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+559 | [rocblas_dtpmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__dtpmv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+560 | [rocblas_ctpmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ctpmv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+561 | [rocblas_ztpmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ztpmv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+562 | [rocblas_stpmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__stpmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+563 | [rocblas_dtpmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dtpmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+564 | [rocblas_ctpmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ctpmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+565 | [rocblas_ztpmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ztpmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+566 | [rocblas_stbmv](interfacehipfort__rocblas_1_1rocblas__stbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+567 | [rocblas_dtbmv](interfacehipfort__rocblas_1_1rocblas__dtbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+568 | [rocblas_ctbmv](interfacehipfort__rocblas_1_1rocblas__ctbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+569 | [rocblas_ztbmv](interfacehipfort__rocblas_1_1rocblas__ztbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+570 | [rocblas_stbmv_64](interfacehipfort__rocblas_1_1rocblas__stbmv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+571 | [rocblas_dtbmv_64](interfacehipfort__rocblas_1_1rocblas__dtbmv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+572 | [rocblas_ctbmv_64](interfacehipfort__rocblas_1_1rocblas__ctbmv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+573 | [rocblas_ztbmv_64](interfacehipfort__rocblas_1_1rocblas__ztbmv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 574 | [rocblas_stbmv_batched](interfacehipfort__rocblas_1_1rocblas__stbmv__batched.html "Interface documentation") | C binding
 575 | [rocblas_dtbmv_batched](interfacehipfort__rocblas_1_1rocblas__dtbmv__batched.html "Interface documentation") | C binding
 576 | [rocblas_ctbmv_batched](interfacehipfort__rocblas_1_1rocblas__ctbmv__batched.html "Interface documentation") | C binding
@@ -583,22 +583,22 @@
 579 | [rocblas_dtbmv_batched_64](interfacehipfort__rocblas_1_1rocblas__dtbmv__batched__64.html "Interface documentation") | C binding
 580 | [rocblas_ctbmv_batched_64](interfacehipfort__rocblas_1_1rocblas__ctbmv__batched__64.html "Interface documentation") | C binding
 581 | [rocblas_ztbmv_batched_64](interfacehipfort__rocblas_1_1rocblas__ztbmv__batched__64.html "Interface documentation") | C binding
-582 | [rocblas_stbmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__stbmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-583 | [rocblas_dtbmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__dtbmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-584 | [rocblas_ctbmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ctbmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-585 | [rocblas_ztbmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ztbmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-586 | [rocblas_stbmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__stbmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-587 | [rocblas_dtbmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dtbmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-588 | [rocblas_ctbmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ctbmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-589 | [rocblas_ztbmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ztbmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-590 | [rocblas_stbsv](interfacehipfort__rocblas_1_1rocblas__stbsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-591 | [rocblas_dtbsv](interfacehipfort__rocblas_1_1rocblas__dtbsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-592 | [rocblas_ctbsv](interfacehipfort__rocblas_1_1rocblas__ctbsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-593 | [rocblas_ztbsv](interfacehipfort__rocblas_1_1rocblas__ztbsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-594 | [rocblas_stbsv_64](interfacehipfort__rocblas_1_1rocblas__stbsv__64.html "Interface documentation") | C binding, rank_0, rank_1
-595 | [rocblas_dtbsv_64](interfacehipfort__rocblas_1_1rocblas__dtbsv__64.html "Interface documentation") | C binding, rank_0, rank_1
-596 | [rocblas_ctbsv_64](interfacehipfort__rocblas_1_1rocblas__ctbsv__64.html "Interface documentation") | C binding, rank_0, rank_1
-597 | [rocblas_ztbsv_64](interfacehipfort__rocblas_1_1rocblas__ztbsv__64.html "Interface documentation") | C binding, rank_0, rank_1
+582 | [rocblas_stbmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__stbmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+583 | [rocblas_dtbmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__dtbmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+584 | [rocblas_ctbmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ctbmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+585 | [rocblas_ztbmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ztbmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+586 | [rocblas_stbmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__stbmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+587 | [rocblas_dtbmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dtbmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+588 | [rocblas_ctbmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ctbmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+589 | [rocblas_ztbmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ztbmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+590 | [rocblas_stbsv](interfacehipfort__rocblas_1_1rocblas__stbsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+591 | [rocblas_dtbsv](interfacehipfort__rocblas_1_1rocblas__dtbsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+592 | [rocblas_ctbsv](interfacehipfort__rocblas_1_1rocblas__ctbsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+593 | [rocblas_ztbsv](interfacehipfort__rocblas_1_1rocblas__ztbsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+594 | [rocblas_stbsv_64](interfacehipfort__rocblas_1_1rocblas__stbsv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+595 | [rocblas_dtbsv_64](interfacehipfort__rocblas_1_1rocblas__dtbsv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+596 | [rocblas_ctbsv_64](interfacehipfort__rocblas_1_1rocblas__ctbsv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+597 | [rocblas_ztbsv_64](interfacehipfort__rocblas_1_1rocblas__ztbsv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 598 | [rocblas_stbsv_batched](interfacehipfort__rocblas_1_1rocblas__stbsv__batched.html "Interface documentation") | C binding
 599 | [rocblas_dtbsv_batched](interfacehipfort__rocblas_1_1rocblas__dtbsv__batched.html "Interface documentation") | C binding
 600 | [rocblas_ctbsv_batched](interfacehipfort__rocblas_1_1rocblas__ctbsv__batched.html "Interface documentation") | C binding
@@ -607,22 +607,22 @@
 603 | [rocblas_dtbsv_batched_64](interfacehipfort__rocblas_1_1rocblas__dtbsv__batched__64.html "Interface documentation") | C binding
 604 | [rocblas_ctbsv_batched_64](interfacehipfort__rocblas_1_1rocblas__ctbsv__batched__64.html "Interface documentation") | C binding
 605 | [rocblas_ztbsv_batched_64](interfacehipfort__rocblas_1_1rocblas__ztbsv__batched__64.html "Interface documentation") | C binding
-606 | [rocblas_stbsv_strided_batched](interfacehipfort__rocblas_1_1rocblas__stbsv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-607 | [rocblas_dtbsv_strided_batched](interfacehipfort__rocblas_1_1rocblas__dtbsv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-608 | [rocblas_ctbsv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ctbsv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-609 | [rocblas_ztbsv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ztbsv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-610 | [rocblas_stbsv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__stbsv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-611 | [rocblas_dtbsv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dtbsv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-612 | [rocblas_ctbsv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ctbsv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-613 | [rocblas_ztbsv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ztbsv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-614 | [rocblas_strsv](interfacehipfort__rocblas_1_1rocblas__strsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-615 | [rocblas_dtrsv](interfacehipfort__rocblas_1_1rocblas__dtrsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-616 | [rocblas_ctrsv](interfacehipfort__rocblas_1_1rocblas__ctrsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-617 | [rocblas_ztrsv](interfacehipfort__rocblas_1_1rocblas__ztrsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-618 | [rocblas_strsv_64](interfacehipfort__rocblas_1_1rocblas__strsv__64.html "Interface documentation") | C binding, rank_0, rank_1
-619 | [rocblas_dtrsv_64](interfacehipfort__rocblas_1_1rocblas__dtrsv__64.html "Interface documentation") | C binding, rank_0, rank_1
-620 | [rocblas_ctrsv_64](interfacehipfort__rocblas_1_1rocblas__ctrsv__64.html "Interface documentation") | C binding, rank_0, rank_1
-621 | [rocblas_ztrsv_64](interfacehipfort__rocblas_1_1rocblas__ztrsv__64.html "Interface documentation") | C binding, rank_0, rank_1
+606 | [rocblas_stbsv_strided_batched](interfacehipfort__rocblas_1_1rocblas__stbsv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+607 | [rocblas_dtbsv_strided_batched](interfacehipfort__rocblas_1_1rocblas__dtbsv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+608 | [rocblas_ctbsv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ctbsv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+609 | [rocblas_ztbsv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ztbsv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+610 | [rocblas_stbsv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__stbsv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+611 | [rocblas_dtbsv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dtbsv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+612 | [rocblas_ctbsv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ctbsv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+613 | [rocblas_ztbsv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ztbsv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+614 | [rocblas_strsv](interfacehipfort__rocblas_1_1rocblas__strsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+615 | [rocblas_dtrsv](interfacehipfort__rocblas_1_1rocblas__dtrsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+616 | [rocblas_ctrsv](interfacehipfort__rocblas_1_1rocblas__ctrsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+617 | [rocblas_ztrsv](interfacehipfort__rocblas_1_1rocblas__ztrsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+618 | [rocblas_strsv_64](interfacehipfort__rocblas_1_1rocblas__strsv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+619 | [rocblas_dtrsv_64](interfacehipfort__rocblas_1_1rocblas__dtrsv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+620 | [rocblas_ctrsv_64](interfacehipfort__rocblas_1_1rocblas__ctrsv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+621 | [rocblas_ztrsv_64](interfacehipfort__rocblas_1_1rocblas__ztrsv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 622 | [rocblas_strsv_batched](interfacehipfort__rocblas_1_1rocblas__strsv__batched.html "Interface documentation") | C binding
 623 | [rocblas_dtrsv_batched](interfacehipfort__rocblas_1_1rocblas__dtrsv__batched.html "Interface documentation") | C binding
 624 | [rocblas_ctrsv_batched](interfacehipfort__rocblas_1_1rocblas__ctrsv__batched.html "Interface documentation") | C binding
@@ -631,22 +631,22 @@
 627 | [rocblas_dtrsv_batched_64](interfacehipfort__rocblas_1_1rocblas__dtrsv__batched__64.html "Interface documentation") | C binding
 628 | [rocblas_ctrsv_batched_64](interfacehipfort__rocblas_1_1rocblas__ctrsv__batched__64.html "Interface documentation") | C binding
 629 | [rocblas_ztrsv_batched_64](interfacehipfort__rocblas_1_1rocblas__ztrsv__batched__64.html "Interface documentation") | C binding
-630 | [rocblas_strsv_strided_batched](interfacehipfort__rocblas_1_1rocblas__strsv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-631 | [rocblas_dtrsv_strided_batched](interfacehipfort__rocblas_1_1rocblas__dtrsv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-632 | [rocblas_ctrsv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ctrsv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-633 | [rocblas_ztrsv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ztrsv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-634 | [rocblas_strsv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__strsv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-635 | [rocblas_dtrsv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dtrsv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-636 | [rocblas_ctrsv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ctrsv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-637 | [rocblas_ztrsv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ztrsv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-638 | [rocblas_stpsv](interfacehipfort__rocblas_1_1rocblas__stpsv.html "Interface documentation") | C binding, rank_0, rank_1
-639 | [rocblas_dtpsv](interfacehipfort__rocblas_1_1rocblas__dtpsv.html "Interface documentation") | C binding, rank_0, rank_1
-640 | [rocblas_ctpsv](interfacehipfort__rocblas_1_1rocblas__ctpsv.html "Interface documentation") | C binding, rank_0, rank_1
-641 | [rocblas_ztpsv](interfacehipfort__rocblas_1_1rocblas__ztpsv.html "Interface documentation") | C binding, rank_0, rank_1
-642 | [rocblas_stpsv_64](interfacehipfort__rocblas_1_1rocblas__stpsv__64.html "Interface documentation") | C binding, rank_0, rank_1
-643 | [rocblas_dtpsv_64](interfacehipfort__rocblas_1_1rocblas__dtpsv__64.html "Interface documentation") | C binding, rank_0, rank_1
-644 | [rocblas_ctpsv_64](interfacehipfort__rocblas_1_1rocblas__ctpsv__64.html "Interface documentation") | C binding, rank_0, rank_1
-645 | [rocblas_ztpsv_64](interfacehipfort__rocblas_1_1rocblas__ztpsv__64.html "Interface documentation") | C binding, rank_0, rank_1
+630 | [rocblas_strsv_strided_batched](interfacehipfort__rocblas_1_1rocblas__strsv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+631 | [rocblas_dtrsv_strided_batched](interfacehipfort__rocblas_1_1rocblas__dtrsv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+632 | [rocblas_ctrsv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ctrsv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+633 | [rocblas_ztrsv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ztrsv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+634 | [rocblas_strsv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__strsv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+635 | [rocblas_dtrsv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dtrsv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+636 | [rocblas_ctrsv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ctrsv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+637 | [rocblas_ztrsv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ztrsv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+638 | [rocblas_stpsv](interfacehipfort__rocblas_1_1rocblas__stpsv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+639 | [rocblas_dtpsv](interfacehipfort__rocblas_1_1rocblas__dtpsv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+640 | [rocblas_ctpsv](interfacehipfort__rocblas_1_1rocblas__ctpsv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+641 | [rocblas_ztpsv](interfacehipfort__rocblas_1_1rocblas__ztpsv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+642 | [rocblas_stpsv_64](interfacehipfort__rocblas_1_1rocblas__stpsv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+643 | [rocblas_dtpsv_64](interfacehipfort__rocblas_1_1rocblas__dtpsv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+644 | [rocblas_ctpsv_64](interfacehipfort__rocblas_1_1rocblas__ctpsv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+645 | [rocblas_ztpsv_64](interfacehipfort__rocblas_1_1rocblas__ztpsv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 646 | [rocblas_stpsv_batched](interfacehipfort__rocblas_1_1rocblas__stpsv__batched.html "Interface documentation") | C binding
 647 | [rocblas_dtpsv_batched](interfacehipfort__rocblas_1_1rocblas__dtpsv__batched.html "Interface documentation") | C binding
 648 | [rocblas_ctpsv_batched](interfacehipfort__rocblas_1_1rocblas__ctpsv__batched.html "Interface documentation") | C binding
@@ -655,22 +655,22 @@
 651 | [rocblas_dtpsv_batched_64](interfacehipfort__rocblas_1_1rocblas__dtpsv__batched__64.html "Interface documentation") | C binding
 652 | [rocblas_ctpsv_batched_64](interfacehipfort__rocblas_1_1rocblas__ctpsv__batched__64.html "Interface documentation") | C binding
 653 | [rocblas_ztpsv_batched_64](interfacehipfort__rocblas_1_1rocblas__ztpsv__batched__64.html "Interface documentation") | C binding
-654 | [rocblas_stpsv_strided_batched](interfacehipfort__rocblas_1_1rocblas__stpsv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-655 | [rocblas_dtpsv_strided_batched](interfacehipfort__rocblas_1_1rocblas__dtpsv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-656 | [rocblas_ctpsv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ctpsv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-657 | [rocblas_ztpsv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ztpsv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-658 | [rocblas_stpsv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__stpsv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-659 | [rocblas_dtpsv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dtpsv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-660 | [rocblas_ctpsv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ctpsv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-661 | [rocblas_ztpsv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ztpsv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-662 | [rocblas_ssymv](interfacehipfort__rocblas_1_1rocblas__ssymv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-663 | [rocblas_dsymv](interfacehipfort__rocblas_1_1rocblas__dsymv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-664 | [rocblas_csymv](interfacehipfort__rocblas_1_1rocblas__csymv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-665 | [rocblas_zsymv](interfacehipfort__rocblas_1_1rocblas__zsymv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-666 | [rocblas_ssymv_64](interfacehipfort__rocblas_1_1rocblas__ssymv__64.html "Interface documentation") | C binding, rank_0, rank_1
-667 | [rocblas_dsymv_64](interfacehipfort__rocblas_1_1rocblas__dsymv__64.html "Interface documentation") | C binding, rank_0, rank_1
-668 | [rocblas_csymv_64](interfacehipfort__rocblas_1_1rocblas__csymv__64.html "Interface documentation") | C binding, rank_0, rank_1
-669 | [rocblas_zsymv_64](interfacehipfort__rocblas_1_1rocblas__zsymv__64.html "Interface documentation") | C binding, rank_0, rank_1
+654 | [rocblas_stpsv_strided_batched](interfacehipfort__rocblas_1_1rocblas__stpsv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+655 | [rocblas_dtpsv_strided_batched](interfacehipfort__rocblas_1_1rocblas__dtpsv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+656 | [rocblas_ctpsv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ctpsv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+657 | [rocblas_ztpsv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ztpsv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+658 | [rocblas_stpsv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__stpsv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+659 | [rocblas_dtpsv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dtpsv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+660 | [rocblas_ctpsv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ctpsv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+661 | [rocblas_ztpsv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ztpsv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+662 | [rocblas_ssymv](interfacehipfort__rocblas_1_1rocblas__ssymv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+663 | [rocblas_dsymv](interfacehipfort__rocblas_1_1rocblas__dsymv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+664 | [rocblas_csymv](interfacehipfort__rocblas_1_1rocblas__csymv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+665 | [rocblas_zsymv](interfacehipfort__rocblas_1_1rocblas__zsymv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+666 | [rocblas_ssymv_64](interfacehipfort__rocblas_1_1rocblas__ssymv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+667 | [rocblas_dsymv_64](interfacehipfort__rocblas_1_1rocblas__dsymv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+668 | [rocblas_csymv_64](interfacehipfort__rocblas_1_1rocblas__csymv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+669 | [rocblas_zsymv_64](interfacehipfort__rocblas_1_1rocblas__zsymv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 670 | [rocblas_ssymv_batched](interfacehipfort__rocblas_1_1rocblas__ssymv__batched.html "Interface documentation") | C binding
 671 | [rocblas_dsymv_batched](interfacehipfort__rocblas_1_1rocblas__dsymv__batched.html "Interface documentation") | C binding
 672 | [rocblas_csymv_batched](interfacehipfort__rocblas_1_1rocblas__csymv__batched.html "Interface documentation") | C binding
@@ -679,50 +679,50 @@
 675 | [rocblas_dsymv_batched_64](interfacehipfort__rocblas_1_1rocblas__dsymv__batched__64.html "Interface documentation") | C binding
 676 | [rocblas_csymv_batched_64](interfacehipfort__rocblas_1_1rocblas__csymv__batched__64.html "Interface documentation") | C binding
 677 | [rocblas_zsymv_batched_64](interfacehipfort__rocblas_1_1rocblas__zsymv__batched__64.html "Interface documentation") | C binding
-678 | [rocblas_ssymv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ssymv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-679 | [rocblas_dsymv_strided_batched](interfacehipfort__rocblas_1_1rocblas__dsymv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-680 | [rocblas_csymv_strided_batched](interfacehipfort__rocblas_1_1rocblas__csymv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-681 | [rocblas_zsymv_strided_batched](interfacehipfort__rocblas_1_1rocblas__zsymv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-682 | [rocblas_ssymv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ssymv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-683 | [rocblas_dsymv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dsymv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-684 | [rocblas_csymv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__csymv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-685 | [rocblas_zsymv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zsymv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-686 | [rocblas_sspmv](interfacehipfort__rocblas_1_1rocblas__sspmv.html "Interface documentation") | C binding, rank_0, rank_1
-687 | [rocblas_dspmv](interfacehipfort__rocblas_1_1rocblas__dspmv.html "Interface documentation") | C binding, rank_0, rank_1
-688 | [rocblas_sspmv_64](interfacehipfort__rocblas_1_1rocblas__sspmv__64.html "Interface documentation") | C binding, rank_0, rank_1
-689 | [rocblas_dspmv_64](interfacehipfort__rocblas_1_1rocblas__dspmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+678 | [rocblas_ssymv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ssymv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+679 | [rocblas_dsymv_strided_batched](interfacehipfort__rocblas_1_1rocblas__dsymv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+680 | [rocblas_csymv_strided_batched](interfacehipfort__rocblas_1_1rocblas__csymv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+681 | [rocblas_zsymv_strided_batched](interfacehipfort__rocblas_1_1rocblas__zsymv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+682 | [rocblas_ssymv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ssymv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+683 | [rocblas_dsymv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dsymv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+684 | [rocblas_csymv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__csymv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+685 | [rocblas_zsymv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zsymv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+686 | [rocblas_sspmv](interfacehipfort__rocblas_1_1rocblas__sspmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+687 | [rocblas_dspmv](interfacehipfort__rocblas_1_1rocblas__dspmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+688 | [rocblas_sspmv_64](interfacehipfort__rocblas_1_1rocblas__sspmv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+689 | [rocblas_dspmv_64](interfacehipfort__rocblas_1_1rocblas__dspmv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 690 | [rocblas_sspmv_batched](interfacehipfort__rocblas_1_1rocblas__sspmv__batched.html "Interface documentation") | C binding
 691 | [rocblas_dspmv_batched](interfacehipfort__rocblas_1_1rocblas__dspmv__batched.html "Interface documentation") | C binding
 692 | [rocblas_sspmv_batched_64](interfacehipfort__rocblas_1_1rocblas__sspmv__batched__64.html "Interface documentation") | C binding
 693 | [rocblas_dspmv_batched_64](interfacehipfort__rocblas_1_1rocblas__dspmv__batched__64.html "Interface documentation") | C binding
-694 | [rocblas_sspmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__sspmv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-695 | [rocblas_dspmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__dspmv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-696 | [rocblas_sspmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sspmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-697 | [rocblas_dspmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dspmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-698 | [rocblas_ssbmv](interfacehipfort__rocblas_1_1rocblas__ssbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-699 | [rocblas_dsbmv](interfacehipfort__rocblas_1_1rocblas__dsbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-700 | [rocblas_ssbmv_64](interfacehipfort__rocblas_1_1rocblas__ssbmv__64.html "Interface documentation") | C binding, rank_0, rank_1
-701 | [rocblas_dsbmv_64](interfacehipfort__rocblas_1_1rocblas__dsbmv__64.html "Interface documentation") | C binding, rank_0, rank_1
+694 | [rocblas_sspmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__sspmv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+695 | [rocblas_dspmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__dspmv__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+696 | [rocblas_sspmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sspmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+697 | [rocblas_dspmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dspmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+698 | [rocblas_ssbmv](interfacehipfort__rocblas_1_1rocblas__ssbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+699 | [rocblas_dsbmv](interfacehipfort__rocblas_1_1rocblas__dsbmv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+700 | [rocblas_ssbmv_64](interfacehipfort__rocblas_1_1rocblas__ssbmv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+701 | [rocblas_dsbmv_64](interfacehipfort__rocblas_1_1rocblas__dsbmv__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 702 | [rocblas_ssbmv_batched](interfacehipfort__rocblas_1_1rocblas__ssbmv__batched.html "Interface documentation") | C binding
 703 | [rocblas_dsbmv_batched](interfacehipfort__rocblas_1_1rocblas__dsbmv__batched.html "Interface documentation") | C binding
 704 | [rocblas_ssbmv_batched_64](interfacehipfort__rocblas_1_1rocblas__ssbmv__batched__64.html "Interface documentation") | C binding
 705 | [rocblas_dsbmv_batched_64](interfacehipfort__rocblas_1_1rocblas__dsbmv__batched__64.html "Interface documentation") | C binding
-706 | [rocblas_ssbmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ssbmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-707 | [rocblas_dsbmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__dsbmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-708 | [rocblas_ssbmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ssbmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-709 | [rocblas_dsbmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dsbmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-710 | [rocblas_sger](interfacehipfort__rocblas_1_1rocblas__sger.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-711 | [rocblas_dger](interfacehipfort__rocblas_1_1rocblas__dger.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-712 | [rocblas_cgeru](interfacehipfort__rocblas_1_1rocblas__cgeru.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-713 | [rocblas_zgeru](interfacehipfort__rocblas_1_1rocblas__zgeru.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-714 | [rocblas_cgerc](interfacehipfort__rocblas_1_1rocblas__cgerc.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-715 | [rocblas_zgerc](interfacehipfort__rocblas_1_1rocblas__zgerc.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-716 | [rocblas_sger_64](interfacehipfort__rocblas_1_1rocblas__sger__64.html "Interface documentation") | C binding, rank_0, rank_1
-717 | [rocblas_dger_64](interfacehipfort__rocblas_1_1rocblas__dger__64.html "Interface documentation") | C binding, rank_0, rank_1
-718 | [rocblas_cgeru_64](interfacehipfort__rocblas_1_1rocblas__cgeru__64.html "Interface documentation") | C binding, rank_0, rank_1
-719 | [rocblas_zgeru_64](interfacehipfort__rocblas_1_1rocblas__zgeru__64.html "Interface documentation") | C binding, rank_0, rank_1
-720 | [rocblas_cgerc_64](interfacehipfort__rocblas_1_1rocblas__cgerc__64.html "Interface documentation") | C binding, rank_0, rank_1
-721 | [rocblas_zgerc_64](interfacehipfort__rocblas_1_1rocblas__zgerc__64.html "Interface documentation") | C binding, rank_0, rank_1
+706 | [rocblas_ssbmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__ssbmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+707 | [rocblas_dsbmv_strided_batched](interfacehipfort__rocblas_1_1rocblas__dsbmv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+708 | [rocblas_ssbmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ssbmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+709 | [rocblas_dsbmv_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dsbmv__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+710 | [rocblas_sger](interfacehipfort__rocblas_1_1rocblas__sger.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+711 | [rocblas_dger](interfacehipfort__rocblas_1_1rocblas__dger.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+712 | [rocblas_cgeru](interfacehipfort__rocblas_1_1rocblas__cgeru.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+713 | [rocblas_zgeru](interfacehipfort__rocblas_1_1rocblas__zgeru.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+714 | [rocblas_cgerc](interfacehipfort__rocblas_1_1rocblas__cgerc.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+715 | [rocblas_zgerc](interfacehipfort__rocblas_1_1rocblas__zgerc.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+716 | [rocblas_sger_64](interfacehipfort__rocblas_1_1rocblas__sger__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+717 | [rocblas_dger_64](interfacehipfort__rocblas_1_1rocblas__dger__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+718 | [rocblas_cgeru_64](interfacehipfort__rocblas_1_1rocblas__cgeru__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+719 | [rocblas_zgeru_64](interfacehipfort__rocblas_1_1rocblas__zgeru__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+720 | [rocblas_cgerc_64](interfacehipfort__rocblas_1_1rocblas__cgerc__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+721 | [rocblas_zgerc_64](interfacehipfort__rocblas_1_1rocblas__zgerc__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 722 | [rocblas_sger_batched](interfacehipfort__rocblas_1_1rocblas__sger__batched.html "Interface documentation") | C binding
 723 | [rocblas_dger_batched](interfacehipfort__rocblas_1_1rocblas__dger__batched.html "Interface documentation") | C binding
 724 | [rocblas_cgeru_batched](interfacehipfort__rocblas_1_1rocblas__cgeru__batched.html "Interface documentation") | C binding
@@ -735,26 +735,26 @@
 731 | [rocblas_zgeru_batched_64](interfacehipfort__rocblas_1_1rocblas__zgeru__batched__64.html "Interface documentation") | C binding
 732 | [rocblas_cgerc_batched_64](interfacehipfort__rocblas_1_1rocblas__cgerc__batched__64.html "Interface documentation") | C binding
 733 | [rocblas_zgerc_batched_64](interfacehipfort__rocblas_1_1rocblas__zgerc__batched__64.html "Interface documentation") | C binding
-734 | [rocblas_sger_strided_batched](interfacehipfort__rocblas_1_1rocblas__sger__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-735 | [rocblas_dger_strided_batched](interfacehipfort__rocblas_1_1rocblas__dger__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-736 | [rocblas_cgeru_strided_batched](interfacehipfort__rocblas_1_1rocblas__cgeru__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-737 | [rocblas_zgeru_strided_batched](interfacehipfort__rocblas_1_1rocblas__zgeru__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-738 | [rocblas_cgerc_strided_batched](interfacehipfort__rocblas_1_1rocblas__cgerc__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-739 | [rocblas_zgerc_strided_batched](interfacehipfort__rocblas_1_1rocblas__zgerc__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-740 | [rocblas_sger_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sger__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-741 | [rocblas_dger_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dger__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-742 | [rocblas_cgeru_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cgeru__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-743 | [rocblas_zgeru_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zgeru__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-744 | [rocblas_cgerc_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cgerc__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-745 | [rocblas_zgerc_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zgerc__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-746 | [rocblas_sspr](interfacehipfort__rocblas_1_1rocblas__sspr.html "Interface documentation") | C binding, rank_0, rank_1
-747 | [rocblas_dspr](interfacehipfort__rocblas_1_1rocblas__dspr.html "Interface documentation") | C binding, rank_0, rank_1
-748 | [rocblas_cspr](interfacehipfort__rocblas_1_1rocblas__cspr.html "Interface documentation") | C binding, rank_0, rank_1
-749 | [rocblas_zspr](interfacehipfort__rocblas_1_1rocblas__zspr.html "Interface documentation") | C binding, rank_0, rank_1
-750 | [rocblas_sspr_64](interfacehipfort__rocblas_1_1rocblas__sspr__64.html "Interface documentation") | C binding, rank_0, rank_1
-751 | [rocblas_dspr_64](interfacehipfort__rocblas_1_1rocblas__dspr__64.html "Interface documentation") | C binding, rank_0, rank_1
-752 | [rocblas_cspr_64](interfacehipfort__rocblas_1_1rocblas__cspr__64.html "Interface documentation") | C binding, rank_0, rank_1
-753 | [rocblas_zspr_64](interfacehipfort__rocblas_1_1rocblas__zspr__64.html "Interface documentation") | C binding, rank_0, rank_1
+734 | [rocblas_sger_strided_batched](interfacehipfort__rocblas_1_1rocblas__sger__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+735 | [rocblas_dger_strided_batched](interfacehipfort__rocblas_1_1rocblas__dger__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+736 | [rocblas_cgeru_strided_batched](interfacehipfort__rocblas_1_1rocblas__cgeru__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+737 | [rocblas_zgeru_strided_batched](interfacehipfort__rocblas_1_1rocblas__zgeru__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+738 | [rocblas_cgerc_strided_batched](interfacehipfort__rocblas_1_1rocblas__cgerc__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+739 | [rocblas_zgerc_strided_batched](interfacehipfort__rocblas_1_1rocblas__zgerc__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+740 | [rocblas_sger_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sger__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+741 | [rocblas_dger_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dger__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+742 | [rocblas_cgeru_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cgeru__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+743 | [rocblas_zgeru_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zgeru__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+744 | [rocblas_cgerc_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cgerc__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+745 | [rocblas_zgerc_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zgerc__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+746 | [rocblas_sspr](interfacehipfort__rocblas_1_1rocblas__sspr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+747 | [rocblas_dspr](interfacehipfort__rocblas_1_1rocblas__dspr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+748 | [rocblas_cspr](interfacehipfort__rocblas_1_1rocblas__cspr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+749 | [rocblas_zspr](interfacehipfort__rocblas_1_1rocblas__zspr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+750 | [rocblas_sspr_64](interfacehipfort__rocblas_1_1rocblas__sspr__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+751 | [rocblas_dspr_64](interfacehipfort__rocblas_1_1rocblas__dspr__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+752 | [rocblas_cspr_64](interfacehipfort__rocblas_1_1rocblas__cspr__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+753 | [rocblas_zspr_64](interfacehipfort__rocblas_1_1rocblas__zspr__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 754 | [rocblas_sspr_batched](interfacehipfort__rocblas_1_1rocblas__sspr__batched.html "Interface documentation") | C binding
 755 | [rocblas_dspr_batched](interfacehipfort__rocblas_1_1rocblas__dspr__batched.html "Interface documentation") | C binding
 756 | [rocblas_cspr_batched](interfacehipfort__rocblas_1_1rocblas__cspr__batched.html "Interface documentation") | C binding
@@ -763,34 +763,34 @@
 759 | [rocblas_dspr_batched_64](interfacehipfort__rocblas_1_1rocblas__dspr__batched__64.html "Interface documentation") | C binding
 760 | [rocblas_cspr_batched_64](interfacehipfort__rocblas_1_1rocblas__cspr__batched__64.html "Interface documentation") | C binding
 761 | [rocblas_zspr_batched_64](interfacehipfort__rocblas_1_1rocblas__zspr__batched__64.html "Interface documentation") | C binding
-762 | [rocblas_sspr_strided_batched](interfacehipfort__rocblas_1_1rocblas__sspr__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-763 | [rocblas_dspr_strided_batched](interfacehipfort__rocblas_1_1rocblas__dspr__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-764 | [rocblas_cspr_strided_batched](interfacehipfort__rocblas_1_1rocblas__cspr__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-765 | [rocblas_zspr_strided_batched](interfacehipfort__rocblas_1_1rocblas__zspr__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-766 | [rocblas_sspr_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sspr__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-767 | [rocblas_dspr_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dspr__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-768 | [rocblas_cspr_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cspr__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-769 | [rocblas_zspr_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zspr__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-770 | [rocblas_sspr2](interfacehipfort__rocblas_1_1rocblas__sspr2.html "Interface documentation") | C binding, rank_0, rank_1
-771 | [rocblas_dspr2](interfacehipfort__rocblas_1_1rocblas__dspr2.html "Interface documentation") | C binding, rank_0, rank_1
-772 | [rocblas_sspr2_64](interfacehipfort__rocblas_1_1rocblas__sspr2__64.html "Interface documentation") | C binding, rank_0, rank_1
-773 | [rocblas_dspr2_64](interfacehipfort__rocblas_1_1rocblas__dspr2__64.html "Interface documentation") | C binding, rank_0, rank_1
+762 | [rocblas_sspr_strided_batched](interfacehipfort__rocblas_1_1rocblas__sspr__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+763 | [rocblas_dspr_strided_batched](interfacehipfort__rocblas_1_1rocblas__dspr__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+764 | [rocblas_cspr_strided_batched](interfacehipfort__rocblas_1_1rocblas__cspr__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+765 | [rocblas_zspr_strided_batched](interfacehipfort__rocblas_1_1rocblas__zspr__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+766 | [rocblas_sspr_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sspr__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+767 | [rocblas_dspr_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dspr__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+768 | [rocblas_cspr_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cspr__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+769 | [rocblas_zspr_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zspr__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+770 | [rocblas_sspr2](interfacehipfort__rocblas_1_1rocblas__sspr2.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+771 | [rocblas_dspr2](interfacehipfort__rocblas_1_1rocblas__dspr2.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+772 | [rocblas_sspr2_64](interfacehipfort__rocblas_1_1rocblas__sspr2__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+773 | [rocblas_dspr2_64](interfacehipfort__rocblas_1_1rocblas__dspr2__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 774 | [rocblas_sspr2_batched](interfacehipfort__rocblas_1_1rocblas__sspr2__batched.html "Interface documentation") | C binding
 775 | [rocblas_dspr2_batched](interfacehipfort__rocblas_1_1rocblas__dspr2__batched.html "Interface documentation") | C binding
 776 | [rocblas_sspr2_batched_64](interfacehipfort__rocblas_1_1rocblas__sspr2__batched__64.html "Interface documentation") | C binding
 777 | [rocblas_dspr2_batched_64](interfacehipfort__rocblas_1_1rocblas__dspr2__batched__64.html "Interface documentation") | C binding
-778 | [rocblas_sspr2_strided_batched](interfacehipfort__rocblas_1_1rocblas__sspr2__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-779 | [rocblas_dspr2_strided_batched](interfacehipfort__rocblas_1_1rocblas__dspr2__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-780 | [rocblas_sspr2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sspr2__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-781 | [rocblas_dspr2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dspr2__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-782 | [rocblas_ssyr](interfacehipfort__rocblas_1_1rocblas__ssyr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-783 | [rocblas_dsyr](interfacehipfort__rocblas_1_1rocblas__dsyr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-784 | [rocblas_csyr](interfacehipfort__rocblas_1_1rocblas__csyr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-785 | [rocblas_zsyr](interfacehipfort__rocblas_1_1rocblas__zsyr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-786 | [rocblas_ssyr_64](interfacehipfort__rocblas_1_1rocblas__ssyr__64.html "Interface documentation") | C binding, rank_0, rank_1
-787 | [rocblas_dsyr_64](interfacehipfort__rocblas_1_1rocblas__dsyr__64.html "Interface documentation") | C binding, rank_0, rank_1
-788 | [rocblas_csyr_64](interfacehipfort__rocblas_1_1rocblas__csyr__64.html "Interface documentation") | C binding, rank_0, rank_1
-789 | [rocblas_zsyr_64](interfacehipfort__rocblas_1_1rocblas__zsyr__64.html "Interface documentation") | C binding, rank_0, rank_1
+778 | [rocblas_sspr2_strided_batched](interfacehipfort__rocblas_1_1rocblas__sspr2__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+779 | [rocblas_dspr2_strided_batched](interfacehipfort__rocblas_1_1rocblas__dspr2__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+780 | [rocblas_sspr2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sspr2__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+781 | [rocblas_dspr2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dspr2__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+782 | [rocblas_ssyr](interfacehipfort__rocblas_1_1rocblas__ssyr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+783 | [rocblas_dsyr](interfacehipfort__rocblas_1_1rocblas__dsyr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+784 | [rocblas_csyr](interfacehipfort__rocblas_1_1rocblas__csyr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+785 | [rocblas_zsyr](interfacehipfort__rocblas_1_1rocblas__zsyr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+786 | [rocblas_ssyr_64](interfacehipfort__rocblas_1_1rocblas__ssyr__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+787 | [rocblas_dsyr_64](interfacehipfort__rocblas_1_1rocblas__dsyr__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+788 | [rocblas_csyr_64](interfacehipfort__rocblas_1_1rocblas__csyr__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+789 | [rocblas_zsyr_64](interfacehipfort__rocblas_1_1rocblas__zsyr__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 790 | [rocblas_ssyr_batched](interfacehipfort__rocblas_1_1rocblas__ssyr__batched.html "Interface documentation") | C binding
 791 | [rocblas_dsyr_batched](interfacehipfort__rocblas_1_1rocblas__dsyr__batched.html "Interface documentation") | C binding
 792 | [rocblas_csyr_batched](interfacehipfort__rocblas_1_1rocblas__csyr__batched.html "Interface documentation") | C binding
@@ -799,22 +799,22 @@
 795 | [rocblas_dsyr_batched_64](interfacehipfort__rocblas_1_1rocblas__dsyr__batched__64.html "Interface documentation") | C binding
 796 | [rocblas_csyr_batched_64](interfacehipfort__rocblas_1_1rocblas__csyr__batched__64.html "Interface documentation") | C binding
 797 | [rocblas_zsyr_batched_64](interfacehipfort__rocblas_1_1rocblas__zsyr__batched__64.html "Interface documentation") | C binding
-798 | [rocblas_ssyr_strided_batched](interfacehipfort__rocblas_1_1rocblas__ssyr__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-799 | [rocblas_dsyr_strided_batched](interfacehipfort__rocblas_1_1rocblas__dsyr__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-800 | [rocblas_csyr_strided_batched](interfacehipfort__rocblas_1_1rocblas__csyr__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-801 | [rocblas_zsyr_strided_batched](interfacehipfort__rocblas_1_1rocblas__zsyr__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-802 | [rocblas_ssyr_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ssyr__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-803 | [rocblas_dsyr_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dsyr__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-804 | [rocblas_csyr_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__csyr__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-805 | [rocblas_zsyr_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zsyr__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-806 | [rocblas_ssyr2](interfacehipfort__rocblas_1_1rocblas__ssyr2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-807 | [rocblas_dsyr2](interfacehipfort__rocblas_1_1rocblas__dsyr2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-808 | [rocblas_csyr2](interfacehipfort__rocblas_1_1rocblas__csyr2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-809 | [rocblas_zsyr2](interfacehipfort__rocblas_1_1rocblas__zsyr2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-810 | [rocblas_ssyr2_64](interfacehipfort__rocblas_1_1rocblas__ssyr2__64.html "Interface documentation") | C binding, rank_0, rank_1
-811 | [rocblas_dsyr2_64](interfacehipfort__rocblas_1_1rocblas__dsyr2__64.html "Interface documentation") | C binding, rank_0, rank_1
-812 | [rocblas_csyr2_64](interfacehipfort__rocblas_1_1rocblas__csyr2__64.html "Interface documentation") | C binding, rank_0, rank_1
-813 | [rocblas_zsyr2_64](interfacehipfort__rocblas_1_1rocblas__zsyr2__64.html "Interface documentation") | C binding, rank_0, rank_1
+798 | [rocblas_ssyr_strided_batched](interfacehipfort__rocblas_1_1rocblas__ssyr__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+799 | [rocblas_dsyr_strided_batched](interfacehipfort__rocblas_1_1rocblas__dsyr__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+800 | [rocblas_csyr_strided_batched](interfacehipfort__rocblas_1_1rocblas__csyr__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+801 | [rocblas_zsyr_strided_batched](interfacehipfort__rocblas_1_1rocblas__zsyr__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+802 | [rocblas_ssyr_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ssyr__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+803 | [rocblas_dsyr_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dsyr__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+804 | [rocblas_csyr_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__csyr__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+805 | [rocblas_zsyr_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zsyr__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+806 | [rocblas_ssyr2](interfacehipfort__rocblas_1_1rocblas__ssyr2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+807 | [rocblas_dsyr2](interfacehipfort__rocblas_1_1rocblas__dsyr2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+808 | [rocblas_csyr2](interfacehipfort__rocblas_1_1rocblas__csyr2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+809 | [rocblas_zsyr2](interfacehipfort__rocblas_1_1rocblas__zsyr2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+810 | [rocblas_ssyr2_64](interfacehipfort__rocblas_1_1rocblas__ssyr2__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+811 | [rocblas_dsyr2_64](interfacehipfort__rocblas_1_1rocblas__dsyr2__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+812 | [rocblas_csyr2_64](interfacehipfort__rocblas_1_1rocblas__csyr2__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+813 | [rocblas_zsyr2_64](interfacehipfort__rocblas_1_1rocblas__zsyr2__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 814 | [rocblas_ssyr2_batched](interfacehipfort__rocblas_1_1rocblas__ssyr2__batched.html "Interface documentation") | C binding
 815 | [rocblas_dsyr2_batched](interfacehipfort__rocblas_1_1rocblas__dsyr2__batched.html "Interface documentation") | C binding
 816 | [rocblas_csyr2_batched](interfacehipfort__rocblas_1_1rocblas__csyr2__batched.html "Interface documentation") | C binding
@@ -823,70 +823,70 @@
 819 | [rocblas_dsyr2_batched_64](interfacehipfort__rocblas_1_1rocblas__dsyr2__batched__64.html "Interface documentation") | C binding
 820 | [rocblas_csyr2_batched_64](interfacehipfort__rocblas_1_1rocblas__csyr2__batched__64.html "Interface documentation") | C binding
 821 | [rocblas_zsyr2_batched_64](interfacehipfort__rocblas_1_1rocblas__zsyr2__batched__64.html "Interface documentation") | C binding
-822 | [rocblas_ssyr2_strided_batched](interfacehipfort__rocblas_1_1rocblas__ssyr2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-823 | [rocblas_dsyr2_strided_batched](interfacehipfort__rocblas_1_1rocblas__dsyr2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-824 | [rocblas_csyr2_strided_batched](interfacehipfort__rocblas_1_1rocblas__csyr2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-825 | [rocblas_zsyr2_strided_batched](interfacehipfort__rocblas_1_1rocblas__zsyr2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-826 | [rocblas_ssyr2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ssyr2__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-827 | [rocblas_dsyr2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dsyr2__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-828 | [rocblas_csyr2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__csyr2__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-829 | [rocblas_zsyr2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zsyr2__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-830 | [rocblas_chemm](interfacehipfort__rocblas_1_1rocblas__chemm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-831 | [rocblas_zhemm](interfacehipfort__rocblas_1_1rocblas__zhemm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-832 | [rocblas_chemm_64](interfacehipfort__rocblas_1_1rocblas__chemm__64.html "Interface documentation") | C binding, rank_0, rank_1
-833 | [rocblas_zhemm_64](interfacehipfort__rocblas_1_1rocblas__zhemm__64.html "Interface documentation") | C binding, rank_0, rank_1
+822 | [rocblas_ssyr2_strided_batched](interfacehipfort__rocblas_1_1rocblas__ssyr2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+823 | [rocblas_dsyr2_strided_batched](interfacehipfort__rocblas_1_1rocblas__dsyr2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+824 | [rocblas_csyr2_strided_batched](interfacehipfort__rocblas_1_1rocblas__csyr2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+825 | [rocblas_zsyr2_strided_batched](interfacehipfort__rocblas_1_1rocblas__zsyr2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+826 | [rocblas_ssyr2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ssyr2__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+827 | [rocblas_dsyr2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dsyr2__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+828 | [rocblas_csyr2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__csyr2__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+829 | [rocblas_zsyr2_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zsyr2__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+830 | [rocblas_chemm](interfacehipfort__rocblas_1_1rocblas__chemm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+831 | [rocblas_zhemm](interfacehipfort__rocblas_1_1rocblas__zhemm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+832 | [rocblas_chemm_64](interfacehipfort__rocblas_1_1rocblas__chemm__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+833 | [rocblas_zhemm_64](interfacehipfort__rocblas_1_1rocblas__zhemm__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 834 | [rocblas_chemm_batched](interfacehipfort__rocblas_1_1rocblas__chemm__batched.html "Interface documentation") | C binding
 835 | [rocblas_zhemm_batched](interfacehipfort__rocblas_1_1rocblas__zhemm__batched.html "Interface documentation") | C binding
 836 | [rocblas_chemm_batched_64](interfacehipfort__rocblas_1_1rocblas__chemm__batched__64.html "Interface documentation") | C binding
 837 | [rocblas_zhemm_batched_64](interfacehipfort__rocblas_1_1rocblas__zhemm__batched__64.html "Interface documentation") | C binding
-838 | [rocblas_chemm_strided_batched](interfacehipfort__rocblas_1_1rocblas__chemm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-839 | [rocblas_zhemm_strided_batched](interfacehipfort__rocblas_1_1rocblas__zhemm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-840 | [rocblas_chemm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__chemm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-841 | [rocblas_zhemm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zhemm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-842 | [rocblas_cherk](interfacehipfort__rocblas_1_1rocblas__cherk.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-843 | [rocblas_zherk](interfacehipfort__rocblas_1_1rocblas__zherk.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-844 | [rocblas_cherk_64](interfacehipfort__rocblas_1_1rocblas__cherk__64.html "Interface documentation") | C binding, rank_0, rank_1
-845 | [rocblas_zherk_64](interfacehipfort__rocblas_1_1rocblas__zherk__64.html "Interface documentation") | C binding, rank_0, rank_1
+838 | [rocblas_chemm_strided_batched](interfacehipfort__rocblas_1_1rocblas__chemm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+839 | [rocblas_zhemm_strided_batched](interfacehipfort__rocblas_1_1rocblas__zhemm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+840 | [rocblas_chemm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__chemm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+841 | [rocblas_zhemm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zhemm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+842 | [rocblas_cherk](interfacehipfort__rocblas_1_1rocblas__cherk.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+843 | [rocblas_zherk](interfacehipfort__rocblas_1_1rocblas__zherk.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+844 | [rocblas_cherk_64](interfacehipfort__rocblas_1_1rocblas__cherk__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+845 | [rocblas_zherk_64](interfacehipfort__rocblas_1_1rocblas__zherk__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 846 | [rocblas_cherk_batched](interfacehipfort__rocblas_1_1rocblas__cherk__batched.html "Interface documentation") | C binding
 847 | [rocblas_zherk_batched](interfacehipfort__rocblas_1_1rocblas__zherk__batched.html "Interface documentation") | C binding
 848 | [rocblas_cherk_batched_64](interfacehipfort__rocblas_1_1rocblas__cherk__batched__64.html "Interface documentation") | C binding
 849 | [rocblas_zherk_batched_64](interfacehipfort__rocblas_1_1rocblas__zherk__batched__64.html "Interface documentation") | C binding
-850 | [rocblas_cherk_strided_batched](interfacehipfort__rocblas_1_1rocblas__cherk__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-851 | [rocblas_zherk_strided_batched](interfacehipfort__rocblas_1_1rocblas__zherk__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-852 | [rocblas_cherk_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cherk__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-853 | [rocblas_zherk_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zherk__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-854 | [rocblas_cher2k](interfacehipfort__rocblas_1_1rocblas__cher2k.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-855 | [rocblas_zher2k](interfacehipfort__rocblas_1_1rocblas__zher2k.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-856 | [rocblas_cher2k_64](interfacehipfort__rocblas_1_1rocblas__cher2k__64.html "Interface documentation") | C binding, rank_0, rank_1
-857 | [rocblas_zher2k_64](interfacehipfort__rocblas_1_1rocblas__zher2k__64.html "Interface documentation") | C binding, rank_0, rank_1
+850 | [rocblas_cherk_strided_batched](interfacehipfort__rocblas_1_1rocblas__cherk__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+851 | [rocblas_zherk_strided_batched](interfacehipfort__rocblas_1_1rocblas__zherk__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+852 | [rocblas_cherk_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cherk__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+853 | [rocblas_zherk_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zherk__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+854 | [rocblas_cher2k](interfacehipfort__rocblas_1_1rocblas__cher2k.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+855 | [rocblas_zher2k](interfacehipfort__rocblas_1_1rocblas__zher2k.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+856 | [rocblas_cher2k_64](interfacehipfort__rocblas_1_1rocblas__cher2k__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+857 | [rocblas_zher2k_64](interfacehipfort__rocblas_1_1rocblas__zher2k__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 858 | [rocblas_cher2k_batched](interfacehipfort__rocblas_1_1rocblas__cher2k__batched.html "Interface documentation") | C binding
 859 | [rocblas_zher2k_batched](interfacehipfort__rocblas_1_1rocblas__zher2k__batched.html "Interface documentation") | C binding
 860 | [rocblas_cher2k_batched_64](interfacehipfort__rocblas_1_1rocblas__cher2k__batched__64.html "Interface documentation") | C binding
 861 | [rocblas_zher2k_batched_64](interfacehipfort__rocblas_1_1rocblas__zher2k__batched__64.html "Interface documentation") | C binding
-862 | [rocblas_cher2k_strided_batched](interfacehipfort__rocblas_1_1rocblas__cher2k__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-863 | [rocblas_zher2k_strided_batched](interfacehipfort__rocblas_1_1rocblas__zher2k__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-864 | [rocblas_cher2k_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cher2k__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-865 | [rocblas_zher2k_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zher2k__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-866 | [rocblas_cherkx](interfacehipfort__rocblas_1_1rocblas__cherkx.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-867 | [rocblas_zherkx](interfacehipfort__rocblas_1_1rocblas__zherkx.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-868 | [rocblas_cherkx_64](interfacehipfort__rocblas_1_1rocblas__cherkx__64.html "Interface documentation") | C binding, rank_0, rank_1
-869 | [rocblas_zherkx_64](interfacehipfort__rocblas_1_1rocblas__zherkx__64.html "Interface documentation") | C binding, rank_0, rank_1
+862 | [rocblas_cher2k_strided_batched](interfacehipfort__rocblas_1_1rocblas__cher2k__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+863 | [rocblas_zher2k_strided_batched](interfacehipfort__rocblas_1_1rocblas__zher2k__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+864 | [rocblas_cher2k_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cher2k__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+865 | [rocblas_zher2k_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zher2k__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+866 | [rocblas_cherkx](interfacehipfort__rocblas_1_1rocblas__cherkx.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+867 | [rocblas_zherkx](interfacehipfort__rocblas_1_1rocblas__zherkx.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+868 | [rocblas_cherkx_64](interfacehipfort__rocblas_1_1rocblas__cherkx__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+869 | [rocblas_zherkx_64](interfacehipfort__rocblas_1_1rocblas__zherkx__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 870 | [rocblas_cherkx_batched](interfacehipfort__rocblas_1_1rocblas__cherkx__batched.html "Interface documentation") | C binding
 871 | [rocblas_zherkx_batched](interfacehipfort__rocblas_1_1rocblas__zherkx__batched.html "Interface documentation") | C binding
 872 | [rocblas_cherkx_batched_64](interfacehipfort__rocblas_1_1rocblas__cherkx__batched__64.html "Interface documentation") | C binding
 873 | [rocblas_zherkx_batched_64](interfacehipfort__rocblas_1_1rocblas__zherkx__batched__64.html "Interface documentation") | C binding
-874 | [rocblas_cherkx_strided_batched](interfacehipfort__rocblas_1_1rocblas__cherkx__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-875 | [rocblas_zherkx_strided_batched](interfacehipfort__rocblas_1_1rocblas__zherkx__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-876 | [rocblas_cherkx_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cherkx__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-877 | [rocblas_zherkx_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zherkx__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-878 | [rocblas_ssymm](interfacehipfort__rocblas_1_1rocblas__ssymm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-879 | [rocblas_dsymm](interfacehipfort__rocblas_1_1rocblas__dsymm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-880 | [rocblas_csymm](interfacehipfort__rocblas_1_1rocblas__csymm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-881 | [rocblas_zsymm](interfacehipfort__rocblas_1_1rocblas__zsymm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-882 | [rocblas_ssymm_64](interfacehipfort__rocblas_1_1rocblas__ssymm__64.html "Interface documentation") | C binding, rank_0, rank_1
-883 | [rocblas_dsymm_64](interfacehipfort__rocblas_1_1rocblas__dsymm__64.html "Interface documentation") | C binding, rank_0, rank_1
-884 | [rocblas_csymm_64](interfacehipfort__rocblas_1_1rocblas__csymm__64.html "Interface documentation") | C binding, rank_0, rank_1
-885 | [rocblas_zsymm_64](interfacehipfort__rocblas_1_1rocblas__zsymm__64.html "Interface documentation") | C binding, rank_0, rank_1
+874 | [rocblas_cherkx_strided_batched](interfacehipfort__rocblas_1_1rocblas__cherkx__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+875 | [rocblas_zherkx_strided_batched](interfacehipfort__rocblas_1_1rocblas__zherkx__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+876 | [rocblas_cherkx_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cherkx__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+877 | [rocblas_zherkx_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zherkx__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+878 | [rocblas_ssymm](interfacehipfort__rocblas_1_1rocblas__ssymm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+879 | [rocblas_dsymm](interfacehipfort__rocblas_1_1rocblas__dsymm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+880 | [rocblas_csymm](interfacehipfort__rocblas_1_1rocblas__csymm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+881 | [rocblas_zsymm](interfacehipfort__rocblas_1_1rocblas__zsymm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+882 | [rocblas_ssymm_64](interfacehipfort__rocblas_1_1rocblas__ssymm__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+883 | [rocblas_dsymm_64](interfacehipfort__rocblas_1_1rocblas__dsymm__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+884 | [rocblas_csymm_64](interfacehipfort__rocblas_1_1rocblas__csymm__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+885 | [rocblas_zsymm_64](interfacehipfort__rocblas_1_1rocblas__zsymm__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 886 | [rocblas_ssymm_batched](interfacehipfort__rocblas_1_1rocblas__ssymm__batched.html "Interface documentation") | C binding
 887 | [rocblas_dsymm_batched](interfacehipfort__rocblas_1_1rocblas__dsymm__batched.html "Interface documentation") | C binding
 888 | [rocblas_csymm_batched](interfacehipfort__rocblas_1_1rocblas__csymm__batched.html "Interface documentation") | C binding
@@ -895,22 +895,22 @@
 891 | [rocblas_dsymm_batched_64](interfacehipfort__rocblas_1_1rocblas__dsymm__batched__64.html "Interface documentation") | C binding
 892 | [rocblas_csymm_batched_64](interfacehipfort__rocblas_1_1rocblas__csymm__batched__64.html "Interface documentation") | C binding
 893 | [rocblas_zsymm_batched_64](interfacehipfort__rocblas_1_1rocblas__zsymm__batched__64.html "Interface documentation") | C binding
-894 | [rocblas_ssymm_strided_batched](interfacehipfort__rocblas_1_1rocblas__ssymm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-895 | [rocblas_dsymm_strided_batched](interfacehipfort__rocblas_1_1rocblas__dsymm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-896 | [rocblas_csymm_strided_batched](interfacehipfort__rocblas_1_1rocblas__csymm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-897 | [rocblas_zsymm_strided_batched](interfacehipfort__rocblas_1_1rocblas__zsymm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-898 | [rocblas_ssymm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ssymm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-899 | [rocblas_dsymm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dsymm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-900 | [rocblas_csymm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__csymm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-901 | [rocblas_zsymm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zsymm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-902 | [rocblas_ssyrk](interfacehipfort__rocblas_1_1rocblas__ssyrk.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-903 | [rocblas_dsyrk](interfacehipfort__rocblas_1_1rocblas__dsyrk.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-904 | [rocblas_csyrk](interfacehipfort__rocblas_1_1rocblas__csyrk.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-905 | [rocblas_zsyrk](interfacehipfort__rocblas_1_1rocblas__zsyrk.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-906 | [rocblas_ssyrk_64](interfacehipfort__rocblas_1_1rocblas__ssyrk__64.html "Interface documentation") | C binding, rank_0, rank_1
-907 | [rocblas_dsyrk_64](interfacehipfort__rocblas_1_1rocblas__dsyrk__64.html "Interface documentation") | C binding, rank_0, rank_1
-908 | [rocblas_csyrk_64](interfacehipfort__rocblas_1_1rocblas__csyrk__64.html "Interface documentation") | C binding, rank_0, rank_1
-909 | [rocblas_zsyrk_64](interfacehipfort__rocblas_1_1rocblas__zsyrk__64.html "Interface documentation") | C binding, rank_0, rank_1
+894 | [rocblas_ssymm_strided_batched](interfacehipfort__rocblas_1_1rocblas__ssymm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+895 | [rocblas_dsymm_strided_batched](interfacehipfort__rocblas_1_1rocblas__dsymm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+896 | [rocblas_csymm_strided_batched](interfacehipfort__rocblas_1_1rocblas__csymm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+897 | [rocblas_zsymm_strided_batched](interfacehipfort__rocblas_1_1rocblas__zsymm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+898 | [rocblas_ssymm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ssymm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+899 | [rocblas_dsymm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dsymm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+900 | [rocblas_csymm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__csymm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+901 | [rocblas_zsymm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zsymm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+902 | [rocblas_ssyrk](interfacehipfort__rocblas_1_1rocblas__ssyrk.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+903 | [rocblas_dsyrk](interfacehipfort__rocblas_1_1rocblas__dsyrk.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+904 | [rocblas_csyrk](interfacehipfort__rocblas_1_1rocblas__csyrk.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+905 | [rocblas_zsyrk](interfacehipfort__rocblas_1_1rocblas__zsyrk.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+906 | [rocblas_ssyrk_64](interfacehipfort__rocblas_1_1rocblas__ssyrk__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+907 | [rocblas_dsyrk_64](interfacehipfort__rocblas_1_1rocblas__dsyrk__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+908 | [rocblas_csyrk_64](interfacehipfort__rocblas_1_1rocblas__csyrk__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+909 | [rocblas_zsyrk_64](interfacehipfort__rocblas_1_1rocblas__zsyrk__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 910 | [rocblas_ssyrk_batched](interfacehipfort__rocblas_1_1rocblas__ssyrk__batched.html "Interface documentation") | C binding
 911 | [rocblas_dsyrk_batched](interfacehipfort__rocblas_1_1rocblas__dsyrk__batched.html "Interface documentation") | C binding
 912 | [rocblas_csyrk_batched](interfacehipfort__rocblas_1_1rocblas__csyrk__batched.html "Interface documentation") | C binding
@@ -919,22 +919,22 @@
 915 | [rocblas_dsyrk_batched_64](interfacehipfort__rocblas_1_1rocblas__dsyrk__batched__64.html "Interface documentation") | C binding
 916 | [rocblas_csyrk_batched_64](interfacehipfort__rocblas_1_1rocblas__csyrk__batched__64.html "Interface documentation") | C binding
 917 | [rocblas_zsyrk_batched_64](interfacehipfort__rocblas_1_1rocblas__zsyrk__batched__64.html "Interface documentation") | C binding
-918 | [rocblas_ssyrk_strided_batched](interfacehipfort__rocblas_1_1rocblas__ssyrk__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-919 | [rocblas_dsyrk_strided_batched](interfacehipfort__rocblas_1_1rocblas__dsyrk__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-920 | [rocblas_csyrk_strided_batched](interfacehipfort__rocblas_1_1rocblas__csyrk__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-921 | [rocblas_zsyrk_strided_batched](interfacehipfort__rocblas_1_1rocblas__zsyrk__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-922 | [rocblas_ssyrk_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ssyrk__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-923 | [rocblas_dsyrk_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dsyrk__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-924 | [rocblas_csyrk_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__csyrk__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-925 | [rocblas_zsyrk_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zsyrk__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-926 | [rocblas_ssyr2k](interfacehipfort__rocblas_1_1rocblas__ssyr2k.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-927 | [rocblas_dsyr2k](interfacehipfort__rocblas_1_1rocblas__dsyr2k.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-928 | [rocblas_csyr2k](interfacehipfort__rocblas_1_1rocblas__csyr2k.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-929 | [rocblas_zsyr2k](interfacehipfort__rocblas_1_1rocblas__zsyr2k.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-930 | [rocblas_ssyr2k_64](interfacehipfort__rocblas_1_1rocblas__ssyr2k__64.html "Interface documentation") | C binding, rank_0, rank_1
-931 | [rocblas_dsyr2k_64](interfacehipfort__rocblas_1_1rocblas__dsyr2k__64.html "Interface documentation") | C binding, rank_0, rank_1
-932 | [rocblas_csyr2k_64](interfacehipfort__rocblas_1_1rocblas__csyr2k__64.html "Interface documentation") | C binding, rank_0, rank_1
-933 | [rocblas_zsyr2k_64](interfacehipfort__rocblas_1_1rocblas__zsyr2k__64.html "Interface documentation") | C binding, rank_0, rank_1
+918 | [rocblas_ssyrk_strided_batched](interfacehipfort__rocblas_1_1rocblas__ssyrk__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+919 | [rocblas_dsyrk_strided_batched](interfacehipfort__rocblas_1_1rocblas__dsyrk__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+920 | [rocblas_csyrk_strided_batched](interfacehipfort__rocblas_1_1rocblas__csyrk__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+921 | [rocblas_zsyrk_strided_batched](interfacehipfort__rocblas_1_1rocblas__zsyrk__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+922 | [rocblas_ssyrk_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ssyrk__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+923 | [rocblas_dsyrk_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dsyrk__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+924 | [rocblas_csyrk_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__csyrk__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+925 | [rocblas_zsyrk_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zsyrk__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+926 | [rocblas_ssyr2k](interfacehipfort__rocblas_1_1rocblas__ssyr2k.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+927 | [rocblas_dsyr2k](interfacehipfort__rocblas_1_1rocblas__dsyr2k.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+928 | [rocblas_csyr2k](interfacehipfort__rocblas_1_1rocblas__csyr2k.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+929 | [rocblas_zsyr2k](interfacehipfort__rocblas_1_1rocblas__zsyr2k.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+930 | [rocblas_ssyr2k_64](interfacehipfort__rocblas_1_1rocblas__ssyr2k__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+931 | [rocblas_dsyr2k_64](interfacehipfort__rocblas_1_1rocblas__dsyr2k__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+932 | [rocblas_csyr2k_64](interfacehipfort__rocblas_1_1rocblas__csyr2k__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+933 | [rocblas_zsyr2k_64](interfacehipfort__rocblas_1_1rocblas__zsyr2k__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 934 | [rocblas_ssyr2k_batched](interfacehipfort__rocblas_1_1rocblas__ssyr2k__batched.html "Interface documentation") | C binding
 935 | [rocblas_dsyr2k_batched](interfacehipfort__rocblas_1_1rocblas__dsyr2k__batched.html "Interface documentation") | C binding
 936 | [rocblas_csyr2k_batched](interfacehipfort__rocblas_1_1rocblas__csyr2k__batched.html "Interface documentation") | C binding
@@ -943,22 +943,22 @@
 939 | [rocblas_dsyr2k_batched_64](interfacehipfort__rocblas_1_1rocblas__dsyr2k__batched__64.html "Interface documentation") | C binding
 940 | [rocblas_csyr2k_batched_64](interfacehipfort__rocblas_1_1rocblas__csyr2k__batched__64.html "Interface documentation") | C binding
 941 | [rocblas_zsyr2k_batched_64](interfacehipfort__rocblas_1_1rocblas__zsyr2k__batched__64.html "Interface documentation") | C binding
-942 | [rocblas_ssyr2k_strided_batched](interfacehipfort__rocblas_1_1rocblas__ssyr2k__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-943 | [rocblas_dsyr2k_strided_batched](interfacehipfort__rocblas_1_1rocblas__dsyr2k__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-944 | [rocblas_csyr2k_strided_batched](interfacehipfort__rocblas_1_1rocblas__csyr2k__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-945 | [rocblas_zsyr2k_strided_batched](interfacehipfort__rocblas_1_1rocblas__zsyr2k__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-946 | [rocblas_ssyr2k_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ssyr2k__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-947 | [rocblas_dsyr2k_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dsyr2k__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-948 | [rocblas_csyr2k_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__csyr2k__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-949 | [rocblas_zsyr2k_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zsyr2k__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-950 | [rocblas_ssyrkx](interfacehipfort__rocblas_1_1rocblas__ssyrkx.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-951 | [rocblas_dsyrkx](interfacehipfort__rocblas_1_1rocblas__dsyrkx.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-952 | [rocblas_csyrkx](interfacehipfort__rocblas_1_1rocblas__csyrkx.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-953 | [rocblas_zsyrkx](interfacehipfort__rocblas_1_1rocblas__zsyrkx.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-954 | [rocblas_ssyrkx_64](interfacehipfort__rocblas_1_1rocblas__ssyrkx__64.html "Interface documentation") | C binding, rank_0, rank_1
-955 | [rocblas_dsyrkx_64](interfacehipfort__rocblas_1_1rocblas__dsyrkx__64.html "Interface documentation") | C binding, rank_0, rank_1
-956 | [rocblas_csyrkx_64](interfacehipfort__rocblas_1_1rocblas__csyrkx__64.html "Interface documentation") | C binding, rank_0, rank_1
-957 | [rocblas_zsyrkx_64](interfacehipfort__rocblas_1_1rocblas__zsyrkx__64.html "Interface documentation") | C binding, rank_0, rank_1
+942 | [rocblas_ssyr2k_strided_batched](interfacehipfort__rocblas_1_1rocblas__ssyr2k__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+943 | [rocblas_dsyr2k_strided_batched](interfacehipfort__rocblas_1_1rocblas__dsyr2k__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+944 | [rocblas_csyr2k_strided_batched](interfacehipfort__rocblas_1_1rocblas__csyr2k__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+945 | [rocblas_zsyr2k_strided_batched](interfacehipfort__rocblas_1_1rocblas__zsyr2k__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+946 | [rocblas_ssyr2k_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ssyr2k__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+947 | [rocblas_dsyr2k_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dsyr2k__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+948 | [rocblas_csyr2k_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__csyr2k__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+949 | [rocblas_zsyr2k_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zsyr2k__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+950 | [rocblas_ssyrkx](interfacehipfort__rocblas_1_1rocblas__ssyrkx.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+951 | [rocblas_dsyrkx](interfacehipfort__rocblas_1_1rocblas__dsyrkx.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+952 | [rocblas_csyrkx](interfacehipfort__rocblas_1_1rocblas__csyrkx.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+953 | [rocblas_zsyrkx](interfacehipfort__rocblas_1_1rocblas__zsyrkx.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+954 | [rocblas_ssyrkx_64](interfacehipfort__rocblas_1_1rocblas__ssyrkx__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+955 | [rocblas_dsyrkx_64](interfacehipfort__rocblas_1_1rocblas__dsyrkx__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+956 | [rocblas_csyrkx_64](interfacehipfort__rocblas_1_1rocblas__csyrkx__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+957 | [rocblas_zsyrkx_64](interfacehipfort__rocblas_1_1rocblas__zsyrkx__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 958 | [rocblas_ssyrkx_batched](interfacehipfort__rocblas_1_1rocblas__ssyrkx__batched.html "Interface documentation") | C binding
 959 | [rocblas_dsyrkx_batched](interfacehipfort__rocblas_1_1rocblas__dsyrkx__batched.html "Interface documentation") | C binding
 960 | [rocblas_csyrkx_batched](interfacehipfort__rocblas_1_1rocblas__csyrkx__batched.html "Interface documentation") | C binding
@@ -967,22 +967,22 @@
 963 | [rocblas_dsyrkx_batched_64](interfacehipfort__rocblas_1_1rocblas__dsyrkx__batched__64.html "Interface documentation") | C binding
 964 | [rocblas_csyrkx_batched_64](interfacehipfort__rocblas_1_1rocblas__csyrkx__batched__64.html "Interface documentation") | C binding
 965 | [rocblas_zsyrkx_batched_64](interfacehipfort__rocblas_1_1rocblas__zsyrkx__batched__64.html "Interface documentation") | C binding
-966 | [rocblas_ssyrkx_strided_batched](interfacehipfort__rocblas_1_1rocblas__ssyrkx__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-967 | [rocblas_dsyrkx_strided_batched](interfacehipfort__rocblas_1_1rocblas__dsyrkx__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-968 | [rocblas_csyrkx_strided_batched](interfacehipfort__rocblas_1_1rocblas__csyrkx__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-969 | [rocblas_zsyrkx_strided_batched](interfacehipfort__rocblas_1_1rocblas__zsyrkx__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-970 | [rocblas_ssyrkx_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ssyrkx__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-971 | [rocblas_dsyrkx_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dsyrkx__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-972 | [rocblas_csyrkx_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__csyrkx__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-973 | [rocblas_zsyrkx_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zsyrkx__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-974 | [rocblas_strmm](interfacehipfort__rocblas_1_1rocblas__strmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-975 | [rocblas_dtrmm](interfacehipfort__rocblas_1_1rocblas__dtrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-976 | [rocblas_ctrmm](interfacehipfort__rocblas_1_1rocblas__ctrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-977 | [rocblas_ztrmm](interfacehipfort__rocblas_1_1rocblas__ztrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-978 | [rocblas_strmm_64](interfacehipfort__rocblas_1_1rocblas__strmm__64.html "Interface documentation") | C binding, rank_0, rank_1
-979 | [rocblas_dtrmm_64](interfacehipfort__rocblas_1_1rocblas__dtrmm__64.html "Interface documentation") | C binding, rank_0, rank_1
-980 | [rocblas_ctrmm_64](interfacehipfort__rocblas_1_1rocblas__ctrmm__64.html "Interface documentation") | C binding, rank_0, rank_1
-981 | [rocblas_ztrmm_64](interfacehipfort__rocblas_1_1rocblas__ztrmm__64.html "Interface documentation") | C binding, rank_0, rank_1
+966 | [rocblas_ssyrkx_strided_batched](interfacehipfort__rocblas_1_1rocblas__ssyrkx__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+967 | [rocblas_dsyrkx_strided_batched](interfacehipfort__rocblas_1_1rocblas__dsyrkx__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+968 | [rocblas_csyrkx_strided_batched](interfacehipfort__rocblas_1_1rocblas__csyrkx__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+969 | [rocblas_zsyrkx_strided_batched](interfacehipfort__rocblas_1_1rocblas__zsyrkx__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+970 | [rocblas_ssyrkx_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ssyrkx__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+971 | [rocblas_dsyrkx_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dsyrkx__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+972 | [rocblas_csyrkx_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__csyrkx__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+973 | [rocblas_zsyrkx_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zsyrkx__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+974 | [rocblas_strmm](interfacehipfort__rocblas_1_1rocblas__strmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+975 | [rocblas_dtrmm](interfacehipfort__rocblas_1_1rocblas__dtrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+976 | [rocblas_ctrmm](interfacehipfort__rocblas_1_1rocblas__ctrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+977 | [rocblas_ztrmm](interfacehipfort__rocblas_1_1rocblas__ztrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+978 | [rocblas_strmm_64](interfacehipfort__rocblas_1_1rocblas__strmm__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+979 | [rocblas_dtrmm_64](interfacehipfort__rocblas_1_1rocblas__dtrmm__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+980 | [rocblas_ctrmm_64](interfacehipfort__rocblas_1_1rocblas__ctrmm__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+981 | [rocblas_ztrmm_64](interfacehipfort__rocblas_1_1rocblas__ztrmm__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 982 | [rocblas_strmm_batched](interfacehipfort__rocblas_1_1rocblas__strmm__batched.html "Interface documentation") | C binding
 983 | [rocblas_dtrmm_batched](interfacehipfort__rocblas_1_1rocblas__dtrmm__batched.html "Interface documentation") | C binding
 984 | [rocblas_ctrmm_batched](interfacehipfort__rocblas_1_1rocblas__ctrmm__batched.html "Interface documentation") | C binding
@@ -991,34 +991,34 @@
 987 | [rocblas_dtrmm_batched_64](interfacehipfort__rocblas_1_1rocblas__dtrmm__batched__64.html "Interface documentation") | C binding
 988 | [rocblas_ctrmm_batched_64](interfacehipfort__rocblas_1_1rocblas__ctrmm__batched__64.html "Interface documentation") | C binding
 989 | [rocblas_ztrmm_batched_64](interfacehipfort__rocblas_1_1rocblas__ztrmm__batched__64.html "Interface documentation") | C binding
-990 | [rocblas_strmm_strided_batched](interfacehipfort__rocblas_1_1rocblas__strmm__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-991 | [rocblas_dtrmm_strided_batched](interfacehipfort__rocblas_1_1rocblas__dtrmm__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-992 | [rocblas_ctrmm_strided_batched](interfacehipfort__rocblas_1_1rocblas__ctrmm__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-993 | [rocblas_ztrmm_strided_batched](interfacehipfort__rocblas_1_1rocblas__ztrmm__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-994 | [rocblas_strmm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__strmm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-995 | [rocblas_dtrmm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dtrmm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-996 | [rocblas_ctrmm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ctrmm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-997 | [rocblas_ztrmm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ztrmm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-998 | [rocblas_strtri](interfacehipfort__rocblas_1_1rocblas__strtri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-999 | [rocblas_dtrtri](interfacehipfort__rocblas_1_1rocblas__dtrtri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1000 | [rocblas_ctrtri](interfacehipfort__rocblas_1_1rocblas__ctrtri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1001 | [rocblas_ztrtri](interfacehipfort__rocblas_1_1rocblas__ztrtri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+990 | [rocblas_strmm_strided_batched](interfacehipfort__rocblas_1_1rocblas__strmm__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+991 | [rocblas_dtrmm_strided_batched](interfacehipfort__rocblas_1_1rocblas__dtrmm__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+992 | [rocblas_ctrmm_strided_batched](interfacehipfort__rocblas_1_1rocblas__ctrmm__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+993 | [rocblas_ztrmm_strided_batched](interfacehipfort__rocblas_1_1rocblas__ztrmm__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+994 | [rocblas_strmm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__strmm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+995 | [rocblas_dtrmm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dtrmm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+996 | [rocblas_ctrmm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ctrmm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+997 | [rocblas_ztrmm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ztrmm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+998 | [rocblas_strtri](interfacehipfort__rocblas_1_1rocblas__strtri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+999 | [rocblas_dtrtri](interfacehipfort__rocblas_1_1rocblas__dtrtri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1000 | [rocblas_ctrtri](interfacehipfort__rocblas_1_1rocblas__ctrtri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1001 | [rocblas_ztrtri](interfacehipfort__rocblas_1_1rocblas__ztrtri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 1002 | [rocblas_strtri_batched](interfacehipfort__rocblas_1_1rocblas__strtri__batched.html "Interface documentation") | C binding
 1003 | [rocblas_dtrtri_batched](interfacehipfort__rocblas_1_1rocblas__dtrtri__batched.html "Interface documentation") | C binding
 1004 | [rocblas_ctrtri_batched](interfacehipfort__rocblas_1_1rocblas__ctrtri__batched.html "Interface documentation") | C binding
 1005 | [rocblas_ztrtri_batched](interfacehipfort__rocblas_1_1rocblas__ztrtri__batched.html "Interface documentation") | C binding
-1006 | [rocblas_strtri_strided_batched](interfacehipfort__rocblas_1_1rocblas__strtri__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1007 | [rocblas_dtrtri_strided_batched](interfacehipfort__rocblas_1_1rocblas__dtrtri__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1008 | [rocblas_ctrtri_strided_batched](interfacehipfort__rocblas_1_1rocblas__ctrtri__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1009 | [rocblas_ztrtri_strided_batched](interfacehipfort__rocblas_1_1rocblas__ztrtri__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1010 | [rocblas_strsm](interfacehipfort__rocblas_1_1rocblas__strsm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1011 | [rocblas_dtrsm](interfacehipfort__rocblas_1_1rocblas__dtrsm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1012 | [rocblas_ctrsm](interfacehipfort__rocblas_1_1rocblas__ctrsm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1013 | [rocblas_ztrsm](interfacehipfort__rocblas_1_1rocblas__ztrsm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1014 | [rocblas_strsm_64](interfacehipfort__rocblas_1_1rocblas__strsm__64.html "Interface documentation") | C binding, rank_0, rank_1
-1015 | [rocblas_dtrsm_64](interfacehipfort__rocblas_1_1rocblas__dtrsm__64.html "Interface documentation") | C binding, rank_0, rank_1
-1016 | [rocblas_ctrsm_64](interfacehipfort__rocblas_1_1rocblas__ctrsm__64.html "Interface documentation") | C binding, rank_0, rank_1
-1017 | [rocblas_ztrsm_64](interfacehipfort__rocblas_1_1rocblas__ztrsm__64.html "Interface documentation") | C binding, rank_0, rank_1
+1006 | [rocblas_strtri_strided_batched](interfacehipfort__rocblas_1_1rocblas__strtri__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1007 | [rocblas_dtrtri_strided_batched](interfacehipfort__rocblas_1_1rocblas__dtrtri__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1008 | [rocblas_ctrtri_strided_batched](interfacehipfort__rocblas_1_1rocblas__ctrtri__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1009 | [rocblas_ztrtri_strided_batched](interfacehipfort__rocblas_1_1rocblas__ztrtri__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1010 | [rocblas_strsm](interfacehipfort__rocblas_1_1rocblas__strsm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1011 | [rocblas_dtrsm](interfacehipfort__rocblas_1_1rocblas__dtrsm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1012 | [rocblas_ctrsm](interfacehipfort__rocblas_1_1rocblas__ctrsm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1013 | [rocblas_ztrsm](interfacehipfort__rocblas_1_1rocblas__ztrsm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1014 | [rocblas_strsm_64](interfacehipfort__rocblas_1_1rocblas__strsm__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1015 | [rocblas_dtrsm_64](interfacehipfort__rocblas_1_1rocblas__dtrsm__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1016 | [rocblas_ctrsm_64](interfacehipfort__rocblas_1_1rocblas__ctrsm__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1017 | [rocblas_ztrsm_64](interfacehipfort__rocblas_1_1rocblas__ztrsm__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 1018 | [rocblas_strsm_batched](interfacehipfort__rocblas_1_1rocblas__strsm__batched.html "Interface documentation") | C binding
 1019 | [rocblas_dtrsm_batched](interfacehipfort__rocblas_1_1rocblas__dtrsm__batched.html "Interface documentation") | C binding
 1020 | [rocblas_ctrsm_batched](interfacehipfort__rocblas_1_1rocblas__ctrsm__batched.html "Interface documentation") | C binding
@@ -1027,24 +1027,24 @@
 1023 | [rocblas_dtrsm_batched_64](interfacehipfort__rocblas_1_1rocblas__dtrsm__batched__64.html "Interface documentation") | C binding
 1024 | [rocblas_ctrsm_batched_64](interfacehipfort__rocblas_1_1rocblas__ctrsm__batched__64.html "Interface documentation") | C binding
 1025 | [rocblas_ztrsm_batched_64](interfacehipfort__rocblas_1_1rocblas__ztrsm__batched__64.html "Interface documentation") | C binding
-1026 | [rocblas_strsm_strided_batched](interfacehipfort__rocblas_1_1rocblas__strsm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1027 | [rocblas_dtrsm_strided_batched](interfacehipfort__rocblas_1_1rocblas__dtrsm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1028 | [rocblas_ctrsm_strided_batched](interfacehipfort__rocblas_1_1rocblas__ctrsm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1029 | [rocblas_ztrsm_strided_batched](interfacehipfort__rocblas_1_1rocblas__ztrsm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1030 | [rocblas_strsm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__strsm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-1031 | [rocblas_dtrsm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dtrsm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-1032 | [rocblas_ctrsm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ctrsm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-1033 | [rocblas_ztrsm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ztrsm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-1034 | [rocblas_sgemm](interfacehipfort__rocblas_1_1rocblas__sgemm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1035 | [rocblas_dgemm](interfacehipfort__rocblas_1_1rocblas__dgemm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1036 | [rocblas_hgemm](interfacehipfort__rocblas_1_1rocblas__hgemm.html "Interface documentation") | C binding, rank_0, rank_1
-1037 | [rocblas_cgemm](interfacehipfort__rocblas_1_1rocblas__cgemm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1038 | [rocblas_zgemm](interfacehipfort__rocblas_1_1rocblas__zgemm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1039 | [rocblas_sgemm_64](interfacehipfort__rocblas_1_1rocblas__sgemm__64.html "Interface documentation") | C binding, rank_0, rank_1
-1040 | [rocblas_dgemm_64](interfacehipfort__rocblas_1_1rocblas__dgemm__64.html "Interface documentation") | C binding, rank_0, rank_1
-1041 | [rocblas_hgemm_64](interfacehipfort__rocblas_1_1rocblas__hgemm__64.html "Interface documentation") | C binding, rank_0, rank_1
-1042 | [rocblas_cgemm_64](interfacehipfort__rocblas_1_1rocblas__cgemm__64.html "Interface documentation") | C binding, rank_0, rank_1
-1043 | [rocblas_zgemm_64](interfacehipfort__rocblas_1_1rocblas__zgemm__64.html "Interface documentation") | C binding, rank_0, rank_1
+1026 | [rocblas_strsm_strided_batched](interfacehipfort__rocblas_1_1rocblas__strsm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1027 | [rocblas_dtrsm_strided_batched](interfacehipfort__rocblas_1_1rocblas__dtrsm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1028 | [rocblas_ctrsm_strided_batched](interfacehipfort__rocblas_1_1rocblas__ctrsm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1029 | [rocblas_ztrsm_strided_batched](interfacehipfort__rocblas_1_1rocblas__ztrsm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1030 | [rocblas_strsm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__strsm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1031 | [rocblas_dtrsm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dtrsm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1032 | [rocblas_ctrsm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ctrsm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1033 | [rocblas_ztrsm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ztrsm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1034 | [rocblas_sgemm](interfacehipfort__rocblas_1_1rocblas__sgemm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1035 | [rocblas_dgemm](interfacehipfort__rocblas_1_1rocblas__dgemm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1036 | [rocblas_hgemm](interfacehipfort__rocblas_1_1rocblas__hgemm.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1037 | [rocblas_cgemm](interfacehipfort__rocblas_1_1rocblas__cgemm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1038 | [rocblas_zgemm](interfacehipfort__rocblas_1_1rocblas__zgemm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1039 | [rocblas_sgemm_64](interfacehipfort__rocblas_1_1rocblas__sgemm__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1040 | [rocblas_dgemm_64](interfacehipfort__rocblas_1_1rocblas__dgemm__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1041 | [rocblas_hgemm_64](interfacehipfort__rocblas_1_1rocblas__hgemm__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1042 | [rocblas_cgemm_64](interfacehipfort__rocblas_1_1rocblas__cgemm__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1043 | [rocblas_zgemm_64](interfacehipfort__rocblas_1_1rocblas__zgemm__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 1044 | [rocblas_sgemm_batched](interfacehipfort__rocblas_1_1rocblas__sgemm__batched.html "Interface documentation") | C binding
 1045 | [rocblas_dgemm_batched](interfacehipfort__rocblas_1_1rocblas__dgemm__batched.html "Interface documentation") | C binding
 1046 | [rocblas_hgemm_batched](interfacehipfort__rocblas_1_1rocblas__hgemm__batched.html "Interface documentation") | C binding
@@ -1055,24 +1055,24 @@
 1051 | [rocblas_hgemm_batched_64](interfacehipfort__rocblas_1_1rocblas__hgemm__batched__64.html "Interface documentation") | C binding
 1052 | [rocblas_cgemm_batched_64](interfacehipfort__rocblas_1_1rocblas__cgemm__batched__64.html "Interface documentation") | C binding
 1053 | [rocblas_zgemm_batched_64](interfacehipfort__rocblas_1_1rocblas__zgemm__batched__64.html "Interface documentation") | C binding
-1054 | [rocblas_sgemm_strided_batched](interfacehipfort__rocblas_1_1rocblas__sgemm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1055 | [rocblas_dgemm_strided_batched](interfacehipfort__rocblas_1_1rocblas__dgemm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1056 | [rocblas_hgemm_strided_batched](interfacehipfort__rocblas_1_1rocblas__hgemm__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-1057 | [rocblas_cgemm_strided_batched](interfacehipfort__rocblas_1_1rocblas__cgemm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1058 | [rocblas_zgemm_strided_batched](interfacehipfort__rocblas_1_1rocblas__zgemm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1059 | [rocblas_sgemm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sgemm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-1060 | [rocblas_dgemm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dgemm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-1061 | [rocblas_hgemm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__hgemm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-1062 | [rocblas_cgemm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cgemm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-1063 | [rocblas_zgemm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zgemm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-1064 | [rocblas_sdgmm](interfacehipfort__rocblas_1_1rocblas__sdgmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1065 | [rocblas_ddgmm](interfacehipfort__rocblas_1_1rocblas__ddgmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1066 | [rocblas_cdgmm](interfacehipfort__rocblas_1_1rocblas__cdgmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1067 | [rocblas_zdgmm](interfacehipfort__rocblas_1_1rocblas__zdgmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1068 | [rocblas_sdgmm_64](interfacehipfort__rocblas_1_1rocblas__sdgmm__64.html "Interface documentation") | C binding, rank_0, rank_1
-1069 | [rocblas_ddgmm_64](interfacehipfort__rocblas_1_1rocblas__ddgmm__64.html "Interface documentation") | C binding, rank_0, rank_1
-1070 | [rocblas_cdgmm_64](interfacehipfort__rocblas_1_1rocblas__cdgmm__64.html "Interface documentation") | C binding, rank_0, rank_1
-1071 | [rocblas_zdgmm_64](interfacehipfort__rocblas_1_1rocblas__zdgmm__64.html "Interface documentation") | C binding, rank_0, rank_1
+1054 | [rocblas_sgemm_strided_batched](interfacehipfort__rocblas_1_1rocblas__sgemm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1055 | [rocblas_dgemm_strided_batched](interfacehipfort__rocblas_1_1rocblas__dgemm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1056 | [rocblas_hgemm_strided_batched](interfacehipfort__rocblas_1_1rocblas__hgemm__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1057 | [rocblas_cgemm_strided_batched](interfacehipfort__rocblas_1_1rocblas__cgemm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1058 | [rocblas_zgemm_strided_batched](interfacehipfort__rocblas_1_1rocblas__zgemm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1059 | [rocblas_sgemm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sgemm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1060 | [rocblas_dgemm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dgemm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1061 | [rocblas_hgemm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__hgemm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1062 | [rocblas_cgemm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cgemm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1063 | [rocblas_zgemm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zgemm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1064 | [rocblas_sdgmm](interfacehipfort__rocblas_1_1rocblas__sdgmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1065 | [rocblas_ddgmm](interfacehipfort__rocblas_1_1rocblas__ddgmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1066 | [rocblas_cdgmm](interfacehipfort__rocblas_1_1rocblas__cdgmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1067 | [rocblas_zdgmm](interfacehipfort__rocblas_1_1rocblas__zdgmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1068 | [rocblas_sdgmm_64](interfacehipfort__rocblas_1_1rocblas__sdgmm__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1069 | [rocblas_ddgmm_64](interfacehipfort__rocblas_1_1rocblas__ddgmm__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1070 | [rocblas_cdgmm_64](interfacehipfort__rocblas_1_1rocblas__cdgmm__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1071 | [rocblas_zdgmm_64](interfacehipfort__rocblas_1_1rocblas__zdgmm__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 1072 | [rocblas_sdgmm_batched](interfacehipfort__rocblas_1_1rocblas__sdgmm__batched.html "Interface documentation") | C binding
 1073 | [rocblas_ddgmm_batched](interfacehipfort__rocblas_1_1rocblas__ddgmm__batched.html "Interface documentation") | C binding
 1074 | [rocblas_cdgmm_batched](interfacehipfort__rocblas_1_1rocblas__cdgmm__batched.html "Interface documentation") | C binding
@@ -1081,22 +1081,22 @@
 1077 | [rocblas_ddgmm_batched_64](interfacehipfort__rocblas_1_1rocblas__ddgmm__batched__64.html "Interface documentation") | C binding
 1078 | [rocblas_cdgmm_batched_64](interfacehipfort__rocblas_1_1rocblas__cdgmm__batched__64.html "Interface documentation") | C binding
 1079 | [rocblas_zdgmm_batched_64](interfacehipfort__rocblas_1_1rocblas__zdgmm__batched__64.html "Interface documentation") | C binding
-1080 | [rocblas_sdgmm_strided_batched](interfacehipfort__rocblas_1_1rocblas__sdgmm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1081 | [rocblas_ddgmm_strided_batched](interfacehipfort__rocblas_1_1rocblas__ddgmm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1082 | [rocblas_cdgmm_strided_batched](interfacehipfort__rocblas_1_1rocblas__cdgmm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1083 | [rocblas_zdgmm_strided_batched](interfacehipfort__rocblas_1_1rocblas__zdgmm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1084 | [rocblas_sdgmm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sdgmm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-1085 | [rocblas_ddgmm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ddgmm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-1086 | [rocblas_cdgmm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cdgmm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-1087 | [rocblas_zdgmm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zdgmm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-1088 | [rocblas_sgeam](interfacehipfort__rocblas_1_1rocblas__sgeam.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1089 | [rocblas_dgeam](interfacehipfort__rocblas_1_1rocblas__dgeam.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1090 | [rocblas_cgeam](interfacehipfort__rocblas_1_1rocblas__cgeam.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1091 | [rocblas_zgeam](interfacehipfort__rocblas_1_1rocblas__zgeam.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1092 | [rocblas_sgeam_64](interfacehipfort__rocblas_1_1rocblas__sgeam__64.html "Interface documentation") | C binding, rank_0, rank_1
-1093 | [rocblas_dgeam_64](interfacehipfort__rocblas_1_1rocblas__dgeam__64.html "Interface documentation") | C binding, rank_0, rank_1
-1094 | [rocblas_cgeam_64](interfacehipfort__rocblas_1_1rocblas__cgeam__64.html "Interface documentation") | C binding, rank_0, rank_1
-1095 | [rocblas_zgeam_64](interfacehipfort__rocblas_1_1rocblas__zgeam__64.html "Interface documentation") | C binding, rank_0, rank_1
+1080 | [rocblas_sdgmm_strided_batched](interfacehipfort__rocblas_1_1rocblas__sdgmm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1081 | [rocblas_ddgmm_strided_batched](interfacehipfort__rocblas_1_1rocblas__ddgmm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1082 | [rocblas_cdgmm_strided_batched](interfacehipfort__rocblas_1_1rocblas__cdgmm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1083 | [rocblas_zdgmm_strided_batched](interfacehipfort__rocblas_1_1rocblas__zdgmm__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1084 | [rocblas_sdgmm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sdgmm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1085 | [rocblas_ddgmm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__ddgmm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1086 | [rocblas_cdgmm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cdgmm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1087 | [rocblas_zdgmm_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zdgmm__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1088 | [rocblas_sgeam](interfacehipfort__rocblas_1_1rocblas__sgeam.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1089 | [rocblas_dgeam](interfacehipfort__rocblas_1_1rocblas__dgeam.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1090 | [rocblas_cgeam](interfacehipfort__rocblas_1_1rocblas__cgeam.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1091 | [rocblas_zgeam](interfacehipfort__rocblas_1_1rocblas__zgeam.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1092 | [rocblas_sgeam_64](interfacehipfort__rocblas_1_1rocblas__sgeam__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1093 | [rocblas_dgeam_64](interfacehipfort__rocblas_1_1rocblas__dgeam__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1094 | [rocblas_cgeam_64](interfacehipfort__rocblas_1_1rocblas__cgeam__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1095 | [rocblas_zgeam_64](interfacehipfort__rocblas_1_1rocblas__zgeam__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 1096 | [rocblas_sgeam_batched](interfacehipfort__rocblas_1_1rocblas__sgeam__batched.html "Interface documentation") | C binding
 1097 | [rocblas_dgeam_batched](interfacehipfort__rocblas_1_1rocblas__dgeam__batched.html "Interface documentation") | C binding
 1098 | [rocblas_cgeam_batched](interfacehipfort__rocblas_1_1rocblas__cgeam__batched.html "Interface documentation") | C binding
@@ -1105,28 +1105,28 @@
 1101 | [rocblas_dgeam_batched_64](interfacehipfort__rocblas_1_1rocblas__dgeam__batched__64.html "Interface documentation") | C binding
 1102 | [rocblas_cgeam_batched_64](interfacehipfort__rocblas_1_1rocblas__cgeam__batched__64.html "Interface documentation") | C binding
 1103 | [rocblas_zgeam_batched_64](interfacehipfort__rocblas_1_1rocblas__zgeam__batched__64.html "Interface documentation") | C binding
-1104 | [rocblas_sgeam_strided_batched](interfacehipfort__rocblas_1_1rocblas__sgeam__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1105 | [rocblas_dgeam_strided_batched](interfacehipfort__rocblas_1_1rocblas__dgeam__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1106 | [rocblas_cgeam_strided_batched](interfacehipfort__rocblas_1_1rocblas__cgeam__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1107 | [rocblas_zgeam_strided_batched](interfacehipfort__rocblas_1_1rocblas__zgeam__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1108 | [rocblas_sgeam_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sgeam__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-1109 | [rocblas_dgeam_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dgeam__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-1110 | [rocblas_cgeam_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cgeam__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-1111 | [rocblas_zgeam_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zgeam__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+1104 | [rocblas_sgeam_strided_batched](interfacehipfort__rocblas_1_1rocblas__sgeam__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1105 | [rocblas_dgeam_strided_batched](interfacehipfort__rocblas_1_1rocblas__dgeam__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1106 | [rocblas_cgeam_strided_batched](interfacehipfort__rocblas_1_1rocblas__cgeam__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1107 | [rocblas_zgeam_strided_batched](interfacehipfort__rocblas_1_1rocblas__zgeam__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1108 | [rocblas_sgeam_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sgeam__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1109 | [rocblas_dgeam_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dgeam__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1110 | [rocblas_cgeam_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cgeam__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1111 | [rocblas_zgeam_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zgeam__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 1112 | [rocblas_gemm_ex](interfacehipfort__rocblas_1_1rocblas__gemm__ex.html "Interface documentation") | C binding
 1113 | [rocblas_gemm_ex_64](interfacehipfort__rocblas_1_1rocblas__gemm__ex__64.html "Interface documentation") | C binding
 1114 | [rocblas_gemm_batched_ex](interfacehipfort__rocblas_1_1rocblas__gemm__batched__ex.html "Interface documentation") | C binding
 1115 | [rocblas_gemm_batched_ex_64](interfacehipfort__rocblas_1_1rocblas__gemm__batched__ex__64.html "Interface documentation") | C binding
 1116 | [rocblas_gemm_strided_batched_ex](interfacehipfort__rocblas_1_1rocblas__gemm__strided__batched__ex.html "Interface documentation") | C binding
 1117 | [rocblas_gemm_strided_batched_ex_64](interfacehipfort__rocblas_1_1rocblas__gemm__strided__batched__ex__64.html "Interface documentation") | C binding
-1118 | [rocblas_sgemmt](interfacehipfort__rocblas_1_1rocblas__sgemmt.html "Interface documentation") | C binding, rank_0, rank_1
-1119 | [rocblas_dgemmt](interfacehipfort__rocblas_1_1rocblas__dgemmt.html "Interface documentation") | C binding, rank_0, rank_1
-1120 | [rocblas_cgemmt](interfacehipfort__rocblas_1_1rocblas__cgemmt.html "Interface documentation") | C binding, rank_0, rank_1
-1121 | [rocblas_zgemmt](interfacehipfort__rocblas_1_1rocblas__zgemmt.html "Interface documentation") | C binding, rank_0, rank_1
-1122 | [rocblas_sgemmt_64](interfacehipfort__rocblas_1_1rocblas__sgemmt__64.html "Interface documentation") | C binding, rank_0, rank_1
-1123 | [rocblas_dgemmt_64](interfacehipfort__rocblas_1_1rocblas__dgemmt__64.html "Interface documentation") | C binding, rank_0, rank_1
-1124 | [rocblas_cgemmt_64](interfacehipfort__rocblas_1_1rocblas__cgemmt__64.html "Interface documentation") | C binding, rank_0, rank_1
-1125 | [rocblas_zgemmt_64](interfacehipfort__rocblas_1_1rocblas__zgemmt__64.html "Interface documentation") | C binding, rank_0, rank_1
+1118 | [rocblas_sgemmt](interfacehipfort__rocblas_1_1rocblas__sgemmt.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1119 | [rocblas_dgemmt](interfacehipfort__rocblas_1_1rocblas__dgemmt.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1120 | [rocblas_cgemmt](interfacehipfort__rocblas_1_1rocblas__cgemmt.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1121 | [rocblas_zgemmt](interfacehipfort__rocblas_1_1rocblas__zgemmt.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1122 | [rocblas_sgemmt_64](interfacehipfort__rocblas_1_1rocblas__sgemmt__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1123 | [rocblas_dgemmt_64](interfacehipfort__rocblas_1_1rocblas__dgemmt__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1124 | [rocblas_cgemmt_64](interfacehipfort__rocblas_1_1rocblas__cgemmt__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1125 | [rocblas_zgemmt_64](interfacehipfort__rocblas_1_1rocblas__zgemmt__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 1126 | [rocblas_sgemmt_batched](interfacehipfort__rocblas_1_1rocblas__sgemmt__batched.html "Interface documentation") | C binding
 1127 | [rocblas_dgemmt_batched](interfacehipfort__rocblas_1_1rocblas__dgemmt__batched.html "Interface documentation") | C binding
 1128 | [rocblas_cgemmt_batched](interfacehipfort__rocblas_1_1rocblas__cgemmt__batched.html "Interface documentation") | C binding
@@ -1135,14 +1135,14 @@
 1131 | [rocblas_dgemmt_batched_64](interfacehipfort__rocblas_1_1rocblas__dgemmt__batched__64.html "Interface documentation") | C binding
 1132 | [rocblas_cgemmt_batched_64](interfacehipfort__rocblas_1_1rocblas__cgemmt__batched__64.html "Interface documentation") | C binding
 1133 | [rocblas_zgemmt_batched_64](interfacehipfort__rocblas_1_1rocblas__zgemmt__batched__64.html "Interface documentation") | C binding
-1134 | [rocblas_sgemmt_strided_batched](interfacehipfort__rocblas_1_1rocblas__sgemmt__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-1135 | [rocblas_dgemmt_strided_batched](interfacehipfort__rocblas_1_1rocblas__dgemmt__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-1136 | [rocblas_cgemmt_strided_batched](interfacehipfort__rocblas_1_1rocblas__cgemmt__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-1137 | [rocblas_zgemmt_strided_batched](interfacehipfort__rocblas_1_1rocblas__zgemmt__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1
-1138 | [rocblas_sgemmt_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sgemmt__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-1139 | [rocblas_dgemmt_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dgemmt__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-1140 | [rocblas_cgemmt_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cgemmt__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
-1141 | [rocblas_zgemmt_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zgemmt__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1
+1134 | [rocblas_sgemmt_strided_batched](interfacehipfort__rocblas_1_1rocblas__sgemmt__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1135 | [rocblas_dgemmt_strided_batched](interfacehipfort__rocblas_1_1rocblas__dgemmt__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1136 | [rocblas_cgemmt_strided_batched](interfacehipfort__rocblas_1_1rocblas__cgemmt__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1137 | [rocblas_zgemmt_strided_batched](interfacehipfort__rocblas_1_1rocblas__zgemmt__strided__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1138 | [rocblas_sgemmt_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__sgemmt__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1139 | [rocblas_dgemmt_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__dgemmt__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1140 | [rocblas_cgemmt_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__cgemmt__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+1141 | [rocblas_zgemmt_strided_batched_64](interfacehipfort__rocblas_1_1rocblas__zgemmt__strided__batched__64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 1142 | [rocblas_geam_ex](interfacehipfort__rocblas_1_1rocblas__geam__ex.html "Interface documentation") | C binding
 1143 | [rocblas_trsm_ex](interfacehipfort__rocblas_1_1rocblas__trsm__ex.html "Interface documentation") | C binding
 1144 | [rocblas_trsm_batched_ex](interfacehipfort__rocblas_1_1rocblas__trsm__batched__ex.html "Interface documentation") | C binding
@@ -1207,11 +1207,11 @@
 1203 | [rocblas_is_managing_device_memory](interfacehipfort__rocblas_1_1rocblas__is__managing__device__memory.html "Interface documentation") | C binding
 1204 | [rocblas_is_user_managing_device_memory](interfacehipfort__rocblas_1_1rocblas__is__user__managing__device__memory.html "Interface documentation") | C binding
 1205 | [rocblas_abort](interfacehipfort__rocblas_1_1rocblas__abort.html "Interface documentation") | C binding
-1206 | [rocblas_set_vector](interfacehipfort__rocblas_1_1rocblas__set__vector.html "Interface documentation") | C binding, full_rank, rank_0
-1207 | [rocblas_get_vector](interfacehipfort__rocblas_1_1rocblas__get__vector.html "Interface documentation") | C binding, full_rank, rank_0
-1208 | [rocblas_set_matrix](interfacehipfort__rocblas_1_1rocblas__set__matrix.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1209 | [rocblas_get_matrix](interfacehipfort__rocblas_1_1rocblas__get__matrix.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1210 | [rocblas_set_vector_async](interfacehipfort__rocblas_1_1rocblas__set__vector__async.html "Interface documentation") | C binding, full_rank, rank_0
-1211 | [rocblas_get_vector_async](interfacehipfort__rocblas_1_1rocblas__get__vector__async.html "Interface documentation") | C binding, full_rank, rank_0
-1212 | [rocblas_set_matrix_async](interfacehipfort__rocblas_1_1rocblas__set__matrix__async.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-1213 | [rocblas_get_matrix_async](interfacehipfort__rocblas_1_1rocblas__get__matrix__async.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+1206 | [rocblas_set_vector](interfacehipfort__rocblas_1_1rocblas__set__vector.html "Interface documentation") | C binding, full_rank, rank_0, assumed_rank
+1207 | [rocblas_get_vector](interfacehipfort__rocblas_1_1rocblas__get__vector.html "Interface documentation") | C binding, full_rank, rank_0, assumed_rank
+1208 | [rocblas_set_matrix](interfacehipfort__rocblas_1_1rocblas__set__matrix.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1209 | [rocblas_get_matrix](interfacehipfort__rocblas_1_1rocblas__get__matrix.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1210 | [rocblas_set_vector_async](interfacehipfort__rocblas_1_1rocblas__set__vector__async.html "Interface documentation") | C binding, full_rank, rank_0, assumed_rank
+1211 | [rocblas_get_vector_async](interfacehipfort__rocblas_1_1rocblas__get__vector__async.html "Interface documentation") | C binding, full_rank, rank_0, assumed_rank
+1212 | [rocblas_set_matrix_async](interfacehipfort__rocblas_1_1rocblas__set__matrix__async.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+1213 | [rocblas_get_matrix_async](interfacehipfort__rocblas_1_1rocblas__get__matrix__async.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank


### PR DESCRIPTION
## Summary

Regenerates `supported_api_hipblas.md` / `supported_api_rocblas.md` so routines that expose an F2018 assumed-rank specific now list **`assumed_rank`** in the variants column — e.g. `hipblasSetVector` → `C binding, full_rank, rank_0, assumed_rank`, and the native/ILP64 routines likewise.

The `gen_supported_api` tool derived the variant column from the module-procedure suffixes but only recognized `full_rank` / `rank_N` / `typed` / `cstr`, so the `_assumed_rank` specifics (under `USE_ASSUMED_RANK_INTERFACES`) were invisible in the tables. The tool now also recognizes `assumed_rank`.

Diff is limited to the variant column of the affected rows (~780 hipBLAS / ~776 rocBLAS); no reordering. Scoped to hipBLAS/rocBLAS.