### PR TITLE
Add HIPFORT_BUILD_NVPTX to skip the CUDA backend archive

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -74,6 +74,9 @@ endif()
 # Requires a Fortran 2018 compiler.
 option(HIPFORT_ASSUMED_RANK "Use the F2018 assumed-rank array interfaces" OFF)
 
+# The CUDA backend is built even on ROCm-only builds; turn it off if unused.
+option(HIPFORT_BUILD_NVPTX "Build the CUDA (nvptx) backend archive" ON)
+
 # Guard the opt-in: assumed-rank is nested in the F2008 interfaces and additionally
 # needs a Fortran 2018 compiler (c_loc() of a dimension(..) argument; see the
 # CMAKE_Fortran_COMPILER_SUPPORTS_F18 probe in the top-level CMakeLists.txt). If it
@@ -126,6 +129,7 @@ set(HIPFORT_ARCH "amdgcn")
            ${CMAKE_Fortran_MODULE_DIRECTORY}
     )
 
+if(HIPFORT_BUILD_NVPTX)
 set(HIPFORT_ARCH "nvptx")
     # nvptx
     set(HIPFORT_LIB     "hipfort-${HIPFORT_ARCH}")
@@ -159,6 +163,7 @@ set(HIPFORT_ARCH "nvptx")
       NAMESPACE hipfort::
       DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/hipfort
     )
+endif()
    
     # Install include files marking as devel component
     rocm_install(DIRECTORY ${CMAKE_BINARY_DIR}/include/hipfort
@@ -341,7 +346,7 @@ if(HIP_PLATFORM STREQUAL "amd")
       DESTINATION lib/cmake/hipfort
     )
   endif()
-elseif(CUDAToolkit_FOUND)
+elseif(CUDAToolkit_FOUND AND TARGET hipfort-nvptx)
   # Only the hip* components exist here; roc* and the FFTW3 API have no CUDA counterpart.
   set(HIPFORT_BASE_LIB hipfort-nvptx)
   foreach(pair "hip:cudart" "hipblas:cublas" "hipfft:cufft"


### PR DESCRIPTION
## Motivation

`libhipfort-nvptx.a` is built in every hipfort build, including ROCm-only ones that will never target CUDA. This adds an option to skip it.

## Technical Details

`HIPFORT_BUILD_NVPTX` defaults to `ON`, so existing builds are unchanged.

When set to `OFF`, the nvptx archive, its install rules and its `hipfort-nvptx-targets` export are skipped. The CUDA component branch is now `elseif(CUDAToolkit_FOUND AND TARGET hipfort-nvptx)` so a CUDA host does not point `hipfort::*` at an archive that was not built. The `HIPFORT_EXTENDED_TESTS` shared-link check already guarded on `if(TARGET hipfort-nvptx)` and needed no change.

Six lines added, one changed, in `lib/CMakeLists.txt`.

## Test Plan

Configured and built both ways with amdflang on an MI300X (ROCm 7.2.4), and compared the archives produced, the tests registered and the errors reported.

## Test Result

|                      | default | `HIPFORT_BUILD_NVPTX=OFF` |
|----------------------|---------|---------------------------|
| configure            | rc=0    | rc=0                      |
| `libhipfort-amdgcn.a`| built   | built                     |
| `libhipfort-nvptx.a` | built   | not built                 |
| registered tests     | 700     | 700                       |
| undefined symbols    | 20      | 20                        |

Identical error counts, so turning the backend off breaks nothing. The 20 are the pre-existing `rocsolver_?sytrs` link failures on this ROCm version and are unrelated to this change.

Library build time was 19s with the backend on and 16s with it off. The saving is small because the two backends compile in parallel; it halves the Fortran sources compiled, which matters more on a serial or core-limited build.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.