### PR TITLE
HIPFORT_EXTENDED_TESTS: make the shared-link check pass with amdflang

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -317,6 +317,17 @@ endif()
 # the corresponding stack. Override the lib directories with HIPFORT_ROCM_LIB_DIR
 # / HIPFORT_CUDA_LIB_DIR (e.g. to point nvptx at a non-default CUDA toolkit).
 if(HIPFORT_EXTENDED_TESTS)
+  # amdflang/LLVMFlang emits absolute R_X86_64_64 relocations for its derived-type
+  # module descriptors (e.g. in the *_types modules) that its default linker,
+  # ld.lld, refuses in a shared object — and -fPIC does not change them (a flang
+  # codegen limitation). Allow text relocations so the shared-link check still
+  # validates symbol resolution; the flag is accepted by both ld.lld and GNU ld.
+  # gfortran + GNU ld links these archives without it.
+  set(_shared_ldflags "")
+  if(CMAKE_Fortran_COMPILER_ID STREQUAL "LLVMFlang" OR CMAKE_Fortran_COMPILER_ID STREQUAL "Flang")
+    set(_shared_ldflags -Wl,-z,notext)
+  endif()
+
   # ---- amdgcn: link against the ROCm runtime libraries ----
   if(TARGET hipfort-amdgcn)
     set(_amd_dir "${HIPFORT_ROCM_LIB_DIR}")
@@ -346,7 +357,7 @@ if(HIPFORT_EXTENDED_TESTS)
         list(APPEND _amd_lflags "-l${_l}")
       endforeach()
       add_test(NAME hipfort_shared_link_amdgcn
-        COMMAND ${CMAKE_Fortran_COMPILER} -fPIC -shared
+        COMMAND ${CMAKE_Fortran_COMPILER} -fPIC -shared ${_shared_ldflags}
                 -Wl,--whole-archive $<TARGET_FILE:hipfort-amdgcn> -Wl,--no-whole-archive
                 -Wl,--no-undefined -L${_amd_dir} ${_amd_lflags}
                 -o ${CMAKE_CURRENT_BINARY_DIR}/libhipfort-amdgcn.so)
@@ -385,7 +396,7 @@ if(HIPFORT_EXTENDED_TESTS)
         list(APPEND _cuda_lflags "-l${_l}")
       endforeach()
       add_test(NAME hipfort_shared_link_nvptx
-        COMMAND ${CMAKE_Fortran_COMPILER} -fPIC -shared
+        COMMAND ${CMAKE_Fortran_COMPILER} -fPIC -shared ${_shared_ldflags}
                 -Wl,--whole-archive $<TARGET_FILE:hipfort-nvptx> -Wl,--no-whole-archive
                 -Wl,--no-undefined -L${_cuda_dir} ${_cuda_lflags}
                 -o ${CMAKE_CURRENT_BINARY_DIR}/libhipfort-nvptx.so)


### PR DESCRIPTION
Follow-up to the `HIPFORT_EXTENDED_TESTS` shared-link check (#486).

## Problem

Tested the extended shared-link check with **both** Fortran compilers. It passed with gfortran but **failed with amdflang** — not on missing symbols, but on relocations:

```
ld.lld: error: relocation R_X86_64_64 cannot be used against symbol
'_QMhipfort_hipfftw_typesEXnXn'; recompile with -fPIC
```

amdflang (LLVMFlang) emits absolute `R_X86_64_64` relocations for its derived-type module descriptors (the `*_types` modules, `__builtin_c_ptr`, …) that its default linker **ld.lld** refuses in a shared object. Crucially, **`-fPIC` does not change these relocations** (verified: 16 `R_X86_64_64` with and without `-fPIC`) — it is a flang codegen limitation. gfortran + GNU ld link the very same archives fine (GNU ld emits text relocations).

## Fix

Add `-Wl,-z,notext` to the shared-link command for `LLVMFlang`/`Flang` only (allows the text relocations; accepted by both ld.lld and GNU ld). gfortran is unchanged.

## Testing (ROCm 7.2.3, CUDA_SDK 13.4)

`ctest` with `-DHIPFORT_EXTENDED_TESTS=ON`:

| compiler | amdgcn | nvptx |
|---|---|---|
| gfortran | ✅ | ✅ |
| amdflang | ✅ | ✅ |

(2/2 for both.)