### PR TITLE
Add hipFFT and hipFFTW tutorial pages

### DIFF
--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -21,6 +21,10 @@ subtrees:
         title: Examples
       - file: tutorials/rocfft-examples.rst
         title: rocFFT examples
+      - file: tutorials/hipfft-examples.rst
+        title: hipFFT examples
+      - file: tutorials/hipfftw-examples.rst
+        title: hipFFTW examples
 
   - caption: API reference
     entries:

--- a/docs/tutorials/hipfft-examples.rst
+++ b/docs/tutorials/hipfft-examples.rst
@@ -1,0 +1,163 @@
+.. meta::
+  :description: hipFFT examples written with the hipFORT Fortran interfaces
+  :keywords: hipFORT, ROCm, hipFFT, FFT, Fortran, examples, tutorials
+
+***************
+hipFFT examples
+***************
+
+`hipFFT <https://rocm.docs.amd.com/projects/hipFFT/en/latest/>`_ is a thin
+portability layer over rocFFT on AMD GPUs and cuFFT on NVIDIA GPUs. Its API
+mirrors cuFFT, so the same source builds against either backend. hipFORT
+exposes it through the ``hipfort_hipfft`` module.
+
+Every program on this page is a complete, self-contained example that is built
+and run as part of the hipFORT test suite. The Fortran 2008 sources live in
+``test/f2008/hipfft`` and the equivalent Fortran 2003 sources, which use
+``type(c_ptr)`` device pointers and explicit byte counts instead of Fortran
+array pointers, live in ``test/f2003/hipfft``.
+
+If you want direct access to rocFFT rather than a portable interface, see
+:doc:`rocfft-examples`.
+
+Transform workflow
+==================
+
+A hipFFT transform follows the same sequence as cuFFT:
+
+#. Create a plan with ``hipfftPlan1d``, ``hipfftPlan2d``, ``hipfftPlan3d`` or
+   ``hipfftPlanMany``, passing the transform lengths, the transform type and
+   the batch count.
+#. Run the transform with the ``hipfftExec`` routine matching the plan type:
+   ``hipfftExecZ2Z`` and ``hipfftExecC2C`` for complex-to-complex,
+   ``hipfftExecD2Z`` and ``hipfftExecR2C`` for real-to-complex,
+   ``hipfftExecZ2D`` and ``hipfftExecC2R`` for complex-to-real.
+#. Release the plan with ``hipfftDestroy``.
+
+Keep the following conventions in mind:
+
+* hipFFT transforms are **unnormalized**. A forward transform followed by an
+  inverse transform of length ``N`` returns ``N`` times the original data.
+* The transform type encodes the precision: ``HIPFFT_Z2Z`` and ``HIPFFT_D2Z``
+  are double precision, ``HIPFFT_C2C`` and ``HIPFFT_R2C`` are single.
+* Complex-to-complex transforms take a direction, ``HIPFFT_FORWARD`` or
+  ``HIPFFT_BACKWARD``. Real transforms take their direction from the type.
+* Real forward transforms produce Hermitian-symmetric output, so only
+  ``N/2 + 1`` complex values are stored. Size the complex buffer accordingly.
+* Multi-dimensional plans take lengths in C order, with the **last** dimension
+  contiguous. This is the opposite of rocFFT, which takes the fastest-varying
+  dimension first.
+* Every hipFFT call returns a status code. The examples wrap them in
+  ``hipfftCheck`` from the ``hipfort_check`` module, which aborts on failure.
+
+Building an example
+===================
+
+The examples only need the ``hipfft`` and ``hip`` hipFORT components:
+
+.. code-block:: cmake
+
+   find_package(hipfort REQUIRED COMPONENTS hip hipfft)
+
+   add_executable(my_fft hipfft_c2c_1d_z.f08)
+   target_link_libraries(my_fft PRIVATE hipfort::hipfft hipfort::hip)
+
+See :doc:`../how-to/using-hipfort` for the full set of build options.
+
+Complex-to-complex transform
+============================
+
+The simplest case: an in-place, single-batch, one-dimensional complex-to-complex
+transform in double precision. The program runs a forward transform followed by
+an inverse transform and checks that the result is ``N`` times the input, which
+demonstrates that hipFFT does not normalize.
+
+.. literalinclude:: ../../test/f2008/hipfft/hipfft_c2c_1d_z.f08
+   :language: fortran
+
+Use ``HIPFFT_C2C`` and ``complex(4)`` host data for a single precision
+transform, as in ``test/f2008/hipfft/hipfft_c2c_1d_c.f08``.
+
+Real-to-complex and complex-to-real transforms
+==============================================
+
+Real transforms use ``HIPFFT_D2Z`` and ``HIPFFT_Z2D``. Because the spectrum of
+real data is Hermitian symmetric, the complex buffer holds ``N/2 + 1`` elements.
+
+.. literalinclude:: ../../test/f2008/hipfft/hipfft_r2c_c2r_1d_d.f08
+   :language: fortran
+
+``test/f2008/hipfft/hipfft_r2c_c2r_1d_s.f08`` is the single precision
+equivalent, using ``HIPFFT_R2C`` and ``HIPFFT_C2R``.
+
+Multi-dimensional transforms
+============================
+
+A two-dimensional transform uses ``hipfftPlan2d``. The last dimension is
+contiguous, so a plan created as ``hipfftPlan2d(plan, Nx, Ny, ...)`` expects
+``Ny`` to vary fastest in memory.
+
+.. literalinclude:: ../../test/f2008/hipfft/hipfft_c2c_2d_z.f08
+   :language: fortran
+
+``test/f2008/hipfft/hipfft_c2c_3d_z.f08`` extends the same pattern to three
+dimensions with ``hipfftPlan3d``.
+
+Batched transforms
+==================
+
+To transform many signals with one plan, use ``hipfftPlanMany`` and pass the
+batch count. The ``inembed`` and ``onembed`` arrays describe the memory layout;
+passing null pointers selects the contiguous default.
+
+.. literalinclude:: ../../test/f2008/hipfft/hipfft_c2c_1d_batched_z.f08
+   :language: fortran
+
+Advanced data layout
+====================
+
+``hipfftPlanMany`` also describes strided and interleaved data. The stride is
+the distance between consecutive elements of one transform, and the distance is
+the gap between the start of consecutive transforms. This example batches a
+two-dimensional transform.
+
+.. literalinclude:: ../../test/f2008/hipfft/hipfft_planmany_2d_z2z.f08
+   :language: fortran
+
+Querying the work area size
+===========================
+
+hipFFT needs scratch memory whose size depends on the transform. There are two
+ways to ask about it. ``hipfftEstimate1d`` and friends give a heuristic upper
+bound before a plan exists, which is useful for budgeting. ``hipfftGetSize1d``
+and ``hipfftGetSize`` report the exact requirement of a plan that has already
+been created.
+
+.. literalinclude:: ../../test/f2008/hipfft/hipfft_estimate_getsize_d.f08
+   :language: fortran
+
+Managing the work area
+======================
+
+By default a plan allocates its own work area. Call
+``hipfftSetAutoAllocation`` with ``0`` before building the plan to turn that
+off, then supply your own buffer with ``hipfftSetWorkArea``. This lets several
+plans share one allocation, or lets the application control when the memory is
+reserved. Plans built this way use ``hipfftCreate`` and ``hipfftMakePlanMany``
+rather than ``hipfftPlanMany``, because the work area has to be configured
+between the two calls.
+
+.. literalinclude:: ../../test/f2008/hipfft/hipfft_makeplanmany_z.f08
+   :language: fortran
+
+Running on HIP streams
+======================
+
+By default hipFFT executes on the null stream. Bind a plan to an
+application-owned stream with ``hipfftSetStream`` to overlap independent
+transforms. Each stream has to be synchronized before its results are read
+back. This example runs two plans, each on its own stream, with different
+input harmonics so that a swapped stream would be visible in the output.
+
+.. literalinclude:: ../../test/f2008/hipfft/hipfft_setstream_z.f08
+   :language: fortran

--- a/docs/tutorials/hipfft-examples.rst
+++ b/docs/tutorials/hipfft-examples.rst
@@ -12,7 +12,7 @@ mirrors cuFFT, so the same source builds against either backend. hipFORT
 exposes it through the ``hipfort_hipfft`` module.
 
 Every program on this page is a complete, self-contained example that is built
-and run as part of the hipFORT test suite. The Fortran 2008 sources live in
+and run as part of the hipFORT test suite. The Fortran 2008 tests live in
 ``test/f2008/hipfft`` and the equivalent Fortran 2003 sources, which use
 ``type(c_ptr)`` device pointers and explicit byte counts instead of Fortran
 array pointers, live in ``test/f2003/hipfft``.

--- a/docs/tutorials/hipfftw-examples.rst
+++ b/docs/tutorials/hipfftw-examples.rst
@@ -17,7 +17,7 @@ The one difference that matters: the ``in`` and ``out`` arguments are
 ``hipMalloc`` passes straight through, but host arrays do not work.
 
 Every program on this page is a complete, self-contained example that is built
-and run as part of the hipFORT test suite. The sources live in
+and run as part of the hipFORT test suite. The tests live in
 ``test/f2003/hipfftw``. Unlike the other FFT libraries there is no Fortran 2008
 variant, because the FFTW API is pointer-based throughout and gains nothing
 from Fortran array pointers.

--- a/docs/tutorials/hipfftw-examples.rst
+++ b/docs/tutorials/hipfftw-examples.rst
@@ -1,0 +1,134 @@
+.. meta::
+  :description: hipFFTW examples written with the hipFORT Fortran interfaces
+  :keywords: hipFORT, ROCm, hipFFTW, FFTW, FFT, Fortran, examples, tutorials
+
+****************
+hipFFTW examples
+****************
+
+hipFFTW is the FFTW3-compatible interface shipped with
+`hipFFT <https://rocm.docs.amd.com/projects/hipFFT/en/latest/>`_. The routine
+names, planner flags and calling sequence are those of FFTW3, so existing FFTW
+code moves across with little change. hipFORT exposes it through the
+``hipfort_hipfftw`` module.
+
+The one difference that matters: the ``in`` and ``out`` arguments are
+**device** pointers. FFTW declares them ``void*``, so a pointer from
+``hipMalloc`` passes straight through, but host arrays do not work.
+
+Every program on this page is a complete, self-contained example that is built
+and run as part of the hipFORT test suite. The sources live in
+``test/f2003/hipfftw``. Unlike the other FFT libraries there is no Fortran 2008
+variant, because the FFTW API is pointer-based throughout and gains nothing
+from Fortran array pointers.
+
+For the cuFFT-style interface to the same library, see :doc:`hipfft-examples`.
+
+Transform workflow
+==================
+
+A hipFFTW transform follows the FFTW3 sequence:
+
+#. Allocate device memory with ``hipMalloc``, or host-accessible memory with
+   ``fftw_alloc_real`` and ``fftw_alloc_complex``.
+#. Build a plan with ``fftw_plan_dft_1d``, ``fftw_plan_dft_r2c_1d``,
+   ``fftw_plan_many_dft`` or ``fftw_plan_guru_dft``.
+#. Run it with the matching ``fftw_execute_dft``, ``fftw_execute_dft_r2c`` or
+   ``fftw_execute_dft_c2r``.
+#. Release the plan with ``fftw_destroy_plan``.
+
+Keep the following conventions in mind:
+
+* FFTW transforms are **unnormalized**. A forward transform followed by an
+  inverse transform of length ``N`` returns ``N`` times the original data.
+* Planner flags are the standard FFTW values. ``FFTW_ESTIMATE`` is not emitted
+  by the generated enums module, so declare it yourself as
+  ``integer(c_int), parameter :: FFTW_ESTIMATE = 64``.
+* Real forward transforms produce Hermitian-symmetric output, so only
+  ``N/2 + 1`` complex values are stored.
+* Multi-dimensional transforms use C row-major order, so the last dimension is
+  contiguous.
+* The double precision routines are named ``fftw_*`` and the single precision
+  ones ``fftwf_*``.
+
+Building an example
+===================
+
+The examples only need the ``hipfftw`` and ``hip`` hipFORT components:
+
+.. code-block:: cmake
+
+   find_package(hipfort REQUIRED COMPONENTS hip hipfftw)
+
+   add_executable(my_fft hipfftw_c2c.f03)
+   target_link_libraries(my_fft PRIVATE hipfort::hipfftw hipfort::hip)
+
+See :doc:`../how-to/using-hipfort` for the full set of build options.
+
+Complex-to-complex transform
+============================
+
+A one-dimensional complex-to-complex transform. The plan is built with
+``fftw_plan_dft_1d`` over two device pointers and executed once. The input is
+a sum of two harmonics, so the output has energy in exactly two bins.
+
+.. literalinclude:: ../../test/f2003/hipfftw/hipfftw_c2c.f03
+   :language: fortran
+
+Real-to-complex and complex-to-real transforms
+==============================================
+
+``fftw_plan_dft_r2c_1d`` and ``fftw_plan_dft_c2r_1d`` build the two halves of a
+real round trip. The complex side holds ``N/2 + 1`` elements.
+
+.. literalinclude:: ../../test/f2003/hipfftw/hipfftw_r2c_c2r.f03
+   :language: fortran
+
+Multi-dimensional transforms
+============================
+
+``fftw_plan_dft_2d`` takes the dimensions in C order, so the second argument
+varies fastest in memory.
+
+.. literalinclude:: ../../test/f2003/hipfftw/hipfftw_dft_2d.f03
+   :language: fortran
+
+``test/f2003/hipfftw/hipfftw_dft_3d.f03`` extends the same pattern to three
+dimensions with ``fftw_plan_dft_3d``.
+
+Batched transforms
+==================
+
+The ``_many`` planners transform a batch of signals with one plan. The
+``inembed`` and ``onembed`` arguments describe the memory layout, ``stride``
+is the gap between elements of one transform and ``dist`` the gap between the
+start of consecutive transforms. This example covers the complex-to-complex,
+real-to-complex and complex-to-real cases.
+
+.. literalinclude:: ../../test/f2003/hipfftw/hipfftw_many.f03
+   :language: fortran
+
+The guru interface
+==================
+
+The guru interface describes a transform as arrays of ``fftw_iodim``
+descriptors, one per dimension, each giving a length and its input and output
+strides. It expresses layouts the simpler planners cannot.
+
+Note how the arrays are passed: the dummy arguments are scalar
+``type(fftw_iodim)``, so the example passes the first element of each array and
+the callee receives the base address of the contiguous struct array.
+
+.. literalinclude:: ../../test/f2003/hipfftw/hipfftw_guru.f03
+   :language: fortran
+
+Allocating buffers
+==================
+
+``fftw_alloc_real`` and ``fftw_alloc_complex``, along with the ``fftwf_``
+single precision forms, return correctly aligned host-accessible buffers that
+can be handed straight to a plan. Use ``c_f_pointer`` to get a Fortran array
+view, and release them with ``fftw_free``.
+
+.. literalinclude:: ../../test/f2003/hipfftw/hipfftw_alloc.f03
+   :language: fortran


### PR DESCRIPTION
## Motivation

The tutorials list in #411 asks for example pages covering the FFT libraries. rocFFT already has one. This adds the same for hipFFT and hipFFTW.

## Technical Details

Two new pages following the structure of `tutorials/rocfft-examples.rst`: an intro naming the hipFORT module, a workflow section with the call sequence and conventions, a CMake snippet, then one section per example.

Every example is pulled in with `literalinclude` from the existing test suite rather than pasted, so the pages cannot drift from code that is compiled and run in CI.

- `tutorials/hipfft-examples.rst` covers all 12 tests in `test/f2008/hipfft`: complex-to-complex, real transforms, multi-dimensional, batched, advanced layout, work area sizing, manual work area, and streams.
- `tutorials/hipfftw-examples.rst` covers all 7 tests in `test/f2003/hipfftw`: complex-to-complex, real round trip, multi-dimensional, batched `_many`, the guru interface, and allocation.

Two points called out because they are easy to get wrong: hipFFTW takes device pointers even though the API is FFTW3, and it has no Fortran 2008 variant because the API is pointer-based throughout. The hipFFT page notes that plan lengths are in C order, the opposite of rocFFT.

Both pages are added to `sphinx/_toc.yml.in`.

## Test Plan

Checked that every `literalinclude` path exists and that each referenced test is registered in the suite, then built the pages with Sphinx.

## Test Result

All 14 `literalinclude` paths resolve. The referenced tests account for 24 hipFFT and 7 hipFFTW ctest entries. Every test file in both directories is referenced except `hipfft.f08`, a legacy smoke test superseded by `hipfft_c2c_1d_z.f08`.

Sphinx reports `build succeeded` with no errors or warnings on either page. A missing include path is an error in Sphinx, so this also confirms the paths.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.