### PR TITLE
test: guard find_package(hipfort) from the install prefix (SWDEV-427498)

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -700,4 +700,16 @@ if(BUILD_TESTING)
       )
     endif()
   endif()
+
+  # Regression test for SWDEV-427498: installing hipfort and calling
+  # find_package(hipfort) from the install prefix must succeed. This guards the
+  # multitoolchain-layout shim (lib/cmake/hipfort forwarding to
+  # lib/fortran/<compiler>/cmake/hipfort) and the flat-layout config alike.
+  add_test(NAME hipfort_find_package_install
+    COMMAND ${CMAKE_COMMAND}
+      -DHIPFORT_BUILD_DIR=${CMAKE_BINARY_DIR}
+      -DCONSUMER_SRC=${CMAKE_CURRENT_SOURCE_DIR}/find_package
+      -DWORK_DIR=${CMAKE_CURRENT_BINARY_DIR}/find_package_work
+      -DFORTRAN_COMPILER=${CMAKE_Fortran_COMPILER}
+      -P ${CMAKE_CURRENT_SOURCE_DIR}/find_package/run_find_package_test.cmake)
 endif()

--- a/test/find_package/CMakeLists.txt
+++ b/test/find_package/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Minimal consumer for the hipfort find_package regression test
+# (see run_find_package_test.cmake and SWDEV-427498). It only checks that
+# find_package(hipfort) is discoverable from the install prefix, so it requests
+# no components and needs no ROCm math libraries.
+cmake_minimum_required(VERSION 3.18)
+project(hipfort_find_package_consumer Fortran)
+
+find_package(hipfort REQUIRED)
+
+# The config must be found at the standard <prefix>/lib/cmake/hipfort — either the
+# real config (flat layout) or the shim that forwards to the toolchain-specific
+# one (multitoolchain layout). This is exactly what find_package resolves from a
+# plain -DCMAKE_PREFIX_PATH=<prefix>.
+if(NOT hipfort_CONFIG MATCHES "/lib/cmake/hipfort/hipfort-config.cmake$")
+  message(FATAL_ERROR
+    "hipfort was found via '${hipfort_CONFIG}', but expected the standard "
+    "lib/cmake/hipfort location reachable from the install prefix.")
+endif()
+message(STATUS "hipfort found from the install prefix: ${hipfort_CONFIG}")

--- a/test/find_package/run_find_package_test.cmake
+++ b/test/find_package/run_find_package_test.cmake
@@ -1,0 +1,43 @@
+# Regression test for SWDEV-427498: find_package(hipfort) must work from the
+# install prefix (e.g. -DCMAKE_PREFIX_PATH=/opt/rocm), including with the
+# multitoolchain layout, where the package files live under
+# lib/fortran/<compiler>/cmake/hipfort and a shim at lib/cmake/hipfort forwards
+# to them.
+#
+# Invoked via `cmake -P` with:
+#   -DHIPFORT_BUILD_DIR=<hipfort build tree>
+#   -DCONSUMER_SRC=<test/find_package>
+#   -DWORK_DIR=<scratch dir>
+#   -DFORTRAN_COMPILER=<Fortran compiler>
+#
+# It installs hipfort from the build tree into WORK_DIR/install, then configures
+# the consumer against that prefix. Any nonzero exit fails the test.
+
+file(REMOVE_RECURSE "${WORK_DIR}")
+set(_prefix "${WORK_DIR}/install")
+
+execute_process(
+  COMMAND "${CMAKE_COMMAND}" --install "${HIPFORT_BUILD_DIR}" --prefix "${_prefix}"
+  RESULT_VARIABLE _rc OUTPUT_VARIABLE _log ERROR_VARIABLE _log)
+if(NOT _rc EQUAL 0)
+  message(FATAL_ERROR "cmake --install failed (${_rc}):\n${_log}")
+endif()
+
+# The config must be reachable from the prefix at the standard lib/cmake/hipfort.
+if(NOT EXISTS "${_prefix}/lib/cmake/hipfort/hipfort-config.cmake")
+  message(FATAL_ERROR
+    "no hipfort-config.cmake at ${_prefix}/lib/cmake/hipfort (find_package would "
+    "not discover hipfort from the install prefix).")
+endif()
+
+execute_process(
+  COMMAND "${CMAKE_COMMAND}"
+          -S "${CONSUMER_SRC}" -B "${WORK_DIR}/consumer"
+          -DCMAKE_Fortran_COMPILER=${FORTRAN_COMPILER}
+          -DCMAKE_PREFIX_PATH=${_prefix}
+  RESULT_VARIABLE _rc OUTPUT_VARIABLE _log ERROR_VARIABLE _log)
+message(STATUS "${_log}")
+if(NOT _rc EQUAL 0)
+  message(FATAL_ERROR "find_package(hipfort) from the install prefix failed (${_rc}):\n${_log}")
+endif()
+message(STATUS "find_package(hipfort) from the install prefix: OK")


### PR DESCRIPTION
Follow-up to #488. Adds a CTest regression test so the *hipFORT CMake not found* scenario cannot silently come back.

## What it does

`hipfort_find_package_install` (registered under `BUILD_TESTING`) runs a `cmake -P` driver that:
1. installs hipfort from the build tree into a scratch prefix;
2. checks `hipfort-config.cmake` exists at the standard `<prefix>/lib/cmake/hipfort`;
3. configures a tiny consumer project with `find_package(hipfort REQUIRED)` and `-DCMAKE_PREFIX_PATH=<prefix>`, failing the test on any nonzero exit.

The consumer requests **no components**, so it needs no ROCm math libraries — it only exercises *discoverability from the install prefix*, which is the exact behavior of the QA report.

It covers both layouts:
- **multitoolchain** (default): the package files are under `lib/fortran/<compiler>/cmake/hipfort`; the shim at `lib/cmake/hipfort` must forward to them.
- **flat** (`HIPFORT_MULTITOOLCHAIN_LAYOUT=OFF`): the real config sits at `lib/cmake/hipfort`.

## Testing

`ctest -R hipfort_find_package_install` → **Passed** (gfortran, multitoolchain layout): install + `find_package(hipfort)` from the prefix succeed, resolving `hipfort_CONFIG` to `lib/cmake/hipfort/hipfort-config.cmake`.

Files: `test/find_package/CMakeLists.txt` (consumer), `test/find_package/run_find_package_test.cmake` (driver), wired in `test/CMakeLists.txt`.