### PR TITLE
Wrap assumed-rank BLAS module procedure lists at 2 names/line

### DIFF
--- a/lib/hipfort/hipfort_hipblas.F90
+++ b/lib/hipfort/hipfort_hipblas.F90
@@ -41733,8 +41733,9 @@ module hipfort_hipblas
 
 #ifdef USE_FPOINTER_INTERFACES
 #ifdef USE_ASSUMED_RANK_INTERFACES
-    module procedure hipblasSetVectorAsync_l_assumed_rank,hipblasSetVectorAsync_i4_assumed_rank,hipblasSetVectorAsync_i8_assumed_rank,&
-      hipblasSetVectorAsync_r4_assumed_rank,hipblasSetVectorAsync_r8_assumed_rank,hipblasSetVectorAsync_c4_assumed_rank,&
+    module procedure hipblasSetVectorAsync_l_assumed_rank,hipblasSetVectorAsync_i4_assumed_rank,&
+      hipblasSetVectorAsync_i8_assumed_rank,hipblasSetVectorAsync_r4_assumed_rank,&
+      hipblasSetVectorAsync_r8_assumed_rank,hipblasSetVectorAsync_c4_assumed_rank,&
       hipblasSetVectorAsync_c8_assumed_rank
 #else
     module procedure hipblasSetVectorAsync_l_rank_0,hipblasSetVectorAsync_l_full_rank,&
@@ -41769,8 +41770,9 @@ module hipfort_hipblas
 
 #ifdef USE_FPOINTER_INTERFACES
 #ifdef USE_ASSUMED_RANK_INTERFACES
-    module procedure hipblasGetVectorAsync_l_assumed_rank,hipblasGetVectorAsync_i4_assumed_rank,hipblasGetVectorAsync_i8_assumed_rank,&
-      hipblasGetVectorAsync_r4_assumed_rank,hipblasGetVectorAsync_r8_assumed_rank,hipblasGetVectorAsync_c4_assumed_rank,&
+    module procedure hipblasGetVectorAsync_l_assumed_rank,hipblasGetVectorAsync_i4_assumed_rank,&
+      hipblasGetVectorAsync_i8_assumed_rank,hipblasGetVectorAsync_r4_assumed_rank,&
+      hipblasGetVectorAsync_r8_assumed_rank,hipblasGetVectorAsync_c4_assumed_rank,&
       hipblasGetVectorAsync_c8_assumed_rank
 #else
     module procedure hipblasGetVectorAsync_l_rank_0,hipblasGetVectorAsync_l_full_rank,&
@@ -41806,8 +41808,9 @@ module hipfort_hipblas
 
 #ifdef USE_FPOINTER_INTERFACES
 #ifdef USE_ASSUMED_RANK_INTERFACES
-    module procedure hipblasSetMatrixAsync_l_assumed_rank,hipblasSetMatrixAsync_i4_assumed_rank,hipblasSetMatrixAsync_i8_assumed_rank,&
-      hipblasSetMatrixAsync_r4_assumed_rank,hipblasSetMatrixAsync_r8_assumed_rank,hipblasSetMatrixAsync_c4_assumed_rank,&
+    module procedure hipblasSetMatrixAsync_l_assumed_rank,hipblasSetMatrixAsync_i4_assumed_rank,&
+      hipblasSetMatrixAsync_i8_assumed_rank,hipblasSetMatrixAsync_r4_assumed_rank,&
+      hipblasSetMatrixAsync_r8_assumed_rank,hipblasSetMatrixAsync_c4_assumed_rank,&
       hipblasSetMatrixAsync_c8_assumed_rank
 #else
     module procedure hipblasSetMatrixAsync_l_full_rank,hipblasSetMatrixAsync_l_rank_0,hipblasSetMatrixAsync_l_rank_1,&
@@ -41843,8 +41846,9 @@ module hipfort_hipblas
 
 #ifdef USE_FPOINTER_INTERFACES
 #ifdef USE_ASSUMED_RANK_INTERFACES
-    module procedure hipblasGetMatrixAsync_l_assumed_rank,hipblasGetMatrixAsync_i4_assumed_rank,hipblasGetMatrixAsync_i8_assumed_rank,&
-      hipblasGetMatrixAsync_r4_assumed_rank,hipblasGetMatrixAsync_r8_assumed_rank,hipblasGetMatrixAsync_c4_assumed_rank,&
+    module procedure hipblasGetMatrixAsync_l_assumed_rank,hipblasGetMatrixAsync_i4_assumed_rank,&
+      hipblasGetMatrixAsync_i8_assumed_rank,hipblasGetMatrixAsync_r4_assumed_rank,&
+      hipblasGetMatrixAsync_r8_assumed_rank,hipblasGetMatrixAsync_c4_assumed_rank,&
       hipblasGetMatrixAsync_c8_assumed_rank
 #else
     module procedure hipblasGetMatrixAsync_l_full_rank,hipblasGetMatrixAsync_l_rank_0,hipblasGetMatrixAsync_l_rank_1,&

--- a/lib/hipfort/hipfort_rocblas.F90
+++ b/lib/hipfort/hipfort_rocblas.F90
@@ -37712,8 +37712,9 @@ module hipfort_rocblas
 
 #ifdef USE_FPOINTER_INTERFACES
 #ifdef USE_ASSUMED_RANK_INTERFACES
-    module procedure rocblas_set_vector_async_l_assumed_rank,rocblas_set_vector_async_i4_assumed_rank,rocblas_set_vector_async_i8_assumed_rank,&
-      rocblas_set_vector_async_r4_assumed_rank,rocblas_set_vector_async_r8_assumed_rank,rocblas_set_vector_async_c4_assumed_rank,&
+    module procedure rocblas_set_vector_async_l_assumed_rank,rocblas_set_vector_async_i4_assumed_rank,&
+      rocblas_set_vector_async_i8_assumed_rank,rocblas_set_vector_async_r4_assumed_rank,&
+      rocblas_set_vector_async_r8_assumed_rank,rocblas_set_vector_async_c4_assumed_rank,&
       rocblas_set_vector_async_c8_assumed_rank
 #else
     module procedure rocblas_set_vector_async_l_rank_0,rocblas_set_vector_async_l_full_rank,&
@@ -37744,8 +37745,9 @@ module hipfort_rocblas
 
 #ifdef USE_FPOINTER_INTERFACES
 #ifdef USE_ASSUMED_RANK_INTERFACES
-    module procedure rocblas_get_vector_async_l_assumed_rank,rocblas_get_vector_async_i4_assumed_rank,rocblas_get_vector_async_i8_assumed_rank,&
-      rocblas_get_vector_async_r4_assumed_rank,rocblas_get_vector_async_r8_assumed_rank,rocblas_get_vector_async_c4_assumed_rank,&
+    module procedure rocblas_get_vector_async_l_assumed_rank,rocblas_get_vector_async_i4_assumed_rank,&
+      rocblas_get_vector_async_i8_assumed_rank,rocblas_get_vector_async_r4_assumed_rank,&
+      rocblas_get_vector_async_r8_assumed_rank,rocblas_get_vector_async_c4_assumed_rank,&
       rocblas_get_vector_async_c8_assumed_rank
 #else
     module procedure rocblas_get_vector_async_l_rank_0,rocblas_get_vector_async_l_full_rank,&
@@ -37777,8 +37779,9 @@ module hipfort_rocblas
 
 #ifdef USE_FPOINTER_INTERFACES
 #ifdef USE_ASSUMED_RANK_INTERFACES
-    module procedure rocblas_set_matrix_async_l_assumed_rank,rocblas_set_matrix_async_i4_assumed_rank,rocblas_set_matrix_async_i8_assumed_rank,&
-      rocblas_set_matrix_async_r4_assumed_rank,rocblas_set_matrix_async_r8_assumed_rank,rocblas_set_matrix_async_c4_assumed_rank,&
+    module procedure rocblas_set_matrix_async_l_assumed_rank,rocblas_set_matrix_async_i4_assumed_rank,&
+      rocblas_set_matrix_async_i8_assumed_rank,rocblas_set_matrix_async_r4_assumed_rank,&
+      rocblas_set_matrix_async_r8_assumed_rank,rocblas_set_matrix_async_c4_assumed_rank,&
       rocblas_set_matrix_async_c8_assumed_rank
 #else
     module procedure rocblas_set_matrix_async_l_full_rank,rocblas_set_matrix_async_l_rank_0,rocblas_set_matrix_async_l_rank_1,&
@@ -37810,8 +37813,9 @@ module hipfort_rocblas
 
 #ifdef USE_FPOINTER_INTERFACES
 #ifdef USE_ASSUMED_RANK_INTERFACES
-    module procedure rocblas_get_matrix_async_l_assumed_rank,rocblas_get_matrix_async_i4_assumed_rank,rocblas_get_matrix_async_i8_assumed_rank,&
-      rocblas_get_matrix_async_r4_assumed_rank,rocblas_get_matrix_async_r8_assumed_rank,rocblas_get_matrix_async_c4_assumed_rank,&
+    module procedure rocblas_get_matrix_async_l_assumed_rank,rocblas_get_matrix_async_i4_assumed_rank,&
+      rocblas_get_matrix_async_i8_assumed_rank,rocblas_get_matrix_async_r4_assumed_rank,&
+      rocblas_get_matrix_async_r8_assumed_rank,rocblas_get_matrix_async_c4_assumed_rank,&
       rocblas_get_matrix_async_c8_assumed_rank
 #else
     module procedure rocblas_get_matrix_async_l_full_rank,rocblas_get_matrix_async_l_rank_0,rocblas_get_matrix_async_l_rank_1,&


### PR DESCRIPTION
## Problem

A build with gfortran and `-Werror=line-truncation` fails on the async BLAS families:

```
hipfort_hipblas.F90:41736:132:
41736 |     module procedure hipblasSetVectorAsync_l_assumed_rank,hipblasSetVectorAsync_i4_assumed_rank,hipblasSetVectorAsync_i8_assumed_rank,&
      |                                                                                                                                    1
Error: Line truncated at (1) [-Werror=line-truncation]
...
Error: Procedure 'hipblasgetmatrixasync_i8_assumed_ran' in generic interface 'hipblasgetmatrixasync' at (1) is neither function nor subroutine
```

The `USE_ASSUMED_RANK_INTERFACES` `module procedure` lists for the 8 async families (hipblas/rocblas Set/Get Vector/Matrix Async) were emitted at **3 names per line**. The `_assumed_rank` suffix pushes the first line past gfortran's 132-column free-form limit (135 cols for hipblas, **144** for rocblas snake_case names). `-Werror=line-truncation` then chops the trailing `&` and the suffix (`_assumed_rank` → `_assumed_ran`), which cascades into the "neither function nor subroutine" errors on the generics.

The non-assumed-rank branch right below already wraps at 2 names/line and was unaffected.

## Fix

Rewrap the 8 affected `module procedure` lists at **2 names/line**. All lines are now ≤ 131 columns. No API change, all specifics preserved.

Generator side fixed accordingly (`blas_generics.jl`: `emit_blas_proc_list(..., 2)`), so a regen reproduces this output byte-for-byte.