### PR TITLE
Make the array-interface levels toggleable with compiler-capability detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,50 @@ IF(NOT DEFINED CMAKE_Fortran_COMPILER_SUPPORTS_F08)
   unset(CMAKE_Fortran_COMPILER_SUPPORTS_F08 CACHE)
 ENDIF(NOT DEFINED CMAKE_Fortran_COMPILER_SUPPORTS_F08)
 
+# Test for Fortran 2018 support using the assumed-rank construct the generated
+# bindings rely on: an assumed-rank (dimension(..)) dummy passed to c_loc(). This
+# is exactly what the USE_ASSUMED_RANK_INTERFACES wrappers do, so it is the right
+# discriminator for whether HIPFORT_ASSUMED_RANK can be enabled.
+IF(NOT DEFINED CMAKE_Fortran_COMPILER_SUPPORTS_F18)
+  MESSAGE(CHECK_START "Checking whether ${CMAKE_Fortran_COMPILER} supports Fortran 2018")
+  INCLUDE(CheckFortranSourceCompiles)
+  # NB: CHECK_FORTRAN_SOURCE_COMPILES writes the snippet to a .F file (fixed form),
+  # so — like the Fortran 08 test above — every statement must start at column 7.
+  CHECK_FORTRAN_SOURCE_COMPILES("
+      module mod18
+      contains
+      function foo(x) result(p)
+      use iso_c_binding
+      integer(c_int),target,contiguous,dimension(..) :: x
+      type(c_ptr) :: p
+      p = c_loc(x)
+      end function
+      end module
+      PROGRAM TESTFortran18
+      use mod18
+      use iso_c_binding
+      implicit none
+      integer(c_int),target :: a(5)
+      type(c_ptr) :: p
+      p = foo(a)
+      END PROGRAM TESTFortran18
+    " CMAKE_Fortran_COMPILER_SUPPORTS_F18)
+  IF(CMAKE_Fortran_COMPILER_SUPPORTS_F18)
+    MESSAGE(CHECK_PASS "yes")
+    file(APPEND ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeOutput.log
+      "Determining if the Fortran compiler supports Fortran 2018 passed with "
+      "the following output:\n${OUTPUT}\n\n")
+    set(CMAKE_Fortran_COMPILER_SUPPORTS_F18 1)
+  ELSE(CMAKE_Fortran_COMPILER_SUPPORTS_F18)
+    MESSAGE(CHECK_FAIL "no")
+    file(APPEND ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeError.log
+      "Determining if the Fortran compiler supports Fortran 2018 failed with "
+      "the following output:\n${OUTPUT}\n\n")
+    set(CMAKE_Fortran_COMPILER_SUPPORTS_F18 0)
+  ENDIF(CMAKE_Fortran_COMPILER_SUPPORTS_F18)
+  unset(CMAKE_Fortran_COMPILER_SUPPORTS_F18 CACHE)
+ENDIF(NOT DEFINED CMAKE_Fortran_COMPILER_SUPPORTS_F18)
+
 # Set compile flags for DEBUG, # RELEASE, or TESTING.  
 INCLUDE(${CMAKE_MODULE_PATH}/SetFortranFlags.cmake) 
 message("-- Done setting FortranFlags")

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -36,6 +36,19 @@ endif()
 # Requires a Fortran 2018 compiler.
 option(HIPFORT_ASSUMED_RANK "Use the F2018 assumed-rank array interfaces" OFF)
 
+# Guard the opt-in against compilers without Fortran 2018 support: the assumed-rank
+# wrappers pass a dimension(..) argument to c_loc(), which is an F2018 feature (see
+# the CMAKE_Fortran_COMPILER_SUPPORTS_F18 probe in the top-level CMakeLists.txt).
+# If it was requested but the compiler can't build it, warn and fall back to the
+# per-rank Fortran 2008 interfaces rather than failing the build.
+if(HIPFORT_ASSUMED_RANK AND NOT CMAKE_Fortran_COMPILER_SUPPORTS_F18)
+  message(WARNING
+    "HIPFORT_ASSUMED_RANK was requested but ${CMAKE_Fortran_COMPILER} does not "
+    "support the Fortran 2018 assumed-rank interfaces; falling back to the "
+    "per-rank Fortran 2008 interfaces.")
+  set(HIPFORT_ASSUMED_RANK OFF)
+endif()
+
 set(HIPFORT_ARCH "amdgcn")
     # amdgcn
     set(HIPFORT_LIB      "hipfort-${HIPFORT_ARCH}")

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -22,11 +22,25 @@ file(GLOB HIPFORT_SRC_HIP_F90 "${CMAKE_CURRENT_SOURCE_DIR}/hipfort/*.f90")
 file(GLOB HIPFORT_SRC_HIP_F90_UPPER "${CMAKE_CURRENT_SOURCE_DIR}/hipfort/*.F90")
 set(HIPFORT_SRC_HIP ${HIPFORT_SRC_HIP_F90} ${HIPFORT_SRC_HIP_F90_UPPER})
 
-# The Fortran 2008 array interfaces (USE_FPOINTER_INTERFACES) are enabled whenever
-# the Fortran compiler supports the Fortran 2008 standard.
-set(HIPFORT_USE_FPOINTER_INTERFACES OFF)
+# The Fortran 2008 array interfaces (USE_FPOINTER_INTERFACES) default ON whenever
+# the compiler supports Fortran 2008. Exposed as a cache option so it can be forced
+# OFF for an old compiler, or one whose F2008 support is buggy (e.g. some Intel
+# releases) — the library then builds with plain C-binding interfaces only.
+set(_hipfort_fpointer_default OFF)
 if(CMAKE_Fortran_COMPILER_SUPPORTS_F08)
-  set(HIPFORT_USE_FPOINTER_INTERFACES ON)
+  set(_hipfort_fpointer_default ON)
+endif()
+option(HIPFORT_USE_FPOINTER_INTERFACES
+  "Enable the Fortran 2008 array interfaces" ${_hipfort_fpointer_default})
+
+# The F2008 interfaces cannot be built on a compiler without F2008 support. FORCE
+# the cache so the effective value is consistent in the test/ subdirectory too.
+if(HIPFORT_USE_FPOINTER_INTERFACES AND NOT CMAKE_Fortran_COMPILER_SUPPORTS_F08)
+  message(WARNING
+    "HIPFORT_USE_FPOINTER_INTERFACES was requested but ${CMAKE_Fortran_COMPILER} "
+    "does not support Fortran 2008; disabling it (plain C-binding build).")
+  set(HIPFORT_USE_FPOINTER_INTERFACES OFF CACHE BOOL
+    "Enable the Fortran 2008 array interfaces" FORCE)
 endif()
 
 # Experimental: replace the per-rank array interfaces (rank_0..rank_N + full_rank)
@@ -36,17 +50,19 @@ endif()
 # Requires a Fortran 2018 compiler.
 option(HIPFORT_ASSUMED_RANK "Use the F2018 assumed-rank array interfaces" OFF)
 
-# Guard the opt-in against compilers without Fortran 2018 support: the assumed-rank
-# wrappers pass a dimension(..) argument to c_loc(), which is an F2018 feature (see
-# the CMAKE_Fortran_COMPILER_SUPPORTS_F18 probe in the top-level CMakeLists.txt).
-# If it was requested but the compiler can't build it, warn and fall back to the
-# per-rank Fortran 2008 interfaces rather than failing the build.
-if(HIPFORT_ASSUMED_RANK AND NOT CMAKE_Fortran_COMPILER_SUPPORTS_F18)
+# Guard the opt-in: assumed-rank is nested in the F2008 interfaces and additionally
+# needs a Fortran 2018 compiler (c_loc() of a dimension(..) argument; see the
+# CMAKE_Fortran_COMPILER_SUPPORTS_F18 probe in the top-level CMakeLists.txt). If it
+# was requested but either prerequisite is missing, warn and fall back to the
+# per-rank interfaces (or plain C bindings if those are off too) rather than
+# failing the build. FORCE the cache so test/ sees the same effective value.
+if(HIPFORT_ASSUMED_RANK AND NOT (HIPFORT_USE_FPOINTER_INTERFACES AND CMAKE_Fortran_COMPILER_SUPPORTS_F18))
   message(WARNING
-    "HIPFORT_ASSUMED_RANK was requested but ${CMAKE_Fortran_COMPILER} does not "
-    "support the Fortran 2018 assumed-rank interfaces; falling back to the "
-    "per-rank Fortran 2008 interfaces.")
-  set(HIPFORT_ASSUMED_RANK OFF)
+    "HIPFORT_ASSUMED_RANK was requested but the Fortran 2018 assumed-rank "
+    "interfaces are unavailable (they need a Fortran 2018 compiler and the F2008 "
+    "interfaces enabled); falling back to the per-rank interfaces.")
+  set(HIPFORT_ASSUMED_RANK OFF CACHE BOOL
+    "Use the F2018 assumed-rank array interfaces" FORCE)
 endif()
 
 set(HIPFORT_ARCH "amdgcn")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,6 +23,12 @@ if(BUILD_TESTING)
   endif()
 
   function(hipfort_add_test lib func dir)
+    # The f2008 tests exercise the array overloads (USE_FPOINTER_INTERFACES) and
+    # the f2018 tests the assumed-rank overloads; skip each when its interface
+    # level is disabled so a plain C-binding build still tests cleanly.
+    if(dir STREQUAL "f2008" AND NOT HIPFORT_USE_FPOINTER_INTERFACES)
+      return()
+    endif()
     if(dir STREQUAL "f2018" AND NOT HIPFORT_ASSUMED_RANK)
       return()
     endif()


### PR DESCRIPTION
## What

Give users explicit control over which Fortran array-interface level hipfort compiles, guarded by compiler-capability probes:

1. **`HIPFORT_USE_FPOINTER_INTERFACES`** (Fortran 2008 array overloads) is now a cache option. It still defaults ON when the compiler supports F2008, but can be forced OFF.
2. **`HIPFORT_ASSUMED_RANK`** (Fortran 2018 assumed-rank overloads) is guarded by a new F2018 probe, and now also requires the F2008 interfaces to be enabled.

## Why

- The F2008 interfaces were auto-enabled whenever the compiler advertised F2008 support, with **no escape hatch** — a problem for a very old compiler, or one whose F2008 support is buggy (e.g. some Intel releases). `-DHIPFORT_USE_FPOINTER_INTERFACES=OFF` now yields a plain C-binding build.
- `HIPFORT_ASSUMED_RANK` had **no F2018 check**, so enabling it on a pre-F2018 compiler would fail the build. This mirrors how F2008 support is already detected.

## How

- **Top-level `CMakeLists.txt`**: new `CMAKE_Fortran_COMPILER_SUPPORTS_F18` probe (mirroring the F08 one) compiling the exact construct the assumed-rank wrappers use — an assumed-rank (`dimension(..)`) dummy passed to `c_loc()`. Written fixed-form-safe (column 7), since `CHECK_FORTRAN_SOURCE_COMPILES` writes to a `.F` file.
- **`lib/CMakeLists.txt`**: `HIPFORT_USE_FPOINTER_INTERFACES` becomes an option (default from the F08 probe); guards disable an unsupported request and `FORCE` the cache so `test/` sees the same value. `HIPFORT_ASSUMED_RANK` falls back to the per-rank interfaces (or plain C bindings) unless both F2018 and the F2008 interfaces are available.
- **`test/CMakeLists.txt`**: skip the f2008 tests when the F2008 interfaces are off, mirroring the existing f2018/assumed-rank skip.

## Testing

Configured with gfortran 13:
```
-- Checking whether gfortran supports Fortran 08 - yes
-- Checking whether gfortran supports Fortran 2018 - yes
```
| configure | FPOINTER | ASSUMED_RANK |
|---|---|---|
| default | ON | OFF |
| `-DHIPFORT_USE_FPOINTER_INTERFACES=OFF` | OFF | OFF |
| `…=OFF -DHIPFORT_ASSUMED_RANK=ON` | OFF | OFF (warns, falls back) |
| `-DHIPFORT_ASSUMED_RANK=ON` | ON | ON |