### PR TITLE
Show the assumed_rank variant in the remaining supported_api tables

### DIFF
--- a/docs/doxygen/input/supported_api_hip.md
+++ b/docs/doxygen/input/supported_api_hip.md
@@ -7,8 +7,8 @@
 3 | [hipHostMalloc](interfacehipfort__hipmalloc_1_1hiphostmalloc.html "Interface documentation") | C binding
 4 | [hipFree](interfacehipfort__hipmalloc_1_1hipfree.html "Interface documentation") | C binding
 5 | [hipHostFree](interfacehipfort__hipmalloc_1_1hiphostfree.html "Interface documentation") | C binding
-6 | [hipMemcpy](interfacehipfort__hipmemcpy_1_1hipmemcpy.html "Interface documentation") | C binding
-7 | [hipMemcpyAsync](interfacehipfort__hipmemcpy_1_1hipmemcpyasync.html "Interface documentation") | C binding
+6 | [hipMemcpy](interfacehipfort__hipmemcpy_1_1hipmemcpy.html "Interface documentation") | C binding, assumed_rank
+7 | [hipMemcpyAsync](interfacehipfort__hipmemcpy_1_1hipmemcpyasync.html "Interface documentation") | C binding, assumed_rank
 8 | [hipMemcpy2D](interfacehipfort__hipmemcpy_1_1hipmemcpy2d.html "Interface documentation") | C binding
 9 | [hipMemcpy2DAsync](interfacehipfort__hipmemcpy_1_1hipmemcpy2dasync.html "Interface documentation") | C binding
 10 | [hipHostRegister](interfacehipfort__hiphostregister_1_1hiphostregister.html "Interface documentation") | C binding

--- a/docs/doxygen/input/supported_api_hipfft.md
+++ b/docs/doxygen/input/supported_api_hipfft.md
@@ -5,33 +5,33 @@
 1 | [hipfftPlan1d](interfacehipfort__hipfft_1_1hipfftplan1d.html "Interface documentation") | C binding
 2 | [hipfftPlan2d](interfacehipfort__hipfft_1_1hipfftplan2d.html "Interface documentation") | C binding
 3 | [hipfftPlan3d](interfacehipfort__hipfft_1_1hipfftplan3d.html "Interface documentation") | C binding
-4 | [hipfftPlanMany](interfacehipfort__hipfft_1_1hipfftplanmany.html "Interface documentation") | C binding, rank_0, rank_1
+4 | [hipfftPlanMany](interfacehipfort__hipfft_1_1hipfftplanmany.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 5 | [hipfftCreate](interfacehipfort__hipfft_1_1hipfftcreate.html "Interface documentation") | C binding
 6 | [hipfftExtPlanScaleFactor](interfacehipfort__hipfft_1_1hipfftextplanscalefactor.html "Interface documentation") | C binding
 7 | [hipfftMakePlan1d](interfacehipfort__hipfft_1_1hipfftmakeplan1d.html "Interface documentation") | C binding
 8 | [hipfftMakePlan2d](interfacehipfort__hipfft_1_1hipfftmakeplan2d.html "Interface documentation") | C binding
 9 | [hipfftMakePlan3d](interfacehipfort__hipfft_1_1hipfftmakeplan3d.html "Interface documentation") | C binding
-10 | [hipfftMakePlanMany](interfacehipfort__hipfft_1_1hipfftmakeplanmany.html "Interface documentation") | C binding, rank_0, rank_1
-11 | [hipfftMakePlanMany64](interfacehipfort__hipfft_1_1hipfftmakeplanmany64.html "Interface documentation") | C binding, rank_0, rank_1
+10 | [hipfftMakePlanMany](interfacehipfort__hipfft_1_1hipfftmakeplanmany.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+11 | [hipfftMakePlanMany64](interfacehipfort__hipfft_1_1hipfftmakeplanmany64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 12 | [hipfftEstimate1d](interfacehipfort__hipfft_1_1hipfftestimate1d.html "Interface documentation") | C binding
 13 | [hipfftEstimate2d](interfacehipfort__hipfft_1_1hipfftestimate2d.html "Interface documentation") | C binding
 14 | [hipfftEstimate3d](interfacehipfort__hipfft_1_1hipfftestimate3d.html "Interface documentation") | C binding
-15 | [hipfftEstimateMany](interfacehipfort__hipfft_1_1hipfftestimatemany.html "Interface documentation") | C binding, rank_0, rank_1
+15 | [hipfftEstimateMany](interfacehipfort__hipfft_1_1hipfftestimatemany.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 16 | [hipfftGetSize1d](interfacehipfort__hipfft_1_1hipfftgetsize1d.html "Interface documentation") | C binding
 17 | [hipfftGetSize2d](interfacehipfort__hipfft_1_1hipfftgetsize2d.html "Interface documentation") | C binding
 18 | [hipfftGetSize3d](interfacehipfort__hipfft_1_1hipfftgetsize3d.html "Interface documentation") | C binding
-19 | [hipfftGetSizeMany](interfacehipfort__hipfft_1_1hipfftgetsizemany.html "Interface documentation") | C binding, rank_0, rank_1
-20 | [hipfftGetSizeMany64](interfacehipfort__hipfft_1_1hipfftgetsizemany64.html "Interface documentation") | C binding, rank_0, rank_1
+19 | [hipfftGetSizeMany](interfacehipfort__hipfft_1_1hipfftgetsizemany.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+20 | [hipfftGetSizeMany64](interfacehipfort__hipfft_1_1hipfftgetsizemany64.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 21 | [hipfftGetSize](interfacehipfort__hipfft_1_1hipfftgetsize.html "Interface documentation") | C binding
 22 | [hipfftSetAutoAllocation](interfacehipfort__hipfft_1_1hipfftsetautoallocation.html "Interface documentation") | C binding
 23 | [hipfftSetWorkArea](interfacehipfort__hipfft_1_1hipfftsetworkarea.html "Interface documentation") | C binding
-24 | [hipfftExecC2C](interfacehipfort__hipfft_1_1hipfftexecc2c.html "Interface documentation") | C binding, rank_0, rank_1, rank_2, rank_3
-25 | [hipfftExecR2C](interfacehipfort__hipfft_1_1hipfftexecr2c.html "Interface documentation") | C binding, rank_0, rank_1, rank_2, rank_3
-26 | [hipfftExecC2R](interfacehipfort__hipfft_1_1hipfftexecc2r.html "Interface documentation") | C binding, rank_0, rank_1, rank_2, rank_3
-27 | [hipfftExecZ2Z](interfacehipfort__hipfft_1_1hipfftexecz2z.html "Interface documentation") | C binding, rank_0, rank_1, rank_2, rank_3
-28 | [hipfftExecD2Z](interfacehipfort__hipfft_1_1hipfftexecd2z.html "Interface documentation") | C binding, rank_0, rank_1, rank_2, rank_3
-29 | [hipfftExecZ2D](interfacehipfort__hipfft_1_1hipfftexecz2d.html "Interface documentation") | C binding, rank_0, rank_1, rank_2, rank_3
+24 | [hipfftExecC2C](interfacehipfort__hipfft_1_1hipfftexecc2c.html "Interface documentation") | C binding, rank_0, rank_1, rank_2, rank_3, assumed_rank
+25 | [hipfftExecR2C](interfacehipfort__hipfft_1_1hipfftexecr2c.html "Interface documentation") | C binding, rank_0, rank_1, rank_2, rank_3, assumed_rank
+26 | [hipfftExecC2R](interfacehipfort__hipfft_1_1hipfftexecc2r.html "Interface documentation") | C binding, rank_0, rank_1, rank_2, rank_3, assumed_rank
+27 | [hipfftExecZ2Z](interfacehipfort__hipfft_1_1hipfftexecz2z.html "Interface documentation") | C binding, rank_0, rank_1, rank_2, rank_3, assumed_rank
+28 | [hipfftExecD2Z](interfacehipfort__hipfft_1_1hipfftexecd2z.html "Interface documentation") | C binding, rank_0, rank_1, rank_2, rank_3, assumed_rank
+29 | [hipfftExecZ2D](interfacehipfort__hipfft_1_1hipfftexecz2d.html "Interface documentation") | C binding, rank_0, rank_1, rank_2, rank_3, assumed_rank
 30 | [hipfftSetStream](interfacehipfort__hipfft_1_1hipfftsetstream.html "Interface documentation") | C binding
 31 | [hipfftDestroy](interfacehipfort__hipfft_1_1hipfftdestroy.html "Interface documentation") | C binding
 32 | [hipfftGetVersion](interfacehipfort__hipfft_1_1hipfftgetversion.html "Interface documentation") | C binding
-33 | [hipfftGetProperty](interfacehipfort__hipfft_1_1hipfftgetproperty.html "Interface documentation") | C binding
+33 | [hipfftGetProperty](interfacehipfort__hipfft_1_1hipfftgetproperty.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank

--- a/docs/doxygen/input/supported_api_hiprand.md
+++ b/docs/doxygen/input/supported_api_hiprand.md
@@ -5,20 +5,20 @@
 1 | [hiprandCreateGenerator](interfacehipfort__hiprand_1_1hiprandcreategenerator.html "Interface documentation") | C binding
 2 | [hiprandCreateGeneratorHost](interfacehipfort__hiprand_1_1hiprandcreategeneratorhost.html "Interface documentation") | C binding
 3 | [hiprandDestroyGenerator](interfacehipfort__hiprand_1_1hipranddestroygenerator.html "Interface documentation") | C binding
-4 | [hiprandGenerate](interfacehipfort__hiprand_1_1hiprandgenerate.html "Interface documentation") | C binding
+4 | [hiprandGenerate](interfacehipfort__hiprand_1_1hiprandgenerate.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 5 | [hiprandGenerateChar](interfacehipfort__hiprand_1_1hiprandgeneratechar.html "Interface documentation") | C binding
 6 | [hiprandGenerateShort](interfacehipfort__hiprand_1_1hiprandgenerateshort.html "Interface documentation") | C binding
-7 | [hiprandGenerateLongLong](interfacehipfort__hiprand_1_1hiprandgeneratelonglong.html "Interface documentation") | C binding
-8 | [hiprandGenerateUniform](interfacehipfort__hiprand_1_1hiprandgenerateuniform.html "Interface documentation") | C binding
-9 | [hiprandGenerateUniformDouble](interfacehipfort__hiprand_1_1hiprandgenerateuniformdouble.html "Interface documentation") | C binding
+7 | [hiprandGenerateLongLong](interfacehipfort__hiprand_1_1hiprandgeneratelonglong.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+8 | [hiprandGenerateUniform](interfacehipfort__hiprand_1_1hiprandgenerateuniform.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+9 | [hiprandGenerateUniformDouble](interfacehipfort__hiprand_1_1hiprandgenerateuniformdouble.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 10 | [hiprandGenerateUniformHalf](interfacehipfort__hiprand_1_1hiprandgenerateuniformhalf.html "Interface documentation") | C binding
-11 | [hiprandGenerateNormal](interfacehipfort__hiprand_1_1hiprandgeneratenormal.html "Interface documentation") | C binding
-12 | [hiprandGenerateNormalDouble](interfacehipfort__hiprand_1_1hiprandgeneratenormaldouble.html "Interface documentation") | C binding
+11 | [hiprandGenerateNormal](interfacehipfort__hiprand_1_1hiprandgeneratenormal.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+12 | [hiprandGenerateNormalDouble](interfacehipfort__hiprand_1_1hiprandgeneratenormaldouble.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 13 | [hiprandGenerateNormalHalf](interfacehipfort__hiprand_1_1hiprandgeneratenormalhalf.html "Interface documentation") | C binding
-14 | [hiprandGenerateLogNormal](interfacehipfort__hiprand_1_1hiprandgeneratelognormal.html "Interface documentation") | C binding
-15 | [hiprandGenerateLogNormalDouble](interfacehipfort__hiprand_1_1hiprandgeneratelognormaldouble.html "Interface documentation") | C binding
+14 | [hiprandGenerateLogNormal](interfacehipfort__hiprand_1_1hiprandgeneratelognormal.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+15 | [hiprandGenerateLogNormalDouble](interfacehipfort__hiprand_1_1hiprandgeneratelognormaldouble.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 16 | [hiprandGenerateLogNormalHalf](interfacehipfort__hiprand_1_1hiprandgeneratelognormalhalf.html "Interface documentation") | C binding
-17 | [hiprandGeneratePoisson](interfacehipfort__hiprand_1_1hiprandgeneratepoisson.html "Interface documentation") | C binding
+17 | [hiprandGeneratePoisson](interfacehipfort__hiprand_1_1hiprandgeneratepoisson.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 18 | [hiprandGenerateSeeds](interfacehipfort__hiprand_1_1hiprandgenerateseeds.html "Interface documentation") | C binding
 19 | [hiprandSetStream](interfacehipfort__hiprand_1_1hiprandsetstream.html "Interface documentation") | C binding
 20 | [hiprandSetPseudoRandomGeneratorSeed](interfacehipfort__hiprand_1_1hiprandsetpseudorandomgeneratorseed.html "Interface documentation") | C binding

--- a/docs/doxygen/input/supported_api_hipsolver.md
+++ b/docs/doxygen/input/supported_api_hipsolver.md
@@ -22,54 +22,54 @@
 18 | [hipsolverXsyevjSetTolerance](interfacehipfort__hipsolver_1_1hipsolverxsyevjsettolerance.html "Interface documentation") | C binding
 19 | [hipsolverXsyevjGetResidual](interfacehipfort__hipsolver_1_1hipsolverxsyevjgetresidual.html "Interface documentation") | C binding
 20 | [hipsolverXsyevjGetSweeps](interfacehipfort__hipsolver_1_1hipsolverxsyevjgetsweeps.html "Interface documentation") | C binding
-21 | [hipsolverSorgbr_bufferSize](interfacehipfort__hipsolver_1_1hipsolversorgbr__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-22 | [hipsolverDorgbr_bufferSize](interfacehipfort__hipsolver_1_1hipsolverdorgbr__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-23 | [hipsolverCungbr_bufferSize](interfacehipfort__hipsolver_1_1hipsolvercungbr__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-24 | [hipsolverZungbr_bufferSize](interfacehipfort__hipsolver_1_1hipsolverzungbr__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-25 | [hipsolverSorgbr](interfacehipfort__hipsolver_1_1hipsolversorgbr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-26 | [hipsolverDorgbr](interfacehipfort__hipsolver_1_1hipsolverdorgbr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-27 | [hipsolverCungbr](interfacehipfort__hipsolver_1_1hipsolvercungbr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-28 | [hipsolverZungbr](interfacehipfort__hipsolver_1_1hipsolverzungbr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-29 | [hipsolverSorgqr_bufferSize](interfacehipfort__hipsolver_1_1hipsolversorgqr__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-30 | [hipsolverDorgqr_bufferSize](interfacehipfort__hipsolver_1_1hipsolverdorgqr__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-31 | [hipsolverCungqr_bufferSize](interfacehipfort__hipsolver_1_1hipsolvercungqr__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-32 | [hipsolverZungqr_bufferSize](interfacehipfort__hipsolver_1_1hipsolverzungqr__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-33 | [hipsolverSorgqr](interfacehipfort__hipsolver_1_1hipsolversorgqr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-34 | [hipsolverDorgqr](interfacehipfort__hipsolver_1_1hipsolverdorgqr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-35 | [hipsolverCungqr](interfacehipfort__hipsolver_1_1hipsolvercungqr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-36 | [hipsolverZungqr](interfacehipfort__hipsolver_1_1hipsolverzungqr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-37 | [hipsolverSorgtr_bufferSize](interfacehipfort__hipsolver_1_1hipsolversorgtr__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-38 | [hipsolverDorgtr_bufferSize](interfacehipfort__hipsolver_1_1hipsolverdorgtr__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-39 | [hipsolverCungtr_bufferSize](interfacehipfort__hipsolver_1_1hipsolvercungtr__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-40 | [hipsolverZungtr_bufferSize](interfacehipfort__hipsolver_1_1hipsolverzungtr__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-41 | [hipsolverSorgtr](interfacehipfort__hipsolver_1_1hipsolversorgtr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-42 | [hipsolverDorgtr](interfacehipfort__hipsolver_1_1hipsolverdorgtr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-43 | [hipsolverCungtr](interfacehipfort__hipsolver_1_1hipsolvercungtr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-44 | [hipsolverZungtr](interfacehipfort__hipsolver_1_1hipsolverzungtr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-45 | [hipsolverSormqr_bufferSize](interfacehipfort__hipsolver_1_1hipsolversormqr__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-46 | [hipsolverDormqr_bufferSize](interfacehipfort__hipsolver_1_1hipsolverdormqr__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-47 | [hipsolverCunmqr_bufferSize](interfacehipfort__hipsolver_1_1hipsolvercunmqr__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-48 | [hipsolverZunmqr_bufferSize](interfacehipfort__hipsolver_1_1hipsolverzunmqr__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-49 | [hipsolverSormqr](interfacehipfort__hipsolver_1_1hipsolversormqr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-50 | [hipsolverDormqr](interfacehipfort__hipsolver_1_1hipsolverdormqr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-51 | [hipsolverCunmqr](interfacehipfort__hipsolver_1_1hipsolvercunmqr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-52 | [hipsolverZunmqr](interfacehipfort__hipsolver_1_1hipsolverzunmqr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-53 | [hipsolverSormtr_bufferSize](interfacehipfort__hipsolver_1_1hipsolversormtr__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-54 | [hipsolverDormtr_bufferSize](interfacehipfort__hipsolver_1_1hipsolverdormtr__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-55 | [hipsolverCunmtr_bufferSize](interfacehipfort__hipsolver_1_1hipsolvercunmtr__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-56 | [hipsolverZunmtr_bufferSize](interfacehipfort__hipsolver_1_1hipsolverzunmtr__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-57 | [hipsolverSormtr](interfacehipfort__hipsolver_1_1hipsolversormtr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-58 | [hipsolverDormtr](interfacehipfort__hipsolver_1_1hipsolverdormtr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-59 | [hipsolverCunmtr](interfacehipfort__hipsolver_1_1hipsolvercunmtr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-60 | [hipsolverZunmtr](interfacehipfort__hipsolver_1_1hipsolverzunmtr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+21 | [hipsolverSorgbr_bufferSize](interfacehipfort__hipsolver_1_1hipsolversorgbr__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+22 | [hipsolverDorgbr_bufferSize](interfacehipfort__hipsolver_1_1hipsolverdorgbr__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+23 | [hipsolverCungbr_bufferSize](interfacehipfort__hipsolver_1_1hipsolvercungbr__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+24 | [hipsolverZungbr_bufferSize](interfacehipfort__hipsolver_1_1hipsolverzungbr__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+25 | [hipsolverSorgbr](interfacehipfort__hipsolver_1_1hipsolversorgbr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+26 | [hipsolverDorgbr](interfacehipfort__hipsolver_1_1hipsolverdorgbr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+27 | [hipsolverCungbr](interfacehipfort__hipsolver_1_1hipsolvercungbr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+28 | [hipsolverZungbr](interfacehipfort__hipsolver_1_1hipsolverzungbr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+29 | [hipsolverSorgqr_bufferSize](interfacehipfort__hipsolver_1_1hipsolversorgqr__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+30 | [hipsolverDorgqr_bufferSize](interfacehipfort__hipsolver_1_1hipsolverdorgqr__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+31 | [hipsolverCungqr_bufferSize](interfacehipfort__hipsolver_1_1hipsolvercungqr__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+32 | [hipsolverZungqr_bufferSize](interfacehipfort__hipsolver_1_1hipsolverzungqr__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+33 | [hipsolverSorgqr](interfacehipfort__hipsolver_1_1hipsolversorgqr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+34 | [hipsolverDorgqr](interfacehipfort__hipsolver_1_1hipsolverdorgqr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+35 | [hipsolverCungqr](interfacehipfort__hipsolver_1_1hipsolvercungqr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+36 | [hipsolverZungqr](interfacehipfort__hipsolver_1_1hipsolverzungqr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+37 | [hipsolverSorgtr_bufferSize](interfacehipfort__hipsolver_1_1hipsolversorgtr__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+38 | [hipsolverDorgtr_bufferSize](interfacehipfort__hipsolver_1_1hipsolverdorgtr__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+39 | [hipsolverCungtr_bufferSize](interfacehipfort__hipsolver_1_1hipsolvercungtr__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+40 | [hipsolverZungtr_bufferSize](interfacehipfort__hipsolver_1_1hipsolverzungtr__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+41 | [hipsolverSorgtr](interfacehipfort__hipsolver_1_1hipsolversorgtr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+42 | [hipsolverDorgtr](interfacehipfort__hipsolver_1_1hipsolverdorgtr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+43 | [hipsolverCungtr](interfacehipfort__hipsolver_1_1hipsolvercungtr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+44 | [hipsolverZungtr](interfacehipfort__hipsolver_1_1hipsolverzungtr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+45 | [hipsolverSormqr_bufferSize](interfacehipfort__hipsolver_1_1hipsolversormqr__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+46 | [hipsolverDormqr_bufferSize](interfacehipfort__hipsolver_1_1hipsolverdormqr__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+47 | [hipsolverCunmqr_bufferSize](interfacehipfort__hipsolver_1_1hipsolvercunmqr__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+48 | [hipsolverZunmqr_bufferSize](interfacehipfort__hipsolver_1_1hipsolverzunmqr__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+49 | [hipsolverSormqr](interfacehipfort__hipsolver_1_1hipsolversormqr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+50 | [hipsolverDormqr](interfacehipfort__hipsolver_1_1hipsolverdormqr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+51 | [hipsolverCunmqr](interfacehipfort__hipsolver_1_1hipsolvercunmqr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+52 | [hipsolverZunmqr](interfacehipfort__hipsolver_1_1hipsolverzunmqr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+53 | [hipsolverSormtr_bufferSize](interfacehipfort__hipsolver_1_1hipsolversormtr__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+54 | [hipsolverDormtr_bufferSize](interfacehipfort__hipsolver_1_1hipsolverdormtr__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+55 | [hipsolverCunmtr_bufferSize](interfacehipfort__hipsolver_1_1hipsolvercunmtr__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+56 | [hipsolverZunmtr_bufferSize](interfacehipfort__hipsolver_1_1hipsolverzunmtr__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+57 | [hipsolverSormtr](interfacehipfort__hipsolver_1_1hipsolversormtr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+58 | [hipsolverDormtr](interfacehipfort__hipsolver_1_1hipsolverdormtr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+59 | [hipsolverCunmtr](interfacehipfort__hipsolver_1_1hipsolvercunmtr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+60 | [hipsolverZunmtr](interfacehipfort__hipsolver_1_1hipsolverzunmtr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 61 | [hipsolverSgebrd_bufferSize](interfacehipfort__hipsolver_1_1hipsolversgebrd__buffersize.html "Interface documentation") | C binding
 62 | [hipsolverDgebrd_bufferSize](interfacehipfort__hipsolver_1_1hipsolverdgebrd__buffersize.html "Interface documentation") | C binding
 63 | [hipsolverCgebrd_bufferSize](interfacehipfort__hipsolver_1_1hipsolvercgebrd__buffersize.html "Interface documentation") | C binding
 64 | [hipsolverZgebrd_bufferSize](interfacehipfort__hipsolver_1_1hipsolverzgebrd__buffersize.html "Interface documentation") | C binding
-65 | [hipsolverSgebrd](interfacehipfort__hipsolver_1_1hipsolversgebrd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-66 | [hipsolverDgebrd](interfacehipfort__hipsolver_1_1hipsolverdgebrd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-67 | [hipsolverCgebrd](interfacehipfort__hipsolver_1_1hipsolvercgebrd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-68 | [hipsolverZgebrd](interfacehipfort__hipsolver_1_1hipsolverzgebrd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+65 | [hipsolverSgebrd](interfacehipfort__hipsolver_1_1hipsolversgebrd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+66 | [hipsolverDgebrd](interfacehipfort__hipsolver_1_1hipsolverdgebrd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+67 | [hipsolverCgebrd](interfacehipfort__hipsolver_1_1hipsolvercgebrd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+68 | [hipsolverZgebrd](interfacehipfort__hipsolver_1_1hipsolverzgebrd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 69 | [hipsolverSSgels_bufferSize](interfacehipfort__hipsolver_1_1hipsolverssgels__buffersize.html "Interface documentation") | C binding
 70 | [hipsolverDDgels_bufferSize](interfacehipfort__hipsolver_1_1hipsolverddgels__buffersize.html "Interface documentation") | C binding
 71 | [hipsolverCCgels_bufferSize](interfacehipfort__hipsolver_1_1hipsolverccgels__buffersize.html "Interface documentation") | C binding
@@ -78,22 +78,22 @@
 74 | [hipsolverDDgels](interfacehipfort__hipsolver_1_1hipsolverddgels.html "Interface documentation") | C binding
 75 | [hipsolverCCgels](interfacehipfort__hipsolver_1_1hipsolverccgels.html "Interface documentation") | C binding
 76 | [hipsolverZZgels](interfacehipfort__hipsolver_1_1hipsolverzzgels.html "Interface documentation") | C binding
-77 | [hipsolverSgeqrf_bufferSize](interfacehipfort__hipsolver_1_1hipsolversgeqrf__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-78 | [hipsolverDgeqrf_bufferSize](interfacehipfort__hipsolver_1_1hipsolverdgeqrf__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-79 | [hipsolverCgeqrf_bufferSize](interfacehipfort__hipsolver_1_1hipsolvercgeqrf__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-80 | [hipsolverZgeqrf_bufferSize](interfacehipfort__hipsolver_1_1hipsolverzgeqrf__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-81 | [hipsolverSgeqrf](interfacehipfort__hipsolver_1_1hipsolversgeqrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-82 | [hipsolverDgeqrf](interfacehipfort__hipsolver_1_1hipsolverdgeqrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-83 | [hipsolverCgeqrf](interfacehipfort__hipsolver_1_1hipsolvercgeqrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-84 | [hipsolverZgeqrf](interfacehipfort__hipsolver_1_1hipsolverzgeqrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-85 | [hipsolverSSgesv_bufferSize](interfacehipfort__hipsolver_1_1hipsolverssgesv__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-86 | [hipsolverDDgesv_bufferSize](interfacehipfort__hipsolver_1_1hipsolverddgesv__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-87 | [hipsolverCCgesv_bufferSize](interfacehipfort__hipsolver_1_1hipsolverccgesv__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-88 | [hipsolverZZgesv_bufferSize](interfacehipfort__hipsolver_1_1hipsolverzzgesv__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-89 | [hipsolverSSgesv](interfacehipfort__hipsolver_1_1hipsolverssgesv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-90 | [hipsolverDDgesv](interfacehipfort__hipsolver_1_1hipsolverddgesv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-91 | [hipsolverCCgesv](interfacehipfort__hipsolver_1_1hipsolverccgesv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-92 | [hipsolverZZgesv](interfacehipfort__hipsolver_1_1hipsolverzzgesv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+77 | [hipsolverSgeqrf_bufferSize](interfacehipfort__hipsolver_1_1hipsolversgeqrf__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+78 | [hipsolverDgeqrf_bufferSize](interfacehipfort__hipsolver_1_1hipsolverdgeqrf__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+79 | [hipsolverCgeqrf_bufferSize](interfacehipfort__hipsolver_1_1hipsolvercgeqrf__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+80 | [hipsolverZgeqrf_bufferSize](interfacehipfort__hipsolver_1_1hipsolverzgeqrf__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+81 | [hipsolverSgeqrf](interfacehipfort__hipsolver_1_1hipsolversgeqrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+82 | [hipsolverDgeqrf](interfacehipfort__hipsolver_1_1hipsolverdgeqrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+83 | [hipsolverCgeqrf](interfacehipfort__hipsolver_1_1hipsolvercgeqrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+84 | [hipsolverZgeqrf](interfacehipfort__hipsolver_1_1hipsolverzgeqrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+85 | [hipsolverSSgesv_bufferSize](interfacehipfort__hipsolver_1_1hipsolverssgesv__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+86 | [hipsolverDDgesv_bufferSize](interfacehipfort__hipsolver_1_1hipsolverddgesv__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+87 | [hipsolverCCgesv_bufferSize](interfacehipfort__hipsolver_1_1hipsolverccgesv__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+88 | [hipsolverZZgesv_bufferSize](interfacehipfort__hipsolver_1_1hipsolverzzgesv__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+89 | [hipsolverSSgesv](interfacehipfort__hipsolver_1_1hipsolverssgesv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+90 | [hipsolverDDgesv](interfacehipfort__hipsolver_1_1hipsolverddgesv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+91 | [hipsolverCCgesv](interfacehipfort__hipsolver_1_1hipsolverccgesv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+92 | [hipsolverZZgesv](interfacehipfort__hipsolver_1_1hipsolverzzgesv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 93 | [hipsolverSgesvd_bufferSize](interfacehipfort__hipsolver_1_1hipsolversgesvd__buffersize.html "Interface documentation") | C binding
 94 | [hipsolverDgesvd_bufferSize](interfacehipfort__hipsolver_1_1hipsolverdgesvd__buffersize.html "Interface documentation") | C binding
 95 | [hipsolverCgesvd_bufferSize](interfacehipfort__hipsolver_1_1hipsolvercgesvd__buffersize.html "Interface documentation") | C binding
@@ -118,30 +118,30 @@
 114 | [hipsolverDgesvdjBatched](interfacehipfort__hipsolver_1_1hipsolverdgesvdjbatched.html "Interface documentation") | C binding
 115 | [hipsolverCgesvdjBatched](interfacehipfort__hipsolver_1_1hipsolvercgesvdjbatched.html "Interface documentation") | C binding
 116 | [hipsolverZgesvdjBatched](interfacehipfort__hipsolver_1_1hipsolverzgesvdjbatched.html "Interface documentation") | C binding
-117 | [hipsolverSgetrf_bufferSize](interfacehipfort__hipsolver_1_1hipsolversgetrf__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-118 | [hipsolverDgetrf_bufferSize](interfacehipfort__hipsolver_1_1hipsolverdgetrf__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-119 | [hipsolverCgetrf_bufferSize](interfacehipfort__hipsolver_1_1hipsolvercgetrf__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-120 | [hipsolverZgetrf_bufferSize](interfacehipfort__hipsolver_1_1hipsolverzgetrf__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-121 | [hipsolverSgetrf](interfacehipfort__hipsolver_1_1hipsolversgetrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-122 | [hipsolverDgetrf](interfacehipfort__hipsolver_1_1hipsolverdgetrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-123 | [hipsolverCgetrf](interfacehipfort__hipsolver_1_1hipsolvercgetrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-124 | [hipsolverZgetrf](interfacehipfort__hipsolver_1_1hipsolverzgetrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-125 | [hipsolverSgetrs_bufferSize](interfacehipfort__hipsolver_1_1hipsolversgetrs__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-126 | [hipsolverDgetrs_bufferSize](interfacehipfort__hipsolver_1_1hipsolverdgetrs__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-127 | [hipsolverCgetrs_bufferSize](interfacehipfort__hipsolver_1_1hipsolvercgetrs__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-128 | [hipsolverZgetrs_bufferSize](interfacehipfort__hipsolver_1_1hipsolverzgetrs__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-129 | [hipsolverSgetrs](interfacehipfort__hipsolver_1_1hipsolversgetrs.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-130 | [hipsolverDgetrs](interfacehipfort__hipsolver_1_1hipsolverdgetrs.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-131 | [hipsolverCgetrs](interfacehipfort__hipsolver_1_1hipsolvercgetrs.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-132 | [hipsolverZgetrs](interfacehipfort__hipsolver_1_1hipsolverzgetrs.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-133 | [hipsolverSpotrf_bufferSize](interfacehipfort__hipsolver_1_1hipsolverspotrf__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-134 | [hipsolverDpotrf_bufferSize](interfacehipfort__hipsolver_1_1hipsolverdpotrf__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-135 | [hipsolverCpotrf_bufferSize](interfacehipfort__hipsolver_1_1hipsolvercpotrf__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-136 | [hipsolverZpotrf_bufferSize](interfacehipfort__hipsolver_1_1hipsolverzpotrf__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-137 | [hipsolverSpotrf](interfacehipfort__hipsolver_1_1hipsolverspotrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-138 | [hipsolverDpotrf](interfacehipfort__hipsolver_1_1hipsolverdpotrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-139 | [hipsolverCpotrf](interfacehipfort__hipsolver_1_1hipsolvercpotrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-140 | [hipsolverZpotrf](interfacehipfort__hipsolver_1_1hipsolverzpotrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+117 | [hipsolverSgetrf_bufferSize](interfacehipfort__hipsolver_1_1hipsolversgetrf__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+118 | [hipsolverDgetrf_bufferSize](interfacehipfort__hipsolver_1_1hipsolverdgetrf__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+119 | [hipsolverCgetrf_bufferSize](interfacehipfort__hipsolver_1_1hipsolvercgetrf__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+120 | [hipsolverZgetrf_bufferSize](interfacehipfort__hipsolver_1_1hipsolverzgetrf__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+121 | [hipsolverSgetrf](interfacehipfort__hipsolver_1_1hipsolversgetrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+122 | [hipsolverDgetrf](interfacehipfort__hipsolver_1_1hipsolverdgetrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+123 | [hipsolverCgetrf](interfacehipfort__hipsolver_1_1hipsolvercgetrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+124 | [hipsolverZgetrf](interfacehipfort__hipsolver_1_1hipsolverzgetrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+125 | [hipsolverSgetrs_bufferSize](interfacehipfort__hipsolver_1_1hipsolversgetrs__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+126 | [hipsolverDgetrs_bufferSize](interfacehipfort__hipsolver_1_1hipsolverdgetrs__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+127 | [hipsolverCgetrs_bufferSize](interfacehipfort__hipsolver_1_1hipsolvercgetrs__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+128 | [hipsolverZgetrs_bufferSize](interfacehipfort__hipsolver_1_1hipsolverzgetrs__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+129 | [hipsolverSgetrs](interfacehipfort__hipsolver_1_1hipsolversgetrs.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+130 | [hipsolverDgetrs](interfacehipfort__hipsolver_1_1hipsolverdgetrs.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+131 | [hipsolverCgetrs](interfacehipfort__hipsolver_1_1hipsolvercgetrs.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+132 | [hipsolverZgetrs](interfacehipfort__hipsolver_1_1hipsolverzgetrs.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+133 | [hipsolverSpotrf_bufferSize](interfacehipfort__hipsolver_1_1hipsolverspotrf__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+134 | [hipsolverDpotrf_bufferSize](interfacehipfort__hipsolver_1_1hipsolverdpotrf__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+135 | [hipsolverCpotrf_bufferSize](interfacehipfort__hipsolver_1_1hipsolvercpotrf__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+136 | [hipsolverZpotrf_bufferSize](interfacehipfort__hipsolver_1_1hipsolverzpotrf__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+137 | [hipsolverSpotrf](interfacehipfort__hipsolver_1_1hipsolverspotrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+138 | [hipsolverDpotrf](interfacehipfort__hipsolver_1_1hipsolverdpotrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+139 | [hipsolverCpotrf](interfacehipfort__hipsolver_1_1hipsolvercpotrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+140 | [hipsolverZpotrf](interfacehipfort__hipsolver_1_1hipsolverzpotrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 141 | [hipsolverSpotrfBatched_bufferSize](interfacehipfort__hipsolver_1_1hipsolverspotrfbatched__buffersize.html "Interface documentation") | C binding
 142 | [hipsolverDpotrfBatched_bufferSize](interfacehipfort__hipsolver_1_1hipsolverdpotrfbatched__buffersize.html "Interface documentation") | C binding
 143 | [hipsolverCpotrfBatched_bufferSize](interfacehipfort__hipsolver_1_1hipsolvercpotrfbatched__buffersize.html "Interface documentation") | C binding
@@ -150,22 +150,22 @@
 146 | [hipsolverDpotrfBatched](interfacehipfort__hipsolver_1_1hipsolverdpotrfbatched.html "Interface documentation") | C binding
 147 | [hipsolverCpotrfBatched](interfacehipfort__hipsolver_1_1hipsolvercpotrfbatched.html "Interface documentation") | C binding
 148 | [hipsolverZpotrfBatched](interfacehipfort__hipsolver_1_1hipsolverzpotrfbatched.html "Interface documentation") | C binding
-149 | [hipsolverSpotri_bufferSize](interfacehipfort__hipsolver_1_1hipsolverspotri__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-150 | [hipsolverDpotri_bufferSize](interfacehipfort__hipsolver_1_1hipsolverdpotri__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-151 | [hipsolverCpotri_bufferSize](interfacehipfort__hipsolver_1_1hipsolvercpotri__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-152 | [hipsolverZpotri_bufferSize](interfacehipfort__hipsolver_1_1hipsolverzpotri__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-153 | [hipsolverSpotri](interfacehipfort__hipsolver_1_1hipsolverspotri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-154 | [hipsolverDpotri](interfacehipfort__hipsolver_1_1hipsolverdpotri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-155 | [hipsolverCpotri](interfacehipfort__hipsolver_1_1hipsolvercpotri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-156 | [hipsolverZpotri](interfacehipfort__hipsolver_1_1hipsolverzpotri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-157 | [hipsolverSpotrs_bufferSize](interfacehipfort__hipsolver_1_1hipsolverspotrs__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-158 | [hipsolverDpotrs_bufferSize](interfacehipfort__hipsolver_1_1hipsolverdpotrs__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-159 | [hipsolverCpotrs_bufferSize](interfacehipfort__hipsolver_1_1hipsolvercpotrs__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-160 | [hipsolverZpotrs_bufferSize](interfacehipfort__hipsolver_1_1hipsolverzpotrs__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-161 | [hipsolverSpotrs](interfacehipfort__hipsolver_1_1hipsolverspotrs.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-162 | [hipsolverDpotrs](interfacehipfort__hipsolver_1_1hipsolverdpotrs.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-163 | [hipsolverCpotrs](interfacehipfort__hipsolver_1_1hipsolvercpotrs.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-164 | [hipsolverZpotrs](interfacehipfort__hipsolver_1_1hipsolverzpotrs.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+149 | [hipsolverSpotri_bufferSize](interfacehipfort__hipsolver_1_1hipsolverspotri__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+150 | [hipsolverDpotri_bufferSize](interfacehipfort__hipsolver_1_1hipsolverdpotri__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+151 | [hipsolverCpotri_bufferSize](interfacehipfort__hipsolver_1_1hipsolvercpotri__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+152 | [hipsolverZpotri_bufferSize](interfacehipfort__hipsolver_1_1hipsolverzpotri__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+153 | [hipsolverSpotri](interfacehipfort__hipsolver_1_1hipsolverspotri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+154 | [hipsolverDpotri](interfacehipfort__hipsolver_1_1hipsolverdpotri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+155 | [hipsolverCpotri](interfacehipfort__hipsolver_1_1hipsolvercpotri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+156 | [hipsolverZpotri](interfacehipfort__hipsolver_1_1hipsolverzpotri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+157 | [hipsolverSpotrs_bufferSize](interfacehipfort__hipsolver_1_1hipsolverspotrs__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+158 | [hipsolverDpotrs_bufferSize](interfacehipfort__hipsolver_1_1hipsolverdpotrs__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+159 | [hipsolverCpotrs_bufferSize](interfacehipfort__hipsolver_1_1hipsolvercpotrs__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+160 | [hipsolverZpotrs_bufferSize](interfacehipfort__hipsolver_1_1hipsolverzpotrs__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+161 | [hipsolverSpotrs](interfacehipfort__hipsolver_1_1hipsolverspotrs.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+162 | [hipsolverDpotrs](interfacehipfort__hipsolver_1_1hipsolverdpotrs.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+163 | [hipsolverCpotrs](interfacehipfort__hipsolver_1_1hipsolvercpotrs.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+164 | [hipsolverZpotrs](interfacehipfort__hipsolver_1_1hipsolverzpotrs.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 165 | [hipsolverSpotrsBatched_bufferSize](interfacehipfort__hipsolver_1_1hipsolverspotrsbatched__buffersize.html "Interface documentation") | C binding
 166 | [hipsolverDpotrsBatched_bufferSize](interfacehipfort__hipsolver_1_1hipsolverdpotrsbatched__buffersize.html "Interface documentation") | C binding
 167 | [hipsolverCpotrsBatched_bufferSize](interfacehipfort__hipsolver_1_1hipsolvercpotrsbatched__buffersize.html "Interface documentation") | C binding
@@ -174,14 +174,14 @@
 170 | [hipsolverDpotrsBatched](interfacehipfort__hipsolver_1_1hipsolverdpotrsbatched.html "Interface documentation") | C binding
 171 | [hipsolverCpotrsBatched](interfacehipfort__hipsolver_1_1hipsolvercpotrsbatched.html "Interface documentation") | C binding
 172 | [hipsolverZpotrsBatched](interfacehipfort__hipsolver_1_1hipsolverzpotrsbatched.html "Interface documentation") | C binding
-173 | [hipsolverSsyevd_bufferSize](interfacehipfort__hipsolver_1_1hipsolverssyevd__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-174 | [hipsolverDsyevd_bufferSize](interfacehipfort__hipsolver_1_1hipsolverdsyevd__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-175 | [hipsolverCheevd_bufferSize](interfacehipfort__hipsolver_1_1hipsolvercheevd__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-176 | [hipsolverZheevd_bufferSize](interfacehipfort__hipsolver_1_1hipsolverzheevd__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-177 | [hipsolverSsyevd](interfacehipfort__hipsolver_1_1hipsolverssyevd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-178 | [hipsolverDsyevd](interfacehipfort__hipsolver_1_1hipsolverdsyevd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-179 | [hipsolverCheevd](interfacehipfort__hipsolver_1_1hipsolvercheevd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-180 | [hipsolverZheevd](interfacehipfort__hipsolver_1_1hipsolverzheevd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+173 | [hipsolverSsyevd_bufferSize](interfacehipfort__hipsolver_1_1hipsolverssyevd__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+174 | [hipsolverDsyevd_bufferSize](interfacehipfort__hipsolver_1_1hipsolverdsyevd__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+175 | [hipsolverCheevd_bufferSize](interfacehipfort__hipsolver_1_1hipsolvercheevd__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+176 | [hipsolverZheevd_bufferSize](interfacehipfort__hipsolver_1_1hipsolverzheevd__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+177 | [hipsolverSsyevd](interfacehipfort__hipsolver_1_1hipsolverssyevd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+178 | [hipsolverDsyevd](interfacehipfort__hipsolver_1_1hipsolverdsyevd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+179 | [hipsolverCheevd](interfacehipfort__hipsolver_1_1hipsolvercheevd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+180 | [hipsolverZheevd](interfacehipfort__hipsolver_1_1hipsolverzheevd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 181 | [hipsolverSsyevdx_bufferSize](interfacehipfort__hipsolver_1_1hipsolverssyevdx__buffersize.html "Interface documentation") | C binding
 182 | [hipsolverDsyevdx_bufferSize](interfacehipfort__hipsolver_1_1hipsolverdsyevdx__buffersize.html "Interface documentation") | C binding
 183 | [hipsolverCheevdx_bufferSize](interfacehipfort__hipsolver_1_1hipsolvercheevdx__buffersize.html "Interface documentation") | C binding
@@ -206,14 +206,14 @@
 202 | [hipsolverDsyevjBatched](interfacehipfort__hipsolver_1_1hipsolverdsyevjbatched.html "Interface documentation") | C binding
 203 | [hipsolverCheevjBatched](interfacehipfort__hipsolver_1_1hipsolvercheevjbatched.html "Interface documentation") | C binding
 204 | [hipsolverZheevjBatched](interfacehipfort__hipsolver_1_1hipsolverzheevjbatched.html "Interface documentation") | C binding
-205 | [hipsolverSsygvd_bufferSize](interfacehipfort__hipsolver_1_1hipsolverssygvd__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-206 | [hipsolverDsygvd_bufferSize](interfacehipfort__hipsolver_1_1hipsolverdsygvd__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-207 | [hipsolverChegvd_bufferSize](interfacehipfort__hipsolver_1_1hipsolverchegvd__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-208 | [hipsolverZhegvd_bufferSize](interfacehipfort__hipsolver_1_1hipsolverzhegvd__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-209 | [hipsolverSsygvd](interfacehipfort__hipsolver_1_1hipsolverssygvd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-210 | [hipsolverDsygvd](interfacehipfort__hipsolver_1_1hipsolverdsygvd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-211 | [hipsolverChegvd](interfacehipfort__hipsolver_1_1hipsolverchegvd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-212 | [hipsolverZhegvd](interfacehipfort__hipsolver_1_1hipsolverzhegvd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+205 | [hipsolverSsygvd_bufferSize](interfacehipfort__hipsolver_1_1hipsolverssygvd__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+206 | [hipsolverDsygvd_bufferSize](interfacehipfort__hipsolver_1_1hipsolverdsygvd__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+207 | [hipsolverChegvd_bufferSize](interfacehipfort__hipsolver_1_1hipsolverchegvd__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+208 | [hipsolverZhegvd_bufferSize](interfacehipfort__hipsolver_1_1hipsolverzhegvd__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+209 | [hipsolverSsygvd](interfacehipfort__hipsolver_1_1hipsolverssygvd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+210 | [hipsolverDsygvd](interfacehipfort__hipsolver_1_1hipsolverdsygvd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+211 | [hipsolverChegvd](interfacehipfort__hipsolver_1_1hipsolverchegvd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+212 | [hipsolverZhegvd](interfacehipfort__hipsolver_1_1hipsolverzhegvd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 213 | [hipsolverSsygvdx_bufferSize](interfacehipfort__hipsolver_1_1hipsolverssygvdx__buffersize.html "Interface documentation") | C binding
 214 | [hipsolverDsygvdx_bufferSize](interfacehipfort__hipsolver_1_1hipsolverdsygvdx__buffersize.html "Interface documentation") | C binding
 215 | [hipsolverChegvdx_bufferSize](interfacehipfort__hipsolver_1_1hipsolverchegvdx__buffersize.html "Interface documentation") | C binding
@@ -230,22 +230,22 @@
 226 | [hipsolverDsygvj](interfacehipfort__hipsolver_1_1hipsolverdsygvj.html "Interface documentation") | C binding
 227 | [hipsolverChegvj](interfacehipfort__hipsolver_1_1hipsolverchegvj.html "Interface documentation") | C binding
 228 | [hipsolverZhegvj](interfacehipfort__hipsolver_1_1hipsolverzhegvj.html "Interface documentation") | C binding
-229 | [hipsolverSsytrd_bufferSize](interfacehipfort__hipsolver_1_1hipsolverssytrd__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-230 | [hipsolverDsytrd_bufferSize](interfacehipfort__hipsolver_1_1hipsolverdsytrd__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-231 | [hipsolverChetrd_bufferSize](interfacehipfort__hipsolver_1_1hipsolverchetrd__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-232 | [hipsolverZhetrd_bufferSize](interfacehipfort__hipsolver_1_1hipsolverzhetrd__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-233 | [hipsolverSsytrd](interfacehipfort__hipsolver_1_1hipsolverssytrd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-234 | [hipsolverDsytrd](interfacehipfort__hipsolver_1_1hipsolverdsytrd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-235 | [hipsolverChetrd](interfacehipfort__hipsolver_1_1hipsolverchetrd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-236 | [hipsolverZhetrd](interfacehipfort__hipsolver_1_1hipsolverzhetrd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-237 | [hipsolverSsytrf_bufferSize](interfacehipfort__hipsolver_1_1hipsolverssytrf__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-238 | [hipsolverDsytrf_bufferSize](interfacehipfort__hipsolver_1_1hipsolverdsytrf__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-239 | [hipsolverCsytrf_bufferSize](interfacehipfort__hipsolver_1_1hipsolvercsytrf__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-240 | [hipsolverZsytrf_bufferSize](interfacehipfort__hipsolver_1_1hipsolverzsytrf__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-241 | [hipsolverSsytrf](interfacehipfort__hipsolver_1_1hipsolverssytrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-242 | [hipsolverDsytrf](interfacehipfort__hipsolver_1_1hipsolverdsytrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-243 | [hipsolverCsytrf](interfacehipfort__hipsolver_1_1hipsolvercsytrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-244 | [hipsolverZsytrf](interfacehipfort__hipsolver_1_1hipsolverzsytrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+229 | [hipsolverSsytrd_bufferSize](interfacehipfort__hipsolver_1_1hipsolverssytrd__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+230 | [hipsolverDsytrd_bufferSize](interfacehipfort__hipsolver_1_1hipsolverdsytrd__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+231 | [hipsolverChetrd_bufferSize](interfacehipfort__hipsolver_1_1hipsolverchetrd__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+232 | [hipsolverZhetrd_bufferSize](interfacehipfort__hipsolver_1_1hipsolverzhetrd__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+233 | [hipsolverSsytrd](interfacehipfort__hipsolver_1_1hipsolverssytrd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+234 | [hipsolverDsytrd](interfacehipfort__hipsolver_1_1hipsolverdsytrd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+235 | [hipsolverChetrd](interfacehipfort__hipsolver_1_1hipsolverchetrd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+236 | [hipsolverZhetrd](interfacehipfort__hipsolver_1_1hipsolverzhetrd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+237 | [hipsolverSsytrf_bufferSize](interfacehipfort__hipsolver_1_1hipsolverssytrf__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+238 | [hipsolverDsytrf_bufferSize](interfacehipfort__hipsolver_1_1hipsolverdsytrf__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+239 | [hipsolverCsytrf_bufferSize](interfacehipfort__hipsolver_1_1hipsolvercsytrf__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+240 | [hipsolverZsytrf_bufferSize](interfacehipfort__hipsolver_1_1hipsolverzsytrf__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+241 | [hipsolverSsytrf](interfacehipfort__hipsolver_1_1hipsolverssytrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+242 | [hipsolverDsytrf](interfacehipfort__hipsolver_1_1hipsolverdsytrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+243 | [hipsolverCsytrf](interfacehipfort__hipsolver_1_1hipsolvercsytrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+244 | [hipsolverZsytrf](interfacehipfort__hipsolver_1_1hipsolverzsytrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 245 | [hipsolverDnCreate](interfacehipfort__hipsolver_1_1hipsolverdncreate.html "Interface documentation") | C binding
 246 | [hipsolverDnDestroy](interfacehipfort__hipsolver_1_1hipsolverdndestroy.html "Interface documentation") | C binding
 247 | [hipsolverDnSetStream](interfacehipfort__hipsolver_1_1hipsolverdnsetstream.html "Interface documentation") | C binding

--- a/docs/doxygen/input/supported_api_hipsparse.md
+++ b/docs/doxygen/input/supported_api_hipsparse.md
@@ -49,242 +49,242 @@
 45 | [hipsparseDestroyCsrgemm2Info](interfacehipfort__hipsparse_1_1hipsparsedestroycsrgemm2info.html "Interface documentation") | C binding
 46 | [hipsparseCreatePruneInfo](interfacehipfort__hipsparse_1_1hipsparsecreatepruneinfo.html "Interface documentation") | C binding
 47 | [hipsparseDestroyPruneInfo](interfacehipfort__hipsparse_1_1hipsparsedestroypruneinfo.html "Interface documentation") | C binding
-48 | [hipsparseSaxpyi](interfacehipfort__hipsparse_1_1hipsparsesaxpyi.html "Interface documentation") | C binding, rank_0, rank_1
-49 | [hipsparseDaxpyi](interfacehipfort__hipsparse_1_1hipsparsedaxpyi.html "Interface documentation") | C binding, rank_0, rank_1
-50 | [hipsparseCaxpyi](interfacehipfort__hipsparse_1_1hipsparsecaxpyi.html "Interface documentation") | C binding, rank_0, rank_1
-51 | [hipsparseZaxpyi](interfacehipfort__hipsparse_1_1hipsparsezaxpyi.html "Interface documentation") | C binding, rank_0, rank_1
-52 | [hipsparseCdotci](interfacehipfort__hipsparse_1_1hipsparsecdotci.html "Interface documentation") | C binding, rank_0, rank_1
-53 | [hipsparseZdotci](interfacehipfort__hipsparse_1_1hipsparsezdotci.html "Interface documentation") | C binding, rank_0, rank_1
-54 | [hipsparseSdoti](interfacehipfort__hipsparse_1_1hipsparsesdoti.html "Interface documentation") | C binding, rank_0, rank_1
-55 | [hipsparseDdoti](interfacehipfort__hipsparse_1_1hipsparseddoti.html "Interface documentation") | C binding, rank_0, rank_1
-56 | [hipsparseCdoti](interfacehipfort__hipsparse_1_1hipsparsecdoti.html "Interface documentation") | C binding, rank_0, rank_1
-57 | [hipsparseZdoti](interfacehipfort__hipsparse_1_1hipsparsezdoti.html "Interface documentation") | C binding, rank_0, rank_1
-58 | [hipsparseSgthr](interfacehipfort__hipsparse_1_1hipsparsesgthr.html "Interface documentation") | C binding, rank_0, rank_1
-59 | [hipsparseDgthr](interfacehipfort__hipsparse_1_1hipsparsedgthr.html "Interface documentation") | C binding, rank_0, rank_1
-60 | [hipsparseCgthr](interfacehipfort__hipsparse_1_1hipsparsecgthr.html "Interface documentation") | C binding, rank_0, rank_1
-61 | [hipsparseZgthr](interfacehipfort__hipsparse_1_1hipsparsezgthr.html "Interface documentation") | C binding, rank_0, rank_1
-62 | [hipsparseSgthrz](interfacehipfort__hipsparse_1_1hipsparsesgthrz.html "Interface documentation") | C binding, rank_0, rank_1
-63 | [hipsparseDgthrz](interfacehipfort__hipsparse_1_1hipsparsedgthrz.html "Interface documentation") | C binding, rank_0, rank_1
-64 | [hipsparseCgthrz](interfacehipfort__hipsparse_1_1hipsparsecgthrz.html "Interface documentation") | C binding, rank_0, rank_1
-65 | [hipsparseZgthrz](interfacehipfort__hipsparse_1_1hipsparsezgthrz.html "Interface documentation") | C binding, rank_0, rank_1
-66 | [hipsparseSroti](interfacehipfort__hipsparse_1_1hipsparsesroti.html "Interface documentation") | C binding, rank_0, rank_1
-67 | [hipsparseDroti](interfacehipfort__hipsparse_1_1hipsparsedroti.html "Interface documentation") | C binding, rank_0, rank_1
-68 | [hipsparseSsctr](interfacehipfort__hipsparse_1_1hipsparsessctr.html "Interface documentation") | C binding, rank_0, rank_1
-69 | [hipsparseDsctr](interfacehipfort__hipsparse_1_1hipsparsedsctr.html "Interface documentation") | C binding, rank_0, rank_1
-70 | [hipsparseCsctr](interfacehipfort__hipsparse_1_1hipsparsecsctr.html "Interface documentation") | C binding, rank_0, rank_1
-71 | [hipsparseZsctr](interfacehipfort__hipsparse_1_1hipsparsezsctr.html "Interface documentation") | C binding, rank_0, rank_1
-72 | [hipsparseSbsrmv](interfacehipfort__hipsparse_1_1hipsparsesbsrmv.html "Interface documentation") | C binding, rank_0, rank_1
-73 | [hipsparseDbsrmv](interfacehipfort__hipsparse_1_1hipsparsedbsrmv.html "Interface documentation") | C binding, rank_0, rank_1
-74 | [hipsparseCbsrmv](interfacehipfort__hipsparse_1_1hipsparsecbsrmv.html "Interface documentation") | C binding, rank_0, rank_1
-75 | [hipsparseZbsrmv](interfacehipfort__hipsparse_1_1hipsparsezbsrmv.html "Interface documentation") | C binding, rank_0, rank_1
+48 | [hipsparseSaxpyi](interfacehipfort__hipsparse_1_1hipsparsesaxpyi.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+49 | [hipsparseDaxpyi](interfacehipfort__hipsparse_1_1hipsparsedaxpyi.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+50 | [hipsparseCaxpyi](interfacehipfort__hipsparse_1_1hipsparsecaxpyi.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+51 | [hipsparseZaxpyi](interfacehipfort__hipsparse_1_1hipsparsezaxpyi.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+52 | [hipsparseCdotci](interfacehipfort__hipsparse_1_1hipsparsecdotci.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+53 | [hipsparseZdotci](interfacehipfort__hipsparse_1_1hipsparsezdotci.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+54 | [hipsparseSdoti](interfacehipfort__hipsparse_1_1hipsparsesdoti.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+55 | [hipsparseDdoti](interfacehipfort__hipsparse_1_1hipsparseddoti.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+56 | [hipsparseCdoti](interfacehipfort__hipsparse_1_1hipsparsecdoti.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+57 | [hipsparseZdoti](interfacehipfort__hipsparse_1_1hipsparsezdoti.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+58 | [hipsparseSgthr](interfacehipfort__hipsparse_1_1hipsparsesgthr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+59 | [hipsparseDgthr](interfacehipfort__hipsparse_1_1hipsparsedgthr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+60 | [hipsparseCgthr](interfacehipfort__hipsparse_1_1hipsparsecgthr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+61 | [hipsparseZgthr](interfacehipfort__hipsparse_1_1hipsparsezgthr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+62 | [hipsparseSgthrz](interfacehipfort__hipsparse_1_1hipsparsesgthrz.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+63 | [hipsparseDgthrz](interfacehipfort__hipsparse_1_1hipsparsedgthrz.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+64 | [hipsparseCgthrz](interfacehipfort__hipsparse_1_1hipsparsecgthrz.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+65 | [hipsparseZgthrz](interfacehipfort__hipsparse_1_1hipsparsezgthrz.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+66 | [hipsparseSroti](interfacehipfort__hipsparse_1_1hipsparsesroti.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+67 | [hipsparseDroti](interfacehipfort__hipsparse_1_1hipsparsedroti.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+68 | [hipsparseSsctr](interfacehipfort__hipsparse_1_1hipsparsessctr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+69 | [hipsparseDsctr](interfacehipfort__hipsparse_1_1hipsparsedsctr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+70 | [hipsparseCsctr](interfacehipfort__hipsparse_1_1hipsparsecsctr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+71 | [hipsparseZsctr](interfacehipfort__hipsparse_1_1hipsparsezsctr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+72 | [hipsparseSbsrmv](interfacehipfort__hipsparse_1_1hipsparsesbsrmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+73 | [hipsparseDbsrmv](interfacehipfort__hipsparse_1_1hipsparsedbsrmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+74 | [hipsparseCbsrmv](interfacehipfort__hipsparse_1_1hipsparsecbsrmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+75 | [hipsparseZbsrmv](interfacehipfort__hipsparse_1_1hipsparsezbsrmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 76 | [hipsparseXbsrsv2_zeroPivot](interfacehipfort__hipsparse_1_1hipsparsexbsrsv2__zeropivot.html "Interface documentation") | C binding
-77 | [hipsparseSbsrsv2_bufferSize](interfacehipfort__hipsparse_1_1hipsparsesbsrsv2__buffersize.html "Interface documentation") | C binding, rank_0, rank_1
-78 | [hipsparseDbsrsv2_bufferSize](interfacehipfort__hipsparse_1_1hipsparsedbsrsv2__buffersize.html "Interface documentation") | C binding, rank_0, rank_1
-79 | [hipsparseCbsrsv2_bufferSize](interfacehipfort__hipsparse_1_1hipsparsecbsrsv2__buffersize.html "Interface documentation") | C binding, rank_0, rank_1
-80 | [hipsparseZbsrsv2_bufferSize](interfacehipfort__hipsparse_1_1hipsparsezbsrsv2__buffersize.html "Interface documentation") | C binding, rank_0, rank_1
-81 | [hipsparseSbsrsv2_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsesbsrsv2__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1
-82 | [hipsparseDbsrsv2_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsedbsrsv2__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1
-83 | [hipsparseCbsrsv2_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsecbsrsv2__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1
-84 | [hipsparseZbsrsv2_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsezbsrsv2__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1
-85 | [hipsparseSbsrsv2_analysis](interfacehipfort__hipsparse_1_1hipsparsesbsrsv2__analysis.html "Interface documentation") | C binding, rank_0, rank_1
-86 | [hipsparseDbsrsv2_analysis](interfacehipfort__hipsparse_1_1hipsparsedbsrsv2__analysis.html "Interface documentation") | C binding, rank_0, rank_1
-87 | [hipsparseCbsrsv2_analysis](interfacehipfort__hipsparse_1_1hipsparsecbsrsv2__analysis.html "Interface documentation") | C binding, rank_0, rank_1
-88 | [hipsparseZbsrsv2_analysis](interfacehipfort__hipsparse_1_1hipsparsezbsrsv2__analysis.html "Interface documentation") | C binding, rank_0, rank_1
-89 | [hipsparseSbsrsv2_solve](interfacehipfort__hipsparse_1_1hipsparsesbsrsv2__solve.html "Interface documentation") | C binding, rank_0, rank_1
-90 | [hipsparseDbsrsv2_solve](interfacehipfort__hipsparse_1_1hipsparsedbsrsv2__solve.html "Interface documentation") | C binding, rank_0, rank_1
-91 | [hipsparseCbsrsv2_solve](interfacehipfort__hipsparse_1_1hipsparsecbsrsv2__solve.html "Interface documentation") | C binding, rank_0, rank_1
-92 | [hipsparseZbsrsv2_solve](interfacehipfort__hipsparse_1_1hipsparsezbsrsv2__solve.html "Interface documentation") | C binding, rank_0, rank_1
-93 | [hipsparseSbsrxmv](interfacehipfort__hipsparse_1_1hipsparsesbsrxmv.html "Interface documentation") | C binding, rank_0, rank_1
-94 | [hipsparseDbsrxmv](interfacehipfort__hipsparse_1_1hipsparsedbsrxmv.html "Interface documentation") | C binding, rank_0, rank_1
-95 | [hipsparseCbsrxmv](interfacehipfort__hipsparse_1_1hipsparsecbsrxmv.html "Interface documentation") | C binding, rank_0, rank_1
-96 | [hipsparseZbsrxmv](interfacehipfort__hipsparse_1_1hipsparsezbsrxmv.html "Interface documentation") | C binding, rank_0, rank_1
-97 | [hipsparseScsrmv](interfacehipfort__hipsparse_1_1hipsparsescsrmv.html "Interface documentation") | C binding, rank_0, rank_1
-98 | [hipsparseDcsrmv](interfacehipfort__hipsparse_1_1hipsparsedcsrmv.html "Interface documentation") | C binding, rank_0, rank_1
-99 | [hipsparseCcsrmv](interfacehipfort__hipsparse_1_1hipsparseccsrmv.html "Interface documentation") | C binding, rank_0, rank_1
-100 | [hipsparseZcsrmv](interfacehipfort__hipsparse_1_1hipsparsezcsrmv.html "Interface documentation") | C binding, rank_0, rank_1
+77 | [hipsparseSbsrsv2_bufferSize](interfacehipfort__hipsparse_1_1hipsparsesbsrsv2__buffersize.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+78 | [hipsparseDbsrsv2_bufferSize](interfacehipfort__hipsparse_1_1hipsparsedbsrsv2__buffersize.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+79 | [hipsparseCbsrsv2_bufferSize](interfacehipfort__hipsparse_1_1hipsparsecbsrsv2__buffersize.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+80 | [hipsparseZbsrsv2_bufferSize](interfacehipfort__hipsparse_1_1hipsparsezbsrsv2__buffersize.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+81 | [hipsparseSbsrsv2_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsesbsrsv2__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+82 | [hipsparseDbsrsv2_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsedbsrsv2__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+83 | [hipsparseCbsrsv2_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsecbsrsv2__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+84 | [hipsparseZbsrsv2_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsezbsrsv2__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+85 | [hipsparseSbsrsv2_analysis](interfacehipfort__hipsparse_1_1hipsparsesbsrsv2__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+86 | [hipsparseDbsrsv2_analysis](interfacehipfort__hipsparse_1_1hipsparsedbsrsv2__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+87 | [hipsparseCbsrsv2_analysis](interfacehipfort__hipsparse_1_1hipsparsecbsrsv2__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+88 | [hipsparseZbsrsv2_analysis](interfacehipfort__hipsparse_1_1hipsparsezbsrsv2__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+89 | [hipsparseSbsrsv2_solve](interfacehipfort__hipsparse_1_1hipsparsesbsrsv2__solve.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+90 | [hipsparseDbsrsv2_solve](interfacehipfort__hipsparse_1_1hipsparsedbsrsv2__solve.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+91 | [hipsparseCbsrsv2_solve](interfacehipfort__hipsparse_1_1hipsparsecbsrsv2__solve.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+92 | [hipsparseZbsrsv2_solve](interfacehipfort__hipsparse_1_1hipsparsezbsrsv2__solve.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+93 | [hipsparseSbsrxmv](interfacehipfort__hipsparse_1_1hipsparsesbsrxmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+94 | [hipsparseDbsrxmv](interfacehipfort__hipsparse_1_1hipsparsedbsrxmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+95 | [hipsparseCbsrxmv](interfacehipfort__hipsparse_1_1hipsparsecbsrxmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+96 | [hipsparseZbsrxmv](interfacehipfort__hipsparse_1_1hipsparsezbsrxmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+97 | [hipsparseScsrmv](interfacehipfort__hipsparse_1_1hipsparsescsrmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+98 | [hipsparseDcsrmv](interfacehipfort__hipsparse_1_1hipsparsedcsrmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+99 | [hipsparseCcsrmv](interfacehipfort__hipsparse_1_1hipsparseccsrmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+100 | [hipsparseZcsrmv](interfacehipfort__hipsparse_1_1hipsparsezcsrmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 101 | [hipsparseXcsrsv2_zeroPivot](interfacehipfort__hipsparse_1_1hipsparsexcsrsv2__zeropivot.html "Interface documentation") | C binding
-102 | [hipsparseScsrsv2_bufferSize](interfacehipfort__hipsparse_1_1hipsparsescsrsv2__buffersize.html "Interface documentation") | C binding, rank_0, rank_1
-103 | [hipsparseDcsrsv2_bufferSize](interfacehipfort__hipsparse_1_1hipsparsedcsrsv2__buffersize.html "Interface documentation") | C binding, rank_0, rank_1
-104 | [hipsparseCcsrsv2_bufferSize](interfacehipfort__hipsparse_1_1hipsparseccsrsv2__buffersize.html "Interface documentation") | C binding, rank_0, rank_1
-105 | [hipsparseZcsrsv2_bufferSize](interfacehipfort__hipsparse_1_1hipsparsezcsrsv2__buffersize.html "Interface documentation") | C binding, rank_0, rank_1
-106 | [hipsparseScsrsv2_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsescsrsv2__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1
-107 | [hipsparseDcsrsv2_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsedcsrsv2__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1
-108 | [hipsparseCcsrsv2_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparseccsrsv2__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1
-109 | [hipsparseZcsrsv2_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsezcsrsv2__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1
-110 | [hipsparseScsrsv2_analysis](interfacehipfort__hipsparse_1_1hipsparsescsrsv2__analysis.html "Interface documentation") | C binding, rank_0, rank_1
-111 | [hipsparseDcsrsv2_analysis](interfacehipfort__hipsparse_1_1hipsparsedcsrsv2__analysis.html "Interface documentation") | C binding, rank_0, rank_1
-112 | [hipsparseCcsrsv2_analysis](interfacehipfort__hipsparse_1_1hipsparseccsrsv2__analysis.html "Interface documentation") | C binding, rank_0, rank_1
-113 | [hipsparseZcsrsv2_analysis](interfacehipfort__hipsparse_1_1hipsparsezcsrsv2__analysis.html "Interface documentation") | C binding, rank_0, rank_1
-114 | [hipsparseScsrsv2_solve](interfacehipfort__hipsparse_1_1hipsparsescsrsv2__solve.html "Interface documentation") | C binding, rank_0, rank_1
-115 | [hipsparseDcsrsv2_solve](interfacehipfort__hipsparse_1_1hipsparsedcsrsv2__solve.html "Interface documentation") | C binding, rank_0, rank_1
-116 | [hipsparseCcsrsv2_solve](interfacehipfort__hipsparse_1_1hipsparseccsrsv2__solve.html "Interface documentation") | C binding, rank_0, rank_1
-117 | [hipsparseZcsrsv2_solve](interfacehipfort__hipsparse_1_1hipsparsezcsrsv2__solve.html "Interface documentation") | C binding, rank_0, rank_1
+102 | [hipsparseScsrsv2_bufferSize](interfacehipfort__hipsparse_1_1hipsparsescsrsv2__buffersize.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+103 | [hipsparseDcsrsv2_bufferSize](interfacehipfort__hipsparse_1_1hipsparsedcsrsv2__buffersize.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+104 | [hipsparseCcsrsv2_bufferSize](interfacehipfort__hipsparse_1_1hipsparseccsrsv2__buffersize.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+105 | [hipsparseZcsrsv2_bufferSize](interfacehipfort__hipsparse_1_1hipsparsezcsrsv2__buffersize.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+106 | [hipsparseScsrsv2_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsescsrsv2__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+107 | [hipsparseDcsrsv2_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsedcsrsv2__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+108 | [hipsparseCcsrsv2_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparseccsrsv2__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+109 | [hipsparseZcsrsv2_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsezcsrsv2__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+110 | [hipsparseScsrsv2_analysis](interfacehipfort__hipsparse_1_1hipsparsescsrsv2__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+111 | [hipsparseDcsrsv2_analysis](interfacehipfort__hipsparse_1_1hipsparsedcsrsv2__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+112 | [hipsparseCcsrsv2_analysis](interfacehipfort__hipsparse_1_1hipsparseccsrsv2__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+113 | [hipsparseZcsrsv2_analysis](interfacehipfort__hipsparse_1_1hipsparsezcsrsv2__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+114 | [hipsparseScsrsv2_solve](interfacehipfort__hipsparse_1_1hipsparsescsrsv2__solve.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+115 | [hipsparseDcsrsv2_solve](interfacehipfort__hipsparse_1_1hipsparsedcsrsv2__solve.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+116 | [hipsparseCcsrsv2_solve](interfacehipfort__hipsparse_1_1hipsparseccsrsv2__solve.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+117 | [hipsparseZcsrsv2_solve](interfacehipfort__hipsparse_1_1hipsparsezcsrsv2__solve.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 118 | [hipsparseSgemvi_bufferSize](interfacehipfort__hipsparse_1_1hipsparsesgemvi__buffersize.html "Interface documentation") | C binding
 119 | [hipsparseDgemvi_bufferSize](interfacehipfort__hipsparse_1_1hipsparsedgemvi__buffersize.html "Interface documentation") | C binding
 120 | [hipsparseCgemvi_bufferSize](interfacehipfort__hipsparse_1_1hipsparsecgemvi__buffersize.html "Interface documentation") | C binding
 121 | [hipsparseZgemvi_bufferSize](interfacehipfort__hipsparse_1_1hipsparsezgemvi__buffersize.html "Interface documentation") | C binding
-122 | [hipsparseSgemvi](interfacehipfort__hipsparse_1_1hipsparsesgemvi.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-123 | [hipsparseDgemvi](interfacehipfort__hipsparse_1_1hipsparsedgemvi.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-124 | [hipsparseCgemvi](interfacehipfort__hipsparse_1_1hipsparsecgemvi.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-125 | [hipsparseZgemvi](interfacehipfort__hipsparse_1_1hipsparsezgemvi.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-126 | [hipsparseShybmv](interfacehipfort__hipsparse_1_1hipsparseshybmv.html "Interface documentation") | C binding, rank_0, rank_1
-127 | [hipsparseDhybmv](interfacehipfort__hipsparse_1_1hipsparsedhybmv.html "Interface documentation") | C binding, rank_0, rank_1
-128 | [hipsparseChybmv](interfacehipfort__hipsparse_1_1hipsparsechybmv.html "Interface documentation") | C binding, rank_0, rank_1
-129 | [hipsparseZhybmv](interfacehipfort__hipsparse_1_1hipsparsezhybmv.html "Interface documentation") | C binding, rank_0, rank_1
-130 | [hipsparseSbsrmm](interfacehipfort__hipsparse_1_1hipsparsesbsrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-131 | [hipsparseDbsrmm](interfacehipfort__hipsparse_1_1hipsparsedbsrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-132 | [hipsparseCbsrmm](interfacehipfort__hipsparse_1_1hipsparsecbsrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-133 | [hipsparseZbsrmm](interfacehipfort__hipsparse_1_1hipsparsezbsrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+122 | [hipsparseSgemvi](interfacehipfort__hipsparse_1_1hipsparsesgemvi.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+123 | [hipsparseDgemvi](interfacehipfort__hipsparse_1_1hipsparsedgemvi.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+124 | [hipsparseCgemvi](interfacehipfort__hipsparse_1_1hipsparsecgemvi.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+125 | [hipsparseZgemvi](interfacehipfort__hipsparse_1_1hipsparsezgemvi.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+126 | [hipsparseShybmv](interfacehipfort__hipsparse_1_1hipsparseshybmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+127 | [hipsparseDhybmv](interfacehipfort__hipsparse_1_1hipsparsedhybmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+128 | [hipsparseChybmv](interfacehipfort__hipsparse_1_1hipsparsechybmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+129 | [hipsparseZhybmv](interfacehipfort__hipsparse_1_1hipsparsezhybmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+130 | [hipsparseSbsrmm](interfacehipfort__hipsparse_1_1hipsparsesbsrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+131 | [hipsparseDbsrmm](interfacehipfort__hipsparse_1_1hipsparsedbsrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+132 | [hipsparseCbsrmm](interfacehipfort__hipsparse_1_1hipsparsecbsrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+133 | [hipsparseZbsrmm](interfacehipfort__hipsparse_1_1hipsparsezbsrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 134 | [hipsparseXbsrsm2_zeroPivot](interfacehipfort__hipsparse_1_1hipsparsexbsrsm2__zeropivot.html "Interface documentation") | C binding
-135 | [hipsparseSbsrsm2_bufferSize](interfacehipfort__hipsparse_1_1hipsparsesbsrsm2__buffersize.html "Interface documentation") | C binding, rank_0, rank_1
-136 | [hipsparseDbsrsm2_bufferSize](interfacehipfort__hipsparse_1_1hipsparsedbsrsm2__buffersize.html "Interface documentation") | C binding, rank_0, rank_1
-137 | [hipsparseCbsrsm2_bufferSize](interfacehipfort__hipsparse_1_1hipsparsecbsrsm2__buffersize.html "Interface documentation") | C binding, rank_0, rank_1
-138 | [hipsparseZbsrsm2_bufferSize](interfacehipfort__hipsparse_1_1hipsparsezbsrsm2__buffersize.html "Interface documentation") | C binding, rank_0, rank_1
-139 | [hipsparseSbsrsm2_analysis](interfacehipfort__hipsparse_1_1hipsparsesbsrsm2__analysis.html "Interface documentation") | C binding, rank_0, rank_1
-140 | [hipsparseDbsrsm2_analysis](interfacehipfort__hipsparse_1_1hipsparsedbsrsm2__analysis.html "Interface documentation") | C binding, rank_0, rank_1
-141 | [hipsparseCbsrsm2_analysis](interfacehipfort__hipsparse_1_1hipsparsecbsrsm2__analysis.html "Interface documentation") | C binding, rank_0, rank_1
-142 | [hipsparseZbsrsm2_analysis](interfacehipfort__hipsparse_1_1hipsparsezbsrsm2__analysis.html "Interface documentation") | C binding, rank_0, rank_1
-143 | [hipsparseSbsrsm2_solve](interfacehipfort__hipsparse_1_1hipsparsesbsrsm2__solve.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-144 | [hipsparseDbsrsm2_solve](interfacehipfort__hipsparse_1_1hipsparsedbsrsm2__solve.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-145 | [hipsparseCbsrsm2_solve](interfacehipfort__hipsparse_1_1hipsparsecbsrsm2__solve.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-146 | [hipsparseZbsrsm2_solve](interfacehipfort__hipsparse_1_1hipsparsezbsrsm2__solve.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-147 | [hipsparseScsrmm](interfacehipfort__hipsparse_1_1hipsparsescsrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-148 | [hipsparseDcsrmm](interfacehipfort__hipsparse_1_1hipsparsedcsrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-149 | [hipsparseCcsrmm](interfacehipfort__hipsparse_1_1hipsparseccsrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-150 | [hipsparseZcsrmm](interfacehipfort__hipsparse_1_1hipsparsezcsrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-151 | [hipsparseScsrmm2](interfacehipfort__hipsparse_1_1hipsparsescsrmm2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-152 | [hipsparseDcsrmm2](interfacehipfort__hipsparse_1_1hipsparsedcsrmm2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-153 | [hipsparseCcsrmm2](interfacehipfort__hipsparse_1_1hipsparseccsrmm2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-154 | [hipsparseZcsrmm2](interfacehipfort__hipsparse_1_1hipsparsezcsrmm2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+135 | [hipsparseSbsrsm2_bufferSize](interfacehipfort__hipsparse_1_1hipsparsesbsrsm2__buffersize.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+136 | [hipsparseDbsrsm2_bufferSize](interfacehipfort__hipsparse_1_1hipsparsedbsrsm2__buffersize.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+137 | [hipsparseCbsrsm2_bufferSize](interfacehipfort__hipsparse_1_1hipsparsecbsrsm2__buffersize.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+138 | [hipsparseZbsrsm2_bufferSize](interfacehipfort__hipsparse_1_1hipsparsezbsrsm2__buffersize.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+139 | [hipsparseSbsrsm2_analysis](interfacehipfort__hipsparse_1_1hipsparsesbsrsm2__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+140 | [hipsparseDbsrsm2_analysis](interfacehipfort__hipsparse_1_1hipsparsedbsrsm2__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+141 | [hipsparseCbsrsm2_analysis](interfacehipfort__hipsparse_1_1hipsparsecbsrsm2__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+142 | [hipsparseZbsrsm2_analysis](interfacehipfort__hipsparse_1_1hipsparsezbsrsm2__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+143 | [hipsparseSbsrsm2_solve](interfacehipfort__hipsparse_1_1hipsparsesbsrsm2__solve.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+144 | [hipsparseDbsrsm2_solve](interfacehipfort__hipsparse_1_1hipsparsedbsrsm2__solve.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+145 | [hipsparseCbsrsm2_solve](interfacehipfort__hipsparse_1_1hipsparsecbsrsm2__solve.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+146 | [hipsparseZbsrsm2_solve](interfacehipfort__hipsparse_1_1hipsparsezbsrsm2__solve.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+147 | [hipsparseScsrmm](interfacehipfort__hipsparse_1_1hipsparsescsrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+148 | [hipsparseDcsrmm](interfacehipfort__hipsparse_1_1hipsparsedcsrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+149 | [hipsparseCcsrmm](interfacehipfort__hipsparse_1_1hipsparseccsrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+150 | [hipsparseZcsrmm](interfacehipfort__hipsparse_1_1hipsparsezcsrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+151 | [hipsparseScsrmm2](interfacehipfort__hipsparse_1_1hipsparsescsrmm2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+152 | [hipsparseDcsrmm2](interfacehipfort__hipsparse_1_1hipsparsedcsrmm2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+153 | [hipsparseCcsrmm2](interfacehipfort__hipsparse_1_1hipsparseccsrmm2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+154 | [hipsparseZcsrmm2](interfacehipfort__hipsparse_1_1hipsparsezcsrmm2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 155 | [hipsparseXcsrsm2_zeroPivot](interfacehipfort__hipsparse_1_1hipsparsexcsrsm2__zeropivot.html "Interface documentation") | C binding
-156 | [hipsparseScsrsm2_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsescsrsm2__buffersizeext.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-157 | [hipsparseDcsrsm2_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsedcsrsm2__buffersizeext.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-158 | [hipsparseCcsrsm2_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparseccsrsm2__buffersizeext.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-159 | [hipsparseZcsrsm2_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsezcsrsm2__buffersizeext.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-160 | [hipsparseScsrsm2_analysis](interfacehipfort__hipsparse_1_1hipsparsescsrsm2__analysis.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-161 | [hipsparseDcsrsm2_analysis](interfacehipfort__hipsparse_1_1hipsparsedcsrsm2__analysis.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-162 | [hipsparseCcsrsm2_analysis](interfacehipfort__hipsparse_1_1hipsparseccsrsm2__analysis.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-163 | [hipsparseZcsrsm2_analysis](interfacehipfort__hipsparse_1_1hipsparsezcsrsm2__analysis.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-164 | [hipsparseScsrsm2_solve](interfacehipfort__hipsparse_1_1hipsparsescsrsm2__solve.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-165 | [hipsparseDcsrsm2_solve](interfacehipfort__hipsparse_1_1hipsparsedcsrsm2__solve.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-166 | [hipsparseCcsrsm2_solve](interfacehipfort__hipsparse_1_1hipsparseccsrsm2__solve.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-167 | [hipsparseZcsrsm2_solve](interfacehipfort__hipsparse_1_1hipsparsezcsrsm2__solve.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-168 | [hipsparseSgemmi](interfacehipfort__hipsparse_1_1hipsparsesgemmi.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-169 | [hipsparseDgemmi](interfacehipfort__hipsparse_1_1hipsparsedgemmi.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-170 | [hipsparseCgemmi](interfacehipfort__hipsparse_1_1hipsparsecgemmi.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-171 | [hipsparseZgemmi](interfacehipfort__hipsparse_1_1hipsparsezgemmi.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-172 | [hipsparseXcsrgeamNnz](interfacehipfort__hipsparse_1_1hipsparsexcsrgeamnnz.html "Interface documentation") | C binding, rank_0, rank_1
-173 | [hipsparseScsrgeam](interfacehipfort__hipsparse_1_1hipsparsescsrgeam.html "Interface documentation") | C binding, rank_0, rank_1
-174 | [hipsparseDcsrgeam](interfacehipfort__hipsparse_1_1hipsparsedcsrgeam.html "Interface documentation") | C binding, rank_0, rank_1
-175 | [hipsparseCcsrgeam](interfacehipfort__hipsparse_1_1hipsparseccsrgeam.html "Interface documentation") | C binding, rank_0, rank_1
-176 | [hipsparseZcsrgeam](interfacehipfort__hipsparse_1_1hipsparsezcsrgeam.html "Interface documentation") | C binding, rank_0, rank_1
-177 | [hipsparseScsrgeam2_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsescsrgeam2__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1
-178 | [hipsparseDcsrgeam2_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsedcsrgeam2__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1
-179 | [hipsparseCcsrgeam2_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparseccsrgeam2__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1
-180 | [hipsparseZcsrgeam2_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsezcsrgeam2__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1
-181 | [hipsparseXcsrgeam2Nnz](interfacehipfort__hipsparse_1_1hipsparsexcsrgeam2nnz.html "Interface documentation") | C binding, rank_0, rank_1
-182 | [hipsparseScsrgeam2](interfacehipfort__hipsparse_1_1hipsparsescsrgeam2.html "Interface documentation") | C binding, rank_0, rank_1
-183 | [hipsparseDcsrgeam2](interfacehipfort__hipsparse_1_1hipsparsedcsrgeam2.html "Interface documentation") | C binding, rank_0, rank_1
-184 | [hipsparseCcsrgeam2](interfacehipfort__hipsparse_1_1hipsparseccsrgeam2.html "Interface documentation") | C binding, rank_0, rank_1
-185 | [hipsparseZcsrgeam2](interfacehipfort__hipsparse_1_1hipsparsezcsrgeam2.html "Interface documentation") | C binding, rank_0, rank_1
-186 | [hipsparseXcsrgemmNnz](interfacehipfort__hipsparse_1_1hipsparsexcsrgemmnnz.html "Interface documentation") | C binding, rank_0, rank_1
-187 | [hipsparseScsrgemm](interfacehipfort__hipsparse_1_1hipsparsescsrgemm.html "Interface documentation") | C binding, rank_0, rank_1
-188 | [hipsparseDcsrgemm](interfacehipfort__hipsparse_1_1hipsparsedcsrgemm.html "Interface documentation") | C binding, rank_0, rank_1
-189 | [hipsparseCcsrgemm](interfacehipfort__hipsparse_1_1hipsparseccsrgemm.html "Interface documentation") | C binding, rank_0, rank_1
-190 | [hipsparseZcsrgemm](interfacehipfort__hipsparse_1_1hipsparsezcsrgemm.html "Interface documentation") | C binding, rank_0, rank_1
-191 | [hipsparseScsrgemm2_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsescsrgemm2__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1
-192 | [hipsparseDcsrgemm2_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsedcsrgemm2__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1
-193 | [hipsparseCcsrgemm2_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparseccsrgemm2__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1
-194 | [hipsparseZcsrgemm2_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsezcsrgemm2__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1
-195 | [hipsparseXcsrgemm2Nnz](interfacehipfort__hipsparse_1_1hipsparsexcsrgemm2nnz.html "Interface documentation") | C binding, rank_0, rank_1
-196 | [hipsparseScsrgemm2](interfacehipfort__hipsparse_1_1hipsparsescsrgemm2.html "Interface documentation") | C binding, rank_0, rank_1
-197 | [hipsparseDcsrgemm2](interfacehipfort__hipsparse_1_1hipsparsedcsrgemm2.html "Interface documentation") | C binding, rank_0, rank_1
-198 | [hipsparseCcsrgemm2](interfacehipfort__hipsparse_1_1hipsparseccsrgemm2.html "Interface documentation") | C binding, rank_0, rank_1
-199 | [hipsparseZcsrgemm2](interfacehipfort__hipsparse_1_1hipsparsezcsrgemm2.html "Interface documentation") | C binding, rank_0, rank_1
+156 | [hipsparseScsrsm2_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsescsrsm2__buffersizeext.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+157 | [hipsparseDcsrsm2_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsedcsrsm2__buffersizeext.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+158 | [hipsparseCcsrsm2_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparseccsrsm2__buffersizeext.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+159 | [hipsparseZcsrsm2_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsezcsrsm2__buffersizeext.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+160 | [hipsparseScsrsm2_analysis](interfacehipfort__hipsparse_1_1hipsparsescsrsm2__analysis.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+161 | [hipsparseDcsrsm2_analysis](interfacehipfort__hipsparse_1_1hipsparsedcsrsm2__analysis.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+162 | [hipsparseCcsrsm2_analysis](interfacehipfort__hipsparse_1_1hipsparseccsrsm2__analysis.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+163 | [hipsparseZcsrsm2_analysis](interfacehipfort__hipsparse_1_1hipsparsezcsrsm2__analysis.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+164 | [hipsparseScsrsm2_solve](interfacehipfort__hipsparse_1_1hipsparsescsrsm2__solve.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+165 | [hipsparseDcsrsm2_solve](interfacehipfort__hipsparse_1_1hipsparsedcsrsm2__solve.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+166 | [hipsparseCcsrsm2_solve](interfacehipfort__hipsparse_1_1hipsparseccsrsm2__solve.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+167 | [hipsparseZcsrsm2_solve](interfacehipfort__hipsparse_1_1hipsparsezcsrsm2__solve.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+168 | [hipsparseSgemmi](interfacehipfort__hipsparse_1_1hipsparsesgemmi.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+169 | [hipsparseDgemmi](interfacehipfort__hipsparse_1_1hipsparsedgemmi.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+170 | [hipsparseCgemmi](interfacehipfort__hipsparse_1_1hipsparsecgemmi.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+171 | [hipsparseZgemmi](interfacehipfort__hipsparse_1_1hipsparsezgemmi.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+172 | [hipsparseXcsrgeamNnz](interfacehipfort__hipsparse_1_1hipsparsexcsrgeamnnz.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+173 | [hipsparseScsrgeam](interfacehipfort__hipsparse_1_1hipsparsescsrgeam.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+174 | [hipsparseDcsrgeam](interfacehipfort__hipsparse_1_1hipsparsedcsrgeam.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+175 | [hipsparseCcsrgeam](interfacehipfort__hipsparse_1_1hipsparseccsrgeam.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+176 | [hipsparseZcsrgeam](interfacehipfort__hipsparse_1_1hipsparsezcsrgeam.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+177 | [hipsparseScsrgeam2_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsescsrgeam2__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+178 | [hipsparseDcsrgeam2_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsedcsrgeam2__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+179 | [hipsparseCcsrgeam2_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparseccsrgeam2__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+180 | [hipsparseZcsrgeam2_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsezcsrgeam2__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+181 | [hipsparseXcsrgeam2Nnz](interfacehipfort__hipsparse_1_1hipsparsexcsrgeam2nnz.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+182 | [hipsparseScsrgeam2](interfacehipfort__hipsparse_1_1hipsparsescsrgeam2.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+183 | [hipsparseDcsrgeam2](interfacehipfort__hipsparse_1_1hipsparsedcsrgeam2.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+184 | [hipsparseCcsrgeam2](interfacehipfort__hipsparse_1_1hipsparseccsrgeam2.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+185 | [hipsparseZcsrgeam2](interfacehipfort__hipsparse_1_1hipsparsezcsrgeam2.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+186 | [hipsparseXcsrgemmNnz](interfacehipfort__hipsparse_1_1hipsparsexcsrgemmnnz.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+187 | [hipsparseScsrgemm](interfacehipfort__hipsparse_1_1hipsparsescsrgemm.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+188 | [hipsparseDcsrgemm](interfacehipfort__hipsparse_1_1hipsparsedcsrgemm.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+189 | [hipsparseCcsrgemm](interfacehipfort__hipsparse_1_1hipsparseccsrgemm.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+190 | [hipsparseZcsrgemm](interfacehipfort__hipsparse_1_1hipsparsezcsrgemm.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+191 | [hipsparseScsrgemm2_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsescsrgemm2__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+192 | [hipsparseDcsrgemm2_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsedcsrgemm2__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+193 | [hipsparseCcsrgemm2_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparseccsrgemm2__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+194 | [hipsparseZcsrgemm2_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsezcsrgemm2__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+195 | [hipsparseXcsrgemm2Nnz](interfacehipfort__hipsparse_1_1hipsparsexcsrgemm2nnz.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+196 | [hipsparseScsrgemm2](interfacehipfort__hipsparse_1_1hipsparsescsrgemm2.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+197 | [hipsparseDcsrgemm2](interfacehipfort__hipsparse_1_1hipsparsedcsrgemm2.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+198 | [hipsparseCcsrgemm2](interfacehipfort__hipsparse_1_1hipsparseccsrgemm2.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+199 | [hipsparseZcsrgemm2](interfacehipfort__hipsparse_1_1hipsparsezcsrgemm2.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 200 | [hipsparseXbsric02_zeroPivot](interfacehipfort__hipsparse_1_1hipsparsexbsric02__zeropivot.html "Interface documentation") | C binding
-201 | [hipsparseSbsric02_bufferSize](interfacehipfort__hipsparse_1_1hipsparsesbsric02__buffersize.html "Interface documentation") | C binding, rank_0, rank_1
-202 | [hipsparseDbsric02_bufferSize](interfacehipfort__hipsparse_1_1hipsparsedbsric02__buffersize.html "Interface documentation") | C binding, rank_0, rank_1
-203 | [hipsparseCbsric02_bufferSize](interfacehipfort__hipsparse_1_1hipsparsecbsric02__buffersize.html "Interface documentation") | C binding, rank_0, rank_1
-204 | [hipsparseZbsric02_bufferSize](interfacehipfort__hipsparse_1_1hipsparsezbsric02__buffersize.html "Interface documentation") | C binding, rank_0, rank_1
-205 | [hipsparseSbsric02_analysis](interfacehipfort__hipsparse_1_1hipsparsesbsric02__analysis.html "Interface documentation") | C binding, rank_0, rank_1
-206 | [hipsparseDbsric02_analysis](interfacehipfort__hipsparse_1_1hipsparsedbsric02__analysis.html "Interface documentation") | C binding, rank_0, rank_1
-207 | [hipsparseCbsric02_analysis](interfacehipfort__hipsparse_1_1hipsparsecbsric02__analysis.html "Interface documentation") | C binding, rank_0, rank_1
-208 | [hipsparseZbsric02_analysis](interfacehipfort__hipsparse_1_1hipsparsezbsric02__analysis.html "Interface documentation") | C binding, rank_0, rank_1
-209 | [hipsparseSbsric02](interfacehipfort__hipsparse_1_1hipsparsesbsric02.html "Interface documentation") | C binding, rank_0, rank_1
-210 | [hipsparseDbsric02](interfacehipfort__hipsparse_1_1hipsparsedbsric02.html "Interface documentation") | C binding, rank_0, rank_1
-211 | [hipsparseCbsric02](interfacehipfort__hipsparse_1_1hipsparsecbsric02.html "Interface documentation") | C binding, rank_0, rank_1
-212 | [hipsparseZbsric02](interfacehipfort__hipsparse_1_1hipsparsezbsric02.html "Interface documentation") | C binding, rank_0, rank_1
+201 | [hipsparseSbsric02_bufferSize](interfacehipfort__hipsparse_1_1hipsparsesbsric02__buffersize.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+202 | [hipsparseDbsric02_bufferSize](interfacehipfort__hipsparse_1_1hipsparsedbsric02__buffersize.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+203 | [hipsparseCbsric02_bufferSize](interfacehipfort__hipsparse_1_1hipsparsecbsric02__buffersize.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+204 | [hipsparseZbsric02_bufferSize](interfacehipfort__hipsparse_1_1hipsparsezbsric02__buffersize.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+205 | [hipsparseSbsric02_analysis](interfacehipfort__hipsparse_1_1hipsparsesbsric02__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+206 | [hipsparseDbsric02_analysis](interfacehipfort__hipsparse_1_1hipsparsedbsric02__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+207 | [hipsparseCbsric02_analysis](interfacehipfort__hipsparse_1_1hipsparsecbsric02__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+208 | [hipsparseZbsric02_analysis](interfacehipfort__hipsparse_1_1hipsparsezbsric02__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+209 | [hipsparseSbsric02](interfacehipfort__hipsparse_1_1hipsparsesbsric02.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+210 | [hipsparseDbsric02](interfacehipfort__hipsparse_1_1hipsparsedbsric02.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+211 | [hipsparseCbsric02](interfacehipfort__hipsparse_1_1hipsparsecbsric02.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+212 | [hipsparseZbsric02](interfacehipfort__hipsparse_1_1hipsparsezbsric02.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 213 | [hipsparseXbsrilu02_zeroPivot](interfacehipfort__hipsparse_1_1hipsparsexbsrilu02__zeropivot.html "Interface documentation") | C binding
 214 | [hipsparseSbsrilu02_numericBoost](interfacehipfort__hipsparse_1_1hipsparsesbsrilu02__numericboost.html "Interface documentation") | C binding
 215 | [hipsparseDbsrilu02_numericBoost](interfacehipfort__hipsparse_1_1hipsparsedbsrilu02__numericboost.html "Interface documentation") | C binding
 216 | [hipsparseCbsrilu02_numericBoost](interfacehipfort__hipsparse_1_1hipsparsecbsrilu02__numericboost.html "Interface documentation") | C binding
 217 | [hipsparseZbsrilu02_numericBoost](interfacehipfort__hipsparse_1_1hipsparsezbsrilu02__numericboost.html "Interface documentation") | C binding
-218 | [hipsparseSbsrilu02_bufferSize](interfacehipfort__hipsparse_1_1hipsparsesbsrilu02__buffersize.html "Interface documentation") | C binding, rank_0, rank_1
-219 | [hipsparseDbsrilu02_bufferSize](interfacehipfort__hipsparse_1_1hipsparsedbsrilu02__buffersize.html "Interface documentation") | C binding, rank_0, rank_1
-220 | [hipsparseCbsrilu02_bufferSize](interfacehipfort__hipsparse_1_1hipsparsecbsrilu02__buffersize.html "Interface documentation") | C binding, rank_0, rank_1
-221 | [hipsparseZbsrilu02_bufferSize](interfacehipfort__hipsparse_1_1hipsparsezbsrilu02__buffersize.html "Interface documentation") | C binding, rank_0, rank_1
-222 | [hipsparseSbsrilu02_analysis](interfacehipfort__hipsparse_1_1hipsparsesbsrilu02__analysis.html "Interface documentation") | C binding, rank_0, rank_1
-223 | [hipsparseDbsrilu02_analysis](interfacehipfort__hipsparse_1_1hipsparsedbsrilu02__analysis.html "Interface documentation") | C binding, rank_0, rank_1
-224 | [hipsparseCbsrilu02_analysis](interfacehipfort__hipsparse_1_1hipsparsecbsrilu02__analysis.html "Interface documentation") | C binding, rank_0, rank_1
-225 | [hipsparseZbsrilu02_analysis](interfacehipfort__hipsparse_1_1hipsparsezbsrilu02__analysis.html "Interface documentation") | C binding, rank_0, rank_1
-226 | [hipsparseSbsrilu02](interfacehipfort__hipsparse_1_1hipsparsesbsrilu02.html "Interface documentation") | C binding, rank_0, rank_1
-227 | [hipsparseDbsrilu02](interfacehipfort__hipsparse_1_1hipsparsedbsrilu02.html "Interface documentation") | C binding, rank_0, rank_1
-228 | [hipsparseCbsrilu02](interfacehipfort__hipsparse_1_1hipsparsecbsrilu02.html "Interface documentation") | C binding, rank_0, rank_1
-229 | [hipsparseZbsrilu02](interfacehipfort__hipsparse_1_1hipsparsezbsrilu02.html "Interface documentation") | C binding, rank_0, rank_1
+218 | [hipsparseSbsrilu02_bufferSize](interfacehipfort__hipsparse_1_1hipsparsesbsrilu02__buffersize.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+219 | [hipsparseDbsrilu02_bufferSize](interfacehipfort__hipsparse_1_1hipsparsedbsrilu02__buffersize.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+220 | [hipsparseCbsrilu02_bufferSize](interfacehipfort__hipsparse_1_1hipsparsecbsrilu02__buffersize.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+221 | [hipsparseZbsrilu02_bufferSize](interfacehipfort__hipsparse_1_1hipsparsezbsrilu02__buffersize.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+222 | [hipsparseSbsrilu02_analysis](interfacehipfort__hipsparse_1_1hipsparsesbsrilu02__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+223 | [hipsparseDbsrilu02_analysis](interfacehipfort__hipsparse_1_1hipsparsedbsrilu02__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+224 | [hipsparseCbsrilu02_analysis](interfacehipfort__hipsparse_1_1hipsparsecbsrilu02__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+225 | [hipsparseZbsrilu02_analysis](interfacehipfort__hipsparse_1_1hipsparsezbsrilu02__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+226 | [hipsparseSbsrilu02](interfacehipfort__hipsparse_1_1hipsparsesbsrilu02.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+227 | [hipsparseDbsrilu02](interfacehipfort__hipsparse_1_1hipsparsedbsrilu02.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+228 | [hipsparseCbsrilu02](interfacehipfort__hipsparse_1_1hipsparsecbsrilu02.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+229 | [hipsparseZbsrilu02](interfacehipfort__hipsparse_1_1hipsparsezbsrilu02.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 230 | [hipsparseXcsric02_zeroPivot](interfacehipfort__hipsparse_1_1hipsparsexcsric02__zeropivot.html "Interface documentation") | C binding
-231 | [hipsparseScsric02_bufferSize](interfacehipfort__hipsparse_1_1hipsparsescsric02__buffersize.html "Interface documentation") | C binding, rank_0, rank_1
-232 | [hipsparseDcsric02_bufferSize](interfacehipfort__hipsparse_1_1hipsparsedcsric02__buffersize.html "Interface documentation") | C binding, rank_0, rank_1
-233 | [hipsparseCcsric02_bufferSize](interfacehipfort__hipsparse_1_1hipsparseccsric02__buffersize.html "Interface documentation") | C binding, rank_0, rank_1
-234 | [hipsparseZcsric02_bufferSize](interfacehipfort__hipsparse_1_1hipsparsezcsric02__buffersize.html "Interface documentation") | C binding, rank_0, rank_1
-235 | [hipsparseScsric02_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsescsric02__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1
-236 | [hipsparseDcsric02_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsedcsric02__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1
-237 | [hipsparseCcsric02_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparseccsric02__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1
-238 | [hipsparseZcsric02_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsezcsric02__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1
-239 | [hipsparseScsric02_analysis](interfacehipfort__hipsparse_1_1hipsparsescsric02__analysis.html "Interface documentation") | C binding, rank_0, rank_1
-240 | [hipsparseDcsric02_analysis](interfacehipfort__hipsparse_1_1hipsparsedcsric02__analysis.html "Interface documentation") | C binding, rank_0, rank_1
-241 | [hipsparseCcsric02_analysis](interfacehipfort__hipsparse_1_1hipsparseccsric02__analysis.html "Interface documentation") | C binding, rank_0, rank_1
-242 | [hipsparseZcsric02_analysis](interfacehipfort__hipsparse_1_1hipsparsezcsric02__analysis.html "Interface documentation") | C binding, rank_0, rank_1
-243 | [hipsparseScsric02](interfacehipfort__hipsparse_1_1hipsparsescsric02.html "Interface documentation") | C binding, rank_0, rank_1
-244 | [hipsparseDcsric02](interfacehipfort__hipsparse_1_1hipsparsedcsric02.html "Interface documentation") | C binding, rank_0, rank_1
-245 | [hipsparseCcsric02](interfacehipfort__hipsparse_1_1hipsparseccsric02.html "Interface documentation") | C binding, rank_0, rank_1
-246 | [hipsparseZcsric02](interfacehipfort__hipsparse_1_1hipsparsezcsric02.html "Interface documentation") | C binding, rank_0, rank_1
+231 | [hipsparseScsric02_bufferSize](interfacehipfort__hipsparse_1_1hipsparsescsric02__buffersize.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+232 | [hipsparseDcsric02_bufferSize](interfacehipfort__hipsparse_1_1hipsparsedcsric02__buffersize.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+233 | [hipsparseCcsric02_bufferSize](interfacehipfort__hipsparse_1_1hipsparseccsric02__buffersize.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+234 | [hipsparseZcsric02_bufferSize](interfacehipfort__hipsparse_1_1hipsparsezcsric02__buffersize.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+235 | [hipsparseScsric02_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsescsric02__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+236 | [hipsparseDcsric02_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsedcsric02__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+237 | [hipsparseCcsric02_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparseccsric02__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+238 | [hipsparseZcsric02_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsezcsric02__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+239 | [hipsparseScsric02_analysis](interfacehipfort__hipsparse_1_1hipsparsescsric02__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+240 | [hipsparseDcsric02_analysis](interfacehipfort__hipsparse_1_1hipsparsedcsric02__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+241 | [hipsparseCcsric02_analysis](interfacehipfort__hipsparse_1_1hipsparseccsric02__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+242 | [hipsparseZcsric02_analysis](interfacehipfort__hipsparse_1_1hipsparsezcsric02__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+243 | [hipsparseScsric02](interfacehipfort__hipsparse_1_1hipsparsescsric02.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+244 | [hipsparseDcsric02](interfacehipfort__hipsparse_1_1hipsparsedcsric02.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+245 | [hipsparseCcsric02](interfacehipfort__hipsparse_1_1hipsparseccsric02.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+246 | [hipsparseZcsric02](interfacehipfort__hipsparse_1_1hipsparsezcsric02.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 247 | [hipsparseXcsrilu02_zeroPivot](interfacehipfort__hipsparse_1_1hipsparsexcsrilu02__zeropivot.html "Interface documentation") | C binding
 248 | [hipsparseScsrilu02_numericBoost](interfacehipfort__hipsparse_1_1hipsparsescsrilu02__numericboost.html "Interface documentation") | C binding
 249 | [hipsparseDcsrilu02_numericBoost](interfacehipfort__hipsparse_1_1hipsparsedcsrilu02__numericboost.html "Interface documentation") | C binding
 250 | [hipsparseCcsrilu02_numericBoost](interfacehipfort__hipsparse_1_1hipsparseccsrilu02__numericboost.html "Interface documentation") | C binding
 251 | [hipsparseZcsrilu02_numericBoost](interfacehipfort__hipsparse_1_1hipsparsezcsrilu02__numericboost.html "Interface documentation") | C binding
-252 | [hipsparseScsrilu02_bufferSize](interfacehipfort__hipsparse_1_1hipsparsescsrilu02__buffersize.html "Interface documentation") | C binding, rank_0, rank_1
-253 | [hipsparseDcsrilu02_bufferSize](interfacehipfort__hipsparse_1_1hipsparsedcsrilu02__buffersize.html "Interface documentation") | C binding, rank_0, rank_1
-254 | [hipsparseCcsrilu02_bufferSize](interfacehipfort__hipsparse_1_1hipsparseccsrilu02__buffersize.html "Interface documentation") | C binding, rank_0, rank_1
-255 | [hipsparseZcsrilu02_bufferSize](interfacehipfort__hipsparse_1_1hipsparsezcsrilu02__buffersize.html "Interface documentation") | C binding, rank_0, rank_1
-256 | [hipsparseScsrilu02_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsescsrilu02__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1
-257 | [hipsparseDcsrilu02_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsedcsrilu02__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1
-258 | [hipsparseCcsrilu02_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparseccsrilu02__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1
-259 | [hipsparseZcsrilu02_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsezcsrilu02__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1
-260 | [hipsparseScsrilu02_analysis](interfacehipfort__hipsparse_1_1hipsparsescsrilu02__analysis.html "Interface documentation") | C binding, rank_0, rank_1
-261 | [hipsparseDcsrilu02_analysis](interfacehipfort__hipsparse_1_1hipsparsedcsrilu02__analysis.html "Interface documentation") | C binding, rank_0, rank_1
-262 | [hipsparseCcsrilu02_analysis](interfacehipfort__hipsparse_1_1hipsparseccsrilu02__analysis.html "Interface documentation") | C binding, rank_0, rank_1
-263 | [hipsparseZcsrilu02_analysis](interfacehipfort__hipsparse_1_1hipsparsezcsrilu02__analysis.html "Interface documentation") | C binding, rank_0, rank_1
-264 | [hipsparseScsrilu02](interfacehipfort__hipsparse_1_1hipsparsescsrilu02.html "Interface documentation") | C binding, rank_0, rank_1
-265 | [hipsparseDcsrilu02](interfacehipfort__hipsparse_1_1hipsparsedcsrilu02.html "Interface documentation") | C binding, rank_0, rank_1
-266 | [hipsparseCcsrilu02](interfacehipfort__hipsparse_1_1hipsparseccsrilu02.html "Interface documentation") | C binding, rank_0, rank_1
-267 | [hipsparseZcsrilu02](interfacehipfort__hipsparse_1_1hipsparsezcsrilu02.html "Interface documentation") | C binding, rank_0, rank_1
-268 | [hipsparseSgpsvInterleavedBatch_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsesgpsvinterleavedbatch__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1
-269 | [hipsparseDgpsvInterleavedBatch_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsedgpsvinterleavedbatch__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1
-270 | [hipsparseCgpsvInterleavedBatch_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsecgpsvinterleavedbatch__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1
-271 | [hipsparseZgpsvInterleavedBatch_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsezgpsvinterleavedbatch__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1
-272 | [hipsparseSgpsvInterleavedBatch](interfacehipfort__hipsparse_1_1hipsparsesgpsvinterleavedbatch.html "Interface documentation") | C binding, rank_0, rank_1
-273 | [hipsparseDgpsvInterleavedBatch](interfacehipfort__hipsparse_1_1hipsparsedgpsvinterleavedbatch.html "Interface documentation") | C binding, rank_0, rank_1
-274 | [hipsparseCgpsvInterleavedBatch](interfacehipfort__hipsparse_1_1hipsparsecgpsvinterleavedbatch.html "Interface documentation") | C binding, rank_0, rank_1
-275 | [hipsparseZgpsvInterleavedBatch](interfacehipfort__hipsparse_1_1hipsparsezgpsvinterleavedbatch.html "Interface documentation") | C binding, rank_0, rank_1
-276 | [hipsparseSgtsv2_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsesgtsv2__buffersizeext.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-277 | [hipsparseDgtsv2_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsedgtsv2__buffersizeext.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-278 | [hipsparseCgtsv2_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsecgtsv2__buffersizeext.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-279 | [hipsparseZgtsv2_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsezgtsv2__buffersizeext.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-280 | [hipsparseSgtsv2](interfacehipfort__hipsparse_1_1hipsparsesgtsv2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-281 | [hipsparseDgtsv2](interfacehipfort__hipsparse_1_1hipsparsedgtsv2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-282 | [hipsparseCgtsv2](interfacehipfort__hipsparse_1_1hipsparsecgtsv2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-283 | [hipsparseZgtsv2](interfacehipfort__hipsparse_1_1hipsparsezgtsv2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+252 | [hipsparseScsrilu02_bufferSize](interfacehipfort__hipsparse_1_1hipsparsescsrilu02__buffersize.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+253 | [hipsparseDcsrilu02_bufferSize](interfacehipfort__hipsparse_1_1hipsparsedcsrilu02__buffersize.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+254 | [hipsparseCcsrilu02_bufferSize](interfacehipfort__hipsparse_1_1hipsparseccsrilu02__buffersize.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+255 | [hipsparseZcsrilu02_bufferSize](interfacehipfort__hipsparse_1_1hipsparsezcsrilu02__buffersize.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+256 | [hipsparseScsrilu02_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsescsrilu02__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+257 | [hipsparseDcsrilu02_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsedcsrilu02__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+258 | [hipsparseCcsrilu02_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparseccsrilu02__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+259 | [hipsparseZcsrilu02_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsezcsrilu02__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+260 | [hipsparseScsrilu02_analysis](interfacehipfort__hipsparse_1_1hipsparsescsrilu02__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+261 | [hipsparseDcsrilu02_analysis](interfacehipfort__hipsparse_1_1hipsparsedcsrilu02__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+262 | [hipsparseCcsrilu02_analysis](interfacehipfort__hipsparse_1_1hipsparseccsrilu02__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+263 | [hipsparseZcsrilu02_analysis](interfacehipfort__hipsparse_1_1hipsparsezcsrilu02__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+264 | [hipsparseScsrilu02](interfacehipfort__hipsparse_1_1hipsparsescsrilu02.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+265 | [hipsparseDcsrilu02](interfacehipfort__hipsparse_1_1hipsparsedcsrilu02.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+266 | [hipsparseCcsrilu02](interfacehipfort__hipsparse_1_1hipsparseccsrilu02.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+267 | [hipsparseZcsrilu02](interfacehipfort__hipsparse_1_1hipsparsezcsrilu02.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+268 | [hipsparseSgpsvInterleavedBatch_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsesgpsvinterleavedbatch__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+269 | [hipsparseDgpsvInterleavedBatch_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsedgpsvinterleavedbatch__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+270 | [hipsparseCgpsvInterleavedBatch_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsecgpsvinterleavedbatch__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+271 | [hipsparseZgpsvInterleavedBatch_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsezgpsvinterleavedbatch__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+272 | [hipsparseSgpsvInterleavedBatch](interfacehipfort__hipsparse_1_1hipsparsesgpsvinterleavedbatch.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+273 | [hipsparseDgpsvInterleavedBatch](interfacehipfort__hipsparse_1_1hipsparsedgpsvinterleavedbatch.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+274 | [hipsparseCgpsvInterleavedBatch](interfacehipfort__hipsparse_1_1hipsparsecgpsvinterleavedbatch.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+275 | [hipsparseZgpsvInterleavedBatch](interfacehipfort__hipsparse_1_1hipsparsezgpsvinterleavedbatch.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+276 | [hipsparseSgtsv2_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsesgtsv2__buffersizeext.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+277 | [hipsparseDgtsv2_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsedgtsv2__buffersizeext.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+278 | [hipsparseCgtsv2_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsecgtsv2__buffersizeext.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+279 | [hipsparseZgtsv2_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsezgtsv2__buffersizeext.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+280 | [hipsparseSgtsv2](interfacehipfort__hipsparse_1_1hipsparsesgtsv2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+281 | [hipsparseDgtsv2](interfacehipfort__hipsparse_1_1hipsparsedgtsv2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+282 | [hipsparseCgtsv2](interfacehipfort__hipsparse_1_1hipsparsecgtsv2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+283 | [hipsparseZgtsv2](interfacehipfort__hipsparse_1_1hipsparsezgtsv2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 284 | [hipsparseSgtsvInterleavedBatch_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsesgtsvinterleavedbatch__buffersizeext.html "Interface documentation") | C binding
 285 | [hipsparseDgtsvInterleavedBatch_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsedgtsvinterleavedbatch__buffersizeext.html "Interface documentation") | C binding
 286 | [hipsparseCgtsvInterleavedBatch_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsecgtsvinterleavedbatch__buffersizeext.html "Interface documentation") | C binding
@@ -293,96 +293,96 @@
 289 | [hipsparseDgtsvInterleavedBatch](interfacehipfort__hipsparse_1_1hipsparsedgtsvinterleavedbatch.html "Interface documentation") | C binding
 290 | [hipsparseCgtsvInterleavedBatch](interfacehipfort__hipsparse_1_1hipsparsecgtsvinterleavedbatch.html "Interface documentation") | C binding
 291 | [hipsparseZgtsvInterleavedBatch](interfacehipfort__hipsparse_1_1hipsparsezgtsvinterleavedbatch.html "Interface documentation") | C binding
-292 | [hipsparseSgtsv2_nopivot_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsesgtsv2__nopivot__buffersizeext.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-293 | [hipsparseDgtsv2_nopivot_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsedgtsv2__nopivot__buffersizeext.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-294 | [hipsparseCgtsv2_nopivot_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsecgtsv2__nopivot__buffersizeext.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-295 | [hipsparseZgtsv2_nopivot_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsezgtsv2__nopivot__buffersizeext.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-296 | [hipsparseSgtsv2_nopivot](interfacehipfort__hipsparse_1_1hipsparsesgtsv2__nopivot.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-297 | [hipsparseDgtsv2_nopivot](interfacehipfort__hipsparse_1_1hipsparsedgtsv2__nopivot.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-298 | [hipsparseCgtsv2_nopivot](interfacehipfort__hipsparse_1_1hipsparsecgtsv2__nopivot.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-299 | [hipsparseZgtsv2_nopivot](interfacehipfort__hipsparse_1_1hipsparsezgtsv2__nopivot.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-300 | [hipsparseSgtsv2StridedBatch_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsesgtsv2stridedbatch__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1
-301 | [hipsparseDgtsv2StridedBatch_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsedgtsv2stridedbatch__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1
-302 | [hipsparseCgtsv2StridedBatch_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsecgtsv2stridedbatch__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1
-303 | [hipsparseZgtsv2StridedBatch_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsezgtsv2stridedbatch__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1
-304 | [hipsparseSgtsv2StridedBatch](interfacehipfort__hipsparse_1_1hipsparsesgtsv2stridedbatch.html "Interface documentation") | C binding, rank_0, rank_1
-305 | [hipsparseDgtsv2StridedBatch](interfacehipfort__hipsparse_1_1hipsparsedgtsv2stridedbatch.html "Interface documentation") | C binding, rank_0, rank_1
-306 | [hipsparseCgtsv2StridedBatch](interfacehipfort__hipsparse_1_1hipsparsecgtsv2stridedbatch.html "Interface documentation") | C binding, rank_0, rank_1
-307 | [hipsparseZgtsv2StridedBatch](interfacehipfort__hipsparse_1_1hipsparsezgtsv2stridedbatch.html "Interface documentation") | C binding, rank_0, rank_1
-308 | [hipsparseSbsr2csr](interfacehipfort__hipsparse_1_1hipsparsesbsr2csr.html "Interface documentation") | C binding, rank_0, rank_1
-309 | [hipsparseDbsr2csr](interfacehipfort__hipsparse_1_1hipsparsedbsr2csr.html "Interface documentation") | C binding, rank_0, rank_1
-310 | [hipsparseCbsr2csr](interfacehipfort__hipsparse_1_1hipsparsecbsr2csr.html "Interface documentation") | C binding, rank_0, rank_1
-311 | [hipsparseZbsr2csr](interfacehipfort__hipsparse_1_1hipsparsezbsr2csr.html "Interface documentation") | C binding, rank_0, rank_1
-312 | [hipsparseXcoo2csr](interfacehipfort__hipsparse_1_1hipsparsexcoo2csr.html "Interface documentation") | C binding, rank_0, rank_1
-313 | [hipsparseXcoosort_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsexcoosort__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1
-314 | [hipsparseXcoosortByRow](interfacehipfort__hipsparse_1_1hipsparsexcoosortbyrow.html "Interface documentation") | C binding, rank_0, rank_1
-315 | [hipsparseXcoosortByColumn](interfacehipfort__hipsparse_1_1hipsparsexcoosortbycolumn.html "Interface documentation") | C binding, rank_0, rank_1
-316 | [hipsparseCreateIdentityPermutation](interfacehipfort__hipsparse_1_1hipsparsecreateidentitypermutation.html "Interface documentation") | C binding, rank_0, rank_1
-317 | [hipsparseScsc2dense](interfacehipfort__hipsparse_1_1hipsparsescsc2dense.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-318 | [hipsparseDcsc2dense](interfacehipfort__hipsparse_1_1hipsparsedcsc2dense.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-319 | [hipsparseCcsc2dense](interfacehipfort__hipsparse_1_1hipsparseccsc2dense.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-320 | [hipsparseZcsc2dense](interfacehipfort__hipsparse_1_1hipsparsezcsc2dense.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-321 | [hipsparseXcscsort_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsexcscsort__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1
-322 | [hipsparseXcscsort](interfacehipfort__hipsparse_1_1hipsparsexcscsort.html "Interface documentation") | C binding, rank_0, rank_1
-323 | [hipsparseXcsr2bsrNnz](interfacehipfort__hipsparse_1_1hipsparsexcsr2bsrnnz.html "Interface documentation") | C binding, rank_0, rank_1
-324 | [hipsparseScsr2bsr](interfacehipfort__hipsparse_1_1hipsparsescsr2bsr.html "Interface documentation") | C binding, rank_0, rank_1
-325 | [hipsparseDcsr2bsr](interfacehipfort__hipsparse_1_1hipsparsedcsr2bsr.html "Interface documentation") | C binding, rank_0, rank_1
-326 | [hipsparseCcsr2bsr](interfacehipfort__hipsparse_1_1hipsparseccsr2bsr.html "Interface documentation") | C binding, rank_0, rank_1
-327 | [hipsparseZcsr2bsr](interfacehipfort__hipsparse_1_1hipsparsezcsr2bsr.html "Interface documentation") | C binding, rank_0, rank_1
-328 | [hipsparseXcsr2coo](interfacehipfort__hipsparse_1_1hipsparsexcsr2coo.html "Interface documentation") | C binding, rank_0, rank_1
-329 | [hipsparseScsr2csc](interfacehipfort__hipsparse_1_1hipsparsescsr2csc.html "Interface documentation") | C binding, rank_0, rank_1
-330 | [hipsparseDcsr2csc](interfacehipfort__hipsparse_1_1hipsparsedcsr2csc.html "Interface documentation") | C binding, rank_0, rank_1
-331 | [hipsparseCcsr2csc](interfacehipfort__hipsparse_1_1hipsparseccsr2csc.html "Interface documentation") | C binding, rank_0, rank_1
-332 | [hipsparseZcsr2csc](interfacehipfort__hipsparse_1_1hipsparsezcsr2csc.html "Interface documentation") | C binding, rank_0, rank_1
+292 | [hipsparseSgtsv2_nopivot_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsesgtsv2__nopivot__buffersizeext.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+293 | [hipsparseDgtsv2_nopivot_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsedgtsv2__nopivot__buffersizeext.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+294 | [hipsparseCgtsv2_nopivot_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsecgtsv2__nopivot__buffersizeext.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+295 | [hipsparseZgtsv2_nopivot_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsezgtsv2__nopivot__buffersizeext.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+296 | [hipsparseSgtsv2_nopivot](interfacehipfort__hipsparse_1_1hipsparsesgtsv2__nopivot.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+297 | [hipsparseDgtsv2_nopivot](interfacehipfort__hipsparse_1_1hipsparsedgtsv2__nopivot.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+298 | [hipsparseCgtsv2_nopivot](interfacehipfort__hipsparse_1_1hipsparsecgtsv2__nopivot.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+299 | [hipsparseZgtsv2_nopivot](interfacehipfort__hipsparse_1_1hipsparsezgtsv2__nopivot.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+300 | [hipsparseSgtsv2StridedBatch_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsesgtsv2stridedbatch__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+301 | [hipsparseDgtsv2StridedBatch_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsedgtsv2stridedbatch__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+302 | [hipsparseCgtsv2StridedBatch_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsecgtsv2stridedbatch__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+303 | [hipsparseZgtsv2StridedBatch_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsezgtsv2stridedbatch__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+304 | [hipsparseSgtsv2StridedBatch](interfacehipfort__hipsparse_1_1hipsparsesgtsv2stridedbatch.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+305 | [hipsparseDgtsv2StridedBatch](interfacehipfort__hipsparse_1_1hipsparsedgtsv2stridedbatch.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+306 | [hipsparseCgtsv2StridedBatch](interfacehipfort__hipsparse_1_1hipsparsecgtsv2stridedbatch.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+307 | [hipsparseZgtsv2StridedBatch](interfacehipfort__hipsparse_1_1hipsparsezgtsv2stridedbatch.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+308 | [hipsparseSbsr2csr](interfacehipfort__hipsparse_1_1hipsparsesbsr2csr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+309 | [hipsparseDbsr2csr](interfacehipfort__hipsparse_1_1hipsparsedbsr2csr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+310 | [hipsparseCbsr2csr](interfacehipfort__hipsparse_1_1hipsparsecbsr2csr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+311 | [hipsparseZbsr2csr](interfacehipfort__hipsparse_1_1hipsparsezbsr2csr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+312 | [hipsparseXcoo2csr](interfacehipfort__hipsparse_1_1hipsparsexcoo2csr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+313 | [hipsparseXcoosort_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsexcoosort__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+314 | [hipsparseXcoosortByRow](interfacehipfort__hipsparse_1_1hipsparsexcoosortbyrow.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+315 | [hipsparseXcoosortByColumn](interfacehipfort__hipsparse_1_1hipsparsexcoosortbycolumn.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+316 | [hipsparseCreateIdentityPermutation](interfacehipfort__hipsparse_1_1hipsparsecreateidentitypermutation.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+317 | [hipsparseScsc2dense](interfacehipfort__hipsparse_1_1hipsparsescsc2dense.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+318 | [hipsparseDcsc2dense](interfacehipfort__hipsparse_1_1hipsparsedcsc2dense.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+319 | [hipsparseCcsc2dense](interfacehipfort__hipsparse_1_1hipsparseccsc2dense.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+320 | [hipsparseZcsc2dense](interfacehipfort__hipsparse_1_1hipsparsezcsc2dense.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+321 | [hipsparseXcscsort_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsexcscsort__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+322 | [hipsparseXcscsort](interfacehipfort__hipsparse_1_1hipsparsexcscsort.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+323 | [hipsparseXcsr2bsrNnz](interfacehipfort__hipsparse_1_1hipsparsexcsr2bsrnnz.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+324 | [hipsparseScsr2bsr](interfacehipfort__hipsparse_1_1hipsparsescsr2bsr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+325 | [hipsparseDcsr2bsr](interfacehipfort__hipsparse_1_1hipsparsedcsr2bsr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+326 | [hipsparseCcsr2bsr](interfacehipfort__hipsparse_1_1hipsparseccsr2bsr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+327 | [hipsparseZcsr2bsr](interfacehipfort__hipsparse_1_1hipsparsezcsr2bsr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+328 | [hipsparseXcsr2coo](interfacehipfort__hipsparse_1_1hipsparsexcsr2coo.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+329 | [hipsparseScsr2csc](interfacehipfort__hipsparse_1_1hipsparsescsr2csc.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+330 | [hipsparseDcsr2csc](interfacehipfort__hipsparse_1_1hipsparsedcsr2csc.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+331 | [hipsparseCcsr2csc](interfacehipfort__hipsparse_1_1hipsparseccsr2csc.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+332 | [hipsparseZcsr2csc](interfacehipfort__hipsparse_1_1hipsparsezcsr2csc.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 333 | [hipsparseCsr2cscEx2_bufferSize](interfacehipfort__hipsparse_1_1hipsparsecsr2cscex2__buffersize.html "Interface documentation") | C binding
 334 | [hipsparseCsr2cscEx2](interfacehipfort__hipsparse_1_1hipsparsecsr2cscex2.html "Interface documentation") | C binding
-335 | [hipsparseScsr2csr_compress](interfacehipfort__hipsparse_1_1hipsparsescsr2csr__compress.html "Interface documentation") | C binding, rank_0, rank_1
-336 | [hipsparseDcsr2csr_compress](interfacehipfort__hipsparse_1_1hipsparsedcsr2csr__compress.html "Interface documentation") | C binding, rank_0, rank_1
-337 | [hipsparseCcsr2csr_compress](interfacehipfort__hipsparse_1_1hipsparseccsr2csr__compress.html "Interface documentation") | C binding, rank_0, rank_1
-338 | [hipsparseZcsr2csr_compress](interfacehipfort__hipsparse_1_1hipsparsezcsr2csr__compress.html "Interface documentation") | C binding, rank_0, rank_1
-339 | [hipsparseScsr2csru](interfacehipfort__hipsparse_1_1hipsparsescsr2csru.html "Interface documentation") | C binding, rank_0, rank_1
-340 | [hipsparseDcsr2csru](interfacehipfort__hipsparse_1_1hipsparsedcsr2csru.html "Interface documentation") | C binding, rank_0, rank_1
-341 | [hipsparseCcsr2csru](interfacehipfort__hipsparse_1_1hipsparseccsr2csru.html "Interface documentation") | C binding, rank_0, rank_1
-342 | [hipsparseZcsr2csru](interfacehipfort__hipsparse_1_1hipsparsezcsr2csru.html "Interface documentation") | C binding, rank_0, rank_1
-343 | [hipsparseScsr2dense](interfacehipfort__hipsparse_1_1hipsparsescsr2dense.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-344 | [hipsparseDcsr2dense](interfacehipfort__hipsparse_1_1hipsparsedcsr2dense.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-345 | [hipsparseCcsr2dense](interfacehipfort__hipsparse_1_1hipsparseccsr2dense.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-346 | [hipsparseZcsr2dense](interfacehipfort__hipsparse_1_1hipsparsezcsr2dense.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-347 | [hipsparseScsr2gebsr_bufferSize](interfacehipfort__hipsparse_1_1hipsparsescsr2gebsr__buffersize.html "Interface documentation") | C binding, rank_0, rank_1
-348 | [hipsparseDcsr2gebsr_bufferSize](interfacehipfort__hipsparse_1_1hipsparsedcsr2gebsr__buffersize.html "Interface documentation") | C binding, rank_0, rank_1
-349 | [hipsparseCcsr2gebsr_bufferSize](interfacehipfort__hipsparse_1_1hipsparseccsr2gebsr__buffersize.html "Interface documentation") | C binding, rank_0, rank_1
-350 | [hipsparseZcsr2gebsr_bufferSize](interfacehipfort__hipsparse_1_1hipsparsezcsr2gebsr__buffersize.html "Interface documentation") | C binding, rank_0, rank_1
-351 | [hipsparseXcsr2gebsrNnz](interfacehipfort__hipsparse_1_1hipsparsexcsr2gebsrnnz.html "Interface documentation") | C binding, rank_0, rank_1
-352 | [hipsparseScsr2gebsr](interfacehipfort__hipsparse_1_1hipsparsescsr2gebsr.html "Interface documentation") | C binding, rank_0, rank_1
-353 | [hipsparseDcsr2gebsr](interfacehipfort__hipsparse_1_1hipsparsedcsr2gebsr.html "Interface documentation") | C binding, rank_0, rank_1
-354 | [hipsparseCcsr2gebsr](interfacehipfort__hipsparse_1_1hipsparseccsr2gebsr.html "Interface documentation") | C binding, rank_0, rank_1
-355 | [hipsparseZcsr2gebsr](interfacehipfort__hipsparse_1_1hipsparsezcsr2gebsr.html "Interface documentation") | C binding, rank_0, rank_1
-356 | [hipsparseScsr2hyb](interfacehipfort__hipsparse_1_1hipsparsescsr2hyb.html "Interface documentation") | C binding, rank_0, rank_1
-357 | [hipsparseDcsr2hyb](interfacehipfort__hipsparse_1_1hipsparsedcsr2hyb.html "Interface documentation") | C binding, rank_0, rank_1
-358 | [hipsparseCcsr2hyb](interfacehipfort__hipsparse_1_1hipsparseccsr2hyb.html "Interface documentation") | C binding, rank_0, rank_1
-359 | [hipsparseZcsr2hyb](interfacehipfort__hipsparse_1_1hipsparsezcsr2hyb.html "Interface documentation") | C binding, rank_0, rank_1
-360 | [hipsparseXcsrsort_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsexcsrsort__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1
-361 | [hipsparseXcsrsort](interfacehipfort__hipsparse_1_1hipsparsexcsrsort.html "Interface documentation") | C binding, rank_0, rank_1
-362 | [hipsparseScsru2csr_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsescsru2csr__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1
-363 | [hipsparseDcsru2csr_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsedcsru2csr__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1
-364 | [hipsparseCcsru2csr_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparseccsru2csr__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1
-365 | [hipsparseZcsru2csr_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsezcsru2csr__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1
-366 | [hipsparseScsru2csr](interfacehipfort__hipsparse_1_1hipsparsescsru2csr.html "Interface documentation") | C binding, rank_0, rank_1
-367 | [hipsparseDcsru2csr](interfacehipfort__hipsparse_1_1hipsparsedcsru2csr.html "Interface documentation") | C binding, rank_0, rank_1
-368 | [hipsparseCcsru2csr](interfacehipfort__hipsparse_1_1hipsparseccsru2csr.html "Interface documentation") | C binding, rank_0, rank_1
-369 | [hipsparseZcsru2csr](interfacehipfort__hipsparse_1_1hipsparsezcsru2csr.html "Interface documentation") | C binding, rank_0, rank_1
-370 | [hipsparseSdense2csc](interfacehipfort__hipsparse_1_1hipsparsesdense2csc.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-371 | [hipsparseDdense2csc](interfacehipfort__hipsparse_1_1hipsparseddense2csc.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-372 | [hipsparseCdense2csc](interfacehipfort__hipsparse_1_1hipsparsecdense2csc.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-373 | [hipsparseZdense2csc](interfacehipfort__hipsparse_1_1hipsparsezdense2csc.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-374 | [hipsparseSdense2csr](interfacehipfort__hipsparse_1_1hipsparsesdense2csr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-375 | [hipsparseDdense2csr](interfacehipfort__hipsparse_1_1hipsparseddense2csr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-376 | [hipsparseCdense2csr](interfacehipfort__hipsparse_1_1hipsparsecdense2csr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-377 | [hipsparseZdense2csr](interfacehipfort__hipsparse_1_1hipsparsezdense2csr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-378 | [hipsparseSgebsr2csr](interfacehipfort__hipsparse_1_1hipsparsesgebsr2csr.html "Interface documentation") | C binding, rank_0, rank_1
-379 | [hipsparseDgebsr2csr](interfacehipfort__hipsparse_1_1hipsparsedgebsr2csr.html "Interface documentation") | C binding, rank_0, rank_1
-380 | [hipsparseCgebsr2csr](interfacehipfort__hipsparse_1_1hipsparsecgebsr2csr.html "Interface documentation") | C binding, rank_0, rank_1
-381 | [hipsparseZgebsr2csr](interfacehipfort__hipsparse_1_1hipsparsezgebsr2csr.html "Interface documentation") | C binding, rank_0, rank_1
+335 | [hipsparseScsr2csr_compress](interfacehipfort__hipsparse_1_1hipsparsescsr2csr__compress.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+336 | [hipsparseDcsr2csr_compress](interfacehipfort__hipsparse_1_1hipsparsedcsr2csr__compress.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+337 | [hipsparseCcsr2csr_compress](interfacehipfort__hipsparse_1_1hipsparseccsr2csr__compress.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+338 | [hipsparseZcsr2csr_compress](interfacehipfort__hipsparse_1_1hipsparsezcsr2csr__compress.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+339 | [hipsparseScsr2csru](interfacehipfort__hipsparse_1_1hipsparsescsr2csru.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+340 | [hipsparseDcsr2csru](interfacehipfort__hipsparse_1_1hipsparsedcsr2csru.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+341 | [hipsparseCcsr2csru](interfacehipfort__hipsparse_1_1hipsparseccsr2csru.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+342 | [hipsparseZcsr2csru](interfacehipfort__hipsparse_1_1hipsparsezcsr2csru.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+343 | [hipsparseScsr2dense](interfacehipfort__hipsparse_1_1hipsparsescsr2dense.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+344 | [hipsparseDcsr2dense](interfacehipfort__hipsparse_1_1hipsparsedcsr2dense.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+345 | [hipsparseCcsr2dense](interfacehipfort__hipsparse_1_1hipsparseccsr2dense.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+346 | [hipsparseZcsr2dense](interfacehipfort__hipsparse_1_1hipsparsezcsr2dense.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+347 | [hipsparseScsr2gebsr_bufferSize](interfacehipfort__hipsparse_1_1hipsparsescsr2gebsr__buffersize.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+348 | [hipsparseDcsr2gebsr_bufferSize](interfacehipfort__hipsparse_1_1hipsparsedcsr2gebsr__buffersize.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+349 | [hipsparseCcsr2gebsr_bufferSize](interfacehipfort__hipsparse_1_1hipsparseccsr2gebsr__buffersize.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+350 | [hipsparseZcsr2gebsr_bufferSize](interfacehipfort__hipsparse_1_1hipsparsezcsr2gebsr__buffersize.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+351 | [hipsparseXcsr2gebsrNnz](interfacehipfort__hipsparse_1_1hipsparsexcsr2gebsrnnz.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+352 | [hipsparseScsr2gebsr](interfacehipfort__hipsparse_1_1hipsparsescsr2gebsr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+353 | [hipsparseDcsr2gebsr](interfacehipfort__hipsparse_1_1hipsparsedcsr2gebsr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+354 | [hipsparseCcsr2gebsr](interfacehipfort__hipsparse_1_1hipsparseccsr2gebsr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+355 | [hipsparseZcsr2gebsr](interfacehipfort__hipsparse_1_1hipsparsezcsr2gebsr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+356 | [hipsparseScsr2hyb](interfacehipfort__hipsparse_1_1hipsparsescsr2hyb.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+357 | [hipsparseDcsr2hyb](interfacehipfort__hipsparse_1_1hipsparsedcsr2hyb.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+358 | [hipsparseCcsr2hyb](interfacehipfort__hipsparse_1_1hipsparseccsr2hyb.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+359 | [hipsparseZcsr2hyb](interfacehipfort__hipsparse_1_1hipsparsezcsr2hyb.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+360 | [hipsparseXcsrsort_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsexcsrsort__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+361 | [hipsparseXcsrsort](interfacehipfort__hipsparse_1_1hipsparsexcsrsort.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+362 | [hipsparseScsru2csr_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsescsru2csr__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+363 | [hipsparseDcsru2csr_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsedcsru2csr__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+364 | [hipsparseCcsru2csr_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparseccsru2csr__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+365 | [hipsparseZcsru2csr_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsezcsru2csr__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+366 | [hipsparseScsru2csr](interfacehipfort__hipsparse_1_1hipsparsescsru2csr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+367 | [hipsparseDcsru2csr](interfacehipfort__hipsparse_1_1hipsparsedcsru2csr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+368 | [hipsparseCcsru2csr](interfacehipfort__hipsparse_1_1hipsparseccsru2csr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+369 | [hipsparseZcsru2csr](interfacehipfort__hipsparse_1_1hipsparsezcsru2csr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+370 | [hipsparseSdense2csc](interfacehipfort__hipsparse_1_1hipsparsesdense2csc.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+371 | [hipsparseDdense2csc](interfacehipfort__hipsparse_1_1hipsparseddense2csc.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+372 | [hipsparseCdense2csc](interfacehipfort__hipsparse_1_1hipsparsecdense2csc.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+373 | [hipsparseZdense2csc](interfacehipfort__hipsparse_1_1hipsparsezdense2csc.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+374 | [hipsparseSdense2csr](interfacehipfort__hipsparse_1_1hipsparsesdense2csr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+375 | [hipsparseDdense2csr](interfacehipfort__hipsparse_1_1hipsparseddense2csr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+376 | [hipsparseCdense2csr](interfacehipfort__hipsparse_1_1hipsparsecdense2csr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+377 | [hipsparseZdense2csr](interfacehipfort__hipsparse_1_1hipsparsezdense2csr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+378 | [hipsparseSgebsr2csr](interfacehipfort__hipsparse_1_1hipsparsesgebsr2csr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+379 | [hipsparseDgebsr2csr](interfacehipfort__hipsparse_1_1hipsparsedgebsr2csr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+380 | [hipsparseCgebsr2csr](interfacehipfort__hipsparse_1_1hipsparsecgebsr2csr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+381 | [hipsparseZgebsr2csr](interfacehipfort__hipsparse_1_1hipsparsezgebsr2csr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 382 | [hipsparseSgebsr2gebsc_bufferSize](interfacehipfort__hipsparse_1_1hipsparsesgebsr2gebsc__buffersize.html "Interface documentation") | C binding
 383 | [hipsparseDgebsr2gebsc_bufferSize](interfacehipfort__hipsparse_1_1hipsparsedgebsr2gebsc__buffersize.html "Interface documentation") | C binding
 384 | [hipsparseCgebsr2gebsc_bufferSize](interfacehipfort__hipsparse_1_1hipsparsecgebsr2gebsc__buffersize.html "Interface documentation") | C binding
@@ -391,63 +391,63 @@
 387 | [hipsparseDgebsr2gebsc](interfacehipfort__hipsparse_1_1hipsparsedgebsr2gebsc.html "Interface documentation") | C binding
 388 | [hipsparseCgebsr2gebsc](interfacehipfort__hipsparse_1_1hipsparsecgebsr2gebsc.html "Interface documentation") | C binding
 389 | [hipsparseZgebsr2gebsc](interfacehipfort__hipsparse_1_1hipsparsezgebsr2gebsc.html "Interface documentation") | C binding
-390 | [hipsparseSgebsr2gebsr_bufferSize](interfacehipfort__hipsparse_1_1hipsparsesgebsr2gebsr__buffersize.html "Interface documentation") | C binding, rank_0, rank_1
-391 | [hipsparseDgebsr2gebsr_bufferSize](interfacehipfort__hipsparse_1_1hipsparsedgebsr2gebsr__buffersize.html "Interface documentation") | C binding, rank_0, rank_1
-392 | [hipsparseCgebsr2gebsr_bufferSize](interfacehipfort__hipsparse_1_1hipsparsecgebsr2gebsr__buffersize.html "Interface documentation") | C binding, rank_0, rank_1
-393 | [hipsparseZgebsr2gebsr_bufferSize](interfacehipfort__hipsparse_1_1hipsparsezgebsr2gebsr__buffersize.html "Interface documentation") | C binding, rank_0, rank_1
-394 | [hipsparseXgebsr2gebsrNnz](interfacehipfort__hipsparse_1_1hipsparsexgebsr2gebsrnnz.html "Interface documentation") | C binding, rank_0, rank_1
-395 | [hipsparseSgebsr2gebsr](interfacehipfort__hipsparse_1_1hipsparsesgebsr2gebsr.html "Interface documentation") | C binding, rank_0, rank_1
-396 | [hipsparseDgebsr2gebsr](interfacehipfort__hipsparse_1_1hipsparsedgebsr2gebsr.html "Interface documentation") | C binding, rank_0, rank_1
-397 | [hipsparseCgebsr2gebsr](interfacehipfort__hipsparse_1_1hipsparsecgebsr2gebsr.html "Interface documentation") | C binding, rank_0, rank_1
-398 | [hipsparseZgebsr2gebsr](interfacehipfort__hipsparse_1_1hipsparsezgebsr2gebsr.html "Interface documentation") | C binding, rank_0, rank_1
-399 | [hipsparseShyb2csr](interfacehipfort__hipsparse_1_1hipsparseshyb2csr.html "Interface documentation") | C binding, rank_0, rank_1
-400 | [hipsparseDhyb2csr](interfacehipfort__hipsparse_1_1hipsparsedhyb2csr.html "Interface documentation") | C binding, rank_0, rank_1
-401 | [hipsparseChyb2csr](interfacehipfort__hipsparse_1_1hipsparsechyb2csr.html "Interface documentation") | C binding, rank_0, rank_1
-402 | [hipsparseZhyb2csr](interfacehipfort__hipsparse_1_1hipsparsezhyb2csr.html "Interface documentation") | C binding, rank_0, rank_1
-403 | [hipsparseSnnz](interfacehipfort__hipsparse_1_1hipsparsesnnz.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-404 | [hipsparseDnnz](interfacehipfort__hipsparse_1_1hipsparsednnz.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-405 | [hipsparseCnnz](interfacehipfort__hipsparse_1_1hipsparsecnnz.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-406 | [hipsparseZnnz](interfacehipfort__hipsparse_1_1hipsparseznnz.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-407 | [hipsparseSnnz_compress](interfacehipfort__hipsparse_1_1hipsparsesnnz__compress.html "Interface documentation") | C binding, rank_0, rank_1
-408 | [hipsparseDnnz_compress](interfacehipfort__hipsparse_1_1hipsparsednnz__compress.html "Interface documentation") | C binding, rank_0, rank_1
-409 | [hipsparseCnnz_compress](interfacehipfort__hipsparse_1_1hipsparsecnnz__compress.html "Interface documentation") | C binding, rank_0, rank_1
-410 | [hipsparseZnnz_compress](interfacehipfort__hipsparse_1_1hipsparseznnz__compress.html "Interface documentation") | C binding, rank_0, rank_1
-411 | [hipsparseSpruneCsr2csr_bufferSize](interfacehipfort__hipsparse_1_1hipsparsesprunecsr2csr__buffersize.html "Interface documentation") | C binding, rank_0, rank_1
-412 | [hipsparseDpruneCsr2csr_bufferSize](interfacehipfort__hipsparse_1_1hipsparsedprunecsr2csr__buffersize.html "Interface documentation") | C binding, rank_0, rank_1
-413 | [hipsparseSpruneCsr2csr_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsesprunecsr2csr__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1
-414 | [hipsparseDpruneCsr2csr_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsedprunecsr2csr__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1
-415 | [hipsparseSpruneCsr2csrNnz](interfacehipfort__hipsparse_1_1hipsparsesprunecsr2csrnnz.html "Interface documentation") | C binding, rank_0, rank_1
-416 | [hipsparseDpruneCsr2csrNnz](interfacehipfort__hipsparse_1_1hipsparsedprunecsr2csrnnz.html "Interface documentation") | C binding, rank_0, rank_1
-417 | [hipsparseSpruneCsr2csr](interfacehipfort__hipsparse_1_1hipsparsesprunecsr2csr.html "Interface documentation") | C binding, rank_0, rank_1
-418 | [hipsparseDpruneCsr2csr](interfacehipfort__hipsparse_1_1hipsparsedprunecsr2csr.html "Interface documentation") | C binding, rank_0, rank_1
-419 | [hipsparseSpruneCsr2csrByPercentage_bufferSize](interfacehipfort__hipsparse_1_1hipsparsesprunecsr2csrbypercentage__buffersize.html "Interface documentation") | C binding, rank_0, rank_1
-420 | [hipsparseDpruneCsr2csrByPercentage_bufferSize](interfacehipfort__hipsparse_1_1hipsparsedprunecsr2csrbypercentage__buffersize.html "Interface documentation") | C binding, rank_0, rank_1
-421 | [hipsparseSpruneCsr2csrByPercentage_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsesprunecsr2csrbypercentage__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1
-422 | [hipsparseDpruneCsr2csrByPercentage_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsedprunecsr2csrbypercentage__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1
-423 | [hipsparseSpruneCsr2csrNnzByPercentage](interfacehipfort__hipsparse_1_1hipsparsesprunecsr2csrnnzbypercentage.html "Interface documentation") | C binding, rank_0, rank_1
-424 | [hipsparseDpruneCsr2csrNnzByPercentage](interfacehipfort__hipsparse_1_1hipsparsedprunecsr2csrnnzbypercentage.html "Interface documentation") | C binding, rank_0, rank_1
-425 | [hipsparseSpruneCsr2csrByPercentage](interfacehipfort__hipsparse_1_1hipsparsesprunecsr2csrbypercentage.html "Interface documentation") | C binding, rank_0, rank_1
-426 | [hipsparseDpruneCsr2csrByPercentage](interfacehipfort__hipsparse_1_1hipsparsedprunecsr2csrbypercentage.html "Interface documentation") | C binding, rank_0, rank_1
-427 | [hipsparseSpruneDense2csr_bufferSize](interfacehipfort__hipsparse_1_1hipsparsesprunedense2csr__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-428 | [hipsparseDpruneDense2csr_bufferSize](interfacehipfort__hipsparse_1_1hipsparsedprunedense2csr__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-429 | [hipsparseSpruneDense2csr_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsesprunedense2csr__buffersizeext.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-430 | [hipsparseDpruneDense2csr_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsedprunedense2csr__buffersizeext.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-431 | [hipsparseSpruneDense2csrNnz](interfacehipfort__hipsparse_1_1hipsparsesprunedense2csrnnz.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-432 | [hipsparseDpruneDense2csrNnz](interfacehipfort__hipsparse_1_1hipsparsedprunedense2csrnnz.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-433 | [hipsparseSpruneDense2csr](interfacehipfort__hipsparse_1_1hipsparsesprunedense2csr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-434 | [hipsparseDpruneDense2csr](interfacehipfort__hipsparse_1_1hipsparsedprunedense2csr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-435 | [hipsparseSpruneDense2csrByPercentage_bufferSize](interfacehipfort__hipsparse_1_1hipsparsesprunedense2csrbypercentage__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-436 | [hipsparseDpruneDense2csrByPercentage_bufferSize](interfacehipfort__hipsparse_1_1hipsparsedprunedense2csrbypercentage__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-437 | [hipsparseSpruneDense2csrByPercentage_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsesprunedense2csrbypercentage__buffersizeext.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-438 | [hipsparseDpruneDense2csrByPercentage_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsedprunedense2csrbypercentage__buffersizeext.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-439 | [hipsparseSpruneDense2csrNnzByPercentage](interfacehipfort__hipsparse_1_1hipsparsesprunedense2csrnnzbypercentage.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-440 | [hipsparseDpruneDense2csrNnzByPercentage](interfacehipfort__hipsparse_1_1hipsparsedprunedense2csrnnzbypercentage.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-441 | [hipsparseSpruneDense2csrByPercentage](interfacehipfort__hipsparse_1_1hipsparsesprunedense2csrbypercentage.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-442 | [hipsparseDpruneDense2csrByPercentage](interfacehipfort__hipsparse_1_1hipsparsedprunedense2csrbypercentage.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-443 | [hipsparseScsrcolor](interfacehipfort__hipsparse_1_1hipsparsescsrcolor.html "Interface documentation") | C binding, rank_0, rank_1
-444 | [hipsparseDcsrcolor](interfacehipfort__hipsparse_1_1hipsparsedcsrcolor.html "Interface documentation") | C binding, rank_0, rank_1
-445 | [hipsparseCcsrcolor](interfacehipfort__hipsparse_1_1hipsparseccsrcolor.html "Interface documentation") | C binding, rank_0, rank_1
-446 | [hipsparseZcsrcolor](interfacehipfort__hipsparse_1_1hipsparsezcsrcolor.html "Interface documentation") | C binding, rank_0, rank_1
+390 | [hipsparseSgebsr2gebsr_bufferSize](interfacehipfort__hipsparse_1_1hipsparsesgebsr2gebsr__buffersize.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+391 | [hipsparseDgebsr2gebsr_bufferSize](interfacehipfort__hipsparse_1_1hipsparsedgebsr2gebsr__buffersize.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+392 | [hipsparseCgebsr2gebsr_bufferSize](interfacehipfort__hipsparse_1_1hipsparsecgebsr2gebsr__buffersize.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+393 | [hipsparseZgebsr2gebsr_bufferSize](interfacehipfort__hipsparse_1_1hipsparsezgebsr2gebsr__buffersize.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+394 | [hipsparseXgebsr2gebsrNnz](interfacehipfort__hipsparse_1_1hipsparsexgebsr2gebsrnnz.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+395 | [hipsparseSgebsr2gebsr](interfacehipfort__hipsparse_1_1hipsparsesgebsr2gebsr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+396 | [hipsparseDgebsr2gebsr](interfacehipfort__hipsparse_1_1hipsparsedgebsr2gebsr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+397 | [hipsparseCgebsr2gebsr](interfacehipfort__hipsparse_1_1hipsparsecgebsr2gebsr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+398 | [hipsparseZgebsr2gebsr](interfacehipfort__hipsparse_1_1hipsparsezgebsr2gebsr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+399 | [hipsparseShyb2csr](interfacehipfort__hipsparse_1_1hipsparseshyb2csr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+400 | [hipsparseDhyb2csr](interfacehipfort__hipsparse_1_1hipsparsedhyb2csr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+401 | [hipsparseChyb2csr](interfacehipfort__hipsparse_1_1hipsparsechyb2csr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+402 | [hipsparseZhyb2csr](interfacehipfort__hipsparse_1_1hipsparsezhyb2csr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+403 | [hipsparseSnnz](interfacehipfort__hipsparse_1_1hipsparsesnnz.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+404 | [hipsparseDnnz](interfacehipfort__hipsparse_1_1hipsparsednnz.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+405 | [hipsparseCnnz](interfacehipfort__hipsparse_1_1hipsparsecnnz.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+406 | [hipsparseZnnz](interfacehipfort__hipsparse_1_1hipsparseznnz.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+407 | [hipsparseSnnz_compress](interfacehipfort__hipsparse_1_1hipsparsesnnz__compress.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+408 | [hipsparseDnnz_compress](interfacehipfort__hipsparse_1_1hipsparsednnz__compress.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+409 | [hipsparseCnnz_compress](interfacehipfort__hipsparse_1_1hipsparsecnnz__compress.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+410 | [hipsparseZnnz_compress](interfacehipfort__hipsparse_1_1hipsparseznnz__compress.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+411 | [hipsparseSpruneCsr2csr_bufferSize](interfacehipfort__hipsparse_1_1hipsparsesprunecsr2csr__buffersize.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+412 | [hipsparseDpruneCsr2csr_bufferSize](interfacehipfort__hipsparse_1_1hipsparsedprunecsr2csr__buffersize.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+413 | [hipsparseSpruneCsr2csr_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsesprunecsr2csr__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+414 | [hipsparseDpruneCsr2csr_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsedprunecsr2csr__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+415 | [hipsparseSpruneCsr2csrNnz](interfacehipfort__hipsparse_1_1hipsparsesprunecsr2csrnnz.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+416 | [hipsparseDpruneCsr2csrNnz](interfacehipfort__hipsparse_1_1hipsparsedprunecsr2csrnnz.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+417 | [hipsparseSpruneCsr2csr](interfacehipfort__hipsparse_1_1hipsparsesprunecsr2csr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+418 | [hipsparseDpruneCsr2csr](interfacehipfort__hipsparse_1_1hipsparsedprunecsr2csr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+419 | [hipsparseSpruneCsr2csrByPercentage_bufferSize](interfacehipfort__hipsparse_1_1hipsparsesprunecsr2csrbypercentage__buffersize.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+420 | [hipsparseDpruneCsr2csrByPercentage_bufferSize](interfacehipfort__hipsparse_1_1hipsparsedprunecsr2csrbypercentage__buffersize.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+421 | [hipsparseSpruneCsr2csrByPercentage_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsesprunecsr2csrbypercentage__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+422 | [hipsparseDpruneCsr2csrByPercentage_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsedprunecsr2csrbypercentage__buffersizeext.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+423 | [hipsparseSpruneCsr2csrNnzByPercentage](interfacehipfort__hipsparse_1_1hipsparsesprunecsr2csrnnzbypercentage.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+424 | [hipsparseDpruneCsr2csrNnzByPercentage](interfacehipfort__hipsparse_1_1hipsparsedprunecsr2csrnnzbypercentage.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+425 | [hipsparseSpruneCsr2csrByPercentage](interfacehipfort__hipsparse_1_1hipsparsesprunecsr2csrbypercentage.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+426 | [hipsparseDpruneCsr2csrByPercentage](interfacehipfort__hipsparse_1_1hipsparsedprunecsr2csrbypercentage.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+427 | [hipsparseSpruneDense2csr_bufferSize](interfacehipfort__hipsparse_1_1hipsparsesprunedense2csr__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+428 | [hipsparseDpruneDense2csr_bufferSize](interfacehipfort__hipsparse_1_1hipsparsedprunedense2csr__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+429 | [hipsparseSpruneDense2csr_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsesprunedense2csr__buffersizeext.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+430 | [hipsparseDpruneDense2csr_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsedprunedense2csr__buffersizeext.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+431 | [hipsparseSpruneDense2csrNnz](interfacehipfort__hipsparse_1_1hipsparsesprunedense2csrnnz.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+432 | [hipsparseDpruneDense2csrNnz](interfacehipfort__hipsparse_1_1hipsparsedprunedense2csrnnz.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+433 | [hipsparseSpruneDense2csr](interfacehipfort__hipsparse_1_1hipsparsesprunedense2csr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+434 | [hipsparseDpruneDense2csr](interfacehipfort__hipsparse_1_1hipsparsedprunedense2csr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+435 | [hipsparseSpruneDense2csrByPercentage_bufferSize](interfacehipfort__hipsparse_1_1hipsparsesprunedense2csrbypercentage__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+436 | [hipsparseDpruneDense2csrByPercentage_bufferSize](interfacehipfort__hipsparse_1_1hipsparsedprunedense2csrbypercentage__buffersize.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+437 | [hipsparseSpruneDense2csrByPercentage_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsesprunedense2csrbypercentage__buffersizeext.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+438 | [hipsparseDpruneDense2csrByPercentage_bufferSizeExt](interfacehipfort__hipsparse_1_1hipsparsedprunedense2csrbypercentage__buffersizeext.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+439 | [hipsparseSpruneDense2csrNnzByPercentage](interfacehipfort__hipsparse_1_1hipsparsesprunedense2csrnnzbypercentage.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+440 | [hipsparseDpruneDense2csrNnzByPercentage](interfacehipfort__hipsparse_1_1hipsparsedprunedense2csrnnzbypercentage.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+441 | [hipsparseSpruneDense2csrByPercentage](interfacehipfort__hipsparse_1_1hipsparsesprunedense2csrbypercentage.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+442 | [hipsparseDpruneDense2csrByPercentage](interfacehipfort__hipsparse_1_1hipsparsedprunedense2csrbypercentage.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+443 | [hipsparseScsrcolor](interfacehipfort__hipsparse_1_1hipsparsescsrcolor.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+444 | [hipsparseDcsrcolor](interfacehipfort__hipsparse_1_1hipsparsedcsrcolor.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+445 | [hipsparseCcsrcolor](interfacehipfort__hipsparse_1_1hipsparseccsrcolor.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+446 | [hipsparseZcsrcolor](interfacehipfort__hipsparse_1_1hipsparsezcsrcolor.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 447 | [hipsparseCreateSpVec](interfacehipfort__hipsparse_1_1hipsparsecreatespvec.html "Interface documentation") | C binding
 448 | [hipsparseCreateConstSpVec](interfacehipfort__hipsparse_1_1hipsparsecreateconstspvec.html "Interface documentation") | C binding
 449 | [hipsparseDestroySpVec](interfacehipfort__hipsparse_1_1hipsparsedestroyspvec.html "Interface documentation") | C binding

--- a/docs/doxygen/input/supported_api_rocrand.md
+++ b/docs/doxygen/input/supported_api_rocrand.md
@@ -6,20 +6,20 @@
 2 | [rocrand_create_generator_host](interfacehipfort__rocrand_1_1rocrand__create__generator__host.html "Interface documentation") | C binding
 3 | [rocrand_create_generator_host_blocking](interfacehipfort__rocrand_1_1rocrand__create__generator__host__blocking.html "Interface documentation") | C binding
 4 | [rocrand_destroy_generator](interfacehipfort__rocrand_1_1rocrand__destroy__generator.html "Interface documentation") | C binding
-5 | [rocrand_generate](interfacehipfort__rocrand_1_1rocrand__generate.html "Interface documentation") | C binding
-6 | [rocrand_generate_long_long](interfacehipfort__rocrand_1_1rocrand__generate__long__long.html "Interface documentation") | C binding
+5 | [rocrand_generate](interfacehipfort__rocrand_1_1rocrand__generate.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+6 | [rocrand_generate_long_long](interfacehipfort__rocrand_1_1rocrand__generate__long__long.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 7 | [rocrand_generate_char](interfacehipfort__rocrand_1_1rocrand__generate__char.html "Interface documentation") | C binding
 8 | [rocrand_generate_short](interfacehipfort__rocrand_1_1rocrand__generate__short.html "Interface documentation") | C binding
-9 | [rocrand_generate_uniform](interfacehipfort__rocrand_1_1rocrand__generate__uniform.html "Interface documentation") | C binding
-10 | [rocrand_generate_uniform_double](interfacehipfort__rocrand_1_1rocrand__generate__uniform__double.html "Interface documentation") | C binding
+9 | [rocrand_generate_uniform](interfacehipfort__rocrand_1_1rocrand__generate__uniform.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+10 | [rocrand_generate_uniform_double](interfacehipfort__rocrand_1_1rocrand__generate__uniform__double.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 11 | [rocrand_generate_uniform_half](interfacehipfort__rocrand_1_1rocrand__generate__uniform__half.html "Interface documentation") | C binding
-12 | [rocrand_generate_normal](interfacehipfort__rocrand_1_1rocrand__generate__normal.html "Interface documentation") | C binding
-13 | [rocrand_generate_normal_double](interfacehipfort__rocrand_1_1rocrand__generate__normal__double.html "Interface documentation") | C binding
+12 | [rocrand_generate_normal](interfacehipfort__rocrand_1_1rocrand__generate__normal.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+13 | [rocrand_generate_normal_double](interfacehipfort__rocrand_1_1rocrand__generate__normal__double.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 14 | [rocrand_generate_normal_half](interfacehipfort__rocrand_1_1rocrand__generate__normal__half.html "Interface documentation") | C binding
-15 | [rocrand_generate_log_normal](interfacehipfort__rocrand_1_1rocrand__generate__log__normal.html "Interface documentation") | C binding
-16 | [rocrand_generate_log_normal_double](interfacehipfort__rocrand_1_1rocrand__generate__log__normal__double.html "Interface documentation") | C binding
+15 | [rocrand_generate_log_normal](interfacehipfort__rocrand_1_1rocrand__generate__log__normal.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+16 | [rocrand_generate_log_normal_double](interfacehipfort__rocrand_1_1rocrand__generate__log__normal__double.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 17 | [rocrand_generate_log_normal_half](interfacehipfort__rocrand_1_1rocrand__generate__log__normal__half.html "Interface documentation") | C binding
-18 | [rocrand_generate_poisson](interfacehipfort__rocrand_1_1rocrand__generate__poisson.html "Interface documentation") | C binding
+18 | [rocrand_generate_poisson](interfacehipfort__rocrand_1_1rocrand__generate__poisson.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 19 | [rocrand_initialize_generator](interfacehipfort__rocrand_1_1rocrand__initialize__generator.html "Interface documentation") | C binding
 20 | [rocrand_set_stream](interfacehipfort__rocrand_1_1rocrand__set__stream.html "Interface documentation") | C binding
 21 | [rocrand_set_seed](interfacehipfort__rocrand_1_1rocrand__set__seed.html "Interface documentation") | C binding
@@ -29,7 +29,7 @@
 25 | [rocrand_set_quasi_random_generator_dimensions](interfacehipfort__rocrand_1_1rocrand__set__quasi__random__generator__dimensions.html "Interface documentation") | C binding
 26 | [rocrand_get_version](interfacehipfort__rocrand_1_1rocrand__get__version.html "Interface documentation") | C binding
 27 | [rocrand_create_poisson_distribution](interfacehipfort__rocrand_1_1rocrand__create__poisson__distribution.html "Interface documentation") | C binding
-28 | [rocrand_create_discrete_distribution](interfacehipfort__rocrand_1_1rocrand__create__discrete__distribution.html "Interface documentation") | C binding
+28 | [rocrand_create_discrete_distribution](interfacehipfort__rocrand_1_1rocrand__create__discrete__distribution.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 29 | [rocrand_destroy_discrete_distribution](interfacehipfort__rocrand_1_1rocrand__destroy__discrete__distribution.html "Interface documentation") | C binding
 30 | [rocrand_get_direction_vectors32](interfacehipfort__rocrand_1_1rocrand__get__direction__vectors32.html "Interface documentation") | C binding
 31 | [rocrand_get_direction_vectors64](interfacehipfort__rocrand_1_1rocrand__get__direction__vectors64.html "Interface documentation") | C binding

--- a/docs/doxygen/input/supported_api_rocsolver.md
+++ b/docs/doxygen/input/supported_api_rocsolver.md
@@ -13,8 +13,8 @@
 9 | [rocsolver_log_flush_profile](interfacehipfort__rocsolver_1_1rocsolver__log__flush__profile.html "Interface documentation") | C binding
 10 | [rocsolver_set_alg_mode](interfacehipfort__rocsolver_1_1rocsolver__set__alg__mode.html "Interface documentation") | C binding
 11 | [rocsolver_get_alg_mode](interfacehipfort__rocsolver_1_1rocsolver__get__alg__mode.html "Interface documentation") | C binding
-12 | [rocsolver_clacgv](interfacehipfort__rocsolver_1_1rocsolver__clacgv.html "Interface documentation") | C binding, rank_0, rank_1
-13 | [rocsolver_zlacgv](interfacehipfort__rocsolver_1_1rocsolver__zlacgv.html "Interface documentation") | C binding, rank_0, rank_1
+12 | [rocsolver_clacgv](interfacehipfort__rocsolver_1_1rocsolver__clacgv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+13 | [rocsolver_zlacgv](interfacehipfort__rocsolver_1_1rocsolver__zlacgv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 14 | [rocsolver_clacgv_64](interfacehipfort__rocsolver_1_1rocsolver__clacgv__64.html "Interface documentation") | C binding
 15 | [rocsolver_zlacgv_64](interfacehipfort__rocsolver_1_1rocsolver__zlacgv__64.html "Interface documentation") | C binding
 16 | [rocsolver_slange](interfacehipfort__rocsolver_1_1rocsolver__slange.html "Interface documentation") | C binding
@@ -33,132 +33,132 @@
 29 | [rocsolver_dgecon_64](interfacehipfort__rocsolver_1_1rocsolver__dgecon__64.html "Interface documentation") | C binding
 30 | [rocsolver_cgecon_64](interfacehipfort__rocsolver_1_1rocsolver__cgecon__64.html "Interface documentation") | C binding
 31 | [rocsolver_zgecon_64](interfacehipfort__rocsolver_1_1rocsolver__zgecon__64.html "Interface documentation") | C binding
-32 | [rocsolver_slaswp](interfacehipfort__rocsolver_1_1rocsolver__slaswp.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-33 | [rocsolver_dlaswp](interfacehipfort__rocsolver_1_1rocsolver__dlaswp.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-34 | [rocsolver_claswp](interfacehipfort__rocsolver_1_1rocsolver__claswp.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-35 | [rocsolver_zlaswp](interfacehipfort__rocsolver_1_1rocsolver__zlaswp.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-36 | [rocsolver_slarfg](interfacehipfort__rocsolver_1_1rocsolver__slarfg.html "Interface documentation") | C binding, rank_0, rank_1
-37 | [rocsolver_dlarfg](interfacehipfort__rocsolver_1_1rocsolver__dlarfg.html "Interface documentation") | C binding, rank_0, rank_1
-38 | [rocsolver_clarfg](interfacehipfort__rocsolver_1_1rocsolver__clarfg.html "Interface documentation") | C binding, rank_0, rank_1
-39 | [rocsolver_zlarfg](interfacehipfort__rocsolver_1_1rocsolver__zlarfg.html "Interface documentation") | C binding, rank_0, rank_1
+32 | [rocsolver_slaswp](interfacehipfort__rocsolver_1_1rocsolver__slaswp.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+33 | [rocsolver_dlaswp](interfacehipfort__rocsolver_1_1rocsolver__dlaswp.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+34 | [rocsolver_claswp](interfacehipfort__rocsolver_1_1rocsolver__claswp.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+35 | [rocsolver_zlaswp](interfacehipfort__rocsolver_1_1rocsolver__zlaswp.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+36 | [rocsolver_slarfg](interfacehipfort__rocsolver_1_1rocsolver__slarfg.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+37 | [rocsolver_dlarfg](interfacehipfort__rocsolver_1_1rocsolver__dlarfg.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+38 | [rocsolver_clarfg](interfacehipfort__rocsolver_1_1rocsolver__clarfg.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+39 | [rocsolver_zlarfg](interfacehipfort__rocsolver_1_1rocsolver__zlarfg.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 40 | [rocsolver_slarfg_64](interfacehipfort__rocsolver_1_1rocsolver__slarfg__64.html "Interface documentation") | C binding
 41 | [rocsolver_dlarfg_64](interfacehipfort__rocsolver_1_1rocsolver__dlarfg__64.html "Interface documentation") | C binding
 42 | [rocsolver_clarfg_64](interfacehipfort__rocsolver_1_1rocsolver__clarfg__64.html "Interface documentation") | C binding
 43 | [rocsolver_zlarfg_64](interfacehipfort__rocsolver_1_1rocsolver__zlarfg__64.html "Interface documentation") | C binding
-44 | [rocsolver_slarft](interfacehipfort__rocsolver_1_1rocsolver__slarft.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-45 | [rocsolver_dlarft](interfacehipfort__rocsolver_1_1rocsolver__dlarft.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-46 | [rocsolver_clarft](interfacehipfort__rocsolver_1_1rocsolver__clarft.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-47 | [rocsolver_zlarft](interfacehipfort__rocsolver_1_1rocsolver__zlarft.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-48 | [rocsolver_slarf](interfacehipfort__rocsolver_1_1rocsolver__slarf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-49 | [rocsolver_dlarf](interfacehipfort__rocsolver_1_1rocsolver__dlarf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-50 | [rocsolver_clarf](interfacehipfort__rocsolver_1_1rocsolver__clarf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-51 | [rocsolver_zlarf](interfacehipfort__rocsolver_1_1rocsolver__zlarf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+44 | [rocsolver_slarft](interfacehipfort__rocsolver_1_1rocsolver__slarft.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+45 | [rocsolver_dlarft](interfacehipfort__rocsolver_1_1rocsolver__dlarft.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+46 | [rocsolver_clarft](interfacehipfort__rocsolver_1_1rocsolver__clarft.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+47 | [rocsolver_zlarft](interfacehipfort__rocsolver_1_1rocsolver__zlarft.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+48 | [rocsolver_slarf](interfacehipfort__rocsolver_1_1rocsolver__slarf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+49 | [rocsolver_dlarf](interfacehipfort__rocsolver_1_1rocsolver__dlarf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+50 | [rocsolver_clarf](interfacehipfort__rocsolver_1_1rocsolver__clarf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+51 | [rocsolver_zlarf](interfacehipfort__rocsolver_1_1rocsolver__zlarf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 52 | [rocsolver_slarf_64](interfacehipfort__rocsolver_1_1rocsolver__slarf__64.html "Interface documentation") | C binding
 53 | [rocsolver_dlarf_64](interfacehipfort__rocsolver_1_1rocsolver__dlarf__64.html "Interface documentation") | C binding
 54 | [rocsolver_clarf_64](interfacehipfort__rocsolver_1_1rocsolver__clarf__64.html "Interface documentation") | C binding
 55 | [rocsolver_zlarf_64](interfacehipfort__rocsolver_1_1rocsolver__zlarf__64.html "Interface documentation") | C binding
-56 | [rocsolver_slarfb](interfacehipfort__rocsolver_1_1rocsolver__slarfb.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-57 | [rocsolver_dlarfb](interfacehipfort__rocsolver_1_1rocsolver__dlarfb.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-58 | [rocsolver_clarfb](interfacehipfort__rocsolver_1_1rocsolver__clarfb.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-59 | [rocsolver_zlarfb](interfacehipfort__rocsolver_1_1rocsolver__zlarfb.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+56 | [rocsolver_slarfb](interfacehipfort__rocsolver_1_1rocsolver__slarfb.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+57 | [rocsolver_dlarfb](interfacehipfort__rocsolver_1_1rocsolver__dlarfb.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+58 | [rocsolver_clarfb](interfacehipfort__rocsolver_1_1rocsolver__clarfb.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+59 | [rocsolver_zlarfb](interfacehipfort__rocsolver_1_1rocsolver__zlarfb.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 60 | [rocsolver_slasr](interfacehipfort__rocsolver_1_1rocsolver__slasr.html "Interface documentation") | C binding
 61 | [rocsolver_dlasr](interfacehipfort__rocsolver_1_1rocsolver__dlasr.html "Interface documentation") | C binding
 62 | [rocsolver_clasr](interfacehipfort__rocsolver_1_1rocsolver__clasr.html "Interface documentation") | C binding
 63 | [rocsolver_zlasr](interfacehipfort__rocsolver_1_1rocsolver__zlasr.html "Interface documentation") | C binding
-64 | [rocsolver_slabrd](interfacehipfort__rocsolver_1_1rocsolver__slabrd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-65 | [rocsolver_dlabrd](interfacehipfort__rocsolver_1_1rocsolver__dlabrd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-66 | [rocsolver_clabrd](interfacehipfort__rocsolver_1_1rocsolver__clabrd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-67 | [rocsolver_zlabrd](interfacehipfort__rocsolver_1_1rocsolver__zlabrd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-68 | [rocsolver_slatrd](interfacehipfort__rocsolver_1_1rocsolver__slatrd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-69 | [rocsolver_dlatrd](interfacehipfort__rocsolver_1_1rocsolver__dlatrd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-70 | [rocsolver_clatrd](interfacehipfort__rocsolver_1_1rocsolver__clatrd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-71 | [rocsolver_zlatrd](interfacehipfort__rocsolver_1_1rocsolver__zlatrd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-72 | [rocsolver_slasyf](interfacehipfort__rocsolver_1_1rocsolver__slasyf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-73 | [rocsolver_dlasyf](interfacehipfort__rocsolver_1_1rocsolver__dlasyf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-74 | [rocsolver_clasyf](interfacehipfort__rocsolver_1_1rocsolver__clasyf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-75 | [rocsolver_zlasyf](interfacehipfort__rocsolver_1_1rocsolver__zlasyf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+64 | [rocsolver_slabrd](interfacehipfort__rocsolver_1_1rocsolver__slabrd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+65 | [rocsolver_dlabrd](interfacehipfort__rocsolver_1_1rocsolver__dlabrd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+66 | [rocsolver_clabrd](interfacehipfort__rocsolver_1_1rocsolver__clabrd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+67 | [rocsolver_zlabrd](interfacehipfort__rocsolver_1_1rocsolver__zlabrd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+68 | [rocsolver_slatrd](interfacehipfort__rocsolver_1_1rocsolver__slatrd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+69 | [rocsolver_dlatrd](interfacehipfort__rocsolver_1_1rocsolver__dlatrd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+70 | [rocsolver_clatrd](interfacehipfort__rocsolver_1_1rocsolver__clatrd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+71 | [rocsolver_zlatrd](interfacehipfort__rocsolver_1_1rocsolver__zlatrd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+72 | [rocsolver_slasyf](interfacehipfort__rocsolver_1_1rocsolver__slasyf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+73 | [rocsolver_dlasyf](interfacehipfort__rocsolver_1_1rocsolver__dlasyf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+74 | [rocsolver_clasyf](interfacehipfort__rocsolver_1_1rocsolver__clasyf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+75 | [rocsolver_zlasyf](interfacehipfort__rocsolver_1_1rocsolver__zlasyf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 76 | [rocsolver_slauum](interfacehipfort__rocsolver_1_1rocsolver__slauum.html "Interface documentation") | C binding
 77 | [rocsolver_dlauum](interfacehipfort__rocsolver_1_1rocsolver__dlauum.html "Interface documentation") | C binding
 78 | [rocsolver_clauum](interfacehipfort__rocsolver_1_1rocsolver__clauum.html "Interface documentation") | C binding
 79 | [rocsolver_zlauum](interfacehipfort__rocsolver_1_1rocsolver__zlauum.html "Interface documentation") | C binding
-80 | [rocsolver_sorg2r](interfacehipfort__rocsolver_1_1rocsolver__sorg2r.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-81 | [rocsolver_dorg2r](interfacehipfort__rocsolver_1_1rocsolver__dorg2r.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-82 | [rocsolver_cung2r](interfacehipfort__rocsolver_1_1rocsolver__cung2r.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-83 | [rocsolver_zung2r](interfacehipfort__rocsolver_1_1rocsolver__zung2r.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-84 | [rocsolver_sorgqr](interfacehipfort__rocsolver_1_1rocsolver__sorgqr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-85 | [rocsolver_dorgqr](interfacehipfort__rocsolver_1_1rocsolver__dorgqr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-86 | [rocsolver_cungqr](interfacehipfort__rocsolver_1_1rocsolver__cungqr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-87 | [rocsolver_zungqr](interfacehipfort__rocsolver_1_1rocsolver__zungqr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-88 | [rocsolver_sorgl2](interfacehipfort__rocsolver_1_1rocsolver__sorgl2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-89 | [rocsolver_dorgl2](interfacehipfort__rocsolver_1_1rocsolver__dorgl2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-90 | [rocsolver_cungl2](interfacehipfort__rocsolver_1_1rocsolver__cungl2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-91 | [rocsolver_zungl2](interfacehipfort__rocsolver_1_1rocsolver__zungl2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-92 | [rocsolver_sorglq](interfacehipfort__rocsolver_1_1rocsolver__sorglq.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-93 | [rocsolver_dorglq](interfacehipfort__rocsolver_1_1rocsolver__dorglq.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-94 | [rocsolver_cunglq](interfacehipfort__rocsolver_1_1rocsolver__cunglq.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-95 | [rocsolver_zunglq](interfacehipfort__rocsolver_1_1rocsolver__zunglq.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-96 | [rocsolver_sorg2l](interfacehipfort__rocsolver_1_1rocsolver__sorg2l.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-97 | [rocsolver_dorg2l](interfacehipfort__rocsolver_1_1rocsolver__dorg2l.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-98 | [rocsolver_cung2l](interfacehipfort__rocsolver_1_1rocsolver__cung2l.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-99 | [rocsolver_zung2l](interfacehipfort__rocsolver_1_1rocsolver__zung2l.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-100 | [rocsolver_sorgql](interfacehipfort__rocsolver_1_1rocsolver__sorgql.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-101 | [rocsolver_dorgql](interfacehipfort__rocsolver_1_1rocsolver__dorgql.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-102 | [rocsolver_cungql](interfacehipfort__rocsolver_1_1rocsolver__cungql.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-103 | [rocsolver_zungql](interfacehipfort__rocsolver_1_1rocsolver__zungql.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-104 | [rocsolver_sorgbr](interfacehipfort__rocsolver_1_1rocsolver__sorgbr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-105 | [rocsolver_dorgbr](interfacehipfort__rocsolver_1_1rocsolver__dorgbr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-106 | [rocsolver_cungbr](interfacehipfort__rocsolver_1_1rocsolver__cungbr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-107 | [rocsolver_zungbr](interfacehipfort__rocsolver_1_1rocsolver__zungbr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-108 | [rocsolver_sorgtr](interfacehipfort__rocsolver_1_1rocsolver__sorgtr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-109 | [rocsolver_dorgtr](interfacehipfort__rocsolver_1_1rocsolver__dorgtr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-110 | [rocsolver_cungtr](interfacehipfort__rocsolver_1_1rocsolver__cungtr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-111 | [rocsolver_zungtr](interfacehipfort__rocsolver_1_1rocsolver__zungtr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-112 | [rocsolver_sorm2r](interfacehipfort__rocsolver_1_1rocsolver__sorm2r.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-113 | [rocsolver_dorm2r](interfacehipfort__rocsolver_1_1rocsolver__dorm2r.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-114 | [rocsolver_cunm2r](interfacehipfort__rocsolver_1_1rocsolver__cunm2r.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-115 | [rocsolver_zunm2r](interfacehipfort__rocsolver_1_1rocsolver__zunm2r.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-116 | [rocsolver_sormqr](interfacehipfort__rocsolver_1_1rocsolver__sormqr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-117 | [rocsolver_dormqr](interfacehipfort__rocsolver_1_1rocsolver__dormqr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-118 | [rocsolver_cunmqr](interfacehipfort__rocsolver_1_1rocsolver__cunmqr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-119 | [rocsolver_zunmqr](interfacehipfort__rocsolver_1_1rocsolver__zunmqr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-120 | [rocsolver_sorml2](interfacehipfort__rocsolver_1_1rocsolver__sorml2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-121 | [rocsolver_dorml2](interfacehipfort__rocsolver_1_1rocsolver__dorml2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-122 | [rocsolver_cunml2](interfacehipfort__rocsolver_1_1rocsolver__cunml2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-123 | [rocsolver_zunml2](interfacehipfort__rocsolver_1_1rocsolver__zunml2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-124 | [rocsolver_sormlq](interfacehipfort__rocsolver_1_1rocsolver__sormlq.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-125 | [rocsolver_dormlq](interfacehipfort__rocsolver_1_1rocsolver__dormlq.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-126 | [rocsolver_cunmlq](interfacehipfort__rocsolver_1_1rocsolver__cunmlq.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-127 | [rocsolver_zunmlq](interfacehipfort__rocsolver_1_1rocsolver__zunmlq.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-128 | [rocsolver_sorm2l](interfacehipfort__rocsolver_1_1rocsolver__sorm2l.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-129 | [rocsolver_dorm2l](interfacehipfort__rocsolver_1_1rocsolver__dorm2l.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-130 | [rocsolver_cunm2l](interfacehipfort__rocsolver_1_1rocsolver__cunm2l.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-131 | [rocsolver_zunm2l](interfacehipfort__rocsolver_1_1rocsolver__zunm2l.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-132 | [rocsolver_sormql](interfacehipfort__rocsolver_1_1rocsolver__sormql.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-133 | [rocsolver_dormql](interfacehipfort__rocsolver_1_1rocsolver__dormql.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-134 | [rocsolver_cunmql](interfacehipfort__rocsolver_1_1rocsolver__cunmql.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-135 | [rocsolver_zunmql](interfacehipfort__rocsolver_1_1rocsolver__zunmql.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-136 | [rocsolver_sormbr](interfacehipfort__rocsolver_1_1rocsolver__sormbr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-137 | [rocsolver_dormbr](interfacehipfort__rocsolver_1_1rocsolver__dormbr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-138 | [rocsolver_cunmbr](interfacehipfort__rocsolver_1_1rocsolver__cunmbr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-139 | [rocsolver_zunmbr](interfacehipfort__rocsolver_1_1rocsolver__zunmbr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-140 | [rocsolver_sormtr](interfacehipfort__rocsolver_1_1rocsolver__sormtr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-141 | [rocsolver_dormtr](interfacehipfort__rocsolver_1_1rocsolver__dormtr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-142 | [rocsolver_cunmtr](interfacehipfort__rocsolver_1_1rocsolver__cunmtr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-143 | [rocsolver_zunmtr](interfacehipfort__rocsolver_1_1rocsolver__zunmtr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-144 | [rocsolver_sbdsqr](interfacehipfort__rocsolver_1_1rocsolver__sbdsqr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-145 | [rocsolver_dbdsqr](interfacehipfort__rocsolver_1_1rocsolver__dbdsqr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-146 | [rocsolver_cbdsqr](interfacehipfort__rocsolver_1_1rocsolver__cbdsqr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-147 | [rocsolver_zbdsqr](interfacehipfort__rocsolver_1_1rocsolver__zbdsqr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-148 | [rocsolver_ssterf](interfacehipfort__rocsolver_1_1rocsolver__ssterf.html "Interface documentation") | C binding, rank_0, rank_1
-149 | [rocsolver_dsterf](interfacehipfort__rocsolver_1_1rocsolver__dsterf.html "Interface documentation") | C binding, rank_0, rank_1
-150 | [rocsolver_ssteqr](interfacehipfort__rocsolver_1_1rocsolver__ssteqr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-151 | [rocsolver_dsteqr](interfacehipfort__rocsolver_1_1rocsolver__dsteqr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-152 | [rocsolver_csteqr](interfacehipfort__rocsolver_1_1rocsolver__csteqr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-153 | [rocsolver_zsteqr](interfacehipfort__rocsolver_1_1rocsolver__zsteqr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-154 | [rocsolver_sstedc](interfacehipfort__rocsolver_1_1rocsolver__sstedc.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-155 | [rocsolver_dstedc](interfacehipfort__rocsolver_1_1rocsolver__dstedc.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-156 | [rocsolver_cstedc](interfacehipfort__rocsolver_1_1rocsolver__cstedc.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-157 | [rocsolver_zstedc](interfacehipfort__rocsolver_1_1rocsolver__zstedc.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+80 | [rocsolver_sorg2r](interfacehipfort__rocsolver_1_1rocsolver__sorg2r.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+81 | [rocsolver_dorg2r](interfacehipfort__rocsolver_1_1rocsolver__dorg2r.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+82 | [rocsolver_cung2r](interfacehipfort__rocsolver_1_1rocsolver__cung2r.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+83 | [rocsolver_zung2r](interfacehipfort__rocsolver_1_1rocsolver__zung2r.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+84 | [rocsolver_sorgqr](interfacehipfort__rocsolver_1_1rocsolver__sorgqr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+85 | [rocsolver_dorgqr](interfacehipfort__rocsolver_1_1rocsolver__dorgqr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+86 | [rocsolver_cungqr](interfacehipfort__rocsolver_1_1rocsolver__cungqr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+87 | [rocsolver_zungqr](interfacehipfort__rocsolver_1_1rocsolver__zungqr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+88 | [rocsolver_sorgl2](interfacehipfort__rocsolver_1_1rocsolver__sorgl2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+89 | [rocsolver_dorgl2](interfacehipfort__rocsolver_1_1rocsolver__dorgl2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+90 | [rocsolver_cungl2](interfacehipfort__rocsolver_1_1rocsolver__cungl2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+91 | [rocsolver_zungl2](interfacehipfort__rocsolver_1_1rocsolver__zungl2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+92 | [rocsolver_sorglq](interfacehipfort__rocsolver_1_1rocsolver__sorglq.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+93 | [rocsolver_dorglq](interfacehipfort__rocsolver_1_1rocsolver__dorglq.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+94 | [rocsolver_cunglq](interfacehipfort__rocsolver_1_1rocsolver__cunglq.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+95 | [rocsolver_zunglq](interfacehipfort__rocsolver_1_1rocsolver__zunglq.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+96 | [rocsolver_sorg2l](interfacehipfort__rocsolver_1_1rocsolver__sorg2l.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+97 | [rocsolver_dorg2l](interfacehipfort__rocsolver_1_1rocsolver__dorg2l.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+98 | [rocsolver_cung2l](interfacehipfort__rocsolver_1_1rocsolver__cung2l.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+99 | [rocsolver_zung2l](interfacehipfort__rocsolver_1_1rocsolver__zung2l.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+100 | [rocsolver_sorgql](interfacehipfort__rocsolver_1_1rocsolver__sorgql.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+101 | [rocsolver_dorgql](interfacehipfort__rocsolver_1_1rocsolver__dorgql.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+102 | [rocsolver_cungql](interfacehipfort__rocsolver_1_1rocsolver__cungql.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+103 | [rocsolver_zungql](interfacehipfort__rocsolver_1_1rocsolver__zungql.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+104 | [rocsolver_sorgbr](interfacehipfort__rocsolver_1_1rocsolver__sorgbr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+105 | [rocsolver_dorgbr](interfacehipfort__rocsolver_1_1rocsolver__dorgbr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+106 | [rocsolver_cungbr](interfacehipfort__rocsolver_1_1rocsolver__cungbr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+107 | [rocsolver_zungbr](interfacehipfort__rocsolver_1_1rocsolver__zungbr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+108 | [rocsolver_sorgtr](interfacehipfort__rocsolver_1_1rocsolver__sorgtr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+109 | [rocsolver_dorgtr](interfacehipfort__rocsolver_1_1rocsolver__dorgtr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+110 | [rocsolver_cungtr](interfacehipfort__rocsolver_1_1rocsolver__cungtr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+111 | [rocsolver_zungtr](interfacehipfort__rocsolver_1_1rocsolver__zungtr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+112 | [rocsolver_sorm2r](interfacehipfort__rocsolver_1_1rocsolver__sorm2r.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+113 | [rocsolver_dorm2r](interfacehipfort__rocsolver_1_1rocsolver__dorm2r.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+114 | [rocsolver_cunm2r](interfacehipfort__rocsolver_1_1rocsolver__cunm2r.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+115 | [rocsolver_zunm2r](interfacehipfort__rocsolver_1_1rocsolver__zunm2r.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+116 | [rocsolver_sormqr](interfacehipfort__rocsolver_1_1rocsolver__sormqr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+117 | [rocsolver_dormqr](interfacehipfort__rocsolver_1_1rocsolver__dormqr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+118 | [rocsolver_cunmqr](interfacehipfort__rocsolver_1_1rocsolver__cunmqr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+119 | [rocsolver_zunmqr](interfacehipfort__rocsolver_1_1rocsolver__zunmqr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+120 | [rocsolver_sorml2](interfacehipfort__rocsolver_1_1rocsolver__sorml2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+121 | [rocsolver_dorml2](interfacehipfort__rocsolver_1_1rocsolver__dorml2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+122 | [rocsolver_cunml2](interfacehipfort__rocsolver_1_1rocsolver__cunml2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+123 | [rocsolver_zunml2](interfacehipfort__rocsolver_1_1rocsolver__zunml2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+124 | [rocsolver_sormlq](interfacehipfort__rocsolver_1_1rocsolver__sormlq.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+125 | [rocsolver_dormlq](interfacehipfort__rocsolver_1_1rocsolver__dormlq.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+126 | [rocsolver_cunmlq](interfacehipfort__rocsolver_1_1rocsolver__cunmlq.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+127 | [rocsolver_zunmlq](interfacehipfort__rocsolver_1_1rocsolver__zunmlq.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+128 | [rocsolver_sorm2l](interfacehipfort__rocsolver_1_1rocsolver__sorm2l.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+129 | [rocsolver_dorm2l](interfacehipfort__rocsolver_1_1rocsolver__dorm2l.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+130 | [rocsolver_cunm2l](interfacehipfort__rocsolver_1_1rocsolver__cunm2l.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+131 | [rocsolver_zunm2l](interfacehipfort__rocsolver_1_1rocsolver__zunm2l.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+132 | [rocsolver_sormql](interfacehipfort__rocsolver_1_1rocsolver__sormql.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+133 | [rocsolver_dormql](interfacehipfort__rocsolver_1_1rocsolver__dormql.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+134 | [rocsolver_cunmql](interfacehipfort__rocsolver_1_1rocsolver__cunmql.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+135 | [rocsolver_zunmql](interfacehipfort__rocsolver_1_1rocsolver__zunmql.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+136 | [rocsolver_sormbr](interfacehipfort__rocsolver_1_1rocsolver__sormbr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+137 | [rocsolver_dormbr](interfacehipfort__rocsolver_1_1rocsolver__dormbr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+138 | [rocsolver_cunmbr](interfacehipfort__rocsolver_1_1rocsolver__cunmbr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+139 | [rocsolver_zunmbr](interfacehipfort__rocsolver_1_1rocsolver__zunmbr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+140 | [rocsolver_sormtr](interfacehipfort__rocsolver_1_1rocsolver__sormtr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+141 | [rocsolver_dormtr](interfacehipfort__rocsolver_1_1rocsolver__dormtr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+142 | [rocsolver_cunmtr](interfacehipfort__rocsolver_1_1rocsolver__cunmtr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+143 | [rocsolver_zunmtr](interfacehipfort__rocsolver_1_1rocsolver__zunmtr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+144 | [rocsolver_sbdsqr](interfacehipfort__rocsolver_1_1rocsolver__sbdsqr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+145 | [rocsolver_dbdsqr](interfacehipfort__rocsolver_1_1rocsolver__dbdsqr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+146 | [rocsolver_cbdsqr](interfacehipfort__rocsolver_1_1rocsolver__cbdsqr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+147 | [rocsolver_zbdsqr](interfacehipfort__rocsolver_1_1rocsolver__zbdsqr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+148 | [rocsolver_ssterf](interfacehipfort__rocsolver_1_1rocsolver__ssterf.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+149 | [rocsolver_dsterf](interfacehipfort__rocsolver_1_1rocsolver__dsterf.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+150 | [rocsolver_ssteqr](interfacehipfort__rocsolver_1_1rocsolver__ssteqr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+151 | [rocsolver_dsteqr](interfacehipfort__rocsolver_1_1rocsolver__dsteqr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+152 | [rocsolver_csteqr](interfacehipfort__rocsolver_1_1rocsolver__csteqr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+153 | [rocsolver_zsteqr](interfacehipfort__rocsolver_1_1rocsolver__zsteqr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+154 | [rocsolver_sstedc](interfacehipfort__rocsolver_1_1rocsolver__sstedc.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+155 | [rocsolver_dstedc](interfacehipfort__rocsolver_1_1rocsolver__dstedc.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+156 | [rocsolver_cstedc](interfacehipfort__rocsolver_1_1rocsolver__cstedc.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+157 | [rocsolver_zstedc](interfacehipfort__rocsolver_1_1rocsolver__zstedc.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 158 | [rocsolver_sstebz](interfacehipfort__rocsolver_1_1rocsolver__sstebz.html "Interface documentation") | C binding
 159 | [rocsolver_dstebz](interfacehipfort__rocsolver_1_1rocsolver__dstebz.html "Interface documentation") | C binding
 160 | [rocsolver_sstein](interfacehipfort__rocsolver_1_1rocsolver__sstein.html "Interface documentation") | C binding
@@ -167,10 +167,10 @@
 163 | [rocsolver_zstein](interfacehipfort__rocsolver_1_1rocsolver__zstein.html "Interface documentation") | C binding
 164 | [rocsolver_sbdsvdx](interfacehipfort__rocsolver_1_1rocsolver__sbdsvdx.html "Interface documentation") | C binding
 165 | [rocsolver_dbdsvdx](interfacehipfort__rocsolver_1_1rocsolver__dbdsvdx.html "Interface documentation") | C binding
-166 | [rocsolver_sgetf2_npvt](interfacehipfort__rocsolver_1_1rocsolver__sgetf2__npvt.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-167 | [rocsolver_dgetf2_npvt](interfacehipfort__rocsolver_1_1rocsolver__dgetf2__npvt.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-168 | [rocsolver_cgetf2_npvt](interfacehipfort__rocsolver_1_1rocsolver__cgetf2__npvt.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-169 | [rocsolver_zgetf2_npvt](interfacehipfort__rocsolver_1_1rocsolver__zgetf2__npvt.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+166 | [rocsolver_sgetf2_npvt](interfacehipfort__rocsolver_1_1rocsolver__sgetf2__npvt.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+167 | [rocsolver_dgetf2_npvt](interfacehipfort__rocsolver_1_1rocsolver__dgetf2__npvt.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+168 | [rocsolver_cgetf2_npvt](interfacehipfort__rocsolver_1_1rocsolver__cgetf2__npvt.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+169 | [rocsolver_zgetf2_npvt](interfacehipfort__rocsolver_1_1rocsolver__zgetf2__npvt.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 170 | [rocsolver_sgetf2_npvt_64](interfacehipfort__rocsolver_1_1rocsolver__sgetf2__npvt__64.html "Interface documentation") | C binding
 171 | [rocsolver_dgetf2_npvt_64](interfacehipfort__rocsolver_1_1rocsolver__dgetf2__npvt__64.html "Interface documentation") | C binding
 172 | [rocsolver_cgetf2_npvt_64](interfacehipfort__rocsolver_1_1rocsolver__cgetf2__npvt__64.html "Interface documentation") | C binding
@@ -183,18 +183,18 @@
 179 | [rocsolver_dgetf2_npvt_batched_64](interfacehipfort__rocsolver_1_1rocsolver__dgetf2__npvt__batched__64.html "Interface documentation") | C binding
 180 | [rocsolver_cgetf2_npvt_batched_64](interfacehipfort__rocsolver_1_1rocsolver__cgetf2__npvt__batched__64.html "Interface documentation") | C binding
 181 | [rocsolver_zgetf2_npvt_batched_64](interfacehipfort__rocsolver_1_1rocsolver__zgetf2__npvt__batched__64.html "Interface documentation") | C binding
-182 | [rocsolver_sgetf2_npvt_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__sgetf2__npvt__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-183 | [rocsolver_dgetf2_npvt_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dgetf2__npvt__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-184 | [rocsolver_cgetf2_npvt_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cgetf2__npvt__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-185 | [rocsolver_zgetf2_npvt_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zgetf2__npvt__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+182 | [rocsolver_sgetf2_npvt_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__sgetf2__npvt__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+183 | [rocsolver_dgetf2_npvt_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dgetf2__npvt__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+184 | [rocsolver_cgetf2_npvt_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cgetf2__npvt__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+185 | [rocsolver_zgetf2_npvt_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zgetf2__npvt__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 186 | [rocsolver_sgetf2_npvt_strided_batched_64](interfacehipfort__rocsolver_1_1rocsolver__sgetf2__npvt__strided__batched__64.html "Interface documentation") | C binding
 187 | [rocsolver_dgetf2_npvt_strided_batched_64](interfacehipfort__rocsolver_1_1rocsolver__dgetf2__npvt__strided__batched__64.html "Interface documentation") | C binding
 188 | [rocsolver_cgetf2_npvt_strided_batched_64](interfacehipfort__rocsolver_1_1rocsolver__cgetf2__npvt__strided__batched__64.html "Interface documentation") | C binding
 189 | [rocsolver_zgetf2_npvt_strided_batched_64](interfacehipfort__rocsolver_1_1rocsolver__zgetf2__npvt__strided__batched__64.html "Interface documentation") | C binding
-190 | [rocsolver_sgetrf_npvt](interfacehipfort__rocsolver_1_1rocsolver__sgetrf__npvt.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-191 | [rocsolver_dgetrf_npvt](interfacehipfort__rocsolver_1_1rocsolver__dgetrf__npvt.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-192 | [rocsolver_cgetrf_npvt](interfacehipfort__rocsolver_1_1rocsolver__cgetrf__npvt.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-193 | [rocsolver_zgetrf_npvt](interfacehipfort__rocsolver_1_1rocsolver__zgetrf__npvt.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+190 | [rocsolver_sgetrf_npvt](interfacehipfort__rocsolver_1_1rocsolver__sgetrf__npvt.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+191 | [rocsolver_dgetrf_npvt](interfacehipfort__rocsolver_1_1rocsolver__dgetrf__npvt.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+192 | [rocsolver_cgetrf_npvt](interfacehipfort__rocsolver_1_1rocsolver__cgetrf__npvt.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+193 | [rocsolver_zgetrf_npvt](interfacehipfort__rocsolver_1_1rocsolver__zgetrf__npvt.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 194 | [rocsolver_sgetrf_npvt_64](interfacehipfort__rocsolver_1_1rocsolver__sgetrf__npvt__64.html "Interface documentation") | C binding
 195 | [rocsolver_dgetrf_npvt_64](interfacehipfort__rocsolver_1_1rocsolver__dgetrf__npvt__64.html "Interface documentation") | C binding
 196 | [rocsolver_cgetrf_npvt_64](interfacehipfort__rocsolver_1_1rocsolver__cgetrf__npvt__64.html "Interface documentation") | C binding
@@ -207,226 +207,226 @@
 203 | [rocsolver_dgetrf_npvt_batched_64](interfacehipfort__rocsolver_1_1rocsolver__dgetrf__npvt__batched__64.html "Interface documentation") | C binding
 204 | [rocsolver_cgetrf_npvt_batched_64](interfacehipfort__rocsolver_1_1rocsolver__cgetrf__npvt__batched__64.html "Interface documentation") | C binding
 205 | [rocsolver_zgetrf_npvt_batched_64](interfacehipfort__rocsolver_1_1rocsolver__zgetrf__npvt__batched__64.html "Interface documentation") | C binding
-206 | [rocsolver_sgetrf_npvt_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__sgetrf__npvt__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-207 | [rocsolver_dgetrf_npvt_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dgetrf__npvt__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-208 | [rocsolver_cgetrf_npvt_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cgetrf__npvt__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-209 | [rocsolver_zgetrf_npvt_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zgetrf__npvt__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+206 | [rocsolver_sgetrf_npvt_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__sgetrf__npvt__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+207 | [rocsolver_dgetrf_npvt_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dgetrf__npvt__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+208 | [rocsolver_cgetrf_npvt_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cgetrf__npvt__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+209 | [rocsolver_zgetrf_npvt_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zgetrf__npvt__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 210 | [rocsolver_sgetrf_npvt_strided_batched_64](interfacehipfort__rocsolver_1_1rocsolver__sgetrf__npvt__strided__batched__64.html "Interface documentation") | C binding
 211 | [rocsolver_dgetrf_npvt_strided_batched_64](interfacehipfort__rocsolver_1_1rocsolver__dgetrf__npvt__strided__batched__64.html "Interface documentation") | C binding
 212 | [rocsolver_cgetrf_npvt_strided_batched_64](interfacehipfort__rocsolver_1_1rocsolver__cgetrf__npvt__strided__batched__64.html "Interface documentation") | C binding
 213 | [rocsolver_zgetrf_npvt_strided_batched_64](interfacehipfort__rocsolver_1_1rocsolver__zgetrf__npvt__strided__batched__64.html "Interface documentation") | C binding
-214 | [rocsolver_sgetf2](interfacehipfort__rocsolver_1_1rocsolver__sgetf2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-215 | [rocsolver_dgetf2](interfacehipfort__rocsolver_1_1rocsolver__dgetf2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-216 | [rocsolver_cgetf2](interfacehipfort__rocsolver_1_1rocsolver__cgetf2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-217 | [rocsolver_zgetf2](interfacehipfort__rocsolver_1_1rocsolver__zgetf2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+214 | [rocsolver_sgetf2](interfacehipfort__rocsolver_1_1rocsolver__sgetf2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+215 | [rocsolver_dgetf2](interfacehipfort__rocsolver_1_1rocsolver__dgetf2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+216 | [rocsolver_cgetf2](interfacehipfort__rocsolver_1_1rocsolver__cgetf2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+217 | [rocsolver_zgetf2](interfacehipfort__rocsolver_1_1rocsolver__zgetf2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 218 | [rocsolver_sgetf2_64](interfacehipfort__rocsolver_1_1rocsolver__sgetf2__64.html "Interface documentation") | C binding
 219 | [rocsolver_dgetf2_64](interfacehipfort__rocsolver_1_1rocsolver__dgetf2__64.html "Interface documentation") | C binding
 220 | [rocsolver_cgetf2_64](interfacehipfort__rocsolver_1_1rocsolver__cgetf2__64.html "Interface documentation") | C binding
 221 | [rocsolver_zgetf2_64](interfacehipfort__rocsolver_1_1rocsolver__zgetf2__64.html "Interface documentation") | C binding
-222 | [rocsolver_sgetf2_batched](interfacehipfort__rocsolver_1_1rocsolver__sgetf2__batched.html "Interface documentation") | C binding, rank_0, rank_1
-223 | [rocsolver_dgetf2_batched](interfacehipfort__rocsolver_1_1rocsolver__dgetf2__batched.html "Interface documentation") | C binding, rank_0, rank_1
-224 | [rocsolver_cgetf2_batched](interfacehipfort__rocsolver_1_1rocsolver__cgetf2__batched.html "Interface documentation") | C binding, rank_0, rank_1
-225 | [rocsolver_zgetf2_batched](interfacehipfort__rocsolver_1_1rocsolver__zgetf2__batched.html "Interface documentation") | C binding, rank_0, rank_1
+222 | [rocsolver_sgetf2_batched](interfacehipfort__rocsolver_1_1rocsolver__sgetf2__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+223 | [rocsolver_dgetf2_batched](interfacehipfort__rocsolver_1_1rocsolver__dgetf2__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+224 | [rocsolver_cgetf2_batched](interfacehipfort__rocsolver_1_1rocsolver__cgetf2__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+225 | [rocsolver_zgetf2_batched](interfacehipfort__rocsolver_1_1rocsolver__zgetf2__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 226 | [rocsolver_sgetf2_batched_64](interfacehipfort__rocsolver_1_1rocsolver__sgetf2__batched__64.html "Interface documentation") | C binding
 227 | [rocsolver_dgetf2_batched_64](interfacehipfort__rocsolver_1_1rocsolver__dgetf2__batched__64.html "Interface documentation") | C binding
 228 | [rocsolver_cgetf2_batched_64](interfacehipfort__rocsolver_1_1rocsolver__cgetf2__batched__64.html "Interface documentation") | C binding
 229 | [rocsolver_zgetf2_batched_64](interfacehipfort__rocsolver_1_1rocsolver__zgetf2__batched__64.html "Interface documentation") | C binding
-230 | [rocsolver_sgetf2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__sgetf2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-231 | [rocsolver_dgetf2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dgetf2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-232 | [rocsolver_cgetf2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cgetf2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-233 | [rocsolver_zgetf2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zgetf2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+230 | [rocsolver_sgetf2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__sgetf2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+231 | [rocsolver_dgetf2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dgetf2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+232 | [rocsolver_cgetf2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cgetf2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+233 | [rocsolver_zgetf2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zgetf2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 234 | [rocsolver_sgetf2_strided_batched_64](interfacehipfort__rocsolver_1_1rocsolver__sgetf2__strided__batched__64.html "Interface documentation") | C binding
 235 | [rocsolver_dgetf2_strided_batched_64](interfacehipfort__rocsolver_1_1rocsolver__dgetf2__strided__batched__64.html "Interface documentation") | C binding
 236 | [rocsolver_cgetf2_strided_batched_64](interfacehipfort__rocsolver_1_1rocsolver__cgetf2__strided__batched__64.html "Interface documentation") | C binding
 237 | [rocsolver_zgetf2_strided_batched_64](interfacehipfort__rocsolver_1_1rocsolver__zgetf2__strided__batched__64.html "Interface documentation") | C binding
-238 | [rocsolver_sgetrf](interfacehipfort__rocsolver_1_1rocsolver__sgetrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-239 | [rocsolver_dgetrf](interfacehipfort__rocsolver_1_1rocsolver__dgetrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-240 | [rocsolver_cgetrf](interfacehipfort__rocsolver_1_1rocsolver__cgetrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-241 | [rocsolver_zgetrf](interfacehipfort__rocsolver_1_1rocsolver__zgetrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+238 | [rocsolver_sgetrf](interfacehipfort__rocsolver_1_1rocsolver__sgetrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+239 | [rocsolver_dgetrf](interfacehipfort__rocsolver_1_1rocsolver__dgetrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+240 | [rocsolver_cgetrf](interfacehipfort__rocsolver_1_1rocsolver__cgetrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+241 | [rocsolver_zgetrf](interfacehipfort__rocsolver_1_1rocsolver__zgetrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 242 | [rocsolver_sgetrf_64](interfacehipfort__rocsolver_1_1rocsolver__sgetrf__64.html "Interface documentation") | C binding
 243 | [rocsolver_dgetrf_64](interfacehipfort__rocsolver_1_1rocsolver__dgetrf__64.html "Interface documentation") | C binding
 244 | [rocsolver_cgetrf_64](interfacehipfort__rocsolver_1_1rocsolver__cgetrf__64.html "Interface documentation") | C binding
 245 | [rocsolver_zgetrf_64](interfacehipfort__rocsolver_1_1rocsolver__zgetrf__64.html "Interface documentation") | C binding
-246 | [rocsolver_sgetrf_batched](interfacehipfort__rocsolver_1_1rocsolver__sgetrf__batched.html "Interface documentation") | C binding, rank_0, rank_1
-247 | [rocsolver_dgetrf_batched](interfacehipfort__rocsolver_1_1rocsolver__dgetrf__batched.html "Interface documentation") | C binding, rank_0, rank_1
-248 | [rocsolver_cgetrf_batched](interfacehipfort__rocsolver_1_1rocsolver__cgetrf__batched.html "Interface documentation") | C binding, rank_0, rank_1
-249 | [rocsolver_zgetrf_batched](interfacehipfort__rocsolver_1_1rocsolver__zgetrf__batched.html "Interface documentation") | C binding, rank_0, rank_1
+246 | [rocsolver_sgetrf_batched](interfacehipfort__rocsolver_1_1rocsolver__sgetrf__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+247 | [rocsolver_dgetrf_batched](interfacehipfort__rocsolver_1_1rocsolver__dgetrf__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+248 | [rocsolver_cgetrf_batched](interfacehipfort__rocsolver_1_1rocsolver__cgetrf__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+249 | [rocsolver_zgetrf_batched](interfacehipfort__rocsolver_1_1rocsolver__zgetrf__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 250 | [rocsolver_sgetrf_batched_64](interfacehipfort__rocsolver_1_1rocsolver__sgetrf__batched__64.html "Interface documentation") | C binding
 251 | [rocsolver_dgetrf_batched_64](interfacehipfort__rocsolver_1_1rocsolver__dgetrf__batched__64.html "Interface documentation") | C binding
 252 | [rocsolver_cgetrf_batched_64](interfacehipfort__rocsolver_1_1rocsolver__cgetrf__batched__64.html "Interface documentation") | C binding
 253 | [rocsolver_zgetrf_batched_64](interfacehipfort__rocsolver_1_1rocsolver__zgetrf__batched__64.html "Interface documentation") | C binding
-254 | [rocsolver_sgetrf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__sgetrf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-255 | [rocsolver_dgetrf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dgetrf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-256 | [rocsolver_cgetrf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cgetrf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-257 | [rocsolver_zgetrf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zgetrf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+254 | [rocsolver_sgetrf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__sgetrf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+255 | [rocsolver_dgetrf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dgetrf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+256 | [rocsolver_cgetrf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cgetrf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+257 | [rocsolver_zgetrf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zgetrf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 258 | [rocsolver_sgetrf_strided_batched_64](interfacehipfort__rocsolver_1_1rocsolver__sgetrf__strided__batched__64.html "Interface documentation") | C binding
 259 | [rocsolver_dgetrf_strided_batched_64](interfacehipfort__rocsolver_1_1rocsolver__dgetrf__strided__batched__64.html "Interface documentation") | C binding
 260 | [rocsolver_cgetrf_strided_batched_64](interfacehipfort__rocsolver_1_1rocsolver__cgetrf__strided__batched__64.html "Interface documentation") | C binding
 261 | [rocsolver_zgetrf_strided_batched_64](interfacehipfort__rocsolver_1_1rocsolver__zgetrf__strided__batched__64.html "Interface documentation") | C binding
-262 | [rocsolver_sgeqr2](interfacehipfort__rocsolver_1_1rocsolver__sgeqr2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-263 | [rocsolver_dgeqr2](interfacehipfort__rocsolver_1_1rocsolver__dgeqr2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-264 | [rocsolver_cgeqr2](interfacehipfort__rocsolver_1_1rocsolver__cgeqr2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-265 | [rocsolver_zgeqr2](interfacehipfort__rocsolver_1_1rocsolver__zgeqr2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+262 | [rocsolver_sgeqr2](interfacehipfort__rocsolver_1_1rocsolver__sgeqr2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+263 | [rocsolver_dgeqr2](interfacehipfort__rocsolver_1_1rocsolver__dgeqr2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+264 | [rocsolver_cgeqr2](interfacehipfort__rocsolver_1_1rocsolver__cgeqr2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+265 | [rocsolver_zgeqr2](interfacehipfort__rocsolver_1_1rocsolver__zgeqr2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 266 | [rocsolver_sgeqr2_64](interfacehipfort__rocsolver_1_1rocsolver__sgeqr2__64.html "Interface documentation") | C binding
 267 | [rocsolver_dgeqr2_64](interfacehipfort__rocsolver_1_1rocsolver__dgeqr2__64.html "Interface documentation") | C binding
 268 | [rocsolver_cgeqr2_64](interfacehipfort__rocsolver_1_1rocsolver__cgeqr2__64.html "Interface documentation") | C binding
 269 | [rocsolver_zgeqr2_64](interfacehipfort__rocsolver_1_1rocsolver__zgeqr2__64.html "Interface documentation") | C binding
-270 | [rocsolver_sgeqr2_batched](interfacehipfort__rocsolver_1_1rocsolver__sgeqr2__batched.html "Interface documentation") | C binding, rank_0, rank_1
-271 | [rocsolver_dgeqr2_batched](interfacehipfort__rocsolver_1_1rocsolver__dgeqr2__batched.html "Interface documentation") | C binding, rank_0, rank_1
-272 | [rocsolver_cgeqr2_batched](interfacehipfort__rocsolver_1_1rocsolver__cgeqr2__batched.html "Interface documentation") | C binding, rank_0, rank_1
-273 | [rocsolver_zgeqr2_batched](interfacehipfort__rocsolver_1_1rocsolver__zgeqr2__batched.html "Interface documentation") | C binding, rank_0, rank_1
+270 | [rocsolver_sgeqr2_batched](interfacehipfort__rocsolver_1_1rocsolver__sgeqr2__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+271 | [rocsolver_dgeqr2_batched](interfacehipfort__rocsolver_1_1rocsolver__dgeqr2__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+272 | [rocsolver_cgeqr2_batched](interfacehipfort__rocsolver_1_1rocsolver__cgeqr2__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+273 | [rocsolver_zgeqr2_batched](interfacehipfort__rocsolver_1_1rocsolver__zgeqr2__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 274 | [rocsolver_sgeqr2_batched_64](interfacehipfort__rocsolver_1_1rocsolver__sgeqr2__batched__64.html "Interface documentation") | C binding
 275 | [rocsolver_dgeqr2_batched_64](interfacehipfort__rocsolver_1_1rocsolver__dgeqr2__batched__64.html "Interface documentation") | C binding
 276 | [rocsolver_cgeqr2_batched_64](interfacehipfort__rocsolver_1_1rocsolver__cgeqr2__batched__64.html "Interface documentation") | C binding
 277 | [rocsolver_zgeqr2_batched_64](interfacehipfort__rocsolver_1_1rocsolver__zgeqr2__batched__64.html "Interface documentation") | C binding
-278 | [rocsolver_sgeqr2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__sgeqr2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-279 | [rocsolver_dgeqr2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dgeqr2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-280 | [rocsolver_cgeqr2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cgeqr2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-281 | [rocsolver_zgeqr2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zgeqr2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+278 | [rocsolver_sgeqr2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__sgeqr2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+279 | [rocsolver_dgeqr2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dgeqr2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+280 | [rocsolver_cgeqr2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cgeqr2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+281 | [rocsolver_zgeqr2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zgeqr2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 282 | [rocsolver_sgeqr2_strided_batched_64](interfacehipfort__rocsolver_1_1rocsolver__sgeqr2__strided__batched__64.html "Interface documentation") | C binding
 283 | [rocsolver_dgeqr2_strided_batched_64](interfacehipfort__rocsolver_1_1rocsolver__dgeqr2__strided__batched__64.html "Interface documentation") | C binding
 284 | [rocsolver_cgeqr2_strided_batched_64](interfacehipfort__rocsolver_1_1rocsolver__cgeqr2__strided__batched__64.html "Interface documentation") | C binding
 285 | [rocsolver_zgeqr2_strided_batched_64](interfacehipfort__rocsolver_1_1rocsolver__zgeqr2__strided__batched__64.html "Interface documentation") | C binding
-286 | [rocsolver_sgerq2](interfacehipfort__rocsolver_1_1rocsolver__sgerq2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-287 | [rocsolver_dgerq2](interfacehipfort__rocsolver_1_1rocsolver__dgerq2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-288 | [rocsolver_cgerq2](interfacehipfort__rocsolver_1_1rocsolver__cgerq2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-289 | [rocsolver_zgerq2](interfacehipfort__rocsolver_1_1rocsolver__zgerq2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-290 | [rocsolver_sgerq2_batched](interfacehipfort__rocsolver_1_1rocsolver__sgerq2__batched.html "Interface documentation") | C binding, rank_0, rank_1
-291 | [rocsolver_dgerq2_batched](interfacehipfort__rocsolver_1_1rocsolver__dgerq2__batched.html "Interface documentation") | C binding, rank_0, rank_1
-292 | [rocsolver_cgerq2_batched](interfacehipfort__rocsolver_1_1rocsolver__cgerq2__batched.html "Interface documentation") | C binding, rank_0, rank_1
-293 | [rocsolver_zgerq2_batched](interfacehipfort__rocsolver_1_1rocsolver__zgerq2__batched.html "Interface documentation") | C binding, rank_0, rank_1
-294 | [rocsolver_sgerq2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__sgerq2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-295 | [rocsolver_dgerq2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dgerq2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-296 | [rocsolver_cgerq2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cgerq2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-297 | [rocsolver_zgerq2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zgerq2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-298 | [rocsolver_sgeql2](interfacehipfort__rocsolver_1_1rocsolver__sgeql2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-299 | [rocsolver_dgeql2](interfacehipfort__rocsolver_1_1rocsolver__dgeql2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-300 | [rocsolver_cgeql2](interfacehipfort__rocsolver_1_1rocsolver__cgeql2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-301 | [rocsolver_zgeql2](interfacehipfort__rocsolver_1_1rocsolver__zgeql2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-302 | [rocsolver_sgeql2_batched](interfacehipfort__rocsolver_1_1rocsolver__sgeql2__batched.html "Interface documentation") | C binding, rank_0, rank_1
-303 | [rocsolver_dgeql2_batched](interfacehipfort__rocsolver_1_1rocsolver__dgeql2__batched.html "Interface documentation") | C binding, rank_0, rank_1
-304 | [rocsolver_cgeql2_batched](interfacehipfort__rocsolver_1_1rocsolver__cgeql2__batched.html "Interface documentation") | C binding, rank_0, rank_1
-305 | [rocsolver_zgeql2_batched](interfacehipfort__rocsolver_1_1rocsolver__zgeql2__batched.html "Interface documentation") | C binding, rank_0, rank_1
-306 | [rocsolver_sgeql2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__sgeql2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-307 | [rocsolver_dgeql2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dgeql2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-308 | [rocsolver_cgeql2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cgeql2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-309 | [rocsolver_zgeql2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zgeql2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-310 | [rocsolver_sgelq2](interfacehipfort__rocsolver_1_1rocsolver__sgelq2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-311 | [rocsolver_dgelq2](interfacehipfort__rocsolver_1_1rocsolver__dgelq2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-312 | [rocsolver_cgelq2](interfacehipfort__rocsolver_1_1rocsolver__cgelq2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-313 | [rocsolver_zgelq2](interfacehipfort__rocsolver_1_1rocsolver__zgelq2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-314 | [rocsolver_sgelq2_batched](interfacehipfort__rocsolver_1_1rocsolver__sgelq2__batched.html "Interface documentation") | C binding, rank_0, rank_1
-315 | [rocsolver_dgelq2_batched](interfacehipfort__rocsolver_1_1rocsolver__dgelq2__batched.html "Interface documentation") | C binding, rank_0, rank_1
-316 | [rocsolver_cgelq2_batched](interfacehipfort__rocsolver_1_1rocsolver__cgelq2__batched.html "Interface documentation") | C binding, rank_0, rank_1
-317 | [rocsolver_zgelq2_batched](interfacehipfort__rocsolver_1_1rocsolver__zgelq2__batched.html "Interface documentation") | C binding, rank_0, rank_1
-318 | [rocsolver_sgelq2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__sgelq2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-319 | [rocsolver_dgelq2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dgelq2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-320 | [rocsolver_cgelq2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cgelq2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-321 | [rocsolver_zgelq2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zgelq2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-322 | [rocsolver_sgeqrf](interfacehipfort__rocsolver_1_1rocsolver__sgeqrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-323 | [rocsolver_dgeqrf](interfacehipfort__rocsolver_1_1rocsolver__dgeqrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-324 | [rocsolver_cgeqrf](interfacehipfort__rocsolver_1_1rocsolver__cgeqrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-325 | [rocsolver_zgeqrf](interfacehipfort__rocsolver_1_1rocsolver__zgeqrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+286 | [rocsolver_sgerq2](interfacehipfort__rocsolver_1_1rocsolver__sgerq2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+287 | [rocsolver_dgerq2](interfacehipfort__rocsolver_1_1rocsolver__dgerq2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+288 | [rocsolver_cgerq2](interfacehipfort__rocsolver_1_1rocsolver__cgerq2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+289 | [rocsolver_zgerq2](interfacehipfort__rocsolver_1_1rocsolver__zgerq2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+290 | [rocsolver_sgerq2_batched](interfacehipfort__rocsolver_1_1rocsolver__sgerq2__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+291 | [rocsolver_dgerq2_batched](interfacehipfort__rocsolver_1_1rocsolver__dgerq2__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+292 | [rocsolver_cgerq2_batched](interfacehipfort__rocsolver_1_1rocsolver__cgerq2__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+293 | [rocsolver_zgerq2_batched](interfacehipfort__rocsolver_1_1rocsolver__zgerq2__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+294 | [rocsolver_sgerq2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__sgerq2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+295 | [rocsolver_dgerq2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dgerq2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+296 | [rocsolver_cgerq2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cgerq2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+297 | [rocsolver_zgerq2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zgerq2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+298 | [rocsolver_sgeql2](interfacehipfort__rocsolver_1_1rocsolver__sgeql2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+299 | [rocsolver_dgeql2](interfacehipfort__rocsolver_1_1rocsolver__dgeql2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+300 | [rocsolver_cgeql2](interfacehipfort__rocsolver_1_1rocsolver__cgeql2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+301 | [rocsolver_zgeql2](interfacehipfort__rocsolver_1_1rocsolver__zgeql2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+302 | [rocsolver_sgeql2_batched](interfacehipfort__rocsolver_1_1rocsolver__sgeql2__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+303 | [rocsolver_dgeql2_batched](interfacehipfort__rocsolver_1_1rocsolver__dgeql2__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+304 | [rocsolver_cgeql2_batched](interfacehipfort__rocsolver_1_1rocsolver__cgeql2__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+305 | [rocsolver_zgeql2_batched](interfacehipfort__rocsolver_1_1rocsolver__zgeql2__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+306 | [rocsolver_sgeql2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__sgeql2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+307 | [rocsolver_dgeql2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dgeql2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+308 | [rocsolver_cgeql2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cgeql2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+309 | [rocsolver_zgeql2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zgeql2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+310 | [rocsolver_sgelq2](interfacehipfort__rocsolver_1_1rocsolver__sgelq2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+311 | [rocsolver_dgelq2](interfacehipfort__rocsolver_1_1rocsolver__dgelq2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+312 | [rocsolver_cgelq2](interfacehipfort__rocsolver_1_1rocsolver__cgelq2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+313 | [rocsolver_zgelq2](interfacehipfort__rocsolver_1_1rocsolver__zgelq2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+314 | [rocsolver_sgelq2_batched](interfacehipfort__rocsolver_1_1rocsolver__sgelq2__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+315 | [rocsolver_dgelq2_batched](interfacehipfort__rocsolver_1_1rocsolver__dgelq2__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+316 | [rocsolver_cgelq2_batched](interfacehipfort__rocsolver_1_1rocsolver__cgelq2__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+317 | [rocsolver_zgelq2_batched](interfacehipfort__rocsolver_1_1rocsolver__zgelq2__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+318 | [rocsolver_sgelq2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__sgelq2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+319 | [rocsolver_dgelq2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dgelq2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+320 | [rocsolver_cgelq2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cgelq2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+321 | [rocsolver_zgelq2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zgelq2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+322 | [rocsolver_sgeqrf](interfacehipfort__rocsolver_1_1rocsolver__sgeqrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+323 | [rocsolver_dgeqrf](interfacehipfort__rocsolver_1_1rocsolver__dgeqrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+324 | [rocsolver_cgeqrf](interfacehipfort__rocsolver_1_1rocsolver__cgeqrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+325 | [rocsolver_zgeqrf](interfacehipfort__rocsolver_1_1rocsolver__zgeqrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 326 | [rocsolver_sgeqrf_64](interfacehipfort__rocsolver_1_1rocsolver__sgeqrf__64.html "Interface documentation") | C binding
 327 | [rocsolver_dgeqrf_64](interfacehipfort__rocsolver_1_1rocsolver__dgeqrf__64.html "Interface documentation") | C binding
 328 | [rocsolver_cgeqrf_64](interfacehipfort__rocsolver_1_1rocsolver__cgeqrf__64.html "Interface documentation") | C binding
 329 | [rocsolver_zgeqrf_64](interfacehipfort__rocsolver_1_1rocsolver__zgeqrf__64.html "Interface documentation") | C binding
-330 | [rocsolver_sgeqrf_batched](interfacehipfort__rocsolver_1_1rocsolver__sgeqrf__batched.html "Interface documentation") | C binding, rank_0, rank_1
-331 | [rocsolver_dgeqrf_batched](interfacehipfort__rocsolver_1_1rocsolver__dgeqrf__batched.html "Interface documentation") | C binding, rank_0, rank_1
-332 | [rocsolver_cgeqrf_batched](interfacehipfort__rocsolver_1_1rocsolver__cgeqrf__batched.html "Interface documentation") | C binding, rank_0, rank_1
-333 | [rocsolver_zgeqrf_batched](interfacehipfort__rocsolver_1_1rocsolver__zgeqrf__batched.html "Interface documentation") | C binding, rank_0, rank_1
+330 | [rocsolver_sgeqrf_batched](interfacehipfort__rocsolver_1_1rocsolver__sgeqrf__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+331 | [rocsolver_dgeqrf_batched](interfacehipfort__rocsolver_1_1rocsolver__dgeqrf__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+332 | [rocsolver_cgeqrf_batched](interfacehipfort__rocsolver_1_1rocsolver__cgeqrf__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+333 | [rocsolver_zgeqrf_batched](interfacehipfort__rocsolver_1_1rocsolver__zgeqrf__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 334 | [rocsolver_sgeqrf_batched_64](interfacehipfort__rocsolver_1_1rocsolver__sgeqrf__batched__64.html "Interface documentation") | C binding
 335 | [rocsolver_dgeqrf_batched_64](interfacehipfort__rocsolver_1_1rocsolver__dgeqrf__batched__64.html "Interface documentation") | C binding
 336 | [rocsolver_cgeqrf_batched_64](interfacehipfort__rocsolver_1_1rocsolver__cgeqrf__batched__64.html "Interface documentation") | C binding
 337 | [rocsolver_zgeqrf_batched_64](interfacehipfort__rocsolver_1_1rocsolver__zgeqrf__batched__64.html "Interface documentation") | C binding
-338 | [rocsolver_sgeqrf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__sgeqrf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-339 | [rocsolver_dgeqrf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dgeqrf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-340 | [rocsolver_cgeqrf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cgeqrf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-341 | [rocsolver_zgeqrf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zgeqrf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+338 | [rocsolver_sgeqrf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__sgeqrf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+339 | [rocsolver_dgeqrf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dgeqrf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+340 | [rocsolver_cgeqrf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cgeqrf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+341 | [rocsolver_zgeqrf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zgeqrf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 342 | [rocsolver_sgeqrf_strided_batched_64](interfacehipfort__rocsolver_1_1rocsolver__sgeqrf__strided__batched__64.html "Interface documentation") | C binding
 343 | [rocsolver_dgeqrf_strided_batched_64](interfacehipfort__rocsolver_1_1rocsolver__dgeqrf__strided__batched__64.html "Interface documentation") | C binding
 344 | [rocsolver_cgeqrf_strided_batched_64](interfacehipfort__rocsolver_1_1rocsolver__cgeqrf__strided__batched__64.html "Interface documentation") | C binding
 345 | [rocsolver_zgeqrf_strided_batched_64](interfacehipfort__rocsolver_1_1rocsolver__zgeqrf__strided__batched__64.html "Interface documentation") | C binding
-346 | [rocsolver_sgerqf](interfacehipfort__rocsolver_1_1rocsolver__sgerqf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-347 | [rocsolver_dgerqf](interfacehipfort__rocsolver_1_1rocsolver__dgerqf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-348 | [rocsolver_cgerqf](interfacehipfort__rocsolver_1_1rocsolver__cgerqf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-349 | [rocsolver_zgerqf](interfacehipfort__rocsolver_1_1rocsolver__zgerqf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-350 | [rocsolver_sgerqf_batched](interfacehipfort__rocsolver_1_1rocsolver__sgerqf__batched.html "Interface documentation") | C binding, rank_0, rank_1
-351 | [rocsolver_dgerqf_batched](interfacehipfort__rocsolver_1_1rocsolver__dgerqf__batched.html "Interface documentation") | C binding, rank_0, rank_1
-352 | [rocsolver_cgerqf_batched](interfacehipfort__rocsolver_1_1rocsolver__cgerqf__batched.html "Interface documentation") | C binding, rank_0, rank_1
-353 | [rocsolver_zgerqf_batched](interfacehipfort__rocsolver_1_1rocsolver__zgerqf__batched.html "Interface documentation") | C binding, rank_0, rank_1
-354 | [rocsolver_sgerqf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__sgerqf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-355 | [rocsolver_dgerqf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dgerqf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-356 | [rocsolver_cgerqf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cgerqf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-357 | [rocsolver_zgerqf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zgerqf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-358 | [rocsolver_sgeqlf](interfacehipfort__rocsolver_1_1rocsolver__sgeqlf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-359 | [rocsolver_dgeqlf](interfacehipfort__rocsolver_1_1rocsolver__dgeqlf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-360 | [rocsolver_cgeqlf](interfacehipfort__rocsolver_1_1rocsolver__cgeqlf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-361 | [rocsolver_zgeqlf](interfacehipfort__rocsolver_1_1rocsolver__zgeqlf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-362 | [rocsolver_sgeqlf_batched](interfacehipfort__rocsolver_1_1rocsolver__sgeqlf__batched.html "Interface documentation") | C binding, rank_0, rank_1
-363 | [rocsolver_dgeqlf_batched](interfacehipfort__rocsolver_1_1rocsolver__dgeqlf__batched.html "Interface documentation") | C binding, rank_0, rank_1
-364 | [rocsolver_cgeqlf_batched](interfacehipfort__rocsolver_1_1rocsolver__cgeqlf__batched.html "Interface documentation") | C binding, rank_0, rank_1
-365 | [rocsolver_zgeqlf_batched](interfacehipfort__rocsolver_1_1rocsolver__zgeqlf__batched.html "Interface documentation") | C binding, rank_0, rank_1
-366 | [rocsolver_sgeqlf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__sgeqlf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-367 | [rocsolver_dgeqlf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dgeqlf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-368 | [rocsolver_cgeqlf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cgeqlf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-369 | [rocsolver_zgeqlf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zgeqlf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-370 | [rocsolver_sgelqf](interfacehipfort__rocsolver_1_1rocsolver__sgelqf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-371 | [rocsolver_dgelqf](interfacehipfort__rocsolver_1_1rocsolver__dgelqf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-372 | [rocsolver_cgelqf](interfacehipfort__rocsolver_1_1rocsolver__cgelqf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-373 | [rocsolver_zgelqf](interfacehipfort__rocsolver_1_1rocsolver__zgelqf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-374 | [rocsolver_sgelqf_batched](interfacehipfort__rocsolver_1_1rocsolver__sgelqf__batched.html "Interface documentation") | C binding, rank_0, rank_1
-375 | [rocsolver_dgelqf_batched](interfacehipfort__rocsolver_1_1rocsolver__dgelqf__batched.html "Interface documentation") | C binding, rank_0, rank_1
-376 | [rocsolver_cgelqf_batched](interfacehipfort__rocsolver_1_1rocsolver__cgelqf__batched.html "Interface documentation") | C binding, rank_0, rank_1
-377 | [rocsolver_zgelqf_batched](interfacehipfort__rocsolver_1_1rocsolver__zgelqf__batched.html "Interface documentation") | C binding, rank_0, rank_1
-378 | [rocsolver_sgelqf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__sgelqf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-379 | [rocsolver_dgelqf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dgelqf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-380 | [rocsolver_cgelqf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cgelqf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-381 | [rocsolver_zgelqf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zgelqf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-382 | [rocsolver_sgebd2](interfacehipfort__rocsolver_1_1rocsolver__sgebd2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-383 | [rocsolver_dgebd2](interfacehipfort__rocsolver_1_1rocsolver__dgebd2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-384 | [rocsolver_cgebd2](interfacehipfort__rocsolver_1_1rocsolver__cgebd2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-385 | [rocsolver_zgebd2](interfacehipfort__rocsolver_1_1rocsolver__zgebd2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-386 | [rocsolver_sgebd2_batched](interfacehipfort__rocsolver_1_1rocsolver__sgebd2__batched.html "Interface documentation") | C binding, rank_0, rank_1
-387 | [rocsolver_dgebd2_batched](interfacehipfort__rocsolver_1_1rocsolver__dgebd2__batched.html "Interface documentation") | C binding, rank_0, rank_1
-388 | [rocsolver_cgebd2_batched](interfacehipfort__rocsolver_1_1rocsolver__cgebd2__batched.html "Interface documentation") | C binding, rank_0, rank_1
-389 | [rocsolver_zgebd2_batched](interfacehipfort__rocsolver_1_1rocsolver__zgebd2__batched.html "Interface documentation") | C binding, rank_0, rank_1
-390 | [rocsolver_sgebd2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__sgebd2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-391 | [rocsolver_dgebd2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dgebd2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-392 | [rocsolver_cgebd2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cgebd2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-393 | [rocsolver_zgebd2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zgebd2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-394 | [rocsolver_sgebrd](interfacehipfort__rocsolver_1_1rocsolver__sgebrd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-395 | [rocsolver_dgebrd](interfacehipfort__rocsolver_1_1rocsolver__dgebrd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-396 | [rocsolver_cgebrd](interfacehipfort__rocsolver_1_1rocsolver__cgebrd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-397 | [rocsolver_zgebrd](interfacehipfort__rocsolver_1_1rocsolver__zgebrd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-398 | [rocsolver_sgebrd_batched](interfacehipfort__rocsolver_1_1rocsolver__sgebrd__batched.html "Interface documentation") | C binding, rank_0, rank_1
-399 | [rocsolver_dgebrd_batched](interfacehipfort__rocsolver_1_1rocsolver__dgebrd__batched.html "Interface documentation") | C binding, rank_0, rank_1
-400 | [rocsolver_cgebrd_batched](interfacehipfort__rocsolver_1_1rocsolver__cgebrd__batched.html "Interface documentation") | C binding, rank_0, rank_1
-401 | [rocsolver_zgebrd_batched](interfacehipfort__rocsolver_1_1rocsolver__zgebrd__batched.html "Interface documentation") | C binding, rank_0, rank_1
-402 | [rocsolver_sgebrd_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__sgebrd__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-403 | [rocsolver_dgebrd_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dgebrd__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-404 | [rocsolver_cgebrd_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cgebrd__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-405 | [rocsolver_zgebrd_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zgebrd__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-406 | [rocsolver_sgetrs](interfacehipfort__rocsolver_1_1rocsolver__sgetrs.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-407 | [rocsolver_dgetrs](interfacehipfort__rocsolver_1_1rocsolver__dgetrs.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-408 | [rocsolver_cgetrs](interfacehipfort__rocsolver_1_1rocsolver__cgetrs.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-409 | [rocsolver_zgetrs](interfacehipfort__rocsolver_1_1rocsolver__zgetrs.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+346 | [rocsolver_sgerqf](interfacehipfort__rocsolver_1_1rocsolver__sgerqf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+347 | [rocsolver_dgerqf](interfacehipfort__rocsolver_1_1rocsolver__dgerqf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+348 | [rocsolver_cgerqf](interfacehipfort__rocsolver_1_1rocsolver__cgerqf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+349 | [rocsolver_zgerqf](interfacehipfort__rocsolver_1_1rocsolver__zgerqf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+350 | [rocsolver_sgerqf_batched](interfacehipfort__rocsolver_1_1rocsolver__sgerqf__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+351 | [rocsolver_dgerqf_batched](interfacehipfort__rocsolver_1_1rocsolver__dgerqf__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+352 | [rocsolver_cgerqf_batched](interfacehipfort__rocsolver_1_1rocsolver__cgerqf__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+353 | [rocsolver_zgerqf_batched](interfacehipfort__rocsolver_1_1rocsolver__zgerqf__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+354 | [rocsolver_sgerqf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__sgerqf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+355 | [rocsolver_dgerqf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dgerqf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+356 | [rocsolver_cgerqf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cgerqf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+357 | [rocsolver_zgerqf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zgerqf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+358 | [rocsolver_sgeqlf](interfacehipfort__rocsolver_1_1rocsolver__sgeqlf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+359 | [rocsolver_dgeqlf](interfacehipfort__rocsolver_1_1rocsolver__dgeqlf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+360 | [rocsolver_cgeqlf](interfacehipfort__rocsolver_1_1rocsolver__cgeqlf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+361 | [rocsolver_zgeqlf](interfacehipfort__rocsolver_1_1rocsolver__zgeqlf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+362 | [rocsolver_sgeqlf_batched](interfacehipfort__rocsolver_1_1rocsolver__sgeqlf__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+363 | [rocsolver_dgeqlf_batched](interfacehipfort__rocsolver_1_1rocsolver__dgeqlf__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+364 | [rocsolver_cgeqlf_batched](interfacehipfort__rocsolver_1_1rocsolver__cgeqlf__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+365 | [rocsolver_zgeqlf_batched](interfacehipfort__rocsolver_1_1rocsolver__zgeqlf__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+366 | [rocsolver_sgeqlf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__sgeqlf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+367 | [rocsolver_dgeqlf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dgeqlf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+368 | [rocsolver_cgeqlf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cgeqlf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+369 | [rocsolver_zgeqlf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zgeqlf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+370 | [rocsolver_sgelqf](interfacehipfort__rocsolver_1_1rocsolver__sgelqf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+371 | [rocsolver_dgelqf](interfacehipfort__rocsolver_1_1rocsolver__dgelqf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+372 | [rocsolver_cgelqf](interfacehipfort__rocsolver_1_1rocsolver__cgelqf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+373 | [rocsolver_zgelqf](interfacehipfort__rocsolver_1_1rocsolver__zgelqf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+374 | [rocsolver_sgelqf_batched](interfacehipfort__rocsolver_1_1rocsolver__sgelqf__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+375 | [rocsolver_dgelqf_batched](interfacehipfort__rocsolver_1_1rocsolver__dgelqf__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+376 | [rocsolver_cgelqf_batched](interfacehipfort__rocsolver_1_1rocsolver__cgelqf__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+377 | [rocsolver_zgelqf_batched](interfacehipfort__rocsolver_1_1rocsolver__zgelqf__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+378 | [rocsolver_sgelqf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__sgelqf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+379 | [rocsolver_dgelqf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dgelqf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+380 | [rocsolver_cgelqf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cgelqf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+381 | [rocsolver_zgelqf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zgelqf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+382 | [rocsolver_sgebd2](interfacehipfort__rocsolver_1_1rocsolver__sgebd2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+383 | [rocsolver_dgebd2](interfacehipfort__rocsolver_1_1rocsolver__dgebd2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+384 | [rocsolver_cgebd2](interfacehipfort__rocsolver_1_1rocsolver__cgebd2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+385 | [rocsolver_zgebd2](interfacehipfort__rocsolver_1_1rocsolver__zgebd2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+386 | [rocsolver_sgebd2_batched](interfacehipfort__rocsolver_1_1rocsolver__sgebd2__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+387 | [rocsolver_dgebd2_batched](interfacehipfort__rocsolver_1_1rocsolver__dgebd2__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+388 | [rocsolver_cgebd2_batched](interfacehipfort__rocsolver_1_1rocsolver__cgebd2__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+389 | [rocsolver_zgebd2_batched](interfacehipfort__rocsolver_1_1rocsolver__zgebd2__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+390 | [rocsolver_sgebd2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__sgebd2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+391 | [rocsolver_dgebd2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dgebd2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+392 | [rocsolver_cgebd2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cgebd2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+393 | [rocsolver_zgebd2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zgebd2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+394 | [rocsolver_sgebrd](interfacehipfort__rocsolver_1_1rocsolver__sgebrd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+395 | [rocsolver_dgebrd](interfacehipfort__rocsolver_1_1rocsolver__dgebrd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+396 | [rocsolver_cgebrd](interfacehipfort__rocsolver_1_1rocsolver__cgebrd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+397 | [rocsolver_zgebrd](interfacehipfort__rocsolver_1_1rocsolver__zgebrd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+398 | [rocsolver_sgebrd_batched](interfacehipfort__rocsolver_1_1rocsolver__sgebrd__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+399 | [rocsolver_dgebrd_batched](interfacehipfort__rocsolver_1_1rocsolver__dgebrd__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+400 | [rocsolver_cgebrd_batched](interfacehipfort__rocsolver_1_1rocsolver__cgebrd__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+401 | [rocsolver_zgebrd_batched](interfacehipfort__rocsolver_1_1rocsolver__zgebrd__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+402 | [rocsolver_sgebrd_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__sgebrd__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+403 | [rocsolver_dgebrd_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dgebrd__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+404 | [rocsolver_cgebrd_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cgebrd__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+405 | [rocsolver_zgebrd_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zgebrd__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+406 | [rocsolver_sgetrs](interfacehipfort__rocsolver_1_1rocsolver__sgetrs.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+407 | [rocsolver_dgetrs](interfacehipfort__rocsolver_1_1rocsolver__dgetrs.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+408 | [rocsolver_cgetrs](interfacehipfort__rocsolver_1_1rocsolver__cgetrs.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+409 | [rocsolver_zgetrs](interfacehipfort__rocsolver_1_1rocsolver__zgetrs.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 410 | [rocsolver_sgetrs_64](interfacehipfort__rocsolver_1_1rocsolver__sgetrs__64.html "Interface documentation") | C binding
 411 | [rocsolver_dgetrs_64](interfacehipfort__rocsolver_1_1rocsolver__dgetrs__64.html "Interface documentation") | C binding
 412 | [rocsolver_cgetrs_64](interfacehipfort__rocsolver_1_1rocsolver__cgetrs__64.html "Interface documentation") | C binding
 413 | [rocsolver_zgetrs_64](interfacehipfort__rocsolver_1_1rocsolver__zgetrs__64.html "Interface documentation") | C binding
-414 | [rocsolver_sgetrs_batched](interfacehipfort__rocsolver_1_1rocsolver__sgetrs__batched.html "Interface documentation") | C binding, rank_0, rank_1
-415 | [rocsolver_dgetrs_batched](interfacehipfort__rocsolver_1_1rocsolver__dgetrs__batched.html "Interface documentation") | C binding, rank_0, rank_1
-416 | [rocsolver_cgetrs_batched](interfacehipfort__rocsolver_1_1rocsolver__cgetrs__batched.html "Interface documentation") | C binding, rank_0, rank_1
-417 | [rocsolver_zgetrs_batched](interfacehipfort__rocsolver_1_1rocsolver__zgetrs__batched.html "Interface documentation") | C binding, rank_0, rank_1
+414 | [rocsolver_sgetrs_batched](interfacehipfort__rocsolver_1_1rocsolver__sgetrs__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+415 | [rocsolver_dgetrs_batched](interfacehipfort__rocsolver_1_1rocsolver__dgetrs__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+416 | [rocsolver_cgetrs_batched](interfacehipfort__rocsolver_1_1rocsolver__cgetrs__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+417 | [rocsolver_zgetrs_batched](interfacehipfort__rocsolver_1_1rocsolver__zgetrs__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 418 | [rocsolver_sgetrs_batched_64](interfacehipfort__rocsolver_1_1rocsolver__sgetrs__batched__64.html "Interface documentation") | C binding
 419 | [rocsolver_dgetrs_batched_64](interfacehipfort__rocsolver_1_1rocsolver__dgetrs__batched__64.html "Interface documentation") | C binding
 420 | [rocsolver_cgetrs_batched_64](interfacehipfort__rocsolver_1_1rocsolver__cgetrs__batched__64.html "Interface documentation") | C binding
 421 | [rocsolver_zgetrs_batched_64](interfacehipfort__rocsolver_1_1rocsolver__zgetrs__batched__64.html "Interface documentation") | C binding
-422 | [rocsolver_sgetrs_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__sgetrs__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-423 | [rocsolver_dgetrs_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dgetrs__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-424 | [rocsolver_cgetrs_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cgetrs__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-425 | [rocsolver_zgetrs_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zgetrs__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+422 | [rocsolver_sgetrs_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__sgetrs__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+423 | [rocsolver_dgetrs_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dgetrs__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+424 | [rocsolver_cgetrs_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cgetrs__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+425 | [rocsolver_zgetrs_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zgetrs__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 426 | [rocsolver_sgetrs_strided_batched_64](interfacehipfort__rocsolver_1_1rocsolver__sgetrs__strided__batched__64.html "Interface documentation") | C binding
 427 | [rocsolver_dgetrs_strided_batched_64](interfacehipfort__rocsolver_1_1rocsolver__dgetrs__strided__batched__64.html "Interface documentation") | C binding
 428 | [rocsolver_cgetrs_strided_batched_64](interfacehipfort__rocsolver_1_1rocsolver__cgetrs__strided__batched__64.html "Interface documentation") | C binding
@@ -455,18 +455,18 @@
 451 | [rocsolver_dsytrs_strided_batched_64](interfacehipfort__rocsolver_1_1rocsolver__dsytrs__strided__batched__64.html "Interface documentation") | C binding
 452 | [rocsolver_csytrs_strided_batched_64](interfacehipfort__rocsolver_1_1rocsolver__csytrs__strided__batched__64.html "Interface documentation") | C binding
 453 | [rocsolver_zsytrs_strided_batched_64](interfacehipfort__rocsolver_1_1rocsolver__zsytrs__strided__batched__64.html "Interface documentation") | C binding
-454 | [rocsolver_sgesv](interfacehipfort__rocsolver_1_1rocsolver__sgesv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-455 | [rocsolver_dgesv](interfacehipfort__rocsolver_1_1rocsolver__dgesv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-456 | [rocsolver_cgesv](interfacehipfort__rocsolver_1_1rocsolver__cgesv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-457 | [rocsolver_zgesv](interfacehipfort__rocsolver_1_1rocsolver__zgesv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-458 | [rocsolver_sgesv_batched](interfacehipfort__rocsolver_1_1rocsolver__sgesv__batched.html "Interface documentation") | C binding, rank_0, rank_1
-459 | [rocsolver_dgesv_batched](interfacehipfort__rocsolver_1_1rocsolver__dgesv__batched.html "Interface documentation") | C binding, rank_0, rank_1
-460 | [rocsolver_cgesv_batched](interfacehipfort__rocsolver_1_1rocsolver__cgesv__batched.html "Interface documentation") | C binding, rank_0, rank_1
-461 | [rocsolver_zgesv_batched](interfacehipfort__rocsolver_1_1rocsolver__zgesv__batched.html "Interface documentation") | C binding, rank_0, rank_1
-462 | [rocsolver_sgesv_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__sgesv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-463 | [rocsolver_dgesv_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dgesv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-464 | [rocsolver_cgesv_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cgesv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-465 | [rocsolver_zgesv_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zgesv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+454 | [rocsolver_sgesv](interfacehipfort__rocsolver_1_1rocsolver__sgesv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+455 | [rocsolver_dgesv](interfacehipfort__rocsolver_1_1rocsolver__dgesv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+456 | [rocsolver_cgesv](interfacehipfort__rocsolver_1_1rocsolver__cgesv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+457 | [rocsolver_zgesv](interfacehipfort__rocsolver_1_1rocsolver__zgesv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+458 | [rocsolver_sgesv_batched](interfacehipfort__rocsolver_1_1rocsolver__sgesv__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+459 | [rocsolver_dgesv_batched](interfacehipfort__rocsolver_1_1rocsolver__dgesv__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+460 | [rocsolver_cgesv_batched](interfacehipfort__rocsolver_1_1rocsolver__cgesv__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+461 | [rocsolver_zgesv_batched](interfacehipfort__rocsolver_1_1rocsolver__zgesv__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+462 | [rocsolver_sgesv_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__sgesv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+463 | [rocsolver_dgesv_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dgesv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+464 | [rocsolver_cgesv_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cgesv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+465 | [rocsolver_zgesv_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zgesv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 466 | [rocsolver_sgetrs_npvt](interfacehipfort__rocsolver_1_1rocsolver__sgetrs__npvt.html "Interface documentation") | C binding
 467 | [rocsolver_dgetrs_npvt](interfacehipfort__rocsolver_1_1rocsolver__dgetrs__npvt.html "Interface documentation") | C binding
 468 | [rocsolver_cgetrs_npvt](interfacehipfort__rocsolver_1_1rocsolver__cgetrs__npvt.html "Interface documentation") | C binding
@@ -491,46 +491,46 @@
 487 | [rocsolver_dgetrs_npvt_strided_batched_64](interfacehipfort__rocsolver_1_1rocsolver__dgetrs__npvt__strided__batched__64.html "Interface documentation") | C binding
 488 | [rocsolver_cgetrs_npvt_strided_batched_64](interfacehipfort__rocsolver_1_1rocsolver__cgetrs__npvt__strided__batched__64.html "Interface documentation") | C binding
 489 | [rocsolver_zgetrs_npvt_strided_batched_64](interfacehipfort__rocsolver_1_1rocsolver__zgetrs__npvt__strided__batched__64.html "Interface documentation") | C binding
-490 | [rocsolver_sgetri](interfacehipfort__rocsolver_1_1rocsolver__sgetri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-491 | [rocsolver_dgetri](interfacehipfort__rocsolver_1_1rocsolver__dgetri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-492 | [rocsolver_cgetri](interfacehipfort__rocsolver_1_1rocsolver__cgetri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-493 | [rocsolver_zgetri](interfacehipfort__rocsolver_1_1rocsolver__zgetri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-494 | [rocsolver_sgetri_batched](interfacehipfort__rocsolver_1_1rocsolver__sgetri__batched.html "Interface documentation") | C binding, rank_0, rank_1
-495 | [rocsolver_dgetri_batched](interfacehipfort__rocsolver_1_1rocsolver__dgetri__batched.html "Interface documentation") | C binding, rank_0, rank_1
-496 | [rocsolver_cgetri_batched](interfacehipfort__rocsolver_1_1rocsolver__cgetri__batched.html "Interface documentation") | C binding, rank_0, rank_1
-497 | [rocsolver_zgetri_batched](interfacehipfort__rocsolver_1_1rocsolver__zgetri__batched.html "Interface documentation") | C binding, rank_0, rank_1
-498 | [rocsolver_sgetri_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__sgetri__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-499 | [rocsolver_dgetri_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dgetri__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-500 | [rocsolver_cgetri_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cgetri__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-501 | [rocsolver_zgetri_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zgetri__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-502 | [rocsolver_sgetri_npvt](interfacehipfort__rocsolver_1_1rocsolver__sgetri__npvt.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-503 | [rocsolver_dgetri_npvt](interfacehipfort__rocsolver_1_1rocsolver__dgetri__npvt.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-504 | [rocsolver_cgetri_npvt](interfacehipfort__rocsolver_1_1rocsolver__cgetri__npvt.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-505 | [rocsolver_zgetri_npvt](interfacehipfort__rocsolver_1_1rocsolver__zgetri__npvt.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+490 | [rocsolver_sgetri](interfacehipfort__rocsolver_1_1rocsolver__sgetri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+491 | [rocsolver_dgetri](interfacehipfort__rocsolver_1_1rocsolver__dgetri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+492 | [rocsolver_cgetri](interfacehipfort__rocsolver_1_1rocsolver__cgetri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+493 | [rocsolver_zgetri](interfacehipfort__rocsolver_1_1rocsolver__zgetri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+494 | [rocsolver_sgetri_batched](interfacehipfort__rocsolver_1_1rocsolver__sgetri__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+495 | [rocsolver_dgetri_batched](interfacehipfort__rocsolver_1_1rocsolver__dgetri__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+496 | [rocsolver_cgetri_batched](interfacehipfort__rocsolver_1_1rocsolver__cgetri__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+497 | [rocsolver_zgetri_batched](interfacehipfort__rocsolver_1_1rocsolver__zgetri__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+498 | [rocsolver_sgetri_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__sgetri__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+499 | [rocsolver_dgetri_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dgetri__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+500 | [rocsolver_cgetri_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cgetri__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+501 | [rocsolver_zgetri_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zgetri__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+502 | [rocsolver_sgetri_npvt](interfacehipfort__rocsolver_1_1rocsolver__sgetri__npvt.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+503 | [rocsolver_dgetri_npvt](interfacehipfort__rocsolver_1_1rocsolver__dgetri__npvt.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+504 | [rocsolver_cgetri_npvt](interfacehipfort__rocsolver_1_1rocsolver__cgetri__npvt.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+505 | [rocsolver_zgetri_npvt](interfacehipfort__rocsolver_1_1rocsolver__zgetri__npvt.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 506 | [rocsolver_sgetri_npvt_batched](interfacehipfort__rocsolver_1_1rocsolver__sgetri__npvt__batched.html "Interface documentation") | C binding
 507 | [rocsolver_dgetri_npvt_batched](interfacehipfort__rocsolver_1_1rocsolver__dgetri__npvt__batched.html "Interface documentation") | C binding
 508 | [rocsolver_cgetri_npvt_batched](interfacehipfort__rocsolver_1_1rocsolver__cgetri__npvt__batched.html "Interface documentation") | C binding
 509 | [rocsolver_zgetri_npvt_batched](interfacehipfort__rocsolver_1_1rocsolver__zgetri__npvt__batched.html "Interface documentation") | C binding
-510 | [rocsolver_sgetri_npvt_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__sgetri__npvt__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-511 | [rocsolver_dgetri_npvt_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dgetri__npvt__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-512 | [rocsolver_cgetri_npvt_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cgetri__npvt__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-513 | [rocsolver_zgetri_npvt_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zgetri__npvt__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-514 | [rocsolver_sgels](interfacehipfort__rocsolver_1_1rocsolver__sgels.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-515 | [rocsolver_dgels](interfacehipfort__rocsolver_1_1rocsolver__dgels.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-516 | [rocsolver_cgels](interfacehipfort__rocsolver_1_1rocsolver__cgels.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-517 | [rocsolver_zgels](interfacehipfort__rocsolver_1_1rocsolver__zgels.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+510 | [rocsolver_sgetri_npvt_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__sgetri__npvt__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+511 | [rocsolver_dgetri_npvt_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dgetri__npvt__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+512 | [rocsolver_cgetri_npvt_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cgetri__npvt__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+513 | [rocsolver_zgetri_npvt_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zgetri__npvt__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+514 | [rocsolver_sgels](interfacehipfort__rocsolver_1_1rocsolver__sgels.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+515 | [rocsolver_dgels](interfacehipfort__rocsolver_1_1rocsolver__dgels.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+516 | [rocsolver_cgels](interfacehipfort__rocsolver_1_1rocsolver__cgels.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+517 | [rocsolver_zgels](interfacehipfort__rocsolver_1_1rocsolver__zgels.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 518 | [rocsolver_sgels_batched](interfacehipfort__rocsolver_1_1rocsolver__sgels__batched.html "Interface documentation") | C binding
 519 | [rocsolver_dgels_batched](interfacehipfort__rocsolver_1_1rocsolver__dgels__batched.html "Interface documentation") | C binding
 520 | [rocsolver_cgels_batched](interfacehipfort__rocsolver_1_1rocsolver__cgels__batched.html "Interface documentation") | C binding
 521 | [rocsolver_zgels_batched](interfacehipfort__rocsolver_1_1rocsolver__zgels__batched.html "Interface documentation") | C binding
-522 | [rocsolver_sgels_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__sgels__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-523 | [rocsolver_dgels_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dgels__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-524 | [rocsolver_cgels_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cgels__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-525 | [rocsolver_zgels_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zgels__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-526 | [rocsolver_spotf2](interfacehipfort__rocsolver_1_1rocsolver__spotf2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-527 | [rocsolver_dpotf2](interfacehipfort__rocsolver_1_1rocsolver__dpotf2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-528 | [rocsolver_cpotf2](interfacehipfort__rocsolver_1_1rocsolver__cpotf2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-529 | [rocsolver_zpotf2](interfacehipfort__rocsolver_1_1rocsolver__zpotf2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+522 | [rocsolver_sgels_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__sgels__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+523 | [rocsolver_dgels_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dgels__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+524 | [rocsolver_cgels_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cgels__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+525 | [rocsolver_zgels_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zgels__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+526 | [rocsolver_spotf2](interfacehipfort__rocsolver_1_1rocsolver__spotf2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+527 | [rocsolver_dpotf2](interfacehipfort__rocsolver_1_1rocsolver__dpotf2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+528 | [rocsolver_cpotf2](interfacehipfort__rocsolver_1_1rocsolver__cpotf2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+529 | [rocsolver_zpotf2](interfacehipfort__rocsolver_1_1rocsolver__zpotf2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 530 | [rocsolver_spotf2_64](interfacehipfort__rocsolver_1_1rocsolver__spotf2__64.html "Interface documentation") | C binding
 531 | [rocsolver_dpotf2_64](interfacehipfort__rocsolver_1_1rocsolver__dpotf2__64.html "Interface documentation") | C binding
 532 | [rocsolver_cpotf2_64](interfacehipfort__rocsolver_1_1rocsolver__cpotf2__64.html "Interface documentation") | C binding
@@ -543,18 +543,18 @@
 539 | [rocsolver_dpotf2_batched_64](interfacehipfort__rocsolver_1_1rocsolver__dpotf2__batched__64.html "Interface documentation") | C binding
 540 | [rocsolver_cpotf2_batched_64](interfacehipfort__rocsolver_1_1rocsolver__cpotf2__batched__64.html "Interface documentation") | C binding
 541 | [rocsolver_zpotf2_batched_64](interfacehipfort__rocsolver_1_1rocsolver__zpotf2__batched__64.html "Interface documentation") | C binding
-542 | [rocsolver_spotf2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__spotf2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-543 | [rocsolver_dpotf2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dpotf2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-544 | [rocsolver_cpotf2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cpotf2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-545 | [rocsolver_zpotf2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zpotf2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+542 | [rocsolver_spotf2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__spotf2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+543 | [rocsolver_dpotf2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dpotf2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+544 | [rocsolver_cpotf2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cpotf2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+545 | [rocsolver_zpotf2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zpotf2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 546 | [rocsolver_spotf2_strided_batched_64](interfacehipfort__rocsolver_1_1rocsolver__spotf2__strided__batched__64.html "Interface documentation") | C binding
 547 | [rocsolver_dpotf2_strided_batched_64](interfacehipfort__rocsolver_1_1rocsolver__dpotf2__strided__batched__64.html "Interface documentation") | C binding
 548 | [rocsolver_cpotf2_strided_batched_64](interfacehipfort__rocsolver_1_1rocsolver__cpotf2__strided__batched__64.html "Interface documentation") | C binding
 549 | [rocsolver_zpotf2_strided_batched_64](interfacehipfort__rocsolver_1_1rocsolver__zpotf2__strided__batched__64.html "Interface documentation") | C binding
-550 | [rocsolver_spotrf](interfacehipfort__rocsolver_1_1rocsolver__spotrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-551 | [rocsolver_dpotrf](interfacehipfort__rocsolver_1_1rocsolver__dpotrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-552 | [rocsolver_cpotrf](interfacehipfort__rocsolver_1_1rocsolver__cpotrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-553 | [rocsolver_zpotrf](interfacehipfort__rocsolver_1_1rocsolver__zpotrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+550 | [rocsolver_spotrf](interfacehipfort__rocsolver_1_1rocsolver__spotrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+551 | [rocsolver_dpotrf](interfacehipfort__rocsolver_1_1rocsolver__dpotrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+552 | [rocsolver_cpotrf](interfacehipfort__rocsolver_1_1rocsolver__cpotrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+553 | [rocsolver_zpotrf](interfacehipfort__rocsolver_1_1rocsolver__zpotrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 554 | [rocsolver_spotrf_64](interfacehipfort__rocsolver_1_1rocsolver__spotrf__64.html "Interface documentation") | C binding
 555 | [rocsolver_dpotrf_64](interfacehipfort__rocsolver_1_1rocsolver__dpotrf__64.html "Interface documentation") | C binding
 556 | [rocsolver_cpotrf_64](interfacehipfort__rocsolver_1_1rocsolver__cpotrf__64.html "Interface documentation") | C binding
@@ -567,18 +567,18 @@
 563 | [rocsolver_dpotrf_batched_64](interfacehipfort__rocsolver_1_1rocsolver__dpotrf__batched__64.html "Interface documentation") | C binding
 564 | [rocsolver_cpotrf_batched_64](interfacehipfort__rocsolver_1_1rocsolver__cpotrf__batched__64.html "Interface documentation") | C binding
 565 | [rocsolver_zpotrf_batched_64](interfacehipfort__rocsolver_1_1rocsolver__zpotrf__batched__64.html "Interface documentation") | C binding
-566 | [rocsolver_spotrf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__spotrf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-567 | [rocsolver_dpotrf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dpotrf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-568 | [rocsolver_cpotrf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cpotrf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-569 | [rocsolver_zpotrf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zpotrf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+566 | [rocsolver_spotrf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__spotrf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+567 | [rocsolver_dpotrf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dpotrf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+568 | [rocsolver_cpotrf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cpotrf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+569 | [rocsolver_zpotrf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zpotrf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 570 | [rocsolver_spotrf_strided_batched_64](interfacehipfort__rocsolver_1_1rocsolver__spotrf__strided__batched__64.html "Interface documentation") | C binding
 571 | [rocsolver_dpotrf_strided_batched_64](interfacehipfort__rocsolver_1_1rocsolver__dpotrf__strided__batched__64.html "Interface documentation") | C binding
 572 | [rocsolver_cpotrf_strided_batched_64](interfacehipfort__rocsolver_1_1rocsolver__cpotrf__strided__batched__64.html "Interface documentation") | C binding
 573 | [rocsolver_zpotrf_strided_batched_64](interfacehipfort__rocsolver_1_1rocsolver__zpotrf__strided__batched__64.html "Interface documentation") | C binding
-574 | [rocsolver_spotrs](interfacehipfort__rocsolver_1_1rocsolver__spotrs.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-575 | [rocsolver_dpotrs](interfacehipfort__rocsolver_1_1rocsolver__dpotrs.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-576 | [rocsolver_cpotrs](interfacehipfort__rocsolver_1_1rocsolver__cpotrs.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-577 | [rocsolver_zpotrs](interfacehipfort__rocsolver_1_1rocsolver__zpotrs.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+574 | [rocsolver_spotrs](interfacehipfort__rocsolver_1_1rocsolver__spotrs.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+575 | [rocsolver_dpotrs](interfacehipfort__rocsolver_1_1rocsolver__dpotrs.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+576 | [rocsolver_cpotrs](interfacehipfort__rocsolver_1_1rocsolver__cpotrs.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+577 | [rocsolver_zpotrs](interfacehipfort__rocsolver_1_1rocsolver__zpotrs.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 578 | [rocsolver_spotrs_64](interfacehipfort__rocsolver_1_1rocsolver__spotrs__64.html "Interface documentation") | C binding
 579 | [rocsolver_dpotrs_64](interfacehipfort__rocsolver_1_1rocsolver__dpotrs__64.html "Interface documentation") | C binding
 580 | [rocsolver_cpotrs_64](interfacehipfort__rocsolver_1_1rocsolver__cpotrs__64.html "Interface documentation") | C binding
@@ -591,50 +591,50 @@
 587 | [rocsolver_dpotrs_batched_64](interfacehipfort__rocsolver_1_1rocsolver__dpotrs__batched__64.html "Interface documentation") | C binding
 588 | [rocsolver_cpotrs_batched_64](interfacehipfort__rocsolver_1_1rocsolver__cpotrs__batched__64.html "Interface documentation") | C binding
 589 | [rocsolver_zpotrs_batched_64](interfacehipfort__rocsolver_1_1rocsolver__zpotrs__batched__64.html "Interface documentation") | C binding
-590 | [rocsolver_spotrs_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__spotrs__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-591 | [rocsolver_dpotrs_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dpotrs__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-592 | [rocsolver_cpotrs_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cpotrs__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-593 | [rocsolver_zpotrs_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zpotrs__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+590 | [rocsolver_spotrs_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__spotrs__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+591 | [rocsolver_dpotrs_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dpotrs__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+592 | [rocsolver_cpotrs_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cpotrs__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+593 | [rocsolver_zpotrs_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zpotrs__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 594 | [rocsolver_spotrs_strided_batched_64](interfacehipfort__rocsolver_1_1rocsolver__spotrs__strided__batched__64.html "Interface documentation") | C binding
 595 | [rocsolver_dpotrs_strided_batched_64](interfacehipfort__rocsolver_1_1rocsolver__dpotrs__strided__batched__64.html "Interface documentation") | C binding
 596 | [rocsolver_cpotrs_strided_batched_64](interfacehipfort__rocsolver_1_1rocsolver__cpotrs__strided__batched__64.html "Interface documentation") | C binding
 597 | [rocsolver_zpotrs_strided_batched_64](interfacehipfort__rocsolver_1_1rocsolver__zpotrs__strided__batched__64.html "Interface documentation") | C binding
-598 | [rocsolver_sposv](interfacehipfort__rocsolver_1_1rocsolver__sposv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-599 | [rocsolver_dposv](interfacehipfort__rocsolver_1_1rocsolver__dposv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-600 | [rocsolver_cposv](interfacehipfort__rocsolver_1_1rocsolver__cposv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-601 | [rocsolver_zposv](interfacehipfort__rocsolver_1_1rocsolver__zposv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+598 | [rocsolver_sposv](interfacehipfort__rocsolver_1_1rocsolver__sposv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+599 | [rocsolver_dposv](interfacehipfort__rocsolver_1_1rocsolver__dposv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+600 | [rocsolver_cposv](interfacehipfort__rocsolver_1_1rocsolver__cposv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+601 | [rocsolver_zposv](interfacehipfort__rocsolver_1_1rocsolver__zposv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 602 | [rocsolver_sposv_batched](interfacehipfort__rocsolver_1_1rocsolver__sposv__batched.html "Interface documentation") | C binding
 603 | [rocsolver_dposv_batched](interfacehipfort__rocsolver_1_1rocsolver__dposv__batched.html "Interface documentation") | C binding
 604 | [rocsolver_cposv_batched](interfacehipfort__rocsolver_1_1rocsolver__cposv__batched.html "Interface documentation") | C binding
 605 | [rocsolver_zposv_batched](interfacehipfort__rocsolver_1_1rocsolver__zposv__batched.html "Interface documentation") | C binding
-606 | [rocsolver_sposv_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__sposv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-607 | [rocsolver_dposv_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dposv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-608 | [rocsolver_cposv_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cposv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-609 | [rocsolver_zposv_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zposv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-610 | [rocsolver_spotri](interfacehipfort__rocsolver_1_1rocsolver__spotri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-611 | [rocsolver_dpotri](interfacehipfort__rocsolver_1_1rocsolver__dpotri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-612 | [rocsolver_cpotri](interfacehipfort__rocsolver_1_1rocsolver__cpotri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-613 | [rocsolver_zpotri](interfacehipfort__rocsolver_1_1rocsolver__zpotri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+606 | [rocsolver_sposv_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__sposv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+607 | [rocsolver_dposv_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dposv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+608 | [rocsolver_cposv_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cposv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+609 | [rocsolver_zposv_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zposv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+610 | [rocsolver_spotri](interfacehipfort__rocsolver_1_1rocsolver__spotri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+611 | [rocsolver_dpotri](interfacehipfort__rocsolver_1_1rocsolver__dpotri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+612 | [rocsolver_cpotri](interfacehipfort__rocsolver_1_1rocsolver__cpotri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+613 | [rocsolver_zpotri](interfacehipfort__rocsolver_1_1rocsolver__zpotri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 614 | [rocsolver_spotri_batched](interfacehipfort__rocsolver_1_1rocsolver__spotri__batched.html "Interface documentation") | C binding
 615 | [rocsolver_dpotri_batched](interfacehipfort__rocsolver_1_1rocsolver__dpotri__batched.html "Interface documentation") | C binding
 616 | [rocsolver_cpotri_batched](interfacehipfort__rocsolver_1_1rocsolver__cpotri__batched.html "Interface documentation") | C binding
 617 | [rocsolver_zpotri_batched](interfacehipfort__rocsolver_1_1rocsolver__zpotri__batched.html "Interface documentation") | C binding
-618 | [rocsolver_spotri_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__spotri__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-619 | [rocsolver_dpotri_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dpotri__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-620 | [rocsolver_cpotri_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cpotri__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-621 | [rocsolver_zpotri_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zpotri__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-622 | [rocsolver_sgesvd](interfacehipfort__rocsolver_1_1rocsolver__sgesvd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-623 | [rocsolver_dgesvd](interfacehipfort__rocsolver_1_1rocsolver__dgesvd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-624 | [rocsolver_cgesvd](interfacehipfort__rocsolver_1_1rocsolver__cgesvd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-625 | [rocsolver_zgesvd](interfacehipfort__rocsolver_1_1rocsolver__zgesvd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-626 | [rocsolver_sgesvd_batched](interfacehipfort__rocsolver_1_1rocsolver__sgesvd__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-627 | [rocsolver_dgesvd_batched](interfacehipfort__rocsolver_1_1rocsolver__dgesvd__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-628 | [rocsolver_cgesvd_batched](interfacehipfort__rocsolver_1_1rocsolver__cgesvd__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-629 | [rocsolver_zgesvd_batched](interfacehipfort__rocsolver_1_1rocsolver__zgesvd__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-630 | [rocsolver_sgesvd_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__sgesvd__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-631 | [rocsolver_dgesvd_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dgesvd__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-632 | [rocsolver_cgesvd_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cgesvd__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-633 | [rocsolver_zgesvd_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zgesvd__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+618 | [rocsolver_spotri_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__spotri__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+619 | [rocsolver_dpotri_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dpotri__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+620 | [rocsolver_cpotri_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cpotri__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+621 | [rocsolver_zpotri_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zpotri__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+622 | [rocsolver_sgesvd](interfacehipfort__rocsolver_1_1rocsolver__sgesvd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+623 | [rocsolver_dgesvd](interfacehipfort__rocsolver_1_1rocsolver__dgesvd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+624 | [rocsolver_cgesvd](interfacehipfort__rocsolver_1_1rocsolver__cgesvd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+625 | [rocsolver_zgesvd](interfacehipfort__rocsolver_1_1rocsolver__zgesvd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+626 | [rocsolver_sgesvd_batched](interfacehipfort__rocsolver_1_1rocsolver__sgesvd__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+627 | [rocsolver_dgesvd_batched](interfacehipfort__rocsolver_1_1rocsolver__dgesvd__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+628 | [rocsolver_cgesvd_batched](interfacehipfort__rocsolver_1_1rocsolver__cgesvd__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+629 | [rocsolver_zgesvd_batched](interfacehipfort__rocsolver_1_1rocsolver__zgesvd__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+630 | [rocsolver_sgesvd_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__sgesvd__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+631 | [rocsolver_dgesvd_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dgesvd__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+632 | [rocsolver_cgesvd_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cgesvd__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+633 | [rocsolver_zgesvd_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zgesvd__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 634 | [rocsolver_sgesdd](interfacehipfort__rocsolver_1_1rocsolver__sgesdd.html "Interface documentation") | C binding
 635 | [rocsolver_dgesdd](interfacehipfort__rocsolver_1_1rocsolver__dgesdd.html "Interface documentation") | C binding
 636 | [rocsolver_cgesdd](interfacehipfort__rocsolver_1_1rocsolver__cgesdd.html "Interface documentation") | C binding
@@ -671,100 +671,100 @@
 667 | [rocsolver_dgesvdx_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dgesvdx__strided__batched.html "Interface documentation") | C binding
 668 | [rocsolver_cgesvdx_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cgesvdx__strided__batched.html "Interface documentation") | C binding
 669 | [rocsolver_zgesvdx_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zgesvdx__strided__batched.html "Interface documentation") | C binding
-670 | [rocsolver_ssytd2](interfacehipfort__rocsolver_1_1rocsolver__ssytd2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-671 | [rocsolver_dsytd2](interfacehipfort__rocsolver_1_1rocsolver__dsytd2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-672 | [rocsolver_chetd2](interfacehipfort__rocsolver_1_1rocsolver__chetd2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-673 | [rocsolver_zhetd2](interfacehipfort__rocsolver_1_1rocsolver__zhetd2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-674 | [rocsolver_ssytd2_batched](interfacehipfort__rocsolver_1_1rocsolver__ssytd2__batched.html "Interface documentation") | C binding, rank_0, rank_1
-675 | [rocsolver_dsytd2_batched](interfacehipfort__rocsolver_1_1rocsolver__dsytd2__batched.html "Interface documentation") | C binding, rank_0, rank_1
-676 | [rocsolver_chetd2_batched](interfacehipfort__rocsolver_1_1rocsolver__chetd2__batched.html "Interface documentation") | C binding, rank_0, rank_1
-677 | [rocsolver_zhetd2_batched](interfacehipfort__rocsolver_1_1rocsolver__zhetd2__batched.html "Interface documentation") | C binding, rank_0, rank_1
-678 | [rocsolver_ssytd2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__ssytd2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-679 | [rocsolver_dsytd2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dsytd2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-680 | [rocsolver_chetd2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__chetd2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-681 | [rocsolver_zhetd2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zhetd2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-682 | [rocsolver_ssytrd](interfacehipfort__rocsolver_1_1rocsolver__ssytrd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-683 | [rocsolver_dsytrd](interfacehipfort__rocsolver_1_1rocsolver__dsytrd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-684 | [rocsolver_chetrd](interfacehipfort__rocsolver_1_1rocsolver__chetrd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-685 | [rocsolver_zhetrd](interfacehipfort__rocsolver_1_1rocsolver__zhetrd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-686 | [rocsolver_ssytrd_batched](interfacehipfort__rocsolver_1_1rocsolver__ssytrd__batched.html "Interface documentation") | C binding, rank_0, rank_1
-687 | [rocsolver_dsytrd_batched](interfacehipfort__rocsolver_1_1rocsolver__dsytrd__batched.html "Interface documentation") | C binding, rank_0, rank_1
-688 | [rocsolver_chetrd_batched](interfacehipfort__rocsolver_1_1rocsolver__chetrd__batched.html "Interface documentation") | C binding, rank_0, rank_1
-689 | [rocsolver_zhetrd_batched](interfacehipfort__rocsolver_1_1rocsolver__zhetrd__batched.html "Interface documentation") | C binding, rank_0, rank_1
-690 | [rocsolver_ssytrd_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__ssytrd__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-691 | [rocsolver_dsytrd_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dsytrd__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-692 | [rocsolver_chetrd_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__chetrd__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-693 | [rocsolver_zhetrd_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zhetrd__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-694 | [rocsolver_ssygs2](interfacehipfort__rocsolver_1_1rocsolver__ssygs2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-695 | [rocsolver_dsygs2](interfacehipfort__rocsolver_1_1rocsolver__dsygs2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-696 | [rocsolver_chegs2](interfacehipfort__rocsolver_1_1rocsolver__chegs2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-697 | [rocsolver_zhegs2](interfacehipfort__rocsolver_1_1rocsolver__zhegs2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+670 | [rocsolver_ssytd2](interfacehipfort__rocsolver_1_1rocsolver__ssytd2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+671 | [rocsolver_dsytd2](interfacehipfort__rocsolver_1_1rocsolver__dsytd2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+672 | [rocsolver_chetd2](interfacehipfort__rocsolver_1_1rocsolver__chetd2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+673 | [rocsolver_zhetd2](interfacehipfort__rocsolver_1_1rocsolver__zhetd2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+674 | [rocsolver_ssytd2_batched](interfacehipfort__rocsolver_1_1rocsolver__ssytd2__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+675 | [rocsolver_dsytd2_batched](interfacehipfort__rocsolver_1_1rocsolver__dsytd2__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+676 | [rocsolver_chetd2_batched](interfacehipfort__rocsolver_1_1rocsolver__chetd2__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+677 | [rocsolver_zhetd2_batched](interfacehipfort__rocsolver_1_1rocsolver__zhetd2__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+678 | [rocsolver_ssytd2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__ssytd2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+679 | [rocsolver_dsytd2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dsytd2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+680 | [rocsolver_chetd2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__chetd2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+681 | [rocsolver_zhetd2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zhetd2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+682 | [rocsolver_ssytrd](interfacehipfort__rocsolver_1_1rocsolver__ssytrd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+683 | [rocsolver_dsytrd](interfacehipfort__rocsolver_1_1rocsolver__dsytrd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+684 | [rocsolver_chetrd](interfacehipfort__rocsolver_1_1rocsolver__chetrd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+685 | [rocsolver_zhetrd](interfacehipfort__rocsolver_1_1rocsolver__zhetrd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+686 | [rocsolver_ssytrd_batched](interfacehipfort__rocsolver_1_1rocsolver__ssytrd__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+687 | [rocsolver_dsytrd_batched](interfacehipfort__rocsolver_1_1rocsolver__dsytrd__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+688 | [rocsolver_chetrd_batched](interfacehipfort__rocsolver_1_1rocsolver__chetrd__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+689 | [rocsolver_zhetrd_batched](interfacehipfort__rocsolver_1_1rocsolver__zhetrd__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+690 | [rocsolver_ssytrd_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__ssytrd__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+691 | [rocsolver_dsytrd_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dsytrd__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+692 | [rocsolver_chetrd_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__chetrd__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+693 | [rocsolver_zhetrd_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zhetrd__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+694 | [rocsolver_ssygs2](interfacehipfort__rocsolver_1_1rocsolver__ssygs2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+695 | [rocsolver_dsygs2](interfacehipfort__rocsolver_1_1rocsolver__dsygs2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+696 | [rocsolver_chegs2](interfacehipfort__rocsolver_1_1rocsolver__chegs2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+697 | [rocsolver_zhegs2](interfacehipfort__rocsolver_1_1rocsolver__zhegs2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 698 | [rocsolver_ssygs2_batched](interfacehipfort__rocsolver_1_1rocsolver__ssygs2__batched.html "Interface documentation") | C binding
 699 | [rocsolver_dsygs2_batched](interfacehipfort__rocsolver_1_1rocsolver__dsygs2__batched.html "Interface documentation") | C binding
 700 | [rocsolver_chegs2_batched](interfacehipfort__rocsolver_1_1rocsolver__chegs2__batched.html "Interface documentation") | C binding
 701 | [rocsolver_zhegs2_batched](interfacehipfort__rocsolver_1_1rocsolver__zhegs2__batched.html "Interface documentation") | C binding
-702 | [rocsolver_ssygs2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__ssygs2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-703 | [rocsolver_dsygs2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dsygs2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-704 | [rocsolver_chegs2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__chegs2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-705 | [rocsolver_zhegs2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zhegs2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-706 | [rocsolver_ssygst](interfacehipfort__rocsolver_1_1rocsolver__ssygst.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-707 | [rocsolver_dsygst](interfacehipfort__rocsolver_1_1rocsolver__dsygst.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-708 | [rocsolver_chegst](interfacehipfort__rocsolver_1_1rocsolver__chegst.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-709 | [rocsolver_zhegst](interfacehipfort__rocsolver_1_1rocsolver__zhegst.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+702 | [rocsolver_ssygs2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__ssygs2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+703 | [rocsolver_dsygs2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dsygs2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+704 | [rocsolver_chegs2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__chegs2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+705 | [rocsolver_zhegs2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zhegs2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+706 | [rocsolver_ssygst](interfacehipfort__rocsolver_1_1rocsolver__ssygst.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+707 | [rocsolver_dsygst](interfacehipfort__rocsolver_1_1rocsolver__dsygst.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+708 | [rocsolver_chegst](interfacehipfort__rocsolver_1_1rocsolver__chegst.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+709 | [rocsolver_zhegst](interfacehipfort__rocsolver_1_1rocsolver__zhegst.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 710 | [rocsolver_ssygst_batched](interfacehipfort__rocsolver_1_1rocsolver__ssygst__batched.html "Interface documentation") | C binding
 711 | [rocsolver_dsygst_batched](interfacehipfort__rocsolver_1_1rocsolver__dsygst__batched.html "Interface documentation") | C binding
 712 | [rocsolver_chegst_batched](interfacehipfort__rocsolver_1_1rocsolver__chegst__batched.html "Interface documentation") | C binding
 713 | [rocsolver_zhegst_batched](interfacehipfort__rocsolver_1_1rocsolver__zhegst__batched.html "Interface documentation") | C binding
-714 | [rocsolver_ssygst_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__ssygst__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-715 | [rocsolver_dsygst_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dsygst__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-716 | [rocsolver_chegst_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__chegst__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-717 | [rocsolver_zhegst_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zhegst__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-718 | [rocsolver_ssyev](interfacehipfort__rocsolver_1_1rocsolver__ssyev.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-719 | [rocsolver_dsyev](interfacehipfort__rocsolver_1_1rocsolver__dsyev.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+714 | [rocsolver_ssygst_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__ssygst__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+715 | [rocsolver_dsygst_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dsygst__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+716 | [rocsolver_chegst_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__chegst__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+717 | [rocsolver_zhegst_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zhegst__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+718 | [rocsolver_ssyev](interfacehipfort__rocsolver_1_1rocsolver__ssyev.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+719 | [rocsolver_dsyev](interfacehipfort__rocsolver_1_1rocsolver__dsyev.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 720 | [rocsolver_ssyev_64](interfacehipfort__rocsolver_1_1rocsolver__ssyev__64.html "Interface documentation") | C binding
 721 | [rocsolver_dsyev_64](interfacehipfort__rocsolver_1_1rocsolver__dsyev__64.html "Interface documentation") | C binding
-722 | [rocsolver_cheev](interfacehipfort__rocsolver_1_1rocsolver__cheev.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-723 | [rocsolver_zheev](interfacehipfort__rocsolver_1_1rocsolver__zheev.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+722 | [rocsolver_cheev](interfacehipfort__rocsolver_1_1rocsolver__cheev.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+723 | [rocsolver_zheev](interfacehipfort__rocsolver_1_1rocsolver__zheev.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 724 | [rocsolver_cheev_64](interfacehipfort__rocsolver_1_1rocsolver__cheev__64.html "Interface documentation") | C binding
 725 | [rocsolver_zheev_64](interfacehipfort__rocsolver_1_1rocsolver__zheev__64.html "Interface documentation") | C binding
-726 | [rocsolver_ssyev_batched](interfacehipfort__rocsolver_1_1rocsolver__ssyev__batched.html "Interface documentation") | C binding, rank_0, rank_1
-727 | [rocsolver_dsyev_batched](interfacehipfort__rocsolver_1_1rocsolver__dsyev__batched.html "Interface documentation") | C binding, rank_0, rank_1
+726 | [rocsolver_ssyev_batched](interfacehipfort__rocsolver_1_1rocsolver__ssyev__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+727 | [rocsolver_dsyev_batched](interfacehipfort__rocsolver_1_1rocsolver__dsyev__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 728 | [rocsolver_ssyev_batched_64](interfacehipfort__rocsolver_1_1rocsolver__ssyev__batched__64.html "Interface documentation") | C binding
 729 | [rocsolver_dsyev_batched_64](interfacehipfort__rocsolver_1_1rocsolver__dsyev__batched__64.html "Interface documentation") | C binding
-730 | [rocsolver_cheev_batched](interfacehipfort__rocsolver_1_1rocsolver__cheev__batched.html "Interface documentation") | C binding, rank_0, rank_1
-731 | [rocsolver_zheev_batched](interfacehipfort__rocsolver_1_1rocsolver__zheev__batched.html "Interface documentation") | C binding, rank_0, rank_1
+730 | [rocsolver_cheev_batched](interfacehipfort__rocsolver_1_1rocsolver__cheev__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+731 | [rocsolver_zheev_batched](interfacehipfort__rocsolver_1_1rocsolver__zheev__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 732 | [rocsolver_cheev_batched_64](interfacehipfort__rocsolver_1_1rocsolver__cheev__batched__64.html "Interface documentation") | C binding
 733 | [rocsolver_zheev_batched_64](interfacehipfort__rocsolver_1_1rocsolver__zheev__batched__64.html "Interface documentation") | C binding
-734 | [rocsolver_ssyev_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__ssyev__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-735 | [rocsolver_dsyev_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dsyev__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+734 | [rocsolver_ssyev_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__ssyev__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+735 | [rocsolver_dsyev_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dsyev__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 736 | [rocsolver_ssyev_strided_batched_64](interfacehipfort__rocsolver_1_1rocsolver__ssyev__strided__batched__64.html "Interface documentation") | C binding
 737 | [rocsolver_dsyev_strided_batched_64](interfacehipfort__rocsolver_1_1rocsolver__dsyev__strided__batched__64.html "Interface documentation") | C binding
-738 | [rocsolver_cheev_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cheev__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-739 | [rocsolver_zheev_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zheev__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+738 | [rocsolver_cheev_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cheev__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+739 | [rocsolver_zheev_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zheev__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 740 | [rocsolver_cheev_strided_batched_64](interfacehipfort__rocsolver_1_1rocsolver__cheev__strided__batched__64.html "Interface documentation") | C binding
 741 | [rocsolver_zheev_strided_batched_64](interfacehipfort__rocsolver_1_1rocsolver__zheev__strided__batched__64.html "Interface documentation") | C binding
-742 | [rocsolver_ssyevd](interfacehipfort__rocsolver_1_1rocsolver__ssyevd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-743 | [rocsolver_dsyevd](interfacehipfort__rocsolver_1_1rocsolver__dsyevd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+742 | [rocsolver_ssyevd](interfacehipfort__rocsolver_1_1rocsolver__ssyevd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+743 | [rocsolver_dsyevd](interfacehipfort__rocsolver_1_1rocsolver__dsyevd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 744 | [rocsolver_ssyevd_64](interfacehipfort__rocsolver_1_1rocsolver__ssyevd__64.html "Interface documentation") | C binding
 745 | [rocsolver_dsyevd_64](interfacehipfort__rocsolver_1_1rocsolver__dsyevd__64.html "Interface documentation") | C binding
-746 | [rocsolver_cheevd](interfacehipfort__rocsolver_1_1rocsolver__cheevd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-747 | [rocsolver_zheevd](interfacehipfort__rocsolver_1_1rocsolver__zheevd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+746 | [rocsolver_cheevd](interfacehipfort__rocsolver_1_1rocsolver__cheevd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+747 | [rocsolver_zheevd](interfacehipfort__rocsolver_1_1rocsolver__zheevd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 748 | [rocsolver_cheevd_64](interfacehipfort__rocsolver_1_1rocsolver__cheevd__64.html "Interface documentation") | C binding
 749 | [rocsolver_zheevd_64](interfacehipfort__rocsolver_1_1rocsolver__zheevd__64.html "Interface documentation") | C binding
-750 | [rocsolver_ssyevd_batched](interfacehipfort__rocsolver_1_1rocsolver__ssyevd__batched.html "Interface documentation") | C binding, rank_0, rank_1
-751 | [rocsolver_dsyevd_batched](interfacehipfort__rocsolver_1_1rocsolver__dsyevd__batched.html "Interface documentation") | C binding, rank_0, rank_1
+750 | [rocsolver_ssyevd_batched](interfacehipfort__rocsolver_1_1rocsolver__ssyevd__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+751 | [rocsolver_dsyevd_batched](interfacehipfort__rocsolver_1_1rocsolver__dsyevd__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 752 | [rocsolver_ssyevd_batched_64](interfacehipfort__rocsolver_1_1rocsolver__ssyevd__batched__64.html "Interface documentation") | C binding
 753 | [rocsolver_dsyevd_batched_64](interfacehipfort__rocsolver_1_1rocsolver__dsyevd__batched__64.html "Interface documentation") | C binding
-754 | [rocsolver_cheevd_batched](interfacehipfort__rocsolver_1_1rocsolver__cheevd__batched.html "Interface documentation") | C binding, rank_0, rank_1
-755 | [rocsolver_zheevd_batched](interfacehipfort__rocsolver_1_1rocsolver__zheevd__batched.html "Interface documentation") | C binding, rank_0, rank_1
+754 | [rocsolver_cheevd_batched](interfacehipfort__rocsolver_1_1rocsolver__cheevd__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+755 | [rocsolver_zheevd_batched](interfacehipfort__rocsolver_1_1rocsolver__zheevd__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 756 | [rocsolver_cheevd_batched_64](interfacehipfort__rocsolver_1_1rocsolver__cheevd__batched__64.html "Interface documentation") | C binding
 757 | [rocsolver_zheevd_batched_64](interfacehipfort__rocsolver_1_1rocsolver__zheevd__batched__64.html "Interface documentation") | C binding
-758 | [rocsolver_ssyevd_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__ssyevd__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-759 | [rocsolver_dsyevd_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dsyevd__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+758 | [rocsolver_ssyevd_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__ssyevd__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+759 | [rocsolver_dsyevd_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dsyevd__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 760 | [rocsolver_ssyevd_strided_batched_64](interfacehipfort__rocsolver_1_1rocsolver__ssyevd__strided__batched__64.html "Interface documentation") | C binding
 761 | [rocsolver_dsyevd_strided_batched_64](interfacehipfort__rocsolver_1_1rocsolver__dsyevd__strided__batched__64.html "Interface documentation") | C binding
-762 | [rocsolver_cheevd_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cheevd__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-763 | [rocsolver_zheevd_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zheevd__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+762 | [rocsolver_cheevd_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cheevd__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+763 | [rocsolver_zheevd_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zheevd__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 764 | [rocsolver_cheevd_strided_batched_64](interfacehipfort__rocsolver_1_1rocsolver__cheevd__strided__batched__64.html "Interface documentation") | C binding
 765 | [rocsolver_zheevd_strided_batched_64](interfacehipfort__rocsolver_1_1rocsolver__zheevd__strided__batched__64.html "Interface documentation") | C binding
 766 | [rocsolver_ssyevdj](interfacehipfort__rocsolver_1_1rocsolver__ssyevdj.html "Interface documentation") | C binding
@@ -815,30 +815,30 @@
 811 | [rocsolver_dsyevx_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dsyevx__strided__batched.html "Interface documentation") | C binding
 812 | [rocsolver_cheevx_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cheevx__strided__batched.html "Interface documentation") | C binding
 813 | [rocsolver_zheevx_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zheevx__strided__batched.html "Interface documentation") | C binding
-814 | [rocsolver_ssygv](interfacehipfort__rocsolver_1_1rocsolver__ssygv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-815 | [rocsolver_dsygv](interfacehipfort__rocsolver_1_1rocsolver__dsygv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-816 | [rocsolver_chegv](interfacehipfort__rocsolver_1_1rocsolver__chegv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-817 | [rocsolver_zhegv](interfacehipfort__rocsolver_1_1rocsolver__zhegv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-818 | [rocsolver_ssygv_batched](interfacehipfort__rocsolver_1_1rocsolver__ssygv__batched.html "Interface documentation") | C binding, rank_0, rank_1
-819 | [rocsolver_dsygv_batched](interfacehipfort__rocsolver_1_1rocsolver__dsygv__batched.html "Interface documentation") | C binding, rank_0, rank_1
-820 | [rocsolver_chegv_batched](interfacehipfort__rocsolver_1_1rocsolver__chegv__batched.html "Interface documentation") | C binding, rank_0, rank_1
-821 | [rocsolver_zhegv_batched](interfacehipfort__rocsolver_1_1rocsolver__zhegv__batched.html "Interface documentation") | C binding, rank_0, rank_1
-822 | [rocsolver_ssygv_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__ssygv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-823 | [rocsolver_dsygv_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dsygv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-824 | [rocsolver_chegv_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__chegv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-825 | [rocsolver_zhegv_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zhegv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-826 | [rocsolver_ssygvd](interfacehipfort__rocsolver_1_1rocsolver__ssygvd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-827 | [rocsolver_dsygvd](interfacehipfort__rocsolver_1_1rocsolver__dsygvd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-828 | [rocsolver_chegvd](interfacehipfort__rocsolver_1_1rocsolver__chegvd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-829 | [rocsolver_zhegvd](interfacehipfort__rocsolver_1_1rocsolver__zhegvd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-830 | [rocsolver_ssygvd_batched](interfacehipfort__rocsolver_1_1rocsolver__ssygvd__batched.html "Interface documentation") | C binding, rank_0, rank_1
-831 | [rocsolver_dsygvd_batched](interfacehipfort__rocsolver_1_1rocsolver__dsygvd__batched.html "Interface documentation") | C binding, rank_0, rank_1
-832 | [rocsolver_chegvd_batched](interfacehipfort__rocsolver_1_1rocsolver__chegvd__batched.html "Interface documentation") | C binding, rank_0, rank_1
-833 | [rocsolver_zhegvd_batched](interfacehipfort__rocsolver_1_1rocsolver__zhegvd__batched.html "Interface documentation") | C binding, rank_0, rank_1
-834 | [rocsolver_ssygvd_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__ssygvd__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-835 | [rocsolver_dsygvd_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dsygvd__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-836 | [rocsolver_chegvd_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__chegvd__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-837 | [rocsolver_zhegvd_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zhegvd__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+814 | [rocsolver_ssygv](interfacehipfort__rocsolver_1_1rocsolver__ssygv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+815 | [rocsolver_dsygv](interfacehipfort__rocsolver_1_1rocsolver__dsygv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+816 | [rocsolver_chegv](interfacehipfort__rocsolver_1_1rocsolver__chegv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+817 | [rocsolver_zhegv](interfacehipfort__rocsolver_1_1rocsolver__zhegv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+818 | [rocsolver_ssygv_batched](interfacehipfort__rocsolver_1_1rocsolver__ssygv__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+819 | [rocsolver_dsygv_batched](interfacehipfort__rocsolver_1_1rocsolver__dsygv__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+820 | [rocsolver_chegv_batched](interfacehipfort__rocsolver_1_1rocsolver__chegv__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+821 | [rocsolver_zhegv_batched](interfacehipfort__rocsolver_1_1rocsolver__zhegv__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+822 | [rocsolver_ssygv_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__ssygv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+823 | [rocsolver_dsygv_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dsygv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+824 | [rocsolver_chegv_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__chegv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+825 | [rocsolver_zhegv_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zhegv__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+826 | [rocsolver_ssygvd](interfacehipfort__rocsolver_1_1rocsolver__ssygvd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+827 | [rocsolver_dsygvd](interfacehipfort__rocsolver_1_1rocsolver__dsygvd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+828 | [rocsolver_chegvd](interfacehipfort__rocsolver_1_1rocsolver__chegvd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+829 | [rocsolver_zhegvd](interfacehipfort__rocsolver_1_1rocsolver__zhegvd.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+830 | [rocsolver_ssygvd_batched](interfacehipfort__rocsolver_1_1rocsolver__ssygvd__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+831 | [rocsolver_dsygvd_batched](interfacehipfort__rocsolver_1_1rocsolver__dsygvd__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+832 | [rocsolver_chegvd_batched](interfacehipfort__rocsolver_1_1rocsolver__chegvd__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+833 | [rocsolver_zhegvd_batched](interfacehipfort__rocsolver_1_1rocsolver__zhegvd__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+834 | [rocsolver_ssygvd_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__ssygvd__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+835 | [rocsolver_dsygvd_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dsygvd__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+836 | [rocsolver_chegvd_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__chegvd__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+837 | [rocsolver_zhegvd_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zhegvd__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 838 | [rocsolver_ssygvj](interfacehipfort__rocsolver_1_1rocsolver__ssygvj.html "Interface documentation") | C binding
 839 | [rocsolver_dsygvj](interfacehipfort__rocsolver_1_1rocsolver__dsygvj.html "Interface documentation") | C binding
 840 | [rocsolver_chegvj](interfacehipfort__rocsolver_1_1rocsolver__chegvj.html "Interface documentation") | C binding
@@ -863,66 +863,66 @@
 859 | [rocsolver_dsygvx_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dsygvx__strided__batched.html "Interface documentation") | C binding
 860 | [rocsolver_chegvx_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__chegvx__strided__batched.html "Interface documentation") | C binding
 861 | [rocsolver_zhegvx_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zhegvx__strided__batched.html "Interface documentation") | C binding
-862 | [rocsolver_sgetri_outofplace](interfacehipfort__rocsolver_1_1rocsolver__sgetri__outofplace.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-863 | [rocsolver_dgetri_outofplace](interfacehipfort__rocsolver_1_1rocsolver__dgetri__outofplace.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-864 | [rocsolver_cgetri_outofplace](interfacehipfort__rocsolver_1_1rocsolver__cgetri__outofplace.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-865 | [rocsolver_zgetri_outofplace](interfacehipfort__rocsolver_1_1rocsolver__zgetri__outofplace.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-866 | [rocsolver_sgetri_outofplace_batched](interfacehipfort__rocsolver_1_1rocsolver__sgetri__outofplace__batched.html "Interface documentation") | C binding, rank_0, rank_1
-867 | [rocsolver_dgetri_outofplace_batched](interfacehipfort__rocsolver_1_1rocsolver__dgetri__outofplace__batched.html "Interface documentation") | C binding, rank_0, rank_1
-868 | [rocsolver_cgetri_outofplace_batched](interfacehipfort__rocsolver_1_1rocsolver__cgetri__outofplace__batched.html "Interface documentation") | C binding, rank_0, rank_1
-869 | [rocsolver_zgetri_outofplace_batched](interfacehipfort__rocsolver_1_1rocsolver__zgetri__outofplace__batched.html "Interface documentation") | C binding, rank_0, rank_1
-870 | [rocsolver_sgetri_outofplace_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__sgetri__outofplace__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-871 | [rocsolver_dgetri_outofplace_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dgetri__outofplace__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-872 | [rocsolver_cgetri_outofplace_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cgetri__outofplace__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-873 | [rocsolver_zgetri_outofplace_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zgetri__outofplace__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-874 | [rocsolver_sgetri_npvt_outofplace](interfacehipfort__rocsolver_1_1rocsolver__sgetri__npvt__outofplace.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-875 | [rocsolver_dgetri_npvt_outofplace](interfacehipfort__rocsolver_1_1rocsolver__dgetri__npvt__outofplace.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-876 | [rocsolver_cgetri_npvt_outofplace](interfacehipfort__rocsolver_1_1rocsolver__cgetri__npvt__outofplace.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-877 | [rocsolver_zgetri_npvt_outofplace](interfacehipfort__rocsolver_1_1rocsolver__zgetri__npvt__outofplace.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+862 | [rocsolver_sgetri_outofplace](interfacehipfort__rocsolver_1_1rocsolver__sgetri__outofplace.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+863 | [rocsolver_dgetri_outofplace](interfacehipfort__rocsolver_1_1rocsolver__dgetri__outofplace.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+864 | [rocsolver_cgetri_outofplace](interfacehipfort__rocsolver_1_1rocsolver__cgetri__outofplace.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+865 | [rocsolver_zgetri_outofplace](interfacehipfort__rocsolver_1_1rocsolver__zgetri__outofplace.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+866 | [rocsolver_sgetri_outofplace_batched](interfacehipfort__rocsolver_1_1rocsolver__sgetri__outofplace__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+867 | [rocsolver_dgetri_outofplace_batched](interfacehipfort__rocsolver_1_1rocsolver__dgetri__outofplace__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+868 | [rocsolver_cgetri_outofplace_batched](interfacehipfort__rocsolver_1_1rocsolver__cgetri__outofplace__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+869 | [rocsolver_zgetri_outofplace_batched](interfacehipfort__rocsolver_1_1rocsolver__zgetri__outofplace__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+870 | [rocsolver_sgetri_outofplace_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__sgetri__outofplace__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+871 | [rocsolver_dgetri_outofplace_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dgetri__outofplace__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+872 | [rocsolver_cgetri_outofplace_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cgetri__outofplace__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+873 | [rocsolver_zgetri_outofplace_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zgetri__outofplace__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+874 | [rocsolver_sgetri_npvt_outofplace](interfacehipfort__rocsolver_1_1rocsolver__sgetri__npvt__outofplace.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+875 | [rocsolver_dgetri_npvt_outofplace](interfacehipfort__rocsolver_1_1rocsolver__dgetri__npvt__outofplace.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+876 | [rocsolver_cgetri_npvt_outofplace](interfacehipfort__rocsolver_1_1rocsolver__cgetri__npvt__outofplace.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+877 | [rocsolver_zgetri_npvt_outofplace](interfacehipfort__rocsolver_1_1rocsolver__zgetri__npvt__outofplace.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 878 | [rocsolver_sgetri_npvt_outofplace_batched](interfacehipfort__rocsolver_1_1rocsolver__sgetri__npvt__outofplace__batched.html "Interface documentation") | C binding
 879 | [rocsolver_dgetri_npvt_outofplace_batched](interfacehipfort__rocsolver_1_1rocsolver__dgetri__npvt__outofplace__batched.html "Interface documentation") | C binding
 880 | [rocsolver_cgetri_npvt_outofplace_batched](interfacehipfort__rocsolver_1_1rocsolver__cgetri__npvt__outofplace__batched.html "Interface documentation") | C binding
 881 | [rocsolver_zgetri_npvt_outofplace_batched](interfacehipfort__rocsolver_1_1rocsolver__zgetri__npvt__outofplace__batched.html "Interface documentation") | C binding
-882 | [rocsolver_sgetri_npvt_outofplace_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__sgetri__npvt__outofplace__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-883 | [rocsolver_dgetri_npvt_outofplace_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dgetri__npvt__outofplace__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-884 | [rocsolver_cgetri_npvt_outofplace_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cgetri__npvt__outofplace__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-885 | [rocsolver_zgetri_npvt_outofplace_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zgetri__npvt__outofplace__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-886 | [rocsolver_strtri](interfacehipfort__rocsolver_1_1rocsolver__strtri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-887 | [rocsolver_dtrtri](interfacehipfort__rocsolver_1_1rocsolver__dtrtri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-888 | [rocsolver_ctrtri](interfacehipfort__rocsolver_1_1rocsolver__ctrtri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-889 | [rocsolver_ztrtri](interfacehipfort__rocsolver_1_1rocsolver__ztrtri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+882 | [rocsolver_sgetri_npvt_outofplace_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__sgetri__npvt__outofplace__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+883 | [rocsolver_dgetri_npvt_outofplace_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dgetri__npvt__outofplace__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+884 | [rocsolver_cgetri_npvt_outofplace_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__cgetri__npvt__outofplace__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+885 | [rocsolver_zgetri_npvt_outofplace_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zgetri__npvt__outofplace__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+886 | [rocsolver_strtri](interfacehipfort__rocsolver_1_1rocsolver__strtri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+887 | [rocsolver_dtrtri](interfacehipfort__rocsolver_1_1rocsolver__dtrtri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+888 | [rocsolver_ctrtri](interfacehipfort__rocsolver_1_1rocsolver__ctrtri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+889 | [rocsolver_ztrtri](interfacehipfort__rocsolver_1_1rocsolver__ztrtri.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 890 | [rocsolver_strtri_batched](interfacehipfort__rocsolver_1_1rocsolver__strtri__batched.html "Interface documentation") | C binding
 891 | [rocsolver_dtrtri_batched](interfacehipfort__rocsolver_1_1rocsolver__dtrtri__batched.html "Interface documentation") | C binding
 892 | [rocsolver_ctrtri_batched](interfacehipfort__rocsolver_1_1rocsolver__ctrtri__batched.html "Interface documentation") | C binding
 893 | [rocsolver_ztrtri_batched](interfacehipfort__rocsolver_1_1rocsolver__ztrtri__batched.html "Interface documentation") | C binding
-894 | [rocsolver_strtri_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__strtri__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-895 | [rocsolver_dtrtri_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dtrtri__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-896 | [rocsolver_ctrtri_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__ctrtri__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-897 | [rocsolver_ztrtri_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__ztrtri__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-898 | [rocsolver_ssytf2](interfacehipfort__rocsolver_1_1rocsolver__ssytf2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-899 | [rocsolver_dsytf2](interfacehipfort__rocsolver_1_1rocsolver__dsytf2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-900 | [rocsolver_csytf2](interfacehipfort__rocsolver_1_1rocsolver__csytf2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-901 | [rocsolver_zsytf2](interfacehipfort__rocsolver_1_1rocsolver__zsytf2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-902 | [rocsolver_ssytf2_batched](interfacehipfort__rocsolver_1_1rocsolver__ssytf2__batched.html "Interface documentation") | C binding, rank_0, rank_1
-903 | [rocsolver_dsytf2_batched](interfacehipfort__rocsolver_1_1rocsolver__dsytf2__batched.html "Interface documentation") | C binding, rank_0, rank_1
-904 | [rocsolver_csytf2_batched](interfacehipfort__rocsolver_1_1rocsolver__csytf2__batched.html "Interface documentation") | C binding, rank_0, rank_1
-905 | [rocsolver_zsytf2_batched](interfacehipfort__rocsolver_1_1rocsolver__zsytf2__batched.html "Interface documentation") | C binding, rank_0, rank_1
-906 | [rocsolver_ssytf2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__ssytf2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-907 | [rocsolver_dsytf2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dsytf2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-908 | [rocsolver_csytf2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__csytf2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-909 | [rocsolver_zsytf2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zsytf2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-910 | [rocsolver_ssytrf](interfacehipfort__rocsolver_1_1rocsolver__ssytrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-911 | [rocsolver_dsytrf](interfacehipfort__rocsolver_1_1rocsolver__dsytrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-912 | [rocsolver_csytrf](interfacehipfort__rocsolver_1_1rocsolver__csytrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-913 | [rocsolver_zsytrf](interfacehipfort__rocsolver_1_1rocsolver__zsytrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-914 | [rocsolver_ssytrf_batched](interfacehipfort__rocsolver_1_1rocsolver__ssytrf__batched.html "Interface documentation") | C binding, rank_0, rank_1
-915 | [rocsolver_dsytrf_batched](interfacehipfort__rocsolver_1_1rocsolver__dsytrf__batched.html "Interface documentation") | C binding, rank_0, rank_1
-916 | [rocsolver_csytrf_batched](interfacehipfort__rocsolver_1_1rocsolver__csytrf__batched.html "Interface documentation") | C binding, rank_0, rank_1
-917 | [rocsolver_zsytrf_batched](interfacehipfort__rocsolver_1_1rocsolver__zsytrf__batched.html "Interface documentation") | C binding, rank_0, rank_1
-918 | [rocsolver_ssytrf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__ssytrf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-919 | [rocsolver_dsytrf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dsytrf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-920 | [rocsolver_csytrf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__csytrf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-921 | [rocsolver_zsytrf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zsytrf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+894 | [rocsolver_strtri_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__strtri__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+895 | [rocsolver_dtrtri_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dtrtri__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+896 | [rocsolver_ctrtri_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__ctrtri__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+897 | [rocsolver_ztrtri_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__ztrtri__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+898 | [rocsolver_ssytf2](interfacehipfort__rocsolver_1_1rocsolver__ssytf2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+899 | [rocsolver_dsytf2](interfacehipfort__rocsolver_1_1rocsolver__dsytf2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+900 | [rocsolver_csytf2](interfacehipfort__rocsolver_1_1rocsolver__csytf2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+901 | [rocsolver_zsytf2](interfacehipfort__rocsolver_1_1rocsolver__zsytf2.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+902 | [rocsolver_ssytf2_batched](interfacehipfort__rocsolver_1_1rocsolver__ssytf2__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+903 | [rocsolver_dsytf2_batched](interfacehipfort__rocsolver_1_1rocsolver__dsytf2__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+904 | [rocsolver_csytf2_batched](interfacehipfort__rocsolver_1_1rocsolver__csytf2__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+905 | [rocsolver_zsytf2_batched](interfacehipfort__rocsolver_1_1rocsolver__zsytf2__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+906 | [rocsolver_ssytf2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__ssytf2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+907 | [rocsolver_dsytf2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dsytf2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+908 | [rocsolver_csytf2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__csytf2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+909 | [rocsolver_zsytf2_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zsytf2__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+910 | [rocsolver_ssytrf](interfacehipfort__rocsolver_1_1rocsolver__ssytrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+911 | [rocsolver_dsytrf](interfacehipfort__rocsolver_1_1rocsolver__dsytrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+912 | [rocsolver_csytrf](interfacehipfort__rocsolver_1_1rocsolver__csytrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+913 | [rocsolver_zsytrf](interfacehipfort__rocsolver_1_1rocsolver__zsytrf.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+914 | [rocsolver_ssytrf_batched](interfacehipfort__rocsolver_1_1rocsolver__ssytrf__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+915 | [rocsolver_dsytrf_batched](interfacehipfort__rocsolver_1_1rocsolver__dsytrf__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+916 | [rocsolver_csytrf_batched](interfacehipfort__rocsolver_1_1rocsolver__csytrf__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+917 | [rocsolver_zsytrf_batched](interfacehipfort__rocsolver_1_1rocsolver__zsytrf__batched.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+918 | [rocsolver_ssytrf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__ssytrf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+919 | [rocsolver_dsytrf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__dsytrf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+920 | [rocsolver_csytrf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__csytrf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+921 | [rocsolver_zsytrf_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zsytrf__strided__batched.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 922 | [rocsolver_sgeblttrf_npvt](interfacehipfort__rocsolver_1_1rocsolver__sgeblttrf__npvt.html "Interface documentation") | C binding
 923 | [rocsolver_dgeblttrf_npvt](interfacehipfort__rocsolver_1_1rocsolver__dgeblttrf__npvt.html "Interface documentation") | C binding
 924 | [rocsolver_cgeblttrf_npvt](interfacehipfort__rocsolver_1_1rocsolver__cgeblttrf__npvt.html "Interface documentation") | C binding
@@ -985,8 +985,8 @@
 981 | [rocsolver_zheevdx_strided_batched](interfacehipfort__rocsolver_1_1rocsolver__zheevdx__strided__batched.html "Interface documentation") | C binding
 982 | [rocsolver_ssygvdx](interfacehipfort__rocsolver_1_1rocsolver__ssygvdx.html "Interface documentation") | C binding
 983 | [rocsolver_dsygvdx](interfacehipfort__rocsolver_1_1rocsolver__dsygvdx.html "Interface documentation") | C binding
-984 | [rocsolver_chegvdx](interfacehipfort__rocsolver_1_1rocsolver__chegvdx.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-985 | [rocsolver_zhegvdx](interfacehipfort__rocsolver_1_1rocsolver__zhegvdx.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+984 | [rocsolver_chegvdx](interfacehipfort__rocsolver_1_1rocsolver__chegvdx.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+985 | [rocsolver_zhegvdx](interfacehipfort__rocsolver_1_1rocsolver__zhegvdx.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 986 | [rocsolver_ssygvdx_batched](interfacehipfort__rocsolver_1_1rocsolver__ssygvdx__batched.html "Interface documentation") | C binding
 987 | [rocsolver_dsygvdx_batched](interfacehipfort__rocsolver_1_1rocsolver__dsygvdx__batched.html "Interface documentation") | C binding
 988 | [rocsolver_chegvdx_batched](interfacehipfort__rocsolver_1_1rocsolver__chegvdx__batched.html "Interface documentation") | C binding

--- a/docs/doxygen/input/supported_api_rocsparse.md
+++ b/docs/doxygen/input/supported_api_rocsparse.md
@@ -174,96 +174,96 @@
 170 | [rocsparse_enable_debug_force_host_assert](interfacehipfort__rocsparse_1_1rocsparse__enable__debug__force__host__assert.html "Interface documentation") | C binding
 171 | [rocsparse_disable_debug_force_host_assert](interfacehipfort__rocsparse_1_1rocsparse__disable__debug__force__host__assert.html "Interface documentation") | C binding
 172 | [rocsparse_state_debug_force_host_assert](interfacehipfort__rocsparse_1_1rocsparse__state__debug__force__host__assert.html "Interface documentation") | C binding
-173 | [rocsparse_sbsr2csr](interfacehipfort__rocsparse_1_1rocsparse__sbsr2csr.html "Interface documentation") | C binding, rank_0, rank_1
-174 | [rocsparse_dbsr2csr](interfacehipfort__rocsparse_1_1rocsparse__dbsr2csr.html "Interface documentation") | C binding, rank_0, rank_1
-175 | [rocsparse_cbsr2csr](interfacehipfort__rocsparse_1_1rocsparse__cbsr2csr.html "Interface documentation") | C binding, rank_0, rank_1
-176 | [rocsparse_zbsr2csr](interfacehipfort__rocsparse_1_1rocsparse__zbsr2csr.html "Interface documentation") | C binding, rank_0, rank_1
+173 | [rocsparse_sbsr2csr](interfacehipfort__rocsparse_1_1rocsparse__sbsr2csr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+174 | [rocsparse_dbsr2csr](interfacehipfort__rocsparse_1_1rocsparse__dbsr2csr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+175 | [rocsparse_cbsr2csr](interfacehipfort__rocsparse_1_1rocsparse__cbsr2csr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+176 | [rocsparse_zbsr2csr](interfacehipfort__rocsparse_1_1rocsparse__zbsr2csr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 177 | [rocsparse_sbsrpad_value](interfacehipfort__rocsparse_1_1rocsparse__sbsrpad__value.html "Interface documentation") | C binding
 178 | [rocsparse_dbsrpad_value](interfacehipfort__rocsparse_1_1rocsparse__dbsrpad__value.html "Interface documentation") | C binding
 179 | [rocsparse_cbsrpad_value](interfacehipfort__rocsparse_1_1rocsparse__cbsrpad__value.html "Interface documentation") | C binding
 180 | [rocsparse_zbsrpad_value](interfacehipfort__rocsparse_1_1rocsparse__zbsrpad__value.html "Interface documentation") | C binding
-181 | [rocsparse_coo2csr](interfacehipfort__rocsparse_1_1rocsparse__coo2csr.html "Interface documentation") | C binding, rank_0, rank_1
-182 | [rocsparse_scoo2dense](interfacehipfort__rocsparse_1_1rocsparse__scoo2dense.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-183 | [rocsparse_dcoo2dense](interfacehipfort__rocsparse_1_1rocsparse__dcoo2dense.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-184 | [rocsparse_ccoo2dense](interfacehipfort__rocsparse_1_1rocsparse__ccoo2dense.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-185 | [rocsparse_zcoo2dense](interfacehipfort__rocsparse_1_1rocsparse__zcoo2dense.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-186 | [rocsparse_coosort_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__coosort__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-187 | [rocsparse_coosort_by_row](interfacehipfort__rocsparse_1_1rocsparse__coosort__by__row.html "Interface documentation") | C binding, rank_0, rank_1
-188 | [rocsparse_coosort_by_column](interfacehipfort__rocsparse_1_1rocsparse__coosort__by__column.html "Interface documentation") | C binding, rank_0, rank_1
-189 | [rocsparse_scsc2dense](interfacehipfort__rocsparse_1_1rocsparse__scsc2dense.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-190 | [rocsparse_dcsc2dense](interfacehipfort__rocsparse_1_1rocsparse__dcsc2dense.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-191 | [rocsparse_ccsc2dense](interfacehipfort__rocsparse_1_1rocsparse__ccsc2dense.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-192 | [rocsparse_zcsc2dense](interfacehipfort__rocsparse_1_1rocsparse__zcsc2dense.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-193 | [rocsparse_cscsort_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__cscsort__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-194 | [rocsparse_cscsort](interfacehipfort__rocsparse_1_1rocsparse__cscsort.html "Interface documentation") | C binding, rank_0, rank_1
-195 | [rocsparse_csr2bsr_nnz](interfacehipfort__rocsparse_1_1rocsparse__csr2bsr__nnz.html "Interface documentation") | C binding, rank_0, rank_1
-196 | [rocsparse_scsr2bsr](interfacehipfort__rocsparse_1_1rocsparse__scsr2bsr.html "Interface documentation") | C binding, rank_0, rank_1
-197 | [rocsparse_dcsr2bsr](interfacehipfort__rocsparse_1_1rocsparse__dcsr2bsr.html "Interface documentation") | C binding, rank_0, rank_1
-198 | [rocsparse_ccsr2bsr](interfacehipfort__rocsparse_1_1rocsparse__ccsr2bsr.html "Interface documentation") | C binding, rank_0, rank_1
-199 | [rocsparse_zcsr2bsr](interfacehipfort__rocsparse_1_1rocsparse__zcsr2bsr.html "Interface documentation") | C binding, rank_0, rank_1
-200 | [rocsparse_csr2coo](interfacehipfort__rocsparse_1_1rocsparse__csr2coo.html "Interface documentation") | C binding, rank_0, rank_1
-201 | [rocsparse_csr2csc_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__csr2csc__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-202 | [rocsparse_scsr2csc](interfacehipfort__rocsparse_1_1rocsparse__scsr2csc.html "Interface documentation") | C binding, rank_0, rank_1
-203 | [rocsparse_dcsr2csc](interfacehipfort__rocsparse_1_1rocsparse__dcsr2csc.html "Interface documentation") | C binding, rank_0, rank_1
-204 | [rocsparse_ccsr2csc](interfacehipfort__rocsparse_1_1rocsparse__ccsr2csc.html "Interface documentation") | C binding, rank_0, rank_1
-205 | [rocsparse_zcsr2csc](interfacehipfort__rocsparse_1_1rocsparse__zcsr2csc.html "Interface documentation") | C binding, rank_0, rank_1
-206 | [rocsparse_scsr2csr_compress](interfacehipfort__rocsparse_1_1rocsparse__scsr2csr__compress.html "Interface documentation") | C binding, rank_0, rank_1
-207 | [rocsparse_dcsr2csr_compress](interfacehipfort__rocsparse_1_1rocsparse__dcsr2csr__compress.html "Interface documentation") | C binding, rank_0, rank_1
-208 | [rocsparse_ccsr2csr_compress](interfacehipfort__rocsparse_1_1rocsparse__ccsr2csr__compress.html "Interface documentation") | C binding, rank_0, rank_1
-209 | [rocsparse_zcsr2csr_compress](interfacehipfort__rocsparse_1_1rocsparse__zcsr2csr__compress.html "Interface documentation") | C binding, rank_0, rank_1
-210 | [rocsparse_scsr2dense](interfacehipfort__rocsparse_1_1rocsparse__scsr2dense.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-211 | [rocsparse_dcsr2dense](interfacehipfort__rocsparse_1_1rocsparse__dcsr2dense.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-212 | [rocsparse_ccsr2dense](interfacehipfort__rocsparse_1_1rocsparse__ccsr2dense.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-213 | [rocsparse_zcsr2dense](interfacehipfort__rocsparse_1_1rocsparse__zcsr2dense.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-214 | [rocsparse_csr2ell_width](interfacehipfort__rocsparse_1_1rocsparse__csr2ell__width.html "Interface documentation") | C binding, rank_0, rank_1
-215 | [rocsparse_scsr2ell](interfacehipfort__rocsparse_1_1rocsparse__scsr2ell.html "Interface documentation") | C binding, rank_0, rank_1
-216 | [rocsparse_dcsr2ell](interfacehipfort__rocsparse_1_1rocsparse__dcsr2ell.html "Interface documentation") | C binding, rank_0, rank_1
-217 | [rocsparse_ccsr2ell](interfacehipfort__rocsparse_1_1rocsparse__ccsr2ell.html "Interface documentation") | C binding, rank_0, rank_1
-218 | [rocsparse_zcsr2ell](interfacehipfort__rocsparse_1_1rocsparse__zcsr2ell.html "Interface documentation") | C binding, rank_0, rank_1
-219 | [rocsparse_scsr2gebsr_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__scsr2gebsr__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-220 | [rocsparse_dcsr2gebsr_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__dcsr2gebsr__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-221 | [rocsparse_ccsr2gebsr_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__ccsr2gebsr__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-222 | [rocsparse_zcsr2gebsr_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__zcsr2gebsr__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-223 | [rocsparse_csr2gebsr_nnz](interfacehipfort__rocsparse_1_1rocsparse__csr2gebsr__nnz.html "Interface documentation") | C binding, rank_0, rank_1
-224 | [rocsparse_scsr2gebsr](interfacehipfort__rocsparse_1_1rocsparse__scsr2gebsr.html "Interface documentation") | C binding, rank_0, rank_1
-225 | [rocsparse_dcsr2gebsr](interfacehipfort__rocsparse_1_1rocsparse__dcsr2gebsr.html "Interface documentation") | C binding, rank_0, rank_1
-226 | [rocsparse_ccsr2gebsr](interfacehipfort__rocsparse_1_1rocsparse__ccsr2gebsr.html "Interface documentation") | C binding, rank_0, rank_1
-227 | [rocsparse_zcsr2gebsr](interfacehipfort__rocsparse_1_1rocsparse__zcsr2gebsr.html "Interface documentation") | C binding, rank_0, rank_1
-228 | [rocsparse_scsr2hyb](interfacehipfort__rocsparse_1_1rocsparse__scsr2hyb.html "Interface documentation") | C binding, rank_0, rank_1
-229 | [rocsparse_dcsr2hyb](interfacehipfort__rocsparse_1_1rocsparse__dcsr2hyb.html "Interface documentation") | C binding, rank_0, rank_1
-230 | [rocsparse_ccsr2hyb](interfacehipfort__rocsparse_1_1rocsparse__ccsr2hyb.html "Interface documentation") | C binding, rank_0, rank_1
-231 | [rocsparse_zcsr2hyb](interfacehipfort__rocsparse_1_1rocsparse__zcsr2hyb.html "Interface documentation") | C binding, rank_0, rank_1
-232 | [rocsparse_csrsort_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__csrsort__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-233 | [rocsparse_csrsort](interfacehipfort__rocsparse_1_1rocsparse__csrsort.html "Interface documentation") | C binding, rank_0, rank_1
-234 | [rocsparse_sdense2coo](interfacehipfort__rocsparse_1_1rocsparse__sdense2coo.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-235 | [rocsparse_ddense2coo](interfacehipfort__rocsparse_1_1rocsparse__ddense2coo.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-236 | [rocsparse_cdense2coo](interfacehipfort__rocsparse_1_1rocsparse__cdense2coo.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-237 | [rocsparse_zdense2coo](interfacehipfort__rocsparse_1_1rocsparse__zdense2coo.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-238 | [rocsparse_sdense2csc](interfacehipfort__rocsparse_1_1rocsparse__sdense2csc.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-239 | [rocsparse_ddense2csc](interfacehipfort__rocsparse_1_1rocsparse__ddense2csc.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-240 | [rocsparse_cdense2csc](interfacehipfort__rocsparse_1_1rocsparse__cdense2csc.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-241 | [rocsparse_zdense2csc](interfacehipfort__rocsparse_1_1rocsparse__zdense2csc.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-242 | [rocsparse_sdense2csr](interfacehipfort__rocsparse_1_1rocsparse__sdense2csr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-243 | [rocsparse_ddense2csr](interfacehipfort__rocsparse_1_1rocsparse__ddense2csr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-244 | [rocsparse_cdense2csr](interfacehipfort__rocsparse_1_1rocsparse__cdense2csr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-245 | [rocsparse_zdense2csr](interfacehipfort__rocsparse_1_1rocsparse__zdense2csr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-246 | [rocsparse_ell2csr_nnz](interfacehipfort__rocsparse_1_1rocsparse__ell2csr__nnz.html "Interface documentation") | C binding, rank_0, rank_1
-247 | [rocsparse_sell2csr](interfacehipfort__rocsparse_1_1rocsparse__sell2csr.html "Interface documentation") | C binding, rank_0, rank_1
-248 | [rocsparse_dell2csr](interfacehipfort__rocsparse_1_1rocsparse__dell2csr.html "Interface documentation") | C binding, rank_0, rank_1
-249 | [rocsparse_cell2csr](interfacehipfort__rocsparse_1_1rocsparse__cell2csr.html "Interface documentation") | C binding, rank_0, rank_1
-250 | [rocsparse_zell2csr](interfacehipfort__rocsparse_1_1rocsparse__zell2csr.html "Interface documentation") | C binding, rank_0, rank_1
-251 | [rocsparse_sgebsr2csr](interfacehipfort__rocsparse_1_1rocsparse__sgebsr2csr.html "Interface documentation") | C binding, rank_0, rank_1
-252 | [rocsparse_dgebsr2csr](interfacehipfort__rocsparse_1_1rocsparse__dgebsr2csr.html "Interface documentation") | C binding, rank_0, rank_1
-253 | [rocsparse_cgebsr2csr](interfacehipfort__rocsparse_1_1rocsparse__cgebsr2csr.html "Interface documentation") | C binding, rank_0, rank_1
-254 | [rocsparse_zgebsr2csr](interfacehipfort__rocsparse_1_1rocsparse__zgebsr2csr.html "Interface documentation") | C binding, rank_0, rank_1
-255 | [rocsparse_sgebsr2gebsc_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__sgebsr2gebsc__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-256 | [rocsparse_dgebsr2gebsc_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__dgebsr2gebsc__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-257 | [rocsparse_cgebsr2gebsc_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__cgebsr2gebsc__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-258 | [rocsparse_zgebsr2gebsc_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__zgebsr2gebsc__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-259 | [rocsparse_sgebsr2gebsc](interfacehipfort__rocsparse_1_1rocsparse__sgebsr2gebsc.html "Interface documentation") | C binding, rank_0, rank_1
-260 | [rocsparse_dgebsr2gebsc](interfacehipfort__rocsparse_1_1rocsparse__dgebsr2gebsc.html "Interface documentation") | C binding, rank_0, rank_1
-261 | [rocsparse_cgebsr2gebsc](interfacehipfort__rocsparse_1_1rocsparse__cgebsr2gebsc.html "Interface documentation") | C binding, rank_0, rank_1
-262 | [rocsparse_zgebsr2gebsc](interfacehipfort__rocsparse_1_1rocsparse__zgebsr2gebsc.html "Interface documentation") | C binding, rank_0, rank_1
+181 | [rocsparse_coo2csr](interfacehipfort__rocsparse_1_1rocsparse__coo2csr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+182 | [rocsparse_scoo2dense](interfacehipfort__rocsparse_1_1rocsparse__scoo2dense.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+183 | [rocsparse_dcoo2dense](interfacehipfort__rocsparse_1_1rocsparse__dcoo2dense.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+184 | [rocsparse_ccoo2dense](interfacehipfort__rocsparse_1_1rocsparse__ccoo2dense.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+185 | [rocsparse_zcoo2dense](interfacehipfort__rocsparse_1_1rocsparse__zcoo2dense.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+186 | [rocsparse_coosort_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__coosort__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+187 | [rocsparse_coosort_by_row](interfacehipfort__rocsparse_1_1rocsparse__coosort__by__row.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+188 | [rocsparse_coosort_by_column](interfacehipfort__rocsparse_1_1rocsparse__coosort__by__column.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+189 | [rocsparse_scsc2dense](interfacehipfort__rocsparse_1_1rocsparse__scsc2dense.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+190 | [rocsparse_dcsc2dense](interfacehipfort__rocsparse_1_1rocsparse__dcsc2dense.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+191 | [rocsparse_ccsc2dense](interfacehipfort__rocsparse_1_1rocsparse__ccsc2dense.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+192 | [rocsparse_zcsc2dense](interfacehipfort__rocsparse_1_1rocsparse__zcsc2dense.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+193 | [rocsparse_cscsort_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__cscsort__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+194 | [rocsparse_cscsort](interfacehipfort__rocsparse_1_1rocsparse__cscsort.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+195 | [rocsparse_csr2bsr_nnz](interfacehipfort__rocsparse_1_1rocsparse__csr2bsr__nnz.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+196 | [rocsparse_scsr2bsr](interfacehipfort__rocsparse_1_1rocsparse__scsr2bsr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+197 | [rocsparse_dcsr2bsr](interfacehipfort__rocsparse_1_1rocsparse__dcsr2bsr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+198 | [rocsparse_ccsr2bsr](interfacehipfort__rocsparse_1_1rocsparse__ccsr2bsr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+199 | [rocsparse_zcsr2bsr](interfacehipfort__rocsparse_1_1rocsparse__zcsr2bsr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+200 | [rocsparse_csr2coo](interfacehipfort__rocsparse_1_1rocsparse__csr2coo.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+201 | [rocsparse_csr2csc_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__csr2csc__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+202 | [rocsparse_scsr2csc](interfacehipfort__rocsparse_1_1rocsparse__scsr2csc.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+203 | [rocsparse_dcsr2csc](interfacehipfort__rocsparse_1_1rocsparse__dcsr2csc.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+204 | [rocsparse_ccsr2csc](interfacehipfort__rocsparse_1_1rocsparse__ccsr2csc.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+205 | [rocsparse_zcsr2csc](interfacehipfort__rocsparse_1_1rocsparse__zcsr2csc.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+206 | [rocsparse_scsr2csr_compress](interfacehipfort__rocsparse_1_1rocsparse__scsr2csr__compress.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+207 | [rocsparse_dcsr2csr_compress](interfacehipfort__rocsparse_1_1rocsparse__dcsr2csr__compress.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+208 | [rocsparse_ccsr2csr_compress](interfacehipfort__rocsparse_1_1rocsparse__ccsr2csr__compress.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+209 | [rocsparse_zcsr2csr_compress](interfacehipfort__rocsparse_1_1rocsparse__zcsr2csr__compress.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+210 | [rocsparse_scsr2dense](interfacehipfort__rocsparse_1_1rocsparse__scsr2dense.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+211 | [rocsparse_dcsr2dense](interfacehipfort__rocsparse_1_1rocsparse__dcsr2dense.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+212 | [rocsparse_ccsr2dense](interfacehipfort__rocsparse_1_1rocsparse__ccsr2dense.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+213 | [rocsparse_zcsr2dense](interfacehipfort__rocsparse_1_1rocsparse__zcsr2dense.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+214 | [rocsparse_csr2ell_width](interfacehipfort__rocsparse_1_1rocsparse__csr2ell__width.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+215 | [rocsparse_scsr2ell](interfacehipfort__rocsparse_1_1rocsparse__scsr2ell.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+216 | [rocsparse_dcsr2ell](interfacehipfort__rocsparse_1_1rocsparse__dcsr2ell.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+217 | [rocsparse_ccsr2ell](interfacehipfort__rocsparse_1_1rocsparse__ccsr2ell.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+218 | [rocsparse_zcsr2ell](interfacehipfort__rocsparse_1_1rocsparse__zcsr2ell.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+219 | [rocsparse_scsr2gebsr_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__scsr2gebsr__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+220 | [rocsparse_dcsr2gebsr_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__dcsr2gebsr__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+221 | [rocsparse_ccsr2gebsr_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__ccsr2gebsr__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+222 | [rocsparse_zcsr2gebsr_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__zcsr2gebsr__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+223 | [rocsparse_csr2gebsr_nnz](interfacehipfort__rocsparse_1_1rocsparse__csr2gebsr__nnz.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+224 | [rocsparse_scsr2gebsr](interfacehipfort__rocsparse_1_1rocsparse__scsr2gebsr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+225 | [rocsparse_dcsr2gebsr](interfacehipfort__rocsparse_1_1rocsparse__dcsr2gebsr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+226 | [rocsparse_ccsr2gebsr](interfacehipfort__rocsparse_1_1rocsparse__ccsr2gebsr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+227 | [rocsparse_zcsr2gebsr](interfacehipfort__rocsparse_1_1rocsparse__zcsr2gebsr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+228 | [rocsparse_scsr2hyb](interfacehipfort__rocsparse_1_1rocsparse__scsr2hyb.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+229 | [rocsparse_dcsr2hyb](interfacehipfort__rocsparse_1_1rocsparse__dcsr2hyb.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+230 | [rocsparse_ccsr2hyb](interfacehipfort__rocsparse_1_1rocsparse__ccsr2hyb.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+231 | [rocsparse_zcsr2hyb](interfacehipfort__rocsparse_1_1rocsparse__zcsr2hyb.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+232 | [rocsparse_csrsort_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__csrsort__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+233 | [rocsparse_csrsort](interfacehipfort__rocsparse_1_1rocsparse__csrsort.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+234 | [rocsparse_sdense2coo](interfacehipfort__rocsparse_1_1rocsparse__sdense2coo.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+235 | [rocsparse_ddense2coo](interfacehipfort__rocsparse_1_1rocsparse__ddense2coo.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+236 | [rocsparse_cdense2coo](interfacehipfort__rocsparse_1_1rocsparse__cdense2coo.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+237 | [rocsparse_zdense2coo](interfacehipfort__rocsparse_1_1rocsparse__zdense2coo.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+238 | [rocsparse_sdense2csc](interfacehipfort__rocsparse_1_1rocsparse__sdense2csc.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+239 | [rocsparse_ddense2csc](interfacehipfort__rocsparse_1_1rocsparse__ddense2csc.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+240 | [rocsparse_cdense2csc](interfacehipfort__rocsparse_1_1rocsparse__cdense2csc.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+241 | [rocsparse_zdense2csc](interfacehipfort__rocsparse_1_1rocsparse__zdense2csc.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+242 | [rocsparse_sdense2csr](interfacehipfort__rocsparse_1_1rocsparse__sdense2csr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+243 | [rocsparse_ddense2csr](interfacehipfort__rocsparse_1_1rocsparse__ddense2csr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+244 | [rocsparse_cdense2csr](interfacehipfort__rocsparse_1_1rocsparse__cdense2csr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+245 | [rocsparse_zdense2csr](interfacehipfort__rocsparse_1_1rocsparse__zdense2csr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+246 | [rocsparse_ell2csr_nnz](interfacehipfort__rocsparse_1_1rocsparse__ell2csr__nnz.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+247 | [rocsparse_sell2csr](interfacehipfort__rocsparse_1_1rocsparse__sell2csr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+248 | [rocsparse_dell2csr](interfacehipfort__rocsparse_1_1rocsparse__dell2csr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+249 | [rocsparse_cell2csr](interfacehipfort__rocsparse_1_1rocsparse__cell2csr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+250 | [rocsparse_zell2csr](interfacehipfort__rocsparse_1_1rocsparse__zell2csr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+251 | [rocsparse_sgebsr2csr](interfacehipfort__rocsparse_1_1rocsparse__sgebsr2csr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+252 | [rocsparse_dgebsr2csr](interfacehipfort__rocsparse_1_1rocsparse__dgebsr2csr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+253 | [rocsparse_cgebsr2csr](interfacehipfort__rocsparse_1_1rocsparse__cgebsr2csr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+254 | [rocsparse_zgebsr2csr](interfacehipfort__rocsparse_1_1rocsparse__zgebsr2csr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+255 | [rocsparse_sgebsr2gebsc_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__sgebsr2gebsc__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+256 | [rocsparse_dgebsr2gebsc_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__dgebsr2gebsc__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+257 | [rocsparse_cgebsr2gebsc_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__cgebsr2gebsc__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+258 | [rocsparse_zgebsr2gebsc_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__zgebsr2gebsc__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+259 | [rocsparse_sgebsr2gebsc](interfacehipfort__rocsparse_1_1rocsparse__sgebsr2gebsc.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+260 | [rocsparse_dgebsr2gebsc](interfacehipfort__rocsparse_1_1rocsparse__dgebsr2gebsc.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+261 | [rocsparse_cgebsr2gebsc](interfacehipfort__rocsparse_1_1rocsparse__cgebsr2gebsc.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+262 | [rocsparse_zgebsr2gebsc](interfacehipfort__rocsparse_1_1rocsparse__zgebsr2gebsc.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 263 | [rocsparse_sgebsr2gebsr_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__sgebsr2gebsr__buffer__size.html "Interface documentation") | C binding
 264 | [rocsparse_dgebsr2gebsr_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__dgebsr2gebsr__buffer__size.html "Interface documentation") | C binding
 265 | [rocsparse_cgebsr2gebsr_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__cgebsr2gebsr__buffer__size.html "Interface documentation") | C binding
@@ -273,46 +273,46 @@
 269 | [rocsparse_dgebsr2gebsr](interfacehipfort__rocsparse_1_1rocsparse__dgebsr2gebsr.html "Interface documentation") | C binding
 270 | [rocsparse_cgebsr2gebsr](interfacehipfort__rocsparse_1_1rocsparse__cgebsr2gebsr.html "Interface documentation") | C binding
 271 | [rocsparse_zgebsr2gebsr](interfacehipfort__rocsparse_1_1rocsparse__zgebsr2gebsr.html "Interface documentation") | C binding
-272 | [rocsparse_hyb2csr_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__hyb2csr__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-273 | [rocsparse_shyb2csr](interfacehipfort__rocsparse_1_1rocsparse__shyb2csr.html "Interface documentation") | C binding, rank_0, rank_1
-274 | [rocsparse_dhyb2csr](interfacehipfort__rocsparse_1_1rocsparse__dhyb2csr.html "Interface documentation") | C binding, rank_0, rank_1
-275 | [rocsparse_chyb2csr](interfacehipfort__rocsparse_1_1rocsparse__chyb2csr.html "Interface documentation") | C binding, rank_0, rank_1
-276 | [rocsparse_zhyb2csr](interfacehipfort__rocsparse_1_1rocsparse__zhyb2csr.html "Interface documentation") | C binding, rank_0, rank_1
-277 | [rocsparse_create_identity_permutation](interfacehipfort__rocsparse_1_1rocsparse__create__identity__permutation.html "Interface documentation") | C binding, rank_0, rank_1
+272 | [rocsparse_hyb2csr_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__hyb2csr__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+273 | [rocsparse_shyb2csr](interfacehipfort__rocsparse_1_1rocsparse__shyb2csr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+274 | [rocsparse_dhyb2csr](interfacehipfort__rocsparse_1_1rocsparse__dhyb2csr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+275 | [rocsparse_chyb2csr](interfacehipfort__rocsparse_1_1rocsparse__chyb2csr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+276 | [rocsparse_zhyb2csr](interfacehipfort__rocsparse_1_1rocsparse__zhyb2csr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+277 | [rocsparse_create_identity_permutation](interfacehipfort__rocsparse_1_1rocsparse__create__identity__permutation.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 278 | [rocsparse_inverse_permutation](interfacehipfort__rocsparse_1_1rocsparse__inverse__permutation.html "Interface documentation") | C binding
 279 | [rocsparse_set_identity_permutation](interfacehipfort__rocsparse_1_1rocsparse__set__identity__permutation.html "Interface documentation") | C binding
-280 | [rocsparse_snnz](interfacehipfort__rocsparse_1_1rocsparse__snnz.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-281 | [rocsparse_dnnz](interfacehipfort__rocsparse_1_1rocsparse__dnnz.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-282 | [rocsparse_cnnz](interfacehipfort__rocsparse_1_1rocsparse__cnnz.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-283 | [rocsparse_znnz](interfacehipfort__rocsparse_1_1rocsparse__znnz.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-284 | [rocsparse_snnz_compress](interfacehipfort__rocsparse_1_1rocsparse__snnz__compress.html "Interface documentation") | C binding, rank_0, rank_1
-285 | [rocsparse_dnnz_compress](interfacehipfort__rocsparse_1_1rocsparse__dnnz__compress.html "Interface documentation") | C binding, rank_0, rank_1
-286 | [rocsparse_cnnz_compress](interfacehipfort__rocsparse_1_1rocsparse__cnnz__compress.html "Interface documentation") | C binding, rank_0, rank_1
-287 | [rocsparse_znnz_compress](interfacehipfort__rocsparse_1_1rocsparse__znnz__compress.html "Interface documentation") | C binding, rank_0, rank_1
-288 | [rocsparse_sprune_csr2csr_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__sprune__csr2csr__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-289 | [rocsparse_dprune_csr2csr_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__dprune__csr2csr__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-290 | [rocsparse_sprune_csr2csr_nnz](interfacehipfort__rocsparse_1_1rocsparse__sprune__csr2csr__nnz.html "Interface documentation") | C binding, rank_0, rank_1
-291 | [rocsparse_dprune_csr2csr_nnz](interfacehipfort__rocsparse_1_1rocsparse__dprune__csr2csr__nnz.html "Interface documentation") | C binding, rank_0, rank_1
-292 | [rocsparse_sprune_csr2csr](interfacehipfort__rocsparse_1_1rocsparse__sprune__csr2csr.html "Interface documentation") | C binding, rank_0, rank_1
-293 | [rocsparse_dprune_csr2csr](interfacehipfort__rocsparse_1_1rocsparse__dprune__csr2csr.html "Interface documentation") | C binding, rank_0, rank_1
-294 | [rocsparse_sprune_csr2csr_by_percentage_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__sprune__csr2csr__by__percentage__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-295 | [rocsparse_dprune_csr2csr_by_percentage_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__dprune__csr2csr__by__percentage__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-296 | [rocsparse_sprune_csr2csr_nnz_by_percentage](interfacehipfort__rocsparse_1_1rocsparse__sprune__csr2csr__nnz__by__percentage.html "Interface documentation") | C binding, rank_0, rank_1
-297 | [rocsparse_dprune_csr2csr_nnz_by_percentage](interfacehipfort__rocsparse_1_1rocsparse__dprune__csr2csr__nnz__by__percentage.html "Interface documentation") | C binding, rank_0, rank_1
-298 | [rocsparse_sprune_csr2csr_by_percentage](interfacehipfort__rocsparse_1_1rocsparse__sprune__csr2csr__by__percentage.html "Interface documentation") | C binding, rank_0, rank_1
-299 | [rocsparse_dprune_csr2csr_by_percentage](interfacehipfort__rocsparse_1_1rocsparse__dprune__csr2csr__by__percentage.html "Interface documentation") | C binding, rank_0, rank_1
-300 | [rocsparse_sprune_dense2csr_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__sprune__dense2csr__buffer__size.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-301 | [rocsparse_dprune_dense2csr_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__dprune__dense2csr__buffer__size.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-302 | [rocsparse_sprune_dense2csr_nnz](interfacehipfort__rocsparse_1_1rocsparse__sprune__dense2csr__nnz.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-303 | [rocsparse_dprune_dense2csr_nnz](interfacehipfort__rocsparse_1_1rocsparse__dprune__dense2csr__nnz.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-304 | [rocsparse_sprune_dense2csr](interfacehipfort__rocsparse_1_1rocsparse__sprune__dense2csr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-305 | [rocsparse_dprune_dense2csr](interfacehipfort__rocsparse_1_1rocsparse__dprune__dense2csr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+280 | [rocsparse_snnz](interfacehipfort__rocsparse_1_1rocsparse__snnz.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+281 | [rocsparse_dnnz](interfacehipfort__rocsparse_1_1rocsparse__dnnz.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+282 | [rocsparse_cnnz](interfacehipfort__rocsparse_1_1rocsparse__cnnz.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+283 | [rocsparse_znnz](interfacehipfort__rocsparse_1_1rocsparse__znnz.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+284 | [rocsparse_snnz_compress](interfacehipfort__rocsparse_1_1rocsparse__snnz__compress.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+285 | [rocsparse_dnnz_compress](interfacehipfort__rocsparse_1_1rocsparse__dnnz__compress.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+286 | [rocsparse_cnnz_compress](interfacehipfort__rocsparse_1_1rocsparse__cnnz__compress.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+287 | [rocsparse_znnz_compress](interfacehipfort__rocsparse_1_1rocsparse__znnz__compress.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+288 | [rocsparse_sprune_csr2csr_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__sprune__csr2csr__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+289 | [rocsparse_dprune_csr2csr_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__dprune__csr2csr__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+290 | [rocsparse_sprune_csr2csr_nnz](interfacehipfort__rocsparse_1_1rocsparse__sprune__csr2csr__nnz.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+291 | [rocsparse_dprune_csr2csr_nnz](interfacehipfort__rocsparse_1_1rocsparse__dprune__csr2csr__nnz.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+292 | [rocsparse_sprune_csr2csr](interfacehipfort__rocsparse_1_1rocsparse__sprune__csr2csr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+293 | [rocsparse_dprune_csr2csr](interfacehipfort__rocsparse_1_1rocsparse__dprune__csr2csr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+294 | [rocsparse_sprune_csr2csr_by_percentage_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__sprune__csr2csr__by__percentage__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+295 | [rocsparse_dprune_csr2csr_by_percentage_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__dprune__csr2csr__by__percentage__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+296 | [rocsparse_sprune_csr2csr_nnz_by_percentage](interfacehipfort__rocsparse_1_1rocsparse__sprune__csr2csr__nnz__by__percentage.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+297 | [rocsparse_dprune_csr2csr_nnz_by_percentage](interfacehipfort__rocsparse_1_1rocsparse__dprune__csr2csr__nnz__by__percentage.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+298 | [rocsparse_sprune_csr2csr_by_percentage](interfacehipfort__rocsparse_1_1rocsparse__sprune__csr2csr__by__percentage.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+299 | [rocsparse_dprune_csr2csr_by_percentage](interfacehipfort__rocsparse_1_1rocsparse__dprune__csr2csr__by__percentage.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+300 | [rocsparse_sprune_dense2csr_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__sprune__dense2csr__buffer__size.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+301 | [rocsparse_dprune_dense2csr_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__dprune__dense2csr__buffer__size.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+302 | [rocsparse_sprune_dense2csr_nnz](interfacehipfort__rocsparse_1_1rocsparse__sprune__dense2csr__nnz.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+303 | [rocsparse_dprune_dense2csr_nnz](interfacehipfort__rocsparse_1_1rocsparse__dprune__dense2csr__nnz.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+304 | [rocsparse_sprune_dense2csr](interfacehipfort__rocsparse_1_1rocsparse__sprune__dense2csr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+305 | [rocsparse_dprune_dense2csr](interfacehipfort__rocsparse_1_1rocsparse__dprune__dense2csr.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 306 | [rocsparse_sprune_dense2csr_by_percentage_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__sprune__dense2csr__by__percentage__buffer__size.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
 307 | [rocsparse_dprune_dense2csr_by_percentage_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__dprune__dense2csr__by__percentage__buffer__size.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-308 | [rocsparse_sprune_dense2csr_nnz_by_percentage](interfacehipfort__rocsparse_1_1rocsparse__sprune__dense2csr__nnz__by__percentage.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-309 | [rocsparse_dprune_dense2csr_nnz_by_percentage](interfacehipfort__rocsparse_1_1rocsparse__dprune__dense2csr__nnz__by__percentage.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-310 | [rocsparse_sprune_dense2csr_by_percentage](interfacehipfort__rocsparse_1_1rocsparse__sprune__dense2csr__by__percentage.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-311 | [rocsparse_dprune_dense2csr_by_percentage](interfacehipfort__rocsparse_1_1rocsparse__dprune__dense2csr__by__percentage.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+308 | [rocsparse_sprune_dense2csr_nnz_by_percentage](interfacehipfort__rocsparse_1_1rocsparse__sprune__dense2csr__nnz__by__percentage.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+309 | [rocsparse_dprune_dense2csr_nnz_by_percentage](interfacehipfort__rocsparse_1_1rocsparse__dprune__dense2csr__nnz__by__percentage.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+310 | [rocsparse_sprune_dense2csr_by_percentage](interfacehipfort__rocsparse_1_1rocsparse__sprune__dense2csr__by__percentage.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+311 | [rocsparse_dprune_dense2csr_by_percentage](interfacehipfort__rocsparse_1_1rocsparse__dprune__dense2csr__by__percentage.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 312 | [rocsparse_bsrgeam_nnzb](interfacehipfort__rocsparse_1_1rocsparse__bsrgeam__nnzb.html "Interface documentation") | C binding
 313 | [rocsparse_sbsrgeam](interfacehipfort__rocsparse_1_1rocsparse__sbsrgeam.html "Interface documentation") | C binding
 314 | [rocsparse_dbsrgeam](interfacehipfort__rocsparse_1_1rocsparse__dbsrgeam.html "Interface documentation") | C binding
@@ -327,20 +327,20 @@
 323 | [rocsparse_dbsrgemm](interfacehipfort__rocsparse_1_1rocsparse__dbsrgemm.html "Interface documentation") | C binding
 324 | [rocsparse_cbsrgemm](interfacehipfort__rocsparse_1_1rocsparse__cbsrgemm.html "Interface documentation") | C binding
 325 | [rocsparse_zbsrgemm](interfacehipfort__rocsparse_1_1rocsparse__zbsrgemm.html "Interface documentation") | C binding
-326 | [rocsparse_csrgeam_nnz](interfacehipfort__rocsparse_1_1rocsparse__csrgeam__nnz.html "Interface documentation") | C binding, rank_0, rank_1
-327 | [rocsparse_scsrgeam](interfacehipfort__rocsparse_1_1rocsparse__scsrgeam.html "Interface documentation") | C binding, rank_0, rank_1
-328 | [rocsparse_dcsrgeam](interfacehipfort__rocsparse_1_1rocsparse__dcsrgeam.html "Interface documentation") | C binding, rank_0, rank_1
-329 | [rocsparse_ccsrgeam](interfacehipfort__rocsparse_1_1rocsparse__ccsrgeam.html "Interface documentation") | C binding, rank_0, rank_1
-330 | [rocsparse_zcsrgeam](interfacehipfort__rocsparse_1_1rocsparse__zcsrgeam.html "Interface documentation") | C binding, rank_0, rank_1
-331 | [rocsparse_scsrgemm_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__scsrgemm__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-332 | [rocsparse_dcsrgemm_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__dcsrgemm__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-333 | [rocsparse_ccsrgemm_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__ccsrgemm__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-334 | [rocsparse_zcsrgemm_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__zcsrgemm__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-335 | [rocsparse_csrgemm_nnz](interfacehipfort__rocsparse_1_1rocsparse__csrgemm__nnz.html "Interface documentation") | C binding, rank_0, rank_1
-336 | [rocsparse_scsrgemm](interfacehipfort__rocsparse_1_1rocsparse__scsrgemm.html "Interface documentation") | C binding, rank_0, rank_1
-337 | [rocsparse_dcsrgemm](interfacehipfort__rocsparse_1_1rocsparse__dcsrgemm.html "Interface documentation") | C binding, rank_0, rank_1
-338 | [rocsparse_ccsrgemm](interfacehipfort__rocsparse_1_1rocsparse__ccsrgemm.html "Interface documentation") | C binding, rank_0, rank_1
-339 | [rocsparse_zcsrgemm](interfacehipfort__rocsparse_1_1rocsparse__zcsrgemm.html "Interface documentation") | C binding, rank_0, rank_1
+326 | [rocsparse_csrgeam_nnz](interfacehipfort__rocsparse_1_1rocsparse__csrgeam__nnz.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+327 | [rocsparse_scsrgeam](interfacehipfort__rocsparse_1_1rocsparse__scsrgeam.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+328 | [rocsparse_dcsrgeam](interfacehipfort__rocsparse_1_1rocsparse__dcsrgeam.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+329 | [rocsparse_ccsrgeam](interfacehipfort__rocsparse_1_1rocsparse__ccsrgeam.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+330 | [rocsparse_zcsrgeam](interfacehipfort__rocsparse_1_1rocsparse__zcsrgeam.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+331 | [rocsparse_scsrgemm_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__scsrgemm__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+332 | [rocsparse_dcsrgemm_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__dcsrgemm__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+333 | [rocsparse_ccsrgemm_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__ccsrgemm__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+334 | [rocsparse_zcsrgemm_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__zcsrgemm__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+335 | [rocsparse_csrgemm_nnz](interfacehipfort__rocsparse_1_1rocsparse__csrgemm__nnz.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+336 | [rocsparse_scsrgemm](interfacehipfort__rocsparse_1_1rocsparse__scsrgemm.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+337 | [rocsparse_dcsrgemm](interfacehipfort__rocsparse_1_1rocsparse__dcsrgemm.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+338 | [rocsparse_ccsrgemm](interfacehipfort__rocsparse_1_1rocsparse__ccsrgemm.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+339 | [rocsparse_zcsrgemm](interfacehipfort__rocsparse_1_1rocsparse__zcsrgemm.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 340 | [rocsparse_csrgemm_symbolic](interfacehipfort__rocsparse_1_1rocsparse__csrgemm__symbolic.html "Interface documentation") | C binding
 341 | [rocsparse_scsrgemm_numeric](interfacehipfort__rocsparse_1_1rocsparse__scsrgemm__numeric.html "Interface documentation") | C binding
 342 | [rocsparse_dcsrgemm_numeric](interfacehipfort__rocsparse_1_1rocsparse__dcsrgemm__numeric.html "Interface documentation") | C binding
@@ -384,62 +384,62 @@
 380 | [rocsparse_v2_spmv](interfacehipfort__rocsparse_1_1rocsparse__v2__spmv.html "Interface documentation") | C binding
 381 | [rocsparse_spmv_set_extra](interfacehipfort__rocsparse_1_1rocsparse__spmv__set__extra.html "Interface documentation") | C binding
 382 | [rocsparse_spmv_clear_extra](interfacehipfort__rocsparse_1_1rocsparse__spmv__clear__extra.html "Interface documentation") | C binding
-383 | [rocsparse_saxpyi](interfacehipfort__rocsparse_1_1rocsparse__saxpyi.html "Interface documentation") | C binding, rank_0, rank_1
-384 | [rocsparse_daxpyi](interfacehipfort__rocsparse_1_1rocsparse__daxpyi.html "Interface documentation") | C binding, rank_0, rank_1
-385 | [rocsparse_caxpyi](interfacehipfort__rocsparse_1_1rocsparse__caxpyi.html "Interface documentation") | C binding, rank_0, rank_1
-386 | [rocsparse_zaxpyi](interfacehipfort__rocsparse_1_1rocsparse__zaxpyi.html "Interface documentation") | C binding, rank_0, rank_1
-387 | [rocsparse_cdotci](interfacehipfort__rocsparse_1_1rocsparse__cdotci.html "Interface documentation") | C binding, rank_0, rank_1
-388 | [rocsparse_zdotci](interfacehipfort__rocsparse_1_1rocsparse__zdotci.html "Interface documentation") | C binding, rank_0, rank_1
-389 | [rocsparse_sdoti](interfacehipfort__rocsparse_1_1rocsparse__sdoti.html "Interface documentation") | C binding, rank_0, rank_1
-390 | [rocsparse_ddoti](interfacehipfort__rocsparse_1_1rocsparse__ddoti.html "Interface documentation") | C binding, rank_0, rank_1
-391 | [rocsparse_cdoti](interfacehipfort__rocsparse_1_1rocsparse__cdoti.html "Interface documentation") | C binding, rank_0, rank_1
-392 | [rocsparse_zdoti](interfacehipfort__rocsparse_1_1rocsparse__zdoti.html "Interface documentation") | C binding, rank_0, rank_1
-393 | [rocsparse_sgthr](interfacehipfort__rocsparse_1_1rocsparse__sgthr.html "Interface documentation") | C binding, rank_0, rank_1
-394 | [rocsparse_dgthr](interfacehipfort__rocsparse_1_1rocsparse__dgthr.html "Interface documentation") | C binding, rank_0, rank_1
-395 | [rocsparse_cgthr](interfacehipfort__rocsparse_1_1rocsparse__cgthr.html "Interface documentation") | C binding, rank_0, rank_1
-396 | [rocsparse_zgthr](interfacehipfort__rocsparse_1_1rocsparse__zgthr.html "Interface documentation") | C binding, rank_0, rank_1
-397 | [rocsparse_sgthrz](interfacehipfort__rocsparse_1_1rocsparse__sgthrz.html "Interface documentation") | C binding, rank_0, rank_1
-398 | [rocsparse_dgthrz](interfacehipfort__rocsparse_1_1rocsparse__dgthrz.html "Interface documentation") | C binding, rank_0, rank_1
-399 | [rocsparse_cgthrz](interfacehipfort__rocsparse_1_1rocsparse__cgthrz.html "Interface documentation") | C binding, rank_0, rank_1
-400 | [rocsparse_zgthrz](interfacehipfort__rocsparse_1_1rocsparse__zgthrz.html "Interface documentation") | C binding, rank_0, rank_1
-401 | [rocsparse_sroti](interfacehipfort__rocsparse_1_1rocsparse__sroti.html "Interface documentation") | C binding, rank_0, rank_1
-402 | [rocsparse_droti](interfacehipfort__rocsparse_1_1rocsparse__droti.html "Interface documentation") | C binding, rank_0, rank_1
-403 | [rocsparse_ssctr](interfacehipfort__rocsparse_1_1rocsparse__ssctr.html "Interface documentation") | C binding, rank_0, rank_1
-404 | [rocsparse_dsctr](interfacehipfort__rocsparse_1_1rocsparse__dsctr.html "Interface documentation") | C binding, rank_0, rank_1
-405 | [rocsparse_csctr](interfacehipfort__rocsparse_1_1rocsparse__csctr.html "Interface documentation") | C binding, rank_0, rank_1
-406 | [rocsparse_zsctr](interfacehipfort__rocsparse_1_1rocsparse__zsctr.html "Interface documentation") | C binding, rank_0, rank_1
-407 | [rocsparse_isctr](interfacehipfort__rocsparse_1_1rocsparse__isctr.html "Interface documentation") | C binding, rank_0, rank_1
+383 | [rocsparse_saxpyi](interfacehipfort__rocsparse_1_1rocsparse__saxpyi.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+384 | [rocsparse_daxpyi](interfacehipfort__rocsparse_1_1rocsparse__daxpyi.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+385 | [rocsparse_caxpyi](interfacehipfort__rocsparse_1_1rocsparse__caxpyi.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+386 | [rocsparse_zaxpyi](interfacehipfort__rocsparse_1_1rocsparse__zaxpyi.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+387 | [rocsparse_cdotci](interfacehipfort__rocsparse_1_1rocsparse__cdotci.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+388 | [rocsparse_zdotci](interfacehipfort__rocsparse_1_1rocsparse__zdotci.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+389 | [rocsparse_sdoti](interfacehipfort__rocsparse_1_1rocsparse__sdoti.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+390 | [rocsparse_ddoti](interfacehipfort__rocsparse_1_1rocsparse__ddoti.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+391 | [rocsparse_cdoti](interfacehipfort__rocsparse_1_1rocsparse__cdoti.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+392 | [rocsparse_zdoti](interfacehipfort__rocsparse_1_1rocsparse__zdoti.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+393 | [rocsparse_sgthr](interfacehipfort__rocsparse_1_1rocsparse__sgthr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+394 | [rocsparse_dgthr](interfacehipfort__rocsparse_1_1rocsparse__dgthr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+395 | [rocsparse_cgthr](interfacehipfort__rocsparse_1_1rocsparse__cgthr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+396 | [rocsparse_zgthr](interfacehipfort__rocsparse_1_1rocsparse__zgthr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+397 | [rocsparse_sgthrz](interfacehipfort__rocsparse_1_1rocsparse__sgthrz.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+398 | [rocsparse_dgthrz](interfacehipfort__rocsparse_1_1rocsparse__dgthrz.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+399 | [rocsparse_cgthrz](interfacehipfort__rocsparse_1_1rocsparse__cgthrz.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+400 | [rocsparse_zgthrz](interfacehipfort__rocsparse_1_1rocsparse__zgthrz.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+401 | [rocsparse_sroti](interfacehipfort__rocsparse_1_1rocsparse__sroti.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+402 | [rocsparse_droti](interfacehipfort__rocsparse_1_1rocsparse__droti.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+403 | [rocsparse_ssctr](interfacehipfort__rocsparse_1_1rocsparse__ssctr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+404 | [rocsparse_dsctr](interfacehipfort__rocsparse_1_1rocsparse__dsctr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+405 | [rocsparse_csctr](interfacehipfort__rocsparse_1_1rocsparse__csctr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+406 | [rocsparse_zsctr](interfacehipfort__rocsparse_1_1rocsparse__zsctr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+407 | [rocsparse_isctr](interfacehipfort__rocsparse_1_1rocsparse__isctr.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 408 | [rocsparse_sbsrmv_analysis](interfacehipfort__rocsparse_1_1rocsparse__sbsrmv__analysis.html "Interface documentation") | C binding
 409 | [rocsparse_dbsrmv_analysis](interfacehipfort__rocsparse_1_1rocsparse__dbsrmv__analysis.html "Interface documentation") | C binding
 410 | [rocsparse_cbsrmv_analysis](interfacehipfort__rocsparse_1_1rocsparse__cbsrmv__analysis.html "Interface documentation") | C binding
 411 | [rocsparse_zbsrmv_analysis](interfacehipfort__rocsparse_1_1rocsparse__zbsrmv__analysis.html "Interface documentation") | C binding
-412 | [rocsparse_sbsrmv](interfacehipfort__rocsparse_1_1rocsparse__sbsrmv.html "Interface documentation") | C binding, rank_0, rank_1
-413 | [rocsparse_dbsrmv](interfacehipfort__rocsparse_1_1rocsparse__dbsrmv.html "Interface documentation") | C binding, rank_0, rank_1
-414 | [rocsparse_cbsrmv](interfacehipfort__rocsparse_1_1rocsparse__cbsrmv.html "Interface documentation") | C binding, rank_0, rank_1
-415 | [rocsparse_zbsrmv](interfacehipfort__rocsparse_1_1rocsparse__zbsrmv.html "Interface documentation") | C binding, rank_0, rank_1
+412 | [rocsparse_sbsrmv](interfacehipfort__rocsparse_1_1rocsparse__sbsrmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+413 | [rocsparse_dbsrmv](interfacehipfort__rocsparse_1_1rocsparse__dbsrmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+414 | [rocsparse_cbsrmv](interfacehipfort__rocsparse_1_1rocsparse__cbsrmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+415 | [rocsparse_zbsrmv](interfacehipfort__rocsparse_1_1rocsparse__zbsrmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 416 | [rocsparse_bsrmv_clear](interfacehipfort__rocsparse_1_1rocsparse__bsrmv__clear.html "Interface documentation") | C binding
 417 | [rocsparse_bsrsv_zero_pivot](interfacehipfort__rocsparse_1_1rocsparse__bsrsv__zero__pivot.html "Interface documentation") | C binding
-418 | [rocsparse_sbsrsv_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__sbsrsv__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-419 | [rocsparse_dbsrsv_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__dbsrsv__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-420 | [rocsparse_cbsrsv_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__cbsrsv__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-421 | [rocsparse_zbsrsv_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__zbsrsv__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-422 | [rocsparse_sbsrsv_analysis](interfacehipfort__rocsparse_1_1rocsparse__sbsrsv__analysis.html "Interface documentation") | C binding, rank_0, rank_1
-423 | [rocsparse_dbsrsv_analysis](interfacehipfort__rocsparse_1_1rocsparse__dbsrsv__analysis.html "Interface documentation") | C binding, rank_0, rank_1
-424 | [rocsparse_cbsrsv_analysis](interfacehipfort__rocsparse_1_1rocsparse__cbsrsv__analysis.html "Interface documentation") | C binding, rank_0, rank_1
-425 | [rocsparse_zbsrsv_analysis](interfacehipfort__rocsparse_1_1rocsparse__zbsrsv__analysis.html "Interface documentation") | C binding, rank_0, rank_1
+418 | [rocsparse_sbsrsv_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__sbsrsv__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+419 | [rocsparse_dbsrsv_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__dbsrsv__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+420 | [rocsparse_cbsrsv_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__cbsrsv__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+421 | [rocsparse_zbsrsv_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__zbsrsv__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+422 | [rocsparse_sbsrsv_analysis](interfacehipfort__rocsparse_1_1rocsparse__sbsrsv__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+423 | [rocsparse_dbsrsv_analysis](interfacehipfort__rocsparse_1_1rocsparse__dbsrsv__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+424 | [rocsparse_cbsrsv_analysis](interfacehipfort__rocsparse_1_1rocsparse__cbsrsv__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+425 | [rocsparse_zbsrsv_analysis](interfacehipfort__rocsparse_1_1rocsparse__zbsrsv__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 426 | [rocsparse_bsrsv_clear](interfacehipfort__rocsparse_1_1rocsparse__bsrsv__clear.html "Interface documentation") | C binding
-427 | [rocsparse_sbsrsv_solve](interfacehipfort__rocsparse_1_1rocsparse__sbsrsv__solve.html "Interface documentation") | C binding, rank_0, rank_1
-428 | [rocsparse_dbsrsv_solve](interfacehipfort__rocsparse_1_1rocsparse__dbsrsv__solve.html "Interface documentation") | C binding, rank_0, rank_1
-429 | [rocsparse_cbsrsv_solve](interfacehipfort__rocsparse_1_1rocsparse__cbsrsv__solve.html "Interface documentation") | C binding, rank_0, rank_1
-430 | [rocsparse_zbsrsv_solve](interfacehipfort__rocsparse_1_1rocsparse__zbsrsv__solve.html "Interface documentation") | C binding, rank_0, rank_1
-431 | [rocsparse_sbsrxmv](interfacehipfort__rocsparse_1_1rocsparse__sbsrxmv.html "Interface documentation") | C binding, rank_0, rank_1
-432 | [rocsparse_dbsrxmv](interfacehipfort__rocsparse_1_1rocsparse__dbsrxmv.html "Interface documentation") | C binding, rank_0, rank_1
-433 | [rocsparse_cbsrxmv](interfacehipfort__rocsparse_1_1rocsparse__cbsrxmv.html "Interface documentation") | C binding, rank_0, rank_1
-434 | [rocsparse_zbsrxmv](interfacehipfort__rocsparse_1_1rocsparse__zbsrxmv.html "Interface documentation") | C binding, rank_0, rank_1
-435 | [rocsparse_scoomv](interfacehipfort__rocsparse_1_1rocsparse__scoomv.html "Interface documentation") | C binding, rank_0, rank_1
-436 | [rocsparse_dcoomv](interfacehipfort__rocsparse_1_1rocsparse__dcoomv.html "Interface documentation") | C binding, rank_0, rank_1
-437 | [rocsparse_ccoomv](interfacehipfort__rocsparse_1_1rocsparse__ccoomv.html "Interface documentation") | C binding, rank_0, rank_1
-438 | [rocsparse_zcoomv](interfacehipfort__rocsparse_1_1rocsparse__zcoomv.html "Interface documentation") | C binding, rank_0, rank_1
+427 | [rocsparse_sbsrsv_solve](interfacehipfort__rocsparse_1_1rocsparse__sbsrsv__solve.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+428 | [rocsparse_dbsrsv_solve](interfacehipfort__rocsparse_1_1rocsparse__dbsrsv__solve.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+429 | [rocsparse_cbsrsv_solve](interfacehipfort__rocsparse_1_1rocsparse__cbsrsv__solve.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+430 | [rocsparse_zbsrsv_solve](interfacehipfort__rocsparse_1_1rocsparse__zbsrsv__solve.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+431 | [rocsparse_sbsrxmv](interfacehipfort__rocsparse_1_1rocsparse__sbsrxmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+432 | [rocsparse_dbsrxmv](interfacehipfort__rocsparse_1_1rocsparse__dbsrxmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+433 | [rocsparse_cbsrxmv](interfacehipfort__rocsparse_1_1rocsparse__cbsrxmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+434 | [rocsparse_zbsrxmv](interfacehipfort__rocsparse_1_1rocsparse__zbsrxmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+435 | [rocsparse_scoomv](interfacehipfort__rocsparse_1_1rocsparse__scoomv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+436 | [rocsparse_dcoomv](interfacehipfort__rocsparse_1_1rocsparse__dcoomv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+437 | [rocsparse_ccoomv](interfacehipfort__rocsparse_1_1rocsparse__ccoomv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+438 | [rocsparse_zcoomv](interfacehipfort__rocsparse_1_1rocsparse__zcoomv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 439 | [rocsparse_csritsv_zero_pivot](interfacehipfort__rocsparse_1_1rocsparse__csritsv__zero__pivot.html "Interface documentation") | C binding
 440 | [rocsparse_scsritsv_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__scsritsv__buffer__size.html "Interface documentation") | C binding
 441 | [rocsparse_dcsritsv_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__dcsritsv__buffer__size.html "Interface documentation") | C binding
@@ -458,107 +458,107 @@
 454 | [rocsparse_dcsritsv_solve_ex](interfacehipfort__rocsparse_1_1rocsparse__dcsritsv__solve__ex.html "Interface documentation") | C binding
 455 | [rocsparse_ccsritsv_solve_ex](interfacehipfort__rocsparse_1_1rocsparse__ccsritsv__solve__ex.html "Interface documentation") | C binding
 456 | [rocsparse_zcsritsv_solve_ex](interfacehipfort__rocsparse_1_1rocsparse__zcsritsv__solve__ex.html "Interface documentation") | C binding
-457 | [rocsparse_scsrmv_analysis](interfacehipfort__rocsparse_1_1rocsparse__scsrmv__analysis.html "Interface documentation") | C binding, rank_0, rank_1
-458 | [rocsparse_dcsrmv_analysis](interfacehipfort__rocsparse_1_1rocsparse__dcsrmv__analysis.html "Interface documentation") | C binding, rank_0, rank_1
-459 | [rocsparse_ccsrmv_analysis](interfacehipfort__rocsparse_1_1rocsparse__ccsrmv__analysis.html "Interface documentation") | C binding, rank_0, rank_1
-460 | [rocsparse_zcsrmv_analysis](interfacehipfort__rocsparse_1_1rocsparse__zcsrmv__analysis.html "Interface documentation") | C binding, rank_0, rank_1
+457 | [rocsparse_scsrmv_analysis](interfacehipfort__rocsparse_1_1rocsparse__scsrmv__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+458 | [rocsparse_dcsrmv_analysis](interfacehipfort__rocsparse_1_1rocsparse__dcsrmv__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+459 | [rocsparse_ccsrmv_analysis](interfacehipfort__rocsparse_1_1rocsparse__ccsrmv__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+460 | [rocsparse_zcsrmv_analysis](interfacehipfort__rocsparse_1_1rocsparse__zcsrmv__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 461 | [rocsparse_csrmv_clear](interfacehipfort__rocsparse_1_1rocsparse__csrmv__clear.html "Interface documentation") | C binding
-462 | [rocsparse_scsrmv](interfacehipfort__rocsparse_1_1rocsparse__scsrmv.html "Interface documentation") | C binding, rank_0, rank_1
-463 | [rocsparse_dcsrmv](interfacehipfort__rocsparse_1_1rocsparse__dcsrmv.html "Interface documentation") | C binding, rank_0, rank_1
-464 | [rocsparse_ccsrmv](interfacehipfort__rocsparse_1_1rocsparse__ccsrmv.html "Interface documentation") | C binding, rank_0, rank_1
-465 | [rocsparse_zcsrmv](interfacehipfort__rocsparse_1_1rocsparse__zcsrmv.html "Interface documentation") | C binding, rank_0, rank_1
+462 | [rocsparse_scsrmv](interfacehipfort__rocsparse_1_1rocsparse__scsrmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+463 | [rocsparse_dcsrmv](interfacehipfort__rocsparse_1_1rocsparse__dcsrmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+464 | [rocsparse_ccsrmv](interfacehipfort__rocsparse_1_1rocsparse__ccsrmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+465 | [rocsparse_zcsrmv](interfacehipfort__rocsparse_1_1rocsparse__zcsrmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 466 | [rocsparse_csrsv_zero_pivot](interfacehipfort__rocsparse_1_1rocsparse__csrsv__zero__pivot.html "Interface documentation") | C binding
-467 | [rocsparse_scsrsv_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__scsrsv__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-468 | [rocsparse_dcsrsv_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__dcsrsv__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-469 | [rocsparse_ccsrsv_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__ccsrsv__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-470 | [rocsparse_zcsrsv_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__zcsrsv__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-471 | [rocsparse_scsrsv_analysis](interfacehipfort__rocsparse_1_1rocsparse__scsrsv__analysis.html "Interface documentation") | C binding, rank_0, rank_1
-472 | [rocsparse_dcsrsv_analysis](interfacehipfort__rocsparse_1_1rocsparse__dcsrsv__analysis.html "Interface documentation") | C binding, rank_0, rank_1
-473 | [rocsparse_ccsrsv_analysis](interfacehipfort__rocsparse_1_1rocsparse__ccsrsv__analysis.html "Interface documentation") | C binding, rank_0, rank_1
-474 | [rocsparse_zcsrsv_analysis](interfacehipfort__rocsparse_1_1rocsparse__zcsrsv__analysis.html "Interface documentation") | C binding, rank_0, rank_1
+467 | [rocsparse_scsrsv_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__scsrsv__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+468 | [rocsparse_dcsrsv_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__dcsrsv__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+469 | [rocsparse_ccsrsv_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__ccsrsv__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+470 | [rocsparse_zcsrsv_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__zcsrsv__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+471 | [rocsparse_scsrsv_analysis](interfacehipfort__rocsparse_1_1rocsparse__scsrsv__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+472 | [rocsparse_dcsrsv_analysis](interfacehipfort__rocsparse_1_1rocsparse__dcsrsv__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+473 | [rocsparse_ccsrsv_analysis](interfacehipfort__rocsparse_1_1rocsparse__ccsrsv__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+474 | [rocsparse_zcsrsv_analysis](interfacehipfort__rocsparse_1_1rocsparse__zcsrsv__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 475 | [rocsparse_csrsv_clear](interfacehipfort__rocsparse_1_1rocsparse__csrsv__clear.html "Interface documentation") | C binding
-476 | [rocsparse_scsrsv_solve](interfacehipfort__rocsparse_1_1rocsparse__scsrsv__solve.html "Interface documentation") | C binding, rank_0, rank_1
-477 | [rocsparse_dcsrsv_solve](interfacehipfort__rocsparse_1_1rocsparse__dcsrsv__solve.html "Interface documentation") | C binding, rank_0, rank_1
-478 | [rocsparse_ccsrsv_solve](interfacehipfort__rocsparse_1_1rocsparse__ccsrsv__solve.html "Interface documentation") | C binding, rank_0, rank_1
-479 | [rocsparse_zcsrsv_solve](interfacehipfort__rocsparse_1_1rocsparse__zcsrsv__solve.html "Interface documentation") | C binding, rank_0, rank_1
-480 | [rocsparse_sellmv](interfacehipfort__rocsparse_1_1rocsparse__sellmv.html "Interface documentation") | C binding, rank_0, rank_1
-481 | [rocsparse_dellmv](interfacehipfort__rocsparse_1_1rocsparse__dellmv.html "Interface documentation") | C binding, rank_0, rank_1
-482 | [rocsparse_cellmv](interfacehipfort__rocsparse_1_1rocsparse__cellmv.html "Interface documentation") | C binding, rank_0, rank_1
-483 | [rocsparse_zellmv](interfacehipfort__rocsparse_1_1rocsparse__zellmv.html "Interface documentation") | C binding, rank_0, rank_1
-484 | [rocsparse_sgebsrmv](interfacehipfort__rocsparse_1_1rocsparse__sgebsrmv.html "Interface documentation") | C binding, rank_0, rank_1
-485 | [rocsparse_dgebsrmv](interfacehipfort__rocsparse_1_1rocsparse__dgebsrmv.html "Interface documentation") | C binding, rank_0, rank_1
-486 | [rocsparse_cgebsrmv](interfacehipfort__rocsparse_1_1rocsparse__cgebsrmv.html "Interface documentation") | C binding, rank_0, rank_1
-487 | [rocsparse_zgebsrmv](interfacehipfort__rocsparse_1_1rocsparse__zgebsrmv.html "Interface documentation") | C binding, rank_0, rank_1
+476 | [rocsparse_scsrsv_solve](interfacehipfort__rocsparse_1_1rocsparse__scsrsv__solve.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+477 | [rocsparse_dcsrsv_solve](interfacehipfort__rocsparse_1_1rocsparse__dcsrsv__solve.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+478 | [rocsparse_ccsrsv_solve](interfacehipfort__rocsparse_1_1rocsparse__ccsrsv__solve.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+479 | [rocsparse_zcsrsv_solve](interfacehipfort__rocsparse_1_1rocsparse__zcsrsv__solve.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+480 | [rocsparse_sellmv](interfacehipfort__rocsparse_1_1rocsparse__sellmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+481 | [rocsparse_dellmv](interfacehipfort__rocsparse_1_1rocsparse__dellmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+482 | [rocsparse_cellmv](interfacehipfort__rocsparse_1_1rocsparse__cellmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+483 | [rocsparse_zellmv](interfacehipfort__rocsparse_1_1rocsparse__zellmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+484 | [rocsparse_sgebsrmv](interfacehipfort__rocsparse_1_1rocsparse__sgebsrmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+485 | [rocsparse_dgebsrmv](interfacehipfort__rocsparse_1_1rocsparse__dgebsrmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+486 | [rocsparse_cgebsrmv](interfacehipfort__rocsparse_1_1rocsparse__cgebsrmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+487 | [rocsparse_zgebsrmv](interfacehipfort__rocsparse_1_1rocsparse__zgebsrmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 488 | [rocsparse_sgemvi_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__sgemvi__buffer__size.html "Interface documentation") | C binding
 489 | [rocsparse_dgemvi_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__dgemvi__buffer__size.html "Interface documentation") | C binding
 490 | [rocsparse_cgemvi_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__cgemvi__buffer__size.html "Interface documentation") | C binding
 491 | [rocsparse_zgemvi_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__zgemvi__buffer__size.html "Interface documentation") | C binding
-492 | [rocsparse_sgemvi](interfacehipfort__rocsparse_1_1rocsparse__sgemvi.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-493 | [rocsparse_dgemvi](interfacehipfort__rocsparse_1_1rocsparse__dgemvi.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-494 | [rocsparse_cgemvi](interfacehipfort__rocsparse_1_1rocsparse__cgemvi.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-495 | [rocsparse_zgemvi](interfacehipfort__rocsparse_1_1rocsparse__zgemvi.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-496 | [rocsparse_shybmv](interfacehipfort__rocsparse_1_1rocsparse__shybmv.html "Interface documentation") | C binding, rank_0, rank_1
-497 | [rocsparse_dhybmv](interfacehipfort__rocsparse_1_1rocsparse__dhybmv.html "Interface documentation") | C binding, rank_0, rank_1
-498 | [rocsparse_chybmv](interfacehipfort__rocsparse_1_1rocsparse__chybmv.html "Interface documentation") | C binding, rank_0, rank_1
-499 | [rocsparse_zhybmv](interfacehipfort__rocsparse_1_1rocsparse__zhybmv.html "Interface documentation") | C binding, rank_0, rank_1
-500 | [rocsparse_sbsrmm](interfacehipfort__rocsparse_1_1rocsparse__sbsrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-501 | [rocsparse_dbsrmm](interfacehipfort__rocsparse_1_1rocsparse__dbsrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-502 | [rocsparse_cbsrmm](interfacehipfort__rocsparse_1_1rocsparse__cbsrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-503 | [rocsparse_zbsrmm](interfacehipfort__rocsparse_1_1rocsparse__zbsrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+492 | [rocsparse_sgemvi](interfacehipfort__rocsparse_1_1rocsparse__sgemvi.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+493 | [rocsparse_dgemvi](interfacehipfort__rocsparse_1_1rocsparse__dgemvi.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+494 | [rocsparse_cgemvi](interfacehipfort__rocsparse_1_1rocsparse__cgemvi.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+495 | [rocsparse_zgemvi](interfacehipfort__rocsparse_1_1rocsparse__zgemvi.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+496 | [rocsparse_shybmv](interfacehipfort__rocsparse_1_1rocsparse__shybmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+497 | [rocsparse_dhybmv](interfacehipfort__rocsparse_1_1rocsparse__dhybmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+498 | [rocsparse_chybmv](interfacehipfort__rocsparse_1_1rocsparse__chybmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+499 | [rocsparse_zhybmv](interfacehipfort__rocsparse_1_1rocsparse__zhybmv.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+500 | [rocsparse_sbsrmm](interfacehipfort__rocsparse_1_1rocsparse__sbsrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+501 | [rocsparse_dbsrmm](interfacehipfort__rocsparse_1_1rocsparse__dbsrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+502 | [rocsparse_cbsrmm](interfacehipfort__rocsparse_1_1rocsparse__cbsrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+503 | [rocsparse_zbsrmm](interfacehipfort__rocsparse_1_1rocsparse__zbsrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 504 | [rocsparse_bsrsm_zero_pivot](interfacehipfort__rocsparse_1_1rocsparse__bsrsm__zero__pivot.html "Interface documentation") | C binding
-505 | [rocsparse_sbsrsm_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__sbsrsm__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-506 | [rocsparse_dbsrsm_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__dbsrsm__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-507 | [rocsparse_cbsrsm_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__cbsrsm__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-508 | [rocsparse_zbsrsm_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__zbsrsm__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-509 | [rocsparse_sbsrsm_analysis](interfacehipfort__rocsparse_1_1rocsparse__sbsrsm__analysis.html "Interface documentation") | C binding, rank_0, rank_1
-510 | [rocsparse_dbsrsm_analysis](interfacehipfort__rocsparse_1_1rocsparse__dbsrsm__analysis.html "Interface documentation") | C binding, rank_0, rank_1
-511 | [rocsparse_cbsrsm_analysis](interfacehipfort__rocsparse_1_1rocsparse__cbsrsm__analysis.html "Interface documentation") | C binding, rank_0, rank_1
-512 | [rocsparse_zbsrsm_analysis](interfacehipfort__rocsparse_1_1rocsparse__zbsrsm__analysis.html "Interface documentation") | C binding, rank_0, rank_1
+505 | [rocsparse_sbsrsm_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__sbsrsm__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+506 | [rocsparse_dbsrsm_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__dbsrsm__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+507 | [rocsparse_cbsrsm_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__cbsrsm__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+508 | [rocsparse_zbsrsm_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__zbsrsm__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+509 | [rocsparse_sbsrsm_analysis](interfacehipfort__rocsparse_1_1rocsparse__sbsrsm__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+510 | [rocsparse_dbsrsm_analysis](interfacehipfort__rocsparse_1_1rocsparse__dbsrsm__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+511 | [rocsparse_cbsrsm_analysis](interfacehipfort__rocsparse_1_1rocsparse__cbsrsm__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+512 | [rocsparse_zbsrsm_analysis](interfacehipfort__rocsparse_1_1rocsparse__zbsrsm__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 513 | [rocsparse_bsrsm_clear](interfacehipfort__rocsparse_1_1rocsparse__bsrsm__clear.html "Interface documentation") | C binding
-514 | [rocsparse_sbsrsm_solve](interfacehipfort__rocsparse_1_1rocsparse__sbsrsm__solve.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-515 | [rocsparse_dbsrsm_solve](interfacehipfort__rocsparse_1_1rocsparse__dbsrsm__solve.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-516 | [rocsparse_cbsrsm_solve](interfacehipfort__rocsparse_1_1rocsparse__cbsrsm__solve.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-517 | [rocsparse_zbsrsm_solve](interfacehipfort__rocsparse_1_1rocsparse__zbsrsm__solve.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-518 | [rocsparse_scsrmm](interfacehipfort__rocsparse_1_1rocsparse__scsrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-519 | [rocsparse_dcsrmm](interfacehipfort__rocsparse_1_1rocsparse__dcsrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-520 | [rocsparse_ccsrmm](interfacehipfort__rocsparse_1_1rocsparse__ccsrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-521 | [rocsparse_zcsrmm](interfacehipfort__rocsparse_1_1rocsparse__zcsrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+514 | [rocsparse_sbsrsm_solve](interfacehipfort__rocsparse_1_1rocsparse__sbsrsm__solve.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+515 | [rocsparse_dbsrsm_solve](interfacehipfort__rocsparse_1_1rocsparse__dbsrsm__solve.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+516 | [rocsparse_cbsrsm_solve](interfacehipfort__rocsparse_1_1rocsparse__cbsrsm__solve.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+517 | [rocsparse_zbsrsm_solve](interfacehipfort__rocsparse_1_1rocsparse__zbsrsm__solve.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+518 | [rocsparse_scsrmm](interfacehipfort__rocsparse_1_1rocsparse__scsrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+519 | [rocsparse_dcsrmm](interfacehipfort__rocsparse_1_1rocsparse__dcsrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+520 | [rocsparse_ccsrmm](interfacehipfort__rocsparse_1_1rocsparse__ccsrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+521 | [rocsparse_zcsrmm](interfacehipfort__rocsparse_1_1rocsparse__zcsrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 522 | [rocsparse_csrsm_zero_pivot](interfacehipfort__rocsparse_1_1rocsparse__csrsm__zero__pivot.html "Interface documentation") | C binding
-523 | [rocsparse_scsrsm_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__scsrsm__buffer__size.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-524 | [rocsparse_dcsrsm_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__dcsrsm__buffer__size.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-525 | [rocsparse_ccsrsm_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__ccsrsm__buffer__size.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-526 | [rocsparse_zcsrsm_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__zcsrsm__buffer__size.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-527 | [rocsparse_scsrsm_analysis](interfacehipfort__rocsparse_1_1rocsparse__scsrsm__analysis.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-528 | [rocsparse_dcsrsm_analysis](interfacehipfort__rocsparse_1_1rocsparse__dcsrsm__analysis.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-529 | [rocsparse_ccsrsm_analysis](interfacehipfort__rocsparse_1_1rocsparse__ccsrsm__analysis.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-530 | [rocsparse_zcsrsm_analysis](interfacehipfort__rocsparse_1_1rocsparse__zcsrsm__analysis.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+523 | [rocsparse_scsrsm_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__scsrsm__buffer__size.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+524 | [rocsparse_dcsrsm_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__dcsrsm__buffer__size.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+525 | [rocsparse_ccsrsm_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__ccsrsm__buffer__size.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+526 | [rocsparse_zcsrsm_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__zcsrsm__buffer__size.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+527 | [rocsparse_scsrsm_analysis](interfacehipfort__rocsparse_1_1rocsparse__scsrsm__analysis.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+528 | [rocsparse_dcsrsm_analysis](interfacehipfort__rocsparse_1_1rocsparse__dcsrsm__analysis.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+529 | [rocsparse_ccsrsm_analysis](interfacehipfort__rocsparse_1_1rocsparse__ccsrsm__analysis.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+530 | [rocsparse_zcsrsm_analysis](interfacehipfort__rocsparse_1_1rocsparse__zcsrsm__analysis.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 531 | [rocsparse_csrsm_clear](interfacehipfort__rocsparse_1_1rocsparse__csrsm__clear.html "Interface documentation") | C binding
-532 | [rocsparse_scsrsm_solve](interfacehipfort__rocsparse_1_1rocsparse__scsrsm__solve.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-533 | [rocsparse_dcsrsm_solve](interfacehipfort__rocsparse_1_1rocsparse__dcsrsm__solve.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-534 | [rocsparse_ccsrsm_solve](interfacehipfort__rocsparse_1_1rocsparse__ccsrsm__solve.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-535 | [rocsparse_zcsrsm_solve](interfacehipfort__rocsparse_1_1rocsparse__zcsrsm__solve.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-536 | [rocsparse_sgebsrmm](interfacehipfort__rocsparse_1_1rocsparse__sgebsrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-537 | [rocsparse_dgebsrmm](interfacehipfort__rocsparse_1_1rocsparse__dgebsrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-538 | [rocsparse_cgebsrmm](interfacehipfort__rocsparse_1_1rocsparse__cgebsrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-539 | [rocsparse_zgebsrmm](interfacehipfort__rocsparse_1_1rocsparse__zgebsrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-540 | [rocsparse_sgemmi](interfacehipfort__rocsparse_1_1rocsparse__sgemmi.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-541 | [rocsparse_dgemmi](interfacehipfort__rocsparse_1_1rocsparse__dgemmi.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-542 | [rocsparse_cgemmi](interfacehipfort__rocsparse_1_1rocsparse__cgemmi.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-543 | [rocsparse_zgemmi](interfacehipfort__rocsparse_1_1rocsparse__zgemmi.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
+532 | [rocsparse_scsrsm_solve](interfacehipfort__rocsparse_1_1rocsparse__scsrsm__solve.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+533 | [rocsparse_dcsrsm_solve](interfacehipfort__rocsparse_1_1rocsparse__dcsrsm__solve.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+534 | [rocsparse_ccsrsm_solve](interfacehipfort__rocsparse_1_1rocsparse__ccsrsm__solve.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+535 | [rocsparse_zcsrsm_solve](interfacehipfort__rocsparse_1_1rocsparse__zcsrsm__solve.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+536 | [rocsparse_sgebsrmm](interfacehipfort__rocsparse_1_1rocsparse__sgebsrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+537 | [rocsparse_dgebsrmm](interfacehipfort__rocsparse_1_1rocsparse__dgebsrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+538 | [rocsparse_cgebsrmm](interfacehipfort__rocsparse_1_1rocsparse__cgebsrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+539 | [rocsparse_zgebsrmm](interfacehipfort__rocsparse_1_1rocsparse__zgebsrmm.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+540 | [rocsparse_sgemmi](interfacehipfort__rocsparse_1_1rocsparse__sgemmi.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+541 | [rocsparse_dgemmi](interfacehipfort__rocsparse_1_1rocsparse__dgemmi.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+542 | [rocsparse_cgemmi](interfacehipfort__rocsparse_1_1rocsparse__cgemmi.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+543 | [rocsparse_zgemmi](interfacehipfort__rocsparse_1_1rocsparse__zgemmi.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
 544 | [rocsparse_bsric0_zero_pivot](interfacehipfort__rocsparse_1_1rocsparse__bsric0__zero__pivot.html "Interface documentation") | C binding
-545 | [rocsparse_sbsric0_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__sbsric0__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-546 | [rocsparse_dbsric0_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__dbsric0__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-547 | [rocsparse_cbsric0_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__cbsric0__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-548 | [rocsparse_zbsric0_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__zbsric0__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-549 | [rocsparse_sbsric0_analysis](interfacehipfort__rocsparse_1_1rocsparse__sbsric0__analysis.html "Interface documentation") | C binding, rank_0, rank_1
-550 | [rocsparse_dbsric0_analysis](interfacehipfort__rocsparse_1_1rocsparse__dbsric0__analysis.html "Interface documentation") | C binding, rank_0, rank_1
-551 | [rocsparse_cbsric0_analysis](interfacehipfort__rocsparse_1_1rocsparse__cbsric0__analysis.html "Interface documentation") | C binding, rank_0, rank_1
-552 | [rocsparse_zbsric0_analysis](interfacehipfort__rocsparse_1_1rocsparse__zbsric0__analysis.html "Interface documentation") | C binding, rank_0, rank_1
+545 | [rocsparse_sbsric0_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__sbsric0__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+546 | [rocsparse_dbsric0_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__dbsric0__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+547 | [rocsparse_cbsric0_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__cbsric0__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+548 | [rocsparse_zbsric0_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__zbsric0__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+549 | [rocsparse_sbsric0_analysis](interfacehipfort__rocsparse_1_1rocsparse__sbsric0__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+550 | [rocsparse_dbsric0_analysis](interfacehipfort__rocsparse_1_1rocsparse__dbsric0__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+551 | [rocsparse_cbsric0_analysis](interfacehipfort__rocsparse_1_1rocsparse__cbsric0__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+552 | [rocsparse_zbsric0_analysis](interfacehipfort__rocsparse_1_1rocsparse__zbsric0__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 553 | [rocsparse_bsric0_clear](interfacehipfort__rocsparse_1_1rocsparse__bsric0__clear.html "Interface documentation") | C binding
-554 | [rocsparse_sbsric0](interfacehipfort__rocsparse_1_1rocsparse__sbsric0.html "Interface documentation") | C binding, rank_0, rank_1
-555 | [rocsparse_dbsric0](interfacehipfort__rocsparse_1_1rocsparse__dbsric0.html "Interface documentation") | C binding, rank_0, rank_1
-556 | [rocsparse_cbsric0](interfacehipfort__rocsparse_1_1rocsparse__cbsric0.html "Interface documentation") | C binding, rank_0, rank_1
-557 | [rocsparse_zbsric0](interfacehipfort__rocsparse_1_1rocsparse__zbsric0.html "Interface documentation") | C binding, rank_0, rank_1
+554 | [rocsparse_sbsric0](interfacehipfort__rocsparse_1_1rocsparse__sbsric0.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+555 | [rocsparse_dbsric0](interfacehipfort__rocsparse_1_1rocsparse__dbsric0.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+556 | [rocsparse_cbsric0](interfacehipfort__rocsparse_1_1rocsparse__cbsric0.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+557 | [rocsparse_zbsric0](interfacehipfort__rocsparse_1_1rocsparse__zbsric0.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 558 | [rocsparse_bsrilu0_zero_pivot](interfacehipfort__rocsparse_1_1rocsparse__bsrilu0__zero__pivot.html "Interface documentation") | C binding
 559 | [rocsparse_sbsrilu0_numeric_boost](interfacehipfort__rocsparse_1_1rocsparse__sbsrilu0__numeric__boost.html "Interface documentation") | C binding
 560 | [rocsparse_dbsrilu0_numeric_boost](interfacehipfort__rocsparse_1_1rocsparse__dbsrilu0__numeric__boost.html "Interface documentation") | C binding
@@ -566,36 +566,36 @@
 562 | [rocsparse_zbsrilu0_numeric_boost](interfacehipfort__rocsparse_1_1rocsparse__zbsrilu0__numeric__boost.html "Interface documentation") | C binding
 563 | [rocsparse_dsbsrilu0_numeric_boost](interfacehipfort__rocsparse_1_1rocsparse__dsbsrilu0__numeric__boost.html "Interface documentation") | C binding
 564 | [rocsparse_dcbsrilu0_numeric_boost](interfacehipfort__rocsparse_1_1rocsparse__dcbsrilu0__numeric__boost.html "Interface documentation") | C binding
-565 | [rocsparse_sbsrilu0_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__sbsrilu0__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-566 | [rocsparse_dbsrilu0_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__dbsrilu0__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-567 | [rocsparse_cbsrilu0_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__cbsrilu0__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-568 | [rocsparse_zbsrilu0_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__zbsrilu0__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-569 | [rocsparse_sbsrilu0_analysis](interfacehipfort__rocsparse_1_1rocsparse__sbsrilu0__analysis.html "Interface documentation") | C binding, rank_0, rank_1
-570 | [rocsparse_dbsrilu0_analysis](interfacehipfort__rocsparse_1_1rocsparse__dbsrilu0__analysis.html "Interface documentation") | C binding, rank_0, rank_1
-571 | [rocsparse_cbsrilu0_analysis](interfacehipfort__rocsparse_1_1rocsparse__cbsrilu0__analysis.html "Interface documentation") | C binding, rank_0, rank_1
-572 | [rocsparse_zbsrilu0_analysis](interfacehipfort__rocsparse_1_1rocsparse__zbsrilu0__analysis.html "Interface documentation") | C binding, rank_0, rank_1
+565 | [rocsparse_sbsrilu0_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__sbsrilu0__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+566 | [rocsparse_dbsrilu0_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__dbsrilu0__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+567 | [rocsparse_cbsrilu0_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__cbsrilu0__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+568 | [rocsparse_zbsrilu0_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__zbsrilu0__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+569 | [rocsparse_sbsrilu0_analysis](interfacehipfort__rocsparse_1_1rocsparse__sbsrilu0__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+570 | [rocsparse_dbsrilu0_analysis](interfacehipfort__rocsparse_1_1rocsparse__dbsrilu0__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+571 | [rocsparse_cbsrilu0_analysis](interfacehipfort__rocsparse_1_1rocsparse__cbsrilu0__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+572 | [rocsparse_zbsrilu0_analysis](interfacehipfort__rocsparse_1_1rocsparse__zbsrilu0__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 573 | [rocsparse_bsrilu0_clear](interfacehipfort__rocsparse_1_1rocsparse__bsrilu0__clear.html "Interface documentation") | C binding
-574 | [rocsparse_sbsrilu0](interfacehipfort__rocsparse_1_1rocsparse__sbsrilu0.html "Interface documentation") | C binding, rank_0, rank_1
-575 | [rocsparse_dbsrilu0](interfacehipfort__rocsparse_1_1rocsparse__dbsrilu0.html "Interface documentation") | C binding, rank_0, rank_1
-576 | [rocsparse_cbsrilu0](interfacehipfort__rocsparse_1_1rocsparse__cbsrilu0.html "Interface documentation") | C binding, rank_0, rank_1
-577 | [rocsparse_zbsrilu0](interfacehipfort__rocsparse_1_1rocsparse__zbsrilu0.html "Interface documentation") | C binding, rank_0, rank_1
+574 | [rocsparse_sbsrilu0](interfacehipfort__rocsparse_1_1rocsparse__sbsrilu0.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+575 | [rocsparse_dbsrilu0](interfacehipfort__rocsparse_1_1rocsparse__dbsrilu0.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+576 | [rocsparse_cbsrilu0](interfacehipfort__rocsparse_1_1rocsparse__cbsrilu0.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+577 | [rocsparse_zbsrilu0](interfacehipfort__rocsparse_1_1rocsparse__zbsrilu0.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 578 | [rocsparse_csric0_zero_pivot](interfacehipfort__rocsparse_1_1rocsparse__csric0__zero__pivot.html "Interface documentation") | C binding
 579 | [rocsparse_csric0_singular_pivot](interfacehipfort__rocsparse_1_1rocsparse__csric0__singular__pivot.html "Interface documentation") | C binding
 580 | [rocsparse_csric0_set_tolerance](interfacehipfort__rocsparse_1_1rocsparse__csric0__set__tolerance.html "Interface documentation") | C binding
 581 | [rocsparse_csric0_get_tolerance](interfacehipfort__rocsparse_1_1rocsparse__csric0__get__tolerance.html "Interface documentation") | C binding
-582 | [rocsparse_scsric0_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__scsric0__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-583 | [rocsparse_dcsric0_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__dcsric0__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-584 | [rocsparse_ccsric0_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__ccsric0__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-585 | [rocsparse_zcsric0_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__zcsric0__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-586 | [rocsparse_scsric0_analysis](interfacehipfort__rocsparse_1_1rocsparse__scsric0__analysis.html "Interface documentation") | C binding, rank_0, rank_1
-587 | [rocsparse_dcsric0_analysis](interfacehipfort__rocsparse_1_1rocsparse__dcsric0__analysis.html "Interface documentation") | C binding, rank_0, rank_1
-588 | [rocsparse_ccsric0_analysis](interfacehipfort__rocsparse_1_1rocsparse__ccsric0__analysis.html "Interface documentation") | C binding, rank_0, rank_1
-589 | [rocsparse_zcsric0_analysis](interfacehipfort__rocsparse_1_1rocsparse__zcsric0__analysis.html "Interface documentation") | C binding, rank_0, rank_1
+582 | [rocsparse_scsric0_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__scsric0__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+583 | [rocsparse_dcsric0_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__dcsric0__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+584 | [rocsparse_ccsric0_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__ccsric0__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+585 | [rocsparse_zcsric0_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__zcsric0__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+586 | [rocsparse_scsric0_analysis](interfacehipfort__rocsparse_1_1rocsparse__scsric0__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+587 | [rocsparse_dcsric0_analysis](interfacehipfort__rocsparse_1_1rocsparse__dcsric0__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+588 | [rocsparse_ccsric0_analysis](interfacehipfort__rocsparse_1_1rocsparse__ccsric0__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+589 | [rocsparse_zcsric0_analysis](interfacehipfort__rocsparse_1_1rocsparse__zcsric0__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 590 | [rocsparse_csric0_clear](interfacehipfort__rocsparse_1_1rocsparse__csric0__clear.html "Interface documentation") | C binding
-591 | [rocsparse_scsric0](interfacehipfort__rocsparse_1_1rocsparse__scsric0.html "Interface documentation") | C binding, rank_0, rank_1
-592 | [rocsparse_dcsric0](interfacehipfort__rocsparse_1_1rocsparse__dcsric0.html "Interface documentation") | C binding, rank_0, rank_1
-593 | [rocsparse_ccsric0](interfacehipfort__rocsparse_1_1rocsparse__ccsric0.html "Interface documentation") | C binding, rank_0, rank_1
-594 | [rocsparse_zcsric0](interfacehipfort__rocsparse_1_1rocsparse__zcsric0.html "Interface documentation") | C binding, rank_0, rank_1
+591 | [rocsparse_scsric0](interfacehipfort__rocsparse_1_1rocsparse__scsric0.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+592 | [rocsparse_dcsric0](interfacehipfort__rocsparse_1_1rocsparse__dcsric0.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+593 | [rocsparse_ccsric0](interfacehipfort__rocsparse_1_1rocsparse__ccsric0.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+594 | [rocsparse_zcsric0](interfacehipfort__rocsparse_1_1rocsparse__zcsric0.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 595 | [rocsparse_csrilu0_zero_pivot](interfacehipfort__rocsparse_1_1rocsparse__csrilu0__zero__pivot.html "Interface documentation") | C binding
 596 | [rocsparse_csrilu0_set_tolerance](interfacehipfort__rocsparse_1_1rocsparse__csrilu0__set__tolerance.html "Interface documentation") | C binding
 597 | [rocsparse_csrilu0_get_tolerance](interfacehipfort__rocsparse_1_1rocsparse__csrilu0__get__tolerance.html "Interface documentation") | C binding
@@ -606,19 +606,19 @@
 602 | [rocsparse_zcsrilu0_numeric_boost](interfacehipfort__rocsparse_1_1rocsparse__zcsrilu0__numeric__boost.html "Interface documentation") | C binding
 603 | [rocsparse_dscsrilu0_numeric_boost](interfacehipfort__rocsparse_1_1rocsparse__dscsrilu0__numeric__boost.html "Interface documentation") | C binding
 604 | [rocsparse_dccsrilu0_numeric_boost](interfacehipfort__rocsparse_1_1rocsparse__dccsrilu0__numeric__boost.html "Interface documentation") | C binding
-605 | [rocsparse_scsrilu0_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__scsrilu0__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-606 | [rocsparse_dcsrilu0_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__dcsrilu0__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-607 | [rocsparse_ccsrilu0_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__ccsrilu0__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-608 | [rocsparse_zcsrilu0_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__zcsrilu0__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-609 | [rocsparse_scsrilu0_analysis](interfacehipfort__rocsparse_1_1rocsparse__scsrilu0__analysis.html "Interface documentation") | C binding, rank_0, rank_1
-610 | [rocsparse_dcsrilu0_analysis](interfacehipfort__rocsparse_1_1rocsparse__dcsrilu0__analysis.html "Interface documentation") | C binding, rank_0, rank_1
-611 | [rocsparse_ccsrilu0_analysis](interfacehipfort__rocsparse_1_1rocsparse__ccsrilu0__analysis.html "Interface documentation") | C binding, rank_0, rank_1
-612 | [rocsparse_zcsrilu0_analysis](interfacehipfort__rocsparse_1_1rocsparse__zcsrilu0__analysis.html "Interface documentation") | C binding, rank_0, rank_1
+605 | [rocsparse_scsrilu0_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__scsrilu0__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+606 | [rocsparse_dcsrilu0_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__dcsrilu0__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+607 | [rocsparse_ccsrilu0_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__ccsrilu0__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+608 | [rocsparse_zcsrilu0_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__zcsrilu0__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+609 | [rocsparse_scsrilu0_analysis](interfacehipfort__rocsparse_1_1rocsparse__scsrilu0__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+610 | [rocsparse_dcsrilu0_analysis](interfacehipfort__rocsparse_1_1rocsparse__dcsrilu0__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+611 | [rocsparse_ccsrilu0_analysis](interfacehipfort__rocsparse_1_1rocsparse__ccsrilu0__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+612 | [rocsparse_zcsrilu0_analysis](interfacehipfort__rocsparse_1_1rocsparse__zcsrilu0__analysis.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 613 | [rocsparse_csrilu0_clear](interfacehipfort__rocsparse_1_1rocsparse__csrilu0__clear.html "Interface documentation") | C binding
-614 | [rocsparse_scsrilu0](interfacehipfort__rocsparse_1_1rocsparse__scsrilu0.html "Interface documentation") | C binding, rank_0, rank_1
-615 | [rocsparse_dcsrilu0](interfacehipfort__rocsparse_1_1rocsparse__dcsrilu0.html "Interface documentation") | C binding, rank_0, rank_1
-616 | [rocsparse_ccsrilu0](interfacehipfort__rocsparse_1_1rocsparse__ccsrilu0.html "Interface documentation") | C binding, rank_0, rank_1
-617 | [rocsparse_zcsrilu0](interfacehipfort__rocsparse_1_1rocsparse__zcsrilu0.html "Interface documentation") | C binding, rank_0, rank_1
+614 | [rocsparse_scsrilu0](interfacehipfort__rocsparse_1_1rocsparse__scsrilu0.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+615 | [rocsparse_dcsrilu0](interfacehipfort__rocsparse_1_1rocsparse__dcsrilu0.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+616 | [rocsparse_ccsrilu0](interfacehipfort__rocsparse_1_1rocsparse__ccsrilu0.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+617 | [rocsparse_zcsrilu0](interfacehipfort__rocsparse_1_1rocsparse__zcsrilu0.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 618 | [rocsparse_csritilu0_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__csritilu0__buffer__size.html "Interface documentation") | C binding
 619 | [rocsparse_csritilu0_preprocess](interfacehipfort__rocsparse_1_1rocsparse__csritilu0__preprocess.html "Interface documentation") | C binding
 620 | [rocsparse_scsritilu0_compute](interfacehipfort__rocsparse_1_1rocsparse__scsritilu0__compute.html "Interface documentation") | C binding
@@ -633,38 +633,38 @@
 629 | [rocsparse_dcsritilu0_history](interfacehipfort__rocsparse_1_1rocsparse__dcsritilu0__history.html "Interface documentation") | C binding
 630 | [rocsparse_ccsritilu0_history](interfacehipfort__rocsparse_1_1rocsparse__ccsritilu0__history.html "Interface documentation") | C binding
 631 | [rocsparse_zcsritilu0_history](interfacehipfort__rocsparse_1_1rocsparse__zcsritilu0__history.html "Interface documentation") | C binding
-632 | [rocsparse_sgpsv_interleaved_batch_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__sgpsv__interleaved__batch__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-633 | [rocsparse_dgpsv_interleaved_batch_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__dgpsv__interleaved__batch__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-634 | [rocsparse_cgpsv_interleaved_batch_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__cgpsv__interleaved__batch__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-635 | [rocsparse_zgpsv_interleaved_batch_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__zgpsv__interleaved__batch__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-636 | [rocsparse_sgpsv_interleaved_batch](interfacehipfort__rocsparse_1_1rocsparse__sgpsv__interleaved__batch.html "Interface documentation") | C binding, rank_0, rank_1
-637 | [rocsparse_dgpsv_interleaved_batch](interfacehipfort__rocsparse_1_1rocsparse__dgpsv__interleaved__batch.html "Interface documentation") | C binding, rank_0, rank_1
-638 | [rocsparse_cgpsv_interleaved_batch](interfacehipfort__rocsparse_1_1rocsparse__cgpsv__interleaved__batch.html "Interface documentation") | C binding, rank_0, rank_1
-639 | [rocsparse_zgpsv_interleaved_batch](interfacehipfort__rocsparse_1_1rocsparse__zgpsv__interleaved__batch.html "Interface documentation") | C binding, rank_0, rank_1
-640 | [rocsparse_sgtsv_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__sgtsv__buffer__size.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-641 | [rocsparse_dgtsv_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__dgtsv__buffer__size.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-642 | [rocsparse_cgtsv_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__cgtsv__buffer__size.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-643 | [rocsparse_zgtsv_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__zgtsv__buffer__size.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-644 | [rocsparse_sgtsv](interfacehipfort__rocsparse_1_1rocsparse__sgtsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-645 | [rocsparse_dgtsv](interfacehipfort__rocsparse_1_1rocsparse__dgtsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-646 | [rocsparse_cgtsv](interfacehipfort__rocsparse_1_1rocsparse__cgtsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-647 | [rocsparse_zgtsv](interfacehipfort__rocsparse_1_1rocsparse__zgtsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-648 | [rocsparse_sgtsv_no_pivot_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__sgtsv__no__pivot__buffer__size.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-649 | [rocsparse_dgtsv_no_pivot_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__dgtsv__no__pivot__buffer__size.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-650 | [rocsparse_cgtsv_no_pivot_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__cgtsv__no__pivot__buffer__size.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-651 | [rocsparse_zgtsv_no_pivot_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__zgtsv__no__pivot__buffer__size.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-652 | [rocsparse_sgtsv_no_pivot](interfacehipfort__rocsparse_1_1rocsparse__sgtsv__no__pivot.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-653 | [rocsparse_dgtsv_no_pivot](interfacehipfort__rocsparse_1_1rocsparse__dgtsv__no__pivot.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-654 | [rocsparse_cgtsv_no_pivot](interfacehipfort__rocsparse_1_1rocsparse__cgtsv__no__pivot.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-655 | [rocsparse_zgtsv_no_pivot](interfacehipfort__rocsparse_1_1rocsparse__zgtsv__no__pivot.html "Interface documentation") | C binding, full_rank, rank_0, rank_1
-656 | [rocsparse_sgtsv_no_pivot_strided_batch_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__sgtsv__no__pivot__strided__batch__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-657 | [rocsparse_dgtsv_no_pivot_strided_batch_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__dgtsv__no__pivot__strided__batch__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-658 | [rocsparse_cgtsv_no_pivot_strided_batch_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__cgtsv__no__pivot__strided__batch__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-659 | [rocsparse_zgtsv_no_pivot_strided_batch_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__zgtsv__no__pivot__strided__batch__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1
-660 | [rocsparse_sgtsv_no_pivot_strided_batch](interfacehipfort__rocsparse_1_1rocsparse__sgtsv__no__pivot__strided__batch.html "Interface documentation") | C binding, rank_0, rank_1
-661 | [rocsparse_dgtsv_no_pivot_strided_batch](interfacehipfort__rocsparse_1_1rocsparse__dgtsv__no__pivot__strided__batch.html "Interface documentation") | C binding, rank_0, rank_1
-662 | [rocsparse_cgtsv_no_pivot_strided_batch](interfacehipfort__rocsparse_1_1rocsparse__cgtsv__no__pivot__strided__batch.html "Interface documentation") | C binding, rank_0, rank_1
-663 | [rocsparse_zgtsv_no_pivot_strided_batch](interfacehipfort__rocsparse_1_1rocsparse__zgtsv__no__pivot__strided__batch.html "Interface documentation") | C binding, rank_0, rank_1
+632 | [rocsparse_sgpsv_interleaved_batch_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__sgpsv__interleaved__batch__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+633 | [rocsparse_dgpsv_interleaved_batch_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__dgpsv__interleaved__batch__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+634 | [rocsparse_cgpsv_interleaved_batch_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__cgpsv__interleaved__batch__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+635 | [rocsparse_zgpsv_interleaved_batch_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__zgpsv__interleaved__batch__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+636 | [rocsparse_sgpsv_interleaved_batch](interfacehipfort__rocsparse_1_1rocsparse__sgpsv__interleaved__batch.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+637 | [rocsparse_dgpsv_interleaved_batch](interfacehipfort__rocsparse_1_1rocsparse__dgpsv__interleaved__batch.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+638 | [rocsparse_cgpsv_interleaved_batch](interfacehipfort__rocsparse_1_1rocsparse__cgpsv__interleaved__batch.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+639 | [rocsparse_zgpsv_interleaved_batch](interfacehipfort__rocsparse_1_1rocsparse__zgpsv__interleaved__batch.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+640 | [rocsparse_sgtsv_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__sgtsv__buffer__size.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+641 | [rocsparse_dgtsv_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__dgtsv__buffer__size.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+642 | [rocsparse_cgtsv_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__cgtsv__buffer__size.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+643 | [rocsparse_zgtsv_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__zgtsv__buffer__size.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+644 | [rocsparse_sgtsv](interfacehipfort__rocsparse_1_1rocsparse__sgtsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+645 | [rocsparse_dgtsv](interfacehipfort__rocsparse_1_1rocsparse__dgtsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+646 | [rocsparse_cgtsv](interfacehipfort__rocsparse_1_1rocsparse__cgtsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+647 | [rocsparse_zgtsv](interfacehipfort__rocsparse_1_1rocsparse__zgtsv.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+648 | [rocsparse_sgtsv_no_pivot_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__sgtsv__no__pivot__buffer__size.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+649 | [rocsparse_dgtsv_no_pivot_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__dgtsv__no__pivot__buffer__size.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+650 | [rocsparse_cgtsv_no_pivot_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__cgtsv__no__pivot__buffer__size.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+651 | [rocsparse_zgtsv_no_pivot_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__zgtsv__no__pivot__buffer__size.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+652 | [rocsparse_sgtsv_no_pivot](interfacehipfort__rocsparse_1_1rocsparse__sgtsv__no__pivot.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+653 | [rocsparse_dgtsv_no_pivot](interfacehipfort__rocsparse_1_1rocsparse__dgtsv__no__pivot.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+654 | [rocsparse_cgtsv_no_pivot](interfacehipfort__rocsparse_1_1rocsparse__cgtsv__no__pivot.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+655 | [rocsparse_zgtsv_no_pivot](interfacehipfort__rocsparse_1_1rocsparse__zgtsv__no__pivot.html "Interface documentation") | C binding, full_rank, rank_0, rank_1, assumed_rank
+656 | [rocsparse_sgtsv_no_pivot_strided_batch_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__sgtsv__no__pivot__strided__batch__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+657 | [rocsparse_dgtsv_no_pivot_strided_batch_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__dgtsv__no__pivot__strided__batch__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+658 | [rocsparse_cgtsv_no_pivot_strided_batch_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__cgtsv__no__pivot__strided__batch__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+659 | [rocsparse_zgtsv_no_pivot_strided_batch_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__zgtsv__no__pivot__strided__batch__buffer__size.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+660 | [rocsparse_sgtsv_no_pivot_strided_batch](interfacehipfort__rocsparse_1_1rocsparse__sgtsv__no__pivot__strided__batch.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+661 | [rocsparse_dgtsv_no_pivot_strided_batch](interfacehipfort__rocsparse_1_1rocsparse__dgtsv__no__pivot__strided__batch.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+662 | [rocsparse_cgtsv_no_pivot_strided_batch](interfacehipfort__rocsparse_1_1rocsparse__cgtsv__no__pivot__strided__batch.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+663 | [rocsparse_zgtsv_no_pivot_strided_batch](interfacehipfort__rocsparse_1_1rocsparse__zgtsv__no__pivot__strided__batch.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 664 | [rocsparse_sgtsv_interleaved_batch_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__sgtsv__interleaved__batch__buffer__size.html "Interface documentation") | C binding
 665 | [rocsparse_dgtsv_interleaved_batch_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__dgtsv__interleaved__batch__buffer__size.html "Interface documentation") | C binding
 666 | [rocsparse_cgtsv_interleaved_batch_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__cgtsv__interleaved__batch__buffer__size.html "Interface documentation") | C binding
@@ -673,10 +673,10 @@
 669 | [rocsparse_dgtsv_interleaved_batch](interfacehipfort__rocsparse_1_1rocsparse__dgtsv__interleaved__batch.html "Interface documentation") | C binding
 670 | [rocsparse_cgtsv_interleaved_batch](interfacehipfort__rocsparse_1_1rocsparse__cgtsv__interleaved__batch.html "Interface documentation") | C binding
 671 | [rocsparse_zgtsv_interleaved_batch](interfacehipfort__rocsparse_1_1rocsparse__zgtsv__interleaved__batch.html "Interface documentation") | C binding
-672 | [rocsparse_scsrcolor](interfacehipfort__rocsparse_1_1rocsparse__scsrcolor.html "Interface documentation") | C binding, rank_0, rank_1
-673 | [rocsparse_dcsrcolor](interfacehipfort__rocsparse_1_1rocsparse__dcsrcolor.html "Interface documentation") | C binding, rank_0, rank_1
-674 | [rocsparse_ccsrcolor](interfacehipfort__rocsparse_1_1rocsparse__ccsrcolor.html "Interface documentation") | C binding, rank_0, rank_1
-675 | [rocsparse_zcsrcolor](interfacehipfort__rocsparse_1_1rocsparse__zcsrcolor.html "Interface documentation") | C binding, rank_0, rank_1
+672 | [rocsparse_scsrcolor](interfacehipfort__rocsparse_1_1rocsparse__scsrcolor.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+673 | [rocsparse_dcsrcolor](interfacehipfort__rocsparse_1_1rocsparse__dcsrcolor.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+674 | [rocsparse_ccsrcolor](interfacehipfort__rocsparse_1_1rocsparse__ccsrcolor.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
+675 | [rocsparse_zcsrcolor](interfacehipfort__rocsparse_1_1rocsparse__zcsrcolor.html "Interface documentation") | C binding, rank_0, rank_1, assumed_rank
 676 | [rocsparse_scheck_matrix_coo_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__scheck__matrix__coo__buffer__size.html "Interface documentation") | C binding
 677 | [rocsparse_dcheck_matrix_coo_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__dcheck__matrix__coo__buffer__size.html "Interface documentation") | C binding
 678 | [rocsparse_ccheck_matrix_coo_buffer_size](interfacehipfort__rocsparse_1_1rocsparse__ccheck__matrix__coo__buffer__size.html "Interface documentation") | C binding


### PR DESCRIPTION
## Summary

Completes the `assumed_rank` variant refresh across the remaining libraries (companion to the hipBLAS/rocBLAS PR). Now that `gen_supported_api` recognizes the `_assumed_rank` suffix, regenerate the tables so routines with an F2018 assumed-rank specific list **`assumed_rank`** in the variants column — e.g. `rocsolver_clacgv` → `C binding, rank_0, rank_1, assumed_rank`.

Touches: hip, hipFFT, hipRAND, hipSOLVER, hipSPARSE, rocRAND, rocSOLVER, rocSPARSE. `hipFFTW` / `rocFFT` have no assumed-rank specifics and are unchanged; hipBLAS/rocBLAS are handled separately.

Only the variant column of the affected rows changes (1390 rows total) — no reordering.