### PR TITLE
Split Fortran sources per backend + add HIPFORT_EXTENDED_TESTS shared-link check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,25 @@ It defaults to `ON` when the compiler supports Fortran 2008; set `-DHIPFORT_USE_
 When enabled, each array generic is backed by a single `dimension(..)` overload that accepts an actual of any rank.
 The overloads are mutually exclusive with the classic per-rank interfaces.
 Only contiguous arrays may be passed.
+* CMake option `HIPFORT_EXTENDED_TESTS` (default `OFF`) that links each backend
+static archive into a shared library with `-Wl,--whole-archive` and
+`-Wl,--no-undefined`, failing on any unresolved symbol. It is opt-in because it
+needs a recent, fully installed ROCm (amdgcn) or CUDA (nvptx) stack with every
+math library present to be certain it passes; each backend's test is skipped when
+its libraries are not found. Override the library directories with
+`HIPFORT_ROCM_LIB_DIR` / `HIPFORT_CUDA_LIB_DIR`.
+
+### Changed
+
+* The per-backend static archives are now cleaned to contain only the symbols
+their backend can resolve. `libhipfort-amdgcn.a` no longer includes
+`hipfort_cuda_errors` (the CUDA `cudaError_t` enum, referenced only under
+`USE_CUDA_NAMES`), and `libhipfort-nvptx.a` no longer includes the AMD-only
+rocBLAS / rocSOLVER / rocSPARSE / rocFFT / rocRAND API modules (whose `roc*`
+symbols have no CUDA equivalent). Each archive can therefore be turned into a
+shared library against its own backend's libraries alone, with no dangling
+symbols. The `roc*_enums` modules stay in both backends — they define only
+`enum, bind(c)` constants that `hipfort_check` uses regardless of backend.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,7 @@ their backend can resolve. `libhipfort-amdgcn.a` no longer includes
 rocBLAS / rocSOLVER / rocSPARSE / rocFFT / rocRAND API modules (whose `roc*`
 symbols have no CUDA equivalent). Each archive can therefore be turned into a
 shared library against its own backend's libraries alone, with no dangling
-symbols. The `roc*_enums` modules stay in both backends. They define only
-`enum, bind(c)` constants that `hipfort_check` uses regardless of backend.
+symbols.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ their backend can resolve. `libhipfort-amdgcn.a` no longer includes
 rocBLAS / rocSOLVER / rocSPARSE / rocFFT / rocRAND API modules (whose `roc*`
 symbols have no CUDA equivalent). Each archive can therefore be turned into a
 shared library against its own backend's libraries alone, with no dangling
-symbols. The `roc*_enums` modules stay in both backends — they define only
+symbols. The `roc*_enums` modules stay in both backends. They define only
 `enum, bind(c)` constants that `hipfort_check` uses regardless of backend.
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,7 +178,10 @@ option(BUILD_TESTING "Build tests" OFF)
 # -Wl,--no-undefined and fail on any unresolved symbol. Each backend's test is
 # only added when all of its runtime libraries are found (see lib/CMakeLists.txt),
 # so this is a no-op on machines without the corresponding ROCm/CUDA stack.
-option(HIPFORT_EXTENDED_TESTS "Test that the backend static archives link into shared libraries with no undefined symbols" OFF)
+# Opt-in (default OFF): it needs a recent, complete ROCm or CUDA install (all math
+# libraries present) to be certain it passes, so it is not part of the default
+# test suite.
+option(HIPFORT_EXTENDED_TESTS "Link each backend static archive into a shared library and fail on undefined symbols (needs a recent, complete ROCm/CUDA install)" OFF)
 set(HIPFORT_ROCM_LIB_DIR "" CACHE PATH "Directory of the ROCm runtime libraries for the amdgcn extended shared-link test (default: <ROCM_PATH>/lib)")
 set(HIPFORT_CUDA_LIB_DIR "" CACHE PATH "Directory of the CUDA runtime libraries for the nvptx extended shared-link test (default: from find_package(CUDAToolkit))")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,7 +173,16 @@ IF(FCNAME STREQUAL "pgf90")
 ENDIF(FCNAME STREQUAL "pgf90")
 
 option(BUILD_TESTING "Build tests" OFF)
-if(BUILD_TESTING)
+
+# Extended tests: link each backend static archive into a shared library with
+# -Wl,--no-undefined and fail on any unresolved symbol. Each backend's test is
+# only added when all of its runtime libraries are found (see lib/CMakeLists.txt),
+# so this is a no-op on machines without the corresponding ROCm/CUDA stack.
+option(HIPFORT_EXTENDED_TESTS "Test that the backend static archives link into shared libraries with no undefined symbols" OFF)
+set(HIPFORT_ROCM_LIB_DIR "" CACHE PATH "Directory of the ROCm runtime libraries for the amdgcn extended shared-link test (default: <ROCM_PATH>/lib)")
+set(HIPFORT_CUDA_LIB_DIR "" CACHE PATH "Directory of the CUDA runtime libraries for the nvptx extended shared-link test (default: from find_package(CUDAToolkit))")
+
+if(BUILD_TESTING OR HIPFORT_EXTENDED_TESTS)
   enable_testing()
 endif()
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -306,3 +306,92 @@ if(HIP_PLATFORM STREQUAL "amd")
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/hipfort
   )
 endif()
+
+# ---------------------------------------------------------------------------
+# HIPFORT_EXTENDED_TESTS: verify each backend static archive links into a shared
+# library with every symbol resolved. Each test runs
+#   $FC -fPIC -shared -Wl,--whole-archive libhipfort-<arch>.a -Wl,--no-whole-archive
+#       -Wl,--no-undefined -L<dir> <-l deps> -o libhipfort-<arch>.so
+# and fails (non-zero exit) on any unresolved symbol. A backend's test is only
+# added when all of its runtime libraries are found, so this is a no-op without
+# the corresponding stack. Override the lib directories with HIPFORT_ROCM_LIB_DIR
+# / HIPFORT_CUDA_LIB_DIR (e.g. to point nvptx at a non-default CUDA toolkit).
+if(HIPFORT_EXTENDED_TESTS)
+  # ---- amdgcn: link against the ROCm runtime libraries ----
+  if(TARGET hipfort-amdgcn)
+    set(_amd_dir "${HIPFORT_ROCM_LIB_DIR}")
+    if(NOT _amd_dir)
+      if(ROCM_PATH)
+        set(_amd_dir "${ROCM_PATH}/lib")
+      else()
+        set(_amd_dir "/opt/rocm/lib")
+      endif()
+    endif()
+    # NB: the HIP runtime is libamdhip64, not "libhip".
+    set(_amd_libs hipfftw hipfft rocfft hipsolver rocsolver hipblas rocblas
+                  rocrand hiprand hipsparse rocsparse amdhip64)
+    set(_amd_ok TRUE)
+    set(_amd_missing "")
+    foreach(_l IN LISTS _amd_libs)
+      unset(_amd_lib_${_l} CACHE)
+      find_library(_amd_lib_${_l} NAMES ${_l} HINTS ${_amd_dir} NO_DEFAULT_PATH)
+      if(NOT _amd_lib_${_l})
+        set(_amd_ok FALSE)
+        list(APPEND _amd_missing ${_l})
+      endif()
+    endforeach()
+    if(_amd_ok)
+      set(_amd_lflags "")
+      foreach(_l IN LISTS _amd_libs)
+        list(APPEND _amd_lflags "-l${_l}")
+      endforeach()
+      add_test(NAME hipfort_shared_link_amdgcn
+        COMMAND ${CMAKE_Fortran_COMPILER} -fPIC -shared
+                -Wl,--whole-archive $<TARGET_FILE:hipfort-amdgcn> -Wl,--no-whole-archive
+                -Wl,--no-undefined -L${_amd_dir} ${_amd_lflags}
+                -o ${CMAKE_CURRENT_BINARY_DIR}/libhipfort-amdgcn.so)
+      message(STATUS "HIPFORT_EXTENDED_TESTS: added amdgcn shared-link test (libs in ${_amd_dir})")
+    else()
+      message(STATUS "HIPFORT_EXTENDED_TESTS: skipping amdgcn shared-link test; missing in ${_amd_dir}: ${_amd_missing}")
+    endif()
+  endif()
+
+  # ---- nvptx: link against the CUDA runtime libraries ----
+  if(TARGET hipfort-nvptx)
+    set(_cuda_dir "${HIPFORT_CUDA_LIB_DIR}")
+    if(NOT _cuda_dir)
+      find_package(CUDAToolkit QUIET)
+      if(CUDAToolkit_FOUND)
+        set(_cuda_dir "${CUDAToolkit_LIBRARY_DIR}")
+      endif()
+    endif()
+    set(_cuda_libs cufft cusolver cublas curand cusparse cudart)
+    set(_cuda_ok FALSE)
+    set(_cuda_missing "")
+    if(_cuda_dir)
+      set(_cuda_ok TRUE)
+      foreach(_l IN LISTS _cuda_libs)
+        unset(_cuda_lib_${_l} CACHE)
+        find_library(_cuda_lib_${_l} NAMES ${_l} HINTS ${_cuda_dir} NO_DEFAULT_PATH)
+        if(NOT _cuda_lib_${_l})
+          set(_cuda_ok FALSE)
+          list(APPEND _cuda_missing ${_l})
+        endif()
+      endforeach()
+    endif()
+    if(_cuda_ok)
+      set(_cuda_lflags "")
+      foreach(_l IN LISTS _cuda_libs)
+        list(APPEND _cuda_lflags "-l${_l}")
+      endforeach()
+      add_test(NAME hipfort_shared_link_nvptx
+        COMMAND ${CMAKE_Fortran_COMPILER} -fPIC -shared
+                -Wl,--whole-archive $<TARGET_FILE:hipfort-nvptx> -Wl,--no-whole-archive
+                -Wl,--no-undefined -L${_cuda_dir} ${_cuda_lflags}
+                -o ${CMAKE_CURRENT_BINARY_DIR}/libhipfort-nvptx.so)
+      message(STATUS "HIPFORT_EXTENDED_TESTS: added nvptx shared-link test (libs in ${_cuda_dir})")
+    else()
+      message(STATUS "HIPFORT_EXTENDED_TESTS: skipping nvptx shared-link test; CUDA libraries not found (set HIPFORT_CUDA_LIB_DIR). missing: ${_cuda_missing}")
+    endif()
+  endif()
+endif()

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -22,6 +22,30 @@ file(GLOB HIPFORT_SRC_HIP_F90 "${CMAKE_CURRENT_SOURCE_DIR}/hipfort/*.f90")
 file(GLOB HIPFORT_SRC_HIP_F90_UPPER "${CMAKE_CURRENT_SOURCE_DIR}/hipfort/*.F90")
 set(HIPFORT_SRC_HIP ${HIPFORT_SRC_HIP_F90} ${HIPFORT_SRC_HIP_F90_UPPER})
 
+# Partition the sources by backend so each archive only carries what its backend
+# can actually resolve:
+#   * the roc* API modules (rocBLAS/rocSOLVER/rocSPARSE/rocFFT/rocRAND) wrap
+#     AMD-only libraries with no CUDA equivalent -> amdgcn only. Compiling them for
+#     nvptx just adds unresolvable roc* symbols to the archive. Their *_enums
+#     modules are kept in both backends: they carry only `enum, bind(c)` constants
+#     (no external symbols) and hipfort_check uses the roc*_status enums for its
+#     error-check helpers regardless of backend.
+#   * hipfort_cuda_errors (the cudaError_t enum) is only used under USE_CUDA_NAMES
+#     -> nvptx only. On amdgcn every `use hipfort_cuda_errors` is #ifdef'd out.
+# Everything else is common to both backends.
+set(HIPFORT_SRC_ROC "")
+foreach(_roclib rocblas rocsolver rocsparse rocfft rocrand)
+  file(GLOB _rocfiles "${CMAKE_CURRENT_SOURCE_DIR}/hipfort/hipfort_${_roclib}.[fF]90")  # API module only, not *_enums
+  list(APPEND HIPFORT_SRC_ROC ${_rocfiles})
+endforeach()
+file(GLOB HIPFORT_SRC_CUDA_ERRORS "${CMAKE_CURRENT_SOURCE_DIR}/hipfort/hipfort_cuda_errors.[fF]90")
+
+set(HIPFORT_SRC_COMMON ${HIPFORT_SRC_HIP})
+list(REMOVE_ITEM HIPFORT_SRC_COMMON ${HIPFORT_SRC_ROC} ${HIPFORT_SRC_CUDA_ERRORS})
+
+set(HIPFORT_SRC_AMDGCN ${HIPFORT_SRC_COMMON} ${HIPFORT_SRC_ROC})            # + AMD-only roc*
+set(HIPFORT_SRC_NVPTX  ${HIPFORT_SRC_COMMON} ${HIPFORT_SRC_CUDA_ERRORS})    # + CUDA-only cuda_errors
+
 # The Fortran 2008 array interfaces (USE_FPOINTER_INTERFACES) default ON whenever
 # the compiler supports Fortran 2008. Exposed as a cache option so it can be forced
 # OFF for an old compiler, or one whose F2008 support is buggy (e.g. some Intel
@@ -71,8 +95,8 @@ set(HIPFORT_ARCH "amdgcn")
     # amdgcn
     set(HIPFORT_LIB      "hipfort-${HIPFORT_ARCH}")
     set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/include/hipfort/${HIPFORT_ARCH})
-    ADD_LIBRARY(${HIPFORT_LIB} STATIC 
-        ${HIPFORT_SRC_HIP} 
+    ADD_LIBRARY(${HIPFORT_LIB} STATIC
+        ${HIPFORT_SRC_AMDGCN}
         )
     target_include_directories(${HIPFORT_LIB}
       PUBLIC
@@ -106,8 +130,8 @@ set(HIPFORT_ARCH "nvptx")
     # nvptx
     set(HIPFORT_LIB     "hipfort-${HIPFORT_ARCH}")
     set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/include/hipfort/${HIPFORT_ARCH})
-    ADD_LIBRARY(${HIPFORT_LIB} STATIC 
-         ${HIPFORT_SRC_HIP} 
+    ADD_LIBRARY(${HIPFORT_LIB} STATIC
+         ${HIPFORT_SRC_NVPTX}
          )
     IF(HIPFORT_USE_FPOINTER_INTERFACES)
     	target_compile_definitions(${HIPFORT_LIB} PRIVATE USE_FPOINTER_INTERFACES)


### PR DESCRIPTION
## What

Two related changes that make each backend archive cleanly convertible into a shared library:

1. **Split the Fortran sources per backend.** Both static archives were built from every `.F90`, so each carried modules its backend can never resolve:
   - `hipfort-nvptx` pulled in the `roc*` API modules (rocBLAS/rocSOLVER/rocSPARSE/rocFFT/rocRAND) — ~1200 AMD-only symbols with no CUDA equivalent.
   - `hipfort-amdgcn` pulled in `hipfort_cuda_errors` (the `cudaError_t` enum), dead outside `USE_CUDA_NAMES`.

   Now: **amdgcn** = common + `roc*` API; **nvptx** = common + `hipfort_cuda_errors`. The `roc*_enums` modules stay in **both** (only `enum, bind(c)` constants, needed by `hipfort_check` on both backends).

2. **New `HIPFORT_EXTENDED_TESTS` option** (default OFF). When ON, and when a backend's runtime libraries are all found, it registers a CTest test that links that archive into a `.so`:
   ```
   $FC -fPIC -shared -Wl,--whole-archive libhipfort-<arch>.a -Wl,--no-whole-archive \
       -Wl,--no-undefined -L<dir> <-l deps> -o libhipfort-<arch>.so
   ```
   failing on any unresolved symbol.
   - **amdgcn** → `HIPFORT_ROCM_LIB_DIR` (default `<ROCM_PATH>/lib`): `-lhipfftw -lhipfft -lrocfft -lhipsolver -lrocsolver -lhipblas -lrocblas -lrocrand -lhiprand -lhipsparse -lrocsparse -lamdhip64`
   - **nvptx** → `HIPFORT_CUDA_LIB_DIR` (default from `find_package(CUDAToolkit)`): `-lcufft -lcusolver -lcublas -lcurand -lcusparse -lcudart`

   Each test is only added when all of its libraries are found → no-op without the corresponding stack.

## Testing (gfortran, ROCm 7.2.3, CUDA_SDK 13.4)

`cmake -DHIPFORT_EXTENDED_TESTS=ON [-DHIPFORT_CUDA_LIB_DIR=...]` then `ctest`:

| test | result |
|---|---|
| `hipfort_shared_link_amdgcn` | ✅ Passed |
| `hipfort_shared_link_nvptx`  | ✅ Passed |