### PR TITLE
Make find_package(hipfort) work at the install prefix with the multitoolchain layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,14 @@ symbols.
 
 ### Fixed
 
+* `find_package(hipfort)` now works from the install prefix (e.g.
+  `-DCMAKE_PREFIX_PATH=/opt/rocm`) with the multitoolchain layout. That layout
+  installs the package files under `lib/fortran/<compiler>/cmake/hipfort`, which
+  is not on CMake's default search path, so `find_package(hipfort)` could not find
+  them. A compiler-agnostic shim is now also installed at the standard
+  `lib/cmake/hipfort`; at configure time it forwards to the subdirectory matching
+  the consuming project's Fortran compiler (or errors listing the available
+  toolchains).
 * Test executables no longer fail to link with compilers whose driver defaults to
   `--as-needed`, such as `gfortran` on Ubuntu. `libhipfort-amdgcn.a` is shared by
   every `hipfort::` component, so CMake placed it after the ROCm shared libraries

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -305,6 +305,27 @@ if(HIP_PLATFORM STREQUAL "amd")
       ${CMAKE_CURRENT_BINARY_DIR}/hipfort-config-version.cmake
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/hipfort
   )
+
+  # With the multitoolchain layout the package files above live under
+  # lib/fortran/<compiler>/cmake/hipfort, which is not on CMake's default
+  # find_package search path. Also install a compiler-agnostic shim at the
+  # standard lib/cmake/hipfort so `find_package(hipfort)` succeeds from the
+  # install prefix (e.g. /opt/rocm); at use time it forwards to the toolchain
+  # subdirectory matching the consumer's Fortran compiler. The version file is
+  # compiler-independent and installed alongside so version checks still work.
+  if(HIPFORT_MULTITOOLCHAIN_LAYOUT)
+    # Plain install() (not rocm_install) because rocm_install does not support
+    # RENAME; the file is still packaged by CPACK.
+    install(
+      FILES ${CMAKE_CURRENT_SOURCE_DIR}/hipfort-config-shim.cmake
+      RENAME hipfort-config.cmake
+      DESTINATION lib/cmake/hipfort
+    )
+    install(
+      FILES ${CMAKE_CURRENT_BINARY_DIR}/hipfort-config-version.cmake
+      DESTINATION lib/cmake/hipfort
+    )
+  endif()
 endif()
 
 # ---------------------------------------------------------------------------

--- a/lib/hipfort-config-shim.cmake
+++ b/lib/hipfort-config-shim.cmake
@@ -1,0 +1,38 @@
+# hipfort package shim.
+#
+# Installed at <prefix>/lib/cmake/hipfort/hipfort-config.cmake when hipfort is
+# built with HIPFORT_MULTITOOLCHAIN_LAYOUT=ON. Fortran .mod files are
+# compiler-specific, so the real hipfort package files are installed under a
+# compiler-specific subdirectory, <prefix>/lib/fortran/<compiler>/cmake/hipfort,
+# which is not on CMake's default find_package search path. This shim lets
+# `find_package(hipfort)` succeed from the install prefix (e.g. /opt/rocm) by
+# forwarding to the subdirectory that matches the consuming project's Fortran
+# compiler. It resolves the compiler at use time, so every toolchain install can
+# write the same shim without conflict.
+
+if(NOT CMAKE_Fortran_COMPILER)
+  set(hipfort_FOUND FALSE)
+  set(hipfort_NOT_FOUND_MESSAGE
+      "hipfort requires the Fortran language to be enabled before find_package(hipfort); add Fortran to project(...) or call enable_language(Fortran).")
+  return()
+endif()
+
+get_filename_component(_hipfort_fc "${CMAKE_Fortran_COMPILER}" NAME)
+get_filename_component(_hipfort_prefix "${CMAKE_CURRENT_LIST_DIR}/../../.." ABSOLUTE)
+set(_hipfort_real "${_hipfort_prefix}/lib/fortran/${_hipfort_fc}/cmake/hipfort/hipfort-config.cmake")
+
+if(NOT EXISTS "${_hipfort_real}")
+  file(GLOB _hipfort_toolchains RELATIVE "${_hipfort_prefix}/lib/fortran" "${_hipfort_prefix}/lib/fortran/*")
+  set(hipfort_FOUND FALSE)
+  set(hipfort_NOT_FOUND_MESSAGE
+      "hipfort is not installed for the Fortran compiler '${_hipfort_fc}'. Available toolchains: ${_hipfort_toolchains}. Rebuild hipfort with this compiler, or set hipfort_DIR to the matching lib/fortran/<compiler>/cmake/hipfort directory.")
+  unset(_hipfort_fc)
+  unset(_hipfort_prefix)
+  unset(_hipfort_real)
+  return()
+endif()
+
+include("${_hipfort_real}")
+unset(_hipfort_fc)
+unset(_hipfort_prefix)
+unset(_hipfort_real)


### PR DESCRIPTION
## Problem

With `HIPFORT_MULTITOOLCHAIN_LAYOUT=ON` (the default), the CMake package files are installed under `lib/fortran/<compiler>/cmake/hipfort` so several Fortran toolchains can coexist. That path is **not** on CMake's default `find_package` search list, so:

```bash
cmake -DCMAKE_PREFIX_PATH=/opt/rocm ..   # find_package(hipfort) → not found
```

Only an explicit `-Dhipfort_DIR=<prefix>/lib/fortran/<compiler>/cmake/hipfort` worked. (This is the scenario behind the *hipFORT CMake not found* QA report — the config is generated and installed, just not discoverable from the prefix with this layout.)

## Fix

Install a **compiler-agnostic shim** at the standard `lib/cmake/hipfort/hipfort-config.cmake` (only when the multitoolchain layout is on). At configure time it resolves the consuming project's Fortran compiler and forwards to the matching `lib/fortran/<compiler>/cmake/hipfort` config, or errors listing the installed toolchains. The shim resolves the compiler at use time, so every toolchain install writes the same file without conflict. The (compiler-independent) version file is installed alongside so version checks keep working.

## Testing (gfortran, ROCm 7.2.3)

Built + installed with the default multitoolchain layout, then a consumer project:

```
-- RESULT hipfort_FOUND=1
-- RESULT hipfort_CONFIG=<prefix>/lib/cmake/hipfort/hipfort-config.cmake
```

- `find_package(hipfort REQUIRED COMPONENTS hip hipfft)` with `-DCMAKE_PREFIX_PATH=<prefix>` now succeeds, forwarding to the gfortran toolchain config.
- A consumer built with a compiler that has no installed toolchain gets: *"hipfort is not installed for the Fortran compiler 'amdflang'. Available toolchains: …"*
- Flat layout (`HIPFORT_MULTITOOLCHAIN_LAYOUT=OFF`) is unchanged (real config already sits at `lib/cmake/hipfort`; no shim installed).