### PR TITLE
Build and run the OpenMP offload tests as part of the main test suite

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -822,9 +822,9 @@ if(BUILD_TESTING)
       -DFORTRAN_COMPILER=${CMAKE_Fortran_COMPILER}
       -P ${CMAKE_CURRENT_SOURCE_DIR}/find_package/run_find_package_test.cmake)
 
-  # test/openmp needs offload (LLVM Flang), rocSOLVER, and a host LAPACK for the
-  # reference, so every other toolchain skips with a reason instead of failing.
-  if(TARGET hipfort::rocsolver AND CMAKE_Fortran_COMPILER_ID MATCHES "LLVMFlang")
+  # test/openmp needs offload (LLVM Flang) and a host LAPACK for the reference,
+  # so every other toolchain skips with a reason instead of failing.
+  if(CMAKE_Fortran_COMPILER_ID MATCHES "LLVMFlang")
     # "native" stays xnack-agnostic; an arch pinned to one HSA_XNACK mode will
     # not load in the other.
     set(HIPFORT_OFFLOAD_ARCH "native" CACHE STRING
@@ -851,16 +851,29 @@ end program" HIPFORT_HAVE_OMP_OFFLOAD)
     elseif(NOT LAPACK_FOUND)
       message(STATUS "Skipping OpenMP offload tests: no host LAPACK for the reference result")
     else()
-      add_executable(hipfort_test_openmp_rocsolver_zhegvdx
-        openmp/rocsolver/test_rocsolver_zhegvdx.f90)
-      target_compile_options(hipfort_test_openmp_rocsolver_zhegvdx PRIVATE ${_offload_flags})
-      target_link_options(hipfort_test_openmp_rocsolver_zhegvdx PRIVATE ${_offload_flags})
-      target_link_libraries(hipfort_test_openmp_rocsolver_zhegvdx
-        PRIVATE hipfort::rocsolver ${LAPACK_LIBRARIES})
-      set_target_properties(hipfort_test_openmp_rocsolver_zhegvdx
-        PROPERTIES LINKER_LANGUAGE Fortran)
-      add_test(NAME hipfort_test_openmp_rocsolver_zhegvdx
-        COMMAND hipfort_test_openmp_rocsolver_zhegvdx)
+      # openmp/<library>/test_<name>.f90 builds against hipfort::<library>, so a
+      # new file is picked up on the next configure with no edit here.
+      file(GLOB _omp_sources CONFIGURE_DEPENDS
+        "${CMAKE_CURRENT_SOURCE_DIR}/openmp/*/test_*.f90")
+      foreach(_src IN LISTS _omp_sources)
+        get_filename_component(_lib "${_src}" DIRECTORY)
+        get_filename_component(_lib "${_lib}" NAME)
+        get_filename_component(_name "${_src}" NAME_WE)
+        string(REGEX REPLACE "^test_" "" _name "${_name}")
+        if(NOT TARGET hipfort::${_lib})
+          message(STATUS "Skipping OpenMP offload test ${_name}: no hipfort::${_lib}")
+          continue()
+        endif()
+        add_executable(hipfort_test_openmp_${_name} "${_src}")
+        target_compile_options(hipfort_test_openmp_${_name} PRIVATE ${_offload_flags})
+        target_link_options(hipfort_test_openmp_${_name} PRIVATE ${_offload_flags})
+        target_link_libraries(hipfort_test_openmp_${_name}
+          PRIVATE hipfort::${_lib} ${LAPACK_LIBRARIES})
+        set_target_properties(hipfort_test_openmp_${_name}
+          PROPERTIES LINKER_LANGUAGE Fortran)
+        add_test(NAME hipfort_test_openmp_${_name}
+          COMMAND hipfort_test_openmp_${_name})
+      endforeach()
     endif()
   endif()
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -821,4 +821,46 @@ if(BUILD_TESTING)
       -DWORK_DIR=${CMAKE_CURRENT_BINARY_DIR}/find_package_work
       -DFORTRAN_COMPILER=${CMAKE_Fortran_COMPILER}
       -P ${CMAKE_CURRENT_SOURCE_DIR}/find_package/run_find_package_test.cmake)
+
+  # test/openmp needs offload (LLVM Flang), rocSOLVER, and a host LAPACK for the
+  # reference, so every other toolchain skips with a reason instead of failing.
+  if(TARGET hipfort::rocsolver AND CMAKE_Fortran_COMPILER_ID MATCHES "LLVMFlang")
+    # "native" stays xnack-agnostic; an arch pinned to one HSA_XNACK mode will
+    # not load in the other.
+    set(HIPFORT_OFFLOAD_ARCH "native" CACHE STRING
+      "AMD GPU architecture for the OpenMP offload tests (gfxNNN, or native)")
+    set(_offload_flags -fopenmp -fopenmp-version=51 -fopenmp-offload-mandatory
+                       --offload-arch=${HIPFORT_OFFLOAD_ARCH})
+
+    # Also the GPU-less guard: --offload-arch=native cannot compile without a GPU.
+    include(CheckFortranSourceCompiles)
+    set(CMAKE_REQUIRED_FLAGS "-fopenmp --offload-arch=${HIPFORT_OFFLOAD_ARCH}")
+    check_fortran_source_compiles("
+program p
+integer :: i(1)
+!$omp target map(tofrom: i)
+i(1) = 1
+!$omp end target
+end program" HIPFORT_HAVE_OMP_OFFLOAD)
+    unset(CMAKE_REQUIRED_FLAGS)
+
+    find_package(LAPACK QUIET)   # zhegvd, the reference for rocsolver_zhegvdx
+
+    if(NOT HIPFORT_HAVE_OMP_OFFLOAD)
+      message(STATUS "Skipping OpenMP offload tests: ${CMAKE_Fortran_COMPILER} cannot offload to ${HIPFORT_OFFLOAD_ARCH}")
+    elseif(NOT LAPACK_FOUND)
+      message(STATUS "Skipping OpenMP offload tests: no host LAPACK for the reference result")
+    else()
+      add_executable(hipfort_test_openmp_rocsolver_zhegvdx
+        openmp/rocsolver/test_rocsolver_zhegvdx.f90)
+      target_compile_options(hipfort_test_openmp_rocsolver_zhegvdx PRIVATE ${_offload_flags})
+      target_link_options(hipfort_test_openmp_rocsolver_zhegvdx PRIVATE ${_offload_flags})
+      target_link_libraries(hipfort_test_openmp_rocsolver_zhegvdx
+        PRIVATE hipfort::rocsolver ${LAPACK_LIBRARIES})
+      set_target_properties(hipfort_test_openmp_rocsolver_zhegvdx
+        PROPERTIES LINKER_LANGUAGE Fortran)
+      add_test(NAME hipfort_test_openmp_rocsolver_zhegvdx
+        COMMAND hipfort_test_openmp_rocsolver_zhegvdx)
+    endif()
+  endif()
 endif()

--- a/test/openmp/rocsolver/test_rocsolver_zhegvdx.f90
+++ b/test/openmp/rocsolver/test_rocsolver_zhegvdx.f90
@@ -11,9 +11,8 @@ program test_rocsolver_zhegvdx
 
         implicit none
 
-        complex(r64), allocatable :: A_lapack(:,:), B_lapack(:,:)
-        complex(r64), pointer, contiguous :: A_rocsolver(:,:), B_rocsolver(:,:)
-        type(c_ptr) :: A_rocsolver_cptr, B_rocsolver_cptr
+        complex(r64), allocatable, target :: A_lapack(:,:), B_lapack(:,:)
+        complex(r64), allocatable, target :: A_rocsolver(:,:), B_rocsolver(:,:)
         type(c_ptr)               :: handle = c_null_ptr
         integer(i32), parameter   :: n = 3
         real(r64), parameter      :: abstol = 1.0e-8_r64
@@ -25,7 +24,7 @@ program test_rocsolver_zhegvdx
         complex(r64), allocatable :: work(:)
         real(r64), allocatable    :: rwork(:)
         integer(r64), allocatable :: iwork(:), ifail(:)
-        integer(i32) :: info, m, cerr
+        integer(i32) :: info, m, cerr, i, j
         real(r64), parameter      :: rtol = 1.0e-6_r64
 
         complex(r64), allocatable :: Z(:,:), Zref(:,:)
@@ -33,7 +32,7 @@ program test_rocsolver_zhegvdx
 
         ! For the rocsolver
         integer(i32) :: device_id
-        type(c_ptr)  :: dA, dB, dW, dZ
+        type(c_ptr)  :: dA, dB, dW, dZ, dInfo
 
         ! Get device id
         device_id = omp_get_default_device()
@@ -55,18 +54,21 @@ program test_rocsolver_zhegvdx
                 (2.3758726221976016, -0.4747827863735063), (3.5288683548091355, 1.5600560529683896), (13.826224543945107, 0.0) &
                 ], shape=[3,3], order=[2,1])
 
-        A_rocsolver_cptr = omp_target_alloc(2 * size(A_lapack) * c_sizeof(1_r64), device_id)
-        B_rocsolver_cptr = omp_target_alloc(2 * size(B_lapack) * c_sizeof(1_r64), device_id)
+        ! rocsolver overwrites its inputs, so hand it device-resident copies.
+        ! Filling them in a target region also proves device code really runs.
+        allocate(A_rocsolver(n,n), B_rocsolver(n,n))
+        !$omp target enter data map(to: A_lapack, B_lapack) map(alloc: A_rocsolver, B_rocsolver)
 
-        call c_f_pointer(A_rocsolver_cptr, A_rocsolver, [n,n])
-        call c_f_pointer(B_rocsolver_cptr, B_rocsolver, [n,n])
-        
-        !$omp target map(to: A_lapack, B_lapack) has_device_addr(A_rocsolver, B_rocsolver) 
-        A_rocsolver(:,:) = A_lapack(:,:)
-        B_rocsolver(:,:) = B_lapack(:,:)
-        !$omp end target
-        
-        nullify(A_rocsolver,B_rocsolver)
+        !$omp target teams distribute parallel do collapse(2) private(i, j)
+        do j = 1, n
+            do i = 1, n
+                A_rocsolver(i,j) = A_lapack(i,j)
+                B_rocsolver(i,j) = B_lapack(i,j)
+            end do
+        end do
+        !$omp end target teams distribute parallel do
+
+        !$omp target exit data map(delete: A_lapack, B_lapack)
 
         ! First create the LAPACK reference
         lwork  = 2*n+n**2
@@ -96,11 +98,15 @@ program test_rocsolver_zhegvdx
         if (cerr /= rocblas_status_success) error stop "rocblas_create_handle failed"
 
         !$omp target data map(from: W, Z, m, info) 
-        !$omp target data use_device_addr(m, info)
+        !$omp target data use_device_addr(m)
+        dA     = get_device_pointer(A_rocsolver, device_id)
+        dB     = get_device_pointer(B_rocsolver, device_id)
         dW     = get_device_pointer(W, device_id)
         dZ     = get_device_pointer(Z, device_id)
+        ! rocsolver_zhegvdx takes info as a device pointer, not a Fortran integer
+        dInfo  = get_device_pointer(info, device_id)
         cerr = rocsolver_zhegvdx(handle, rocblas_eform_ax, rocblas_evect_original, rocblas_erange_index, rocblas_fill_upper, &
-                                 n, A_rocsolver_cptr, n, B_rocsolver_cptr, n, vl, vu, il, iu, m, dW, dZ, n, info)
+                                 n, dA, n, dB, n, vl, vu, il, iu, m, dW, dZ, n, dInfo)
         if (cerr /= rocblas_status_success) error stop "rocsolver_zhegvdx failed"
 
         ! NOTE: it will be better to get the stream of the rocblas handler and sync that instead of the whole device
@@ -123,8 +129,7 @@ program test_rocsolver_zhegvdx
         cerr = rocblas_destroy_handle(handle)
         if (cerr /= rocblas_status_success) error stop "rocblas_destroy_handle failed"
 
-        call omp_target_free(A_rocsolver_cptr, device_id)
-        call omp_target_free(B_rocsolver_cptr, device_id)
+        !$omp target exit data map(delete: A_rocsolver, B_rocsolver)
 
         deallocate(A_lapack, B_lapack)
 
@@ -153,7 +158,9 @@ contains
           type(*), target, intent(in) :: host_data(..)
           integer, intent(in) :: device_id
           get_device_pointer = omp_get_mapped_ptr(c_loc(host_data), device_id)
-          if (.not. c_associated(get_device_pointer)) error stop "Error(get_device_pointer) : returned null pointer"
+          ! Under unified shared memory nothing is mapped, so there is no device
+          ! pointer to look up: the host address is already device-accessible.
+          if (.not. c_associated(get_device_pointer)) get_device_pointer = c_loc(host_data)
         end function get_device_pointer
       
 end program test_rocsolver_zhegvdx


### PR DESCRIPTION
## Motivation

The tests in `test/openmp` had their own standalone CMake project, so the main suite never built them and CI never ran them. Nothing checked that hipfort still works when called from an OpenMP target-offload region.

## Technical Details

- Build `test/openmp/rocsolver/test_rocsolver_zhegvdx.f90` from `test/CMakeLists.txt` and register it as the ctest test `hipfort_test_openmp_rocsolver_zhegvdx`. It links the in-tree `hipfort::rocsolver` instead of recompiling the hipfort sources.
- Guard the block on LLVM Flang, rocSOLVER, a host LAPACK for the reference result, and a compile probe for offload. Any toolchain that misses one skips with a message rather than failing to configure. The probe also covers a host with no GPU.
- Add `HIPFORT_OFFLOAD_ARCH`, defaulting to `native`. The target id is left xnack-agnostic because an arch pinned to one `HSA_XNACK` mode will not load in the other.
- Discover the tests by globbing `openmp/library/test_name.f90` and link `hipfort::library` from the directory name, so a new test needs no CMake edit.

Fix three defects in the test that only appeared once it was compiled against the in-tree library:

- `has_device_addr` is unimplemented in the ROCm flang. Replaced with mapped allocatables and `target enter data`.
- An array assignment inside a target region requires the `flang_rt.hostdevice` device runtime. Replaced with an explicit loop nest, which also confirms device code runs.
- `info` was passed to `rocsolver_zhegvdx` as a Fortran integer. It takes a device pointer.

The tests need LLVM Flang. gfortran in the CI image cannot offload to AMD GPUs, since `gcc-13-offload-amdgcn` is not installed, and GCC 13 accepts only up to gfx90a, so gfx942 and gfx950 are out of reach regardless. The gfortran stages skip with a message.

No CI configuration changes. The existing ctest run picks the test up.

## Test Plan

- Configure with `amdflang`, build the test, and run it on a GPU.
- Configure with `gfortran` and confirm the test is not registered and configure still succeeds.
- Configure with a bogus `HIPFORT_OFFLOAD_ARCH` and confirm the skip path reports a reason.
- Confirm the math-ci image provides amdflang and a LAPACK that `find_package(LAPACK)` resolves.

## Test Result

Run in the `compute-rocm-rel-7.2` container, ROCm 7.2.4, on gfx942.

- amdflang: configure, build, and run all succeed. `100% tests passed, 0 tests failed out of 2`, covering the new offload test and the existing line-length check.
- gfortran: configure succeeds and the offload test is absent, as intended.
- `HIPFORT_OFFLOAD_ARCH=gfx000`: `Skipping OpenMP offload tests: amdflang cannot offload to gfx000`, configure still succeeds.
- math-ci image `mci-base/ubu24-stg1`: provides `/opt/rocm/bin/amdflang`, `liblapack3`, and `libopenblas-dev`, and `find_package(LAPACK)` returns `LAPACK_FOUND=TRUE`. The test will run in the amdflang stages.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.