### PR TITLE
Document that the installed CMake package is ROCm-only and add the NVPTX option to the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ needs a recent, fully installed ROCm (amdgcn) or CUDA (nvptx) stack with every
 math library present to be certain it passes; each backend's test is skipped when
 its libraries are not found. Override the library directories with
 `HIPFORT_ROCM_LIB_DIR` / `HIPFORT_CUDA_LIB_DIR`.
+* CMake option `HIPFORT_BUILD_NVPTX` (default `ON`) that controls whether the CUDA
+(nvptx) backend archive is built. Build with `-DHIPFORT_BUILD_NVPTX=OFF` to skip
+`libhipfort-nvptx` on ROCm-only systems, which halves the build time and avoids
+installing an archive that will never be linked.
 
 ### Changed
 

--- a/docs/install/install.rst
+++ b/docs/install/install.rst
@@ -84,6 +84,13 @@ against the appropriate ROCm libraries. hipFORT provides exported CMake targets 
    add_executable(my_app main.f08)
    target_link_libraries(my_app PRIVATE hipfort::hipblas hipfort::hip)
 
+The installed CMake package targets the ROCm backend only. ``hipfort-config.cmake``
+is written when hipFORT is configured for ROCm; it pulls in ``libhipfort-amdgcn`` and
+resolves each component against its ROCm package, so ``find_package(hipfort)`` does
+not work against the optional CUDA (``nvptx``) backend even when that archive is
+built and installed. Link ``libhipfort-nvptx`` and the CUDA libraries directly
+instead.
+
 
 Examples and tests
 ====================


### PR DESCRIPTION
## Motivation

Two gaps in the docs for the optional CUDA backend.

`find_package(hipfort)` looks like it should work for either backend, but it cannot work for CUDA. `hipfort-config.cmake` is only written when hipFORT is configured for ROCm, it pulls in `libhipfort-amdgcn` by name, and it resolves each component against its ROCm package. Nothing says so, and the `hipfort_find_package_install` test fails on a CUDA build for exactly this reason.

`HIPFORT_BUILD_NVPTX` was added without a changelog entry.

## Technical Details

`docs/install/install.rst`: a short paragraph after the `find_package` example stating the installed CMake package targets ROCm only, and that CUDA users should link `libhipfort-nvptx` and the CUDA libraries directly.

`CHANGELOG.md`: an entry under Added for `HIPFORT_BUILD_NVPTX`, noting the default and what `-DHIPFORT_BUILD_NVPTX=OFF` saves on ROCm-only systems.

Documentation only, no build or code changes.

## Test Plan

Read against the actual install logic in `lib/CMakeLists.txt` and `lib/hipfort-config.cmake.in` to confirm the claim, rather than inferring it.

## Test Result

`configure_package_config_file` and the install of `hipfort-config.cmake` sit inside the `if(HIP_PLATFORM STREQUAL "amd")` branch. The template hardcodes `hipfort-amdgcn-targets.cmake` and calls `find_dependency` on ROCm packages. The
CUDA branch registers components but installs no package config, so `find_package(hipfort)` cannot resolve there. Consistent with `hipfort_find_package_install` failing on the CUDA backend.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.