### PR TITLE
Document the HIPFORT_USE_FPOINTER_INTERFACES toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * CMake option `HIPFORT_USE_FPOINTER_INTERFACES` to control the Fortran 2008 array interfaces (`USE_FPOINTER_INTERFACES`).
 It defaults to `ON` when the compiler supports Fortran 2008; set `-DHIPFORT_USE_FPOINTER_INTERFACES=OFF` to build with the plain Fortran 2003 `type(c_ptr)` interfaces only, for an old compiler or one whose Fortran 2008 support is buggy.
-`hipfort` now also probes for Fortran 2018 support at configure time: `HIPFORT_ASSUMED_RANK` is gated on it (and on `HIPFORT_USE_FPOINTER_INTERFACES`), and falls back to the per-rank interfaces with a warning instead of failing the build when a prerequisite is missing.
+`hipfort` now also probes for Fortran 2018 support at configure time: `HIPFORT_ASSUMED_RANK` is gated on it (and on `HIPFORT_USE_FPOINTER_INTERFACES`). Without a Fortran 2018 compiler it warns and falls back to the per-rank Fortran 2008 interfaces instead of failing the build; with `-DHIPFORT_USE_FPOINTER_INTERFACES=OFF` there are no array interfaces at all, only the plain Fortran 2003 `type(c_ptr)` ones.
 * Experimental Fortran 2018 assumed-rank array interfaces, enabled with the `-DHIPFORT_ASSUMED_RANK=ON` CMake option (guarded by `USE_ASSUMED_RANK_INTERFACES`).
 When enabled, each array generic is backed by a single `dimension(..)` overload that accepts an actual of any rank.
 The overloads are mutually exclusive with the classic per-rank interfaces.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+* CMake option `HIPFORT_USE_FPOINTER_INTERFACES` to control the Fortran 2008 array interfaces (`USE_FPOINTER_INTERFACES`).
+It defaults to `ON` when the compiler supports Fortran 2008; set `-DHIPFORT_USE_FPOINTER_INTERFACES=OFF` to build with the plain Fortran 2003 `type(c_ptr)` interfaces only, for an old compiler or one whose Fortran 2008 support is buggy.
+`hipfort` now also probes for Fortran 2018 support at configure time: `HIPFORT_ASSUMED_RANK` is gated on it (and on `HIPFORT_USE_FPOINTER_INTERFACES`), and falls back to the per-rank interfaces with a warning instead of failing the build when a prerequisite is missing.
 * Experimental Fortran 2018 assumed-rank array interfaces, enabled with the `-DHIPFORT_ASSUMED_RANK=ON` CMake option (guarded by `USE_ASSUMED_RANK_INTERFACES`).
 When enabled, each array generic is backed by a single `dimension(..)` overload that accepts an actual of any rank.
 The overloads are mutually exclusive with the classic per-rank interfaces.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ support is ignored (with a warning).
 **Experimental (`-DHIPFORT_ASSUMED_RANK=ON`).** By default each array generic is resolved by a set of rank-specific overloads (`rank_0`, `rank_1`, ...).
 With this option `hipfort` builds a single Fortran 2018 assumed-rank (`dimension(..)`) overload per routine instead.
 It requires a compiler with F2018 assumed-rank plus `c_loc` support, which `hipfort` probes for at configure time;
-if the probe fails (or `HIPFORT_USE_FPOINTER_INTERFACES` is off), it warns and falls back to the per-rank interfaces instead of failing the build.
+if the probe fails, it warns and falls back to the per-rank Fortran 2008 interfaces instead of failing the build.
+It also requires `HIPFORT_USE_FPOINTER_INTERFACES` (on which the per-rank interfaces themselves depend); with that off there are no array interfaces at all, only the plain Fortran 2003 `type(c_ptr)` ones.
 Off by default.
 
 The assumed-rank wrapper takes the base address of the array with `c_loc`, so the actual argument must be contiguous (the dummy is declared `contiguous`).

--- a/README.md
+++ b/README.md
@@ -61,9 +61,17 @@ definition, which `hipfort` enables automatically once it detects Fortran 2008 s
 in your compiler. By convention, application and test sources that rely on them use the
 `.f08` file extension (see the `test/f2008` examples), while Fortran 2003 sources use `.f03`.
 
+You can override the automatic detection with the `HIPFORT_USE_FPOINTER_INTERFACES`
+CMake option. It defaults to `ON` when the compiler supports Fortran 2008; set
+`-DHIPFORT_USE_FPOINTER_INTERFACES=OFF` to build with the plain Fortran 2003
+`type(c_ptr)` interfaces only. This is useful for an old compiler, or one whose
+Fortran 2008 support is buggy. Requesting it on a compiler without Fortran 2008
+support is ignored (with a warning).
+
 **Experimental (`-DHIPFORT_ASSUMED_RANK=ON`).** By default each array generic is resolved by a set of rank-specific overloads (`rank_0`, `rank_1`, ...).
 With this option `hipfort` builds a single Fortran 2018 assumed-rank (`dimension(..)`) overload per routine instead.
-It requires a compiler with F2018 assumed-rank plus `c_loc` support.
+It requires a compiler with F2018 assumed-rank plus `c_loc` support, which `hipfort` probes for at configure time;
+if the probe fails (or `HIPFORT_USE_FPOINTER_INTERFACES` is off), it warns and falls back to the per-rank interfaces instead of failing the build.
 Off by default.
 
 The assumed-rank wrapper takes the base address of the array with `c_loc`, so the actual argument must be contiguous (the dummy is declared `contiguous`).

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -60,7 +60,9 @@ if(HIPFORT_ASSUMED_RANK AND NOT (HIPFORT_USE_FPOINTER_INTERFACES AND CMAKE_Fortr
   message(WARNING
     "HIPFORT_ASSUMED_RANK was requested but the Fortran 2018 assumed-rank "
     "interfaces are unavailable (they need a Fortran 2018 compiler and the F2008 "
-    "interfaces enabled); falling back to the per-rank interfaces.")
+    "interfaces enabled); disabling the assumed-rank interfaces (the build falls "
+    "back to the per-rank F2008 interfaces, or the plain F2003 C bindings if "
+    "HIPFORT_USE_FPOINTER_INTERFACES is off).")
   set(HIPFORT_ASSUMED_RANK OFF CACHE BOOL
     "Use the F2018 assumed-rank array interfaces" FORCE)
 endif()


### PR DESCRIPTION
Follow-up docs for #479.

Documents the CMake option for the Fortran 2008 array interfaces, and corrects the fallback wording:

- **`HIPFORT_USE_FPOINTER_INTERFACES`** (README + CHANGELOG) — defaults `ON` when the compiler supports Fortran 2008; `-DHIPFORT_USE_FPOINTER_INTERFACES=OFF` builds the plain Fortran 2003 `type(c_ptr)` interfaces only (for an old compiler, or one whose F2008 support is buggy). Requesting it without F2008 support is ignored with a warning.
- **`HIPFORT_ASSUMED_RANK`** is gated by a Fortran 2018 configure-time probe (and by `HIPFORT_USE_FPOINTER_INTERFACES`). The two fallbacks are now stated correctly: a missing F2018 compiler (with FPOINTER on) → the per-rank F2008 interfaces; `HIPFORT_USE_FPOINTER_INTERFACES=OFF` → no array interfaces at all, only the plain F2003 `type(c_ptr)` ones (the per-rank interfaces *are* the F2008 interfaces).
- Also fixes the corresponding `message(WARNING ...)` string in `lib/CMakeLists.txt`, which had the same imprecise "falls back to the per-rank interfaces" wording.