### PR TITLE
Drop the unused C++ language requirement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,8 +30,8 @@ if(DEFINED HIPFORT_INSTALL_DIR)
   set(CMAKE_INSTALL_PREFIX "${HIPFORT_INSTALL_DIR}" CACHE STRING "Install directory")
 endif()
 
-# hip-config.cmake requires CXX enabled
-PROJECT(hipfort VERSION 0.8.0 LANGUAGES Fortran C CXX)
+# hipfort itself is pure Fortran. C is enabled because hip-config.cmake pulls in FindThreads.
+PROJECT(hipfort VERSION 0.8.0 LANGUAGES Fortran C)
 
 # get compiler name
 get_filename_component(FCNAME ${CMAKE_Fortran_COMPILER} NAME)

--- a/cmake/toolchains/amdflang.cmake
+++ b/cmake/toolchains/amdflang.cmake
@@ -15,7 +15,6 @@ endif()
 
 set(CMAKE_Fortran_COMPILER amdflang   CACHE FILEPATH "Fortran compiler")
 set(CMAKE_C_COMPILER       amdclang   CACHE FILEPATH "C compiler")
-set(CMAKE_CXX_COMPILER     amdclang++ CACHE FILEPATH "C++ compiler")
 
 # Free-form parsing and C preprocessing are enabled by hipfort itself, via
 # CMAKE_Fortran_FORMAT and CMAKE_Fortran_PREPROCESS in the top-level

--- a/cmake/toolchains/cray.cmake
+++ b/cmake/toolchains/cray.cmake
@@ -4,12 +4,11 @@
 # PrgEnv-cray and rocm), then configure with:
 #   cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/cray.cmake
 #
-# The Cray compiler drivers (ftn/cc/CC) forward to the underlying compilers and
+# The Cray compiler drivers (ftn/cc) forward to the underlying compilers and
 # already know about the system headers and libraries.
 
 set(CMAKE_Fortran_COMPILER ftn CACHE FILEPATH "Cray Fortran wrapper")
 set(CMAKE_C_COMPILER       cc  CACHE FILEPATH "Cray C wrapper")
-set(CMAKE_CXX_COMPILER     CC  CACHE FILEPATH "Cray C++ wrapper")
 
 # cmake/Modules/SetFortranFlags.cmake already special-cases the Cray compiler,
 # so no extra Fortran flags are needed here. Ensure ROCM_PATH points at the

--- a/cmake/toolchains/gnu.cmake
+++ b/cmake/toolchains/gnu.cmake
@@ -7,11 +7,8 @@
 
 set(CMAKE_Fortran_COMPILER gfortran CACHE FILEPATH "Fortran compiler")
 
-# find_package(hip) pulls in hip-config.cmake, which requires C and CXX to be
-# enabled. The stock gcc/g++ are sufficient: hipfort builds only Fortran module
-# files, so no device (.hip) sources are compiled here.
+# find_package(hip) pulls in hip-config.cmake, which needs the C language enabled.
 set(CMAKE_C_COMPILER   gcc CACHE FILEPATH "C compiler")
-set(CMAKE_CXX_COMPILER g++ CACHE FILEPATH "C++ compiler")
 
 # Point CMake at your ROCm installation when it is not in the default location
 # (equivalent to passing -DROCM_PATH=... on the command line).

--- a/cmake/toolchains/intel-classic.cmake
+++ b/cmake/toolchains/intel-classic.cmake
@@ -9,7 +9,6 @@
 
 set(CMAKE_Fortran_COMPILER ifort CACHE FILEPATH "Classic Intel Fortran compiler")
 set(CMAKE_C_COMPILER       icx   CACHE FILEPATH "Intel C compiler (LLVM)")
-set(CMAKE_CXX_COMPILER     icpx  CACHE FILEPATH "Intel C++ compiler (LLVM)")
 
 if(NOT DEFINED ROCM_PATH AND DEFINED ENV{ROCM_PATH})
   set(ROCM_PATH "$ENV{ROCM_PATH}" CACHE PATH "ROCm installation root")

--- a/cmake/toolchains/intel.cmake
+++ b/cmake/toolchains/intel.cmake
@@ -1,6 +1,6 @@
 # Intel oneAPI toolchain file for hipfort (ifx, AMD ROCm backend).
 #
-# Uses the LLVM-based Intel compilers (ifx/icx/icpx). For the end-of-life
+# Uses the LLVM-based Intel compilers (ifx/icx). For the end-of-life
 # classic ifort compiler, see intel-classic.cmake.
 #
 # Usage:
@@ -9,7 +9,6 @@
 
 set(CMAKE_Fortran_COMPILER ifx  CACHE FILEPATH "Intel Fortran compiler (LLVM)")
 set(CMAKE_C_COMPILER       icx  CACHE FILEPATH "Intel C compiler (LLVM)")
-set(CMAKE_CXX_COMPILER     icpx CACHE FILEPATH "Intel C++ compiler (LLVM)")
 
 if(NOT DEFINED ROCM_PATH AND DEFINED ENV{ROCM_PATH})
   set(ROCM_PATH "$ENV{ROCM_PATH}" CACHE PATH "ROCm installation root")

--- a/cmake/toolchains/nvhpc.cmake
+++ b/cmake/toolchains/nvhpc.cmake
@@ -11,7 +11,6 @@
 
 set(CMAKE_Fortran_COMPILER nvfortran CACHE FILEPATH "NVIDIA Fortran compiler")
 set(CMAKE_C_COMPILER       nvc       CACHE FILEPATH "NVIDIA C compiler")
-set(CMAKE_CXX_COMPILER     nvc++     CACHE FILEPATH "NVIDIA C++ compiler")
 
 # Select the NVIDIA HIP backend. Adjust the paths to your HIP/CUDA install.
 # set(HIP_PLATFORM nvidia    CACHE STRING "HIP platform (amd or nvidia)")

--- a/test/openmp/CMakeLists.txt
+++ b/test/openmp/CMakeLists.txt
@@ -1,7 +1,7 @@
 # HIPFORT using OpenMP offload with amdflang to AMD GPUs
 
 cmake_minimum_required(VERSION 3.25)
-project(hipfort_openmp LANGUAGES Fortran C CXX)
+project(hipfort_openmp LANGUAGES Fortran C)
 
 ##### Compiler ##############
 # This file is intended to be used with amdflang


### PR DESCRIPTION
## Motivation

hipfort declared `LANGUAGES Fortran C CXX` but compiles no C or C++ sources of its own. Requiring a C++ compiler that is never used narrows who can build the project.

## Technical Details

The `PROJECT` comment claimed hip-config.cmake needs CXX. It does not. `hip-config.cmake` pulls in `FindThreads`, which only requires C *or* CXX, and C is already enabled. The language list is now `Fortran C`.

With CXX no longer enabled, `CMAKE_CXX_COMPILER` is dead in all six toolchain files and is removed, along with the comments naming a C++ compiler. `test/openmp/CMakeLists.txt` also declared CXX and compiles no C or C++, so it drops it too.

C stays. Removing it would mean no `find_package(hip)`, so no `hipfort::*` targets and no `hipfort-config.cmake`.

`cmake/Modules/SetCompileFlag.cmake` still mentions CXX. It is a generic helper whose language argument accepts Fortran, C or CXX, and hipfort only calls it with Fortran.

## Test Plan

Built and tested on gfx1201, ROCm 7.2.4, with gfortran and amdflang, against develop as the baseline. No C++ compiler is configured in either build after this change.

Also probed `find_package(hip)` on its own with each language combination to confirm which one it actually needs.

## Test Result

`find_package(hip)` succeeds with `Fortran C` and with `Fortran CXX`, and fails with `Fortran` alone, so CXX was never the requirement.

Build and ctest match develop: 18 failed of 793 with gfortran, 18 failed of 794 with amdflang, identical failure sets, all pre-existing rocSPARSE ones. `CMakeCXXCompiler.cmake` is absent from the patched builds, confirming CXX is no longer enabled, and the four vecadd tests still build since their kernels go through the HIP language.

Note for consumers: `hipfort-config.cmake` calls `find_dependency(hip)`, so a project using hipfort still needs C or CXX enabled on its own side. A consumer declaring only `Fortran` fails on `FindThreads`. This is unchanged by this PR.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.