### PR TITLE
Fix inexact real literals in rocsolver_dsterf tests

### DIFF
--- a/test/f2003/rocsolver/rocsolver_dsterf.f03
+++ b/test/f2003/rocsolver/rocsolver_dsterf.f03
@@ -15,7 +15,7 @@ program dsterf
   ! Define our input data
   real(c_double), target :: hD(3) = (/ 2, 2, 2 /)
   real(c_double), target :: hE(2) = (/ -1, -1 /)
-  real(c_double), target :: hResult(3) = (/ 0.58578643762690495, 2.0000000000000000, 3.4142135627309505 /)
+  real(c_double), target :: hResult(3) = (/ 0.58578643762690485d0, 2.0d0, 3.41421356237309515d0 /)
   integer(c_int), target :: hInfo = -1
 
   integer(c_int), parameter :: n = 3

--- a/test/f2008/rocsolver/rocsolver_dsterf.f08
+++ b/test/f2008/rocsolver/rocsolver_dsterf.f08
@@ -15,7 +15,7 @@ program dsterf
   ! Define our input data
   real(c_double) :: hD(3) = (/ 2, 2, 2 /)
   real(c_double) :: hE(2) = (/ -1, -1 /)
-  real(c_double) :: hResult(3) = (/ 0.58578643762690495, 2.0000000000000000, 3.4142135627309505 /)
+  real(c_double) :: hResult(3) = (/ 0.58578643762690485d0, 2.0d0, 3.41421356237309515d0 /)
   integer(c_int) :: hInfo = -1
 
   integer(c_int), parameter :: n = 3


### PR DESCRIPTION
## Summary

Fixes the `-Wreal-constant-widening` warnings Alexis reported on the `dsterf`
tests. The `hResult` reference eigenvalues were written as bare default-precision
literals in a `real(c_double)` context:

```fortran
real(c_double) :: hResult(3) = (/ 0.58578643762690495, 2.0000000000000000, 3.4142135627309505 /)
```

gfortran evaluates those constants in single precision and widens to REAL(8),
so the stored values are silently inexact (the compiler warns that
`0.585786...` rounds through `REAL(4)`). Adding `d0` kind suffixes makes the
double-precision expected eigenvalues (`2 ± sqrt(2)`) exact:

```fortran
real(c_double) :: hResult(3) = (/ 0.58578643762690485d0, 2.0d0, 3.41421356237309515d0 /)
```

Applied to both the f2003 and f2008 `dsterf` tests.

## Test plan

- [x] Both `dsterf` tiers compile with **zero** warnings (was `-Wreal-constant-widening` on each)
- [x] Both tests still PASS on gfx90a (MI210), ROCm 7.1.0, gfortran 13.3 (the more precise reference is well within `error_max`)