### PR TITLE
Build and run the test suite on NVIDIA

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -144,8 +144,20 @@ set(HIPFORT_ARCH "nvptx")
     # Install Target hipfort-nvptx
     rocm_install_targets(
         TARGETS ${HIPFORT_LIB}
+        EXPORT hipfort-nvptx-targets
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
         INCLUDE
            ${CMAKE_Fortran_MODULE_DIRECTORY}
+    )
+
+    rocm_install(
+      EXPORT hipfort-nvptx-targets
+      FILE hipfort-nvptx-targets.cmake
+      NAMESPACE hipfort::
+      DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/hipfort
     )
    
     # Install include files marking as devel component
@@ -163,6 +175,10 @@ rocm_install(
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/hipfort
 )
 
+if(NOT DEFINED HIPFORT_BASE_LIB)
+  set(HIPFORT_BASE_LIB hipfort-amdgcn)
+endif()
+
 macro(hipfort_add_component name imported_target)
   add_library(hipfort-${name} INTERFACE)
   add_library(hipfort::${name} ALIAS hipfort-${name})
@@ -170,10 +186,10 @@ macro(hipfort_add_component name imported_target)
     PROPERTIES
       EXPORT_NAME ${name}
   )
-  target_link_libraries(hipfort-${name} INTERFACE hipfort-amdgcn ${imported_target})
+  target_link_libraries(hipfort-${name} INTERFACE ${HIPFORT_BASE_LIB} ${imported_target})
   # The archive is shared by every component, so CMake orders it after the ROCm
   # .so files and --as-needed drops them. This dependency puts the archive first.
-  target_link_libraries(hipfort-amdgcn INTERFACE "$<BUILD_INTERFACE:${imported_target}>")
+  target_link_libraries(${HIPFORT_BASE_LIB} INTERFACE "$<BUILD_INTERFACE:${imported_target}>")
   rocm_install(
     TARGETS
       hipfort-${name}
@@ -192,6 +208,7 @@ macro(hipfort_add_component name imported_target)
 endmacro()
 
 find_package(hip PATHS ${ROCM_PATH} /opt/rocm)
+find_package(CUDAToolkit QUIET)
 if(HIP_PLATFORM STREQUAL "amd")
   if(hip_FOUND)
     hipfort_add_component(hip hip::host)
@@ -326,6 +343,20 @@ if(HIP_PLATFORM STREQUAL "amd")
       DESTINATION lib/cmake/hipfort
     )
   endif()
+elseif(CUDAToolkit_FOUND)
+  # Only the hip* components exist here; roc* and the FFTW3 API have no CUDA counterpart.
+  set(HIPFORT_BASE_LIB hipfort-nvptx)
+  foreach(pair "hip:cudart" "hipblas:cublas" "hipfft:cufft"
+               "hiprand:curand" "hipsolver:cusolver" "hipsparse:cusparse")
+    string(REPLACE ":" ";" pair "${pair}")
+    list(GET pair 0 _comp)
+    list(GET pair 1 _cudalib)
+    if(TARGET CUDA::${_cudalib})
+      hipfort_add_component(${_comp} CUDA::${_cudalib})
+    else()
+      message(STATUS "Skipping hipfort::${_comp} target export (no CUDA::${_cudalib})")
+    endif()
+  endforeach()
 endif()
 
 # ---------------------------------------------------------------------------

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -175,9 +175,7 @@ rocm_install(
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/hipfort
 )
 
-if(NOT DEFINED HIPFORT_BASE_LIB)
-  set(HIPFORT_BASE_LIB hipfort-amdgcn)
-endif()
+set(HIPFORT_BASE_LIB hipfort-amdgcn)
 
 macro(hipfort_add_component name imported_target)
   add_library(hipfort-${name} INTERFACE)

--- a/lib/hipfort/hipfort_hiprand_enums.F90
+++ b/lib/hipfort/hipfort_hiprand_enums.F90
@@ -49,17 +49,61 @@ module hipfort_hiprand_enums
   ! hiprandRngType
   enum, bind(c)
     enumerator :: HIPRAND_RNG_TEST = 0
+#ifdef USE_CUDA_NAMES
+    enumerator :: HIPRAND_RNG_PSEUDO_DEFAULT = 100
+#else
     enumerator :: HIPRAND_RNG_PSEUDO_DEFAULT = 400
+#endif
+#ifdef USE_CUDA_NAMES
+    enumerator :: HIPRAND_RNG_PSEUDO_XORWOW = 101
+#else
     enumerator :: HIPRAND_RNG_PSEUDO_XORWOW = 401
+#endif
+#ifdef USE_CUDA_NAMES
+    enumerator :: HIPRAND_RNG_PSEUDO_MRG32K3A = 121
+#else
     enumerator :: HIPRAND_RNG_PSEUDO_MRG32K3A = 402
+#endif
+#ifdef USE_CUDA_NAMES
+    enumerator :: HIPRAND_RNG_PSEUDO_MTGP32 = 141
+#else
     enumerator :: HIPRAND_RNG_PSEUDO_MTGP32 = 403
+#endif
+#ifdef USE_CUDA_NAMES
+    enumerator :: HIPRAND_RNG_PSEUDO_MT19937 = 142
+#else
     enumerator :: HIPRAND_RNG_PSEUDO_MT19937 = 404
+#endif
+#ifdef USE_CUDA_NAMES
+    enumerator :: HIPRAND_RNG_PSEUDO_PHILOX4_32_10 = 161
+#else
     enumerator :: HIPRAND_RNG_PSEUDO_PHILOX4_32_10 = 405
+#endif
+#ifdef USE_CUDA_NAMES
+    enumerator :: HIPRAND_RNG_QUASI_DEFAULT = 200
+#else
     enumerator :: HIPRAND_RNG_QUASI_DEFAULT = 500
+#endif
+#ifdef USE_CUDA_NAMES
+    enumerator :: HIPRAND_RNG_QUASI_SOBOL32 = 201
+#else
     enumerator :: HIPRAND_RNG_QUASI_SOBOL32 = 501
+#endif
+#ifdef USE_CUDA_NAMES
+    enumerator :: HIPRAND_RNG_QUASI_SCRAMBLED_SOBOL32 = 202
+#else
     enumerator :: HIPRAND_RNG_QUASI_SCRAMBLED_SOBOL32 = 502
+#endif
+#ifdef USE_CUDA_NAMES
+    enumerator :: HIPRAND_RNG_QUASI_SOBOL64 = 203
+#else
     enumerator :: HIPRAND_RNG_QUASI_SOBOL64 = 503
+#endif
+#ifdef USE_CUDA_NAMES
+    enumerator :: HIPRAND_RNG_QUASI_SCRAMBLED_SOBOL64 = 204
+#else
     enumerator :: HIPRAND_RNG_QUASI_SCRAMBLED_SOBOL64 = 504
+#endif
   end enum
 
   ! hiprandOrdering

--- a/test/f2003/hipblas/cgemm_batched.f03
+++ b/test/f2003/hipblas/cgemm_batched.f03
@@ -28,7 +28,8 @@ program hip_cgemm_batched
   type(c_ptr) :: handle = c_null_ptr
 
   double precision :: error
-  double precision, parameter :: error_max = 10*epsilon(error)
+  ! epsilon of the data kind, not the accumulator: these results are complex(kind=4).
+  double precision, parameter :: error_max = 10*epsilon(real(1.0,kind=4))
 
   write(*,"(a)",advance="no") "-- Running test 'CGEMM_BATCHED' (Fortran 2003 interfaces) - "
 

--- a/test/f2003/hipblas/cgemm_strided_batched.f03
+++ b/test/f2003/hipblas/cgemm_strided_batched.f03
@@ -24,7 +24,8 @@ program hip_cgemm_strided_batched
   type(c_ptr) :: handle = c_null_ptr
 
   double precision :: error
-  double precision, parameter :: error_max = 10*epsilon(error)
+  ! epsilon of the data kind, not the accumulator: these results are complex(kind=4).
+  double precision, parameter :: error_max = 10*epsilon(real(1.0,kind=4))
 
   write(*,"(a)",advance="no") "-- Running test 'CGEMM_STRIDED_BATCHED' (Fortran 2003 interfaces) - "
 

--- a/test/f2008/hipblas/cgemm_batched.f08
+++ b/test/f2008/hipblas/cgemm_batched.f08
@@ -34,7 +34,8 @@ program hip_cgemm_batched
   type(c_ptr) :: handle = c_null_ptr
 
   double precision :: error
-  double precision, parameter :: error_max = 10*epsilon(error)
+  ! epsilon of the data kind, not the accumulator: these results are complex(kind=4).
+  double precision, parameter :: error_max = 10*epsilon(real(1.0,kind=4))
 
   write(*,"(a)",advance="no") "-- Running test 'CGEMM_BATCHED' (Fortran 2008 interfaces) - "
 

--- a/test/f2008/hipblas/cgemm_strided_batched.f08
+++ b/test/f2008/hipblas/cgemm_strided_batched.f08
@@ -22,7 +22,8 @@ program hip_cgemm_strided_batched
   type(c_ptr) :: handle = c_null_ptr
 
   double precision :: error
-  double precision, parameter :: error_max = 10*epsilon(error)
+  ! epsilon of the data kind, not the accumulator: these results are complex(kind=4).
+  double precision, parameter :: error_max = 10*epsilon(real(1.0,kind=4))
 
   write(*,"(a)",advance="no") "-- Running test 'CGEMM_STRIDED_BATCHED' (Fortran 2008 interfaces) - "
 


### PR DESCRIPTION
## Motivation

hipfort's bindings can target CUDA instead of ROCm, but no test was ever built for it. #486 cleaned up each backend's library and added a symbol check. This adds the missing piece, so the tests actually build and run against CUDA.

## Technical Details

### `lib/CMakeLists.txt`

- Tell the tests where NVIDIA's libraries are. The AMD side already said "hipblas means rocBLAS", but nobody had written the NVIDIA half, so no tests were built at all. Each library is checked on its own, so a machine with cuBLAS but no cuFFT gets one set of tests and skips the other.
- Let the labels point at the NVIDIA library instead of the AMD one. This was hardcoded.
- Register the NVIDIA library for install. It was installed but not registered, which was fine until something referred to it. Without this, configure now fails with 6 errors.
- Detect CUDA earlier, so the above can use the result.

#### `lib/hipfort/hipfort_hiprand_enums.F90`

Random generators are picked by number, and AMD and NVIDIA use different numbers for the same one. We were sending AMD's numbers to NVIDIA, so every random test failed. 11 numbers differ. Adds both sets, picked at build time.

#### `test/{f2003,f2008}/hipblas/cgemm_{batched,strided_batched}`

One line each. The test compared single precision results against a double precision limit, which is tighter than single precision can ever reach. Also a bug on AMD, passing there by luck.

Builds on #486, no overlap.

## Test Plan

- Build with no CUDA installed, confirm nothing changes for AMD users.
- Build against CUDA and run the full suite on an NVIDIA GPU.
- Run the shared library check from #486.

## Test Result

NVIDIA RTX PRO 4000 Blackwell, CUDA 13.1, gfortran 13.

| Metric | Count |
|---|---|
| Tests built | 186 |
| Passing | 178 |

By library: hipblas 75, hipsparse 52, hipfft 24, hiprand 16, hip 11. hiprand went from 0 to 16 after the number fix.

`hipfort_shared_link_nvptx` from #486 passes. Its AMD counterpart correctly skips itself on a machine without ROCm.

With no CUDA installed, configure and build both succeed and no CUDA tests are registered.

Remaining failures, none caused by this PR:

- 99 hipsolver, hipsparse and graph tests use functions CUDA removed, or interfaces whose arguments differ between the two vendors. To be handled by dropping those bindings in the generator.
- 4 double precision complex tests crash inside cuBLAS while their single precision versions pass. Not diagnosed, worth a separate look.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.