### PR TITLE
Build and run the test suite against CUDA with -DUSE_CUDA_NAMES

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -102,19 +102,14 @@ set(HIPFORT_ARCH "amdgcn")
            ${CMAKE_Fortran_MODULE_DIRECTORY}
     )
 
-# The CUDA-name variant of the bindings (every bind(c) name swapped from hipFoo to
-# cudaFoo). It is never linked on an AMD build, so it is opt-in rather than built
-# every time.
+# The CUDA-name variant of the bindings. Never linked on an AMD build, so opt-in.
 option(USE_CUDA_NAMES "Also build hipfort-nvptx, the CUDA-name variant of the bindings" OFF)
 if(USE_CUDA_NAMES)
 set(HIPFORT_ARCH "nvptx")
     # nvptx
     set(HIPFORT_LIB     "hipfort-${HIPFORT_ARCH}")
     set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/include/hipfort/${HIPFORT_ARCH})
-    # rocBLAS, rocFFT, rocSOLVER, rocSPARSE and rocRAND are AMD-only and have no
-    # CUDA equivalent, so their binding modules are left out: compiling them here
-    # would leave ~1200 unresolvable roc* symbols. The matching *_enums modules
-    # stay, since other modules use them and they declare no bind(c) names.
+    # The roc* modules are AMD-only; compiling them here leaves ~1200 dangling symbols.
     set(HIPFORT_SRC_CUDA ${HIPFORT_SRC_HIP})
     list(FILTER HIPFORT_SRC_CUDA EXCLUDE REGEX
          "hipfort_roc(blas|blas_auxiliary|fft|rand|solver|sparse)\\.F90$")
@@ -148,10 +143,8 @@ set(HIPFORT_ARCH "nvptx")
     )
    
 
-    # A static archive is never linked, so nothing would check that the cuda* names
-    # in the bindings actually resolve. Link the CUDA libraries and force every
-    # archive member into a small executable, which turns a wrong or missing CUDA
-    # symbol into a build failure instead of a surprise for the first NVIDIA user.
+    # A static archive is never linked, so force every member into an executable:
+    # that is what turns a wrong cuda* name into a build failure.
     find_package(CUDAToolkit)
     if(CUDAToolkit_FOUND)
       set(HIPFORT_CUDA_LIBS "")
@@ -185,8 +178,7 @@ rocm_install(
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/hipfort
 )
 
-# Which binding archive the components wrap: the AMD one, or the CUDA-name one
-# when targeting NVIDIA.
+# Which binding archive the components wrap: amdgcn, or nvptx when targeting NVIDIA.
 if(NOT DEFINED HIPFORT_BASE_LIB)
   set(HIPFORT_BASE_LIB hipfort-amdgcn)
 endif()
@@ -334,10 +326,7 @@ if(HIP_PLATFORM STREQUAL "amd")
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/hipfort
   )
 elseif(USE_CUDA_NAMES AND CUDAToolkit_FOUND)
-  # NVIDIA: the same Fortran bindings, bound to CUDA symbols, wrapping the
-  # hipfort-nvptx archive instead of hipfort-amdgcn. Only the hip* components
-  # exist: rocBLAS, rocFFT, rocSOLVER, rocSPARSE, rocRAND and the FFTW3 API are
-  # AMD-only and have no CUDA counterpart, so their tests do not exist here.
+  # Only the hip* components exist here; roc* and the FFTW3 API have no CUDA counterpart.
   set(HIPFORT_BASE_LIB hipfort-nvptx)
   foreach(pair "hip:cudart" "hipblas:cublas" "hipfft:cufft"
                "hiprand:curand" "hipsolver:cusolver" "hipsparse:cusparse")

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -140,27 +140,7 @@ set(HIPFORT_ARCH "nvptx")
     )
    
 
-    # A static archive is never linked; forcing every member in makes a wrong cuda* name fail the build.
     find_package(CUDAToolkit)
-    if(CUDAToolkit_FOUND)
-      set(HIPFORT_CUDA_LIBS "")
-      foreach(t cudart cublas cufft curand cusparse cusolver)
-        if(TARGET CUDA::${t})
-          list(APPEND HIPFORT_CUDA_LIBS CUDA::${t})
-        endif()
-      endforeach()
-      target_link_libraries(${HIPFORT_LIB} PUBLIC ${HIPFORT_CUDA_LIBS})
-
-      if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU|LLVMFlang|Flang|Intel|NVHPC")
-        set(_lc ${CMAKE_CURRENT_BINARY_DIR}/hipfort_nvptx_link_check.f90)
-        file(WRITE ${_lc} "program hipfort_nvptx_link_check\nend program hipfort_nvptx_link_check\n")
-        add_executable(hipfort-nvptx-link-check ${_lc})
-        target_link_libraries(hipfort-nvptx-link-check PRIVATE
-          -Wl,--whole-archive ${HIPFORT_LIB} -Wl,--no-whole-archive ${HIPFORT_CUDA_LIBS})
-      endif()
-    else()
-      message(STATUS "CUDAToolkit not found: building hipfort-nvptx without a link check")
-    endif()
     # Install include files marking as devel component
     rocm_install(DIRECTORY ${CMAKE_BINARY_DIR}/include/hipfort
                  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -102,8 +102,9 @@ set(HIPFORT_ARCH "amdgcn")
            ${CMAKE_Fortran_MODULE_DIRECTORY}
     )
 
-# The CUDA-name variant of the bindings. Never linked on an AMD build, so opt-in.
-option(USE_CUDA_NAMES "Also build hipfort-nvptx, the CUDA-name variant of the bindings" OFF)
+# The CUDA-name variant of the bindings, built as it always was. Components and
+# tests only appear when the CUDA libraries are actually detected, below.
+option(USE_CUDA_NAMES "Also build hipfort-nvptx, the CUDA-name variant of the bindings" ON)
 if(USE_CUDA_NAMES)
 set(HIPFORT_ARCH "nvptx")
     # nvptx

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -102,10 +102,6 @@ set(HIPFORT_ARCH "amdgcn")
            ${CMAKE_Fortran_MODULE_DIRECTORY}
     )
 
-# The CUDA-name variant of the bindings, built as it always was. Components and
-# tests only appear when the CUDA libraries are actually detected, below.
-option(USE_CUDA_NAMES "Also build hipfort-nvptx, the CUDA-name variant of the bindings" ON)
-if(USE_CUDA_NAMES)
 set(HIPFORT_ARCH "nvptx")
     # nvptx
     set(HIPFORT_LIB     "hipfort-${HIPFORT_ARCH}")
@@ -144,8 +140,7 @@ set(HIPFORT_ARCH "nvptx")
     )
    
 
-    # A static archive is never linked, so force every member into an executable:
-    # that is what turns a wrong cuda* name into a build failure.
+    # A static archive is never linked; forcing every member in makes a wrong cuda* name fail the build.
     find_package(CUDAToolkit)
     if(CUDAToolkit_FOUND)
       set(HIPFORT_CUDA_LIBS "")
@@ -166,7 +161,6 @@ set(HIPFORT_ARCH "nvptx")
     else()
       message(STATUS "CUDAToolkit not found: building hipfort-nvptx without a link check")
     endif()
-endif()
     # Install include files marking as devel component
     rocm_install(DIRECTORY ${CMAKE_BINARY_DIR}/include/hipfort
                  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
@@ -179,7 +173,6 @@ rocm_install(
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/hipfort
 )
 
-# Which binding archive the components wrap: amdgcn, or nvptx when targeting NVIDIA.
 if(NOT DEFINED HIPFORT_BASE_LIB)
   set(HIPFORT_BASE_LIB hipfort-amdgcn)
 endif()
@@ -326,7 +319,7 @@ if(HIP_PLATFORM STREQUAL "amd")
       ${CMAKE_CURRENT_BINARY_DIR}/hipfort-config-version.cmake
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/hipfort
   )
-elseif(USE_CUDA_NAMES AND CUDAToolkit_FOUND)
+elseif(CUDAToolkit_FOUND)
   # Only the hip* components exist here; roc* and the FFTW3 API have no CUDA counterpart.
   set(HIPFORT_BASE_LIB hipfort-nvptx)
   foreach(pair "hip:cudart" "hipblas:cublas" "hipfft:cufft"

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -102,12 +102,24 @@ set(HIPFORT_ARCH "amdgcn")
            ${CMAKE_Fortran_MODULE_DIRECTORY}
     )
 
+# The CUDA-name variant of the bindings (every bind(c) name swapped from hipFoo to
+# cudaFoo). It is never linked on an AMD build, so it is opt-in rather than built
+# every time.
+option(USE_CUDA_NAMES "Also build hipfort-nvptx, the CUDA-name variant of the bindings" OFF)
+if(USE_CUDA_NAMES)
 set(HIPFORT_ARCH "nvptx")
     # nvptx
     set(HIPFORT_LIB     "hipfort-${HIPFORT_ARCH}")
     set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/include/hipfort/${HIPFORT_ARCH})
-    ADD_LIBRARY(${HIPFORT_LIB} STATIC 
-         ${HIPFORT_SRC_HIP} 
+    # rocBLAS, rocFFT, rocSOLVER, rocSPARSE and rocRAND are AMD-only and have no
+    # CUDA equivalent, so their binding modules are left out: compiling them here
+    # would leave ~1200 unresolvable roc* symbols. The matching *_enums modules
+    # stay, since other modules use them and they declare no bind(c) names.
+    set(HIPFORT_SRC_CUDA ${HIPFORT_SRC_HIP})
+    list(FILTER HIPFORT_SRC_CUDA EXCLUDE REGEX
+         "hipfort_roc(blas|blas_auxiliary|fft|rand|solver|sparse)\\.F90$")
+    ADD_LIBRARY(${HIPFORT_LIB} STATIC
+         ${HIPFORT_SRC_CUDA}
          )
     IF(HIPFORT_USE_FPOINTER_INTERFACES)
     	target_compile_definitions(${HIPFORT_LIB} PRIVATE USE_FPOINTER_INTERFACES)
@@ -120,17 +132,51 @@ set(HIPFORT_ARCH "nvptx")
     # Install Target hipfort-nvptx
     rocm_install_targets(
         TARGETS ${HIPFORT_LIB}
+        EXPORT hipfort-nvptx-targets
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         INCLUDE
            ${CMAKE_Fortran_MODULE_DIRECTORY}
     )
+
+    rocm_install(
+      EXPORT hipfort-nvptx-targets
+      FILE hipfort-nvptx-targets.cmake
+      NAMESPACE hipfort::
+      DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/hipfort
+    )
    
+
+    # A static archive is never linked, so nothing would check that the cuda* names
+    # in the bindings actually resolve. Link the CUDA libraries and force every
+    # archive member into a small executable, which turns a wrong or missing CUDA
+    # symbol into a build failure instead of a surprise for the first NVIDIA user.
+    find_package(CUDAToolkit)
+    if(CUDAToolkit_FOUND)
+      set(HIPFORT_CUDA_LIBS "")
+      foreach(t cudart cublas cufft curand cusparse cusolver)
+        if(TARGET CUDA::${t})
+          list(APPEND HIPFORT_CUDA_LIBS CUDA::${t})
+        endif()
+      endforeach()
+      target_link_libraries(${HIPFORT_LIB} PUBLIC ${HIPFORT_CUDA_LIBS})
+
+      if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU|LLVMFlang|Flang|Intel|NVHPC")
+        set(_lc ${CMAKE_CURRENT_BINARY_DIR}/hipfort_nvptx_link_check.f90)
+        file(WRITE ${_lc} "program hipfort_nvptx_link_check\nend program hipfort_nvptx_link_check\n")
+        add_executable(hipfort-nvptx-link-check ${_lc})
+        target_link_libraries(hipfort-nvptx-link-check PRIVATE
+          -Wl,--whole-archive ${HIPFORT_LIB} -Wl,--no-whole-archive ${HIPFORT_CUDA_LIBS})
+      endif()
+    else()
+      message(STATUS "CUDAToolkit not found: building hipfort-nvptx without a link check")
+    endif()
+endif()
     # Install include files marking as devel component
     rocm_install(DIRECTORY ${CMAKE_BINARY_DIR}/include/hipfort
                  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 		 COMPONENT devel)
-
-#   target_link_libraries(${HIPFORT_LIB} PUBLIC 
-#   /usr/local/cuda/targets/x86_64-linux/lib/libcudart_static.a)
 
 rocm_install(
   EXPORT hipfort-amdgcn-targets
@@ -139,6 +185,12 @@ rocm_install(
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/hipfort
 )
 
+# Which binding archive the components wrap: the AMD one, or the CUDA-name one
+# when targeting NVIDIA.
+if(NOT DEFINED HIPFORT_BASE_LIB)
+  set(HIPFORT_BASE_LIB hipfort-amdgcn)
+endif()
+
 macro(hipfort_add_component name imported_target)
   add_library(hipfort-${name} INTERFACE)
   add_library(hipfort::${name} ALIAS hipfort-${name})
@@ -146,10 +198,10 @@ macro(hipfort_add_component name imported_target)
     PROPERTIES
       EXPORT_NAME ${name}
   )
-  target_link_libraries(hipfort-${name} INTERFACE hipfort-amdgcn ${imported_target})
+  target_link_libraries(hipfort-${name} INTERFACE ${HIPFORT_BASE_LIB} ${imported_target})
   # The archive is shared by every component, so CMake orders it after the ROCm
   # .so files and --as-needed drops them. This dependency puts the archive first.
-  target_link_libraries(hipfort-amdgcn INTERFACE "$<BUILD_INTERFACE:${imported_target}>")
+  target_link_libraries(${HIPFORT_BASE_LIB} INTERFACE "$<BUILD_INTERFACE:${imported_target}>")
   rocm_install(
     TARGETS
       hipfort-${name}
@@ -281,4 +333,21 @@ if(HIP_PLATFORM STREQUAL "amd")
       ${CMAKE_CURRENT_BINARY_DIR}/hipfort-config-version.cmake
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/hipfort
   )
+elseif(USE_CUDA_NAMES AND CUDAToolkit_FOUND)
+  # NVIDIA: the same Fortran bindings, bound to CUDA symbols, wrapping the
+  # hipfort-nvptx archive instead of hipfort-amdgcn. Only the hip* components
+  # exist: rocBLAS, rocFFT, rocSOLVER, rocSPARSE, rocRAND and the FFTW3 API are
+  # AMD-only and have no CUDA counterpart, so their tests do not exist here.
+  set(HIPFORT_BASE_LIB hipfort-nvptx)
+  foreach(pair "hip:cudart" "hipblas:cublas" "hipfft:cufft"
+               "hiprand:curand" "hipsolver:cusolver" "hipsparse:cusparse")
+    string(REPLACE ":" ";" pair "${pair}")
+    list(GET pair 0 _comp)
+    list(GET pair 1 _cudalib)
+    if(TARGET CUDA::${_cudalib})
+      hipfort_add_component(${_comp} CUDA::${_cudalib})
+    else()
+      message(STATUS "Skipping hipfort::${_comp} target export (no CUDA::${_cudalib})")
+    endif()
+  endforeach()
 endif()

--- a/lib/hipfort/hipfort_hipmalloc.F90
+++ b/lib/hipfort/hipfort_hipmalloc.F90
@@ -443,7 +443,11 @@ module hipfort_hipmalloc
   !>
   !>
   !>   @see hipSetDeviceFlags, hiptHostFree
+#ifdef USE_CUDA_NAMES
+    function hipHostMalloc_(ptr, sizeBytes, flags) bind(c, name="cudaHostAlloc")
+#else
     function hipHostMalloc_(ptr, sizeBytes, flags) bind(c, name="hipHostMalloc")
+#endif
       use iso_c_binding
       implicit none
       integer(c_int) :: hipHostMalloc_
@@ -703,7 +707,11 @@ module hipfort_hipmalloc
   !>
   !>   @see hipMalloc, hipMallocPitch, hipFree, hipMallocArray, hipFreeArray, hipMalloc3D,
   !>  hipMalloc3DArray, hipHostMalloc
+#ifdef USE_CUDA_NAMES
+    function hipHostFree_(ptr) bind(c, name="cudaFreeHost")
+#else
     function hipHostFree_(ptr) bind(c, name="hipHostFree")
+#endif
       use iso_c_binding
       implicit none
       integer(c_int) :: hipHostFree_

--- a/lib/hipfort/hipfort_hiprand_enums.F90
+++ b/lib/hipfort/hipfort_hiprand_enums.F90
@@ -49,17 +49,61 @@ module hipfort_hiprand_enums
   ! hiprandRngType
   enum, bind(c)
     enumerator :: HIPRAND_RNG_TEST = 0
+#ifdef USE_CUDA_NAMES
+    enumerator :: HIPRAND_RNG_PSEUDO_DEFAULT = 100
+#else
     enumerator :: HIPRAND_RNG_PSEUDO_DEFAULT = 400
+#endif
+#ifdef USE_CUDA_NAMES
+    enumerator :: HIPRAND_RNG_PSEUDO_XORWOW = 101
+#else
     enumerator :: HIPRAND_RNG_PSEUDO_XORWOW = 401
+#endif
+#ifdef USE_CUDA_NAMES
+    enumerator :: HIPRAND_RNG_PSEUDO_MRG32K3A = 121
+#else
     enumerator :: HIPRAND_RNG_PSEUDO_MRG32K3A = 402
+#endif
+#ifdef USE_CUDA_NAMES
+    enumerator :: HIPRAND_RNG_PSEUDO_MTGP32 = 141
+#else
     enumerator :: HIPRAND_RNG_PSEUDO_MTGP32 = 403
+#endif
+#ifdef USE_CUDA_NAMES
+    enumerator :: HIPRAND_RNG_PSEUDO_MT19937 = 142
+#else
     enumerator :: HIPRAND_RNG_PSEUDO_MT19937 = 404
+#endif
+#ifdef USE_CUDA_NAMES
+    enumerator :: HIPRAND_RNG_PSEUDO_PHILOX4_32_10 = 161
+#else
     enumerator :: HIPRAND_RNG_PSEUDO_PHILOX4_32_10 = 405
+#endif
+#ifdef USE_CUDA_NAMES
+    enumerator :: HIPRAND_RNG_QUASI_DEFAULT = 200
+#else
     enumerator :: HIPRAND_RNG_QUASI_DEFAULT = 500
+#endif
+#ifdef USE_CUDA_NAMES
+    enumerator :: HIPRAND_RNG_QUASI_SOBOL32 = 201
+#else
     enumerator :: HIPRAND_RNG_QUASI_SOBOL32 = 501
+#endif
+#ifdef USE_CUDA_NAMES
+    enumerator :: HIPRAND_RNG_QUASI_SCRAMBLED_SOBOL32 = 202
+#else
     enumerator :: HIPRAND_RNG_QUASI_SCRAMBLED_SOBOL32 = 502
+#endif
+#ifdef USE_CUDA_NAMES
+    enumerator :: HIPRAND_RNG_QUASI_SOBOL64 = 203
+#else
     enumerator :: HIPRAND_RNG_QUASI_SOBOL64 = 503
+#endif
+#ifdef USE_CUDA_NAMES
+    enumerator :: HIPRAND_RNG_QUASI_SCRAMBLED_SOBOL64 = 204
+#else
     enumerator :: HIPRAND_RNG_QUASI_SCRAMBLED_SOBOL64 = 504
+#endif
   end enum
 
   ! hiprandOrdering

--- a/test/f2003/hipblas/cgemm_batched.f03
+++ b/test/f2003/hipblas/cgemm_batched.f03
@@ -28,8 +28,7 @@ program hip_cgemm_batched
   type(c_ptr) :: handle = c_null_ptr
 
   double precision :: error
-  ! epsilon of the DATA kind, not of the accumulator: the results are
-  ! complex(kind=4), so a double-precision bound is tighter than single rounding.
+  ! epsilon of the data kind, not the accumulator: these results are complex(kind=4).
   double precision, parameter :: error_max = 10*epsilon(real(1.0,kind=4))
 
   write(*,"(a)",advance="no") "-- Running test 'CGEMM_BATCHED' (Fortran 2003 interfaces) - "

--- a/test/f2003/hipblas/cgemm_batched.f03
+++ b/test/f2003/hipblas/cgemm_batched.f03
@@ -28,7 +28,9 @@ program hip_cgemm_batched
   type(c_ptr) :: handle = c_null_ptr
 
   double precision :: error
-  double precision, parameter :: error_max = 10*epsilon(error)
+  ! epsilon of the DATA kind, not of the accumulator: the results are
+  ! complex(kind=4), so a double-precision bound is tighter than single rounding.
+  double precision, parameter :: error_max = 10*epsilon(real(1.0,kind=4))
 
   write(*,"(a)",advance="no") "-- Running test 'CGEMM_BATCHED' (Fortran 2003 interfaces) - "
 

--- a/test/f2003/hipblas/cgemm_strided_batched.f03
+++ b/test/f2003/hipblas/cgemm_strided_batched.f03
@@ -24,8 +24,7 @@ program hip_cgemm_strided_batched
   type(c_ptr) :: handle = c_null_ptr
 
   double precision :: error
-  ! epsilon of the DATA kind, not of the accumulator: the results are
-  ! complex(kind=4), so a double-precision bound is tighter than single rounding.
+  ! epsilon of the data kind, not the accumulator: these results are complex(kind=4).
   double precision, parameter :: error_max = 10*epsilon(real(1.0,kind=4))
 
   write(*,"(a)",advance="no") "-- Running test 'CGEMM_STRIDED_BATCHED' (Fortran 2003 interfaces) - "

--- a/test/f2003/hipblas/cgemm_strided_batched.f03
+++ b/test/f2003/hipblas/cgemm_strided_batched.f03
@@ -24,7 +24,9 @@ program hip_cgemm_strided_batched
   type(c_ptr) :: handle = c_null_ptr
 
   double precision :: error
-  double precision, parameter :: error_max = 10*epsilon(error)
+  ! epsilon of the DATA kind, not of the accumulator: the results are
+  ! complex(kind=4), so a double-precision bound is tighter than single rounding.
+  double precision, parameter :: error_max = 10*epsilon(real(1.0,kind=4))
 
   write(*,"(a)",advance="no") "-- Running test 'CGEMM_STRIDED_BATCHED' (Fortran 2003 interfaces) - "
 

--- a/test/f2008/hipblas/cgemm_batched.f08
+++ b/test/f2008/hipblas/cgemm_batched.f08
@@ -34,7 +34,9 @@ program hip_cgemm_batched
   type(c_ptr) :: handle = c_null_ptr
 
   double precision :: error
-  double precision, parameter :: error_max = 10*epsilon(error)
+  ! epsilon of the DATA kind, not of the accumulator: the results are
+  ! complex(kind=4), so a double-precision bound is tighter than single rounding.
+  double precision, parameter :: error_max = 10*epsilon(real(1.0,kind=4))
 
   write(*,"(a)",advance="no") "-- Running test 'CGEMM_BATCHED' (Fortran 2008 interfaces) - "
 

--- a/test/f2008/hipblas/cgemm_batched.f08
+++ b/test/f2008/hipblas/cgemm_batched.f08
@@ -34,8 +34,7 @@ program hip_cgemm_batched
   type(c_ptr) :: handle = c_null_ptr
 
   double precision :: error
-  ! epsilon of the DATA kind, not of the accumulator: the results are
-  ! complex(kind=4), so a double-precision bound is tighter than single rounding.
+  ! epsilon of the data kind, not the accumulator: these results are complex(kind=4).
   double precision, parameter :: error_max = 10*epsilon(real(1.0,kind=4))
 
   write(*,"(a)",advance="no") "-- Running test 'CGEMM_BATCHED' (Fortran 2008 interfaces) - "

--- a/test/f2008/hipblas/cgemm_strided_batched.f08
+++ b/test/f2008/hipblas/cgemm_strided_batched.f08
@@ -22,8 +22,7 @@ program hip_cgemm_strided_batched
   type(c_ptr) :: handle = c_null_ptr
 
   double precision :: error
-  ! epsilon of the DATA kind, not of the accumulator: the results are
-  ! complex(kind=4), so a double-precision bound is tighter than single rounding.
+  ! epsilon of the data kind, not the accumulator: these results are complex(kind=4).
   double precision, parameter :: error_max = 10*epsilon(real(1.0,kind=4))
 
   write(*,"(a)",advance="no") "-- Running test 'CGEMM_STRIDED_BATCHED' (Fortran 2008 interfaces) - "

--- a/test/f2008/hipblas/cgemm_strided_batched.f08
+++ b/test/f2008/hipblas/cgemm_strided_batched.f08
@@ -22,7 +22,9 @@ program hip_cgemm_strided_batched
   type(c_ptr) :: handle = c_null_ptr
 
   double precision :: error
-  double precision, parameter :: error_max = 10*epsilon(error)
+  ! epsilon of the DATA kind, not of the accumulator: the results are
+  ! complex(kind=4), so a double-precision bound is tighter than single rounding.
+  double precision, parameter :: error_max = 10*epsilon(real(1.0,kind=4))
 
   write(*,"(a)",advance="no") "-- Running test 'CGEMM_STRIDED_BATCHED' (Fortran 2008 interfaces) - "
 


### PR DESCRIPTION
## Motivation

The bindings already carry CUDA names behind `#ifdef USE_CUDA_NAMES`, but nothing ever enable the tests.
The variant was compiled on every build but no test could be built for NVIDIA, so the mappings were unverified. Two of them named symbols that do not exist.

This makes the CUDA path buildable, linkable and runnable, so the mappings are checked by a compiler and a GPU instead of by inspection.

## Technical Details

`lib/CMakeLists.txt`

- `USE_CUDA_NAMES` becomes a CMake option, default `OFF`. It previously existed only as a hardcoded compile definition, so `hipfort-nvptx` was built unconditionally and discarded.
- The CUDA variant excludes the `roc*` binding modules. rocBLAS, rocFFT, rocSOLVER, rocSPARSE and rocRAND have no CUDA equivalent and contributed ~1200 unresolvable symbols.
- `find_package(CUDAToolkit)` replaces the commented-out hardcoded `libcudart_static.a` path.
- New `hipfort-nvptx-link-check` target. A static archive is never linked, so nothing validated the `cuda*` names. This pulls in every member with `--whole-archive`, turning a wrong name into a build failure.
- `hipfort_add_component` is parameterised on `HIPFORT_BASE_LIB`, with a new NVIDIA branch mapping components to `CUDA::cudart`, `cublas`, `cufft`, `curand`, `cusolver`, `cusparse`. Without this no `hipfort::*` target existed on NVIDIA, so zero tests were registered.
- Adds the missing `EXPORT` argument to the nvptx `rocm_install_targets`.

`lib/hipfort/hipfort_hipmalloc.F90`

`hipHostMalloc` and `hipHostFree` were left with no `#ifdef` by 9d22358b, so they bound to HIP names in a CUDA build: 685 undefined references, 74 broken test links. Now mapped to `cudaHostAlloc` and `cudaFreeHost`, which match on arity (`cudaMallocHost` would not).

`lib/hipfort/hipfort_hiprand_enums.F90`

Every `hiprandRngType` value differs from cuRAND (`PSEUDO_PHILOX4_32_10` is 405 in HIP, 161 in CUDA), so all hiprand tests failed with `HIPRAND ERROR: code = 103`. Adds `#ifdef USE_CUDA_NAMES` branches for the 11 differing values, matching `hipfort_hipblas_enums.F90`. The generator table is a companion change
in rocm-fortran.

Default AMD builds are unaffected: the option is `OFF` and no existing line changes behaviour.

## Test Plan

- Build with the flag off, confirm only `libhipfort-amdgcn.a` is produced and module installation is unchanged.
- Build with `-DUSE_CUDA_NAMES=ON` against CUDA 13.1 and confirm the link check resolves every symbol.
- Mutation check the link check by reintroducing a bad CUDA name.
- Audit every enum module against the CUDA headers, since no linker catches value mismatches.
- Build and run the test suite on an NVIDIA GPU.

## Test Result

NVIDIA RTX PRO 4000 Blackwell, CUDA 13.1, gfortran 13.

| | |
|---|---|
| Tests registered | 180 (was 0) |
| Executables built | 151 |
| Passing | 144 |

By library: hipblas 71, hipfft 24, hipsparse 18, hiprand 16, hip core 11. hiprand went from 0 to 16 after the enum fix.

Link check passes. Reintroducing `cudaHostMalloc` fails the build with `undefined reference`, so the check has teeth.

Enum audit: hipblas, hipfft, hipsolver already mapped. hipsparse (93 constants) and HIP core (1051) coincidentally match. Only hiprand was broken.

Default AMD path: configure and build both `rc=0`, only `libhipfort-amdgcn.a` produced.

Remaining failures are pre-existing API gaps, not regressions: 15 hipsparse tests use `csrgemm`/`csr2csc`, removed from cuSPARSE in CUDA 12; 12 hipsolver tests use the AMD-only API whose `Dn` equivalents have different signatures; 3 hip graph tests return `cudaErrorInvalidValue`; 4 double-complex tests
segfault inside cuBLAS while their single-precision counterparts pass.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.