### PR TITLE
rocRAND: fix real literal kinds in double-precision tests

### DIFF
--- a/test/f2003/rocrand/philox_normal_double.f03
+++ b/test/f2003/rocrand/philox_normal_double.f03
@@ -34,7 +34,7 @@ program rocrand_philox_normal_double_test
     integer(c_size_t), parameter :: N = 65536
     integer(c_size_t), parameter :: Nbytes = N * 8 ! double precision
     integer(c_int64_t), parameter :: seed = 12345_c_int64_t
-    real(c_double), parameter :: mean = 0.0_c_double, stddev = 1.0_c_double, delta = 0.2
+    real(c_double), parameter :: mean = 0.0_c_double, stddev = 1.0_c_double, delta = 0.2_c_double
 
     type(c_ptr) :: gen = c_null_ptr
     type(c_ptr) :: dx = c_null_ptr

--- a/test/f2003/rocrand/philox_uniform_double.f03
+++ b/test/f2003/rocrand/philox_uniform_double.f03
@@ -34,7 +34,7 @@ program rocrand_philox_uniform_double_test
     integer(c_size_t), parameter :: N = 65536
     integer(c_size_t), parameter :: Nbytes = N * 8 ! double precision
     integer(c_int64_t), parameter :: seed = 12345_c_int64_t
-    real(c_double), parameter :: expected_mean = 0.5, delta = 0.1
+    real(c_double), parameter :: expected_mean = 0.5_c_double, delta = 0.1_c_double
 
     type(c_ptr) :: gen = c_null_ptr
     type(c_ptr) :: dx = c_null_ptr

--- a/test/f2003/rocrand/xorwow_normal_double.f03
+++ b/test/f2003/rocrand/xorwow_normal_double.f03
@@ -34,7 +34,7 @@ program rocrand_xorwow_normal_double_test
     integer(c_size_t), parameter :: N = 65536
     integer(c_size_t), parameter :: Nbytes = N * 8 ! double precision
     integer(c_int64_t), parameter :: seed = 12345_c_int64_t
-    real(c_double), parameter :: mean = 0.0_c_double, stddev = 1.0_c_double, delta = 0.2
+    real(c_double), parameter :: mean = 0.0_c_double, stddev = 1.0_c_double, delta = 0.2_c_double
 
     type(c_ptr) :: gen = c_null_ptr
     type(c_ptr) :: dx = c_null_ptr

--- a/test/f2003/rocrand/xorwow_uniform_double.f03
+++ b/test/f2003/rocrand/xorwow_uniform_double.f03
@@ -34,7 +34,7 @@ program rocrand_xorwow_uniform_double_test
     integer(c_size_t), parameter :: N = 65536
     integer(c_size_t), parameter :: Nbytes = N * 8 ! double precision
     integer(c_int64_t), parameter :: seed = 12345_c_int64_t
-    real(c_double), parameter :: expected_mean = 0.5, delta = 0.1
+    real(c_double), parameter :: expected_mean = 0.5_c_double, delta = 0.1_c_double
 
     type(c_ptr) :: gen = c_null_ptr
     type(c_ptr) :: dx = c_null_ptr

--- a/test/f2008/rocrand/philox_normal_double.f08
+++ b/test/f2008/rocrand/philox_normal_double.f08
@@ -33,7 +33,7 @@ program rocrand_philox_normal_double_test
 
     integer(c_size_t), parameter :: N = 65536
     integer(c_int64_t), parameter :: seed = 12345_c_int64_t
-    real(c_double), parameter :: mean = 0.0_c_double, stddev = 1.0_c_double, delta = 0.2
+    real(c_double), parameter :: mean = 0.0_c_double, stddev = 1.0_c_double, delta = 0.2_c_double
 
     type(c_ptr) :: gen = c_null_ptr
 

--- a/test/f2008/rocrand/philox_uniform_double.f08
+++ b/test/f2008/rocrand/philox_uniform_double.f08
@@ -33,7 +33,7 @@ program rocrand_philox_uniform_double_test
 
     integer(c_size_t), parameter :: N = 65536
     integer(c_int64_t), parameter :: seed = 12345_c_int64_t
-    real(c_double), parameter :: expected_mean = 0.5, delta = 0.1
+    real(c_double), parameter :: expected_mean = 0.5_c_double, delta = 0.1_c_double
 
     type(c_ptr) :: gen = c_null_ptr
 

--- a/test/f2008/rocrand/xorwow_normal_double.f08
+++ b/test/f2008/rocrand/xorwow_normal_double.f08
@@ -33,7 +33,7 @@ program rocrand_xorwow_normal_double_test
 
     integer(c_size_t), parameter :: N = 65536
     integer(c_int64_t), parameter :: seed = 12345_c_int64_t
-    real(c_double), parameter :: mean = 0.0_c_double, stddev = 1.0_c_double, delta = 0.2
+    real(c_double), parameter :: mean = 0.0_c_double, stddev = 1.0_c_double, delta = 0.2_c_double
 
     type(c_ptr) :: gen = c_null_ptr
 

--- a/test/f2008/rocrand/xorwow_uniform_double.f08
+++ b/test/f2008/rocrand/xorwow_uniform_double.f08
@@ -33,7 +33,7 @@ program rocrand_xorwow_uniform_double_test
 
     integer(c_size_t), parameter :: N = 65536
     integer(c_int64_t), parameter :: seed = 12345_c_int64_t
-    real(c_double), parameter :: expected_mean = 0.5, delta = 0.1
+    real(c_double), parameter :: expected_mean = 0.5_c_double, delta = 0.1_c_double
 
     type(c_ptr) :: gen = c_null_ptr
 


### PR DESCRIPTION
 Adding _c_double to the tolerance literals so they aren't rounded to single precision first. 